### PR TITLE
Fixing the bug with DailyTimeIntervalTrigger related to Timezones

### DIFF
--- a/src/Quartz/TimeOfDay.cs
+++ b/src/Quartz/TimeOfDay.cs
@@ -197,10 +197,9 @@ namespace Quartz
             if (dateTime == null)
                 return null;
 
-            DateTimeOffset cal = dateTime.Value.Date;
+            DateTimeOffset cal = new DateTimeOffset(dateTime.Value.Date, dateTime.Value.Offset);
             TimeSpan t = new TimeSpan(0, hour, minute, second);
             return cal.Add(t);
-        
         }
 
         public override string ToString()


### PR DESCRIPTION
As you can see, the fix is very simple. The bug was caused because we were getting the Date property of a DateTimeOffset, thus losing the timezone.
