### PR TITLE
Switch MySQL library to MySqlConnector

### DIFF
--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
@@ -102,7 +102,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         {
             NameValueCollection properties = new NameValueCollection();
             properties["quartz.jobStore.driverDelegateType"] = "Quartz.Impl.AdoJobStore.MySQLDelegate, Quartz";
-            return RunAdoJobStoreTest("MySql", "MySQL", serializerType, properties);
+            return RunAdoJobStoreTest("MySqlConnector", "MySQL", serializerType, properties);
         }
 
 #if NETCORE

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbMetadataTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbMetadataTest.cs
@@ -44,7 +44,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore.Common
         [Test]
         public void TestDbMetadataMySql()
         {
-            TestDbMetadata("MySql");
+            TestDbMetadata("MySqlConnector");
         }
 
 #if !NETCORE

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FakeItEasy" Version="5.2.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MySql.Data" Version="8.0.17" />
+    <PackageReference Include="MySqlConnector" Version="0.61.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Npgsql" Version="4.0.9" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.111" />

--- a/src/Quartz/Impl/AdoJobStore/Common/dbproviders.netstandard.properties
+++ b/src/Quartz/Impl/AdoJobStore/Common/dbproviders.netstandard.properties
@@ -26,7 +26,7 @@ quartz.dbprovider.Npgsql.useParameterNamePrefixInParameterCollection=true
 quartz.dbprovider.Npgsql.bindByName=true
 
 # MySQL
-quartz.dbprovider.MySql.productName=MySQL, MySQL provider
+quartz.dbprovider.MySql.productName=MySQL, Oracle MySQL Connector/NET provider
 quartz.dbprovider.MySql.assemblyName=MySql.Data
 quartz.dbprovider.MySql.connectionType=MySql.Data.MySqlClient.MySqlConnection, MySql.Data
 quartz.dbprovider.MySql.commandType=MySql.Data.MySqlClient.MySqlCommand, MySql.Data
@@ -38,6 +38,20 @@ quartz.dbprovider.MySql.exceptionType=MySql.Data.MySqlClient.MySqlException, MyS
 quartz.dbprovider.MySql.useParameterNamePrefixInParameterCollection=true
 quartz.dbprovider.MySql.bindByName=true
 quartz.dbprovider.MySql.dbBinaryTypeName=Blob
+
+# MySqlConnector
+quartz.dbprovider.MySqlConnector.productName=MySQL, MySqlConnector provider
+quartz.dbprovider.MySqlConnector.assemblyName=MySqlConnector
+quartz.dbprovider.MySqlConnector.connectionType=MySql.Data.MySqlClient.MySqlConnection, MySqlConnector
+quartz.dbprovider.MySqlConnector.commandType=MySql.Data.MySqlClient.MySqlCommand, MySqlConnector
+quartz.dbprovider.MySqlConnector.parameterType=MySql.Data.MySqlClient.MySqlParameter, MySqlConnector
+quartz.dbprovider.MySqlConnector.parameterDbType=MySql.Data.MySqlClient.MySqlDbType, MySqlConnector
+quartz.dbprovider.MySqlConnector.parameterDbTypePropertyName=MySqlDbType
+quartz.dbprovider.MySqlConnector.parameterNamePrefix=?
+quartz.dbprovider.MySqlConnector.exceptionType=MySql.Data.MySqlClient.MySqlException, MySqlConnector
+quartz.dbprovider.MySqlConnector.useParameterNamePrefixInParameterCollection=true
+quartz.dbprovider.MySqlConnector.bindByName=true
+quartz.dbprovider.MySqlConnector.dbBinaryTypeName=Blob
 
 # SQLite
 quartz.dbprovider.SQLite.assemblyName=System.Data.SQLite

--- a/src/Quartz/Impl/AdoJobStore/Common/dbproviders.properties
+++ b/src/Quartz/Impl/AdoJobStore/Common/dbproviders.properties
@@ -42,7 +42,7 @@ quartz.dbprovider.OracleODPManaged.bindByName=true
 quartz.dbprovider.OracleODPManaged.dbBinaryTypeName=Blob
 
 # MySQL
-quartz.dbprovider.MySql.productName=MySQL, MySQL provider
+quartz.dbprovider.MySql.productName=MySQL, Oracle MySQL Connector/NET provider
 quartz.dbprovider.MySql.assemblyName=MySql.Data
 quartz.dbprovider.MySql.connectionType=MySql.Data.MySqlClient.MySqlConnection, MySql.Data
 quartz.dbprovider.MySql.commandType=MySql.Data.MySqlClient.MySqlCommand, MySql.Data
@@ -54,6 +54,20 @@ quartz.dbprovider.MySql.exceptionType=MySql.Data.MySqlClient.MySqlException, MyS
 quartz.dbprovider.MySql.useParameterNamePrefixInParameterCollection=true
 quartz.dbprovider.MySql.bindByName=true
 quartz.dbprovider.MySql.dbBinaryTypeName=Blob
+
+# MySqlConnector
+quartz.dbprovider.MySqlConnector.productName=MySQL, MySqlConnector provider
+quartz.dbprovider.MySqlConnector.assemblyName=MySqlConnector
+quartz.dbprovider.MySqlConnector.connectionType=MySql.Data.MySqlClient.MySqlConnection, MySqlConnector
+quartz.dbprovider.MySqlConnector.commandType=MySql.Data.MySqlClient.MySqlCommand, MySqlConnector
+quartz.dbprovider.MySqlConnector.parameterType=MySql.Data.MySqlClient.MySqlParameter, MySqlConnector
+quartz.dbprovider.MySqlConnector.parameterDbType=MySql.Data.MySqlClient.MySqlDbType, MySqlConnector
+quartz.dbprovider.MySqlConnector.parameterDbTypePropertyName=MySqlDbType
+quartz.dbprovider.MySqlConnector.parameterNamePrefix=?
+quartz.dbprovider.MySqlConnector.exceptionType=MySql.Data.MySqlClient.MySqlException, MySqlConnector
+quartz.dbprovider.MySqlConnector.useParameterNamePrefixInParameterCollection=true
+quartz.dbprovider.MySqlConnector.bindByName=true
+quartz.dbprovider.MySqlConnector.dbBinaryTypeName=Blob
 
 # PostgreSQL Npgsql without version
 quartz.dbprovider.Npgsql.productName=Npgsql


### PR DESCRIPTION
#768

I wasn't sure if the existing library should be changed in-place (to give users good async behaviour by default) or if a new named provider should be added instead (less of a breaking change?).