### PR TITLE
Handle DST better

### DIFF
--- a/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
+++ b/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
@@ -26,6 +26,21 @@ namespace Quartz.Tests.Unit
     [TestFixture]
     public class DaylightSavingTimeTest
     {
+        private Func<DateTimeOffset> OriginalUtcNow;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            OriginalUtcNow = SystemTime.UtcNow;
+            SystemTime.UtcNow = () => new DateTimeOffset(2016, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            SystemTime.UtcNow = OriginalUtcNow;
+        }
+
         [Test]
         public void ShouldHandleDstSpringForwardTransition()
         {

--- a/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
+++ b/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
@@ -1,0 +1,107 @@
+﻿#region License
+/* 
+ * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved. 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+ * use this file except in compliance with the License. You may obtain a copy 
+ * of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+ * License for the specific language governing permissions and limitations 
+ * under the License.
+ * 
+ */
+#endregion
+
+using System;
+
+using NUnit.Framework;
+
+namespace Quartz.Tests.Unit
+{
+    [TestFixture]
+    public class DaylightSavingTimeTest
+    {
+        [Test]
+        public void ShouldHandleDstSpringForwardTransition()
+        {
+            TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger1", "group1")
+                .WithSchedule(CronScheduleBuilder.DailyAtHourAndMinute(2, 30).InTimeZone(tz))
+                .ForJob("job1", "group1")
+                .Build();
+
+            DateTimeOffset midnight = new DateTimeOffset(2016, 3, 13, 0, 0, 0, TimeSpan.FromHours(-8));
+            DateTimeOffset? fireTime = trigger.GetFireTimeAfter(midnight);
+
+            // It should fire at the equivalent valid local time.  2:30-8 does not exist, so it should run at 3:30-7.
+            DateTimeOffset expectedTime = new DateTimeOffset(2016, 3, 13, 3, 30, 0, TimeSpan.FromHours(-7));
+
+            // We should definitely have a value
+            Assert.NotNull(fireTime);
+
+            // fireTime always is in UTC, but DateTimeOffset comparison normalized to UTC anyway.
+            // Conversion here is for clarity of interpreting errors if the test fails.
+            DateTimeOffset convertedFireTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
+            Assert.AreEqual(expectedTime, convertedFireTime);
+        }
+
+        [Test]
+        public void ShouldHandleDstFallBackTransition()
+        {
+            TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger1", "group1")
+                .WithSchedule(CronScheduleBuilder.DailyAtHourAndMinute(1, 30).InTimeZone(tz))
+                .ForJob("job1", "group1")
+                .Build();
+
+            DateTimeOffset midnight = new DateTimeOffset(2016, 11, 6, 0, 0, 0, TimeSpan.FromHours(-7));
+            DateTimeOffset? fireTime = trigger.GetFireTimeAfter(midnight);
+
+            // It should fire at the first instance, which is 1:30-7 - the DAYLIGHT time, not the standard time.
+            DateTimeOffset expectedTime = new DateTimeOffset(2016, 11, 6, 1, 30, 0, TimeSpan.FromHours(-7));
+
+            // We should definitely have a value
+            Assert.NotNull(fireTime);
+
+            // fireTime always is in UTC, but DateTimeOffset comparison normalized to UTC anyway.
+            // Conversion here is for clarity of interpreting errors if the test fails.
+            DateTimeOffset convertedFireTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
+            Assert.AreEqual(expectedTime, convertedFireTime);
+        }
+
+        [Test]
+        public void ShouldHandleDstFallBackTransition_AndNotRunTwiceOnTheSameDay()
+        {
+            TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger1", "group1")
+                .WithSchedule(CronScheduleBuilder.DailyAtHourAndMinute(1, 30).InTimeZone(tz))
+                .ForJob("job1", "group1")
+                .Build();
+
+            DateTimeOffset firstRun = new DateTimeOffset(2016, 11, 6, 1, 30, 0, TimeSpan.FromHours(-7));
+            DateTimeOffset? fireTime = trigger.GetFireTimeAfter(firstRun);
+
+            // It should not fire again at 1:30-8 on the same day, but should instead fire at 1:30-8 the following day.
+            DateTimeOffset expectedTime = new DateTimeOffset(2016, 11, 7, 1, 30, 0, TimeSpan.FromHours(-8));
+
+            // We should definitely have a value
+            Assert.NotNull(fireTime);
+
+            // fireTime always is in UTC, but DateTimeOffset comparison normalized to UTC anyway.
+            // Conversion here is for clarity of interpreting errors if the test fails.
+            DateTimeOffset convertedFireTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
+            Assert.AreEqual(expectedTime, convertedFireTime);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -59,6 +59,7 @@
     <Compile Include="CronTriggerTest.cs" />
     <Compile Include="DailyTimeIntervalScheduleBuilderTest.cs" />
     <Compile Include="DateBuilderTest.cs" />
+    <Compile Include="DaylightSavingTimeTests.cs" />
     <Compile Include="DisallowConcurrentJobExecutionTest.cs" />
     <Compile Include="Impl\AdoJobStore\JobStoreCMTTest.cs" />
     <Compile Include="Impl\AdoJobStore\JobStoreSupportTest.cs" />

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -2065,7 +2065,7 @@ namespace Quartz
                 d = new DateTimeOffset(year, d.Month, d.Day, d.Hour, d.Minute, d.Second, d.Offset);
 
                 //apply the proper offset for this date
-                d = new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, d.Minute, d.Second, this.TimeZone.GetUtcOffset(d.DateTime));
+                d = new DateTimeOffset(d.DateTime, TimeZoneUtil.GetUtcOffset(d.DateTime, this.TimeZone));
 
                 gotOne = true;
             } // while( !done )

--- a/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
+++ b/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using Quartz.Collection;
 using Quartz.Impl.Triggers;
 using Quartz.Spi;
+using Quartz.Util;
 
 namespace Quartz
 {
@@ -378,8 +379,8 @@ namespace Quartz
 
             //apply proper offsets according to timezone
             TimeZoneInfo targetTimeZone = timeZone ?? TimeZoneInfo.Local;
-            startTimeOfDayDate = new DateTimeOffset(startTimeOfDayDate.DateTime, targetTimeZone.GetUtcOffset(startTimeOfDayDate.DateTime));
-            maxEndTimeOfDayDate = new DateTimeOffset(maxEndTimeOfDayDate.DateTime, targetTimeZone.GetUtcOffset(maxEndTimeOfDayDate.DateTime));
+            startTimeOfDayDate = new DateTimeOffset(startTimeOfDayDate.DateTime, TimeZoneUtil.GetUtcOffset(startTimeOfDayDate.DateTime, targetTimeZone));
+            maxEndTimeOfDayDate = new DateTimeOffset(maxEndTimeOfDayDate.DateTime, TimeZoneUtil.GetUtcOffset(maxEndTimeOfDayDate.DateTime, targetTimeZone));
 
             TimeSpan remainingMillisInDay = maxEndTimeOfDayDate - startTimeOfDayDate;
             TimeSpan intervalInMillis;

--- a/src/Quartz/DateBuilder.cs
+++ b/src/Quartz/DateBuilder.cs
@@ -21,6 +21,8 @@
 
 using System;
 
+using Quartz.Util;
+
 namespace Quartz
 {
     /// <summary>
@@ -123,19 +125,9 @@ namespace Quartz
         /// <returns>New date time based on builder parameters.</returns>
         public DateTimeOffset Build()
         {
-            DateTimeOffset cal;
-
-            if (tz != null)
-            {
-                cal = new DateTimeOffset(year, month, day, hour, minute, second, 0, tz.BaseUtcOffset);
-            }
-            else
-            {
-                var utcOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(year, month, day, hour, minute, second));
-                cal = new DateTimeOffset(year, month, day, hour, minute, second, utcOffset);
-            }
-
-            return cal;
+            DateTime dt = new DateTime(year, month, day, hour, minute, second);
+            TimeSpan offset = TimeZoneUtil.GetUtcOffset(dt, tz ?? TimeZoneInfo.Local);
+            return new DateTimeOffset(dt, offset);
         }
 
         /// <summary>
@@ -338,9 +330,8 @@ namespace Quartz
             ValidateHour(hour);
 
             DateTimeOffset c = SystemTime.Now();
-
-            var utcOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(c.Year, c.Month, c.Day, hour, minute, second));
-            return new DateTimeOffset(c.Year, c.Month, c.Day, hour, minute, second, utcOffset);
+            DateTime dt = new DateTime(c.Year, c.Month, c.Day, hour, minute, second);
+            return new DateTimeOffset(dt, TimeZoneUtil.GetUtcOffset(dt, TimeZoneInfo.Local));
         }
 
         /// <summary>
@@ -363,9 +354,8 @@ namespace Quartz
             ValidateMonth(month);
 
             DateTimeOffset c = SystemTime.Now();
-
-            var utcOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(c.Year, month, dayOfMonth, hour, minute, second));
-            return new DateTimeOffset(c.Year, month, dayOfMonth, hour, minute, second, utcOffset);
+            DateTime dt = new DateTime(c.Year, month, dayOfMonth, hour, minute, second);
+            return new DateTimeOffset(dt, TimeZoneUtil.GetUtcOffset(dt, TimeZoneInfo.Local));
         }
 
         /// <summary>
@@ -391,8 +381,8 @@ namespace Quartz
             ValidateMonth(month);
             ValidateYear(year);
 
-            var utcOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(year, month, dayOfMonth, hour, minute, second));
-            return new DateTimeOffset(year, month, dayOfMonth, hour, minute, second, utcOffset);
+            DateTime dt = new DateTime(year, month, dayOfMonth, hour, minute, second);
+            return new DateTimeOffset(dt, TimeZoneUtil.GetUtcOffset(dt, TimeZoneInfo.Local));
         }
 
         /// <summary>

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -782,7 +782,7 @@ namespace Quartz.Impl.Triggers
             {
                 //first apply the date, and then find the proper timezone offset
                 newTime = new DateTimeOffset(newTime.Year, newTime.Month, newTime.Day, initialHourOfDay, newTime.Minute, newTime.Second, newTime.Millisecond, TimeSpan.Zero);
-                newTime = new DateTimeOffset(newTime.DateTime, this.TimeZone.GetUtcOffset(newTime.DateTime));
+                newTime = new DateTimeOffset(newTime.DateTime, TimeZoneUtil.GetUtcOffset(newTime.DateTime, this.TimeZone));
 
                 //TimeZone.IsInvalidTime is true, if this hour does not exist in the specified timezone
                 bool isInvalid = this.TimeZone.IsInvalidTime(newTime.DateTime);
@@ -800,7 +800,7 @@ namespace Quartz.Impl.Triggers
                     }
 
                     //apply proper offset for the adjusted time
-                    newTime = new DateTimeOffset(newTime.DateTime, this.TimeZone.GetUtcOffset(newTime.DateTime));
+                    newTime = new DateTimeOffset(newTime.DateTime, TimeZoneUtil.GetUtcOffset(newTime.DateTime, this.TimeZone));
                 }
             }
             return false;
@@ -823,7 +823,7 @@ namespace Quartz.Impl.Triggers
             {
                 //first apply the date, and then find the proper timezone offset
                 sTime = new DateTimeOffset(initalYear, initalMonth, initialDay, initialHourOfDay, sTime.Minute, sTime.Second, sTime.Millisecond, TimeSpan.Zero);
-                sTime = new DateTimeOffset(sTime.DateTime, this.TimeZone.GetUtcOffset(sTime.DateTime));
+                sTime = new DateTimeOffset(sTime.DateTime, TimeZoneUtil.GetUtcOffset(sTime.DateTime, this.TimeZone));
             }
         }
 

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -672,13 +672,13 @@ namespace Quartz.Impl.Triggers
             }
 
             // apply the proper offset for the end date
-            fireTimeEndDate = new DateTimeOffset(fireTimeEndDate.DateTime, TimeZone.GetUtcOffset(fireTimeEndDate.DateTime));
+            fireTimeEndDate = new DateTimeOffset(fireTimeEndDate.DateTime, TimeZoneUtil.GetUtcOffset(fireTimeEndDate.DateTime, this.TimeZone));
 
             // e. Check fireTime against startTime or startTimeOfDay to see which go first.
             DateTimeOffset fireTimeStartDate = startTimeOfDay.GetTimeOfDayForDate(fireTime).Value;
 
             // apply the proper offset for the start date
-            fireTimeStartDate = new DateTimeOffset(fireTimeStartDate.DateTime, TimeZone.GetUtcOffset(fireTimeStartDate.DateTime));
+            fireTimeStartDate = new DateTimeOffset(fireTimeStartDate.DateTime, TimeZoneUtil.GetUtcOffset(fireTimeStartDate.DateTime, this.TimeZone));
 
             if (fireTime < fireTimeStartDate)
             {
@@ -741,7 +741,7 @@ namespace Quartz.Impl.Triggers
 
             // apply proper offset
             var d = fireTime.Value;
-            d = new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, d.Minute, d.Second, TimeZone.GetUtcOffset(d.DateTime));
+            d = new DateTimeOffset(d.DateTime, TimeZoneUtil.GetUtcOffset(d.DateTime, this.TimeZone));
 
             return d.ToUniversalTime();
         }

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Quartz.Logging;
 
@@ -79,6 +80,19 @@ namespace Quartz.Util
             }
 
             return timeZoneInfo.GetUtcOffset(dateTimeOffset);
+        }
+
+        public static TimeSpan GetUtcOffset(DateTime dateTime, TimeZoneInfo timeZoneInfo)
+        {
+            // Unlike the default behavior of TimeZoneInfo.GetUtcOffset, it is prefered to choose
+            // the DAYLIGHT time when the input is ambiguous, because the daylight instance is the
+            // FIRST instance, and time moves in a forward direction.
+
+            TimeSpan offset = timeZoneInfo.IsAmbiguousTime(dateTime)
+                ? timeZoneInfo.GetAmbiguousTimeOffsets(dateTime).Max()
+                : timeZoneInfo.GetUtcOffset(dateTime);
+
+            return offset;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR addresses the challenges of scheduling a daily event when considering daylight saving time transitions.

First, it's worth pointing out that the Quartz.net documentation's description of how DST is handled is wrong.  It states multiple times ([in the FAQ here](http://www.quartz-scheduler.net/documentation/faq.html#daylight-saving-time-and-triggers), [in the CronTrigger Tutorial here](http://www.quartz-scheduler.net/documentation/quartz-2.x/tutorial/crontrigger.html#notes), [in the Best Practices here](http://www.quartz-scheduler.net/documentation/best-practices.html#daylight-savings-time), and probably in the API docs somewhere) that an occurrence in the spring-forward gap could be _skipped_ and an occurrence in the fall-back overlap could execute _twice_.  **This is not actually the current implemented behavior**.

The current implemented behavior is actually:
- In the spring, when a local time doesn't exist, run at the same moment in time as if the transition did not occur.
- In the fall, when two occurrences exist with the same local time, run at the _standard time_ occurrence.

This behavior is ultimately coming from `TimeZoneInfo.GetUtcOffset`, which always returns the standard time offset when in doubt.

While the spring behavior is fine, unfortunately the fall behavior is usually undesired in scheduling systems.  When there are two occurrences of the same local time, a daily event should be expected to run at the _first_ occurrence encountered, since time progresses in a forward direction.  The first occurrence corresponds to the _daylight_ time, not the _standard_ time.

This PR addresses this by adding an overload of `Quartz.Util.TimeZoneUtil.GetUtcOffset` that accepts a `DateTime`, and has the desired implementation.  Then throughout the code, anywhere that `TimeZoneInfo.GetUtcOffset` was used, this new method is used instead.

Unit tests are included, and all existing unit tests pass.

The documentation should also be updated to reflect the actual behavior.  Thanks.
