### PR TITLE
Use 2.1 as the minimum version for the .NET Platform Extensions

### DIFF
--- a/src/Quartz.AspNetCore/AspNetCore/HealthChecks/QuartzHealthCheck.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HealthChecks/QuartzHealthCheck.cs
@@ -1,3 +1,4 @@
+#if SUPPORTS_HEALTH_CHECKS
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -50,3 +51,4 @@ namespace Quartz.AspNetCore.HealthChecks
         }
     }
 }
+#endif

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -1,25 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Description>Quartz.NET ASP.NET Core integration; $(Description)</Description>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <RootNamespace>Quartz</RootNamespace>
-        <GenerateDocumentationFile>True</GenerateDocumentationFile>
-        <Authors>Lewis Zou, Marko Lahma, Quartz.NET</Authors>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="..\AssemblyInfo.cs" />
-    </ItemGroup>
+  <PropertyGroup>
+    <Description>Quartz.NET ASP.NET Core integration; $(Description)</Description>
+    <TargetFrameworks>netcoreapp2.2;netstandard2.0</TargetFrameworks>
+    <RootNamespace>Quartz</RootNamespace>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <Authors>Lewis Zou, Marko Lahma, Quartz.NET</Authors>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Quartz.Extensions.DependencyInjection\Quartz.Extensions.DependencyInjection.csproj" />
-      <ProjectReference Include="..\Quartz.Extensions.Hosting\Quartz.Extensions.Hosting.csproj" />
-      <ProjectReference Include="..\Quartz\Quartz.csproj" />
-    </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz.Extensions.DependencyInjection\Quartz.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\Quartz.Extensions.Hosting\Quartz.Extensions.Hosting.csproj" />
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_HEALTH_CHECKS</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/Quartz.AspNetCore/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz.AspNetCore/QuartzServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 
+#if SUPPORTS_HEALTH_CHECKS
 using Quartz.AspNetCore.HealthChecks;
+#endif
 
 namespace Quartz
 {
@@ -13,22 +14,16 @@ namespace Quartz
             this IServiceCollection services,
             Action<QuartzHostedServiceOptions>? configure = null)
         {
+#if SUPPORTS_HEALTH_CHECKS
             var check = new QuartzHealthCheck();
             services
                 .AddHealthChecks()
-                .AddQuartzHealthCheck<QuartzHealthCheck>("scheduler", check);
+                .AddCheck("quartz-scheduler", check);
 
             services.AddSingleton<ISchedulerListener>(check);
+#endif
 
             return services.AddQuartzHostedService(configure);
-        }
-
-        private static IHealthChecksBuilder AddQuartzHealthCheck<T>(
-            this IHealthChecksBuilder builder,
-            string suffix,
-            IHealthCheck check)
-        {
-            return builder.AddCheck($"quartz-{suffix}", check);
         }
     }
 }

--- a/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj
+++ b/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.6" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.6" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj
+++ b/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj
@@ -7,12 +7,13 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Andrew Lock, Marko Lahma, Quartz.NET</Authors>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Server/Quartz.Server.csproj
+++ b/src/Quartz.Server/Quartz.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFullFrameworkVersion);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFullFrameworkVersion);netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;$(TargetFullFrameworkVersion)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
   </PropertyGroup>
@@ -21,7 +21,7 @@
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;$(TargetFullFrameworkVersion)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <ProjectReference Include="..\Quartz.Plugins.TimeZoneConverter\Quartz.Plugins.TimeZoneConverter.csproj" />
     <ProjectReference Include="..\Quartz.Serialization.Json\Quartz.Serialization.Json.csproj" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
As discussed in https://github.com/openiddict/openiddict-core/issues/361, this PR updates the various .csproj to use 2.1 as the minimum version for the .NET Platform Extensions, but without forcing a specific range to allow users to explicitly reference newer versions.

/cc @lahma 