### PR TITLE
Reuse lock requestor id for subsequent calls in ExecuteInNonManagedTXLock

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,8 +9,12 @@
 * NEW FEATURES
 
 	* DI configuration now supports adding schdeuler, job and trigger listeners (#877)
-	* DI configuration now processes appsettings.json section "Quartz" looking for key value pairs
-	* Use Microsoft.Data.SqlClient as SQL Server connection library
+	* DI configuration now processes appsettings.json section "Quartz" looking for key value pairs (#877)
+	* Use Microsoft.Data.SqlClient as SQL Server connection library (#839)
+	
+* FIXES
+
+    * Fix potential scheduler deadlock caused by changed lock request id inside ExecuteInNonManagedTXLock (#794)
 
 ## Release 3.1.0 beta 1, Jul 8 2020
 


### PR DESCRIPTION

fixes #794