### PR TITLE
Oracle client update

### DIFF
--- a/Quartz.build
+++ b/Quartz.build
@@ -526,7 +526,7 @@
 	<property name="nunit-dll" value="packages/NUnit.2.6.3/lib/nunit.framework.dll" />
 	<property name="fakeiteasy-dll" value="packages/FakeItEasy.1.25.2/lib/net40/FakeItEasy.dll" />
   <property name="topshelf-dll" value="packages/TopShelf.3.1.4/lib/net40-full/Topshelf.dll" />
-	<property name="oracle-odp-managed-dll" value="packages/odp.net.managed.121.1.1/lib/net40/Oracle.ManagedDataAccess.dll" />
+	<property name="oracle-odp-managed-dll" value="packages/Oracle.ManagedDataAccess.12.1.2400/lib/net40/Oracle.ManagedDataAccess.dll" />
 	
 	<property name="log4net-dll" value="packages/log4net.2.0.3/lib/${nuget-framework}-full/log4net.dll" unless="${client-profile}" />
 	<property name="log4net-dll" value="packages/log4net.2.0.3/lib/${nuget-framework}-client/log4net.dll" if="${client-profile}" />

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -92,8 +92,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Oracle.ManagedDataAccess">
-      <HintPath>../../packages/odp.net.managed.121.1.1/lib/net40/Oracle.ManagedDataAccess.dll</HintPath>
+    <Reference Include="Oracle.ManagedDataAccess, Version=4.121.2.0, Culture=neutral, PublicKeyToken=89b483f429c47342, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Oracle.ManagedDataAccess.12.1.2400\lib\net40\Oracle.ManagedDataAccess.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/src/Quartz.Tests.Integration/packages.config
+++ b/src/Quartz.Tests.Integration/packages.config
@@ -3,5 +3,5 @@
   <package id="FakeItEasy" version="1.25.2" targetFramework="net4" userInstalled="true" />
   <package id="FirebirdSql.Data.FirebirdClient" version="4.5.0.0" targetFramework="net4" userInstalled="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net4" userInstalled="true" />
-  <package id="odp.net.managed" version="121.1.1" targetFramework="net4" userInstalled="true" />
+  <package id="Oracle.ManagedDataAccess" version="12.1.2400" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -89,8 +89,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Oracle.ManagedDataAccess">
-      <HintPath>../../packages/odp.net.managed.121.1.1/lib/net40/Oracle.ManagedDataAccess.dll</HintPath>
+    <Reference Include="Oracle.ManagedDataAccess, Version=4.121.2.0, Culture=neutral, PublicKeyToken=89b483f429c47342, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Oracle.ManagedDataAccess.12.1.2400\lib\net40\Oracle.ManagedDataAccess.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/src/Quartz.Tests.Unit/packages.config
+++ b/src/Quartz.Tests.Unit/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="FakeItEasy" version="1.25.2" targetFramework="net45" userInstalled="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net4" userInstalled="true" />
-  <package id="odp.net.managed" version="121.1.1" targetFramework="net4" userInstalled="true" />
+  <package id="Oracle.ManagedDataAccess" version="12.1.2400" targetFramework="net45" userInstalled="true" />
 </packages>


### PR DESCRIPTION
I could not compile it locally since it complained it couldn't find the `odp.net.managed.121.1.1` nuget package. I updated now to the official managed client from oracle.