### PR TITLE
timeZoneIdAliases for +5 timeZone

### DIFF
--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -44,6 +44,9 @@ namespace Quartz.Util
 
             timeZoneIdAliases["Hawaiian Standard Time"] = "US/Hawaii";
             timeZoneIdAliases["US/Hawaii"] = "Hawaiian Standard Time";
+            
+            timeZoneIdAliases["Pakistan Standard Time"] = "Asia/Karachi";
+            timeZoneIdAliases["Asia/Karachi"] = "Pakistan Standard Time";
         }
 
         public static Func<string, TimeZoneInfo> CustomResolver = id => null;


### PR DESCRIPTION
Add timeZoneIdAliases for Asia/Karachi and Pakistan Standard Time.