### PR TITLE
Update RAMJobStore.AcquireNextTriggers() to reduce allocations

### DIFF
--- a/src/Quartz/Util/SortedSetExtensions.cs
+++ b/src/Quartz/Util/SortedSetExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Quartz.Util
 {
@@ -7,6 +8,33 @@ namespace Quartz.Util
         internal static SortedSet<int> TailSet(this SortedSet<int> set, int value)
         {
             return set.GetViewBetween(value, 9999999);
+        }
+
+        /// <summary>
+        /// Returns the first element of the specified <see cref="SortedSet{TSource}"/>, or a default
+        /// value if no element is found.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The <see cref="SortedSet{TSource}"/> to return the first element of.</param>
+        /// <returns>
+        /// The default value for <typeparamref name="TSource"/> if <paramref name="source"/> is empty;
+        /// otherwise, the first element in <paramref name="source"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        internal static TSource FirstOrDefault<TSource>(this SortedSet<TSource> source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            using (var enumerator = source.GetEnumerator())
+            {
+                if (!enumerator.MoveNext())
+                {
+                    return default;
+                }
+
+                return enumerator.Current;
+            }
         }
     }
 }


### PR DESCRIPTION
* Update `RAMJobStore.AcquireNextTriggers()` to reduce allocations when the store has no triggers.
* Use return value of `SortedSet.Add()` to determine whether a trigger was already acquired for a job that does not allow concurrent execution.
* Use hand-rolled `FirstOrDefault()` extension method for **SortedSet** to eliminate type checks.

I only have a benchmark result for the last change (as `RAMJobStore.AcquireNextTriggers()` is hard to benchmark as it changes state):

|                    Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|       FirstOrDefault_Linq | 216.3 ns | 0.5124 ns | 0.4793 ns |      0.1216 |           - |           - |               192 B |
| FirstOrDefault_HandRolled | 162.4 ns | 3.8830 ns | 4.7686 ns |      0.0913 |           - |           - |               144 B |

