### PR TITLE
2 fixes for QuartzNet

### DIFF
--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -138,7 +138,11 @@ namespace Quartz.Impl
 
         private static readonly ILog log = LogProvider.GetLogger(typeof(StdSchedulerFactory));
 
-        private string SchedulerName => cfg.GetStringProperty(PropertySchedulerInstanceName, "QuartzScheduler");
+        private string SchedulerName
+        {
+            // ReSharper disable once ArrangeAccessorOwnerBody
+            get { return cfg.GetStringProperty(PropertySchedulerInstanceName, "QuartzScheduler"); }
+        }
 
         private ILog Log => log;
 

--- a/src/Quartz/Listener/BroadcastJobListener.cs
+++ b/src/Quartz/Listener/BroadcastJobListener.cs
@@ -25,6 +25,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Quartz.Logging;
+
 namespace Quartz.Listener
 {
     /// <summary>
@@ -44,6 +46,7 @@ namespace Quartz.Listener
     public class BroadcastJobListener : IJobListener
     {
         private readonly List<IJobListener> listeners;
+        private readonly ILog log;
 
         /// <summary>
         /// Construct an instance with the given name.
@@ -56,6 +59,7 @@ namespace Quartz.Listener
         {
             Name = name ?? throw new ArgumentNullException(nameof(name), "Listener name cannot be null!");
             listeners = new List<IJobListener>();
+            log = LogProvider.GetLogger(GetType());
         }
 
         /// <summary>
@@ -99,14 +103,43 @@ namespace Quartz.Listener
             IJobExecutionContext context, 
             CancellationToken cancellationToken = default)
         {
-            return Task.WhenAll(listeners.Select(l => l.JobToBeExecuted(context, cancellationToken)));
+            return Task.WhenAll(listeners.Select(l =>
+            {
+                try
+                {
+                    return l.JobToBeExecuted(context, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    if (log.IsDebugEnabled())
+                    {
+                        log.Debug($"JobListener {l.Name} - JobToBeExecuted method raised an exception: {e.Message}");
+                    }
+                    return Task.CompletedTask;
+                }
+            }));
         }
 
         public Task JobExecutionVetoed(
             IJobExecutionContext context,
             CancellationToken cancellationToken = default)
         {
-            return Task.WhenAll(listeners.Select(l => l.JobExecutionVetoed(context, cancellationToken)));
+            return Task.WhenAll(listeners.Select(l =>
+            {
+                try
+                {
+                    return l.JobExecutionVetoed(context, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    if (log.IsDebugEnabled())
+                    {
+                        log.Debug($"JobListener {l.Name} - JobExecutionVetoed method raised an exception: {e.Message}");
+                    }
+
+                    return Task.CompletedTask;
+                }
+            }));
         }
 
         public Task JobWasExecuted(
@@ -114,7 +147,22 @@ namespace Quartz.Listener
             JobExecutionException jobException,
             CancellationToken cancellationToken = default)
         {
-            return Task.WhenAll(listeners.Select(l => l.JobWasExecuted(context, jobException, cancellationToken)));
+            return Task.WhenAll(listeners.Select(l =>
+            {
+                try
+                {
+                    return l.JobWasExecuted(context, jobException, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    if (log.IsDebugEnabled())
+                    {
+                        log.Debug($"JobListener {l.Name} - JobWasExecuted method raised an exception: {e.Message}");
+                    }
+
+                    return Task.CompletedTask;
+                }
+            }));
         }
     }
 }

--- a/src/Quartz/Listener/BroadcastJobListener.cs
+++ b/src/Quartz/Listener/BroadcastJobListener.cs
@@ -115,7 +115,7 @@ namespace Quartz.Listener
                     {
                         log.Debug($"JobListener {l.Name} - JobToBeExecuted method raised an exception: {e.Message}");
                     }
-                    return Task.FromResult(0);
+                    return TaskUtil.CompletedTask;
                 }
             }));
         }
@@ -137,7 +137,7 @@ namespace Quartz.Listener
                         log.Debug($"JobListener {l.Name} - JobExecutionVetoed method raised an exception: {e.Message}");
                     }
 
-                    return Task.FromResult(0);
+                    return TaskUtil.CompletedTask;
                 }
             }));
         }
@@ -160,7 +160,7 @@ namespace Quartz.Listener
                         log.Debug($"JobListener {l.Name} - JobWasExecuted method raised an exception: {e.Message}");
                     }
 
-                    return Task.FromResult(0);
+                    return TaskUtil.CompletedTask;
                 }
             }));
         }

--- a/src/Quartz/Listener/BroadcastJobListener.cs
+++ b/src/Quartz/Listener/BroadcastJobListener.cs
@@ -111,7 +111,7 @@ namespace Quartz.Listener
                 }
                 catch (Exception e)
                 {
-                    if (log.IsDebugEnabled())
+                    if (log.IsWarnEnabled())
                     {
                         log.Debug($"JobListener {l.Name} - JobToBeExecuted method raised an exception: {e.Message}");
                     }
@@ -132,7 +132,7 @@ namespace Quartz.Listener
                 }
                 catch (Exception e)
                 {
-                    if (log.IsDebugEnabled())
+                    if (log.IsWarnEnabled())
                     {
                         log.Debug($"JobListener {l.Name} - JobExecutionVetoed method raised an exception: {e.Message}");
                     }
@@ -155,7 +155,7 @@ namespace Quartz.Listener
                 }
                 catch (Exception e)
                 {
-                    if (log.IsDebugEnabled())
+                    if (log.IsWarnEnabled())
                     {
                         log.Debug($"JobListener {l.Name} - JobWasExecuted method raised an exception: {e.Message}");
                     }

--- a/src/Quartz/Listener/BroadcastJobListener.cs
+++ b/src/Quartz/Listener/BroadcastJobListener.cs
@@ -115,7 +115,7 @@ namespace Quartz.Listener
                     {
                         log.Debug($"JobListener {l.Name} - JobToBeExecuted method raised an exception: {e.Message}");
                     }
-                    return Task.CompletedTask;
+                    return Task.FromResult(0);
                 }
             }));
         }
@@ -137,7 +137,7 @@ namespace Quartz.Listener
                         log.Debug($"JobListener {l.Name} - JobExecutionVetoed method raised an exception: {e.Message}");
                     }
 
-                    return Task.CompletedTask;
+                    return Task.FromResult(0);
                 }
             }));
         }
@@ -160,7 +160,7 @@ namespace Quartz.Listener
                         log.Debug($"JobListener {l.Name} - JobWasExecuted method raised an exception: {e.Message}");
                     }
 
-                    return Task.CompletedTask;
+                    return Task.FromResult(0);
                 }
             }));
         }


### PR DESCRIPTION
- Prevent faulty JobListeners from influencing QuartzNet logic.
- Do not always trust ReSharper to use properties with expression bodies.

See the TestRemoting -> Test method, I call the StdSchedulerFactory overthere twice and the second call would raise an exception that the remoteinstance scheduler already existed.