### PR TITLE
Fix UseTimeZoneConverter when using IServiceCollectionQuartzConfigurator

### DIFF
--- a/src/Quartz.Plugins.TimeZoneConverter/TimeZonePluginConfigurationExtensions.cs
+++ b/src/Quartz.Plugins.TimeZoneConverter/TimeZonePluginConfigurationExtensions.cs
@@ -5,7 +5,7 @@ namespace Quartz
 {
     public static class TimeZonePluginConfigurationExtensions
     {
-        public static T UseTimeZoneConverter<T>(this T schedulerBuilder) where T : IPropertyConfigurationRoot
+        public static T UseTimeZoneConverter<T>(this T schedulerBuilder) where T : IPropertySetter
         {
             schedulerBuilder.SetProperty("quartz.plugin.timeZoneConverter.type", typeof(TimeZoneConverterPlugin).AssemblyQualifiedNameWithoutVersion());
             return schedulerBuilder;


### PR DESCRIPTION
I am not sure if this is the correct thing to do, but it is easier to simply show you the suggested changes for you to review.
I get this compile error message as follows:
> The type 'Quartz.IServiceCollectionQuartzConfigurator' cannot be used as type parameter 'T' in the generic type or method 'TimeZonePluginConfigurationExtensions.UseTimeZoneConverter<T>(T)'. There is no implicit reference conversion from 'Quartz.IServiceCollectionQuartzConfigurator' to 'Quartz.IPropertyConfigurationRoot'

`IServiceCollectionQuartzConfigurator` has the interface `IPropertyConfigurer` which itself has the interface `IPropertySetter`. `IPropertyConfigurationRoot` also has the `IPropertySetter` interface. By changing the interface requirements the problem should disappear (not tested).