### PR TITLE
fixes #939 SqlServer AdoJobStore SqlParameter without text size

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
@@ -78,6 +78,12 @@ namespace Quartz.Impl.AdoJobStore
                 size = -1;
             }
 
+            // avoid size inferred from value that cause multiple query plans
+            if (size == null && paramValue is string)
+            {
+                size = 4000;
+            }
+
             base.AddCommandParameter(cmd, paramName, paramValue, dataType, size);
         }
     }


### PR DESCRIPTION
fixes #939 SqlServer AdoJobStore SqlParameter without text size.

I'm not sure about the comment in the committed code, if you want to keep it or not.