### PR TITLE
Fix for #477:  converted Quartz.Web project to asp.net core 2.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,36 @@
             "type": "coreclr",
             "request": "attach",
             "processName": "<example>"
+        },
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceRoot}/src/Quartz.Web/bin/Debug/netcoreapp2.0/Quartz.Web.dll",
+            "args": [],
+            "cwd": "${workspaceRoot}/src/Quartz.Web",
+            "stopAtEntry": false,
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceRoot}/Views"
+            }
         }
     ]
 }

--- a/Quartz.sln
+++ b/Quartz.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26127.3
@@ -25,6 +25,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quartz.Serialization.Json", "src\Quartz.Serialization.Json\Quartz.Serialization.Json.csproj", "{CBDA9E9D-5C24-4597-96EC-C930A5F452AC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quartz.Server", "src\Quartz.Server\Quartz.Server.csproj", "{09082B9A-906C-4A17-A2E5-6C947DAC7C85}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{EEA6E11D-5C26-4C28-8216-BB88B0DFB763}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quartz.Web", "src\Quartz.Web\Quartz.Web.csproj", "{69DA8576-BFB3-431B-B3B2-EB22850A147E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -56,8 +60,15 @@ Global
 		{09082B9A-906C-4A17-A2E5-6C947DAC7C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{09082B9A-906C-4A17-A2E5-6C947DAC7C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09082B9A-906C-4A17-A2E5-6C947DAC7C85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69DA8576-BFB3-431B-B3B2-EB22850A147E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69DA8576-BFB3-431B-B3B2-EB22850A147E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69DA8576-BFB3-431B-B3B2-EB22850A147E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69DA8576-BFB3-431B-B3B2-EB22850A147E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{69DA8576-BFB3-431B-B3B2-EB22850A147E} = {EEA6E11D-5C26-4C28-8216-BB88B0DFB763}
 	EndGlobalSection
 EndGlobal

--- a/src/Quartz.Web/Api/CalendarsController.cs
+++ b/src/Quartz.Web/Api/CalendarsController.cs
@@ -1,14 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-using System.Web.Http;
+using Microsoft.AspNetCore.Mvc;
 using Quartz.Impl;
 using Quartz.Web.Api.Dto;
 
 namespace Quartz.Web.Api
 {
-    [RoutePrefix("api/schedulers/{schedulerName}/calendars")]
-    public class CalendarsController : ApiController
+    [Route("api/schedulers/{schedulerName}/calendars")]
+    public class CalendarsController : Controller
     {
         [HttpGet]
         [Route("")]
@@ -51,7 +51,8 @@ namespace Quartz.Web.Api
             var scheduler = await SchedulerRepository.Instance.Lookup(schedulerName).ConfigureAwait(false);
             if (scheduler == null)
             {
-                throw new HttpResponseException(HttpStatusCode.NotFound);
+                //throw new HttpResponseException(HttpStatusCode.NotFound);
+                throw new KeyNotFoundException($"Scheduler {schedulerName} not found!");
             }
             return scheduler;
         }

--- a/src/Quartz.Web/Api/Dto/CalendarDetailDto.cs
+++ b/src/Quartz.Web/Api/Dto/CalendarDetailDto.cs
@@ -71,7 +71,7 @@ namespace Quartz.Web.Api.Dto
                 TimeZone = new TimeZoneDto(calendar.TimeZone);
             }
 
-            public IReadOnlyList<DateTimeOffset> DaysExcluded { get; }
+            public ISet<DateTime> DaysExcluded { get; }
             public TimeZoneDto TimeZone { get; }
         }
 

--- a/src/Quartz.Web/Api/JobsController.cs
+++ b/src/Quartz.Web/Api/JobsController.cs
@@ -3,14 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using System.Web.Http;
+using Microsoft.AspNetCore.Mvc;
+
 using Quartz.Impl;
 using Quartz.Web.Api.Dto;
 
 namespace Quartz.Web.Api
 {
-    [RoutePrefix("api/schedulers/{schedulerName}/jobs")]
-    public class JobsController : ApiController
+    [Route("api/schedulers/{schedulerName}/jobs")]
+    public class JobsController : Controller
     {
         [HttpGet]
         [Route("")]
@@ -112,7 +113,8 @@ namespace Quartz.Web.Api
             var scheduler = await SchedulerRepository.Instance.Lookup(schedulerName).ConfigureAwait(false);
             if (scheduler == null)
             {
-                throw new HttpResponseException(HttpStatusCode.NotFound);
+                //throw new HttpResponseException(HttpStatusCode.NotFound);
+                throw new KeyNotFoundException($"Scheduler {schedulerName} not found!");
             }
             return scheduler;
         }

--- a/src/Quartz.Web/Api/SchedulerController.cs
+++ b/src/Quartz.Web/Api/SchedulerController.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using System.Web.Http;
+
+using Microsoft.AspNetCore.Mvc;
 
 using Quartz.Impl;
 using Quartz.Web.Api.Dto;
@@ -13,8 +14,8 @@ namespace Quartz.Web.Api
     /// <summary>
     /// Web API endpoint for scheduler information.
     /// </summary>
-    [RoutePrefix("api/schedulers")]
-    public class SchedulerController : ApiController
+    [Route("api/schedulers")]
+    public class SchedulerController : Controller
     {
         [HttpGet]
         [Route("")]
@@ -77,7 +78,8 @@ namespace Quartz.Web.Api
             var scheduler = await SchedulerRepository.Instance.Lookup(schedulerName).ConfigureAwait(false);
             if (scheduler == null)
             {
-                throw new HttpResponseException(HttpStatusCode.NotFound);
+                //throw new HttpResponseException(HttpStatusCode.NotFound);
+                throw new KeyNotFoundException($"Scheduler {schedulerName} not found!");
             }
             return scheduler;
         }

--- a/src/Quartz.Web/Api/ServerController.cs
+++ b/src/Quartz.Web/Api/ServerController.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Web.Http;
+
+using Microsoft.AspNetCore.Mvc;
 
 using Quartz.Impl;
 using Quartz.Web.Api.Dto;
@@ -11,7 +12,7 @@ namespace Quartz.Web.Api
     /// <summary>
     /// Web API endpoint for scheduler information.
     /// </summary>
-    public class ServerController : ApiController
+    public class ServerController : Controller
     {
         [HttpGet]
         [Route("api/servers")]

--- a/src/Quartz.Web/Api/TriggersController.cs
+++ b/src/Quartz.Web/Api/TriggersController.cs
@@ -2,14 +2,16 @@
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using System.Web.Http;
+
+using Microsoft.AspNetCore.Mvc;
+
 using Quartz.Impl;
 using Quartz.Web.Api.Dto;
 
 namespace Quartz.Web.Api
 {
-    [RoutePrefix("api/schedulers/{schedulerName}/triggers")]
-    public class TriggersController : ApiController
+    [Route("api/schedulers/{schedulerName}/triggers")]
+    public class TriggersController : Controller
     {
         [HttpGet]
         [Route("")]
@@ -73,7 +75,8 @@ namespace Quartz.Web.Api
             var scheduler = await SchedulerRepository.Instance.Lookup(schedulerName).ConfigureAwait(false);
             if (scheduler == null)
             {
-                throw new HttpResponseException(HttpStatusCode.NotFound);
+                //throw new HttpResponseException(HttpStatusCode.NotFound);
+                throw new KeyNotFoundException($"Scheduler {schedulerName} not found!");
             }
             return scheduler;
         }

--- a/src/Quartz.Web/History/DatabaseExecutionHistoryPlugin.cs
+++ b/src/Quartz.Web/History/DatabaseExecutionHistoryPlugin.cs
@@ -49,11 +49,12 @@ namespace Quartz.Web.History
         /// Called during creation of the <see cref="IScheduler" /> in order to give
         /// the <see cref="ISchedulerPlugin" /> a chance to Initialize.
         /// </summary>
-        public virtual void Initialize(string pluginName, IScheduler scheduler)
+        public virtual Task Initialize(string pluginName, IScheduler scheduler)
         {
             Name = pluginName;
             Delegate = new JobHistoryDelegate(DataSource, DriverDelegateType, TablePrefix);
             scheduler.ListenerManager.AddJobListener(this, EverythingMatcher<JobKey>.AllJobs());
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Quartz.Web/History/JobExecutionHistoryController.cs
+++ b/src/Quartz.Web/History/JobExecutionHistoryController.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Http;
+
+using Microsoft.AspNetCore.Mvc;
+
 using Quartz.Logging;
 using Quartz.Web.Api.Dto;
 
@@ -10,7 +12,7 @@ namespace Quartz.Web.History
     /// <summary>
     /// Web API endpoint for job history. Requires persistent storage to work with.
     /// </summary>
-    public class JobExecutionHistoryController : ApiController
+    public class JobExecutionHistoryController : Controller
     {
         private static readonly ILog log = LogProvider.GetLogger(typeof (JobExecutionHistoryController));
 

--- a/src/Quartz.Web/History/JobHistoryDelegate.cs
+++ b/src/Quartz.Web/History/JobHistoryDelegate.cs
@@ -100,7 +100,7 @@ namespace Quartz.Web.History
                     Delegate.AddCommandParameter(command, "errorMessage", jobException?.ToString());
 
                     await command.ExecuteNonQueryAsync().ConfigureAwait(false);
-                    connection.Commit();
+                    connection.Commit(false);
                 }
             }
         }

--- a/src/Quartz.Web/LiveLog/LiveLogHub.cs
+++ b/src/Quartz.Web/LiveLog/LiveLogHub.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.AspNet.SignalR;
+﻿/*using System;
+using Microsoft.AspNetCore.SignalR;
 
 namespace Quartz.Web.LiveLog
 {
@@ -8,3 +8,4 @@ namespace Quartz.Web.LiveLog
     {
     }
 }
+*/

--- a/src/Quartz.Web/LiveLog/LiveLogPlugin.cs
+++ b/src/Quartz.Web/LiveLog/LiveLogPlugin.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿/*using System;
 using System.Threading.Tasks;
-using Microsoft.AspNet.SignalR;
+using Microsoft.AspNetCore.SignalR;
 using Quartz.Util;
 using Quartz.Web.Api.Dto;
 
@@ -158,3 +158,4 @@ namespace Quartz.Web.LiveLog
         }
     }
 }
+*/

--- a/src/Quartz.Web/Program.cs
+++ b/src/Quartz.Web/Program.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Quartz.Web
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseWebRoot("App")
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/src/Quartz.Web/Properties/AssemblyInfo.cs
+++ b/src/Quartz.Web/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-﻿using System.Reflection;
-
-[assembly: AssemblyTitle("Quartz.WebConsole")]

--- a/src/Quartz.Web/Quartz.Web.csproj
+++ b/src/Quartz.Web/Quartz.Web.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
-    <AssemblyName>Quartz.Web</AssemblyName>
-    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,46 +22,19 @@
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
     <ProjectReference Include="..\Quartz.Serialization.Json\Quartz.Serialization.Json.csproj" />
 
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />
+
     <PackageReference Include="bootbox.TypeScript.DefinitelyTyped" Version="1.2.0" />
     <PackageReference Include="bootstrap.TypeScript.DefinitelyTyped" Version="0.9.1" />
     <PackageReference Include="jQuery" Version="2.2.3" />
     <PackageReference Include="jquery.TypeScript.DefinitelyTyped" Version="3.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
     <PackageReference Include="moment.TypeScript.DefinitelyTyped" Version="1.7.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="RequireJS" Version="2.1.17" />
     <PackageReference Include="signalr.TypeScript.DefinitelyTyped" Version="0.3.9" />
     <PackageReference Include="toastr.TypeScript.DefinitelyTyped" Version="0.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <PackageReference Include="System.Collections.NonGeneric" Version="4.0.1" />
-    <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.1.0" />
-    <PackageReference Include="System.Data.Common" Version="4.1.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.1.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
-    <PackageReference Include="System.Diagnostics.Tools" Version="4.0.1" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.0.11" />
-    <PackageReference Include="System.Net.Http" Version="4.1.1" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-    <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.1.1" />
-    <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.0.1" />
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
-    <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10" />
-    <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
+    
   </ItemGroup>
 
 </Project>

--- a/src/Quartz.Web/Startup.cs
+++ b/src/Quartz.Web/Startup.cs
@@ -1,15 +1,106 @@
-﻿using System.IO;
-using System.Net.Http.Formatting;
-using System.Web.Http;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.PlatformAbstractions;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
-using Owin;
+
+using Quartz.Impl;
 using Quartz.Logging;
-using Swashbuckle.Application;
+using Quartz.Impl.Calendar;
+//using Quartz.Web.LiveLog;
+
+using Swashbuckle.AspNetCore;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace Quartz.Web
 {
+
+    public class Startup
+    {
+        //public IConfigurationRoot Configuration { get; }
+
+        public Startup(IHostingEnvironment env)
+        {   
+        }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            //call this in case you need aspnet-user-authtype/aspnet-user-identity
+            //services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            ConfigureQuartz(services);
+            services.AddSwaggerGen(c =>
+                {
+                    c.SwaggerDoc("v1", new Info {
+                         Title = "Quartz.Web API",
+                         Version = "alpha",
+                         Description = "",
+                         TermsOfService = "",
+                         Contact = new Contact
+                         {
+                            Name = "",
+                            Email = ""
+                         },
+                        });
+                    //var filePath = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "APIdocumentation.xml");
+                    //c.IncludeXmlComments(filePath);
+                    c.DescribeAllEnumsAsStrings();
+                });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            
+            app.UseMvc();
+            
+            app.UseSwagger();
+            app.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "API V1");
+                });
+            
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+        }
+
+
+        void ConfigureQuartz(IServiceCollection services)
+        {
+            
+            // First we must get a reference to a scheduler
+            ISchedulerFactory sf = new StdSchedulerFactory();
+            IScheduler scheduler = sf.GetScheduler().Result;
+
+            // var liveLogPlugin = new LiveLogPlugin();
+            // scheduler.ListenerManager.AddJobListener(liveLogPlugin);
+            // scheduler.ListenerManager.AddTriggerListener(liveLogPlugin);
+            // scheduler.ListenerManager.AddSchedulerListener(liveLogPlugin);
+
+            scheduler.AddCalendar(typeof (AnnualCalendar).Name, new AnnualCalendar(), false, false);
+            scheduler.AddCalendar(typeof (CronCalendar).Name, new CronCalendar("0 0/5 * * * ?"), false, false);
+            scheduler.AddCalendar(typeof (DailyCalendar).Name, new DailyCalendar("12:01", "13:04"), false, false);
+            scheduler.AddCalendar(typeof (HolidayCalendar).Name, new HolidayCalendar(), false, false);
+            scheduler.AddCalendar(typeof (MonthlyCalendar).Name, new MonthlyCalendar(), false, false);
+            //scheduler.AddCalendar(typeof (WeeklyCalendar).Name, new WeeklyCalendar(), false, false);
+
+            services.AddSingleton<IScheduler>(scheduler);
+        }
+    }
+
+    /*
     /// <summary>
     /// Initializes the Web API infrastructure.
     /// </summary>
@@ -74,4 +165,5 @@ namespace Quartz.Web
             config.Formatters.JsonFormatter.SerializerSettings = serializerSettings;
         }
     }
+    */
 }

--- a/src/Quartz.Web/WebConsolePlugin.cs
+++ b/src/Quartz.Web/WebConsolePlugin.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Owin.Hosting;
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
 using Quartz.Impl.Calendar;
 using Quartz.Logging;
 using Quartz.Spi;
 using Quartz.Util;
-using Quartz.Web.LiveLog;
+//using Quartz.Web.LiveLog;
 
 namespace Quartz.Web
 {
@@ -19,10 +22,10 @@ namespace Quartz.Web
 
         public Task Initialize(string pluginName, IScheduler scheduler)
         {
-            var liveLogPlugin = new LiveLogPlugin();
-            scheduler.ListenerManager.AddJobListener(liveLogPlugin);
-            scheduler.ListenerManager.AddTriggerListener(liveLogPlugin);
-            scheduler.ListenerManager.AddSchedulerListener(liveLogPlugin);
+            // var liveLogPlugin = new LiveLogPlugin();
+            // scheduler.ListenerManager.AddJobListener(liveLogPlugin);
+            // scheduler.ListenerManager.AddTriggerListener(liveLogPlugin);
+            // scheduler.ListenerManager.AddSchedulerListener(liveLogPlugin);
 
             // TODO REMOVE
             scheduler.AddCalendar(typeof (AnnualCalendar).Name, new AnnualCalendar(), false, false);
@@ -39,7 +42,11 @@ namespace Quartz.Web
         {
             string baseAddress = $"http://{HostName ?? "localhost"}:{Port ?? 28682}/";
 
-            host = WebApp.Start<Startup>(url: baseAddress);
+            //host = WebApp.Start<Startup>(url: baseAddress);
+            host = WebHost.CreateDefaultBuilder()
+                .UseStartup<Startup>()
+                .Build();
+            
             log.InfoFormat("Quartz Web Console bound to address {0}", baseAddress);
             return TaskUtil.CompletedTask;
         }


### PR DESCRIPTION
Hi Marko,
I have converted the Quartz.Web project to asp.net core 2.0. 

- Project compiles and it has been added to the Quartz.sln file
- Swagger works on localhost:5000/swagger
- SignalR is commented out for it is not included yet in the official asp.net core release
- Index.html is hosted by default, but it does not show anything but the title. I am not a web expert so I have not touched any of the web files in /App