### PR TITLE
Type conversion exception discovered in StdAdoDelegate

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
@@ -55,7 +55,7 @@ namespace Quartz.Impl.AdoJobStore
         public override bool GetBooleanFromDbValue(object columnValue)
         {
             // we store things as string in oracle with 1/0 as value
-            if (columnValue != null)
+            if (columnValue != null && columnValue != DBNull.Value)
             {
                 return Convert.ToInt32(columnValue) == 1;
             }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -536,7 +536,7 @@ namespace Quartz.Impl.AdoJobStore
         /// <returns></returns>
         public virtual bool GetBooleanFromDbValue(object columnValue)
         {
-            if (columnValue != null)
+            if (columnValue != null && columnValue != DBNull.Value)
             {
                 return (bool) columnValue;
             }
@@ -561,7 +561,7 @@ namespace Quartz.Impl.AdoJobStore
         /// <returns></returns>
         public virtual DateTimeOffset? GetDateTimeFromDbValue(object columnValue)
         {
-            if (columnValue != null)
+            if (columnValue != null && columnValue != DBNull.Value)
             {
                 var ticks = Convert.ToInt64(columnValue, CultureInfo.CurrentCulture);
                 if (ticks > 0)
@@ -589,7 +589,7 @@ namespace Quartz.Impl.AdoJobStore
         /// <returns></returns>
         public virtual TimeSpan? GetTimeSpanFromDbValue(object columnValue)
         {
-            if (columnValue != null)
+            if (columnValue != null && columnValue != DBNull.Value)
             {
                 var millis = Convert.ToInt64(columnValue, CultureInfo.CurrentCulture);
                 if (millis > 0)


### PR DESCRIPTION
Some DB providers return DBNull which isn't handled by the System.Convert methods.
