### PR TITLE
Minor optimizations for TaskSchedulingThreadPool

### DIFF
--- a/src/Quartz/Simpl/TaskSchedulingThreadPool.cs
+++ b/src/Quartz/Simpl/TaskSchedulingThreadPool.cs
@@ -220,10 +220,7 @@ namespace Quartz.Simpl
             concurrencySemaphore.Release();
             lock (taskListLock)
             {
-                if (completedTask != null && runningTasks.Contains(completedTask))
-                {
-                    runningTasks.Remove(completedTask);
-                }
+                runningTasks.Remove(completedTask);
             }
         }
 
@@ -241,15 +238,14 @@ namespace Quartz.Simpl
             // If waitForJobsToComplete is true, wait for runningTasks
             if (waitForJobsToComplete)
             {
-                log.DebugFormat($"Waiting for {runningTasks.Count} threads to complete.");
-
-                Task[] tasksArray = new Task[0];
+                Task[] tasksArray;
                 lock (taskListLock)
                 {
                     // Cancellation has been signaled, so no new tasks will begin once
                     // shutdown has acquired this lock
                     tasksArray = runningTasks.ToArray();
                 }
+                log.DebugFormat($"Waiting for {tasksArray.Length} threads to complete.");
                 Task.WaitAll(tasksArray);
                 log.Debug("No executing jobs remaining, all threads stopped.");
             }


### PR DESCRIPTION
In `TaskSchedulingThreadPool.RemoveTaskFromRunningList(Task completedTask)`, do not first check if the completed task is null and in the list of running tasks. The task should never be null and always be in the list of running tasks, and, even if this does happen, invoking `runningTasks.Remove(completedTask)` with a null task is not a problem.

In `TaskSchedulingThreadPool.Shutdown(bool)` use the actual number of threads that we wait on in the log message. This also ensures we always access **runningTasks** in a synchronized block.

Remove an extra allocation in `TaskSchedulingThreadPool.Shutdown(bool)`.