### PR TITLE
small important change to clustering functionality

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -2990,7 +2990,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             TimeSpan passed = SystemTime.UtcNow() - lastCheckin;
             TimeSpan ts = rec.CheckinInterval > passed ? rec.CheckinInterval : passed;
-            return rec.CheckinTimestamp.Add(ts).Add(TimeSpan.FromMilliseconds(7500));
+            return rec.CheckinTimestamp.Add(ts).Add(ClusterCheckinInterval);
         }
 
         protected virtual IList<SchedulerStateRecord> ClusterCheckIn(ConnectionAndTransactionHolder conn)


### PR DESCRIPTION
Hello, I tried to change the ClusterCheckinInterval property for JobStoreTx , but I was not able to change it less then 7.5 seconds. If I set the property 

quartz.jobStore.clusterCheckinInterval to value 1000

and switch off one cluster node, another one goes into action only 7.5 seconds later. I found the problem in CalcFailedIfAfter method in JobStoreSupport class and fixed it.

Thanks.
