### PR TITLE
fix TimeZoneInfo.GetUtcOffset(DateTimeOffset dateTimeOffset) not implemented in Mono

### DIFF
--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -511,7 +511,7 @@ namespace Quartz.Impl.Triggers
         /// </returns>        
         public override DateTimeOffset? ComputeFirstFireTimeUtc(ICalendar calendar)
         {
-            nextFireTimeUtc  = GetFireTimeAfter(StartTimeUtc.AddSeconds(-1));
+            nextFireTimeUtc = GetFireTimeAfter(StartTimeUtc.AddSeconds(-1));
 
             // Check calendar for date-time exclusion
             while (nextFireTimeUtc != null && calendar != null
@@ -649,7 +649,7 @@ namespace Quartz.Impl.Triggers
             }
 
             // apply timezone for this date & time
-            fireTime = new DateTimeOffset(fireTime.Value.DateTime, TimeZone.GetUtcOffset(fireTime.Value.DateTime));
+            fireTime = new DateTimeOffset(fireTime.Value.DateTime, TimeZoneUtil.GetUtcOffset(fireTime.Value, TimeZone));
 
             // d. Calculate and save fireTimeEndDate variable for later use
             DateTimeOffset fireTimeEndDate;

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -33,6 +33,22 @@ namespace Quartz.Util
         }
 
         /// <summary>
+        /// TimeZoneInfo.GetUtcOffset(DateTimeOffset) is not supported under mono
+        /// </summary>
+        /// <param name="dateTimeOffset"></param>
+        /// <param name="timeZoneInfo"></param>
+        /// <returns></returns>
+        public static TimeSpan GetUtcOffset(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
+        {
+            if (QuartzEnvironment.IsRunningOnMono)
+            {
+                return timeZoneInfo.GetUtcOffset(dateTimeOffset.UtcDateTime);
+            }
+
+            return timeZoneInfo.GetUtcOffset(dateTimeOffset);
+        }
+
+        /// <summary>
         /// Tries to find time zone with given id, has ability do some fallbacks when necessary.
         /// </summary>
         /// <param name="id">System id of the time zone.</param>


### PR DESCRIPTION
use TimeZoneInfo.GetUtcOffset(DateTime dateTime) instead
