### PR TITLE
QuartzScheduler inheritance and BlockForAvailableThreads fixes

### DIFF
--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1608,7 +1608,7 @@ namespace Quartz.Core
             }
         }
 
-        protected internal virtual void NotifyJobStoreJobVetoed(IOperableTrigger trigger, IJobDetail detail, SchedulerInstruction instCode)
+        public virtual void NotifyJobStoreJobVetoed(IOperableTrigger trigger, IJobDetail detail, SchedulerInstruction instCode)
         {
             resources.JobStore.TriggeredJobComplete(trigger, detail, instCode);
         }
@@ -1619,7 +1619,7 @@ namespace Quartz.Core
         /// <param name="trigger">The trigger.</param>
         /// <param name="detail">The detail.</param>
         /// <param name="instCode">The instruction code.</param>
-        protected internal virtual void NotifyJobStoreJobComplete(IOperableTrigger trigger, IJobDetail detail, SchedulerInstruction instCode)
+        public virtual void NotifyJobStoreJobComplete(IOperableTrigger trigger, IJobDetail detail, SchedulerInstruction instCode)
         {
             resources.JobStore.TriggeredJobComplete(trigger, detail, instCode);
         }

--- a/src/Quartz/Simpl/SimpleThreadPool.cs
+++ b/src/Quartz/Simpl/SimpleThreadPool.cs
@@ -321,7 +321,7 @@ namespace Quartz.Simpl
         {
             lock (nextRunnableLock)
             {
-                while ((availWorkers.Count < 1 || handoffPending) && !isShutdown)
+                if ((availWorkers.Count < 1 || handoffPending) && !isShutdown)
                 {
                     try
                     {


### PR DESCRIPTION
Pretty please can you make the two `NotifyJobStore*` methods in `QuartzScheduler` public? I really need this, plus it makes them consistent with all the other virtual methods in this class.

I've also fixed the shutdown issue that I described in the groups [here](https://groups.google.com/forum/#!topic/quartznet/E1x2HSoGJ4U). I realise that the `BlockForAvailableThreads` name doesn't make as much sense if it only blocks for 500ms, but this very small change easily fixes the shutdown issue because `QuartzSchedulerThread` already handles zero return values correctly on [line 281](https://github.com/quartznet/quartznet/blob/133c99e7527f6e1301e5ba866d11f9dd056ff0b4/src/Quartz/Core/QuartzSchedulerThread.cs#L281).
