### PR TITLE
More extensible QuartzScheduler plus minor DirectSchedulerFactory initialization fix

### DIFF
--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1603,7 +1603,7 @@ namespace Quartz.Core
             }
         }
 
-        protected internal void NotifyJobStoreJobVetoed(IOperableTrigger trigger, IJobDetail detail, SchedulerInstruction instCode)
+        public virtual void NotifyJobStoreJobVetoed(IOperableTrigger trigger, IJobDetail detail, SchedulerInstruction instCode)
         {
             resources.JobStore.TriggeredJobComplete(trigger, detail, instCode);
         }
@@ -1614,7 +1614,7 @@ namespace Quartz.Core
         /// <param name="trigger">The trigger.</param>
         /// <param name="detail">The detail.</param>
         /// <param name="instCode">The instruction code.</param>
-        protected internal virtual void NotifyJobStoreJobComplete(IOperableTrigger trigger, IJobDetail detail, SchedulerInstruction instCode)
+        public virtual void NotifyJobStoreJobComplete(IOperableTrigger trigger, IJobDetail detail, SchedulerInstruction instCode)
         {
             resources.JobStore.TriggeredJobComplete(trigger, detail, instCode);
         }
@@ -2145,7 +2145,7 @@ namespace Quartz.Core
             }
         }
 
-        public void NotifySchedulerListenersInStandbyMode()
+        public virtual void NotifySchedulerListenersInStandbyMode()
         {
             // notify all scheduler listeners
             foreach (ISchedulerListener listener in BuildSchedulerListenerList())

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -308,6 +308,15 @@ namespace Quartz.Core
         }
 
         /// <summary>
+        /// Create a <see cref="QuartzScheduler" />.
+        /// </summary>
+        /// <seealso cref="QuartzSchedulerResources" />
+        public QuartzScheduler()
+        {
+            log = LogManager.GetLogger(GetType());
+        }
+
+        /// <summary>
         /// Create a <see cref="QuartzScheduler" /> with the given configuration
         /// properties.
         /// </summary>

--- a/src/Quartz/Impl/DirectSchedulerFactory.cs
+++ b/src/Quartz/Impl/DirectSchedulerFactory.cs
@@ -317,14 +317,13 @@ namespace Quartz.Impl
 
             // Fire everything u
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            SchedulerDetailsSetter.SetDetails(threadPool, schedulerName, schedulerInstanceId);
             threadPool.Initialize();
 
             QuartzSchedulerResources qrs = new QuartzSchedulerResources();
 
             qrs.Name = schedulerName;
             qrs.InstanceId = schedulerInstanceId;
-
-            SchedulerDetailsSetter.SetDetails(threadPool, schedulerName, schedulerInstanceId);
 
             qrs.JobRunShellFactory = jrsf;
             qrs.ThreadPool = threadPool;


### PR DESCRIPTION
I'm doing some advanced work with running the scheduler (`QuartzScheduler`) and worker (`JobRunShell`) in different OS processes. I really need a default public constructor on `QuartzScheduler` and all its notify methods to be public virtual. I hope you'll accept these very low risk tweaks.

This pull request also includes a minor bug fix in `DirectSchedulerFactory` to ensure that the `InstanceId` and `InstanceName` properties are set before `IThreadPool.Initialize` is called.