### PR TITLE
Handling misfires using batch commands

### DIFF
--- a/src/Quartz.Tests.Integration/MisfireBatchRecoveryTest.cs
+++ b/src/Quartz.Tests.Integration/MisfireBatchRecoveryTest.cs
@@ -1,0 +1,382 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Quartz.Impl;
+using Quartz.Impl.Matchers;
+using Quartz.Listener;
+using Quartz.Util;
+
+namespace Quartz.Tests.Integration
+{
+    [TestFixture]
+    public class MisfireBatchRecoveryTest
+    {
+        private static readonly Dictionary<string, string> dbConnectionStrings = new Dictionary<string, string>();
+        private ILogProvider oldProvider;
+
+        static MisfireBatchRecoveryTest()
+        {
+            dbConnectionStrings["Oracle"] = "Data Source=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=xe)));User Id=system;Password=oracle;";
+            dbConnectionStrings["SQLServer"] = TestConstants.SqlServerConnectionString;
+            dbConnectionStrings["MySQL"] = "Server = localhost; Database = quartznet; Uid = quartznet; Pwd = quartznet";
+            dbConnectionStrings["PostgreSQL"] = "Server=127.0.0.1;Port=5432;Userid=quartznet;Password=quartznet;Pooling=true;MinPoolSize=1;MaxPoolSize=20;Timeout=15;SslMode=Disable;Database=quartznet";
+        }
+
+        [OneTimeSetUp]
+        public void FixtureSetUp()
+        {
+            // set Adapter to report problems
+            oldProvider = (ILogProvider)typeof(LogProvider).GetField("s_currentLogProvider", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+            LogProvider.SetCurrentLogProvider(new FailFastLoggerFactoryAdapter());
+        }
+
+        [OneTimeTearDown]
+        public void FixtureTearDown()
+        {
+            // default back to old
+            LogProvider.SetCurrentLogProvider(oldProvider);
+        }
+
+        [Test]
+        [Category("sqlserver")]
+        public Task TestSqlServer()
+        {
+            var properties = new NameValueCollection
+            {
+                ["quartz.jobStore.driverDelegateType"] = typeof(Quartz.Impl.AdoJobStore.SqlServerDelegate).AssemblyQualifiedNameWithoutVersion()
+            };
+            return RunTests(TestConstants.DefaultSqlServerProvider, "SQLServer", properties);
+        }
+
+        [Test]
+        [Category("postgresql")]
+        public Task TestPostgreSql()
+        {
+            NameValueCollection properties = new NameValueCollection();
+            properties["quartz.jobStore.driverDelegateType"] = "Quartz.Impl.AdoJobStore.PostgreSQLDelegate, Quartz";
+            return RunTests("Npgsql", "PostgreSQL", properties);
+        }
+
+        [Test]
+        [Category("mysql")]
+        public Task TestMySql()
+        {
+            NameValueCollection properties = new NameValueCollection();
+            properties["quartz.jobStore.driverDelegateType"] = "Quartz.Impl.AdoJobStore.MySQLDelegate, Quartz";
+            return RunTests("MySql", "MySQL", properties);
+        }
+
+        [Test]
+        [Category("oracle")]
+        public Task TestOracleODPManaged()
+        {
+            NameValueCollection properties = new NameValueCollection();
+            properties["quartz.jobStore.driverDelegateType"] = "Quartz.Impl.AdoJobStore.OracleDelegate, Quartz";
+            return RunTests("OracleODPManaged", "Oracle", properties);
+        }
+
+        private static readonly TimeSpan MisfireThreshold = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan MisfireHandlerFrequency = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan TimeToPass = TimeSpan.FromMilliseconds(1000);
+        private static readonly TimeSpan TriggerInterval = TimeSpan.FromMilliseconds(1000);
+        private const int MaxRetryCount = 15;
+
+        private async Task RunTests(
+            string dbProvider,
+            string connectionStringId,
+            NameValueCollection extraProperties = null)
+        {
+            var tests = new Tuple<int, int>[]
+            {
+                new Tuple<int, int>(10, 3),
+                new Tuple<int, int>(23, 7),
+                new Tuple<int, int>(21, 10),
+                new Tuple<int, int>(7, 10),
+            };
+
+            IScheduler sched;
+            foreach (var test in tests)
+            {
+                var jobsCount = test.Item1;
+                var batchSize = test.Item2;
+
+                await TestContext.Progress.WriteLineAsync($"{DateTime.Now.ToString("HH:mm:ss.fff")} - Test for misfires with {jobsCount} jobs and batch size {batchSize}...");
+                sched = await CreateScheduler(dbProvider, connectionStringId, "json", extraProperties, batchSize);
+                await sched.Clear();
+                await RunMisfireDuringJobExecutionTest(sched, jobsCount);
+                await sched.Shutdown(true);
+            }
+
+            // Now run a recovery test
+            await TestContext.Progress.WriteLineAsync($"{DateTime.Now.ToString("HH:mm:ss.fff")} - Test for recovery of misfired triggers.");
+            sched = await CreateScheduler(dbProvider, connectionStringId, "json", extraProperties, 3);
+
+            await RunMisfireFromRecoveryTest(sched);
+
+            await sched.Clear();
+
+            Assert.IsEmpty(FailFastLoggerFactoryAdapter.Errors, "Found error from logging output");
+        }
+
+        private async Task RunMisfireFromRecoveryTest(IScheduler sched)
+        {
+            var jobsKeys = new HashSet<JobKey>((await sched.GetJobKeys(GroupMatcher<JobKey>.AnyGroup())).Where(x => IsTestJob(x)));
+            Assert.IsTrue(jobsKeys.Any());
+
+            var triggersListner = new TriggersListner();
+            triggersListner.ShouldRecordFiredTriggers = true;
+            sched.ListenerManager.AddTriggerListener(triggersListner, GroupMatcher<TriggerKey>.AnyGroup());
+
+            await sched.Start();
+
+            await sched.Standby();
+            // Wait before starting the scheduler so all triggers are misfired.
+            await Task.Delay(TriggerInterval.Add(TriggerInterval));
+
+            await sched.Start();
+
+            // Do some retries as this is timing sensitive.
+            var retry = 0;
+            while (retry++ < MaxRetryCount && jobsKeys.Count > triggersListner.FiredTriggers.Count)
+            {
+                WriteLog($"Waiting {TimeToPass}ms for recovery - retry: {retry}");
+                await Task.Delay(TimeToPass);
+            }
+
+            Assert.AreEqual(jobsKeys.Count, triggersListner.MisfiredTriggers.Count, $"Recovery: Expected {jobsKeys.Count} misfired triggers, got {triggersListner.MisfiredTriggers.Count} {triggersListner.MisfiredTriggers}");
+            Assert.IsTrue(jobsKeys.SetEquals(triggersListner.MisfiredTriggers.Keys), "Recovery: Expected all triggers to be misfired.");
+
+            Assert.AreEqual(jobsKeys.Count, triggersListner.MisfiredTriggers.Count, $"Recovery: Expected {jobsKeys.Count} fired triggers, got {triggersListner.FiredTriggers.Count}");
+            Assert.IsTrue(jobsKeys.SetEquals(triggersListner.FiredTriggers.Keys), "Recovery: Expected all triggers to have fired.");
+        }
+
+        private const string SemaphoreKey = "BlockingSemKey";
+        private const string BlockingJobGroup = "BlockingJob";
+        private const string TestJobPrefix = "Test_";
+
+        private async Task RunMisfireDuringJobExecutionTest(IScheduler sched, int jobsToCreate)
+        {
+            var triggersListner = new TriggersListner();
+            sched.ListenerManager.AddTriggerListener(triggersListner, GroupMatcher<TriggerKey>.AnyGroup());
+
+            var sem = new SemaphoreSlim(0);
+            sched.Context.Put(SemaphoreKey, sem);
+
+            IJobDetail blockingJob = JobBuilder.Create<BlockingJob>()
+                .WithIdentity("blockingJob", BlockingJobGroup)
+                .StoreDurably()
+                .Build();
+
+            var jobsKeys = new HashSet<JobKey>();
+            for (int i = 0; i < jobsToCreate; i++)
+            {
+                ITrigger t = TriggerBuilder.Create()
+                    .WithIdentity($"Test_t{i}")
+                    .WithSimpleSchedule(x => x
+                        .WithInterval(TriggerInterval)
+                        .RepeatForever()
+                        .WithMisfireHandlingInstructionFireNow())
+                    .Build();
+
+                if (i % 2 == 0)
+                {
+                    IJobDetail nakedJob = JobBuilder.Create<TestJob>()
+                        .WithIdentity($"{TestJobPrefix}nakedJob{i}")
+                        .Build();
+
+                    await sched.ScheduleJob(nakedJob, t);
+                    jobsKeys.Add(nakedJob.Key);
+                }
+                else
+                {
+                    IJobDetail jobWithData = JobBuilder.Create<TestJob2>()
+                        .WithIdentity($"{TestJobPrefix}jobWithData{i}", "datagroup")
+                        .WithDescription("job with data")
+                        .UsingJobData("some", "data")
+                        .UsingJobData("other", true)
+                        .Build();
+
+                    await sched.ScheduleJob(jobWithData, t);
+                    jobsKeys.Add(jobWithData.Key);
+                }
+            }
+
+            // Get the jobs to run a bit.
+            await sched.Start();
+            await Task.Delay(TimeToPass);
+            // This job will cause the others to misfire.
+            await sched.AddJob(blockingJob, replace: false);
+            await sched.TriggerJob(blockingJob.Key);
+
+            // After we block the scheduler we should have misfired triggers reported.
+            // Do some retries as this is timing sensitive.
+            var retry = 0;
+            while (retry++ < MaxRetryCount && jobsKeys.Count > triggersListner.MisfiredTriggers.Count)
+            {
+                WriteLog($"Waiting {TimeToPass}ms for misfires - retry: {retry}");
+                await Task.Delay(TimeToPass);
+            }
+
+            Assert.AreEqual(jobsKeys.Count, triggersListner.MisfiredTriggers.Count, $"Expected {jobsKeys.Count} misfired triggers, got {triggersListner.MisfiredTriggers.Count}");
+            Assert.IsTrue(jobsKeys.SetEquals(triggersListner.MisfiredTriggers.Keys), "Expected all triggers to be misfired.");
+
+            // Start recording jobs that will run after releasing the blocking job.
+            triggersListner.ShouldRecordFiredTriggers = true;
+            sem.Release();
+            WriteLog($"Sem for blocking job {blockingJob.Key} released.");
+            // Wait a bit more to give the misfire handler time to process the batches.
+            // Do some retries as this is timing sensitive.
+            retry = 0;
+            while (retry++ < MaxRetryCount && jobsKeys.Count > triggersListner.FiredTriggers.Count)
+            {
+                WriteLog($"Waiting {TimeToPass}ms for fires - retry: {retry}");
+                await Task.Delay(TimeToPass);
+            }
+
+            Assert.AreEqual(jobsKeys.Count, triggersListner.FiredTriggers.Count, $"Expected {jobsKeys.Count} fired triggers, got {triggersListner.FiredTriggers.Count}");
+            Assert.IsTrue(jobsKeys.SetEquals(triggersListner.FiredTriggers.Keys), "Expected all triggers to have fired.");
+
+            await TestContext.Out.FlushAsync();
+
+            sem.Dispose();
+        }
+
+        private static bool IsTestJob(JobKey key)
+        {
+            return key.Name.StartsWith(TestJobPrefix);
+        }
+
+        public class TestJob: IJob
+        {
+            public virtual Task Execute(IJobExecutionContext context)
+            {
+                JobKey key = context.JobDetail.Key;
+                JobDataMap dataMap = context.JobDetail.JobDataMap;
+
+                WriteLog($"Executing job {key}");
+                if (GroupMatcher<JobKey>.GroupContains("datagroup").IsMatch(key))
+                {
+                    Assert.AreEqual("data", dataMap.GetString("some"));
+                    Assert.IsTrue(dataMap.GetBooleanValue("other"));
+                }
+
+                return TaskUtil.CompletedTask;
+            }
+        }
+
+        [DisallowConcurrentExecution]
+        [PersistJobDataAfterExecution]
+        public class TestJob2 : TestJob
+        {
+        }
+
+        public class BlockingJob: IJob
+        {
+            public async Task Execute(IJobExecutionContext context)
+            {
+                var sem = context.Scheduler.Context.Get(SemaphoreKey) as SemaphoreSlim;
+                Assert.IsNotNull(sem);
+                JobKey key = context.JobDetail.Key;
+
+                WriteLog($"Executing blocking job {key}");
+                // Long running job to cause misfires.
+                var sw = Stopwatch.StartNew();
+                await sem.WaitAsync();
+                sw.Stop();
+                WriteLog($"Completed blocking job {key} - elapsed time = {sw.Elapsed}");
+            }
+        }
+
+        public class TriggersListner : TriggerListenerSupport
+        {
+            public ConcurrentDictionary<JobKey, int> MisfiredTriggers { get; } = new ConcurrentDictionary<JobKey, int>();
+            public ConcurrentDictionary<JobKey, int> FiredTriggers{ get; } = new ConcurrentDictionary<JobKey, int>();
+            public bool ShouldRecordFiredTriggers = false;
+
+
+            public override string Name => "execution and misfire listner";
+
+            public override Task TriggerFired(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                if (ShouldRecordFiredTriggers && IsTestJob(trigger.JobKey))
+                {
+                    FiredTriggers[trigger.JobKey] = 1;
+                }
+                return base.TriggerFired(trigger, context, cancellationToken);
+            }
+
+            public override Task TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default)
+            {
+                if (IsTestJob(trigger.JobKey))
+                {
+                    WriteLog($"Misfire reported for {trigger.Key}");
+                    MisfiredTriggers[trigger.JobKey] = 1;
+                }
+                return base.TriggerMisfired(trigger, cancellationToken);
+            }
+        }
+
+        private static void WriteLog(string message)
+        {
+            TestContext.WriteLine($"{DateTime.Now.ToString("HH:mm:ss.fff")} - {Thread.CurrentThread.ManagedThreadId}: {message}");
+        }
+
+        private static async Task<IScheduler> CreateScheduler(
+            string dbProvider, 
+            string connectionStringId, 
+            string serializerType, 
+            NameValueCollection extraProperties,
+            int maxMisfiresToHandleAtTime
+        )
+        {
+            var properties = new NameValueCollection
+            {
+                ["quartz.scheduler.instanceName"] = "MisfireTestScheduler",
+                ["quartz.threadPool.type"] = "Quartz.Simpl.SimpleThreadPool, Quartz",
+                ["quartz.threadPool.threadCount"] = "1",
+                ["quartz.jobStore.misfireThreshold"] = MisfireThreshold.Milliseconds.ToString(),
+                ["quartz.jobStore.misfireHandlerFrequency"] = MisfireHandlerFrequency.Milliseconds.ToString(),
+                ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.JobStoreTX, Quartz",
+                ["quartz.jobStore.driverDelegateType"] = "Quartz.Impl.AdoJobStore.StdAdoDelegate, Quartz",
+                ["quartz.jobStore.useProperties"] = "false",
+                ["quartz.jobStore.dataSource"] = "default",
+                ["quartz.jobStore.tablePrefix"] = "QRTZ_",
+                ["quartz.jobStore.maxMisfiresToHandleAtATime"] = maxMisfiresToHandleAtTime.ToString(),
+                ["quartz.jobStore.batchMisfireHandling"] = "true",
+                ["quartz.serializer.type"] = serializerType
+            };
+
+            if (extraProperties != null)
+            {
+                foreach (string key in extraProperties.Keys)
+                {
+                    properties[key] = extraProperties[key];
+                }
+            }
+
+            if (!dbConnectionStrings.TryGetValue(connectionStringId, out var connectionString))
+            {
+                throw new Exception("Unknown connection string id: " + connectionStringId);
+            }
+            properties["quartz.dataSource.default.connectionString"] = connectionString;
+            properties["quartz.dataSource.default.provider"] = dbProvider;
+
+            // Clear any old errors from the log
+            FailFastLoggerFactoryAdapter.Errors.Clear();
+
+            // First we must get a reference to a scheduler
+            ISchedulerFactory sf = new StdSchedulerFactory(properties);
+            IScheduler sched = await sf.GetScheduler();
+
+            return sched;
+        }
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/IDbAccessor.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDbAccessor.cs
@@ -16,7 +16,7 @@ namespace Quartz.Impl.AdoJobStore
         /// <param name="cth">Connection and transaction pair</param>
         /// <param name="commandText">SQL to run</param>
         /// <returns></returns>
-        DbCommand PrepareCommand(ConnectionAndTransactionHolder cth, string commandText);
+        DbCommand PrepareCommand(ConnectionAndTransactionHolder cth, string commandText = null);
 
         /// <summary>
         /// Adds a parameter to <see cref="IDbCommand" />.

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -49,6 +49,8 @@ namespace Quartz.Impl.AdoJobStore
     /// <author>Marko Lahma (.NET)</author>
     public interface IDriverDelegate
     {
+        bool SupportsBatching { get; }
+
         /// <summary>
         /// Initializes the driver delegate with configuration data.
         /// </summary>
@@ -257,6 +259,20 @@ namespace Quartz.Impl.AdoJobStore
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Select the JobDetails for an array of jobkeys.
+        /// </summary>
+        /// <param name="conn">The DB Connection</param>
+        /// <param name="jobKeys">The keys identifying the job.</param>
+        /// <param name="classLoadHelper">The class load helper.</param>
+        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <returns>The populated JobDetail objects</returns>
+        Task<IJobDetail[]> SelectJobsDetails(
+            ConnectionAndTransactionHolder conn,
+            JobKey[] jobKeys,
+            ITypeLoadHelper classLoadHelper,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Select the total number of jobs stored.
         /// </summary>
         /// <param name="conn">The DB Connection</param>
@@ -334,6 +350,25 @@ namespace Quartz.Impl.AdoJobStore
             IOperableTrigger trigger, 
             string state, 
             IJobDetail jobDetail,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update the base trigger data.
+        /// <para>
+        /// Important: does not save JobDataMap.
+        /// </para>
+        /// </summary>
+        /// <param name="conn">The DB Connection.</param>
+        /// <param name="triggers">The triggers to insert.</param>
+        /// <param name="states">The state that the trigger should be stored in.</param>
+        /// <param name="jobDetails">The job details.</param>
+        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <returns>The number of rows updated.</returns>
+        Task<int> BatchUpdateMisfiredTriggers(
+            ConnectionAndTransactionHolder conn,
+            IOperableTrigger[] triggers,
+            string[] states,
+            IJobDetail[] jobDetails,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -598,6 +633,19 @@ namespace Quartz.Impl.AdoJobStore
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Select a trigger.
+        /// </summary>
+        /// <param name="conn">The DB Connection.</param>
+        /// <param name="triggerKeys">The keys identifying the triggers.</param>
+        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <returns>The <see cref="ITrigger" /> objects.
+        /// </returns>
+        Task<IOperableTrigger[]> SelectTriggers(
+            ConnectionAndTransactionHolder conn,
+            TriggerKey[] triggerKeys,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Select a trigger's JobDataMap.
         /// </summary>
         /// <param name="conn">The DB Connection.</param>
@@ -816,6 +864,18 @@ namespace Quartz.Impl.AdoJobStore
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Select calendars.
+        /// </summary>
+        /// <param name="conn">The DB Connection.</param>
+        /// <param name="calendarNames">The names of the calendars.</param>
+        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <returns>The Calendars.</returns>
+        Task<ICalendar[]> SelectCalendars(
+            ConnectionAndTransactionHolder conn,
+            string[] calendarNames,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Check whether or not a calendar is referenced by any triggers.
         /// </summary>
         /// <param name="conn">The DB Connection.</param>
@@ -923,6 +983,18 @@ namespace Quartz.Impl.AdoJobStore
             ConnectionAndTransactionHolder conn,
             string jobName,
             string groupName,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Select the fired-trigger records for a given array of jobkeys.
+        /// </summary>
+        /// <param name="conn">The DB connection.</param>
+        /// <param name="jobKeys">Job Keys</param>
+        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <returns>a List of <see cref="FiredTriggerRecord" /> objects for the jobKeys.</returns>
+        Task<IReadOnlyCollection<FiredTriggerRecord>[]> SelectFiredTriggerRecordsByJobs(
+            ConnectionAndTransactionHolder conn,
+            JobKey[] jobKeys,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/ITriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/ITriggerPersistenceDelegate.cs
@@ -36,7 +36,7 @@ namespace Quartz.Impl.AdoJobStore
         /// <summary>
         /// Initializes the persistence delegate.
         /// </summary>
-        void Initialize(string tablePrefix, string schedulerName, IDbAccessor dbAccessor);
+        void Initialize(string tablePrefix, string schedulerName, StdAdoDelegate dbAccessor);
 
         /// <summary>
         /// Returns whether the trigger type can be handled by delegate.
@@ -69,6 +69,16 @@ namespace Quartz.Impl.AdoJobStore
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Updates special properties for an array of triggers.
+        /// </summary>
+        Task<int> UpdateExtendedTriggerProperties(
+            ConnectionAndTransactionHolder conn,
+            IOperableTrigger[] triggers,
+            string[] states,
+            IJobDetail[] jobDetails,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Deletes trigger's special properties.
         /// </summary>
         Task<int> DeleteExtendedTriggerProperties(
@@ -82,6 +92,14 @@ namespace Quartz.Impl.AdoJobStore
         Task<TriggerPropertyBundle> LoadExtendedTriggerProperties(
             ConnectionAndTransactionHolder conn,
             TriggerKey triggerKey,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Loads the special properties for an array of triggers.
+        /// </summary>
+        Task<TriggerPropertyBundle[]> LoadExtendedTriggerProperties(
+            ConnectionAndTransactionHolder conn,
+            TriggerKey[] triggerKeys,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -43,5 +43,7 @@ namespace Quartz.Impl.AdoJobStore
             }
             return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
         }
+
+        public override bool SupportsBatching { get; } = true;
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
@@ -66,5 +66,7 @@ namespace Quartz.Impl.AdoJobStore
 
             throw new ArgumentException("Value must be non-null.");
         }
+
+        public override bool SupportsBatching { get; } = true;
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
@@ -45,5 +45,7 @@ namespace Quartz.Impl.AdoJobStore
             }
             return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
         }
+
+        public override bool SupportsBatching { get; } = true;
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
@@ -80,5 +80,7 @@ namespace Quartz.Impl.AdoJobStore
 
             base.AddCommandParameter(cmd, paramName, paramValue, dataType, size);
         }
+
+        public override bool SupportsBatching { get; } = true;
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -117,12 +117,12 @@ namespace Quartz.Impl.AdoJobStore
         // SELECT
 
         public static readonly string SqlSelectBlobTrigger =
-            string.Format("SELECT {6} FROM {0}{1} WHERE {2} = {3} AND {4} = @triggerName AND {5} = @triggerGroup", TablePrefixSubst,
+            string.Format("SELECT {6}, {4}, {5} FROM {0}{1} WHERE {2} = {3} AND {4} = @triggerName AND {5} = @triggerGroup", TablePrefixSubst,
                 TableBlobTriggers, ColumnSchedulerName, SchedulerNameSubst, ColumnTriggerName, ColumnTriggerGroup,
                 ColumnBlob);
 
         public static readonly string SqlSelectCalendar =
-            string.Format("SELECT {5} FROM {0}{1} WHERE {2} = {3} AND {4} = @calendarName", TablePrefixSubst, TableCalendars,
+            string.Format("SELECT {5}, {4} FROM {0}{1} WHERE {2} = {3} AND {4} = @calendarName", TablePrefixSubst, TableCalendars,
                 ColumnSchedulerName, SchedulerNameSubst, ColumnCalendarName, ColumnCalendar);
 
         public static readonly string SqlSelectCalendarExistence =
@@ -240,7 +240,7 @@ namespace Quartz.Impl.AdoJobStore
             $"SELECT * FROM {TablePrefixSubst}{TableSimpleTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectTrigger =
-            string.Format("SELECT {6},{7},{8},{9},{10},{11},{12},{13},{14},{15},{16},{17} FROM {0}{1} WHERE {2} = {3} AND {4} = @triggerName AND {5} = @triggerGroup",
+            string.Format("SELECT {6},{7},{8},{9},{10},{11},{12},{13},{14},{15},{16},{17},{4},{5} FROM {0}{1} WHERE {2} = {3} AND {4} = @triggerName AND {5} = @triggerGroup",
                 TablePrefixSubst, TableTriggers, ColumnSchedulerName, SchedulerNameSubst, ColumnTriggerName, ColumnTriggerGroup,
                 ColumnJobName, ColumnJobGroup, ColumnDescription, ColumnNextFireTime, ColumnPreviousFireTime, ColumnTriggerType, ColumnStartTime, ColumnEndTime, ColumnCalendarName, ColumnMifireInstruction, ColumnPriority, ColumnJobDataMap);
 


### PR DESCRIPTION
Handling of misfired triggers using database batch commands. The goal is to minimize database round-trips to reduce handling time when there is a large number of misfires.
 - New boolean setting: quartz.jobStore.batchMisfireHandling to control feature.
 - When batchMisfireHandling is set, the misfire handler will process misfired triggers in batches of size maxMisfiresToHandleAtATime
- To support batch processing of triggers, multi-object methods have been added. They mirror the exiting single-object methods.
- The single-object methods are kept as they are for backward-compatibility.
- Not all supported stores can handle batches and this is controlled in code by IDriverDelegate.SupportsBatching override.
- Unit-tests and tests have been added to cover the changes.

#758