### PR TITLE
Allow concurrent access to XML file with job and trigger definitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,10 +10,7 @@ This is a maintenance release containing mostly bud fixes.
 
   * Make QuartzOptions Triggers and JobDetails public (#981)
   * Fix configuration system injection for dictionary/quartz.jobStore.misfireThreshold in DI (#983)
-
-* NEW FEATURE
-
-  * Allow concurrent access to XML file with job and trigger definitions (#993)
+  * XMLSchedulingDataProcessor can cause IOException due to file locking (#993)
 
 ## Release 3.2.0, Oct 1 2020
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ This is a maintenance release containing mostly bud fixes.
   * Make QuartzOptions Triggers and JobDetails public (#981)
   * Fix configuration system injection for dictionary/quartz.jobStore.misfireThreshold in DI (#983)
 
+* NEW FEATURE
+
+  * Allow concurrent access to XML file with job and trigger definitions (#993)
+
 ## Release 3.2.0, Oct 1 2020
 
 This is a release that focuses on restructuring some packages that warrants for a minor version number increment.

--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -173,7 +173,7 @@ namespace Quartz.Xml
 
             Log.InfoFormat("Parsing XML file: {0} with systemId: {1}", fileName, systemId);
 
-            using (var stream = File.Open(fileName, FileMode.Open, FileAccess.Read))
+            using (var stream = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (StreamReader sr = new StreamReader(stream))
             {
                 ProcessInternal(await sr.ReadToEndAsync().ConfigureAwait(false));


### PR DESCRIPTION
Changes the way how XMLSchedulingDataProcessor opens the XML file with job and trigger definitions to allow concurrent read-only access from other processes.

fixes #993