### PR TITLE
Fix a race condition that could cause duplicate trigger firings

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -415,6 +415,25 @@ namespace Quartz.Impl.AdoJobStore
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Update the given trigger to the given new state, if it is in the given
+        /// old state and has the given next fire time.
+        /// </summary>
+        /// <param name="conn">The DB connection</param>
+        /// <param name="triggerKey">The key identifying the trigger.</param>
+        /// <param name="newState">The new state for the trigger </param>
+        /// <param name="oldState">The old state the trigger must be in</param>
+        /// <param name="nextFireTime">The next fire time the trigger must have</param>
+        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <returns> int the number of rows updated</returns>
+        Task<int> UpdateTriggerStateFromOtherStateWithNextFireTime(
+            ConnectionAndTransactionHolder conn,
+            TriggerKey triggerKey,
+            string newState,
+            string oldState,
+            DateTimeOffset nextFireTime,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Update all triggers in the given group to the given new state, if they
         /// are in one of the given old states.
         /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -2643,14 +2643,16 @@ namespace Quartz.Impl.AdoJobStore
                             acquiredJobKeysForNoConcurrentExec.Add(jobKey);
                         }
 
-                        if (nextTrigger.GetNextFireTimeUtc() > batchEnd)
+                        var nextFireTimeUtc = nextTrigger.GetNextFireTimeUtc();
+
+                        if (nextFireTimeUtc == null || nextFireTimeUtc > batchEnd)
                         {
                             break;
                         }
 
                         // We now have a acquired trigger, let's add to return list.
                         // If our trigger was no longer in the expected state, try a new one.
-                        int rowsUpdated = await Delegate.UpdateTriggerStateFromOtherState(conn, triggerKey, StateAcquired, StateWaiting, cancellationToken).ConfigureAwait(false);
+                        int rowsUpdated = await Delegate.UpdateTriggerStateFromOtherStateWithNextFireTime(conn, triggerKey, StateAcquired, StateWaiting, nextFireTimeUtc.Value, cancellationToken).ConfigureAwait(false);
                         if (rowsUpdated <= 0)
                         {
                             // TODO: Hum... shouldn't we log a warning here?

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -340,6 +340,9 @@ namespace Quartz.Impl.AdoJobStore
         public static readonly string SqlUpdateTriggerStateFromStates =
             $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)";
 
+        public static readonly string SqlUpdateTriggerStateFromStateWithNextFireTime =
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @oldState AND {ColumnNextFireTime} = @nextFireTime";
+
         public static readonly string SqlUpdateTriggerStatesFromOtherStates =
             $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2)";
     }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -1461,6 +1461,37 @@ namespace Quartz.Impl.AdoJobStore
         }
 
         /// <summary>
+        /// Update the given trigger to the given new state, if it is in the given
+        /// old state and has the given next fire time.
+        /// </summary>
+        /// <param name="conn">The DB connection</param>
+        /// <param name="triggerKey">The key identifying the trigger.</param>
+        /// <param name="newState">The new state for the trigger </param>
+        /// <param name="oldState">The old state the trigger must be in</param>
+        /// <param name="nextFireTime">The next fire time the trigger must have</param>
+        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <returns> int the number of rows updated</returns>
+        public async Task<int> UpdateTriggerStateFromOtherStateWithNextFireTime(
+            ConnectionAndTransactionHolder conn,
+            TriggerKey triggerKey,
+            string newState,
+            string oldState,
+            DateTimeOffset nextFireTime,
+            CancellationToken cancellationToken = default)
+        {
+            using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerStateFromStateWithNextFireTime)))
+            {
+                AddCommandParameter(cmd, "newState", newState);
+                AddCommandParameter(cmd, "triggerName", triggerKey.Name);
+                AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+                AddCommandParameter(cmd, "oldState", oldState);
+                AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(nextFireTime));
+
+                return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Update all of the triggers of the given group to the given new state, if
         /// they are in the given old state.
         /// </summary>


### PR DESCRIPTION
I've identified a race condition in `JobStoreSupport.AcquireNextTrigger()` that is causing duplicate trigger firings in a cluster of Quartz.Net 3.0.6 scheduler instances when under load.

I'm using the `JobStoreTX` job store with `AdoJobStore.SqlServerDelegate`.

The duplicate firing occurs when a scheduler instance gets delayed in `JobStoreSupport.AcquireNextTrigger()` between the calls to `SelectTriggerToAcquire()` and `UpdateTriggerStateFromOtherState()`. Suppose that the same trigger was simultaneously returned by `SelectTriggerToAcquire()` in two scheduler instances (A and B). If the firing of the trigger completes in instance A before `UpdateTriggerStateFromOtherState()` is called in instance B, then instance B will perform a duplicate firing.

This happens because instance A will have transitioned the trigger state to Acquired and then back to Waiting. The call to `UpdateTriggerStateFromOtherState()` in instance B will then set the trigger to Acquired a second time (because the state has returned to Waiting again) and the already-fired trigger will be returned.

I've been able to replicate this issue by:

- Modifying `JobStoreSupport.AcquireNextTrigger()` to simulate a load-induced delay by adding `await Task.Delay(10000)` before the call to `UpdateTriggerStateFromOtherState()`
- Setting `quartz.jobStore.clusterCheckinInterval` to 2000.
- Creating a trigger that fires every minute.
- Running two scheduler instances.

This pull request modifies `JobStoreSupport.AcquireNextTrigger()` to guard against this condition by checking that the next fire time hasn't changed when acquiring the trigger. In the above example, instance B would fail to acquire the trigger because of the change made to the next fire time by instance A.

This is the first time I've had cause to dive into the internals of Quartz.Net (it's otherwise been running perfectly). I'd welcome any feedback or suggestions for alternative ways to resolve this issue.