### PR TITLE
DailyTimeIntervalScheduleBuilder.EndingDailyAfterCount(...) doesn't pass validation

### DIFF
--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -220,6 +220,19 @@ namespace Quartz.Tests.Unit
         }
 
         [Test]
+        public void TestEndingAtAfterCountEndTimeOfDayValidation()
+        {
+            DailyTimeIntervalTriggerImpl trigger = (DailyTimeIntervalTriggerImpl)TriggerBuilder.Create()
+                    .WithIdentity("testTrigger")
+                    .ForJob("testJob")
+                    .WithDailyTimeIntervalSchedule(x =>
+                        x.StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(8, 0))
+                        .EndingDailyAfterCount(1))
+                    .Build();
+            Assert.DoesNotThrow(trigger.Validate, "We should accept EndTimeOfDay specified by EndingDailyAfterCount(x).");
+        }
+
+        [Test]
         public void TestCanSetTimeZone()
         {
             TimeZoneInfo est = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -878,7 +878,7 @@ namespace Quartz.Impl.Triggers
             }
 
             // Ensure timeOfDay is in order.
-            if (EndTimeOfDay != null && !StartTimeOfDay.Before(EndTimeOfDay))
+            if (EndTimeOfDay != null && EndTimeOfDay.Before(StartTimeOfDay))
             {
                 throw new SchedulerException("StartTimeOfDay " + startTimeOfDay + " should not come after endTimeOfDay " + endTimeOfDay);
             }


### PR DESCRIPTION
**Issue:** trigger built with using of `DailyTimeIntervalScheduleBuilder.EndingDailyAfterCount(...)` won't pass validation as `DailyTimeIntervalTriggerImpl` property `EndTimeOfDay` will be equal to `StartTimeOfDay` which is denied by validation rule.

**Supposed solution:** `DailyTimeIntervalTriggerImpl` has corellated properties `StartTimeUtc` and `EndTimeUtc` which setters check `EndTimeUtc` for being greater or equal to `StartTimeUtc`.  So it looks logically to allow `EndTimeOfDay` to be equal to `StartTimeOfDay` during entire `DailyTimeIntervalTriggerImpl` trigger validation.

Please review.
