### PR TITLE
Set TimeZoneUtil.CustomResolver in TimeZoneConverterPlugin.Initialize method

### DIFF
--- a/src/Quartz.Plugins.TimeZoneConverter/Plugin/TimeZoneConverter/TimeZoneConverterPlugin.cs
+++ b/src/Quartz.Plugins.TimeZoneConverter/Plugin/TimeZoneConverter/TimeZoneConverterPlugin.cs
@@ -35,8 +35,6 @@ namespace Quartz.Plugin.TimeZoneConverter
     /// </summary>
     public class TimeZoneConverterPlugin : ISchedulerPlugin
     {
-        private Func<string, TimeZoneInfo> originalResolver;
-
         /// <summary>
         /// Called during creation of the <see cref="IScheduler" /> in order to give
         /// the <see cref="ISchedulerPlugin" /> a chance to Initialize.
@@ -46,7 +44,8 @@ namespace Quartz.Plugin.TimeZoneConverter
             IScheduler scheduler,
             CancellationToken cancellationToken = default)
         {
-            // do nothing...
+            TimeZoneUtil.CustomResolver = TZConvert.GetTimeZoneInfo;
+
             return TaskUtil.CompletedTask;
         }
 
@@ -57,8 +56,6 @@ namespace Quartz.Plugin.TimeZoneConverter
         /// </summary>
         public Task Start(CancellationToken cancellationToken = default)
         {
-            originalResolver = TimeZoneUtil.CustomResolver;
-            TimeZoneUtil.CustomResolver = TZConvert.GetTimeZoneInfo;
             return TaskUtil.CompletedTask;
         }
 
@@ -69,7 +66,6 @@ namespace Quartz.Plugin.TimeZoneConverter
         /// </summary>
         public Task Shutdown(CancellationToken cancellationToken = default)
         {
-            TimeZoneUtil.CustomResolver = originalResolver;
             return TaskUtil.CompletedTask;
         }
     }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -369,8 +369,8 @@ namespace Quartz.Core
             if (!initialStart.HasValue)
             {
                 initialStart = SystemTime.UtcNow();
-                await StartPlugins(cancellationToken).ConfigureAwait(false);
                 await resources.JobStore.SchedulerStarted(cancellationToken).ConfigureAwait(false);
+                await StartPlugins(cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -369,8 +369,8 @@ namespace Quartz.Core
             if (!initialStart.HasValue)
             {
                 initialStart = SystemTime.UtcNow();
-                await resources.JobStore.SchedulerStarted(cancellationToken).ConfigureAwait(false);
                 await StartPlugins(cancellationToken).ConfigureAwait(false);
+                await resources.JobStore.SchedulerStarted(cancellationToken).ConfigureAwait(false);
             }
             else
             {


### PR DESCRIPTION
This fixes issue #831 with System.TimeZoneNotFoundException thrown even when Quartz.Plugins.TimeZoneConverter is used.