### PR TITLE
Update OracleDelegate.cs

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
@@ -34,14 +34,7 @@ namespace Quartz.Impl.AdoJobStore
         /// </summary>
         protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
         {
-            string sqlSelectNextTriggerToAcquire = SqlSelectNextTriggerToAcquire;
-
-            int whereEndIdx = sqlSelectNextTriggerToAcquire.IndexOf("WHERE", StringComparison.OrdinalIgnoreCase) + 6;
-            string beginningAndWhere = sqlSelectNextTriggerToAcquire.Substring(0, whereEndIdx);
-            string theRest = sqlSelectNextTriggerToAcquire.Substring(whereEndIdx);
-
-            // add limit clause to correct place
-            return beginningAndWhere + " rownum <= " + maxCount + " AND " + theRest;
+            return "select * from ("+SqlSelectNextTriggerToAcquire+") where rownum<="+maxCount; 
         }
 
         protected override string GetSelectNextMisfiredTriggersInStateToAcquireSql(int count)


### PR DESCRIPTION
Oracle may execute automatic SQL tuning task at 22:00 every day.This task includes DB index statistics update.After tuning the index ,the result of the SQL string changed.The rownum will indicate the order of record inserted,not the order of NEXT_FIRE_TIME,as the index NEXT_FIRE_TIME will never be used in this SQL. 
https://github.com/quartznet/quartznet/issues/413
