### PR TITLE
Allow scheduling relative to replaced trigger with XML configuration

### DIFF
--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -985,6 +985,10 @@ namespace Quartz.Core
             }
             
             trigger.JobKey = oldTrigger.JobKey;
+            
+            var oldTriggerPreviousFireTime = oldTrigger.GetPreviousFireTimeUtc();
+            trigger.StartTimeUtc = oldTrigger.StartTimeUtc;
+            trigger.SetPreviousFireTimeUtc(oldTriggerPreviousFireTime);
             trigger.Validate();
 
             ICalendar cal = null;
@@ -1000,6 +1004,8 @@ namespace Quartz.Core
                 var message = string.Format("Based on configured schedule, the given trigger '{0}' will never fire.", trigger.Key);
                 throw new SchedulerException(message);
             }
+
+            trigger.SetNextFireTimeUtc(trigger.GetFireTimeAfter(oldTriggerPreviousFireTime));
 
             if (resources.JobStore.ReplaceTrigger(triggerKey, trigger))
             {


### PR DESCRIPTION
A replacement trigger should schedule its next firing time relative to
the firing time of the trigger being replaced.  Example: a trigger fires
every 5 minutes.  It is replaced with a trigger that fires every 10
minutes.  It should not fire immediately upon replacement.  It should
instead fire 10 minutes after the last fire time.  So, if the old
trigger last fired at 12:05, the new trigger should fire at 12:15 (or
now if misfire).  Existing behavior was losing the old trigger's firing
history and thus firing immediately always.  This is most problematic with SimpleTrigger.
