### PR TITLE
Update timezoneconverter-integration.md

### DIFF
--- a/docs/documentation/quartz-3.x/packages/timezoneconverter-integration.md
+++ b/docs/documentation/quartz-3.x/packages/timezoneconverter-integration.md
@@ -14,7 +14,7 @@ You need to add NuGet package reference to your project which uses Quartz.
 ```csharp
 var properties = new NameValueCollection
 {
-	["quartz.plugin.timeZoneConverter.type"] = "Quartz.Plugin.TimeZoneConverter, Quartz.Plugins.TimeZoneConverter"
+	["quartz.plugin.timeZoneConverter.type"] = "Quartz.Plugin.TimeZoneConverter.TimeZoneConverterPlugin, Quartz.Plugins.TimeZoneConverter"
 };
 ISchedulerFactory schedulerFactory = new StdSchedulerFactory(properties);
 ```


### PR DESCRIPTION
Update docs to use correct plugin namespace.

Using the current namespace from the documentation yields the following startup exception.
```
Using custom data access locking (synchronization): Quartz.Impl.AdoJobStore.UpdateLockRowSemaphore
Unhandled exception. Quartz.SchedulerException: SchedulerPlugin of type 'Quartz.Plugin.TimeZoneConverter, Quartz.Plugins.TimeZoneConverter' could not be instantiated.
```