### PR TITLE
Raise exception in case of duplicated trigger in xml

### DIFF
--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -24,6 +24,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Schema;
+using System.Linq;
 using System.Xml.Serialization;
 
 using Quartz.Impl.Matchers;
@@ -31,6 +32,7 @@ using Quartz.Logging;
 using Quartz.Spi;
 using Quartz.Util;
 using Quartz.Xml.JobSchedulingData20;
+using Quartz.Impl.AdoJobStore;
 
 namespace Quartz.Xml
 {
@@ -403,6 +405,13 @@ namespace Quartz.Xml
                         triggerEntries.AddRange(schedule.trigger);
                     }
                 }
+            }
+
+            // check for triggers with the same name
+            var duplicatedTriggers = triggerEntries.GroupBy(c => c.Item.name).Where(c => c.Count() > 1);
+            foreach(var duplicatedEntry in duplicatedTriggers)
+            {
+                throw new InvalidConfigurationException("Found duplicated TriggerName: " + duplicatedEntry.Key);
             }
 
             Log.Debug("Found " + triggerEntries.Count + " trigger definitions.");


### PR DESCRIPTION
Currently, in case of multiple triggers with the same name in xml files, Quartz ignores the first ones
which misleading us why the first triggers didn't fire. In such case, the xml config
is invalid and qaurtz should raises exception, so that we will know what is wrong