### PR TITLE
Register an ITypeLoadHelper by default in services.AddQuartz()

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 
 using Quartz.Logging;
 using Quartz.Simpl;
+using Quartz.Spi;
 
 namespace Quartz
 {
@@ -33,6 +34,9 @@ namespace Quartz
             
             var builder = new ServiceCollectionQuartzConfigurator(services, SchedulerBuilder.Create());
             configure?.Invoke(builder);
+            
+            // Note that we can't call UseSimpleTypeLoader(), as that would overwrite any other configured type loaders
+            services.TryAddSingleton(typeof(ITypeLoadHelper), typeof(SimpleTypeLoadHelper));
             
             services.AddSingleton<ISchedulerFactory>(serviceProvider =>
             {


### PR DESCRIPTION
The `SimpleTypeLoadHelper` is used by default in the `StdSchedulerFactory` if no other `ITypeLoadHelper` is registered:

https://github.com/quartznet/quartznet/blob/9193fac3587b9a020bf861d2404d463d67e05b07/src/Quartz/Impl/StdSchedulerFactory.cs#L416

But if you don't explicitly call `UseSimpleTypeLoader()`, the required type isn't registered in DI and you get an `InvalidOperationException` on startup.

This changes registers the required service, as long as no other `ITypeLoadHelper` is added inside the call to `AddQuartz()`.

Unfortunately we can't call UseSimpleTypeLoader(), as that would overwrite the configuration for any other configured type loader (while leaving the service registration intact):

https://github.com/quartznet/quartznet/blob/89b414f142010086d057c70085d4fe3c65b39f26/src/Quartz.Extensions.DependencyInjection/ServiceCollectionQuartzConfigurator.cs#L76-L80

Fixes #924