### PR TITLE
SchedName added to queries as sql paramter

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
@@ -17,6 +17,7 @@
  */
 #endregion
 
+using System;
 using System.Globalization;
 
 namespace Quartz.Impl.AdoJobStore
@@ -28,17 +29,30 @@ namespace Quartz.Impl.AdoJobStore
 	/// <author>Marko Lahma (.NET)</author>
 	public static class AdoJobStoreUtil
 	{
-	    /// <summary>
-		/// Replace the table prefix in a query by replacing any occurrences of
-		/// "{0}" with the table prefix.
-		/// </summary>
-		/// <param name="query">The unsubstituted query</param>
-		/// <param name="tablePrefix">The table prefix</param>
-		/// <param name="schedNameLiteral">the scheduler name</param>
-		/// <returns>The query, with proper table prefix substituted</returns>
-		public static string ReplaceTablePrefix(string query, string tablePrefix, string schedNameLiteral)
-		{
-			return string.Format(CultureInfo.InvariantCulture, query, tablePrefix, schedNameLiteral);
-		}
-	}
+        /// <summary>
+        /// Replace the table prefix in a query by replacing any occurrences of
+        /// "{0}" with the table prefix.
+        /// </summary>
+        /// <param name="query">The unsubstituted query</param>
+        /// <param name="tablePrefix">The table prefix</param>
+        /// <param name="schedNameLiteral">the scheduler name - no longer required, scheduler name is now a sql parameter</param>
+        /// <returns>The query, with proper table prefix substituted</returns>
+        [Obsolete("Use overload with schedNameLiteral, scheduler name is now a sql parameter")]
+        public static string ReplaceTablePrefix(string query, string tablePrefix, string schedNameLiteral)
+        {
+            return string.Format(CultureInfo.InvariantCulture, query, tablePrefix, schedNameLiteral);
+        }
+
+        /// <summary>
+        /// Replace the table prefix in a query by replacing any occurrences of
+        /// "{0}" with the table prefix.
+        /// </summary>
+        /// <param name="query">The unsubstituted query</param>
+        /// <param name="tablePrefix">The table prefix</param>
+        /// <returns>The query, with proper table prefix substituted</returns>
+        public static string ReplaceTablePrefix(string query, string tablePrefix)
+        {
+            return string.Format(CultureInfo.InvariantCulture, query, tablePrefix);
+        }
+    }
 }

--- a/src/Quartz/Impl/AdoJobStore/CronTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/CronTriggerPersistenceDelegate.cs
@@ -39,15 +39,21 @@ namespace Quartz.Impl.AdoJobStore
         public void Initialize(string tablePrefix, string schedName, IDbAccessor dbAccessor)
         {
             TablePrefix = tablePrefix;
-            SchedNameLiteral = "'" + schedName + "'";
             DbAccessor = dbAccessor;
+            SchedName = schedName;
+
+            // No longer used in this file
+            SchedNameLiteral = "'" + schedName + "'";
         }
 
         protected string TablePrefix { get; private set; }
 
         protected IDbAccessor DbAccessor { get; private set; }
 
+        [Obsolete("Scheduler name is now added to queries as a parameter")]
         protected string SchedNameLiteral { get; private set; }
+
+        protected string SchedName { get; private set; }
 
         public string GetHandledTriggerTypeDiscriminator()
         {
@@ -64,8 +70,9 @@ namespace Quartz.Impl.AdoJobStore
             TriggerKey triggerKey,
             CancellationToken cancellationToken = default)
         {
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlDeleteCronTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlDeleteCronTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -82,8 +89,9 @@ namespace Quartz.Impl.AdoJobStore
         {
             ICronTrigger cronTrigger = (ICronTrigger) trigger;
 
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlInsertCronTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlInsertCronTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
                 DbAccessor.AddCommandParameter(cmd, "triggerCronExpression", cronTrigger.CronExpressionString);
@@ -98,8 +106,9 @@ namespace Quartz.Impl.AdoJobStore
             TriggerKey triggerKey,
             CancellationToken cancellationToken = default)
         {
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectCronTriggers, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectCronTriggers, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -121,7 +130,7 @@ namespace Quartz.Impl.AdoJobStore
                     }
                 }
 
-                throw new InvalidOperationException("No record found for selection of Trigger with key: '" + triggerKey + "' and statement: " + AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectCronTriggers, TablePrefix, SchedNameLiteral));
+                throw new InvalidOperationException("No record found for selection of Trigger with key: '" + triggerKey + "' and statement: " + AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectCronTriggers, TablePrefix));
             }
         }
 
@@ -134,8 +143,9 @@ namespace Quartz.Impl.AdoJobStore
         {
             ICronTrigger cronTrigger = (ICronTrigger) trigger;
 
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlUpdateCronTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlUpdateCronTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerCronExpression", cronTrigger.CronExpressionString);
                 DbAccessor.AddCommandParameter(cmd, "timeZoneId", cronTrigger.TimeZone.Id);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", trigger.Key.Name);

--- a/src/Quartz/Impl/AdoJobStore/DBSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/DBSemaphore.cs
@@ -214,15 +214,16 @@ namespace Quartz.Impl.AdoJobStore
 
         private void SetExpandedSql()
         {
-            if (TablePrefix != null && SchedName != null && sql != null && insertSql != null)
+            if (TablePrefix != null && sql != null && insertSql != null)
             {
-                expandedSQL = AdoJobStoreUtil.ReplaceTablePrefix(sql, TablePrefix, SchedulerNameLiteral);
-                expandedInsertSQL = AdoJobStoreUtil.ReplaceTablePrefix(insertSql, TablePrefix, SchedulerNameLiteral);
+                expandedSQL = AdoJobStoreUtil.ReplaceTablePrefix(sql, TablePrefix);
+                expandedInsertSQL = AdoJobStoreUtil.ReplaceTablePrefix(insertSql, TablePrefix);
             }
         }
 
         private string schedNameLiteral;
 
+        [Obsolete("SchedName is now a sql parameter")]
         protected string SchedulerNameLiteral
         {
             get
@@ -241,7 +242,6 @@ namespace Quartz.Impl.AdoJobStore
             set
             {
                 schedName = value;
-                SetExpandedSql();
             }
         }
 

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -503,7 +503,7 @@ namespace Quartz.Impl.AdoJobStore
                     {
                         if (SelectWithLockSQL == null)
                         {
-                            const string DefaultLockSql = "SELECT * FROM {0}LOCKS WITH (UPDLOCK,ROWLOCK) WHERE " + ColumnSchedulerName + " = {1} AND LOCK_NAME = @lockName";
+                            const string DefaultLockSql = "SELECT * FROM {0}LOCKS WITH (UPDLOCK,ROWLOCK) WHERE " + ColumnSchedulerName + " = @schedulerName AND LOCK_NAME = @lockName";
                             Log.InfoFormat("Detected usage of SqlServerDelegate - defaulting 'selectWithLockSQL' to '" + DefaultLockSql + "'.", TablePrefix, "'" + InstanceName + "'");
                             SelectWithLockSQL = DefaultLockSql;
                         }

--- a/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateSupport.cs
@@ -57,12 +57,12 @@ namespace Quartz.Impl.AdoJobStore
 
         protected const string SelectSimplePropsTrigger = "SELECT *" + " FROM "
                                                           + StdAdoConstants.TablePrefixSubst + TableSimplePropertiesTriggers + " WHERE "
-                                                          + AdoConstants.ColumnSchedulerName + " = " + StdAdoConstants.SchedulerNameSubst
+                                                          + AdoConstants.ColumnSchedulerName + " = @schedulerName"
                                                           + " AND " + AdoConstants.ColumnTriggerName + " = @triggerName AND " + AdoConstants.ColumnTriggerGroup + " = @triggerGroup";
 
         protected const string DeleteSimplePropsTrigger = "DELETE FROM "
                                                           + StdAdoConstants.TablePrefixSubst + TableSimplePropertiesTriggers + " WHERE "
-                                                          + AdoConstants.ColumnSchedulerName + " = " + StdAdoConstants.SchedulerNameSubst
+                                                          + AdoConstants.ColumnSchedulerName + " = @schedulerName"
                                                           + " AND " + AdoConstants.ColumnTriggerName + " = @triggerName AND " + AdoConstants.ColumnTriggerGroup + " = @triggerGroup";
 
         protected const string InsertSimplePropsTrigger = "INSERT INTO "
@@ -74,7 +74,7 @@ namespace Quartz.Impl.AdoJobStore
                                                           + ColumnLongProp1 + ", " + ColumnLongProp2 + ", "
                                                           + ColumnDecProp1 + ", " + ColumnDecProp2 + ", "
                                                           + ColumnBoolProp1 + ", " + ColumnBoolProp2 + ", " + ColumnTimeZoneId
-                                                          + ") " + " VALUES(" + StdAdoConstants.SchedulerNameSubst + ", @triggerName, @triggerGroup, @string1, @string2, @string3, @int1, @int2, @long1, @long2, @decimal1, @decimal2, @boolean1, @boolean2, @timeZoneId)";
+                                                          + ") " + " VALUES(@schedulerName" + ", @triggerName, @triggerGroup, @string1, @string2, @string3, @int1, @int2, @long1, @long2, @decimal1, @decimal2, @boolean1, @boolean2, @timeZoneId)";
 
         protected const string UpdateSimplePropsTrigger = "UPDATE "
                                                           + StdAdoConstants.TablePrefixSubst + TableSimplePropertiesTriggers + " SET "
@@ -83,7 +83,7 @@ namespace Quartz.Impl.AdoJobStore
                                                           + ColumnLongProp1 + " = @long1, " + ColumnLongProp2 + " = @long2, "
                                                           + ColumnDecProp1 + " = @decimal1, " + ColumnDecProp2 + " = @decimal2, "
                                                           + ColumnBoolProp1 + " = @boolean1, " + ColumnBoolProp2
-                                                          + " = @boolean2, " + ColumnTimeZoneId + " = @timeZoneId WHERE " + AdoConstants.ColumnSchedulerName + " = " + StdAdoConstants.SchedulerNameSubst
+                                                          + " = @boolean2, " + ColumnTimeZoneId + " = @timeZoneId WHERE " + AdoConstants.ColumnSchedulerName + " = @schedulerName"
                                                           + " AND " + AdoConstants.ColumnTriggerName
                                                           + " = @triggerName AND " + AdoConstants.ColumnTriggerGroup + " = @triggerGroup";
 
@@ -91,6 +91,9 @@ namespace Quartz.Impl.AdoJobStore
         {
             TablePrefix = tablePrefix;
             DbAccessor = dbAccessor;
+            SchedName = schedName;
+
+            // No longer used
             SchedNameLiteral = "'" + schedName + "'";
         }
 
@@ -110,7 +113,10 @@ namespace Quartz.Impl.AdoJobStore
 
         protected string TablePrefix { get; private set; }
 
+        [Obsolete("Scheduler name is now added to queries as a parameter")]
         protected string SchedNameLiteral { get; private set; }
+
+        protected string SchedName { get; private set; }
 
         protected IDbAccessor DbAccessor { get; private set; }
 
@@ -119,8 +125,9 @@ namespace Quartz.Impl.AdoJobStore
             TriggerKey triggerKey,
             CancellationToken cancellationToken = default)
         {
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(DeleteSimplePropsTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(DeleteSimplePropsTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -137,8 +144,9 @@ namespace Quartz.Impl.AdoJobStore
         {
             SimplePropertiesTriggerProperties properties = GetTriggerProperties(trigger);
 
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(InsertSimplePropsTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(InsertSimplePropsTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
 
@@ -164,8 +172,9 @@ namespace Quartz.Impl.AdoJobStore
             TriggerKey triggerKey,
             CancellationToken cancellationToken = default)
         {
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(SelectSimplePropsTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(SelectSimplePropsTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -193,7 +202,7 @@ namespace Quartz.Impl.AdoJobStore
                 }
             }
 
-            throw new InvalidOperationException("No record found for selection of Trigger with key: '" + triggerKey + "' and statement: " + AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectSimpleTrigger, TablePrefix, SchedNameLiteral));
+            throw new InvalidOperationException("No record found for selection of Trigger with key: '" + triggerKey + "' and statement: " + AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectSimpleTrigger, TablePrefix));
         }
 
         public async Task<int> UpdateExtendedTriggerProperties(
@@ -205,8 +214,9 @@ namespace Quartz.Impl.AdoJobStore
         {
             SimplePropertiesTriggerProperties properties = GetTriggerProperties(trigger);
 
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(UpdateSimplePropsTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(UpdateSimplePropsTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "string1", properties.String1);
                 DbAccessor.AddCommandParameter(cmd, "string2", properties.String2);
                 DbAccessor.AddCommandParameter(cmd, "string3", properties.String3);

--- a/src/Quartz/Impl/AdoJobStore/SimpleTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimpleTriggerPersistenceDelegate.cs
@@ -35,13 +35,19 @@ namespace Quartz.Impl.AdoJobStore
 
         protected string TablePrefix { get; private set; }
 
+        [Obsolete("Scheduler name is now added to queries as a parameter")]
         protected string SchedNameLiteral { get; private set; }
+
+        protected string SchedName { get; private set; }
 
         public void Initialize(string tablePrefix, string schedName, IDbAccessor dbAccessor)
         {
             TablePrefix = tablePrefix;
-            SchedNameLiteral = "'" + schedName + "'";
+            SchedName = schedName;
             DbAccessor = dbAccessor;
+
+            // No longer required
+            SchedNameLiteral = "'" + schedName + "'";
         }
 
         public string GetHandledTriggerTypeDiscriminator()
@@ -59,8 +65,9 @@ namespace Quartz.Impl.AdoJobStore
             TriggerKey triggerKey,
             CancellationToken cancellationToken = default)
         {
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlDeleteSimpleTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlDeleteSimpleTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -77,8 +84,9 @@ namespace Quartz.Impl.AdoJobStore
         {
             ISimpleTrigger simpleTrigger = (ISimpleTrigger) trigger;
 
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlInsertSimpleTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlInsertSimpleTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
                 DbAccessor.AddCommandParameter(cmd, "triggerRepeatCount", simpleTrigger.RepeatCount);
@@ -94,8 +102,9 @@ namespace Quartz.Impl.AdoJobStore
             TriggerKey triggerKey,
             CancellationToken cancellationToken = default)
         {
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectSimpleTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectSimpleTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -117,7 +126,7 @@ namespace Quartz.Impl.AdoJobStore
                         return new TriggerPropertyBundle(sb, statePropertyNames, statePropertyValues);
                     }
                 }
-                throw new InvalidOperationException("No record found for selection of Trigger with key: '" + triggerKey + "' and statement: " + AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectSimpleTrigger, TablePrefix, SchedNameLiteral));
+                throw new InvalidOperationException("No record found for selection of Trigger with key: '" + triggerKey + "' and statement: " + AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlSelectSimpleTrigger, TablePrefix));
             }
         }
 
@@ -130,8 +139,9 @@ namespace Quartz.Impl.AdoJobStore
         {
             ISimpleTrigger simpleTrigger = (ISimpleTrigger) trigger;
 
-            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlUpdateSimpleTrigger, TablePrefix, SchedNameLiteral)))
+            using (var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlUpdateSimpleTrigger, TablePrefix)))
             {
+                DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
                 DbAccessor.AddCommandParameter(cmd, "triggerRepeatCount", simpleTrigger.RepeatCount);
                 DbAccessor.AddCommandParameter(cmd, "triggerRepeatInterval", DbAccessor.GetDbTimeSpanValue(simpleTrigger.RepeatInterval));
                 DbAccessor.AddCommandParameter(cmd, "triggerTimesTriggered", simpleTrigger.TimesTriggered);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using System;
+
 namespace Quartz.Impl.AdoJobStore
 {
     /// <summary>
@@ -33,317 +35,318 @@ namespace Quartz.Impl.AdoJobStore
         public const string TablePrefixSubst = "{0}";
 
         // table prefix substitution string
+        [Obsolete("Scheduler name injection has been replaced with sql parameter @schedulerName")]
         public const string SchedulerNameSubst = "{1}";
 
         // DELETE
         public static readonly string SqlDeleteBlobTrigger =
-            $"DELETE FROM {TablePrefixSubst}{TableBlobTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"DELETE FROM {TablePrefixSubst}{TableBlobTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlDeleteCalendar =
-            $"DELETE FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnCalendarName} = @calendarName";
+            $"DELETE FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnCalendarName} = @calendarName";
 
         public static readonly string SqlDeleteCronTrigger =
-            $"DELETE FROM {TablePrefixSubst}{TableCronTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"DELETE FROM {TablePrefixSubst}{TableCronTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlDeleteFiredTrigger =
-            $"DELETE FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnEntryId} = @triggerEntryId";
+            $"DELETE FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnEntryId} = @triggerEntryId";
 
         public static readonly string SqlDeleteFiredTriggers =
-            $"DELETE FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"DELETE FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlDeleteInstancesFiredTriggers =
-            $"DELETE FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnInstanceName} = @instanceName";
+            $"DELETE FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName";
 
         public static readonly string SqlDeleteJobDetail =
-            $"DELETE FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"DELETE FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlDeleteNoRecoveryFiredTriggers =
-            $"DELETE FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnInstanceName} = @instanceName AND {ColumnRequestsRecovery} = @requestsRecovery";
+            $"DELETE FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName AND {ColumnRequestsRecovery} = @requestsRecovery";
 
         public static readonly string SqlDeletePausedTriggerGroup =
-            $"DELETE FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerGroup} LIKE @triggerGroup";
+            $"DELETE FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup";
 
         public static readonly string SqlDeletePausedTriggerGroups =
-            $"DELETE FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"DELETE FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlDeleteSchedulerState =
-            $"DELETE FROM {TablePrefixSubst}{TableSchedulerState} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnInstanceName} = @instanceName";
+            $"DELETE FROM {TablePrefixSubst}{TableSchedulerState} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName";
 
         public static readonly string SqlDeleteSimpleTrigger =
-            $"DELETE FROM {TablePrefixSubst}{TableSimpleTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"DELETE FROM {TablePrefixSubst}{TableSimpleTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlDeleteTrigger =
-            $"DELETE FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"DELETE FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
-        public static readonly string SqlDeleteAllSimpleTriggers = $"DELETE FROM {TablePrefixSubst}SIMPLE_TRIGGERS WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
-        public static readonly string SqlDeleteAllSimpropTriggers = $"DELETE FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
-        public static readonly string SqlDeleteAllCronTriggers = $"DELETE FROM {TablePrefixSubst}CRON_TRIGGERS WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
-        public static readonly string SqlDeleteAllBlobTriggers = $"DELETE FROM {TablePrefixSubst}BLOB_TRIGGERS WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
-        public static readonly string SqlDeleteAllTriggers = $"DELETE FROM {TablePrefixSubst}TRIGGERS WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
-        public static readonly string SqlDeleteAllJobDetails = $"DELETE FROM {TablePrefixSubst}JOB_DETAILS WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
-        public static readonly string SqlDeleteAllCalendars = $"DELETE FROM {TablePrefixSubst}CALENDARS WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
-        public static readonly string SqlDeleteAllPausedTriggerGrps = $"DELETE FROM {TablePrefixSubst}PAUSED_TRIGGER_GRPS WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+        public static readonly string SqlDeleteAllSimpleTriggers = $"DELETE FROM {TablePrefixSubst}SIMPLE_TRIGGERS WHERE {ColumnSchedulerName} = @schedulerName";
+        public static readonly string SqlDeleteAllSimpropTriggers = $"DELETE FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {ColumnSchedulerName} = @schedulerName";
+        public static readonly string SqlDeleteAllCronTriggers = $"DELETE FROM {TablePrefixSubst}CRON_TRIGGERS WHERE {ColumnSchedulerName} = @schedulerName";
+        public static readonly string SqlDeleteAllBlobTriggers = $"DELETE FROM {TablePrefixSubst}BLOB_TRIGGERS WHERE {ColumnSchedulerName} = @schedulerName";
+        public static readonly string SqlDeleteAllTriggers = $"DELETE FROM {TablePrefixSubst}TRIGGERS WHERE {ColumnSchedulerName} = @schedulerName";
+        public static readonly string SqlDeleteAllJobDetails = $"DELETE FROM {TablePrefixSubst}JOB_DETAILS WHERE {ColumnSchedulerName} = @schedulerName";
+        public static readonly string SqlDeleteAllCalendars = $"DELETE FROM {TablePrefixSubst}CALENDARS WHERE {ColumnSchedulerName} = @schedulerName";
+        public static readonly string SqlDeleteAllPausedTriggerGrps = $"DELETE FROM {TablePrefixSubst}PAUSED_TRIGGER_GRPS WHERE {ColumnSchedulerName} = @schedulerName";
 
         // INSERT
 
         public static readonly string SqlInsertBlobTrigger =
-            $"INSERT INTO {TablePrefixSubst}{TableBlobTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnBlob})  VALUES({SchedulerNameSubst}, @triggerName, @triggerGroup, @blob)";
+            $"INSERT INTO {TablePrefixSubst}{TableBlobTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnBlob})  VALUES(@schedulerName, @triggerName, @triggerGroup, @blob)";
 
         public static readonly string SqlInsertCalendar =
-            $"INSERT INTO {TablePrefixSubst}{TableCalendars} ({ColumnSchedulerName}, {ColumnCalendarName}, {ColumnCalendar})  VALUES({SchedulerNameSubst}, @calendarName, @calendar)";
+            $"INSERT INTO {TablePrefixSubst}{TableCalendars} ({ColumnSchedulerName}, {ColumnCalendarName}, {ColumnCalendar})  VALUES(@schedulerName, @calendarName, @calendar)";
 
         public static readonly string SqlInsertCronTrigger =
-            $"INSERT INTO {TablePrefixSubst}{TableCronTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnCronExpression}, {ColumnTimeZoneId}) VALUES({SchedulerNameSubst}, @triggerName, @triggerGroup, @triggerCronExpression, @triggerTimeZone)";
+            $"INSERT INTO {TablePrefixSubst}{TableCronTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnCronExpression}, {ColumnTimeZoneId}) VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerCronExpression, @triggerTimeZone)";
 
         public static readonly string SqlInsertFiredTrigger =
-            $"INSERT INTO {TablePrefixSubst}{TableFiredTriggers} ({ColumnSchedulerName}, {ColumnEntryId}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnInstanceName}, {ColumnFiredTime}, {ColumnScheduledTime}, {ColumnEntryState}, {ColumnJobName}, {ColumnJobGroup}, {ColumnIsNonConcurrent}, {ColumnRequestsRecovery}, {ColumnPriority}) VALUES({SchedulerNameSubst}, @triggerEntryId, @triggerName, @triggerGroup, @triggerInstanceName, @triggerFireTime, @triggerScheduledTime, @triggerState, @triggerJobName, @triggerJobGroup, @triggerJobStateful, @triggerJobRequestsRecovery, @triggerPriority)";
+            $"INSERT INTO {TablePrefixSubst}{TableFiredTriggers} ({ColumnSchedulerName}, {ColumnEntryId}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnInstanceName}, {ColumnFiredTime}, {ColumnScheduledTime}, {ColumnEntryState}, {ColumnJobName}, {ColumnJobGroup}, {ColumnIsNonConcurrent}, {ColumnRequestsRecovery}, {ColumnPriority}) VALUES(@schedulerName, @triggerEntryId, @triggerName, @triggerGroup, @triggerInstanceName, @triggerFireTime, @triggerScheduledTime, @triggerState, @triggerJobName, @triggerJobGroup, @triggerJobStateful, @triggerJobRequestsRecovery, @triggerPriority)";
 
         public static readonly string SqlInsertJobDetail =
-            $"INSERT INTO {TablePrefixSubst}{TableJobDetails} ({ColumnSchedulerName}, {ColumnJobName}, {ColumnJobGroup}, {ColumnDescription}, {ColumnJobClass}, {ColumnIsDurable}, {ColumnIsNonConcurrent}, {ColumnIsUpdateData}, {ColumnRequestsRecovery}, {ColumnJobDataMap})  VALUES({SchedulerNameSubst}, @jobName, @jobGroup, @jobDescription, @jobType, @jobDurable, @jobVolatile, @jobStateful, @jobRequestsRecovery, @jobDataMap)";
+            $"INSERT INTO {TablePrefixSubst}{TableJobDetails} ({ColumnSchedulerName}, {ColumnJobName}, {ColumnJobGroup}, {ColumnDescription}, {ColumnJobClass}, {ColumnIsDurable}, {ColumnIsNonConcurrent}, {ColumnIsUpdateData}, {ColumnRequestsRecovery}, {ColumnJobDataMap})  VALUES(@schedulerName, @jobName, @jobGroup, @jobDescription, @jobType, @jobDurable, @jobVolatile, @jobStateful, @jobRequestsRecovery, @jobDataMap)";
 
         public static readonly string SqlInsertPausedTriggerGroup =
-            $"INSERT INTO {TablePrefixSubst}{TablePausedTriggers} ({ColumnSchedulerName}, {ColumnTriggerGroup}) VALUES ({SchedulerNameSubst}, @triggerGroup)";
+            $"INSERT INTO {TablePrefixSubst}{TablePausedTriggers} ({ColumnSchedulerName}, {ColumnTriggerGroup}) VALUES (@schedulerName, @triggerGroup)";
 
         public static readonly string SqlInsertSchedulerState =
-            $"INSERT INTO {TablePrefixSubst}{TableSchedulerState} ({ColumnSchedulerName}, {ColumnInstanceName}, {ColumnLastCheckinTime}, {ColumnCheckinInterval}) VALUES({SchedulerNameSubst}, @instanceName, @lastCheckinTime, @checkinInterval)";
+            $"INSERT INTO {TablePrefixSubst}{TableSchedulerState} ({ColumnSchedulerName}, {ColumnInstanceName}, {ColumnLastCheckinTime}, {ColumnCheckinInterval}) VALUES(@schedulerName, @instanceName, @lastCheckinTime, @checkinInterval)";
 
         public static readonly string SqlInsertSimpleTrigger =
-            $"INSERT INTO {TablePrefixSubst}{TableSimpleTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnRepeatCount}, {ColumnRepeatInterval}, {ColumnTimesTriggered})  VALUES({SchedulerNameSubst}, @triggerName, @triggerGroup, @triggerRepeatCount, @triggerRepeatInterval, @triggerTimesTriggered)";
+            $"INSERT INTO {TablePrefixSubst}{TableSimpleTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnRepeatCount}, {ColumnRepeatInterval}, {ColumnTimesTriggered})  VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerRepeatCount, @triggerRepeatInterval, @triggerTimesTriggered)";
 
         public static readonly string SqlInsertTrigger =
             $@"INSERT INTO {TablePrefixSubst}{TableTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnJobName}, {ColumnJobGroup}, {ColumnDescription}, {ColumnNextFireTime}, {ColumnPreviousFireTime}, {ColumnTriggerState}, {ColumnTriggerType}, {ColumnStartTime}, {ColumnEndTime}, {ColumnCalendarName}, {ColumnMifireInstruction}, {ColumnJobDataMap}, {ColumnPriority})  
-                        VALUES({SchedulerNameSubst}, @triggerName, @triggerGroup, @triggerJobName, @triggerJobGroup, @triggerDescription, @triggerNextFireTime, @triggerPreviousFireTime, @triggerState, @triggerType, @triggerStartTime, @triggerEndTime, @triggerCalendarName, @triggerMisfireInstruction, @triggerJobJobDataMap, @triggerPriority)";
+                        VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerJobName, @triggerJobGroup, @triggerDescription, @triggerNextFireTime, @triggerPreviousFireTime, @triggerState, @triggerType, @triggerStartTime, @triggerEndTime, @triggerCalendarName, @triggerMisfireInstruction, @triggerJobJobDataMap, @triggerPriority)";
 
         // SELECT
 
         public static readonly string SqlSelectBlobTrigger =
             string.Format("SELECT {6} FROM {0}{1} WHERE {2} = {3} AND {4} = @triggerName AND {5} = @triggerGroup", TablePrefixSubst,
-                TableBlobTriggers, ColumnSchedulerName, SchedulerNameSubst, ColumnTriggerName, ColumnTriggerGroup,
+                TableBlobTriggers, ColumnSchedulerName, "@schedulerName", ColumnTriggerName, ColumnTriggerGroup,
                 ColumnBlob);
 
         public static readonly string SqlSelectCalendar =
             string.Format("SELECT {5} FROM {0}{1} WHERE {2} = {3} AND {4} = @calendarName", TablePrefixSubst, TableCalendars,
-                ColumnSchedulerName, SchedulerNameSubst, ColumnCalendarName, ColumnCalendar);
+                ColumnSchedulerName, "@schedulerName", ColumnCalendarName, ColumnCalendar);
 
         public static readonly string SqlSelectCalendarExistence =
-            $"SELECT {ColumnCalendarName} FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnCalendarName} = @calendarName";
+            $"SELECT {ColumnCalendarName} FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnCalendarName} = @calendarName";
 
         public static readonly string SqlSelectCalendars =
-            $"SELECT {ColumnCalendarName} FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT {ColumnCalendarName} FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectCronTriggers =
-            $"SELECT * FROM {TablePrefixSubst}{TableCronTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT * FROM {TablePrefixSubst}{TableCronTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectFiredTrigger =
-            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectFiredTriggerGroup =
-            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectFiredTriggers =
-            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectFiredTriggerInstanceNames =
-            $"SELECT DISTINCT {ColumnInstanceName} FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT DISTINCT {ColumnInstanceName} FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectFiredTriggersOfJob =
-            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectFiredTriggersOfJobGroup =
-            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectInstancesFiredTriggers =
-            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnInstanceName} = @instanceName";
+            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName";
 
         public static readonly string SqlSelectInstancesRecoverableFiredTriggers =
-            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnInstanceName} = @instanceName AND {ColumnRequestsRecovery} = @requestsRecovery";
+            $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName AND {ColumnRequestsRecovery} = @requestsRecovery";
 
         public static readonly string SqlSelectJobDetail =
             string.Format(
                 "SELECT {6},{7},{8},{9},{10},{11},{12} FROM {0}{1} WHERE {2} = {3} AND {4} = @jobName AND {5} = @jobGroup",
-                TablePrefixSubst, TableJobDetails, ColumnSchedulerName, SchedulerNameSubst, ColumnJobName, ColumnJobGroup,
+                TablePrefixSubst, TableJobDetails, ColumnSchedulerName, "@schedulerName", ColumnJobName, ColumnJobGroup,
                 ColumnJobName, ColumnJobGroup, ColumnDescription, ColumnJobClass, ColumnIsDurable, ColumnRequestsRecovery, ColumnJobDataMap);
 
         public static readonly string SqlSelectJobExecutionCount =
-            $"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectJobExistence =
-            $"SELECT {ColumnJobName} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT {ColumnJobName} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectJobForTrigger =
-            $"SELECT J.{ColumnJobName}, J.{ColumnJobGroup}, J.{ColumnIsDurable}, J.{ColumnJobClass}, J.{ColumnRequestsRecovery} FROM {TablePrefixSubst}{TableTriggers} T, {TablePrefixSubst}{TableJobDetails} J WHERE T.{ColumnSchedulerName} = {SchedulerNameSubst} AND T.{ColumnSchedulerName} = J.{ColumnSchedulerName} AND T.{ColumnTriggerName} = @triggerName AND T.{ColumnTriggerGroup} = @triggerGroup AND T.{ColumnJobName} = J.{ColumnJobName} AND T.{ColumnJobGroup} = J.{ColumnJobGroup}";
+            $"SELECT J.{ColumnJobName}, J.{ColumnJobGroup}, J.{ColumnIsDurable}, J.{ColumnJobClass}, J.{ColumnRequestsRecovery} FROM {TablePrefixSubst}{TableTriggers} T, {TablePrefixSubst}{TableJobDetails} J WHERE T.{ColumnSchedulerName} = @schedulerName AND T.{ColumnSchedulerName} = J.{ColumnSchedulerName} AND T.{ColumnTriggerName} = @triggerName AND T.{ColumnTriggerGroup} = @triggerGroup AND T.{ColumnJobName} = J.{ColumnJobName} AND T.{ColumnJobGroup} = J.{ColumnJobGroup}";
 
         public static readonly string SqlSelectJobGroups =
-            $"SELECT DISTINCT({ColumnJobGroup}) FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT DISTINCT({ColumnJobGroup}) FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectJobNonConcurrent =
-            $"SELECT {ColumnIsNonConcurrent} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT {ColumnIsNonConcurrent} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectJobsInGroupLike =
-            $"SELECT {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobGroup} LIKE @jobGroup";
+            $"SELECT {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobGroup} LIKE @jobGroup";
 
         public static readonly string SqlSelectJobsInGroup =
-            $"SELECT {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectMisfiredTriggers =
-            $"SELECT * FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC";
+            $"SELECT * FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC";
 
         public static readonly string SqlSelectMisfiredTriggersInGroupInState =
-            $"SELECT {ColumnTriggerName} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @state ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC";
+            $"SELECT {ColumnTriggerName} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @state ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC";
 
         public static readonly string SqlSelectMisfiredTriggersInState =
-            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC";
+            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC";
 
         public static readonly string SqlCountMisfiredTriggersInStates =
-            $"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state1";
+            $"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state1";
 
         public static readonly string SqlSelectHasMisfiredTriggersInState =
-            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state1 ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC";
+            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state1 ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC";
 
         public static readonly string SqlSelectNextTriggerToAcquire =
             string.Format("SELECT {0}, {1}, {2}, {3} FROM {4}{5} WHERE {6} = {7} AND {8} = @state AND {9} <= @noLaterThan AND ({10} = -1 OR ({10} <> -1 AND {9} >= @noEarlierThan)) ORDER BY {9} ASC, {11} DESC",
                 ColumnTriggerName, ColumnTriggerGroup, ColumnNextFireTime, ColumnPriority,
-                TablePrefixSubst, TableTriggers, ColumnSchedulerName, SchedulerNameSubst,
+                TablePrefixSubst, TableTriggers, ColumnSchedulerName, "@schedulerName",
                 ColumnTriggerState, ColumnNextFireTime, ColumnMifireInstruction, ColumnPriority);
 
         public static readonly string SqlSelectNumCalendars =
-            $"SELECT COUNT({ColumnCalendarName})  FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT COUNT({ColumnCalendarName})  FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectNumJobs =
-            $"SELECT COUNT({ColumnJobName})  FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT COUNT({ColumnJobName})  FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectNumTriggers =
-            $"SELECT COUNT({ColumnTriggerName})  FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT COUNT({ColumnTriggerName})  FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectNumTriggersForJob =
-            $"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectNumTriggersInGroup =
-            $"SELECT COUNT({ColumnTriggerName})  FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT COUNT({ColumnTriggerName})  FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectPausedTriggerGroup =
-            $"SELECT {ColumnTriggerGroup} FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT {ColumnTriggerGroup} FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectPausedTriggerGroups =
-            $"SELECT {ColumnTriggerGroup} FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT {ColumnTriggerGroup} FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectReferencedCalendar =
-            $"SELECT {ColumnCalendarName} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnCalendarName} = @calendarName";
+            $"SELECT {ColumnCalendarName} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnCalendarName} = @calendarName";
 
         public static readonly string SqlSelectSchedulerState =
-            $"SELECT * FROM {TablePrefixSubst}{TableSchedulerState} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnInstanceName} = @instanceName";
+            $"SELECT * FROM {TablePrefixSubst}{TableSchedulerState} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName";
 
         public static readonly string SqlSelectSchedulerStates =
-            $"SELECT * FROM {TablePrefixSubst}{TableSchedulerState} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT * FROM {TablePrefixSubst}{TableSchedulerState} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectSimpleTrigger =
-            $"SELECT * FROM {TablePrefixSubst}{TableSimpleTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT * FROM {TablePrefixSubst}{TableSimpleTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectTrigger =
             string.Format("SELECT {6},{7},{8},{9},{10},{11},{12},{13},{14},{15},{16},{17} FROM {0}{1} WHERE {2} = {3} AND {4} = @triggerName AND {5} = @triggerGroup",
-                TablePrefixSubst, TableTriggers, ColumnSchedulerName, SchedulerNameSubst, ColumnTriggerName, ColumnTriggerGroup,
+                TablePrefixSubst, TableTriggers, ColumnSchedulerName, "@schedulerName", ColumnTriggerName, ColumnTriggerGroup,
                 ColumnJobName, ColumnJobGroup, ColumnDescription, ColumnNextFireTime, ColumnPreviousFireTime, ColumnTriggerType, ColumnStartTime, ColumnEndTime, ColumnCalendarName, ColumnMifireInstruction, ColumnPriority, ColumnJobDataMap);
 
         public static readonly string SqlSelectTriggerData =
-            $"SELECT {ColumnJobDataMap} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT {ColumnJobDataMap} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectTriggerExistence =
-            $"SELECT {ColumnTriggerName} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT {ColumnTriggerName} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectTriggerForFireTime =
-            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} = @nextFireTime";
+            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} = @nextFireTime";
 
         public static readonly string SqlSelectTriggerGroups =
-            $"SELECT DISTINCT({ColumnTriggerGroup}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst}";
+            $"SELECT DISTINCT({ColumnTriggerGroup}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName";
 
         public static readonly string SqlSelectTriggerGroupsFiltered =
             string.Format("SELECT DISTINCT({0}) FROM {1}{2} WHERE {3} = {4} AND {0} LIKE @triggerGroup",
-                ColumnTriggerGroup, TablePrefixSubst, TableTriggers, ColumnSchedulerName, SchedulerNameSubst);
+                ColumnTriggerGroup, TablePrefixSubst, TableTriggers, ColumnSchedulerName, "@schedulerName");
 
         public static readonly string SqlSelectTriggerState =
-            $"SELECT {ColumnTriggerState} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT {ColumnTriggerState} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectTriggerStatus =
-            $"SELECT {ColumnTriggerState}, {ColumnNextFireTime}, {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT {ColumnTriggerState}, {ColumnNextFireTime}, {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectTriggersForCalendar =
-            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnCalendarName} = @calendarName";
+            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnCalendarName} = @calendarName";
 
         public static readonly string SqlSelectTriggersForJob =
-            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectTriggersInGroupLike =
-            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerGroup} LIKE @triggerGroup";
+            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup";
 
         public static readonly string SqlSelectTriggersInGroup =
-            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerGroup} = @triggerGroup";
+            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlSelectTriggersInState =
-            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerState} = @state";
+            $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state";
 
         // UPDATE 
 
         public static readonly string SqlUpdateBlobTrigger =
-            $"UPDATE {TablePrefixSubst}{TableBlobTriggers} SET {ColumnBlob} = @blob WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"UPDATE {TablePrefixSubst}{TableBlobTriggers} SET {ColumnBlob} = @blob WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlUpdateCalendar =
-            $"UPDATE {TablePrefixSubst}{TableCalendars} SET {ColumnCalendar} = @calendar WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnCalendarName} = @calendarName";
+            $"UPDATE {TablePrefixSubst}{TableCalendars} SET {ColumnCalendar} = @calendar WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnCalendarName} = @calendarName";
 
         public static readonly string SqlUpdateCronTrigger =
-            $"UPDATE {TablePrefixSubst}{TableCronTriggers} SET {ColumnCronExpression} = @triggerCronExpression, {ColumnTimeZoneId} = @timeZoneId WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"UPDATE {TablePrefixSubst}{TableCronTriggers} SET {ColumnCronExpression} = @triggerCronExpression, {ColumnTimeZoneId} = @timeZoneId WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlUpdateJobData =
-            $"UPDATE {TablePrefixSubst}{TableJobDetails} SET {ColumnJobDataMap} = @jobDataMap WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"UPDATE {TablePrefixSubst}{TableJobDetails} SET {ColumnJobDataMap} = @jobDataMap WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlUpdateJobDetail =
-            $"UPDATE {TablePrefixSubst}{TableJobDetails} SET {ColumnDescription} = @jobDescription, {ColumnJobClass} = @jobType, {ColumnIsDurable} = @jobDurable, {ColumnIsNonConcurrent} = @jobVolatile, {ColumnIsUpdateData} = @jobStateful, {ColumnRequestsRecovery} = @jobRequestsRecovery, {ColumnJobDataMap} = @jobDataMap  WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"UPDATE {TablePrefixSubst}{TableJobDetails} SET {ColumnDescription} = @jobDescription, {ColumnJobClass} = @jobType, {ColumnIsDurable} = @jobDurable, {ColumnIsNonConcurrent} = @jobVolatile, {ColumnIsUpdateData} = @jobStateful, {ColumnRequestsRecovery} = @jobRequestsRecovery, {ColumnJobDataMap} = @jobDataMap  WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlUpdateJobTriggerStates =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @state WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @state WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlUpdateJobTriggerStatesFromOtherState =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @state WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup AND {ColumnTriggerState} = @oldState";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @state WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup AND {ColumnTriggerState} = @oldState";
 
         public static readonly string SqlUpdateSchedulerState =
-            $"UPDATE {TablePrefixSubst}{TableSchedulerState} SET {ColumnLastCheckinTime} = @lastCheckinTime WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnInstanceName} = @instanceName";
+            $"UPDATE {TablePrefixSubst}{TableSchedulerState} SET {ColumnLastCheckinTime} = @lastCheckinTime WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName";
 
         public static readonly string SqlUpdateSimpleTrigger =
-            $"UPDATE {TablePrefixSubst}{TableSimpleTriggers} SET {ColumnRepeatCount} = @triggerRepeatCount, {ColumnRepeatInterval} = @triggerRepeatInterval, {ColumnTimesTriggered} = @triggerTimesTriggered WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"UPDATE {TablePrefixSubst}{TableSimpleTriggers} SET {ColumnRepeatCount} = @triggerRepeatCount, {ColumnRepeatInterval} = @triggerRepeatInterval, {ColumnTimesTriggered} = @triggerTimesTriggered WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlUpdateTrigger =
             $@"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnJobName} = @triggerJobName, {ColumnJobGroup} = @triggerJobGroup, {ColumnDescription} = @triggerDescription, {ColumnNextFireTime} = @triggerNextFireTime, {ColumnPreviousFireTime} = @triggerPreviousFireTime,
                         {ColumnTriggerState} = @triggerState, {ColumnTriggerType} = @triggerType, {ColumnStartTime} = @triggerStartTime, {ColumnEndTime} = @triggerEndTime, {ColumnCalendarName} = @triggerCalendarName, {ColumnMifireInstruction} = @triggerMisfireInstruction, {ColumnPriority} = @triggerPriority, {ColumnJobDataMap} = @triggerJobJobDataMap
-                        WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+                        WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlUpdateFiredTrigger = string.Format(
             "UPDATE {0}{1} SET {2} = @instanceName, {3} = @firedTime, {12} = @scheduledTime, {4} = @entryState, {5} = @jobName, {6} = @jobGroup, {7} = @isNonConcurrent, {8} = @requestsRecover WHERE {9} = {10} AND {11} = @entryId",
             TablePrefixSubst, TableFiredTriggers, ColumnInstanceName, ColumnFiredTime, ColumnEntryState,
-            ColumnJobName, ColumnJobGroup, ColumnIsNonConcurrent, ColumnRequestsRecovery, ColumnSchedulerName, SchedulerNameSubst, ColumnEntryId, ColumnScheduledTime);
+            ColumnJobName, ColumnJobGroup, ColumnIsNonConcurrent, ColumnRequestsRecovery, ColumnSchedulerName, "@schedulerName", ColumnEntryId, ColumnScheduledTime);
 
         public static readonly string SqlUpdateTriggerGroupStateFromState =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerGroup} LIKE @triggerGroup AND {ColumnTriggerState} = @oldState";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup AND {ColumnTriggerState} = @oldState";
 
         public static readonly string SqlUpdateTriggerGroupStateFromStates =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerGroup} LIKE @groupName AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @groupName AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)";
 
         public static readonly string SqlUpdateTriggerSkipData =
             $@"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnJobName} = @triggerJobName, {ColumnJobGroup} = @triggerJobGroup, {ColumnDescription} = @triggerDescription, {ColumnNextFireTime} = @triggerNextFireTime, {ColumnPreviousFireTime} = @triggerPreviousFireTime, 
                         {ColumnTriggerState} = @triggerState, {ColumnTriggerType} = @triggerType, {ColumnStartTime} = @triggerStartTime, {ColumnEndTime} = @triggerEndTime, {ColumnCalendarName} = @triggerCalendarName, {ColumnMifireInstruction} = @triggerMisfireInstruction, {ColumnPriority} = @triggerPriority
-                    WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+                    WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlUpdateTriggerState =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @state WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @state WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
         public static readonly string SqlUpdateTriggerStateFromState =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @oldState";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @oldState";
 
         public static readonly string SqlUpdateTriggerStateFromStates =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)";
 
         public static readonly string SqlUpdateTriggerStateFromStateWithNextFireTime =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @oldState AND {ColumnNextFireTime} = @nextFireTime";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @oldState AND {ColumnNextFireTime} = @nextFireTime";
 
         public static readonly string SqlUpdateTriggerStatesFromOtherStates =
-            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2)";
+            $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2)";
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -194,6 +194,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerStatesFromOtherStates)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "newState", newState);
                 AddCommandParameter(cmd, "oldState1", oldState1);
                 AddCommandParameter(cmd, "oldState2", oldState2);
@@ -215,6 +216,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectMisfiredTriggers)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "timestamp", GetDbDateTimeValue(ts));
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -244,6 +246,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggersInState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "state", state);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -275,6 +278,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectMisfiredTriggersInState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "timestamp", GetDbDateTimeValue(ts));
                 AddCommandParameter(cmd, "state", state);
 
@@ -318,6 +322,7 @@ namespace Quartz.Impl.AdoJobStore
             var sql = ReplaceTablePrefix(GetSelectNextMisfiredTriggersInStateToAcquireSql(count != -1 ? count + 1 : count));
             using (var cmd = PrepareCommand(conn, sql))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
                 AddCommandParameter(cmd, "state1", state1);
 
@@ -366,6 +371,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlCountMisfiredTriggersInStates)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
                 AddCommandParameter(cmd, "state1", state1);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -399,6 +405,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectMisfiredTriggersInGroupInState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "timestamp", GetDbDateTimeValue(ts));
                 AddCommandParameter(cmd, "triggerGroup", groupName);
                 AddCommandParameter(cmd, "state", state);
@@ -442,6 +449,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectInstancesRecoverableFiredTriggers)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "instanceName", instanceId);
                 AddCommandParameter(cmd, "requestsRecovery", GetDbBooleanValue(true));
 
@@ -509,6 +517,8 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteFiredTriggers)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
+
                 return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
@@ -527,6 +537,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteInstancesFiredTriggers)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "instanceName", instanceName);
                 return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -543,22 +554,31 @@ namespace Quartz.Impl.AdoJobStore
             CancellationToken cancellationToken = default)
         {
             DbCommand ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteAllSimpleTriggers));
+            AddCommandParameter(ps, "schedulerName", schedName);
             await ps.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteAllSimpropTriggers));
+            AddCommandParameter(ps, "schedulerName", schedName);
             await ps.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteAllCronTriggers));
+            AddCommandParameter(ps, "schedulerName", schedName);
             await ps.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteAllBlobTriggers));
+            AddCommandParameter(ps, "schedulerName", schedName);
             await ps.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteAllTriggers));
+            AddCommandParameter(ps, "schedulerName", schedName);
             await ps.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteAllJobDetails));
+            AddCommandParameter(ps, "schedulerName", schedName);
             await ps.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteAllCalendars));
+            AddCommandParameter(ps, "schedulerName", schedName);
             await ps.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteAllPausedTriggerGrps));
+            AddCommandParameter(ps, "schedulerName", schedName);
             await ps.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             ps = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteFiredTriggers));
+            AddCommandParameter(ps, "schedulerName", schedName);
             ps.ExecuteNonQuery();
         }
 
@@ -585,6 +605,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlInsertJobDetail)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", job.Key.Name);
                 AddCommandParameter(cmd, "jobGroup", job.Key.Group);
                 AddCommandParameter(cmd, "jobDescription", job.Description);
@@ -719,6 +740,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateJobDetail)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobDescription", job.Description);
                 AddCommandParameter(cmd, "jobType", GetStorableJobTypeName(job.JobType));
                 AddCommandParameter(cmd, "jobDurable", GetDbBooleanValue(job.Durable));
@@ -749,6 +771,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggersForJob)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -783,6 +806,7 @@ namespace Quartz.Impl.AdoJobStore
                 {
                     logger.Debug("Deleting job: " + jobKey);
                 }
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
                 return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -805,6 +829,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectJobNonConcurrent)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
 
@@ -832,6 +857,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectJobExistence)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
                 using (var dr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -862,6 +888,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateJobData)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobDataMap", baos, DbProvider.Metadata.DbBinaryType);
                 AddCommandParameter(cmd, "jobName", job.Key.Name);
                 AddCommandParameter(cmd, "jobGroup", job.Key.Group);
@@ -886,6 +913,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectJobDetail)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -987,6 +1015,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectNumJobs)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 return (int) await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
             }
         }
@@ -1003,6 +1032,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectJobGroups)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
                     List<string> list = new List<string>();
@@ -1043,6 +1073,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, sql))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobGroup", parameter);
 
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -1125,6 +1156,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlInsertTrigger)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
                 AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
                 AddCommandParameter(cmd, "triggerJobName", trigger.JobKey.Name);
@@ -1189,6 +1221,7 @@ namespace Quartz.Impl.AdoJobStore
             {
                 // update the blob
                 byte[] buf = SerializeObject(trigger);
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
                 AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
                 AddCommandParameter(cmd, "blob", buf, DbProvider.Metadata.DbBinaryType);
@@ -1232,6 +1265,7 @@ namespace Quartz.Impl.AdoJobStore
                 cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerSkipData));
             }
 
+            AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "triggerJobName", trigger.JobKey.Name);
             AddCommandParameter(cmd, "triggerJobGroup", trigger.JobKey.Group);
             AddCommandParameter(cmd, "triggerDescription", trigger.Description);
@@ -1306,6 +1340,7 @@ namespace Quartz.Impl.AdoJobStore
                 // update the blob
                 byte[] os = SerializeObject(trigger);
 
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "blob", os, DbProvider.Metadata.DbBinaryType);
                 AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
                 AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
@@ -1328,6 +1363,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerExistence)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -1358,6 +1394,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "state", state);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
@@ -1389,6 +1426,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerStateFromStates)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "newState", newState);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
@@ -1423,6 +1461,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerGroupStateFromStates)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "newState", newState);
                 AddCommandParameter(cmd, "groupName", ToSqlLikeClause(matcher));
                 AddCommandParameter(cmd, "oldState1", oldState1);
@@ -1452,6 +1491,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerStateFromState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "newState", newState);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
@@ -1482,6 +1522,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerStateFromStateWithNextFireTime)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "newState", newState);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
@@ -1511,6 +1552,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerGroupStateFromState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "newState", newState);
                 AddCommandParameter(cmd, "triggerGroup", ToSqlLikeClause(matcher));
                 AddCommandParameter(cmd, "oldState", oldState);
@@ -1535,6 +1577,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateJobTriggerStates)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "state", state);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
@@ -1561,6 +1604,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateJobTriggerStatesFromOtherState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "state", state);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
@@ -1584,6 +1628,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteBlobTrigger)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -1607,6 +1652,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteTrigger)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -1644,6 +1690,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectNumTriggersForJob)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
 
@@ -1676,6 +1723,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectJobForTrigger)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -1723,6 +1771,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggersForJob)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
 
@@ -1765,6 +1814,7 @@ namespace Quartz.Impl.AdoJobStore
             List<TriggerKey> keys = new List<TriggerKey>();
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggersForCalendar)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "calendarName", calName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -1812,6 +1862,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTrigger)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -1844,6 +1895,7 @@ namespace Quartz.Impl.AdoJobStore
             {
                 using (var cmd2 = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectBlobTrigger)))
                 {
+                    AddCommandParameter(cmd2, "schedulerName", schedName);
                     AddCommandParameter(cmd2, "triggerName", triggerKey.Name);
                     AddCommandParameter(cmd2, "triggerGroup", triggerKey.Group);
                     using (var rs2 = await cmd2.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -1915,6 +1967,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTrigger)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -1949,6 +2002,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerData)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
@@ -1984,6 +2038,7 @@ namespace Quartz.Impl.AdoJobStore
             {
                 string state;
 
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -2019,6 +2074,7 @@ namespace Quartz.Impl.AdoJobStore
             {
                 TriggerStatus status = null;
 
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -2053,6 +2109,8 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectNumTriggers)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
+
                 int count = 0;
 
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -2081,6 +2139,8 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerGroups)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
+
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
                     List<string> list = new List<string>();
@@ -2101,6 +2161,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerGroupsFiltered)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerGroup", ToSqlLikeClause(matcher));
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2144,6 +2205,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerGroup", parameter);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2171,6 +2233,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlInsertPausedTriggerGroup)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerGroup", groupName);
                 int rows = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
@@ -2192,6 +2255,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeletePausedTriggerGroup)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerGroup", groupName);
                 int rows = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
@@ -2206,6 +2270,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeletePausedTriggerGroup)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerGroup", ToSqlLikeClause(matcher));
                 int rows = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
@@ -2225,6 +2290,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeletePausedTriggerGroups)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 int rows = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 return rows;
             }
@@ -2246,6 +2312,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectPausedTriggerGroup)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerGroup", groupName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2270,6 +2337,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectNumTriggersInGroup)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerGroup", groupName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2306,6 +2374,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlInsertCalendar)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "calendarName", calendarName);
                 AddCommandParameter(cmd, "calendar", baos, DbProvider.Metadata.DbBinaryType);
 
@@ -2332,6 +2401,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateCalendar)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "calendar", baos, DbProvider.Metadata.DbBinaryType);
                 AddCommandParameter(cmd, "calendarName", calendarName);
 
@@ -2355,6 +2425,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectCalendarExistence)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "calendarName", calendarName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2382,6 +2453,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectCalendar)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "calendarName", calendarName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2415,6 +2487,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectReferencedCalendar)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "calendarName", calendarName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2442,6 +2515,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteCalendar)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "calendarName", calendarName);
                 return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -2459,6 +2533,8 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectNumCalendars)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
+
                 int count = 0;
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2485,6 +2561,8 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectCalendars)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
+
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
                     List<string> list = new List<string>();
@@ -2519,6 +2597,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerForFireTime)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "state", StateWaiting);
                 AddCommandParameter(cmd, "fireTime", GetDbDateTimeValue(fireTime));
 
@@ -2560,6 +2639,7 @@ namespace Quartz.Impl.AdoJobStore
             {
                 List<TriggerKey> nextTriggers = new List<TriggerKey>();
 
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "state", StateWaiting);
                 AddCommandParameter(cmd, "noLaterThan", GetDbDateTimeValue(noLaterThan));
                 AddCommandParameter(cmd, "noEarlierThan", GetDbDateTimeValue(noEarlierThan));
@@ -2599,6 +2679,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlInsertFiredTrigger)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerEntryId", trigger.FireInstanceId);
                 AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
                 AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
@@ -2648,6 +2729,7 @@ namespace Quartz.Impl.AdoJobStore
             CancellationToken cancellationToken = default)
         {
             var ps = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateFiredTrigger));
+            AddCommandParameter(ps, "schedulerName", schedName);
             AddCommandParameter(ps, "instanceName", instanceId);
             AddCommandParameter(ps, "firedTime", GetDbDateTimeValue(SystemTime.UtcNow()));
             AddCommandParameter(ps, "scheduledTime", GetDbDateTimeValue(trigger.GetNextFireTimeUtc()));
@@ -2695,12 +2777,14 @@ namespace Quartz.Impl.AdoJobStore
             if (triggerName != null)
             {
                 cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectFiredTrigger));
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerName", triggerName);
                 AddCommandParameter(cmd, "triggerGroup", groupName);
             }
             else
             {
                 cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectFiredTriggerGroup));
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerGroup", groupName);
             }
 
@@ -2750,12 +2834,14 @@ namespace Quartz.Impl.AdoJobStore
             if (jobName != null)
             {
                 cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectFiredTriggersOfJob));
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobName);
                 AddCommandParameter(cmd, "jobGroup", groupName);
             }
             else
             {
                 cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectFiredTriggersOfJobGroup));
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobGroup", groupName);
             }
 
@@ -2801,6 +2887,7 @@ namespace Quartz.Impl.AdoJobStore
 
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectInstancesFiredTriggers)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "instanceName", instanceName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -2845,6 +2932,7 @@ namespace Quartz.Impl.AdoJobStore
             var instanceNames = new ReadOnlyCompatibleHashSet<string>();
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectFiredTriggerInstanceNames)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
                     while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -2871,6 +2959,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteFiredTrigger)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "triggerEntryId", entryId);
                 return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -2890,6 +2979,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectJobExecutionCount)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "jobName", jobKey.Name);
                 AddCommandParameter(cmd, "jobGroup", jobKey.Group);
 
@@ -2923,6 +3013,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlInsertSchedulerState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "instanceName", instanceName);
                 AddCommandParameter(cmd, "lastCheckinTime", GetDbDateTimeValue(checkInTime));
                 AddCommandParameter(cmd, "checkinInterval", GetDbTimeSpanValue(interval));
@@ -2945,6 +3036,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeleteSchedulerState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "instanceName", instanceName);
 
                 return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -2967,6 +3059,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateSchedulerState)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 AddCommandParameter(cmd, "lastCheckinTime", GetDbDateTimeValue(checkInTime));
                 AddCommandParameter(cmd, "instanceName", instanceName);
 
@@ -3002,6 +3095,9 @@ namespace Quartz.Impl.AdoJobStore
             {
                 cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectSchedulerStates));
             }
+
+            AddCommandParameter(cmd, "schedulerName", schedName);
+
             using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
             {
                 while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -3030,12 +3126,13 @@ namespace Quartz.Impl.AdoJobStore
         {
             if (!cachedQueries.TryGetValue(query, out var result))
             {
-                cachedQueries[query] = result = AdoJobStoreUtil.ReplaceTablePrefix(query, tablePrefix, SchedulerNameLiteral);
+                cachedQueries[query] = result = AdoJobStoreUtil.ReplaceTablePrefix(query, tablePrefix);
             }
-            
+
             return result;
         }
 
+        [Obsolete("Scheduler name is now added to queries as a parameter")]
         protected string SchedulerNameLiteral
         {
             get
@@ -3239,6 +3336,7 @@ namespace Quartz.Impl.AdoJobStore
             var retValue = new ReadOnlyCompatibleHashSet<string>();
             using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectPausedTriggerGroups)))
             {
+                AddCommandParameter(cmd, "schedulerName", schedName);
                 using (var dr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                 {
                     while (await dr.ReadAsync(cancellationToken).ConfigureAwait(false))

--- a/src/Quartz/Impl/AdoJobStore/UpdateRowLockSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/UpdateRowLockSemaphore.cs
@@ -48,10 +48,10 @@ namespace Quartz.Impl.AdoJobStore
     public class UpdateLockRowSemaphore : DBSemaphore
     {
         public static readonly string SqlUpdateForLock =
-            $"UPDATE {TablePrefixSubst}{TableLocks} SET {ColumnLockName} = {ColumnLockName} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnLockName} = @lockName";
+            $"UPDATE {TablePrefixSubst}{TableLocks} SET {ColumnLockName} = {ColumnLockName} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnLockName} = @lockName";
 
         public static readonly string SqlInsertLock =
-            $"INSERT INTO {TablePrefixSubst}{TableLocks}({ColumnSchedulerName}, {ColumnLockName}) VALUES ({SchedulerNameSubst}, @lockName)";
+            $"INSERT INTO {TablePrefixSubst}{TableLocks}({ColumnSchedulerName}, {ColumnLockName}) VALUES (@schedulerName, @lockName)";
 
         protected virtual int RetryCount => 2;
 
@@ -130,6 +130,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             using (DbCommand cmd = AdoUtil.PrepareCommand(conn, sql))
             {
+                AdoUtil.AddCommandParameter(cmd, "schedulerName", SchedName);
                 AdoUtil.AddCommandParameter(cmd, "lockName", lockName);
 
                 if (Log.IsDebugEnabled())
@@ -156,14 +157,16 @@ namespace Quartz.Impl.AdoJobStore
             {
                 Log.DebugFormat("Inserting new lock row for lock: '{0}' being obtained: {1}", lockName, requestorId);
             }
+
             using (var cmd = AdoUtil.PrepareCommand(conn, sql))
             {
+                AdoUtil.AddCommandParameter(cmd, "schedulerName", SchedName);
                 AdoUtil.AddCommandParameter(cmd, "lockName", lockName);
 
                 if (await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false) != 1)
                 {
                     throw new InvalidOperationException(
-                        AdoJobStoreUtil.ReplaceTablePrefix("No row exists, and one could not be inserted in table " + TablePrefixSubst + TableLocks + " for lock named: " + lockName, TablePrefix, SchedulerNameLiteral));
+                        AdoJobStoreUtil.ReplaceTablePrefix("No row exists, and one could not be inserted in table " + TablePrefixSubst + TableLocks + " for lock named: " + lockName, TablePrefix));
                 }
             }
         }

--- a/src/Quartz/Impl/AdoJobStore/UpdateRowLockSemaphoreMOT.cs
+++ b/src/Quartz/Impl/AdoJobStore/UpdateRowLockSemaphoreMOT.cs
@@ -31,10 +31,10 @@ namespace Quartz.Impl.AdoJobStore
     public class UpdateLockRowSemaphoreMOT : UpdateLockRowSemaphore
     {
         private static readonly string SqlUpdateForLockMOT =
-            $"UPDATE {TablePrefixSubst}{TableLocks} WITH (SNAPSHOT) SET {ColumnLockName} = {ColumnLockName} WHERE {ColumnSchedulerName} = {SchedulerNameSubst} AND {ColumnLockName} = @lockName";
+            $"UPDATE {TablePrefixSubst}{TableLocks} WITH (SNAPSHOT) SET {ColumnLockName} = {ColumnLockName} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnLockName} = @lockName";
 
         private static readonly string SqlInsertLockMOT =
-            $"INSERT INTO {TablePrefixSubst}{TableLocks}({ColumnSchedulerName}, {ColumnLockName}) VALUES ({SchedulerNameSubst}, @lockName)";
+            $"INSERT INTO {TablePrefixSubst}{TableLocks}({ColumnSchedulerName}, {ColumnLockName}) VALUES (@schedulerName, @lockName)";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateLockRowSemaphoreMOT"/> class.


### PR DESCRIPTION
Running multiple schedulers against a single database results in high cpu due to multiple query plans being created,
by adding the scheduler name as a sql parameter, sql server is able to reuse the plans across multiple schedulers.

The SchedulerNameLiteral property available on a number of classes is no longer required by the core Quartz code, but has been left to maintain backward compatibility.

#817