### PR TITLE
GetTimeBefore() and GetFinalFireTime() throw NotImplementedException

### DIFF
--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -2120,7 +2120,7 @@ namespace Quartz
         public virtual DateTimeOffset? GetTimeBefore(DateTimeOffset? endTime)
         {
             // TODO: implement
-            return null;
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -2131,7 +2131,7 @@ namespace Quartz
         public virtual DateTimeOffset? GetFinalFireTime()
         {
             // TODO: implement QUARTZ-423
-            return null;
+            throw new NotImplementedException();
         }
 
         /// <summary>


### PR DESCRIPTION
It seems strange that public functions that are just TODOs would return null instead of throwing an exception, as this can be confusing for users who would expect the functionality to exist. Is there a particular reason this has been left as null?