### PR TITLE
Fix Deserialization of DateTimeOffset when using JsonObjectSerializer

### DIFF
--- a/src/Quartz.Serialization.Json/Simpl/JsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.Json/Simpl/JsonObjectSerializer.cs
@@ -46,7 +46,8 @@ namespace Quartz.Simpl
                 {
                     IgnoreSerializableInterface = true
                 },
-                NullValueHandling = NullValueHandling.Ignore
+                NullValueHandling = NullValueHandling.Ignore,
+                DateParseHandling = DateParseHandling.DateTimeOffset
             };
         }
 


### PR DESCRIPTION
fixes #840
fixes #834

This fix instructs Newtonsoft to Serialize and Deserialize date objects as a DateTimeOffset. Because a DateTimeOffset can be cast in to a DateTime object, this fix shouldn't effect any DateTime serialization.

Here is an example that demonstrates the original issue: https://dotnetfiddle.net/5Q1gUZ