### PR TITLE
TriggerBuilder.UsingJobData(JobDataMap newJobDataMap) should ovewrite existing

### DIFF
--- a/src/Quartz/TriggerBuilder.cs
+++ b/src/Quartz/TriggerBuilder.cs
@@ -472,12 +472,11 @@ namespace Quartz
         /// <seealso cref="ITrigger.JobDataMap" />
         public TriggerBuilder UsingJobData(JobDataMap newJobDataMap)
         {
-            // add any existing data to this new map
-            foreach (string k in jobDataMap.Keys)
+            // add data from new map to existing map (overrides old values)
+            foreach (string k in newJobDataMap.Keys)
             {
-                newJobDataMap.Put(k, jobDataMap.Get(k));
+                jobDataMap.Put(k, newJobDataMap.Get(k));
             }
-            jobDataMap = newJobDataMap; // set new map as the map to use
             return this;
         }
     }


### PR DESCRIPTION
Update TriggerBuilder.UsingJobData(JobDataMap newJobDataMap) behavior to match that of TriggerBuilder.UsingJobData(string key, T value) overloads.  When duplicate key is found use value from newJobDataMap.