### PR TITLE
Optimize job dispatch performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ node_modules
 
 docs/.vuepress/dist
 /node_modules
+BenchmarkDotNet.Artifacts

--- a/Quartz.sln
+++ b/Quartz.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quartz.Extensions.Hosting",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quartz.Examples.Worker", "src\Quartz.Examples.Worker\Quartz.Examples.Worker.csproj", "{2BB03F5A-7736-42E9-A572-5D60336A9BFF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quartz.Benchmark", "src\Quartz.Benchmark\Quartz.Benchmark.csproj", "{23DEAB6E-D12C-40F6-A50E-6584FEAA389C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -113,6 +115,10 @@ Global
 		{2BB03F5A-7736-42E9-A572-5D60336A9BFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2BB03F5A-7736-42E9-A572-5D60336A9BFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2BB03F5A-7736-42E9-A572-5D60336A9BFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23DEAB6E-D12C-40F6-A50E-6584FEAA389C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23DEAB6E-D12C-40F6-A50E-6584FEAA389C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23DEAB6E-D12C-40F6-A50E-6584FEAA389C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23DEAB6E-D12C-40F6-A50E-6584FEAA389C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@ now also works as expected.
 * IMPROVEMENTS
   
   * Unify MS dependency injection job factory logic and configuration (#995)
-  * Improve job dispatch performance to reduce latency before hitting Execute (#996)
+  * Improve job dispatch performance to reduce latency before hitting Execute (RAMJobStore) (#996)
 
 ## Release 3.2.0, Oct 1 2020
 

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ now also works as expected.
 * IMPROVEMENTS
   
   * Unify MS dependency injection job factory logic and configuration (#995)
+  * Improve job dispatch performance to reduce latency before hitting Execute (#996)
 
 ## Release 3.2.0, Oct 1 2020
 

--- a/src/Quartz.Benchmark/JobDispatchBenchmark.cs
+++ b/src/Quartz.Benchmark/JobDispatchBenchmark.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using Quartz.Core;
+using Quartz.Impl;
+using Quartz.Job;
+using Quartz.Spi;
+
+namespace Quartz.Benchmark
+{
+    [MemoryDiagnoser]
+    public class JobDispatchBenchmark
+    {
+        private StdScheduler scheduler;
+        private JobRunShell shell;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            scheduler = (StdScheduler) new StdSchedulerFactory().GetScheduler().GetAwaiter().GetResult();
+            var job = JobBuilder.Create<NoOpJob>().Build();
+            var trigger = (IOperableTrigger) TriggerBuilder.Create().ForJob(job.Key).WithSimpleSchedule().StartNow().Build();
+            trigger.FireInstanceId = "fire-instance-id";
+            var bundle = new TriggerFiredBundle(job, trigger, null, false, DateTimeOffset.UtcNow, null, null, null);
+            shell = new JobRunShell(scheduler, bundle);
+        }
+        
+        [Benchmark]
+        public async Task Run()
+        {
+            await shell.Initialize(scheduler.sched);
+            await shell.Run();
+        }
+    }
+}

--- a/src/Quartz.Benchmark/JobDispatchBenchmark.cs
+++ b/src/Quartz.Benchmark/JobDispatchBenchmark.cs
@@ -21,8 +21,14 @@ namespace Quartz.Benchmark
         {
             scheduler = (StdScheduler) new StdSchedulerFactory().GetScheduler().GetAwaiter().GetResult();
             var job = JobBuilder.Create<NoOpJob>().Build();
-            var trigger = (IOperableTrigger) TriggerBuilder.Create().ForJob(job.Key).WithSimpleSchedule().StartNow().Build();
+            var trigger = (IOperableTrigger) TriggerBuilder.Create()
+                .ForJob(job.Key)
+                .WithSimpleSchedule()
+                .StartNow()
+                .Build();
+
             trigger.FireInstanceId = "fire-instance-id";
+            trigger.SetNextFireTimeUtc(DateTimeOffset.UtcNow.AddSeconds(10));
             var bundle = new TriggerFiredBundle(job, trigger, null, false, DateTimeOffset.UtcNow, null, null, null);
             shell = new JobRunShell(scheduler, bundle);
         }

--- a/src/Quartz.Benchmark/Program.cs
+++ b/src/Quartz.Benchmark/Program.cs
@@ -8,9 +8,9 @@ namespace Quartz.Benchmark
     {
         private static void Main(string[] args)
         {
-            //BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run();
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run();
 
-            DispatchBenchmark();
+            //DispatchBenchmark();
         }
 
         private static void DispatchBenchmark()

--- a/src/Quartz.Benchmark/Program.cs
+++ b/src/Quartz.Benchmark/Program.cs
@@ -8,9 +8,9 @@ namespace Quartz.Benchmark
     {
         private static void Main(string[] args)
         {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run();
+            //BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run();
 
-            //DispatchBenchmark();
+            DispatchBenchmark();
         }
 
         private static void DispatchBenchmark()

--- a/src/Quartz.Benchmark/Program.cs
+++ b/src/Quartz.Benchmark/Program.cs
@@ -1,0 +1,34 @@
+﻿using System.Runtime.CompilerServices;
+
+using BenchmarkDotNet.Running;
+
+namespace Quartz.Benchmark
+{
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run();
+
+            //DispatchBenchmark();
+        }
+
+        private static void DispatchBenchmark()
+        {
+            var benchmark = new JobDispatchBenchmark();
+            benchmark.Setup();
+            benchmark.Run().GetAwaiter().GetResult();
+
+            RunDispatch(benchmark);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void RunDispatch(JobDispatchBenchmark benchmark)
+        {
+            for (int i = 0; i < 100; ++i)
+            {
+                benchmark.Run().GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Quartz.Jobs\Quartz.Jobs.csproj" />
+      <ProjectReference Include="..\Quartz\Quartz.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Quartz.Examples/01_SimpleJobScheduler/HelloJob.cs
+++ b/src/Quartz.Examples/01_SimpleJobScheduler/HelloJob.cs
@@ -39,7 +39,8 @@ namespace Quartz.Examples.Example01
         public virtual Task Execute(IJobExecutionContext context)
         {
             // Say Hello to the World and display the date/time
-            Console.WriteLine($"Hello World! - {DateTime.Now:r}");
+            var timestamp = DateTime.Now;
+            Console.WriteLine($"Hello World! - {timestamp:yyyy-MM-dd HH:mm:ss.fff}");
             return Task.CompletedTask;
         }
     }

--- a/src/Quartz/Collections/EmptyEnumerator.cs
+++ b/src/Quartz/Collections/EmptyEnumerator.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Quartz.Collections
+{
+    internal class EmptyEnumerator<T> : IEnumerator<T>
+    {
+        public static EmptyEnumerator<T> Instance = new EmptyEnumerator<T>();
+        
+        public bool MoveNext() => false;
+
+        public void Reset()
+        {
+        }
+
+        public T Current => default!;
+
+        object? IEnumerator.Current => Current;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Quartz/Collections/EmptyReadOnlyCollection.cs
+++ b/src/Quartz/Collections/EmptyReadOnlyCollection.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Quartz.Collections
+{
+    internal sealed class EmptyReadOnlyCollection<T> : IReadOnlyCollection<T>
+    {
+        public static readonly IReadOnlyCollection<T> Instance = new EmptyReadOnlyCollection<T>();
+
+        public EmptyEnumerator<T> GetEnumerator() => EmptyEnumerator<T>.Instance;
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => EmptyEnumerator<T>.Instance;
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public int Count => 0;
+    }
+}

--- a/src/Quartz/Collections/HashHelpers.cs
+++ b/src/Quartz/Collections/HashHelpers.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace Quartz.Collections
+{
+    internal static partial class HashHelpers
+    {
+        internal static int PowerOf2(int v)
+        {
+            if ((v & (v - 1)) == 0) return v;
+            int i = 2;
+            while (i < v) i <<= 1;
+            return i;
+        }
+
+        // must never be written to
+        internal static readonly int[] SizeOneIntArray = new int[1];
+
+        public const int HashCollisionThreshold = 100;
+
+        // This is the maximum prime smaller than Array.MaxArrayLength
+        public const int MaxPrimeArrayLength = 0x7FEFFFFD;
+
+        public const int HashPrime = 101;
+
+        // Table of prime numbers to use as hash table sizes. 
+        // A typical resize algorithm would pick the smallest prime number in this array
+        // that is larger than twice the previous capacity. 
+        // Suppose our Hashtable currently has capacity x and enough elements are added 
+        // such that a resize needs to occur. Resizing first computes 2x then finds the 
+        // first prime in the table greater than 2x, i.e. if primes are ordered 
+        // p_1, p_2, ..., p_i, ..., it finds p_n such that p_n-1 < 2x < p_n. 
+        // Doubling is important for preserving the asymptotic complexity of the 
+        // hashtable operations such as add.  Having a prime guarantees that double 
+        // hashing does not lead to infinite loops.  IE, your hash function will be 
+        // h1(key) + i*h2(key), 0 <= i < size.  h2 and the size must be relatively prime.
+        // We prefer the low computation costs of higher prime numbers over the increased
+        // memory allocation of a fixed prime number i.e. when right sizing a HashSet.
+        public static readonly int[] primes = {
+            3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
+            1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
+            17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
+            187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
+            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369 };
+
+        public static bool IsPrime(int candidate)
+        {
+            if ((candidate & 1) != 0)
+            {
+                int limit = (int)Math.Sqrt(candidate);
+                for (int divisor = 3; divisor <= limit; divisor += 2)
+                {
+                    if ((candidate % divisor) == 0)
+                        return false;
+                }
+                return true;
+            }
+            return (candidate == 2);
+        }
+
+        public static int GetPrime(int min)
+        {
+            if (min < 0)
+                throw new ArgumentException("Hashtable's capacity overflowed and went negative. Check load factor, capacity and the current size of the table.");
+
+            for (int i = 0; i < primes.Length; i++)
+            {
+                int prime = primes[i];
+                if (prime >= min)
+                    return prime;
+            }
+
+            //outside of our predefined table. 
+            //compute the hard way. 
+            for (int i = (min | 1); i < int.MaxValue; i += 2)
+            {
+                if (IsPrime(i) && ((i - 1) % HashPrime != 0))
+                    return i;
+            }
+            return min;
+        }
+
+        // Returns size of hashtable to grow to.
+        public static int ExpandPrime(int oldSize)
+        {
+            int newSize = 2 * oldSize;
+
+            // Allow the hashtables to grow to maximum possible size (~2G elements) before encountering capacity overflow.
+            // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
+            if ((uint)newSize > MaxPrimeArrayLength && MaxPrimeArrayLength > oldSize)
+            {
+                Debug.Assert(MaxPrimeArrayLength == GetPrime(MaxPrimeArrayLength), "Invalid MaxPrimeArrayLength");
+                return MaxPrimeArrayLength;
+            }
+
+            return GetPrime(newSize);
+        }
+    }
+}

--- a/src/Quartz/Collections/IDictionaryDebugView.cs
+++ b/src/Quartz/Collections/IDictionaryDebugView.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Quartz.Collections
+{
+    internal sealed class IDictionaryDebugView<K, V> where K :  notnull
+    {
+        private readonly IDictionary<K, V> _dict;
+
+        public IDictionaryDebugView(IDictionary<K, V> dictionary)
+        {
+            _dict = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<K, V>[] Items
+        {
+            get
+            {
+                KeyValuePair<K, V>[] items = new KeyValuePair<K, V>[_dict.Count];
+                _dict.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+
+    internal sealed class DictionaryKeyCollectionDebugView<TKey, TValue>
+    {
+        private readonly ICollection<TKey> _collection;
+
+        public DictionaryKeyCollectionDebugView(ICollection<TKey> collection)
+        {
+            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TKey[] Items
+        {
+            get
+            {
+                TKey[] items = new TKey[_collection.Count];
+                _collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+
+    internal sealed class DictionaryValueCollectionDebugView<TKey, TValue>
+    {
+        private readonly ICollection<TValue> _collection;
+
+        public DictionaryValueCollectionDebugView(ICollection<TValue> collection)
+        {
+            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TValue[] Items
+        {
+            get
+            {
+                TValue[] items = new TValue[_collection.Count];
+                _collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+}

--- a/src/Quartz/Collections/OrderedDictionary.KeyCollection.cs
+++ b/src/Quartz/Collections/OrderedDictionary.KeyCollection.cs
@@ -1,0 +1,165 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Quartz.Collections
+{
+    internal partial class OrderedDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// Represents the collection of keys in a <see cref="OrderedDictionary{TKey, TValue}" />. This class cannot be inherited.
+        /// </summary>
+        [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
+        [DebuggerDisplay("Count = {Count}")]
+        public sealed class KeyCollection : IList<TKey>, IReadOnlyList<TKey>
+        {
+            private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+
+            /// <summary>
+            /// Gets the number of elements contained in the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.
+            /// </summary>
+            /// <returns>The number of elements contained in the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.</returns>
+            public int Count => _orderedDictionary.Count;
+
+            /// <summary>
+            /// Gets the key at the specified index as an O(1) operation.
+            /// </summary>
+            /// <param name="index">The zero-based index of the key to get.</param>
+            /// <returns>The key at the specified index.</returns>
+            /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.KeyCollection.Count" />.</exception>
+            public TKey this[int index] => ((IList<KeyValuePair<TKey, TValue>>)_orderedDictionary)[index].Key;
+
+            TKey IList<TKey>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException();
+            }
+
+            bool ICollection<TKey>.IsReadOnly => true;
+
+            internal KeyCollection(OrderedDictionary<TKey, TValue> orderedDictionary)
+            {
+                _orderedDictionary = orderedDictionary;
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.
+            /// </summary>
+            /// <returns>A <see cref="OrderedDictionary{TKey, TValue}.KeyCollection.Enumerator" /> for the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.</returns>
+            public Enumerator GetEnumerator() => new Enumerator(_orderedDictionary);
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            int IList<TKey>.IndexOf(TKey item) => _orderedDictionary.IndexOf(item);
+
+            void IList<TKey>.Insert(int index, TKey item) => throw new NotSupportedException();
+
+            void IList<TKey>.RemoveAt(int index) => throw new NotSupportedException();
+
+            void ICollection<TKey>.Add(TKey item) => throw new NotSupportedException();
+
+            void ICollection<TKey>.Clear() => throw new NotSupportedException();
+
+            bool ICollection<TKey>.Contains(TKey item) => _orderedDictionary.ContainsKey(item);
+
+            void ICollection<TKey>.CopyTo(TKey[] array, int arrayIndex)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException(nameof(array));
+                }
+                if ((uint)arrayIndex > (uint)array.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+                }
+                int count = Count;
+                if (array.Length - arrayIndex < count)
+                {
+                    throw new ArgumentException();
+                }
+
+                Entry[] entries = _orderedDictionary._entries;
+                for (int i = 0; i < count; ++i)
+                {
+                    array[i + arrayIndex] = entries[i].Key;
+                }
+            }
+
+            bool ICollection<TKey>.Remove(TKey item) => throw new NotSupportedException();
+
+            /// <summary>
+            /// Enumerates the elements of a <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.
+            /// </summary>
+            public struct Enumerator : IEnumerator<TKey>
+            {
+                private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+                private readonly int _version;
+                private int _index;
+                private TKey _current;
+
+                /// <summary>
+                /// Gets the element at the current position of the enumerator.
+                /// </summary>
+                /// <returns>The element in the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" /> at the current position of the enumerator.</returns>
+                public TKey Current => _current;
+
+                object IEnumerator.Current => _current!;
+
+                internal Enumerator(OrderedDictionary<TKey, TValue> orderedDictionary)
+                {
+                    _orderedDictionary = orderedDictionary;
+                    _version = orderedDictionary._version;
+                    _index = 0;
+                    _current = default!;
+                }
+
+                /// <summary>
+                /// Releases all resources used by the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection.Enumerator" />.
+                /// </summary>
+                public void Dispose()
+                {
+                }
+
+                /// <summary>
+                /// Advances the enumerator to the next element of the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.
+                /// </summary>
+                /// <returns>true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.</returns>
+                /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+                public bool MoveNext()
+                {
+                    if (_version != _orderedDictionary._version)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    if (_index < _orderedDictionary.Count)
+                    {
+                        _current = _orderedDictionary._entries[_index].Key;
+                        ++_index;
+                        return true;
+                    }
+                    _current = default!;
+                    return false;
+                }
+
+                void IEnumerator.Reset()
+                {
+                    if (_version != _orderedDictionary._version)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    _index = 0;
+                    _current = default!;
+                }
+            }
+        }
+    }
+}

--- a/src/Quartz/Collections/OrderedDictionary.ValueCollection.cs
+++ b/src/Quartz/Collections/OrderedDictionary.ValueCollection.cs
@@ -1,0 +1,178 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Quartz.Collections
+{
+    internal partial class OrderedDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// Represents the collection of values in a <see cref="OrderedDictionary{TKey, TValue}" />. This class cannot be inherited.
+        /// </summary>
+        [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
+        [DebuggerDisplay("Count = {Count}")]
+        public sealed class ValueCollection : IList<TValue>, IReadOnlyList<TValue>
+        {
+            private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+
+            /// <summary>
+            /// Gets the number of elements contained in the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.
+            /// </summary>
+            /// <returns>The number of elements contained in the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.</returns>
+            public int Count => _orderedDictionary.Count;
+
+            /// <summary>
+            /// Gets the value at the specified index as an O(1) operation.
+            /// </summary>
+            /// <param name="index">The zero-based index of the value to get.</param>
+            /// <returns>The value at the specified index.</returns>
+            /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.ValueCollection.Count" />.</exception>
+            public TValue this[int index] => _orderedDictionary[index];
+
+            TValue IList<TValue>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException();
+            }
+
+            bool ICollection<TValue>.IsReadOnly => true;
+
+            internal ValueCollection(OrderedDictionary<TKey, TValue> orderedDictionary)
+            {
+                _orderedDictionary = orderedDictionary;
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.
+            /// </summary>
+            /// <returns>A <see cref="OrderedDictionary{TKey, TValue}.ValueCollection.Enumerator" /> for the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.</returns>
+            public Enumerator GetEnumerator() => new Enumerator(_orderedDictionary);
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            int IList<TValue>.IndexOf(TValue item)
+            {
+                EqualityComparer<TValue> comparer = EqualityComparer<TValue>.Default;
+                Entry[] entries = _orderedDictionary._entries;
+                int count = Count;
+                for (int i = 0; i < count; ++i)
+                {
+                    if (comparer.Equals(entries[i].Value, item))
+                    {
+                        return i;
+                    }
+                }
+                return -1;
+            }
+
+            void IList<TValue>.Insert(int index, TValue item) => throw new NotSupportedException();
+
+            void IList<TValue>.RemoveAt(int index) => throw new NotSupportedException();
+
+            void ICollection<TValue>.Add(TValue item) => throw new NotSupportedException();
+
+            void ICollection<TValue>.Clear() => throw new NotSupportedException();
+
+            bool ICollection<TValue>.Contains(TValue item) => ((IList<TValue>)this).IndexOf(item) >= 0;
+
+            void ICollection<TValue>.CopyTo(TValue[] array, int arrayIndex)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException(nameof(array));
+                }
+                if ((uint)arrayIndex > (uint)array.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+                }
+                int count = Count;
+                if (array.Length - arrayIndex < count)
+                {
+                    throw new ArgumentException();
+                }
+
+                Entry[] entries = _orderedDictionary._entries;
+                for (int i = 0; i < count; ++i)
+                {
+                    array[i + arrayIndex] = entries[i].Value;
+                }
+            }
+
+            bool ICollection<TValue>.Remove(TValue item) => throw new NotSupportedException();
+
+            /// <summary>
+            /// Enumerates the elements of a <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.
+            /// </summary>
+            public struct Enumerator : IEnumerator<TValue>
+            {
+                private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+                private readonly int _version;
+                private int _index;
+                private TValue _current;
+
+                /// <summary>
+                /// Gets the element at the current position of the enumerator.
+                /// </summary>
+                /// <returns>The element in the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" /> at the current position of the enumerator.</returns>
+                public TValue Current => _current;
+
+                object IEnumerator.Current => _current!;
+
+                internal Enumerator(OrderedDictionary<TKey, TValue> orderedDictionary)
+                {
+                    _orderedDictionary = orderedDictionary;
+                    _version = orderedDictionary._version;
+                    _index = 0;
+                    _current = default!;
+                }
+
+                /// <summary>
+                /// Releases all resources used by the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection.Enumerator" />.
+                /// </summary>
+                public void Dispose()
+                {
+                }
+
+                /// <summary>
+                /// Advances the enumerator to the next element of the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.
+                /// </summary>
+                /// <returns>true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.</returns>
+                /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+                public bool MoveNext()
+                {
+                    if (_version != _orderedDictionary._version)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    if (_index < _orderedDictionary.Count)
+                    {
+                        _current = _orderedDictionary._entries[_index].Value;
+                        ++_index;
+                        return true;
+                    }
+                    _current = default!;
+                    return false;
+                }
+
+                void IEnumerator.Reset()
+                {
+                    if (_version != _orderedDictionary._version)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    _index = 0;
+                    _current = default!;
+                }
+            }
+        }
+    }
+}

--- a/src/Quartz/Collections/OrderedDictionary.cs
+++ b/src/Quartz/Collections/OrderedDictionary.cs
@@ -1,0 +1,927 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Quartz.Collections
+{
+    internal enum InsertionBehavior
+    {
+        None = 0,
+        OverwriteExisting = 1,
+        ThrowOnExisting = 2
+    }
+
+    /// <summary>
+    /// Represents an ordered collection of keys and values with the same performance as <see cref="Dictionary{TKey, TValue}"/> with O(1) lookups and adds but with O(n) inserts and removes.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+    [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}")]
+    internal partial class OrderedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>, IList<KeyValuePair<TKey, TValue>>, IReadOnlyList<KeyValuePair<TKey, TValue>> where TKey : notnull
+    {
+        private struct Entry
+        {
+            public uint HashCode;
+            public TKey Key;
+            public TValue Value;
+            public int Next; // the index of the next item in the same bucket, -1 if last
+        }
+
+        // We want to initialize without allocating arrays. We also want to avoid null checks.
+        // Array.Empty would give divide by zero in modulo operation. So we use static one element arrays.
+        // The first add will cause a resize replacing these with real arrays of three elements.
+        // Arrays are wrapped in a class to avoid being duplicated for each <TKey, TValue>
+        private static readonly Entry[] InitialEntries = new Entry[1];
+        // 1-based index into _entries; 0 means empty
+        private int[] _buckets = HashHelpers.SizeOneIntArray;
+        // remains contiguous and maintains order
+        private Entry[] _entries = InitialEntries;
+        private int _count;
+        private int _version;
+        // is null when comparer is EqualityComparer<TKey>.Default so that the GetHashCode method is used explicitly on the object
+        private readonly IEqualityComparer<TKey>? _comparer;
+        private KeyCollection? _keys;
+        private ValueCollection? _values;
+
+        /// <summary>
+        /// Gets the number of key/value pairs contained in the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        /// <returns>The number of key/value pairs contained in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        public int Count => _count;
+
+        /// <summary>
+        /// Gets the <see cref="IEqualityComparer{TKey}" /> that is used to determine equality of keys for the dictionary.
+        /// </summary>
+        /// <returns>The <see cref="IEqualityComparer{TKey}" /> generic interface implementation that is used to determine equality of keys for the current <see cref="OrderedDictionary{TKey, TValue}" /> and to provide hash values for the keys.</returns>
+        public IEqualityComparer<TKey> Comparer => _comparer ?? EqualityComparer<TKey>.Default;
+
+        /// <summary>
+        /// Gets a collection containing the keys in the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        /// <returns>An <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" /> containing the keys in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        public KeyCollection Keys => _keys ?? (_keys = new KeyCollection(this));
+
+        /// <summary>
+        /// Gets a collection containing the values in the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        /// <returns>An <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" /> containing the values in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        public ValueCollection Values => _values ?? (_values = new ValueCollection(this));
+
+        /// <summary>
+        /// Gets or sets the value associated with the specified key as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the value to get or set.</param>
+        /// <returns>The value associated with the specified key. If the specified key is not found, a get operation throws a <see cref="KeyNotFoundException" />, and a set operation creates a new element with the specified key.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        /// <exception cref="KeyNotFoundException">The property is retrieved and <paramref name="key" /> does not exist in the collection.</exception>
+        public TValue this[TKey key]
+        {
+            get
+            {
+                int index = IndexOf(key);
+                if (index < 0)
+                {
+                    throw new KeyNotFoundException();
+                }
+                return _entries[index].Value;
+            }
+            set => TryInsert(null, key, value, InsertionBehavior.OverwriteExisting);
+        }
+
+        /// <summary>
+        /// Gets or sets the value at the specified index as an O(1) operation.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get or set.</param>
+        /// <returns>The value at the specified index.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public TValue this[int index]
+        {
+            get
+            {
+                if ((uint)index >= (uint)Count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return _entries[index].Value;
+            }
+            set
+            {
+                if ((uint)index >= (uint)Count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                _entries[index].Value = value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that is empty, has the default initial capacity, and uses the default equality comparer for the key type.
+        /// </summary>
+        public OrderedDictionary()
+            : this(0, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that is empty, has the specified initial capacity, and uses the default equality comparer for the key type.
+        /// </summary>
+        /// <param name="capacity">The initial number of elements that the <see cref="OrderedDictionary{TKey, TValue}" /> can contain.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0.</exception>
+        public OrderedDictionary(int capacity)
+            : this(capacity, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that is empty, has the default initial capacity, and uses the specified <see cref="IEqualityComparer{T}" />.
+        /// </summary>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing keys, or null to use the default <see cref="EqualityComparer{T}" /> for the type of the key.</param>
+        public OrderedDictionary(IEqualityComparer<TKey> comparer)
+            : this(0, comparer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that is empty, has the specified initial capacity, and uses the specified <see cref="IEqualityComparer{T}" />.
+        /// </summary>
+        /// <param name="capacity">The initial number of elements that the <see cref="OrderedDictionary{TKey, TValue}" /> can contain.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing keys, or null to use the default <see cref="EqualityComparer{T}" /> for the type of the key.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0.</exception>
+        public OrderedDictionary(int capacity, IEqualityComparer<TKey>? comparer)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+            if (capacity > 0)
+            {
+                int newSize = HashHelpers.GetPrime(capacity);
+                _buckets = new int[newSize];
+                _entries = new Entry[newSize];
+            }
+
+            if (comparer != EqualityComparer<TKey>.Default)
+            {
+                _comparer = comparer;
+            }
+        }
+
+        public OrderedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection)
+            : this(collection, null)
+        {
+        }
+
+        public OrderedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer)
+            : this((collection as ICollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0, comparer)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            foreach (KeyValuePair<TKey, TValue> pair in collection)
+            {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
+        /// <summary>
+        /// Adds the specified key and value to the dictionary as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value of the element to add. The value can be null for reference types.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        /// <exception cref="ArgumentException">An element with the same key already exists in the <see cref="OrderedDictionary{TKey, TValue}" />.</exception>
+        public void Add(TKey key, TValue value) => TryInsert(null, key, value, InsertionBehavior.ThrowOnExisting);
+
+        /// <summary>
+        /// Removes all keys and values from the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        public void Clear()
+        {
+            if (_count > 0)
+            {
+                Array.Clear(_buckets, 0, _buckets.Length);
+                Array.Clear(_entries, 0, _count);
+                _count = 0;
+                ++_version;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the <see cref="OrderedDictionary{TKey, TValue}" /> contains the specified key as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key to locate in the <see cref="OrderedDictionary{TKey, TValue}" />.</param>
+        /// <returns>true if the <see cref="OrderedDictionary{TKey, TValue}" /> contains an element with the specified key; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool ContainsKey(TKey key) => IndexOf(key) >= 0;
+
+        /// <summary>
+        /// Resizes the internal data structure if necessary to ensure no additional resizing to support the specified capacity.
+        /// </summary>
+        /// <param name="capacity">The number of elements that the <see cref="OrderedDictionary{TKey, TValue}" /> must be able to contain.</param>
+        /// <returns>The capacity of the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0.</exception>
+        public int EnsureCapacity(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            if (_entries.Length >= capacity)
+            {
+                return _entries.Length;
+            }
+            int newSize = HashHelpers.GetPrime(capacity);
+            Resize(newSize);
+            ++_version;
+            return newSize;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        /// <returns>An <see cref="OrderedDictionary{TKey, TValue}.Enumerator" /> structure for the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="OrderedDictionary{TKey, TValue}" /> if the key does not already exist as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value to be added, if the key does not already exist.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already in the dictionary, or the new value if the key was not in the dictionary.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public TValue GetOrAdd(TKey key, TValue value) => GetOrAdd(key, () => value);
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="OrderedDictionary{TKey, TValue}" /> by using the specified function, if the key does not already exist as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The function used to generate a value for the key.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already in the dictionary, or the new value for the key as returned by valueFactory if the key was not in the dictionary.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.-or-<paramref name="valueFactory"/> is null.</exception>
+        public TValue GetOrAdd(TKey key, Func<TValue> valueFactory)
+        {
+            if (valueFactory == null)
+            {
+                throw new ArgumentNullException(nameof(valueFactory));
+            }
+
+            int index = IndexOf(key, out uint hashCode);
+            TValue value;
+            if (index < 0)
+            {
+                value = valueFactory();
+                AddInternal(null, key, value, hashCode);
+            }
+            else
+            {
+                value = _entries[index].Value;
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Returns the zero-based index of the element with the specified key within the <see cref="OrderedDictionary{TKey, TValue}" /> as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to locate.</param>
+        /// <returns>The zero-based index of the element with the specified key within the <see cref="OrderedDictionary{TKey, TValue}" />, if found; otherwise, -1.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public int IndexOf(TKey key) => IndexOf(key, out _);
+
+        /// <summary>
+        /// Inserts the specified key/value pair into the <see cref="OrderedDictionary{TKey, TValue}" /> at the specified index as an O(n) operation.
+        /// </summary>
+        /// <param name="index">The zero-based index of the key/value pair to insert.</param>
+        /// <param name="key">The key of the element to insert.</param>
+        /// <param name="value">The value of the element to insert.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        /// <exception cref="ArgumentException">An element with the same key already exists in the <see cref="OrderedDictionary{TKey, TValue}" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public void Insert(int index, TKey key, TValue value)
+        {
+            if ((uint)index > (uint)Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            TryInsert(index, key, value, InsertionBehavior.ThrowOnExisting);
+        }
+
+        /// <summary>
+        /// Moves the element at the specified fromIndex to the specified toIndex while re-arranging the elements in between.
+        /// </summary>
+        /// <param name="fromIndex">The zero-based index of the element to move.</param>
+        /// <param name="toIndex">The zero-based index to move the element to.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="fromIndex"/> is less than 0.
+        /// -or-
+        /// <paramref name="fromIndex"/> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />
+        /// -or-
+        /// <paramref name="toIndex"/> is less than 0.
+        /// -or-
+        /// <paramref name="toIndex"/> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />
+        /// </exception>
+        public void Move(int fromIndex, int toIndex)
+        {
+            if ((uint)fromIndex >= (uint)Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fromIndex));
+            }
+            if ((uint)toIndex >= (uint)Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(toIndex));
+            }
+
+            if (fromIndex == toIndex)
+            {
+                return;
+            }
+
+            Entry[] entries = _entries;
+            Entry temp = entries[fromIndex];
+            RemoveEntryFromBucket(fromIndex);
+            int direction = fromIndex < toIndex ? 1 : -1;
+            for (int i = fromIndex; i != toIndex; i += direction)
+            {
+                entries[i] = entries[i + direction];
+                UpdateBucketIndex(i + direction, -direction);
+            }
+            AddEntryToBucket(ref temp, toIndex, _buckets);
+            entries[toIndex] = temp;
+            ++_version;
+        }
+
+        /// <summary>
+        /// Moves the specified number of elements at the specified fromIndex to the specified toIndex while re-arranging the elements in between.
+        /// </summary>
+        /// <param name="fromIndex">The zero-based index of the elements to move.</param>
+        /// <param name="toIndex">The zero-based index to move the elements to.</param>
+        /// <param name="count">The number of elements to move.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="fromIndex"/> is less than 0.
+        /// -or-
+        /// <paramref name="fromIndex"/> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.
+        /// -or-
+        /// <paramref name="toIndex"/> is less than 0.
+        /// -or-
+        /// <paramref name="toIndex"/> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.
+        /// -or-
+        /// <paramref name="count"/> is less than 0.</exception>
+        /// <exception cref="ArgumentException"><paramref name="fromIndex"/> + <paramref name="count"/> is greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.
+        /// -or-
+        /// <paramref name="toIndex"/> + <paramref name="count"/> is greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public void MoveRange(int fromIndex, int toIndex, int count)
+        {
+            if (count == 1)
+            {
+                Move(fromIndex, toIndex);
+                return;
+            }
+
+            if ((uint)fromIndex >= (uint)Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fromIndex));
+            }
+            if ((uint)toIndex >= (uint)Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(toIndex));
+            }
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+            if (fromIndex + count > Count)
+            {
+                throw new ArgumentException();
+            }
+            if (toIndex + count > Count)
+            {
+                throw new ArgumentException();
+            }
+
+            if (fromIndex == toIndex || count == 0)
+            {
+                return;
+            }
+
+            Entry[] entries = _entries;
+            // Make a copy of the entries to move. Consider using ArrayPool instead to avoid allocations?
+            Entry[] entriesToMove = new Entry[count];
+            for (int i = 0; i < count; ++i)
+            {
+                entriesToMove[i] = entries[fromIndex + i];
+                RemoveEntryFromBucket(fromIndex + i);
+            }
+
+            // Move entries in between
+            int direction = 1;
+            int amount = count;
+            int start = fromIndex;
+            int end = toIndex;
+            if (fromIndex > toIndex)
+            {
+                direction = -1;
+                amount = -count;
+                start = fromIndex + count - 1;
+                end = toIndex + count - 1;
+            }
+            for (int i = start; i != end; i += direction)
+            {
+                entries[i] = entries[i + amount];
+                UpdateBucketIndex(i + amount, -amount);
+            }
+
+            int[] buckets = _buckets;
+            // Copy entries to destination
+            for (int i = 0; i < count; ++i)
+            {
+                Entry temp = entriesToMove[i];
+                AddEntryToBucket(ref temp, toIndex + i, buckets);
+                entries[toIndex + i] = temp;
+            }
+            ++_version;
+        }
+
+        /// <summary>
+        /// Removes the value with the specified key from the <see cref="OrderedDictionary{TKey, TValue}" /> as an O(n) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <returns>true if the element is successfully found and removed; otherwise, false. This method returns false if <paramref name="key" /> is not found in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool Remove(TKey key) => Remove(key, out _);
+
+        /// <summary>
+        /// Removes the value with the specified key from the <see cref="OrderedDictionary{TKey, TValue}" /> and returns the value as an O(n) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <param name="value">When this method returns, contains the value associated with the specified key, if the key is found; otherwise, the default value for the type of the <paramref name="value" /> parameter. This parameter is passed uninitialized.</param>
+        /// <returns>true if the element is successfully found and removed; otherwise, false. This method returns false if <paramref name="key" /> is not found in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool Remove(TKey key, out TValue value)
+        {
+            int index = IndexOf(key);
+            if (index >= 0)
+            {
+                value = _entries[index].Value;
+                RemoveAt(index);
+                return true;
+            }
+            value = default!;
+            return false;
+        }
+
+        /// <summary>
+        /// Removes the value at the specified index from the <see cref="OrderedDictionary{TKey, TValue}" /> as an O(n) operation.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public void RemoveAt(int index)
+        {
+            int count = Count;
+            if ((uint)index >= (uint)count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            // Remove the entry from the bucket
+            RemoveEntryFromBucket(index);
+
+            // Decrement the indices > index
+            Entry[] entries = _entries;
+            for (int i = index + 1; i < count; ++i)
+            {
+                entries[i - 1] = entries[i];
+                UpdateBucketIndex(i, incrementAmount: -1);
+            }
+            --_count;
+            entries[_count] = default;
+            ++_version;
+        }
+
+        /// <summary>
+        /// Sets the capacity of an <see cref="OrderedDictionary{TKey, TValue}" /> object to the actual number of elements it contains, rounded up to a nearby, implementation-specific value.
+        /// </summary>
+        public void TrimExcess() => TrimExcess(Count);
+
+        /// <summary>
+        /// Sets the capacity of an <see cref="OrderedDictionary{TKey, TValue}" /> object to the specified capacity, rounded up to a nearby, implementation-specific value.
+        /// </summary>
+        /// <param name="capacity">The number of elements that the <see cref="OrderedDictionary{TKey, TValue}" /> must be able to contain.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public void TrimExcess(int capacity)
+        {
+            if (capacity < Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            int newSize = HashHelpers.GetPrime(capacity);
+            if (newSize < _entries.Length)
+            {
+                Resize(newSize);
+                ++_version;
+            }
+        }
+
+        /// <summary>
+        /// Tries to add the specified key and value to the dictionary as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value of the element to add. The value can be null for reference types.</param>
+        /// <returns>true if the element was added to the <see cref="OrderedDictionary{TKey, TValue}" />; false if the <see cref="OrderedDictionary{TKey, TValue}" /> already contained an element with the specified key.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool TryAdd(TKey key, TValue value) => TryInsert(null, key, value, InsertionBehavior.None);
+
+        /// <summary>
+        /// Gets the value associated with the specified key as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <param name="value">When this method returns, contains the value associated with the specified key, if the key is found; otherwise, the default value for the type of the <paramref name="value" /> parameter. This parameter is passed uninitialized.</param>
+        /// <returns>true if the <see cref="OrderedDictionary{TKey, TValue}" /> contains an element with the specified key; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            int index = IndexOf(key);
+            if (index >= 0)
+            {
+                value = _entries[index].Value;
+                return true;
+            }
+            value = default!;
+            return false;
+        }
+
+        #region Explicit Interface Implementation
+        KeyValuePair<TKey, TValue> IList<KeyValuePair<TKey, TValue>>.this[int index]
+        {
+            get
+            {
+                if ((uint)index >= (uint)Count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                Entry entry = _entries[index];
+                return new KeyValuePair<TKey, TValue>(entry.Key, entry.Value);
+            }
+            set
+            {
+                if ((uint)index >= (uint)Count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                TKey key = value.Key;
+                int foundIndex = IndexOf(key, out uint hashCode);
+                // key does not exist in dictionary thus replace entry at index
+                if (foundIndex < 0)
+                {
+                    RemoveEntryFromBucket(index);
+                    Entry entry = new Entry { HashCode = hashCode, Key = key, Value = value.Value };
+                    AddEntryToBucket(ref entry, index, _buckets);
+                    _entries[index] = entry;
+                    ++_version;
+                }
+                // key already exists in dictionary at the specified index thus just replace the key and value as hashCode remains the same
+                else if (foundIndex == index)
+                {
+                    ref Entry entry = ref _entries[index];
+                    entry.Key = key;
+                    entry.Value = value.Value;
+                }
+                // key already exists in dictionary but not at the specified index thus throw exception as this method shouldn't affect the indices of other entries
+                else
+                {
+                    throw new ArgumentException();
+                }
+            }
+        }
+
+        KeyValuePair<TKey, TValue> IReadOnlyList<KeyValuePair<TKey, TValue>>.this[int index] => ((IList<KeyValuePair<TKey, TValue>>)this)[index];
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item) => Add(item.Key, item.Value);
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item) => TryGetValue(item.Key, out TValue value) && EqualityComparer<TValue>.Default.Equals(value, item.Value);
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+            if ((uint)arrayIndex > (uint)array.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+            }
+            int count = Count;
+            if (array.Length - arrayIndex < count)
+            {
+                throw new ArgumentException();
+            }
+
+            Entry[] entries = _entries;
+            for (int i = 0; i < count; ++i)
+            {
+                Entry entry = entries[i];
+                array[i + arrayIndex] = new KeyValuePair<TKey, TValue>(entry.Key, entry.Value);
+            }
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+        {
+            int index = IndexOf(item.Key);
+            if (index >= 0 && EqualityComparer<TValue>.Default.Equals(_entries[index].Value, item.Value))
+            {
+                RemoveAt(index);
+                return true;
+            }
+            return false;
+        }
+
+        int IList<KeyValuePair<TKey, TValue>>.IndexOf(KeyValuePair<TKey, TValue> item)
+        {
+            int index = IndexOf(item.Key);
+            if (index >= 0 && !EqualityComparer<TValue>.Default.Equals(_entries[index].Value, item.Value))
+            {
+                index = -1;
+            }
+            return index;
+        }
+
+        void IList<KeyValuePair<TKey, TValue>>.Insert(int index, KeyValuePair<TKey, TValue> item) => Insert(index, item.Key, item.Value);
+        #endregion
+
+        private Entry[] Resize(int newSize)
+        {
+            int[] newBuckets = new int[newSize];
+            Entry[] newEntries = new Entry[newSize];
+
+            int count = Count;
+            Array.Copy(_entries, newEntries, count);
+            for (int i = 0; i < count; ++i)
+            {
+                AddEntryToBucket(ref newEntries[i], i, newBuckets);
+            }
+
+            _buckets = newBuckets;
+            _entries = newEntries;
+            return newEntries;
+        }
+
+        private int IndexOf(TKey key, out uint hashCode)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            IEqualityComparer<TKey>? comparer = _comparer;
+            hashCode = (uint)(comparer?.GetHashCode(key) ?? key.GetHashCode());
+            int index = _buckets[(int)(hashCode % (uint)_buckets.Length)] - 1;
+            if (index >= 0)
+            {
+                if (comparer == null)
+                {
+                    comparer = EqualityComparer<TKey>.Default;
+                }
+                Entry[] entries = _entries;
+                int collisionCount = 0;
+                do
+                {
+                    Entry entry = entries[index];
+                    if (entry.HashCode == hashCode && comparer.Equals(entry.Key, key))
+                    {
+                        break;
+                    }
+                    index = entry.Next;
+                    if (collisionCount >= entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        throw new InvalidOperationException();
+                    }
+                    ++collisionCount;
+                } while (index >= 0);
+            }
+            return index;
+        }
+
+        private bool TryInsert(int? index, TKey key, TValue value, InsertionBehavior behavior)
+        {
+            int i = IndexOf(key, out uint hashCode);
+            if (i >= 0)
+            {
+                switch (behavior)
+                {
+                    case InsertionBehavior.OverwriteExisting:
+                        _entries[i].Value = value;
+                        return true;
+                    case InsertionBehavior.ThrowOnExisting:
+                        throw new ArgumentException();
+                    default:
+                        return false;
+                }
+            }
+
+            AddInternal(index, key, value, hashCode);
+            return true;
+        }
+
+        private int AddInternal(int? index, TKey key, TValue value, uint hashCode)
+        {
+            Entry[] entries = _entries;
+            // Check if resize is needed
+            int count = Count;
+            if (entries.Length == count || entries.Length == 1)
+            {
+                entries = Resize(HashHelpers.ExpandPrime(entries.Length));
+            }
+
+            // Increment indices >= index;
+            int actualIndex = index ?? count;
+            for (int i = count - 1; i >= actualIndex; --i)
+            {
+                entries[i + 1] = entries[i];
+                UpdateBucketIndex(i, incrementAmount: 1);
+            }
+
+            ref Entry entry = ref entries[actualIndex];
+            entry.HashCode = hashCode;
+            entry.Key = key;
+            entry.Value = value;
+            AddEntryToBucket(ref entry, actualIndex, _buckets);
+            ++_count;
+            ++_version;
+            return actualIndex;
+        }
+
+        // Returns the index of the next entry in the bucket
+        private void AddEntryToBucket(ref Entry entry, int entryIndex, int[] buckets)
+        {
+            ref int b = ref buckets[(int)(entry.HashCode % (uint)buckets.Length)];
+            entry.Next = b - 1;
+            b = entryIndex + 1;
+        }
+
+        private void RemoveEntryFromBucket(int entryIndex)
+        {
+            Entry[] entries = _entries;
+            Entry entry = entries[entryIndex];
+            ref int b = ref _buckets[(int)(entry.HashCode % (uint)_buckets.Length)];
+            // Bucket was pointing to removed entry. Update it to point to the next in the chain
+            if (b == entryIndex + 1)
+            {
+                b = entry.Next + 1;
+            }
+            else
+            {
+                // Start at the entry the bucket points to, and walk the chain until we find the entry with the index we want to remove, then fix the chain
+                int i = b - 1;
+                int collisionCount = 0;
+                while (true)
+                {
+                    ref Entry e = ref entries[i];
+                    if (e.Next == entryIndex)
+                    {
+                        e.Next = entry.Next;
+                        return;
+                    }
+                    i = e.Next;
+                    if (collisionCount >= entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        throw new InvalidOperationException();
+                    }
+                    ++collisionCount;
+                }
+            }
+        }
+
+        private void UpdateBucketIndex(int entryIndex, int incrementAmount)
+        {
+            Entry[] entries = _entries;
+            Entry entry = entries[entryIndex];
+            ref int b = ref _buckets[(int)(entry.HashCode % (uint)_buckets.Length)];
+            // Bucket was pointing to entry. Increment the index by incrementAmount.
+            if (b == entryIndex + 1)
+            {
+                b += incrementAmount;
+            }
+            else
+            {
+                // Start at the entry the bucket points to, and walk the chain until we find the entry with the index we want to increment.
+                int i = b - 1;
+                int collisionCount = 0;
+                while (true)
+                {
+                    ref Entry e = ref entries[i];
+                    if (e.Next == entryIndex)
+                    {
+                        e.Next += incrementAmount;
+                        return;
+                    }
+                    i = e.Next;
+                    if (collisionCount >= entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        throw new InvalidOperationException();
+                    }
+                    ++collisionCount;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Enumerates the elements of a <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
+        {
+            private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+            private readonly int _version;
+            private int _index;
+            private KeyValuePair<TKey, TValue> _current;
+
+            /// <summary>
+            /// Gets the element at the current position of the enumerator.
+            /// </summary>
+            /// <returns>The element in the <see cref="OrderedDictionary{TKey, TValue}" /> at the current position of the enumerator.</returns>
+            public KeyValuePair<TKey, TValue> Current => _current;
+
+            object? IEnumerator.Current => _current;
+
+            internal Enumerator(OrderedDictionary<TKey, TValue> orderedDictionary)
+            {
+                _orderedDictionary = orderedDictionary;
+                _version = orderedDictionary._version;
+                _index = 0;
+                _current = default;
+            }
+
+            /// <summary>
+            /// Releases all resources used by the <see cref="OrderedDictionary{TKey, TValue}.Enumerator" />.
+            /// </summary>
+            public void Dispose()
+            {
+            }
+
+            /// <summary>
+            /// Advances the enumerator to the next element of the <see cref="OrderedDictionary{TKey, TValue}" />.
+            /// </summary>
+            /// <returns>true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.</returns>
+            /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+            public bool MoveNext()
+            {
+                if (_version != _orderedDictionary._version)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                if (_index < _orderedDictionary.Count)
+                {
+                    Entry entry = _orderedDictionary._entries[_index];
+                    _current = new KeyValuePair<TKey, TValue>(entry.Key, entry.Value);
+                    ++_index;
+                    return true;
+                }
+                _current = default;
+                return false;
+            }
+
+            void IEnumerator.Reset()
+            {
+                if (_version != _orderedDictionary._version)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                _index = 0;
+                _current = default;
+            }
+        }
+    }
+}

--- a/src/Quartz/Collections/ReadOnlyCollectionWrapper.cs
+++ b/src/Quartz/Collections/ReadOnlyCollectionWrapper.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Quartz.Collections
+{
+    internal sealed class ReadOnlyCollectionWrapper<T> : IReadOnlyCollection<T>
+    {
+        private readonly ICollection<T> values;
+
+        public ReadOnlyCollectionWrapper(ICollection<T> values)
+        {
+            this.values = values;
+        }
+
+        public IEnumerator<T> GetEnumerator() => values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public int Count => values.Count;
+    }
+}

--- a/src/Quartz/Collections/ThrowHelper.cs
+++ b/src/Quartz/Collections/ThrowHelper.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Quartz.Collections
+{
+    internal static class ThrowHelper
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowInvalidOperationException_ConcurrentOperationsNotSupported()
+        {
+            throw new InvalidOperationException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowKeyArgumentNullException()
+        {
+            throw new ArgumentNullException("key");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowCapacityArgumentOutOfRangeException()
+        {
+            throw new ArgumentOutOfRangeException("capacity");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static bool ThrowNotSupportedException_ReadOnly_Modification()
+        {
+            throw new NotSupportedException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static bool ThrowNotSupportedException()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Quartz/Core/ListenerManagerImpl.cs
+++ b/src/Quartz/Core/ListenerManagerImpl.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Quartz.Collections;
 using Quartz.Impl.Matchers;

--- a/src/Quartz/Core/ListenerManagerImpl.cs
+++ b/src/Quartz/Core/ListenerManagerImpl.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 
+using Quartz.Collections;
 using Quartz.Impl.Matchers;
 using Quartz.Util;
 
@@ -13,9 +13,9 @@ namespace Quartz.Core
     /// </summary>
     public class ListenerManagerImpl : IListenerManager
     {
-        private readonly OrderedDictionary globalJobListeners = new OrderedDictionary(10);
+        private readonly OrderedDictionary<string, IJobListener> globalJobListeners = new OrderedDictionary<string, IJobListener>(10);
 
-        private readonly OrderedDictionary globalTriggerListeners = new OrderedDictionary(10);
+        private readonly OrderedDictionary<string, ITriggerListener> globalTriggerListeners = new OrderedDictionary<string, ITriggerListener>(10);
 
         private readonly Dictionary<string, List<IMatcher<JobKey>>> globalJobListenersMatchers = new Dictionary<string, List<IMatcher<JobKey>>>(10);
 
@@ -32,8 +32,7 @@ namespace Quartz.Core
         {
             if (string.IsNullOrEmpty(jobListener.Name))
             {
-                throw new ArgumentException(
-                    "JobListener name cannot be empty.");
+                throw new ArgumentException("JobListener name cannot be empty.");
             }
 
             lock (globalJobListeners)
@@ -123,12 +122,7 @@ namespace Quartz.Core
         {
             lock (globalJobListeners)
             {
-                if (globalJobListeners.Contains(name))
-                {
-                    globalJobListeners.Remove(name);
-                    return true;
-                }
-                return false;
+                return globalJobListeners.Remove(name);
             }
         }
 
@@ -136,7 +130,7 @@ namespace Quartz.Core
         {
             lock (globalJobListeners)
             {
-                return new List<IJobListener>(globalJobListeners.Values.Cast<IJobListener>()).AsReadOnly();
+                return new List<IJobListener>(globalJobListeners.Values);
             }
         }
 
@@ -144,7 +138,7 @@ namespace Quartz.Core
         {
             lock (globalJobListeners)
             {
-                return (IJobListener) globalJobListeners[name];
+                return globalJobListeners[name];
             }
         }
 
@@ -267,12 +261,7 @@ namespace Quartz.Core
         {
             lock (globalTriggerListeners)
             {
-                if (globalTriggerListeners.Contains(name))
-                {
-                    globalTriggerListeners.Remove(name);
-                    return true;
-                }
-                return false;
+                return globalTriggerListeners.Remove(name);
             }
         }
 
@@ -280,7 +269,7 @@ namespace Quartz.Core
         {
             lock (globalTriggerListeners)
             {
-                return new List<ITriggerListener>(globalTriggerListeners.Values.Cast<ITriggerListener>()).AsReadOnly();
+                return new List<ITriggerListener>(globalTriggerListeners.Values);
             }
         }
 
@@ -288,7 +277,7 @@ namespace Quartz.Core
         {
             lock (globalTriggerListeners)
             {
-                return (ITriggerListener) globalTriggerListeners[name];
+                return globalTriggerListeners[name];
             }
         }
 

--- a/src/Quartz/Core/ListenerManagerImpl.cs
+++ b/src/Quartz/Core/ListenerManagerImpl.cs
@@ -129,7 +129,9 @@ namespace Quartz.Core
         {
             lock (globalJobListeners)
             {
-                return new List<IJobListener>(globalJobListeners.Values);
+                return globalJobListeners.Count > 0 
+                    ? new List<IJobListener>(globalJobListeners.Values) 
+                    : EmptyReadOnlyCollection<IJobListener>.Instance;
             }
         }
 
@@ -268,7 +270,9 @@ namespace Quartz.Core
         {
             lock (globalTriggerListeners)
             {
-                return new List<ITriggerListener>(globalTriggerListeners.Values);
+                return globalTriggerListeners.Count > 0
+                    ? new List<ITriggerListener>(globalTriggerListeners.Values)
+                    : EmptyReadOnlyCollection<ITriggerListener>.Instance;
             }
         }
 
@@ -300,7 +304,9 @@ namespace Quartz.Core
         {
             lock (schedulerListeners)
             {
-                return schedulerListeners.AsReadOnly();
+                return schedulerListeners.Count > 0 
+                    ? new List<ISchedulerListener>(schedulerListeners)
+                    : EmptyReadOnlyCollection<ISchedulerListener>.Instance;
             }
         }
     }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -30,6 +30,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Quartz.Collections;
 using Quartz.Impl;
 using Quartz.Impl.Matchers;
 using Quartz.Impl.Triggers;
@@ -1522,7 +1523,7 @@ namespace Quartz.Core
         /// Get a list containing all of the <see cref="ITriggerListener" />s
         /// in the <see cref="IScheduler" />'s <i>internal</i> list.
         /// </summary>
-        public IReadOnlyCollection<ITriggerListener> InternalTriggerListeners => new List<ITriggerListener>(internalTriggerListeners.Values);
+        public IReadOnlyCollection<ITriggerListener> InternalTriggerListeners => new ReadOnlyCollectionWrapper<ITriggerListener>(internalTriggerListeners.Values);
 
         /// <summary>
         /// Get the <i>internal</i> <see cref="ITriggerListener" /> that
@@ -1565,28 +1566,38 @@ namespace Quartz.Core
             }
         }
 
-        private List<ITriggerListener> BuildTriggerListenerList()
+        private IEnumerable<ITriggerListener>? BuildTriggerListenerList()
         {
-            var listeners = new List<ITriggerListener>();
-            listeners.AddRange(ListenerManager.GetTriggerListeners());
-            listeners.AddRange(internalTriggerListeners.Values);
-            return listeners;
+            var listeners = ListenerManager.GetTriggerListeners();
+
+            if (listeners.Count == 0 && internalTriggerListeners.Count == 0)
+            {
+                // default case that we don't have any 
+                return null;
+            }
+            
+            return listeners.Concat(internalTriggerListeners.Values);
         }
 
-        private List<IJobListener> BuildJobListenerList()
+        private (IJobListener?, IEnumerable<IJobListener>?) BuildJobListenerList()
         {
-            var listeners = new List<IJobListener>();
-            listeners.AddRange(ListenerManager.GetJobListeners());
-            listeners.AddRange(internalJobListeners.Values);
-            return listeners;
+            var listeners = ListenerManager.GetJobListeners();
+            var internalListeners = internalJobListeners.Values;
+
+            if (listeners.Count == 0 && internalListeners.Count == 1)
+            {
+                // default case is that we only have our internal one
+                using var enumerator = internalListeners.GetEnumerator();
+                enumerator.MoveNext();
+                return (enumerator.Current, null);
+            }
+
+            return (null, listeners.Concat(internalListeners));
         }
 
-        private List<ISchedulerListener> BuildSchedulerListenerList()
+        private IEnumerable<ISchedulerListener> BuildSchedulerListenerList()
         {
-            var allListeners = new List<ISchedulerListener>();
-            allListeners.AddRange(ListenerManager.GetSchedulerListeners());
-            allListeners.AddRange(InternalSchedulerListeners);
-            return allListeners;
+            return ListenerManager.GetSchedulerListeners().Concat(InternalSchedulerListeners);
         }
 
         private bool MatchJobListener(IJobListener listener, JobKey key)
@@ -1622,39 +1633,41 @@ namespace Quartz.Core
         /// <param name="jec">The job execution context.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns></returns>
-        public virtual async Task<bool> NotifyTriggerListenersFired(
+        public virtual Task<bool> NotifyTriggerListenersFired(
             IJobExecutionContext jec,
             CancellationToken cancellationToken = default)
         {
-            bool vetoedExecution = false;
-
-            // build a list of all trigger listeners that are to be notified...
             var listeners = BuildTriggerListenerList();
+            return listeners is null ? Task.FromResult(false) : NotifyAwaited();
 
-            // notify all trigger listeners in the list
-            foreach (ITriggerListener tl in listeners)
+            async Task<bool> NotifyAwaited()
             {
-                if (!MatchTriggerListener(tl, jec.Trigger.Key))
+                var vetoedExecution = false;
+                foreach (ITriggerListener tl in listeners)
                 {
-                    continue;
-                }
-                try
-                {
-                    await tl.TriggerFired(jec.Trigger, jec, cancellationToken).ConfigureAwait(false);
-
-                    if (await tl.VetoJobExecution(jec.Trigger, jec, cancellationToken).ConfigureAwait(false))
+                    if (!MatchTriggerListener(tl, jec.Trigger.Key))
                     {
-                        vetoedExecution = true;
+                        continue;
+                    }
+
+                    try
+                    {
+                        await tl.TriggerFired(jec.Trigger, jec, cancellationToken).ConfigureAwait(false);
+
+                        if (await tl.VetoJobExecution(jec.Trigger, jec, cancellationToken).ConfigureAwait(false))
+                        {
+                            vetoedExecution = true;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        SchedulerException se = new SchedulerException($"TriggerListener '{tl.Name}' threw exception: {e.Message}", e);
+                        throw se;
                     }
                 }
-                catch (Exception e)
-                {
-                    SchedulerException se = new SchedulerException($"TriggerListener '{tl.Name}' threw exception: {e.Message}", e);
-                    throw se;
-                }
-            }
 
-            return vetoedExecution;
+                return vetoedExecution;
+            }
         }
 
         /// <summary>
@@ -1662,28 +1675,31 @@ namespace Quartz.Core
         /// </summary>
         /// <param name="trigger">The trigger.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
-        public virtual async Task NotifyTriggerListenersMisfired(
+        public virtual Task NotifyTriggerListenersMisfired(
             ITrigger trigger,
             CancellationToken cancellationToken = default)
         {
-            // build a list of all trigger listeners that are to be notified...
             var listeners = BuildTriggerListenerList();
+            return listeners is null ? Task.CompletedTask : NotifyAwaited();
 
-            // notify all trigger listeners in the list
-            foreach (ITriggerListener tl in listeners)
+            async Task NotifyAwaited()
             {
-                if (!MatchTriggerListener(tl, trigger.Key))
+                foreach (ITriggerListener tl in listeners)
                 {
-                    continue;
-                }
-                try
-                {
-                    await tl.TriggerMisfired(trigger, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    SchedulerException se = new SchedulerException($"TriggerListener '{tl.Name}' threw exception: {e.Message}", e);
-                    throw se;
+                    if (!MatchTriggerListener(tl, trigger.Key))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        await tl.TriggerMisfired(trigger, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        SchedulerException se = new SchedulerException($"TriggerListener '{tl.Name}' threw exception: {e.Message}", e);
+                        throw se;
+                    }
                 }
             }
         }
@@ -1694,31 +1710,37 @@ namespace Quartz.Core
         /// <param name="jec">The job execution context.</param>
         /// <param name="instCode">The instruction code to report to triggers.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
-        public virtual async Task NotifyTriggerListenersComplete(
+        public virtual Task NotifyTriggerListenersComplete(
             IJobExecutionContext jec,
             SchedulerInstruction instCode,
             CancellationToken cancellationToken = default)
         {
-            // build a list of all trigger listeners that are to be notified...
             var listeners = BuildTriggerListenerList();
-
-            // notify all trigger listeners in the list
-            for (var i = 0; i < listeners.Count; i++)
+            if (listeners is null)
             {
-                ITriggerListener tl = listeners[i];
-                if (!MatchTriggerListener(tl, jec.Trigger.Key))
-                {
-                    continue;
-                }
+                return Task.CompletedTask;
+            }
 
-                try
+            return NotifyAwaited();
+
+            async Task NotifyAwaited()
+            {
+                foreach (var tl in listeners)
                 {
-                    await tl.TriggerComplete(jec.Trigger, jec, instCode, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    SchedulerException se = new SchedulerException($"TriggerListener '{tl.Name}' threw exception: {e.Message}", e);
-                    throw se;
+                    if (!MatchTriggerListener(tl, jec.Trigger.Key))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        await tl.TriggerComplete(jec.Trigger, jec, instCode, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        SchedulerException se = new SchedulerException($"TriggerListener '{tl.Name}' threw exception: {e.Message}", e);
+                        throw se;
+                    }
                 }
             }
         }
@@ -1728,31 +1750,11 @@ namespace Quartz.Core
         /// </summary>
         /// <param name="jec">The jec.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
-        public virtual async Task NotifyJobListenersToBeExecuted(
+        public virtual Task NotifyJobListenersToBeExecuted(
             IJobExecutionContext jec,
             CancellationToken cancellationToken = default)
         {
-            // build a list of all job listeners that are to be notified...
-            var listeners = BuildJobListenerList();
-
-            // notify all job listeners
-            for (var i = 0; i < listeners.Count; i++)
-            {
-                IJobListener jl = listeners[i];
-                if (!MatchJobListener(jl, jec.JobDetail.Key))
-                {
-                    continue;
-                }
-                try
-                {
-                    await jl.JobToBeExecuted(jec, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    SchedulerException se = new SchedulerException($"JobListener '{jl.Name}' threw exception: {e.Message}", e);
-                    throw se;
-                }
-            }
+            return NotifyJobListeners(jl => jl.JobToBeExecuted(jec, cancellationToken), jec, null);
         }
 
         /// <summary>
@@ -1760,30 +1762,11 @@ namespace Quartz.Core
         /// </summary>
         /// <param name="jec">The job execution context.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
-        public virtual async Task NotifyJobListenersWasVetoed(
+        public virtual Task NotifyJobListenersWasVetoed(
             IJobExecutionContext jec,
             CancellationToken cancellationToken = default)
         {
-            // build a list of all job listeners that are to be notified...
-            var listeners = BuildJobListenerList();
-
-            // notify all job listeners
-            foreach (IJobListener jl in listeners)
-            {
-                if (!MatchJobListener(jl, jec.JobDetail.Key))
-                {
-                    continue;
-                }
-                try
-                {
-                    await jl.JobExecutionVetoed(jec, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    SchedulerException se = new SchedulerException($"JobListener '{jl.Name}' threw exception: {e.Message}", e);
-                    throw se;
-                }
-            }
+            return NotifyJobListeners(jl => jl.JobExecutionVetoed(jec, cancellationToken), jec, null);
         }
 
         /// <summary>
@@ -1792,25 +1775,60 @@ namespace Quartz.Core
         /// <param name="jec">The jec.</param>
         /// <param name="je">The je.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
-        public virtual async Task NotifyJobListenersWasExecuted(
+        public virtual Task NotifyJobListenersWasExecuted(
             IJobExecutionContext jec,
             JobExecutionException? je,
             CancellationToken cancellationToken = default)
         {
-            // build a list of all job listeners that are to be notified...
-            var listeners = BuildJobListenerList();
+            return NotifyJobListeners(jl => jl.JobWasExecuted(jec, je, cancellationToken), jec, je);
+        }
 
-            // notify all job listeners
-            for (var i = 0; i < listeners.Count; i++)
+        // optimized version to reduce state machine creations
+        private Task NotifyJobListeners(           
+            Func<IJobListener, Task> notifyAction, 
+            IJobExecutionContext jec,
+            JobExecutionException? je)
+        {
+            var (singleListener, listeners) = BuildJobListenerList();
+            if (singleListener != null)
             {
-                IJobListener jl = listeners[i];
-                if (!MatchJobListener(jl, jec.JobDetail.Key))
+                if (!MatchJobListener(singleListener, jec.JobDetail.Key))
                 {
-                    continue;
+                    return Task.CompletedTask;
                 }
+
                 try
                 {
-                    await jl.JobWasExecuted(jec, je, cancellationToken).ConfigureAwait(false);
+                    var task = notifyAction(singleListener);
+                    return task.IsCompletedSuccessfully() ? Task.CompletedTask : NotifySingle(task, singleListener);
+                }
+                catch (Exception e)
+                {
+                    SchedulerException se = new SchedulerException($"JobListener '{singleListener.Name}' threw exception: {e.Message}", e);
+                    throw se;
+                }
+            }
+            
+            return singleListener != null || listeners is null ? Task.CompletedTask : NotifyAwaited();
+
+            async Task NotifyAwaited()
+            {
+                foreach (var jl in listeners)
+                {
+                    if (!MatchJobListener(jl, jec.JobDetail.Key))
+                    {
+                        continue;
+                    }
+
+                    await NotifySingle(notifyAction(jl), jl).ConfigureAwait(false);
+                }
+            }
+
+            static async Task NotifySingle(Task t, IJobListener jl)
+            {
+                try
+                {
+                    await t.ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -1835,9 +1853,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.SchedulerError(msg, se, cancellationToken).ConfigureAwait(false);
@@ -1873,9 +1890,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     if (triggerKey == null)
@@ -1922,9 +1938,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.TriggersPaused(@group, cancellationToken).ConfigureAwait(false);
@@ -1947,9 +1962,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.TriggerPaused(triggerKey, cancellationToken).ConfigureAwait(false);
@@ -1984,9 +1998,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.TriggerResumed(triggerKey, cancellationToken).ConfigureAwait(false);
@@ -2009,9 +2022,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     sl.JobPaused(jobKey, cancellationToken);
@@ -2034,9 +2046,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.JobsPaused(@group, cancellationToken).ConfigureAwait(false);
@@ -2059,9 +2070,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.JobResumed(jobKey, cancellationToken).ConfigureAwait(false);
@@ -2084,9 +2094,8 @@ namespace Quartz.Core
             var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            for (var i = 0; i < schedListeners.Count; i++)
+            foreach (var sl in schedListeners)
             {
-                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.JobsResumed(@group, cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1569,7 +1569,7 @@ namespace Quartz.Core
         {
             var listeners = new List<ITriggerListener>();
             listeners.AddRange(ListenerManager.GetTriggerListeners());
-            listeners.AddRange(InternalTriggerListeners);
+            listeners.AddRange(internalTriggerListeners.Values);
             return listeners;
         }
 
@@ -1577,7 +1577,7 @@ namespace Quartz.Core
         {
             var listeners = new List<IJobListener>();
             listeners.AddRange(ListenerManager.GetJobListeners());
-            listeners.AddRange(InternalJobListeners);
+            listeners.AddRange(internalJobListeners.Values);
             return listeners;
         }
 
@@ -1703,12 +1703,14 @@ namespace Quartz.Core
             var listeners = BuildTriggerListenerList();
 
             // notify all trigger listeners in the list
-            foreach (ITriggerListener tl in listeners)
+            for (var i = 0; i < listeners.Count; i++)
             {
+                ITriggerListener tl = listeners[i];
                 if (!MatchTriggerListener(tl, jec.Trigger.Key))
                 {
                     continue;
                 }
+
                 try
                 {
                     await tl.TriggerComplete(jec.Trigger, jec, instCode, cancellationToken).ConfigureAwait(false);
@@ -1731,11 +1733,12 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<IJobListener> listeners = BuildJobListenerList();
+            var listeners = BuildJobListenerList();
 
             // notify all job listeners
-            foreach (IJobListener jl in listeners)
+            for (var i = 0; i < listeners.Count; i++)
             {
+                IJobListener jl = listeners[i];
                 if (!MatchJobListener(jl, jec.JobDetail.Key))
                 {
                     continue;
@@ -1795,11 +1798,12 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<IJobListener> listeners = BuildJobListenerList();
+            var listeners = BuildJobListenerList();
 
             // notify all job listeners
-            foreach (IJobListener jl in listeners)
+            for (var i = 0; i < listeners.Count; i++)
             {
+                IJobListener jl = listeners[i];
                 if (!MatchJobListener(jl, jec.JobDetail.Key))
                 {
                     continue;
@@ -1828,11 +1832,12 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all scheduler listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.SchedulerError(msg, se, cancellationToken).ConfigureAwait(false);
@@ -1865,11 +1870,12 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all scheduler listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     if (triggerKey == null)
@@ -1913,18 +1919,19 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
-                    await sl.TriggersPaused(group, cancellationToken).ConfigureAwait(false);
+                    await sl.TriggersPaused(@group, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
-                    log.ErrorException($"Error while notifying SchedulerListener of paused group: {group}", e);
+                    log.ErrorException($"Error while notifying SchedulerListener of paused group: {@group}", e);
                 }
             }
         }
@@ -1937,11 +1944,12 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.TriggerPaused(triggerKey, cancellationToken).ConfigureAwait(false);
@@ -1973,11 +1981,12 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.TriggerResumed(triggerKey, cancellationToken).ConfigureAwait(false);
@@ -1997,11 +2006,12 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     sl.JobPaused(jobKey, cancellationToken);
@@ -2021,18 +2031,19 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
-                    await sl.JobsPaused(group, cancellationToken).ConfigureAwait(false);
+                    await sl.JobsPaused(@group, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
-                    log.ErrorException($"Error while notifying SchedulerListener of paused group: {group}", e);
+                    log.ErrorException($"Error while notifying SchedulerListener of paused group: {@group}", e);
                 }
             }
         }
@@ -2045,11 +2056,12 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
                     await sl.JobResumed(jobKey, cancellationToken).ConfigureAwait(false);
@@ -2069,18 +2081,19 @@ namespace Quartz.Core
             CancellationToken cancellationToken = default)
         {
             // build a list of all job listeners that are to be notified...
-            IEnumerable<ISchedulerListener> schedListeners = BuildSchedulerListenerList();
+            var schedListeners = BuildSchedulerListenerList();
 
             // notify all scheduler listeners
-            foreach (ISchedulerListener sl in schedListeners)
+            for (var i = 0; i < schedListeners.Count; i++)
             {
+                ISchedulerListener sl = schedListeners[i];
                 try
                 {
-                    await sl.JobsResumed(group, cancellationToken).ConfigureAwait(false);
+                    await sl.JobsResumed(@group, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
-                    log.ErrorException($"Error while notifying SchedulerListener of resumed group: {group}", e);
+                    log.ErrorException($"Error while notifying SchedulerListener of resumed group: {@group}", e);
                 }
             }
         }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -2155,7 +2155,8 @@ namespace Quartz.Core
         }
 
         protected virtual async Task NotifySchedulerListeners(
-            Func<ISchedulerListener, Task> notifier, string action)
+            Func<ISchedulerListener, Task> notifier, 
+            string action)
         {
             // notify all scheduler listeners
             var listeners = BuildSchedulerListenerList();

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1570,7 +1570,7 @@ namespace Quartz.Core
         {
             var listeners = ListenerManager.GetTriggerListeners();
 
-            if (listeners.Count == 0 && internalTriggerListeners.Count == 0)
+            if (listeners.Count == 0 && !internalTriggerListeners.GetEnumerator().MoveNext())
             {
                 // default case that we don't have any 
                 return null;

--- a/src/Quartz/ExceptionHelper.cs
+++ b/src/Quartz/ExceptionHelper.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Quartz
+{
+    internal static class ExceptionHelper
+    {
+        [DoesNotReturn]
+        public static void ThrowArgumentNullException(string? paramName, string? message)
+        {
+            throw new ArgumentNullException(paramName, message);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowArgumentException(string message, string paramName)
+        {
+            throw new ArgumentException(message, paramName);
+        }
+    }
+}

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -105,7 +105,7 @@ namespace Quartz.Impl
             PreviousFireTimeUtc = firedBundle.PrevFireTimeUtc;
             NextFireTimeUtc = firedBundle.NextFireTimeUtc;
 
-            jobDataMap = new JobDataMap();
+            jobDataMap = new JobDataMap(jobDetail.JobDataMap.Count + trigger.JobDataMap.Count);
             jobDataMap.PutAll(jobDetail.JobDataMap);
             jobDataMap.PutAll(trigger.JobDataMap);
             cancellationTokenSource = new CancellationTokenSource();
@@ -195,10 +195,7 @@ namespace Quartz.Impl
         /// interfaces.
         /// </para>
         /// </summary>
-        public virtual IJob JobInstance
-        {
-            get { return jobInstance; }
-        }
+        public virtual IJob JobInstance => jobInstance;
 
         /// <summary>
         /// The actual time the trigger fired. For instance the scheduled time may

--- a/src/Quartz/JobDataMap.cs
+++ b/src/Quartz/JobDataMap.cs
@@ -67,14 +67,21 @@ namespace Quartz
         /// <summary>
         /// Create an empty <see cref="JobDataMap" />.
         /// </summary>
-        public JobDataMap() : base(15)
+        public JobDataMap() : this(0)
+        {
+        }
+
+        /// <summary>
+        /// Create <see cref="JobDataMap" /> with initial capacity.
+        /// </summary>
+        public JobDataMap(int initialCapacity) : base(initialCapacity)
         {
         }
 
         /// <summary>
         /// Create a <see cref="JobDataMap" /> with the given data.
         /// </summary>
-        public JobDataMap(IDictionary<string, object> map) : this()
+        public JobDataMap(IDictionary<string, object> map) : this(map.Count)
         {
             PutAll(map);
 
@@ -86,7 +93,7 @@ namespace Quartz
         /// <summary>
         /// Create a <see cref="JobDataMap" /> with the given data.
         /// </summary>
-        public JobDataMap(IDictionary map) : this()
+        public JobDataMap(IDictionary map) : this(map.Count)
         {
 #pragma warning disable 8605
             foreach (DictionaryEntry entry in map)

--- a/src/Quartz/Simpl/PropertySettingJobFactory.cs
+++ b/src/Quartz/Simpl/PropertySettingJobFactory.cs
@@ -95,14 +95,23 @@ namespace Quartz.Simpl
 
 			var jobDataMap = BuildJobDataMap(bundle, scheduler);
 
-			SetObjectProperties(job, jobDataMap);
+			if (jobDataMap.Count > 0)
+			{
+				SetObjectProperties(job, jobDataMap);
+			}
 
 			return job;
 		}
 
 	    protected virtual JobDataMap BuildJobDataMap(TriggerFiredBundle bundle, IScheduler scheduler)
 	    {
-		    JobDataMap jobDataMap = new JobDataMap();
+		    var capacity = scheduler.Context.Count + bundle.JobDetail.JobDataMap.Count + bundle.Trigger.JobDataMap.Count;
+		    JobDataMap jobDataMap = new JobDataMap(capacity);
+		    if (capacity == 0)
+		    {
+			    return jobDataMap;
+		    }
+
 		    jobDataMap.PutAll(scheduler.Context);
 		    jobDataMap.PutAll(bundle.JobDetail.JobDataMap);
 		    jobDataMap.PutAll(bundle.Trigger.JobDataMap);
@@ -135,8 +144,12 @@ namespace Quartz.Simpl
 	    /// <param name="value">Value to set.</param>
 	    protected virtual void SetObjectProperty(object job, string name, object? value)
 	    {
-		    string c = CultureInfo.InvariantCulture.TextInfo.ToUpper(name.Substring(0, 1));
-		    string propName = c + name.Substring(1);
+		    string propName = name; 
+		    if (!char.IsUpper(name[0]))
+		    {
+			    var c = char.ToUpper(name[0]);
+			    propName = c + name.Substring(1);
+		    }
 
 		    var o = value;
 		    var prop = job.GetType().GetProperty(propName);

--- a/src/Quartz/TaskExtensions.cs
+++ b/src/Quartz/TaskExtensions.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Quartz
+{
+    internal static class TaskExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsCompletedSuccessfully(this Task t)
+        {
+            return t.Status == TaskStatus.RanToCompletion && !t.IsFaulted && !t.IsCanceled;
+        }   
+    }
+}

--- a/src/Quartz/Util/ObjectUtils.cs
+++ b/src/Quartz/Util/ObjectUtils.cs
@@ -106,15 +106,15 @@ namespace Quartz.Util
         {
             if (type == null)
             {
-                throw new ArgumentNullException(nameof(type), "Cannot instantiate null");
+                ExceptionHelper.ThrowArgumentNullException(nameof(type), "Cannot instantiate null");
             }
             
             var ci = type.GetConstructor(Type.EmptyTypes);
             if (ci == null)
             {
-                throw new ArgumentException("Cannot instantiate type which has no empty constructor", type.Name);
+                ExceptionHelper.ThrowArgumentException("Cannot instantiate type which has no empty constructor", type.Name);
             }
-            return (T) ci.Invoke(new object[0]);
+            return (T) ci.Invoke(Array.Empty<object>());
         }
 
         /// <summary>


### PR DESCRIPTION
Reduce memory usage and state machine creations.

## Before

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.508 (2004/?/20H1)
AMD Ryzen 7 2700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-rc.2.20479.15
  [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  DefaultJob : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT


```
| Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|    Run | 5.736 μs | 0.0658 μs | 0.0615 μs | 0.9232 |     - |     - |   3.79 KB |


## After

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.508 (2004/?/20H1)
AMD Ryzen 7 2700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-rc.2.20479.15
  [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  DefaultJob : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT


```
| Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|    Run | 3.786 μs | 0.0322 μs | 0.0301 μs | 0.4959 |     - |     - |   2.05 KB |
