### PR TITLE
Override with sys props

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
@@ -22,6 +22,7 @@ using System.Collections.Specialized;
 using NUnit.Framework;
 
 using Quartz.Impl;
+using System;
 
 namespace Quartz.Tests.Unit.Impl
 {
@@ -46,7 +47,7 @@ namespace Quartz.Tests.Unit.Impl
             StdSchedulerFactory factory = new StdSchedulerFactory(new NameValueCollection());
             factory.GetScheduler();
         }
-        
+
         [Test]
         [ExpectedException(
             ExpectedException = typeof(SchedulerConfigException),
@@ -84,6 +85,21 @@ namespace Quartz.Tests.Unit.Impl
             NameValueCollection properties = new NameValueCollection();
             properties["my.unknown.property"] = "1";
             new StdSchedulerFactory(properties);
+        }
+        [Test]
+        public void TestFactoryShouldOverrideConfigurationWithSysProperties()
+        {
+            NameValueCollection properties = new NameValueCollection();
+            var factory = new StdSchedulerFactory();
+            factory.Initialize();
+            var scheduler=factory.GetScheduler();
+            Assert.AreEqual("DefaultQuartzScheduler",scheduler.SchedulerName);
+
+            Environment.SetEnvironmentVariable("quartz.scheduler.instanceName", "fromSystemProperties");
+            factory = new StdSchedulerFactory();
+            scheduler = factory.GetScheduler();
+            Assert.AreEqual("fromSystemProperties", scheduler.SchedulerName);
+            
         }
     }
 }

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -262,11 +262,11 @@ Please add configuration to your application config file to correctly initialize
         private static NameValueCollection OverrideWithSysProps(NameValueCollection props)
         {
             NameValueCollection retValue = new NameValueCollection(props);
-            ICollection keys = Environment.GetEnvironmentVariables().Keys;
+            IDictionary vars = Environment.GetEnvironmentVariables();
 
-            foreach (string key in keys)
+            foreach (string key in vars.Keys)
             {
-                retValue.Set(key, props[key]);
+                retValue.Set(key, vars[key] as string);
             }
             return retValue;
         }


### PR DESCRIPTION
Hi Marko

This is a fix for QRTZNET-246: Setting environment variables does not override configuration files values. I'm also including a passing unit test.

If you set one of the configuration settings for Quartz.Net in an environment variable, the value should overwrite any value set in the configuration fault. Here is the java documentation:
/**
     \* Add all System properties to the given <code>props</code>. Will override
     \* any properties that already exist in the given <code>props</code>.
     */
The current Quartz.Net implementation copies over the environment variable name but with no values and it does not override any configuration file settings.
