### PR TITLE
Use `Task.Run` inside `QuartzSchedulerThread`

### DIFF
--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -561,7 +561,7 @@ namespace Quartz.Core
         public void Start()
         {
             cancellationTokenSource = new CancellationTokenSource();
-            task = Task.Factory.StartNew(() => RunAsync(cancellationTokenSource.Token), CancellationToken.None);
+            task = Task.Run(() => RunAsync(cancellationTokenSource.Token));
         }
 
         public async Task ShutdownAsync()


### PR DESCRIPTION
`Task.Factory.StartNew` with async delegate returns `Task<Task>`, you have to call `.Unwrap()`. For majority of cases `Task.Run` is the safer option.