### PR TITLE
timeZoneIdAliases for +5 timeZone

### DIFF
--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -48,6 +48,9 @@ namespace Quartz.Util
             timeZoneIdAliases["China Standard Time"] = "Asia/Beijing";
             timeZoneIdAliases["Asia/Shanghai"] = "China Standard Time";
             timeZoneIdAliases["Asia/Beijing"] = "China Standard Time";
+            
+            timeZoneIdAliases["Pakistan Standard Time"] = "Asia/Karachi";
+            timeZoneIdAliases["Asia/Karachi"] = "Pakistan Standard Time";
         }
 
         public static Func<string, TimeZoneInfo> CustomResolver = id => null;


### PR DESCRIPTION
Add timeZoneIdAliases for Asia/Karachi and Pakistan Standard Time.
Can you merge it in quartznet v2?