### PR TITLE
Use TEXT type instead of fixed-length VARCHAR

### DIFF
--- a/database/tables/tables_postgres.sql
+++ b/database/tables/tables_postgres.sql
@@ -13,11 +13,11 @@ DROP TABLE IF EXISTS qrtz_calendars;
 
 CREATE TABLE qrtz_job_details
   (
-    sched_name VARCHAR(120) NOT NULL,
-	job_name  VARCHAR(200) NOT NULL,
-    job_group VARCHAR(200) NOT NULL,
-    description VARCHAR(250) NULL,
-    job_class_name   VARCHAR(250) NOT NULL, 
+    sched_name TEXT NOT NULL,
+	job_name  TEXT NOT NULL,
+    job_group TEXT NOT NULL,
+    description TEXT NULL,
+    job_class_name   TEXT NOT NULL, 
     is_durable BOOL NOT NULL,
     is_nonconcurrent BOOL NOT NULL,
     is_update_data BOOL NOT NULL,
@@ -28,20 +28,20 @@ CREATE TABLE qrtz_job_details
 
 CREATE TABLE qrtz_triggers
   (
-    sched_name VARCHAR(120) NOT NULL,
-	trigger_name VARCHAR(150) NOT NULL,
-    trigger_group VARCHAR(150) NOT NULL,
-    job_name  VARCHAR(200) NOT NULL, 
-    job_group VARCHAR(200) NOT NULL,
-    description VARCHAR(250) NULL,
+    sched_name TEXT NOT NULL,
+	trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    job_name  TEXT NOT NULL, 
+    job_group TEXT NOT NULL,
+    description TEXT NULL,
     next_fire_time BIGINT NULL,
     prev_fire_time BIGINT NULL,
     priority INTEGER NULL,
-    trigger_state VARCHAR(16) NOT NULL,
-    trigger_type VARCHAR(8) NOT NULL,
+    trigger_state TEXT NOT NULL,
+    trigger_type TEXT NOT NULL,
     start_time BIGINT NOT NULL,
     end_time BIGINT NULL,
-    calendar_name VARCHAR(200) NULL,
+    calendar_name TEXT NULL,
     misfire_instr SMALLINT NULL,
     job_data BYTEA NULL,
     PRIMARY KEY (sched_name,trigger_name,trigger_group),
@@ -51,9 +51,9 @@ CREATE TABLE qrtz_triggers
 
 CREATE TABLE qrtz_simple_triggers
   (
-    sched_name VARCHAR(120) NOT NULL,
-	trigger_name VARCHAR(150) NOT NULL,
-    trigger_group VARCHAR(150) NOT NULL,
+    sched_name TEXT NOT NULL,
+	trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
     repeat_count BIGINT NOT NULL,
     repeat_interval BIGINT NOT NULL,
     times_triggered BIGINT NOT NULL,
@@ -64,12 +64,12 @@ CREATE TABLE qrtz_simple_triggers
 
 CREATE TABLE QRTZ_SIMPROP_TRIGGERS 
   (
-    sched_name VARCHAR (120) NOT NULL,
-    trigger_name VARCHAR (150) NOT NULL ,
-    trigger_group VARCHAR (150) NOT NULL ,
-    str_prop_1 VARCHAR (512) NULL,
-    str_prop_2 VARCHAR (512) NULL,
-    str_prop_3 VARCHAR (512) NULL,
+    sched_name TEXT NOT NULL,
+    trigger_name TEXT NOT NULL ,
+    trigger_group TEXT NOT NULL ,
+    str_prop_1 TEXT NULL,
+    str_prop_2 TEXT NULL,
+    str_prop_3 TEXT NULL,
     int_prop_1 INTEGER NULL,
     int_prop_2 INTEGER NULL,
     long_prop_1 BIGINT NULL,
@@ -78,7 +78,7 @@ CREATE TABLE QRTZ_SIMPROP_TRIGGERS
     dec_prop_2 NUMERIC NULL,
     bool_prop_1 BOOL NULL,
     bool_prop_2 BOOL NULL,
-	time_zone_id VARCHAR(80) NULL,
+	time_zone_id TEXT NULL,
 	PRIMARY KEY (sched_name,trigger_name,trigger_group),
     FOREIGN KEY (sched_name,trigger_name,trigger_group) 
 		REFERENCES qrtz_triggers(sched_name,trigger_name,trigger_group) ON DELETE CASCADE
@@ -86,11 +86,11 @@ CREATE TABLE QRTZ_SIMPROP_TRIGGERS
 
 CREATE TABLE qrtz_cron_triggers
   (
-    sched_name VARCHAR (120) NOT NULL,
-    trigger_name VARCHAR(150) NOT NULL,
-    trigger_group VARCHAR(150) NOT NULL,
-    cron_expression VARCHAR(250) NOT NULL,
-    time_zone_id VARCHAR(80),
+    sched_name TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    cron_expression TEXT NOT NULL,
+    time_zone_id TEXT,
     PRIMARY KEY (sched_name,trigger_name,trigger_group),
     FOREIGN KEY (sched_name,trigger_name,trigger_group) 
 		REFERENCES qrtz_triggers(sched_name,trigger_name,trigger_group) ON DELETE CASCADE
@@ -98,9 +98,9 @@ CREATE TABLE qrtz_cron_triggers
 
 CREATE TABLE qrtz_blob_triggers
   (
-    sched_name VARCHAR (120) NOT NULL,
-    trigger_name VARCHAR(150) NOT NULL,
-    trigger_group VARCHAR(150) NOT NULL,
+    sched_name TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
     blob_data BYTEA NULL,
     PRIMARY KEY (sched_name,trigger_name,trigger_group),
     FOREIGN KEY (sched_name,trigger_name,trigger_group) 
@@ -109,32 +109,32 @@ CREATE TABLE qrtz_blob_triggers
 
 CREATE TABLE qrtz_calendars
   (
-    sched_name VARCHAR (120) NOT NULL,
-    calendar_name  VARCHAR(200) NOT NULL, 
+    sched_name TEXT NOT NULL,
+    calendar_name  TEXT NOT NULL, 
     calendar BYTEA NOT NULL,
     PRIMARY KEY (sched_name,calendar_name)
 );
 
 CREATE TABLE qrtz_paused_trigger_grps
   (
-    sched_name VARCHAR (120) NOT NULL,
-    trigger_group VARCHAR(150) NOT NULL, 
+    sched_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL, 
     PRIMARY KEY (sched_name,trigger_group)
 );
 
 CREATE TABLE qrtz_fired_triggers 
   (
-    sched_name VARCHAR (120) NOT NULL,
-    entry_id VARCHAR(140) NOT NULL,
-    trigger_name VARCHAR(150) NOT NULL,
-    trigger_group VARCHAR(150) NOT NULL,
-    instance_name VARCHAR(200) NOT NULL,
+    sched_name TEXT NOT NULL,
+    entry_id TEXT NOT NULL,
+    trigger_name TEXT NOT NULL,
+    trigger_group TEXT NOT NULL,
+    instance_name TEXT NOT NULL,
     fired_time BIGINT NOT NULL,
 	sched_time BIGINT NOT NULL,
     priority INTEGER NOT NULL,
-    state VARCHAR(16) NOT NULL,
-    job_name VARCHAR(200) NULL,
-    job_group VARCHAR(200) NULL,
+    state TEXT NOT NULL,
+    job_name TEXT NULL,
+    job_group TEXT NULL,
     is_nonconcurrent BOOL NOT NULL,
     requests_recovery BOOL NULL,
     PRIMARY KEY (sched_name,entry_id)
@@ -142,8 +142,8 @@ CREATE TABLE qrtz_fired_triggers
 
 CREATE TABLE qrtz_scheduler_state 
   (
-    sched_name VARCHAR (120) NOT NULL,
-    instance_name VARCHAR(200) NOT NULL,
+    sched_name TEXT NOT NULL,
+    instance_name TEXT NOT NULL,
     last_checkin_time BIGINT NOT NULL,
     checkin_interval BIGINT NOT NULL,
     PRIMARY KEY (sched_name,instance_name)
@@ -151,8 +151,8 @@ CREATE TABLE qrtz_scheduler_state
 
 CREATE TABLE qrtz_locks
   (
-    sched_name VARCHAR (120) NOT NULL,
-    lock_name  VARCHAR(40) NOT NULL, 
+    sched_name TEXT NOT NULL,
+    lock_name  TEXT NOT NULL, 
     PRIMARY KEY (sched_name,lock_name)
 );
 


### PR DESCRIPTION
for Postgres tables.

It's quite annoying to get errors about exceeding the limit when e.g. some job class name is very long.
I don't see any reason not to represent them as unlimited TEXT... this data type as been in Postgres since very old versions (7.1 from 2001 has it!) and [Postgres docs say "There is no performance difference"](https://www.postgresql.org/docs/10/datatype-character.html)