### PR TITLE
Make JobInterrupted method virtual in class SchedulerListenerSupport

### DIFF
--- a/src/Quartz/Listener/SchedulerListenerSupport.cs
+++ b/src/Quartz/Listener/SchedulerListenerSupport.cs
@@ -97,7 +97,7 @@ namespace Quartz.Listener
             return TaskUtil.CompletedTask;
         }
 
-        public Task JobInterrupted(
+        public virtual Task JobInterrupted(
             JobKey jobKey,
             CancellationToken cancellationToken = new CancellationToken())
         {


### PR DESCRIPTION
It seems `JobInterrupted` had the wrong signature in the `SchedulerListenerSupport` class, it was impossible to execute logic on job interruption.

This very simple commit marks the method `virtual` so inheritors could override it.