### PR TITLE
add mysql 6.9.9 provider support

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/Common/dbproviders.properties
+++ b/src/Quartz/Impl/AdoJobStore/Common/dbproviders.properties
@@ -199,6 +199,25 @@ quartz.dbprovider.MySql-695.useParameterNamePrefixInParameterCollection=true
 quartz.dbprovider.MySql-695.bindByName=true
 quartz.dbprovider.MySql-695.dbBinaryTypeName=Blob
 
+
+# Connector/NET 6.9 (.NET 2.0/4.0) -->
+
+quartz.dbprovider.MySql-69.productName=MySQL, MySQL provider 6.9.9
+quartz.dbprovider.MySql-69.assemblyName=MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d
+quartz.dbprovider.MySql-69.connectionType=MySql.Data.MySqlClient.MySqlConnection, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d
+quartz.dbprovider.MySql-69.commandType=MySql.Data.MySqlClient.MySqlCommand, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d
+quartz.dbprovider.MySql-69.parameterType=MySql.Data.MySqlClient.MySqlParameter, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d
+quartz.dbprovider.MySql-69.parameterDbType=MySql.Data.MySqlClient.MySqlDbType, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d
+quartz.dbprovider.MySql-69.parameterDbTypePropertyName=MySqlDbType
+quartz.dbprovider.MySql-69.parameterNamePrefix=?
+quartz.dbprovider.MySql-69.exceptionType=MySql.Data.MySqlClient.MySqlException, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d
+quartz.dbprovider.MySql-69.useParameterNamePrefixInParameterCollection=true
+quartz.dbprovider.MySql-69.bindByName=true
+quartz.dbprovider.MySql-69.dbBinaryTypeName=Blob
+
+
+
+
 quartz.dbprovider.MySql.productName=MySQL, MySQL provider
 quartz.dbprovider.MySql.assemblyName=MySql.Data
 quartz.dbprovider.MySql.connectionType=MySql.Data.MySqlClient.MySqlConnection, MySql.Data


### PR DESCRIPTION
my sql
![image](https://user-images.githubusercontent.com/12858618/29450832-eba5d558-8432-11e7-8aca-d8ecb5611c28.png)

mysql.data 6.9.9 is stable version in nuget ,so add mysql 6.9.9 provider support.
please update quartz.net in nuget.
thanks 
