### PR TITLE
Fix for future day and week calendar schedules being generated incorrectly

### DIFF
--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -672,8 +672,6 @@ namespace Quartz.Impl.Triggers
                     }
 
                     // now baby-step the rest of the way there...
-                    sTime = TimeZoneUtil.ConvertTime(sTime, this.TimeZone); //apply the timezone because we are comparing only the DateTime portions.
-
                     while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < YearToGiveupSchedulingAt)
                     {
                         sTime = sTime.AddDays(RepeatInterval);
@@ -716,8 +714,6 @@ namespace Quartz.Impl.Triggers
                         }
                         sTime = sTime.AddDays((int) (RepeatInterval*jumpCount*7));
                     }
-
-                    sTime = TimeZoneUtil.ConvertTime(sTime, this.TimeZone); //apply the timezone because we are comparing only the DateTime portions.
 
                     while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < YearToGiveupSchedulingAt)
                     {


### PR DESCRIPTION
If this is deemed technically sound it should fix the problem described in [CalendarIntervalScheduleBuilder produces incorrect schedule #154](https://github.com/quartznet/quartznet/issues/154)

I tested generating daily and weekly schedules far into the future and did not observe the issue any more after making this change.
