### PR TITLE
Handled exceptions thrown while retrieving the misfired trigger

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -751,7 +751,17 @@ namespace Quartz.Impl.AdoJobStore
 
             foreach (TriggerKey triggerKey in misfiredTriggers)
             {
-                var trig = await RetrieveTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false);
+                IOperableTrigger? trig;
+                try
+                {
+                    trig = await RetrieveTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    Log.ErrorException($"Error retrieving the misfired trigger: '{triggerKey}'", e);
+                    continue;
+                }
+
                 if (trig == null)
                 {
                     continue;

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -767,7 +767,15 @@ namespace Quartz.Impl.AdoJobStore
                     continue;
                 }
 
-                await DoUpdateOfMisfiredTrigger(conn, trig, false, StateWaiting, recovering).ConfigureAwait(false);
+                try
+                {
+                    await DoUpdateOfMisfiredTrigger(conn, trig, false, StateWaiting, recovering).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    Log.ErrorException($"Error updating misfired trigger: '{trig.Key}'", e);
+                    continue;
+                }
 
                 DateTimeOffset? nextTime = trig.GetNextFireTimeUtc();
                 if (nextTime.HasValue && nextTime.Value < earliestNewTime)


### PR DESCRIPTION
When the scheduler tries to recover all misfired triggers, if one of the triggers throws an exception due to some reason(Invalid CRON expression in my case), the remaining triggers are skipped due to the fact that the exception is not handled. So, we made this change to make the misfired trigger recovery process resilient to any kind if exception.