### PR TITLE
Interruptable job

### DIFF
--- a/src/Quartz.Examples/example11/SimpleJob.cs
+++ b/src/Quartz.Examples/example11/SimpleJob.cs
@@ -53,7 +53,7 @@ namespace Quartz.Examples.Example11
             // wait for a period of time
             long delayTime = context.JobDetail.JobDataMap.GetLong(DelayTime);
 
-            await Task.Delay(new TimeSpan(10000 * delayTime));
+            await Task.Delay(new TimeSpan(10000 * delayTime), context.CancellationToken);
 
             log.InfoFormat("Finished Executing job: {0} at {1}", jobKey, DateTime.Now.ToString("r"));
         }

--- a/src/Quartz.Examples/example16/AsyncJob.cs
+++ b/src/Quartz.Examples/example16/AsyncJob.cs
@@ -47,20 +47,18 @@ namespace Quartz.Examples.example16
 
             log.InfoFormat("Job initially executing on thread {0}", Thread.CurrentThread.ManagedThreadId);
 
-            context.ThrowIfCancellationRequested();
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(1), context.CancellationToken);
 
             log.InfoFormat("Job continuing executing on thread {0} after first await", Thread.CurrentThread.ManagedThreadId);
 
-            context.ThrowIfCancellationRequested();
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(1), context.CancellationToken);
 
             log.InfoFormat("Job continuing executing on thread {0} after second await", Thread.CurrentThread.ManagedThreadId);
 
-            await Task.Delay(TimeSpan.FromSeconds(10));
-            log.InfoFormat("Cancellation requested: {0}", context.IsCancellationRequested);
+            await Task.Delay(TimeSpan.FromSeconds(10), context.CancellationToken);
+            log.InfoFormat("Cancellation requested: {0}", context.CancellationToken.IsCancellationRequested);
    
-            context.ThrowIfCancellationRequested();
+            context.CancellationToken.ThrowIfCancellationRequested();
 
             log.InfoFormat("Finished Executing job: {0} at {1}", jobKey, DateTime.Now.ToString("r"));
         }

--- a/src/Quartz.Examples/example7/DumbInterruptableJob.cs
+++ b/src/Quartz.Examples/example7/DumbInterruptableJob.cs
@@ -20,7 +20,6 @@
 #endregion
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Quartz.Logging;
 
@@ -32,9 +31,7 @@ namespace Quartz.Examples.Example7
     /// <author>  <a href="mailto:bonhamcm@thirdeyeconsulting.com">Chris Bonham</a></author>
     /// <author>Bill Kratzer</author>
     /// <author>Marko Lahma (.NET)</author>
-#pragma warning disable 618
-    public class DumbInterruptableJob : IInterruptableJob
-#pragma warning restore 618
+    public class DumbInterruptableJob : IJob
     {
         // logging services
         private static readonly ILog log = LogProvider.GetLogger(typeof (DumbInterruptableJob));
@@ -59,7 +56,7 @@ namespace Quartz.Examples.Example7
 
                 for (int i = 0; i < 4; i++)
                 {
-                    await Task.Delay(10*1000);
+                    await Task.Delay(10*1000, context.CancellationToken);
 
                     // periodically check if we've been interrupted...
                     if (interrupted)

--- a/src/Quartz.Tests.Unit/Plugin/History/LoggingJobHistoryPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/History/LoggingJobHistoryPluginTest.cs
@@ -101,12 +101,11 @@ namespace Quartz.Tests.Unit.Plugin.History
             A.CallTo(() => mockLog.Log(A<LogLevel>.That.IsEqualTo(LogLevel.Info), A<Func<string>>.That.Not.IsNull(), A<Exception>.That.IsNull(), A<object[]>.That.Not.IsNull())).MustHaveHappened();
         }
 
-        protected virtual IJobExecutionContext CreateJobExecutionContext()
+        protected virtual ICancellableJobExecutionContext CreateJobExecutionContext()
         {
             IOperableTrigger t = new SimpleTriggerImpl("name", "group");
             TriggerFiredBundle firedBundle = TestUtil.CreateMinimalFiredBundleWithTypedJobDetail(typeof(NoOpJob), t);
-            IJobExecutionContext ctx = new JobExecutionContextImpl(null,  firedBundle, null);
-
+            ICancellableJobExecutionContext ctx = new JobExecutionContextImpl(null,  firedBundle, null);
             return ctx;
         }
 

--- a/src/Quartz/ICancellableJobExecutionContext.cs
+++ b/src/Quartz/ICancellableJobExecutionContext.cs
@@ -1,0 +1,13 @@
+namespace Quartz
+{
+    /// <summary>
+    /// Represents a job execution context which can be cancelled.
+    /// </summary>
+    public interface ICancellableJobExecutionContext : IJobExecutionContext
+    {
+        /// <summary>
+        /// Cancels the execution of the job. It is the responsibility of the job instance to observe the cancellation token if it can be cancelled.
+        /// </summary>
+        void Cancel();
+    }
+}

--- a/src/Quartz/IInterruptableJob.cs
+++ b/src/Quartz/IInterruptableJob.cs
@@ -18,7 +18,6 @@
 #endregion
 
 using System;
-using System.Threading;
 
 namespace Quartz
 {
@@ -31,46 +30,19 @@ namespace Quartz
 	/// <remarks>
 	/// <para>
 	/// The means of actually interrupting the Job must be implemented within the
-	/// <see cref="IJob" /> itself (the <see cref="Interrupt" /> method of this 
-	/// interface is simply a means for the scheduler to inform the <see cref="IJob" />
-	/// that a request has been made for it to be interrupted). The mechanism that
+	/// <see cref="IJob" /> itself by observing the cancellation token <see cref="IJobExecutionContext.CancellationToken" />. The mechanism that
 	/// your jobs use to interrupt themselves might vary between implementations.
 	/// However the principle idea in any implementation should be to have the
-	/// body of the job's <see cref="IJob.Execute" /> periodically check some flag to
-	/// see if an interruption has been requested, and if the flag is set, somehow
-	/// abort the performance of the rest of the job's work.  An example of 
+	/// body of the job's <see cref="IJob.Execute" /> periodically check the cancellation token or pass it onto the asynchronous method that support cancellation.  An example of 
 	/// interrupting a job can be found in the source for the class Example7's DumbInterruptableJob 
-	/// It is legal to use
-	/// some combination of <see cref="Monitor.Wait(object)" /> and <see cref="Monitor.Pulse" /> 
-	/// synchronization within <see cref="Thread.Interrupt" /> and <see cref="IJob.Execute" />
-	/// in order to have the <see cref="Thread.Interrupt" /> method block until the
-	/// <see cref="IJob.Execute" /> signals that it has noticed the set flag.
-	/// </para>
-	/// 
-	/// <para>
-	/// If the Job performs some form of blocking I/O or similar functions, you may
-	/// want to consider having the <see cref="IJob.Execute" /> method store a
-	/// reference to the calling <see cref="Thread" /> as a member variable.  Then the
-	/// implementation of this interfaces <see cref="Thread.Interrupt" /> method can call 
-	/// <see cref="Thread.Interrupt" /> on that Thread.   Before attempting this, make
-	/// sure that you fully understand what <see cref="Thread.Interrupt" /> 
-	/// does and doesn't do.  Also make sure that you clear the Job's member 
-	/// reference to the Thread when the Execute(..) method exits (preferably in a
-	/// <see langword="finally" /> block).
 	/// </para>
     /// </remarks>
 	/// <seealso cref="IJob" />
 	/// <seealso cref="IScheduler.InterruptAsync(JobKey)"/>
     /// <seealso cref="IScheduler.InterruptAsync(string)"/>
     /// <author>Marko Lahma (.NET)</author>
-    [Obsolete("You should check for JobExecutionContext.IsCancellationRequested or call JobExecutionContext.ThrowIfCancellationRequested()")]
+    [Obsolete("You should check for JobExecutionContext.CancellationToken")]
     public interface IInterruptableJob : IJob
 	{
-		/// <summary>
-		/// Called by the <see cref="IScheduler" /> when a user
-		/// interrupts the <see cref="IJob" />.
-		/// </summary>
-		/// <returns> void (nothing) if job interrupt is successful.</returns>
-		void Interrupt();
 	}
 }

--- a/src/Quartz/IJobExecutionContext.cs
+++ b/src/Quartz/IJobExecutionContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Quartz
 {
@@ -186,14 +187,9 @@ namespace Quartz
         object Get(object key);
 
         /// <summary>
-        /// Returns whether the job cancellation has been requested via <see cref="IScheduler.InterruptAsync(JobKey)"/>
+        /// Returns the cancellation token which will be cancelled when the job cancellation has been requested via <see cref="IScheduler.InterruptAsync(JobKey)"/>
         /// or <see cref="IScheduler.InterruptAsync(string)"/>.
         /// </summary>
-        bool IsCancellationRequested { get; }
-
-        /// <summary>
-        /// Allows job to throw <see cref="OperationCanceledException"/> if job has been requested to be interrupted.
-        /// </summary>
-        void ThrowIfCancellationRequested();
+        CancellationToken CancellationToken { get; }
     }
 }

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -68,7 +68,7 @@ namespace Quartz.Impl
     /// <author>James House</author>
     /// <author>Marko Lahma (.NET)</author>
     [Serializable]
-    public class JobExecutionContextImpl : IJobExecutionContext
+    public class JobExecutionContextImpl : ICancellableJobExecutionContext
     {
         [NonSerialized] private readonly IScheduler scheduler;
         private readonly ITrigger trigger;
@@ -107,6 +107,7 @@ namespace Quartz.Impl
             jobDataMap.PutAll(jobDetail.JobDataMap);
             jobDataMap.PutAll(trigger.JobDataMap);
             cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken = cancellationTokenSource.Token;
         }
 
         /// <summary>
@@ -321,21 +322,16 @@ namespace Quartz.Impl
             return retValue;
         }
 
+        public virtual void Cancel()
+        {
+            cancellationTokenSource.Cancel();
+        }
+
         /// <summary>
         /// Returns the fire instance id.
         /// </summary>
         public string FireInstanceId => ((IOperableTrigger) trigger).FireInstanceId;
 
-        public bool IsCancellationRequested => cancellationTokenSource.Token.IsCancellationRequested;
-
-        public void ThrowIfCancellationRequested()
-        {
-            cancellationTokenSource.Token.ThrowIfCancellationRequested();
-        }
-
-        public void Cancel()
-        {
-            cancellationTokenSource.Cancel();
-        }
+        public CancellationToken CancellationToken { get; }
     }
 }

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Collection\ReadOnlySet.cs" />
     <Compile Include="Core\ErrorLogger.cs" />
     <Compile Include="Core\ExecutingJobsManager.cs" />
+    <Compile Include="ICancellableJobExecutionContext.cs" />
     <Compile Include="IInterruptableJob.cs" />
     <Compile Include="Impl\AdoJobStore\RecoverMisfiredJobsResult.cs" />
     <Compile Include="Impl\AdoJobStore\ClusterManager.cs" />


### PR DESCRIPTION
Connects to #331 

This gets rid of `IInterruptableJob` in favour of CancellationToken. The CancellationToken is available on the job execution context and can be queried for cancellation and/or passed into the async methods supporting cancellation. For separation of concerns, I introduced a `ICancellableJobExecutionContext` which allows canceling a job.

There is one TODO. I'd argue we could remove the try/catch. But since the member `cancel` is virtual should we leave it? 

https://github.com/quartznet/quartznet/pull/339/files#diff-3670816342511c486ea84cb94c3ef967R491

Currently based on top of #336, will rebase when those are merged