### PR TITLE
AbstractTrigger.StartTimeUtc setter loses UTC offset information

### DIFF
--- a/src/Quartz/Impl/Triggers/AbstractTrigger.cs
+++ b/src/Quartz/Impl/Triggers/AbstractTrigger.cs
@@ -394,7 +394,7 @@ namespace Quartz.Impl.Triggers
 				if (!HasMillisecondPrecision)
 				{
 					// round off millisecond...	
-					startTimeUtc = new DateTime(value.Year, value.Month, value.Day, value.Hour, value.Minute, value.Second);
+					startTimeUtc = value.AddMilliseconds(-value.Millisecond);
 				}
 				else
 				{


### PR DESCRIPTION
When it invokes startTimeUtc = new DateTime(value.Year, value.Month, value.Day, value.Hour, value.Minute, value.Second), it creates time value in current TimeZone, but not in UTC.