### PR TITLE
BugFix: In the SimplePropertiesTriggerPersistenceDelegateSupport long properties read as int

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateSupport.cs
@@ -166,8 +166,8 @@ namespace Quartz.Impl.AdoJobStore
                         properties.String3 = rs.GetString(ColumnStrProp3);
                         properties.Int1 = rs.GetInt32(ColumnIntProp1);
                         properties.Int2 = rs.GetInt32(ColumnIntProp2);
-                        properties.Long1 = rs.GetInt32(ColumnLongProp1);
-                        properties.Long2 = rs.GetInt32(ColumnLongProp2);
+                        properties.Long1 = rs.GetInt64(ColumnLongProp1);
+                        properties.Long2 = rs.GetInt64(ColumnLongProp2);
                         properties.Decimal1 = rs.GetDecimal(ColumnDecProp1);
                         properties.Decimal2 = rs.GetDecimal(ColumnDecProp2);
                         properties.Boolean1 = DbAccessor.GetBooleanFromDbValue(rs[ColumnBoolProp1]);


### PR DESCRIPTION
When the saved long values were greater then the max int value then an exception was thrown during the read phase.
