### PR TITLE
Fixup serialization attributes

### DIFF
--- a/src/Quartz/Collection/TreeSet.cs
+++ b/src/Quartz/Collection/TreeSet.cs
@@ -20,7 +20,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 namespace Quartz.Collection
 {
@@ -31,7 +30,6 @@ namespace Quartz.Collection
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]  // TODO (NetCore Port): Confirm that data contract serialization works as expected here
     internal class TreeSet<T> : SortedSet<T>
     {
         // No non-binary-formatter alternative is needed since this will not be deserialized by new .NET Core versions of Quartz.Net
@@ -50,7 +48,6 @@ namespace Quartz.Collection
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     internal class TreeSet : ArrayList
     {
     }

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -398,8 +398,6 @@ namespace Quartz.Core
 #if BINARY_SERIALIZATION
         [Serializable]
 #endif // BINARY_SERIALIZATION
-        // TODO (NetCore Port): Is this type ever persisted or is it only serializable for remoting purposes?
-        // [DataContract]
         internal class VetoedException : Exception
         {
             private readonly JobRunShell enclosingInstance;

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -17,6 +17,7 @@
  */
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -211,7 +212,6 @@ namespace Quartz
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class CronExpression : object
 #if ICLONEABLE
         , ICloneable
@@ -278,7 +278,7 @@ namespace Quartz
         private static readonly Dictionary<string, int> monthMap = new Dictionary<string, int>(20);
         private static readonly Dictionary<string, int> dayMap = new Dictionary<string, int>(60);
 
-        [DataMember]
+        [JsonProperty]
         private readonly string cronExpressionString;
 
         private TimeZoneInfo timeZone;
@@ -288,7 +288,7 @@ namespace Quartz
         // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
         // on timelines, it may be worth doign the mapping here.
         // More info: https://github.com/dotnet/corefx/issues/7757
-        [DataMember]
+        [JsonProperty]
         private string timeZoneInfoId
         {
             get { return timeZone?.Id; }
@@ -523,6 +523,7 @@ namespace Quartz
         /// Sets or gets the time zone for which the <see cref="CronExpression" /> of this
         /// <see cref="ICronTrigger" /> will be resolved.
         /// </summary>
+        [JsonIgnore]
         public virtual TimeZoneInfo TimeZone
         {
             set { timeZone = value; }

--- a/src/Quartz/Impl/AdoJobStore/FiredTriggerRecord.cs
+++ b/src/Quartz/Impl/AdoJobStore/FiredTriggerRecord.cs
@@ -20,7 +20,6 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 namespace Quartz.Impl.AdoJobStore
 {
@@ -32,75 +31,64 @@ namespace Quartz.Impl.AdoJobStore
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class FiredTriggerRecord
     {
         /// <summary>
         /// Gets or sets the fire instance id.
         /// </summary>
         /// <value>The fire instance id.</value>
-        [DataMember]
         public virtual string FireInstanceId { get; set; }
 
         /// <summary>
         /// Gets or sets the fire timestamp.
         /// </summary>
         /// <value>The fire timestamp.</value>
-        [DataMember]
         public virtual DateTimeOffset FireTimestamp { get; set; }
 
         /// <summary>
         /// Gets or sets the scheduled fire timestamp.
         /// </summary>
-        [DataMember]
         public virtual DateTimeOffset ScheduleTimestamp { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether job disallows concurrent execution.
         /// </summary>
-        [DataMember]
         public virtual bool JobDisallowsConcurrentExecution { get; set; }
 
         /// <summary>
         /// Gets or sets the job key.
         /// </summary>
         /// <value>The job key.</value>
-        [DataMember]
         public virtual JobKey JobKey { get; set; }
 
         /// <summary>
         /// Gets or sets the scheduler instance id.
         /// </summary>
         /// <value>The scheduler instance id.</value>
-        [DataMember]
         public virtual string SchedulerInstanceId { get; set; }
 
         /// <summary>
         /// Gets or sets the trigger key.
         /// </summary>
         /// <value>The trigger key.</value>
-        [DataMember]
         public virtual TriggerKey TriggerKey { get; set; }
 
         /// <summary>
         /// Gets or sets the state of the fire instance.
         /// </summary>
         /// <value>The state of the fire instance.</value>
-        [DataMember]
         public virtual string FireInstanceState { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether [job requests recovery].
         /// </summary>
         /// <value><c>true</c> if [job requests recovery]; otherwise, <c>false</c>.</value>
-        [DataMember]
         public virtual bool JobRequestsRecovery { get; set; }
 
         /// <summary>
         /// Gets or sets the priority.
         /// </summary>
         /// <value>The priority.</value>
-        [DataMember]
         public virtual int Priority { get; set; }
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/LockException.cs
+++ b/src/Quartz/Impl/AdoJobStore/LockException.cs
@@ -32,7 +32,6 @@ namespace Quartz.Impl.AdoJobStore
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    // TODO (NetCore Port): Is this actually persisted anywhere or is it only serializable for remoting?
     public class LockException : JobPersistenceException
 	{
 		public LockException(string msg) : base(msg)

--- a/src/Quartz/Impl/AdoJobStore/NoSuchDelegateException.cs
+++ b/src/Quartz/Impl/AdoJobStore/NoSuchDelegateException.cs
@@ -31,7 +31,6 @@ namespace Quartz.Impl.AdoJobStore
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    // TODO (NetCore Port): Is this actually persisted anywhere or is it only serializable for remoting?
     public class NoSuchDelegateException : JobPersistenceException
 	{
 		public NoSuchDelegateException(string msg, Exception cause) : base(msg, cause)

--- a/src/Quartz/Impl/AdoJobStore/SchedulerStateRecord.cs
+++ b/src/Quartz/Impl/AdoJobStore/SchedulerStateRecord.cs
@@ -18,7 +18,6 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 namespace Quartz.Impl.AdoJobStore
 {
@@ -30,28 +29,24 @@ namespace Quartz.Impl.AdoJobStore
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class SchedulerStateRecord
 	{
 	    /// <summary>
 	    /// Gets or sets the checkin interval.
 	    /// </summary>
 	    /// <value>The checkin interval.</value>
-	    [DataMember]
         public virtual TimeSpan CheckinInterval { get; set; }
 
 	    /// <summary>
 	    /// Gets or sets the checkin timestamp.
 	    /// </summary>
 	    /// <value>The checkin timestamp.</value>
-	    [DataMember]
         public virtual DateTimeOffset CheckinTimestamp { get; set; }
 
 	    /// <summary>
 	    /// Gets or sets the scheduler instance id.
 	    /// </summary>
 	    /// <value>The scheduler instance id.</value>
-	    [DataMember]
         public virtual string SchedulerInstanceId { get; set; }
 	}
 

--- a/src/Quartz/Impl/Calendar/AnnualCalendar.cs
+++ b/src/Quartz/Impl/Calendar/AnnualCalendar.cs
@@ -40,10 +40,8 @@ namespace Quartz.Impl.Calendar
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class AnnualCalendar : BaseCalendar
     {
-        [DataMember]
         private List<DateTimeOffset> excludeDays = new List<DateTimeOffset>();
 
         // true, if excludeDays is sorted

--- a/src/Quartz/Impl/Calendar/BaseCalendar.cs
+++ b/src/Quartz/Impl/Calendar/BaseCalendar.cs
@@ -17,6 +17,7 @@
  */
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Runtime.Serialization;
 using System.Security;
@@ -42,16 +43,13 @@ namespace Quartz.Impl.Calendar
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class BaseCalendar : ICalendar
 #if BINARY_SERIALIZATION
         , ISerializable
 #endif // BINARY_SERIALIZATION
     {
         // A optional base calendar.
-        [DataMember]
         private ICalendar baseCalendar;
-        [DataMember]
         private string description;
         private TimeZoneInfo timeZone;
 
@@ -60,7 +58,7 @@ namespace Quartz.Impl.Calendar
         // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
         // on timelines, it may be worth doign the mapping here.
         // More info: https://github.com/dotnet/corefx/issues/7757
-        [DataMember]
+        [JsonProperty]
         private string timeZoneInfoId
         {
             get { return timeZone?.Id; }
@@ -141,6 +139,7 @@ namespace Quartz.Impl.Calendar
         /// Gets or sets the time zone.
         /// </summary>
         /// <value>The time zone.</value>
+        [JsonIgnore]
         public virtual TimeZoneInfo TimeZone
 	    {
 	        get

--- a/src/Quartz/Impl/Calendar/CronCalendar.cs
+++ b/src/Quartz/Impl/Calendar/CronCalendar.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Runtime.Serialization;
 using System.Security;
@@ -48,10 +49,8 @@ namespace Quartz.Impl.Calendar
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class CronCalendar : BaseCalendar
     {
-        [DataMember]
         private CronExpression cronExpression;
 
         /// <summary>
@@ -132,6 +131,7 @@ namespace Quartz.Impl.Calendar
         }
 #endif // BINARY_SERIALIZATION
 
+        [JsonIgnore]
         public override TimeZoneInfo TimeZone
         {
             get { return cronExpression.TimeZone; }

--- a/src/Quartz/Impl/Calendar/DailyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/DailyCalendar.cs
@@ -17,6 +17,7 @@
  */
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Globalization;
 using System.Runtime.Serialization;
@@ -54,7 +55,6 @@ namespace Quartz.Impl.Calendar
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class DailyCalendar : BaseCalendar
     {
         private const string InvalidHourOfDay = "Invalid hour of day: ";
@@ -66,16 +66,19 @@ namespace Quartz.Impl.Calendar
         private const long OneMillis = 1;
         private const char Colon = ':';
 
-        [DataMember] private int rangeStartingHourOfDay;
-        [DataMember] private int rangeStartingMinute;
-        [DataMember] private int rangeStartingSecond;
-        [DataMember] private int rangeStartingMillis;
-        [DataMember] private int rangeEndingHourOfDay;
-        [DataMember] private int rangeEndingMinute;
-        [DataMember] private int rangeEndingSecond;
-        [DataMember] private int rangeEndingMillis;
+        // JsonProperty attributes are necessary because no public field/property exposes these directly
+        // Adding RangeStartingTimeUTC and RangeEndingTimeUTC properties with getters/setters to control
+        // these would remove the need for the attribute.
+        [JsonProperty] private int rangeStartingHourOfDay;
+        [JsonProperty] private int rangeStartingMinute;
+        [JsonProperty] private int rangeStartingSecond;
+        [JsonProperty] private int rangeStartingMillis;
+        [JsonProperty] private int rangeEndingHourOfDay;
+        [JsonProperty] private int rangeEndingMinute;
+        [JsonProperty] private int rangeEndingSecond;
+        [JsonProperty] private int rangeEndingMillis;
 
-        [DataMember] private bool invertTimeRange;
+        private bool invertTimeRange;
 
 
         /// <summary>

--- a/src/Quartz/Impl/Calendar/HolidayCalendar.cs
+++ b/src/Quartz/Impl/Calendar/HolidayCalendar.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -45,7 +46,6 @@ namespace Quartz.Impl.Calendar
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class HolidayCalendar : BaseCalendar
     {
         /// <summary>
@@ -56,7 +56,7 @@ namespace Quartz.Impl.Calendar
         public virtual ISet<DateTime> ExcludedDates => new SortedSet<DateTime>(dates);
 
         // A sorted set to store the holidays
-        [DataMember]
+        [JsonProperty]
         private SortedSet<DateTime> dates = new SortedSet<DateTime>();
 
         /// <summary>

--- a/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
@@ -39,18 +39,15 @@ namespace Quartz.Impl.Calendar
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class MonthlyCalendar : BaseCalendar
     {
         private const int MaxDaysInMonth = 31;
 
         // An array to store a months days which are to be excluded.
         // Day as index.
-        [DataMember]
         private bool[] excludeDays = new bool[MaxDaysInMonth];
 
         // Will be set to true, if all week days are excluded
-        [DataMember]
         private bool excludeAll;
 
         /// <summary>

--- a/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
@@ -39,16 +39,13 @@ namespace Quartz.Impl.Calendar
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class WeeklyCalendar : BaseCalendar
     {
         // An array to store the week days which are to be excluded.
         // DayOfWeek enumeration values are used as index.
-        [DataMember]
         private bool[] excludeDays = new bool[7];
 
         // Will be set to true, if all week days are excluded
-        [DataMember]
         private bool excludeAll;
 
         /// <summary>

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -19,10 +19,10 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Globalization;
 using System.Reflection;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -54,25 +54,15 @@ namespace Quartz.Impl
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class JobDetailImpl : IJobDetail
     {
-        [DataMember] private string name;
-        [DataMember] private string group = SchedulerConstants.DefaultGroup;
-        [DataMember] private string description;
-        [DataMember] private JobDataMap jobDataMap;
-        [DataMember] private bool durability;
-        [DataMember] private bool shouldRecover;
-
+        private string name;
+        private string group = SchedulerConstants.DefaultGroup;
+        private string description;
+        private JobDataMap jobDataMap;
+        private bool durability;
+        private bool shouldRecover;
         private Type jobType;
-
-        // TODO (NetCore Port): Verify that this works for serializing System.Type
-        [DataMember]
-        private string jobTypeName
-        {
-            get { return jobType?.FullName; }
-            set { jobType = Type.GetType(value); }
-        }
 
 #if BINARY_SERIALIZATION
         [NonSerialized] // we have the key in string fields
@@ -202,6 +192,7 @@ namespace Quartz.Impl
         /// Gets the key.
         /// </summary>
         /// <value>The key.</value>
+        [JsonIgnore] // The key is already captured from string properties
         public virtual JobKey Key
         {
             get

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -19,11 +19,11 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using Quartz.Spi;
-using System.Runtime.Serialization;
 
 namespace Quartz.Impl
 {
@@ -71,7 +71,6 @@ namespace Quartz.Impl
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class JobExecutionContextImpl : ICancellableJobExecutionContext
     {
 #if BINARY_SERIALIZATION
@@ -84,19 +83,19 @@ namespace Quartz.Impl
 #endif // BINARY_SERIALIZATION
         private readonly IJob job;
 
-        [DataMember] private readonly ITrigger trigger;
-        [DataMember] private readonly IJobDetail jobDetail;
-        [DataMember] private readonly JobDataMap jobDataMap;
+        [JsonProperty] private readonly ITrigger trigger;
+        [JsonProperty] private readonly IJobDetail jobDetail;
+        [JsonProperty] private readonly JobDataMap jobDataMap;
 
-        [DataMember] private readonly ICalendar calendar;
-        [DataMember] private readonly bool recovering;
-        [DataMember] private int numRefires;
-        [DataMember] private readonly DateTimeOffset? prevFireTimeUtc;
-        [DataMember] private readonly DateTimeOffset? nextFireTimeUtc;
-        [DataMember] private TimeSpan jobRunTime = TimeSpan.MinValue;
-        [DataMember] private object result; // Note that DCS will limit what sorts of results can be serialized
+        [JsonProperty] private readonly ICalendar calendar;
+        [JsonProperty] private readonly bool recovering;
+        [JsonProperty] private int numRefires;
+        [JsonProperty] private readonly DateTimeOffset? prevFireTimeUtc;
+        [JsonProperty] private readonly DateTimeOffset? nextFireTimeUtc;
+        private TimeSpan jobRunTime = TimeSpan.MinValue;
+        private object result; 
 
-        [DataMember] private readonly IDictionary<object, object> data = new Dictionary<object, object>();
+        [JsonProperty] private readonly IDictionary<object, object> data = new Dictionary<object, object>();
         private readonly CancellationTokenSource cancellationTokenSource;
 
         /// <summary>

--- a/src/Quartz/Impl/Matchers/AndMatcher.cs
+++ b/src/Quartz/Impl/Matchers/AndMatcher.cs
@@ -19,8 +19,8 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -34,12 +34,13 @@ namespace Quartz.Impl.Matchers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class AndMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
     {
-        [DataMember]
+        // Need the JsonProperty attribute to serialize these non-public members. If the Operand properties had setters, we could skip
+        // the json attributes since public fields/properties are serialized automatically.
+        [JsonProperty]
         private readonly IMatcher<TKey> leftOperand;
-        [DataMember]
+        [JsonProperty]
         private readonly IMatcher<TKey> rightOperand;
 
         protected AndMatcher(IMatcher<TKey> leftOperand, IMatcher<TKey> rightOperand)

--- a/src/Quartz/Impl/Matchers/GroupMatcher.cs
+++ b/src/Quartz/Impl/Matchers/GroupMatcher.cs
@@ -20,7 +20,6 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -34,7 +33,6 @@ namespace Quartz.Impl.Matchers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class GroupMatcher<TKey> : StringMatcher<TKey> where TKey : Key<TKey>
     {
         protected GroupMatcher(string compareTo, StringOperator compareWith) : base(compareTo, compareWith)

--- a/src/Quartz/Impl/Matchers/KeyMatcher.cs
+++ b/src/Quartz/Impl/Matchers/KeyMatcher.cs
@@ -19,8 +19,8 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -34,10 +34,9 @@ namespace Quartz.Impl.Matchers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class KeyMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
     {
-        [DataMember]
+        [JsonProperty]
         private readonly TKey compareTo;
 
         protected KeyMatcher(TKey compareTo)

--- a/src/Quartz/Impl/Matchers/NameMatcher.cs
+++ b/src/Quartz/Impl/Matchers/NameMatcher.cs
@@ -20,7 +20,6 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -34,7 +33,6 @@ namespace Quartz.Impl.Matchers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class NameMatcher<TKey> : StringMatcher<TKey> where TKey : Key<TKey>
     {
         protected NameMatcher(string compareTo, StringOperator compareWith) : base(compareTo, compareWith)

--- a/src/Quartz/Impl/Matchers/NotMatcher.cs
+++ b/src/Quartz/Impl/Matchers/NotMatcher.cs
@@ -19,8 +19,8 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -34,10 +34,9 @@ namespace Quartz.Impl.Matchers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class NotMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
     {
-        [DataMember]
+        [JsonProperty]
         private readonly IMatcher<TKey> operand;
 
         protected NotMatcher(IMatcher<TKey> operand)

--- a/src/Quartz/Impl/Matchers/OrMatcher.cs
+++ b/src/Quartz/Impl/Matchers/OrMatcher.cs
@@ -19,8 +19,8 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -34,12 +34,11 @@ namespace Quartz.Impl.Matchers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class OrMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
     {
-        [DataMember]
+        [JsonProperty]
         private readonly IMatcher<TKey> leftOperand;
-        [DataMember]
+        [JsonProperty]
         private readonly IMatcher<TKey> rightOperand;
 
         protected OrMatcher(IMatcher<TKey> leftOperand, IMatcher<TKey> rightOperand)

--- a/src/Quartz/Impl/Matchers/StringMatcher.cs
+++ b/src/Quartz/Impl/Matchers/StringMatcher.cs
@@ -19,8 +19,8 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -34,12 +34,11 @@ namespace Quartz.Impl.Matchers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public abstract class StringMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
     {
-        [DataMember]
+        [JsonProperty]
         private readonly string compareTo;
-        [DataMember]
+        [JsonProperty]
         private readonly StringOperator compareWith;
 
         protected StringMatcher(string compareTo, StringOperator compareWith)

--- a/src/Quartz/Impl/Triggers/AbstractTrigger.cs
+++ b/src/Quartz/Impl/Triggers/AbstractTrigger.cs
@@ -17,9 +17,9 @@
  */
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Globalization;
-using System.Runtime.Serialization;
 
 using Quartz.Spi;
 
@@ -56,23 +56,22 @@ namespace Quartz.Impl.Triggers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public abstract class AbstractTrigger : IOperableTrigger, IEquatable<AbstractTrigger>
 	{
-        [DataMember] private string name;
-        [DataMember] private string group = SchedulerConstants.DefaultGroup;
-        [DataMember] private string jobName;
-        [DataMember] private string jobGroup = SchedulerConstants.DefaultGroup;
-        [DataMember] private string description;
-        [DataMember] private JobDataMap jobDataMap;
-        [DataMember] private string calendarName;
-        [DataMember] private string fireInstanceId;
+        private string name;
+        private string group = SchedulerConstants.DefaultGroup;
+        private string jobName;
+        private string jobGroup = SchedulerConstants.DefaultGroup;
+        private string description;
+        private JobDataMap jobDataMap;
+        private string calendarName;
+        private string fireInstanceId;
 
-        [DataMember] private int misfireInstruction = Quartz.MisfireInstruction.InstructionNotSet;
+        private int misfireInstruction = Quartz.MisfireInstruction.InstructionNotSet;
 
-        [DataMember] private DateTimeOffset? endTimeUtc;
-        [DataMember] private DateTimeOffset startTimeUtc;
-		[DataMember] private int priority = TriggerConstants.DefaultPriority;
+        private DateTimeOffset? endTimeUtc;
+        private DateTimeOffset startTimeUtc;
+		private int priority = TriggerConstants.DefaultPriority;
 
 #if BINARY_SERIALIZATION
         [NonSerialized] // we have the key in string fields
@@ -187,6 +186,7 @@ namespace Quartz.Impl.Triggers
 		/// Gets the key.
 		/// </summary>
 		/// <value>The key.</value>
+        [JsonIgnore] // Captured in string properties
         public virtual TriggerKey Key
 		{
 		    get

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -19,8 +19,8 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -57,20 +57,19 @@ namespace Quartz.Impl.Triggers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarIntervalTrigger
     {
         private static readonly int YearToGiveupSchedulingAt = DateTime.Now.AddYears(100).Year;
 
-        [DataMember] private DateTimeOffset startTime;
-        [DataMember] private DateTimeOffset? endTime;
-        [DataMember] private DateTimeOffset? nextFireTimeUtc;
-        [DataMember] private DateTimeOffset? previousFireTimeUtc;
-        [DataMember] private int repeatInterval;
-        [DataMember] private IntervalUnit repeatIntervalUnit = IntervalUnit.Day;
-        [DataMember] private bool preserveHourOfDayAcrossDaylightSavings; // false is backward-compatible with behavior
-        [DataMember] private bool skipDayIfHourDoesNotExist;
-        [DataMember] private int timesTriggered;
+        private DateTimeOffset startTime;
+        private DateTimeOffset? endTime;
+        [JsonProperty] private DateTimeOffset? nextFireTimeUtc; // Making a public property which called GetNextFireTime/SetNextFireTime would make the json attribute unnecessary
+        [JsonProperty] private DateTimeOffset? previousFireTimeUtc; // Making a public property which called GetPreviousFireTime/SetPreviousFireTime would make the json attribute unnecessary
+        private int repeatInterval;
+        private IntervalUnit repeatIntervalUnit = IntervalUnit.Day;
+        private bool preserveHourOfDayAcrossDaylightSavings; // false is backward-compatible with behavior
+        private bool skipDayIfHourDoesNotExist;
+        private int timesTriggered;
         private TimeZoneInfo timeZone;
 
         // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
@@ -78,7 +77,7 @@ namespace Quartz.Impl.Triggers
         // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
         // on timelines, it may be worth doign the mapping here.
         // More info: https://github.com/dotnet/corefx/issues/7757
-        [DataMember]
+        [JsonProperty]
         private string timeZoneInfoId
         {
             get { return timeZone?.Id; }
@@ -262,6 +261,7 @@ namespace Quartz.Impl.Triggers
             }
         }
 
+        [JsonIgnore]
         public TimeZoneInfo TimeZone
         {
             get

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -19,9 +19,9 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 using Quartz.Util;
 
@@ -76,7 +76,6 @@ namespace Quartz.Impl.Triggers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalTrigger
     {
         /// <summary>
@@ -88,18 +87,18 @@ namespace Quartz.Impl.Triggers
 
         private static readonly int YearToGiveupSchedulingAt = DateTime.Now.Year + 100;
 
-        [DataMember] private DateTimeOffset startTimeUtc;
-        [DataMember] private DateTimeOffset? endTimeUtc;
-        [DataMember] private DateTimeOffset? nextFireTimeUtc;
-        [DataMember] private DateTimeOffset? previousFireTimeUtc;
-        [DataMember] private int repeatInterval = 1;
-        [DataMember] private IntervalUnit repeatIntervalUnit = IntervalUnit.Minute;
-        [DataMember] private ISet<DayOfWeek> daysOfWeek;
-        [DataMember] private TimeOfDay startTimeOfDay;
-        [DataMember] private TimeOfDay endTimeOfDay;
-        [DataMember] private int timesTriggered;
-        [DataMember] private bool complete;
-        [DataMember] private int repeatCount = RepeatIndefinitely;
+        private DateTimeOffset startTimeUtc;
+        private DateTimeOffset? endTimeUtc;
+        [JsonProperty] private DateTimeOffset? nextFireTimeUtc; // Making a public property which called GetNextFireTime/SetNextFireTime would make the json attribute unnecessary
+        [JsonProperty] private DateTimeOffset? previousFireTimeUtc; // Making a public property which called GetPreviousFireTime/SetPreviousFireTime would make the json attribute unnecessary
+        private int repeatInterval = 1;
+        private IntervalUnit repeatIntervalUnit = IntervalUnit.Minute;
+        private ISet<DayOfWeek> daysOfWeek;
+        private TimeOfDay startTimeOfDay;
+        private TimeOfDay endTimeOfDay;
+        private int timesTriggered;
+        private bool complete;
+        private int repeatCount = RepeatIndefinitely;
         private TimeZoneInfo timeZone;
 
         // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
@@ -107,7 +106,7 @@ namespace Quartz.Impl.Triggers
         // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
         // on timelines, it may be worth doign the mapping here.
         // More info: https://github.com/dotnet/corefx/issues/7757
-        [DataMember]
+        [JsonProperty]
         private string timeZoneInfoId
         {
             get { return timeZone?.Id; }
@@ -349,6 +348,7 @@ namespace Quartz.Impl.Triggers
             set { timesTriggered = value; }
         }
 
+        [JsonIgnore]
         public TimeZoneInfo TimeZone
         {
             get

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -17,8 +17,8 @@
  */
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 namespace Quartz.Impl.Triggers
 {
@@ -34,7 +34,6 @@ namespace Quartz.Impl.Triggers
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
 	{
         /// <summary>
@@ -45,12 +44,12 @@ namespace Quartz.Impl.Triggers
         public const int RepeatIndefinitely = -1;
         private const int YearToGiveupSchedulingAt = 2299;
 
-        [DataMember] private DateTimeOffset? nextFireTimeUtc;
-		[DataMember] private DateTimeOffset? previousFireTimeUtc;
+        [JsonProperty] private DateTimeOffset? nextFireTimeUtc; // Making a public property which called GetNextFireTime/SetNextFireTime would make the json attribute unnecessary
+        [JsonProperty] private DateTimeOffset? previousFireTimeUtc; // Making a public property which called GetPreviousFireTime/SetPreviousFireTime would make the json attribute unnecessary
 
-        [DataMember] private int repeatCount;
-        [DataMember] private TimeSpan repeatInterval = TimeSpan.Zero;
-        [DataMember] private int timesTriggered;
+        private int repeatCount;
+        private TimeSpan repeatInterval = TimeSpan.Zero;
+        private int timesTriggered;
 
         /// <summary>
         /// Create a <see cref="SimpleTriggerImpl" /> with no settings.

--- a/src/Quartz/JobDataMap.cs
+++ b/src/Quartz/JobDataMap.cs
@@ -59,7 +59,6 @@ namespace Quartz
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class JobDataMap : StringKeyDirtyFlagMap
     {
         /// <summary>

--- a/src/Quartz/JobKey.cs
+++ b/src/Quartz/JobKey.cs
@@ -22,7 +22,6 @@
 using System;
 
 using Quartz.Util;
-using System.Runtime.Serialization;
 
 namespace Quartz
 {
@@ -61,7 +60,6 @@ namespace Quartz
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public sealed class JobKey : Key<JobKey>
     {
         public JobKey(string name) : base(name, null)

--- a/src/Quartz/SPI/TriggerFiredBundle.cs
+++ b/src/Quartz/SPI/TriggerFiredBundle.cs
@@ -17,8 +17,8 @@
  */
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 using Quartz.Core;
 
@@ -34,17 +34,17 @@ namespace Quartz.Spi
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class TriggerFiredBundle
     {
-        [DataMember] private readonly IJobDetail job;
-        [DataMember] private readonly IOperableTrigger trigger;
-        [DataMember] private readonly ICalendar cal;
-        [DataMember] private readonly bool jobIsRecovering;
-        [DataMember] private readonly DateTimeOffset? fireTimeUtc;
-        [DataMember] private readonly DateTimeOffset? scheduledFireTimeUtc;
-        [DataMember] private readonly DateTimeOffset? prevFireTimeUtc;
-        [DataMember] private readonly DateTimeOffset? nextFireTimeUtc;
+        // JsonProperty attributes are used since Json.Net's default behavior is to serialize public members and the properties wrapping these fields are read-only
+        [JsonProperty] private readonly IJobDetail job;
+        [JsonProperty] private readonly IOperableTrigger trigger;
+        [JsonProperty] private readonly ICalendar cal;
+        [JsonProperty] private readonly bool jobIsRecovering;
+        [JsonProperty] private readonly DateTimeOffset? fireTimeUtc;
+        [JsonProperty] private readonly DateTimeOffset? scheduledFireTimeUtc;
+        [JsonProperty] private readonly DateTimeOffset? prevFireTimeUtc;
+        [JsonProperty] private readonly DateTimeOffset? nextFireTimeUtc;
 
         /// <summary>
         /// Gets the job detail.

--- a/src/Quartz/SPI/TriggerFiredResult.cs
+++ b/src/Quartz/SPI/TriggerFiredResult.cs
@@ -1,5 +1,5 @@
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 namespace Quartz.Spi
 {
@@ -9,11 +9,11 @@ namespace Quartz.Spi
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class TriggerFiredResult
     {
-        [DataMember] private readonly TriggerFiredBundle triggerFiredBundle;
-        [DataMember] private readonly Exception exception;
+        // JsonProperty attributes are used since Json.Net's default behavior is to serialize public members and the properties wrapping these fields are read-only
+        [JsonProperty] private readonly TriggerFiredBundle triggerFiredBundle;
+        [JsonProperty] private readonly Exception exception;
 
         ///<summary>
         /// Constructor.

--- a/src/Quartz/SchedulerContext.cs
+++ b/src/Quartz/SchedulerContext.cs
@@ -40,7 +40,6 @@ namespace Quartz
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class SchedulerContext : StringKeyDirtyFlagMap
 	{
 

--- a/src/Quartz/SchedulerMetaData.cs
+++ b/src/Quartz/SchedulerMetaData.cs
@@ -17,10 +17,10 @@
  */
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Text;
 using System.Threading;
-using System.Runtime.Serialization;
 
 using Quartz.Spi;
 
@@ -35,46 +35,24 @@ namespace Quartz
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class SchedulerMetaData
 	{
-		[DataMember] private readonly string schedName;
-		[DataMember] private readonly string schedInst;
-		private Type schedType;
-		[DataMember] private readonly bool isRemote;
-		[DataMember] private readonly bool started;
-		[DataMember] private readonly bool isInStandbyMode;
-		[DataMember] private readonly bool shutdown;
-        [DataMember] private readonly DateTimeOffset? startTime;
-        [DataMember] private readonly int numberOfJobsExec;
-		private Type jsType;
-		[DataMember] private readonly bool jsPersistent;
-	    [DataMember] private readonly bool jsClustered;
-		private Type tpType;
-		[DataMember] private readonly int tpSize;
-		[DataMember] private readonly string version;
-
-        [DataMember]
-        private string schedTypeName
-        {
-            get { return schedType.FullName; }
-            set { schedType = Type.GetType(value); }
-        }
-
-        [DataMember]
-        private string jsTypeName
-        {
-            get { return jsType.FullName; }
-            set { jsType = Type.GetType(value); }
-        }
-
-        [DataMember]
-        private string tpTypeName
-        {
-            get { return tpType.FullName; }
-            set { tpType = Type.GetType(value); }
-        }
-
+		[JsonProperty] private readonly string schedName;
+		[JsonProperty] private readonly string schedInst;
+		[JsonProperty] private Type schedType;
+		[JsonProperty] private readonly bool isRemote;
+		[JsonProperty] private readonly bool started;
+		[JsonProperty] private readonly bool isInStandbyMode;
+		[JsonProperty] private readonly bool shutdown;
+        [JsonProperty] private readonly DateTimeOffset? startTime;
+        [JsonProperty] private readonly int numberOfJobsExec;
+		[JsonProperty] private Type jsType;
+		[JsonProperty] private readonly bool jsPersistent;
+	    [JsonProperty] private readonly bool jsClustered;
+		[JsonProperty] private Type tpType;
+		[JsonProperty] private readonly int tpSize;
+		[JsonProperty] private readonly string version;
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="SchedulerMetaData"/> class.
         /// </summary>

--- a/src/Quartz/Simpl/DefaultObjectSerializer.cs
+++ b/src/Quartz/Simpl/DefaultObjectSerializer.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 #endif // BINARY_SERIALIZATION
 
 using Quartz.Spi;
+using Quartz.Util;
 
 namespace Quartz.Simpl
 {
@@ -16,35 +17,6 @@ namespace Quartz.Simpl
     /// <author>Marko Lahma</author>
     public class DefaultObjectSerializer : IObjectSerializer
     {
-#if DataContractSerializer // Currently unused. Can be removed in the future, but leaving temporarily while confirming that JSON.NET serialization works well
-        static Type[] KnownQuartzTypes = new Type[]
-        {
-            typeof(JobDataMap),
-            typeof(Impl.JobDetailImpl),
-            typeof(Impl.Triggers.AbstractTrigger),
-            typeof(Impl.Triggers.CalendarIntervalTriggerImpl),
-            typeof(Impl.Triggers.CronTriggerImpl),
-            typeof(Impl.Triggers.DailyTimeIntervalTriggerImpl),
-            typeof(Impl.Triggers.SimpleTriggerImpl),
-            typeof(Impl.Calendar.AnnualCalendar),
-            typeof(Impl.Calendar.BaseCalendar),
-            typeof(Impl.Calendar.CronCalendar),
-            typeof(Impl.Calendar.DailyCalendar),
-            typeof(Impl.Calendar.HolidayCalendar),
-            typeof(Impl.Calendar.MonthlyCalendar),
-            typeof(Impl.Calendar.WeeklyCalendar),
-            typeof(Impl.Matchers.AndMatcher<>),
-            typeof(Impl.Matchers.GroupMatcher<>),
-            typeof(Impl.Matchers.KeyMatcher<>),
-            typeof(Impl.Matchers.NameMatcher<>),
-            typeof(Impl.Matchers.NotMatcher<>),
-            typeof(Impl.Matchers.OrMatcher<>),
-            typeof(Impl.Matchers.StringMatcher<>),
-            typeof(Util.StringKeyDirtyFlagMap),
-            typeof(Util.DirtyFlagMap<,>)
-        };
-#endif // DataContractSerialization
-
         /// <summary>
         /// Serializes given object as bytes 
         /// that can be stored to permanent stores.
@@ -63,6 +35,7 @@ namespace Quartz.Simpl
                     var js = new JsonSerializer();
                     js.TypeNameHandling = TypeNameHandling.All;
                     js.PreserveReferencesHandling = PreserveReferencesHandling.All;
+                    js.ContractResolver = new WritablePropertiesOnlyResolver();
                     js.Serialize(sw, obj);
                 }
 #endif // BINARY_SERIALIZATION

--- a/src/Quartz/TimeOfDay.cs
+++ b/src/Quartz/TimeOfDay.cs
@@ -19,8 +19,8 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 namespace Quartz
 {
@@ -39,12 +39,12 @@ namespace Quartz
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class TimeOfDay
     {
-        [DataMember] private readonly int hour;
-        [DataMember] private readonly int minute;
-        [DataMember] private readonly int second;
+        // JsonProperty attributes needed since the public properties wrapping these fields are read-only
+        [JsonProperty] private readonly int hour;
+        [JsonProperty] private readonly int minute;
+        [JsonProperty] private readonly int second;
 
         /// <summary>
         /// Create a TimeOfDay instance for the given hour, minute and second.

--- a/src/Quartz/TriggerKey.cs
+++ b/src/Quartz/TriggerKey.cs
@@ -1,7 +1,6 @@
 using System;
 
 using Quartz.Util;
-using System.Runtime.Serialization;
 
 namespace Quartz
 {
@@ -43,7 +42,6 @@ namespace Quartz
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public sealed class TriggerKey : Key<TriggerKey>
     {
         public TriggerKey(string name) : base(name, null)

--- a/src/Quartz/Util/DirtyFlagMap.cs
+++ b/src/Quartz/Util/DirtyFlagMap.cs
@@ -17,6 +17,7 @@
  */
 #endregion
 
+using Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -34,7 +35,7 @@ namespace Quartz.Util
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
+    [JsonObject]
     public class DirtyFlagMap<TKey, TValue> : 
         IDictionary<TKey, TValue>, 
         IDictionary
@@ -45,8 +46,9 @@ namespace Quartz.Util
         ,ISerializable
 #endif // BINARY_SERIALIZATION
     {
-        [DataMember] private bool dirty;
-        [DataMember] private Dictionary<TKey, TValue> map;
+        // JsonProperty attributes are used since Json.Net's default behavior is to serialize public members and the properties wrapping these fields are read-only
+        [JsonProperty] private bool dirty;
+        [JsonProperty] private Dictionary<TKey, TValue> map;
         private readonly object syncRoot = new object();
 
         /// <summary>

--- a/src/Quartz/Util/Key.cs
+++ b/src/Quartz/Util/Key.cs
@@ -19,8 +19,8 @@
 
 #endregion
 
+using Newtonsoft.Json;
 using System;
-using System.Runtime.Serialization;
 
 namespace Quartz.Util
 {
@@ -32,7 +32,6 @@ namespace Quartz.Util
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class Key<T> : IComparable<Key<T>>
     {
         /// <summary>
@@ -40,9 +39,9 @@ namespace Quartz.Util
         /// </summary>
         public const string DefaultGroup = "DEFAULT";
 
-        [DataMember]
+        [JsonProperty]
         private readonly string name;
-        [DataMember]
+        [JsonProperty]
         private readonly string group;
 
         /// <summary> 

--- a/src/Quartz/Util/StringKeyDirtyFlagMap.cs
+++ b/src/Quartz/Util/StringKeyDirtyFlagMap.cs
@@ -36,7 +36,6 @@ namespace Quartz.Util
 #if BINARY_SERIALIZATION
     [Serializable]
 #endif // BINARY_SERIALIZATION
-    [DataContract]
     public class StringKeyDirtyFlagMap : DirtyFlagMap<string, object>
     {
         /// <summary>

--- a/src/Quartz/Util/WritablePropertiesOnlyResolver.cs
+++ b/src/Quartz/Util/WritablePropertiesOnlyResolver.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Quartz.Util
+{
+    class WritablePropertiesOnlyResolver : DefaultContractResolver
+    {
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+        {
+            return base.CreateProperties(type, memberSerialization).Where(p => p.Writable).ToList();
+        }
+    }
+}


### PR DESCRIPTION
This removes all the unnecessary DataContractSerialization attributes.

It adds in a few needed Json.NET attributes needed, instead. Also, adds a custom Json.Net contract resolver to prevent serializing read-only properties (since they aren't needed for deserialization and only bloat the serialized json).