### PR TITLE
Fix - Parsing boolean db value

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -651,7 +651,7 @@ namespace Quartz.Impl.AdoJobStore
         {
             if (columnValue != null && columnValue != DBNull.Value)
             {
-                return Convert.ToBoolean(columnValue);
+                return !bool.TryParse(columnValue as string, out var success) ? columnValue.ToString() == "1" : success;
             }
 
             throw new ArgumentException("Value must be non-null.");


### PR DESCRIPTION
DbValue for boolean is "0" or "1" and cannot be parsed by bool.Parse. It throws an exception.
Falling back on TryParse then check string equality on error.