### PR TITLE
Allow HttpChannel name override

### DIFF
--- a/server/Quartz.Server/quartz.config
+++ b/server/Quartz.Server/quartz.config
@@ -18,3 +18,4 @@ quartz.scheduler.exporter.type = Quartz.Simpl.RemotingSchedulerExporter, Quartz
 quartz.scheduler.exporter.port = 555
 quartz.scheduler.exporter.bindName = QuartzScheduler
 quartz.scheduler.exporter.channelType = tcp
+quartz.scheduler.exporter.channelName = httpQuartz

--- a/src/Quartz.Examples/example12/RemoteServerExample.cs
+++ b/src/Quartz.Examples/example12/RemoteServerExample.cs
@@ -58,7 +58,8 @@ namespace Quartz.Examples.Example12
             properties["quartz.scheduler.exporter.port"] = "555";
             properties["quartz.scheduler.exporter.bindName"] = "QuartzScheduler";
             properties["quartz.scheduler.exporter.channelType"] = "tcp";
-            
+            properties["quartz.scheduler.exporter.channelName"] = "httpQuartz";
+
             ISchedulerFactory sf = new StdSchedulerFactory(properties);
             IScheduler sched = sf.GetScheduler();
 			

--- a/src/Quartz/Simpl/RemotingSchedulerExporter.cs
+++ b/src/Quartz/Simpl/RemotingSchedulerExporter.cs
@@ -43,10 +43,12 @@ namespace Quartz.Simpl
         public const string ChannelTypeTcp = "tcp";
         public const string ChannelTypeHttp = "http";
         private const string DefaultBindName = "QuartzScheduler";
+        private const string DefaultChannelName = "http";
 
         private readonly ILog log;
         private int port = -1;
         private string bindName = DefaultBindName;
+        private string channelName = DefaultChannelName;
         private string channelType = ChannelTypeTcp;
         private TypeFilterLevel typeFilgerLevel = TypeFilterLevel.Full;
         private static readonly Dictionary<string, object> registeredChannels = new Dictionary<string, object>();
@@ -100,7 +102,8 @@ namespace Quartz.Simpl
 
                 IDictionary props = new Hashtable();
                 props["port"] = port;
-                
+                props["name"] = "";
+
                 // use binary formatter
                 BinaryServerFormatterSinkProvider formatprovider = new BinaryServerFormatterSinkProvider(props, null);
                 formatprovider.TypeFilterLevel = typeFilgerLevel;
@@ -124,8 +127,8 @@ namespace Quartz.Simpl
                 {
                     throw new ArgumentException("Unknown remoting channel type '" + channelType + "'");
                 }
-               
-                Log.Info(string.Format(CultureInfo.InvariantCulture, "Registering remoting channel of type '{0}' to port ({1})", chan.GetType(), port));
+
+                Log.Info(string.Format(CultureInfo.InvariantCulture, "Registering remoting channel of type '{0}' to port ({1}) with name ({2})", chan.GetType(), port, channelName));
 
                 ChannelServices.RegisterChannel(chan, false);
 
@@ -190,6 +193,16 @@ namespace Quartz.Simpl
         {
             get { return bindName; }
             set { bindName = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the name to use when binding to 
+        /// tcp channel.
+        /// </summary>
+        public virtual string ChannelName
+        {
+            get { return channelName; }
+            set { channelName = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
According to the MSDN docs (http://bit.ly/nK5vy2)

The name property on HttpChannel specifies if more than one HttpChannel is registered, each must have a unique name. By default, the HttpChannel sets this to be 'http'.

This patch allows an override to be set for users that may have pre-existing HttpChannels.

Commit Log:
Added ChannelName to RemotingSchedulerExporter to allow overriding the default HttpChannel name
through quartz.config;
