### PR TITLE
eliminate the chance that the factory code will run multiple times

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/Common/DbProvider.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/DbProvider.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -49,7 +50,8 @@ namespace Quartz.Impl.AdoJobStore.Common
         private readonly MethodInfo commandBindByNamePropertySetter;
 
         private static readonly List<DbMetadataFactory> dbMetadataFactories;
-        private static readonly Dictionary<string, DbMetadata> dbMetadataLookup = new Dictionary<string, DbMetadata>();
+        // needs to allow concurrent threads to read and update, since field is static
+        private static readonly ConcurrentDictionary<string, DbMetadata> dbMetadataLookup = new ConcurrentDictionary<string, DbMetadata>();
 
         /// <summary>
         /// Parse metadata once in static constructor.


### PR DESCRIPTION
I changed dbMetadataLookup from ConcurrentDictionary<string, DbMetadata> to ConcurrentDictionary<string, Lazy<DbMetadata>> and changed GetDbMetadata to use GetOrAdd.  What this does is prevent dbMetadataFactory.GetDbMetadata from getting called multiple times if the same provider is requested at the same time on multiple threads at initialization.  It won't prevent any exceptions from the previous version of code, but it will eliminate the possibility that potentially slow code might execute more than once.