### PR TITLE
Use System.Version instead of FileVersionInfo to retive current Quartz version

### DIFF
--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -36,6 +36,15 @@ namespace Quartz.Tests.Unit.Core
     public class QuartzSchedulerTest
     {
         [Test]
+        public void TestVersionInfo()
+        {
+            var versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetAssembly(typeof(Quartz.Core.QuartzScheduler)).Location);
+            Assert.AreEqual(versionInfo.FileMajorPart.ToString(System.Globalization.CultureInfo.InvariantCulture), Quartz.Core.QuartzScheduler.VersionMajor);
+            Assert.AreEqual(versionInfo.FileMinorPart.ToString(System.Globalization.CultureInfo.InvariantCulture), Quartz.Core.QuartzScheduler.VersionMinor);
+            Assert.AreEqual(versionInfo.FileBuildPart.ToString(System.Globalization.CultureInfo.InvariantCulture), Quartz.Core.QuartzScheduler.VersionIteration);
+        }
+
+        [Test]
         public void TestInvalidCalendarScheduling()
         {
             const string ExpectedError = "Calendar not found: FOOBAR";

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -55,7 +55,7 @@ namespace Quartz.Core
     public class QuartzScheduler : MarshalByRefObject, IRemotableQuartzScheduler
     {
         private readonly ILog log;
-        private static readonly FileVersionInfo versionInfo;
+        private static readonly Version version; 
 
         private readonly QuartzSchedulerResources resources;
 
@@ -86,10 +86,11 @@ namespace Quartz.Core
         /// </summary>
         static QuartzScheduler()
         {
-            Assembly asm = Assembly.GetAssembly(typeof (QuartzScheduler));
+            var asm = Assembly.GetAssembly(typeof(QuartzScheduler));
+
             if (asm != null)
             {
-                versionInfo = FileVersionInfo.GetVersionInfo(asm.Location);
+                version = asm.GetName().Version;
             }
         }
 
@@ -99,8 +100,8 @@ namespace Quartz.Core
         /// <value>The version.</value>
         public string Version
         {
-            get { return versionInfo.FileVersion; }
-        }
+            get { return version.ToString(); }
+        } 
 
         /// <summary>
         /// Gets the version major.
@@ -108,8 +109,8 @@ namespace Quartz.Core
         /// <value>The version major.</value>
         public static string VersionMajor
         {
-            get { return versionInfo.FileMajorPart.ToString(CultureInfo.InvariantCulture); }
-        }
+            get { return version.Major.ToString(CultureInfo.InvariantCulture); }
+        } 
 
         /// <summary>
         /// Gets the version minor.
@@ -117,7 +118,7 @@ namespace Quartz.Core
         /// <value>The version minor.</value>
         public static string VersionMinor
         {
-            get { return versionInfo.FileMinorPart.ToString(CultureInfo.InvariantCulture); }
+            get { return version.Minor.ToString(CultureInfo.InvariantCulture); }
         }
 
         /// <summary>
@@ -126,7 +127,7 @@ namespace Quartz.Core
         /// <value>The version iteration.</value>
         public static string VersionIteration
         {
-            get { return versionInfo.FileBuildPart.ToString(CultureInfo.InvariantCulture); }
+            get { return version.Build.ToString(CultureInfo.InvariantCulture); }
         }
 
         /// <summary>


### PR DESCRIPTION
I've encounter problems loading Quartz assembly without file, the
cause of my problem is QuartzScheduler class which uses
FileVersionInfo.GetVersionInfo to retive current Quartz version.

My proposal is to use Version class from Reflection instead of
FileVersionInfo from Diagnostics
