### PR TITLE
JobBuilder.UsingJobData(string key, string value) should be JobBuilder.UsingJobData(string key, string? value)

### DIFF
--- a/src/Quartz/JobBuilder.cs
+++ b/src/Quartz/JobBuilder.cs
@@ -277,7 +277,7 @@ namespace Quartz
         /// </summary>
         ///<returns>the updated JobBuilder</returns>
         /// <seealso cref="IJobDetail.JobDataMap" />
-        public JobBuilder UsingJobData(string key, string value)
+        public JobBuilder UsingJobData(string key, string? value)
         {
             jobDataMap.Put(key, value);
             return this;


### PR DESCRIPTION
JobBuilder.UsingJobData(string key, string value) should be JobBuilder.UsingJobData(string key, string? value)

fixes #1025 