### PR TITLE
Add clear exception message, remove not null check

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -35,11 +35,14 @@ namespace Quartz
             services.AddOptions();
             services.TryAddSingleton<MicrosoftLoggingProvider?>(serviceProvider =>
             {
-                var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-                if (loggerFactory != null)
+                var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+
+                if (loggerFactory is null)
                 {
-                    LogContext.SetCurrentLogProvider(loggerFactory);
+                    throw new InvalidOperationException($"{nameof(ILoggerFactory)} service is required");
                 }
+
+                LogContext.SetCurrentLogProvider(loggerFactory);
 
                 return LogProvider.CurrentLogProvider as MicrosoftLoggingProvider;
             });


### PR DESCRIPTION
I am trying to integrate MassTransit with Quartz scheduler https://github.com/MassTransit/MassTransit/issues/2065

MassTransit integration breaks Quartz jobs replacing JobFactory with special one

For workaround i create new DI container, configure new ISchedulerFactory and pass it to MassTransit to not to affect old one for Quartz

Example:
```cs
var scheduler = new ServiceCollection()
        // My common Quartz extension, uses .AddQuartz()
	.AddQuartzExtension(
		connectionStringBuilder,
		environment,
		configurator =>
		{
			// ...
		})
        // ILoggerFactory is required
	.AddSingleton(context.GetRequiredService<ILoggerFactory>())
	.BuildServiceProvider()
	.GetRequiredService<ISchedulerFactory>();
```

If in new DI container is no `ILoggerFactory` quartz throws because of `.GetRequiredService`, next check for `!= null` is redundant and long, unreadable exception throws from DI