### PR TITLE
Improve StringKeyDirtyFlagMap.GetDateTime

### DIFF
--- a/src/Quartz/Util/StringKeyDirtyFlagMap.cs
+++ b/src/Quartz/Util/StringKeyDirtyFlagMap.cs
@@ -331,7 +331,10 @@ namespace Quartz.Util
 
             try
             {
-                return Convert.ToDateTime(obj, CultureInfo.InvariantCulture);
+                return
+                    obj is DateTimeOffset dto
+                        ? dto.DateTime
+                        : Convert.ToDateTime(obj, CultureInfo.InvariantCulture);
             }
             catch (Exception)
             {


### PR DESCRIPTION
* can handle DateTimeOffset (possible due Json serializer)

fixes #1027