### PR TITLE
Updated JobRunShell to handle only scheduler-related cancellations

### DIFF
--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -197,6 +197,9 @@ namespace Quartz.Core
                         endTime = SystemTime.UtcNow();
                     }
                     catch (OperationCanceledException)
+                    
+                    // handle only scheduler-related cancellations
+                    when (cancellationToken.IsCancellationRequested)
                     {
                         endTime = SystemTime.UtcNow();
                         log.InfoFormat($"Job {jobDetail.Key} was cancelled");


### PR DESCRIPTION
Updated JobRunShell to handle only scheduler-related cancellations.
Closes #1064 