### PR TITLE
System.TimeZoneNotFoundException fix

### DIFF
--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -43,6 +43,10 @@ namespace Quartz.Util
 
             timeZoneIdAliases["Hawaiian Standard Time"] = "US/Hawaii";
             timeZoneIdAliases["US/Hawaii"] = "Hawaiian Standard Time";
+
+            timeZoneIdAliases["China Standard Time"] = "Asia/Beijing";
+            timeZoneIdAliases["Asia/Shanghai"] = "China Standard Time";
+            timeZoneIdAliases["Asia/Beijing"] = "China Standard Time";
         }
 
         /// <summary>


### PR DESCRIPTION
"Couldn't retrieve trigger: Exception of type 'System.TimeZoneNotFoundException' was thrown."

added timezone alias to fix this