### PR TITLE
Fix possible NRE in QuartzHostedService.StopAsync

### DIFF
--- a/src/Quartz.Extensions.Hosting/QuartzHostedService.cs
+++ b/src/Quartz.Extensions.Hosting/QuartzHostedService.cs
@@ -26,9 +26,12 @@ namespace Quartz
             await scheduler.Start(cancellationToken);
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
-            return scheduler.Shutdown(options.Value.WaitForJobsToComplete, cancellationToken);
+            if (scheduler != null)
+            {
+                await scheduler.Shutdown(options.Value.WaitForJobsToComplete, cancellationToken);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix `NullReferenceException` in `QuartzHostedService.StopAsync` if
`StartAsync` has not been run.

`StartAsync` won't run if there's another hosted service that is registered
earlier and throws in its `StartAsync`. Exception in `StartAsync` causes
Asp.Net Core to begin shutdown during which all hosted services are stopped
via `StopAsync`.

#1123 