### PR TITLE
Replaced the type cast (twice with 'is) with better syntax (once with 'as')

### DIFF
--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -583,11 +583,12 @@ namespace Quartz.Core
                 IList<IJobExecutionContext> jobs = CurrentlyExecutingJobs;
                 foreach (IJobExecutionContext job in jobs)
                 {
-                    if (job.JobInstance is IInterruptableJob)
+                    IInterruptableJob jobInstance = job.JobInstance as IInterruptableJob;
+                    if (jobInstance != null)
                     {
                         try
                         {
-                            ((IInterruptableJob) job.JobInstance).Interrupt();
+                            jobInstance.Interrupt();
                         }
                         catch (Exception ex)
                         {
@@ -2285,10 +2286,10 @@ namespace Quartz.Core
                 jobDetail = jec.JobDetail;
                 if (jobKey.Equals(jobDetail.Key))
                 {
-                    IJob job = jec.JobInstance;
-                    if (job is IInterruptableJob)
+                    IInterruptableJob jobInstance = jec.JobInstance as IInterruptableJob;
+                    if (jobInstance != null)
                     {
-                        ((IInterruptableJob) job).Interrupt();
+                        jobInstance.Interrupt();
                         interrupted = true;
                     }
                     else
@@ -2320,10 +2321,10 @@ namespace Quartz.Core
             {
                 if (jec.FireInstanceId.Equals(fireInstanceId))
                 {
-                    IJob job = jec.JobInstance;
-                    if (job is IInterruptableJob)
+                    IInterruptableJob jobInstance = jec.JobInstance as IInterruptableJob;
+                    if (jobInstance != null)
                     {
-                        ((IInterruptableJob) job).Interrupt();
+                        jobInstance.Interrupt();
                         return true;
                     }
                     throw new UnableToInterruptJobException("Job " + jec.JobDetail.Key + " can not be interrupted, since it does not implement " + typeof (IInterruptableJob).Name);

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -109,8 +109,8 @@ namespace Quartz.Impl
         public const string PropertySchedulerName = "schedName";
         public const string PropertyJobStoreType = "quartz.jobStore.type";
         public const string PropertyDataSourcePrefix = "quartz.dataSource";
-		public const string PropertyDbProvider = "quartz.dbprovider";
-		public const string PropertyDbProviderType = "connectionProvider.type";
+        public const string PropertyDbProvider = "quartz.dbprovider";
+        public const string PropertyDbProviderType = "connectionProvider.type";
         public const string PropertyDataSourceProvider = "provider";
         public const string PropertyDataSourceConnectionString = "connectionString";
         public const string PropertyDataSourceConnectionStringName = "connectionStringName";
@@ -672,7 +672,8 @@ Please add configuration to your application config file to correctly initialize
                 throw initException;
             }
 
-            if (js is JobStoreSupport)
+            JobStoreSupport jobStoreSupport = js as JobStoreSupport;
+            if (jobStoreSupport != null)
             {
                 // Install custom lock handler (Semaphore)
                 Type lockHandlerType = loadHelper.LoadType(cfg.GetStringProperty(PropertyJobStoreLockHandlerType));
@@ -686,7 +687,7 @@ Please add configuration to your application config file to correctly initialize
                         if (cWithDbProvider != null)
                         {
                             // takes db provider
-                            IDbProvider dbProvider = DBConnectionManager.Instance.GetDbProvider(((JobStoreSupport) js).DataSource);
+                            IDbProvider dbProvider = DBConnectionManager.Instance.GetDbProvider(jobStoreSupport.DataSource);
                             lockHandler = (ISemaphore) cWithDbProvider.Invoke(new object[] { dbProvider });
                         }
                         else
@@ -699,7 +700,7 @@ Please add configuration to your application config file to correctly initialize
                         // If this lock handler requires the table prefix, add it to its properties.
                         if (lockHandler is ITablePrefixAware)
                         {
-                            tProps[PropertyTablePrefix] = ((JobStoreSupport) js).TablePrefix;
+                            tProps[PropertyTablePrefix] = jobStoreSupport.TablePrefix;
                             tProps[PropertySchedulerName] = schedName;
                         }
 
@@ -713,7 +714,7 @@ Please add configuration to your application config file to correctly initialize
                             throw initException;
                         }
 
-                        ((JobStoreSupport) js).LockHandler = lockHandler;
+                        jobStoreSupport.LockHandler = lockHandler;
                         Log.Info("Using custom data access locking (synchronization): " + lockHandlerType);
                     }
                     catch (Exception e)
@@ -933,14 +934,13 @@ Please add configuration to your application config file to correctly initialize
                     }
                 }
 
-            
-                if (js is JobStoreSupport)
+                jobStoreSupport = js as JobStoreSupport;
+                if (jobStoreSupport != null)
                 {
-                    JobStoreSupport jjs = (JobStoreSupport) js;
-                    jjs.DbRetryInterval = dbFailureRetry;
-                    jjs.ThreadExecutor = threadExecutor;
+                    jobStoreSupport.DbRetryInterval = dbFailureRetry;
+                    jobStoreSupport.ThreadExecutor = threadExecutor;
                     // object serializer
-                    jjs.ObjectSerializer = objectSerializer; 
+                    jobStoreSupport.ObjectSerializer = objectSerializer; 
                 }
 
                 QuartzSchedulerResources rsrcs = new QuartzSchedulerResources();

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1934,10 +1934,10 @@ namespace Quartz.Simpl
 
         public override bool Equals(object obj)
         {
-            if (obj is JobWrapper)
+            JobWrapper jobWrapper = obj as JobWrapper;
+            if (jobWrapper != null)
             {
-                JobWrapper jw = (JobWrapper)obj;
-                if (jw.key.Equals(key))
+                if (jobWrapper.key.Equals(key))
                 {
                     return true;
                 }


### PR DESCRIPTION
When checking a variable with 'is' and then casting it results in the type being checked twice.
Replaced it with 'as' and then checking for null. This results in the type only being checked once.
