### PR TITLE
Use ActivatorUtilities in MicrosoftDependencyInjectionJobFactory

### DIFF
--- a/docs/documentation/quartz-3.x/packages/hosted-services-integration.md
+++ b/docs/documentation/quartz-3.x/packages/hosted-services-integration.md
@@ -58,13 +58,7 @@ public class Program
                     // we take this from appsettings.json, just show it's possible
                     // q.SchedulerName = "Quartz ASP.NET Core Sample Scheduler";
 
-                    // we could leave DI configuration intact and then jobs need to have public no-arg constructor
-                    // the MS DI is expected to produce transient job instances 
-                    q.UseMicrosoftDependencyInjectionJobFactory(options =>
-                    {
-                        // if we don't have the job in DI, allow fallback to configure via default constructor
-                        options.AllowDefaultConstructor = true;
-                    });
+                    q.UseMicrosoftDependencyInjectionJobFactory();
 
                     // or 
                     // q.UseMicrosoftDependencyInjectionScopedJobFactory();

--- a/docs/documentation/quartz-3.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-3.x/packages/microsoft-di-integration.md
@@ -53,16 +53,8 @@ public void ConfigureServices(IServiceCollection services)
         // we take this from appsettings.json, just show it's possible
         // q.SchedulerName = "Quartz ASP.NET Core Sample Scheduler";
         
-        // we could leave DI configuration intact and then jobs need
-        // to have public no-arg constructor
-        // the MS DI is expected to produce transient job instances
         // this WONT'T work with scoped services like EF Core's DbContext
-        q.UseMicrosoftDependencyInjectionJobFactory(options =>
-        {
-            // if we don't have the job in DI, allow fallback 
-			// to configure via default constructor
-            options.AllowDefaultConstructor = true;
-        });
+        q.UseMicrosoftDependencyInjectionJobFactory();
 
         // or for scoped service support like EF Core DbContext
         // q.UseMicrosoftDependencyInjectionScopedJobFactory();

--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -75,15 +75,9 @@ namespace Quartz.Examples.AspNetCore
                 // we take this from appsettings.json, just show it's possible
                 // q.SchedulerName = "Quartz ASP.NET Core Sample Scheduler";
 
-                // we could leave DI configuration intact and then jobs need to have public no-arg constructor
-                // the MS DI is expected to produce transient job instances
-                
                 // this is default configuration if you don't alter it
                 q.UseMicrosoftDependencyInjectionJobFactory(options =>
                 {
-                    // if we don't have the job in DI, allow fallback to configure via default constructor
-                    options.AllowDefaultConstructor = true;
-                    
                     // set to true if you want to inject scoped services like Entity Framework's DbContext
                     options.CreateScope = false;
                 });

--- a/src/Quartz.Examples.Worker/Program.cs
+++ b/src/Quartz.Examples.Worker/Program.cs
@@ -37,9 +37,6 @@ namespace Quartz.Examples.Worker
                         // this is default configuration if you don't alter it
                         q.UseMicrosoftDependencyInjectionJobFactory(options =>
                         {
-                            // if we don't have the job in DI, allow fallback to configure via default constructor
-                            options.AllowDefaultConstructor = true;
-                    
                             // set to true if you want to inject scoped services like Entity Framework's DbContext
                             options.CreateScope = false;
                         });

--- a/src/Quartz.Extensions.DependencyInjection/JobFactoryOptions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/JobFactoryOptions.cs
@@ -1,7 +1,15 @@
+using System;
+
 namespace Quartz
 {
     public class JobFactoryOptions
     {
+        /// <summary>
+        /// When DI has not been configured with the job type, should the default no-arg public constructor be tried.
+        /// </summary>
+        [Obsolete("The value is ignored as all jobs are created with ActivatorUtilities.CreateInstance (see https://github.com/quartznet/quartznet/issues/1120).")]
+        public bool AllowDefaultConstructor { get; set; }
+
         /// <summary>
         /// Whether to use scopes when building job instances, enables injection of scoped services like
         /// Entity Framework's DbContext.

--- a/src/Quartz.Extensions.DependencyInjection/JobFactoryOptions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/JobFactoryOptions.cs
@@ -3,11 +3,6 @@ namespace Quartz
     public class JobFactoryOptions
     {
         /// <summary>
-        /// When DI has not been configured with the job type, should the default no-arg public constructor be tried.
-        /// </summary>
-        public bool AllowDefaultConstructor { get; set; }
-
-        /// <summary>
         /// Whether to use scopes when building job instances, enables injection of scoped services like
         /// Entity Framework's DbContext.
         /// </summary>

--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -62,6 +62,8 @@ namespace Quartz
                 services.TryAddSingleton(typeof(ITypeLoadHelper), typeof(SimpleTypeLoadHelper));
             }
 
+            services.TryAddSingleton<JobActivatorCache>();
+
             var allowDefaultConstructor = false;
             if (string.IsNullOrWhiteSpace(properties[StdSchedulerFactory.PropertySchedulerJobFactoryType]))
             {

--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -193,8 +193,6 @@ namespace Quartz
                 quartzOptions.jobDetails.Add(jobDetail);
             });
 
-            options.Services.TryAddTransient(jobDetail.JobType);
-
             var triggerConfigurator = new TriggerConfigurator();
             triggerConfigurator.ForJob(jobDetail);
 

--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -64,12 +64,10 @@ namespace Quartz
 
             services.TryAddSingleton<JobActivatorCache>();
 
-            var allowDefaultConstructor = false;
             if (string.IsNullOrWhiteSpace(properties[StdSchedulerFactory.PropertySchedulerJobFactoryType]))
             {
-                // there's no explicit job factory defined, use MS version and allow default constructor
+                // there's no explicit job factory defined, use MS version
                 services.TryAddSingleton(typeof(IJobFactory), typeof(MicrosoftDependencyInjectionJobFactory));
-                allowDefaultConstructor = true;
             }
 
             services.Configure<QuartzOptions>(options =>
@@ -77,11 +75,6 @@ namespace Quartz
                 foreach (var key in schedulerBuilder.Properties.AllKeys)
                 {
                     options[key] = schedulerBuilder.Properties[key];
-                }
-
-                if (allowDefaultConstructor)
-                {
-                    options.JobFactory.AllowDefaultConstructor = true;
                 }
             });
 

--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -62,8 +62,6 @@ namespace Quartz
                 services.TryAddSingleton(typeof(ITypeLoadHelper), typeof(SimpleTypeLoadHelper));
             }
 
-            services.TryAddSingleton<JobActivatorCache>();
-
             if (string.IsNullOrWhiteSpace(properties[StdSchedulerFactory.PropertySchedulerJobFactoryType]))
             {
                 // there's no explicit job factory defined, use MS version

--- a/src/Quartz.Extensions.DependencyInjection/Simpl/JobActivatorCache.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/JobActivatorCache.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Quartz.Simpl
 {
-    public class JobActivatorCache
+    internal class JobActivatorCache
     {
         private readonly ConcurrentDictionary<Type, ObjectFactory> activatorCache = new ConcurrentDictionary<Type, ObjectFactory>();
         private readonly Func<Type, ObjectFactory> createFactory = type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes);

--- a/src/Quartz.Extensions.DependencyInjection/Simpl/JobActivatorCache.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/JobActivatorCache.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Concurrent;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Simpl
+{
+    public class JobActivatorCache
+    {
+        private readonly ConcurrentDictionary<Type, ObjectFactory> activatorCache = new ConcurrentDictionary<Type, ObjectFactory>();
+        private readonly Func<Type, ObjectFactory> createFactory = type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes);
+
+        public IJob CreateInstance(IServiceProvider serviceProvider, Type jobType)
+        {
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            if (jobType is null)
+            {
+                throw new ArgumentNullException(nameof(jobType));
+            }
+
+            var factory = activatorCache.GetOrAdd(jobType, createFactory);
+            return (IJob)factory(serviceProvider, null);
+        }
+    }
+}

--- a/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
@@ -19,12 +19,11 @@ namespace Quartz.Simpl
 
         public MicrosoftDependencyInjectionJobFactory(
             IServiceProvider serviceProvider,
-            IOptions<QuartzOptions> options,
-            JobActivatorCache activatorCache)
+            IOptions<QuartzOptions> options)
         {
             this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
-            this.activatorCache = activatorCache ?? throw new ArgumentNullException(nameof(activatorCache));
+            this.activatorCache = new JobActivatorCache();
         }
 
         protected override IJob InstantiateJob(TriggerFiredBundle bundle, IScheduler scheduler)

--- a/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
@@ -15,13 +15,16 @@ namespace Quartz.Simpl
     {
         private readonly IServiceProvider serviceProvider;
         private readonly IOptions<QuartzOptions> options;
+        private readonly JobActivatorCache activatorCache;
 
         public MicrosoftDependencyInjectionJobFactory(
             IServiceProvider serviceProvider,
-            IOptions<QuartzOptions> options)
+            IOptions<QuartzOptions> options,
+            JobActivatorCache activatorCache)
         {
             this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            this.options = options;
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.activatorCache = activatorCache ?? throw new ArgumentNullException(nameof(activatorCache));
         }
 
         protected override IJob InstantiateJob(TriggerFiredBundle bundle, IScheduler scheduler)
@@ -33,22 +36,17 @@ namespace Quartz.Simpl
                 //	e.g. database contexts
                 var scope = serviceProvider.CreateScope();
 
-                var job = CreateJob(bundle, scheduler, scope.ServiceProvider);
+                var job = CreateJob(bundle, scope.ServiceProvider);
 
                 return new ScopedJob(scope, job);
             }
 
-            return CreateJob(bundle, scheduler, serviceProvider);
+            return CreateJob(bundle, serviceProvider);
         }
 
-        private IJob CreateJob(TriggerFiredBundle bundle, IScheduler scheduler, IServiceProvider serviceProvider)
+        private IJob CreateJob(TriggerFiredBundle bundle, IServiceProvider serviceProvider)
         {
-            if (options.Value.JobFactory.AllowDefaultConstructor)
-            {
-                return (IJob)(serviceProvider.GetService(bundle.JobDetail.JobType) ?? base.InstantiateJob(bundle, scheduler));
-            }
-
-            return (IJob) serviceProvider.GetRequiredService(bundle.JobDetail.JobType);
+            return activatorCache.CreateInstance(serviceProvider, bundle.JobDetail.JobType);
         }
 
         public override void ReturnJob(IJob job)

--- a/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
@@ -69,8 +69,8 @@ namespace Quartz.Simpl
 
             public void Dispose()
             {
-                scope.Dispose();
                 (innerJob as IDisposable)?.Dispose();
+                scope.Dispose();
             }
 
             public Task Execute(IJobExecutionContext context)


### PR DESCRIPTION
This PR changes `MicrosoftDependencyInjectionJobFactory` to stop resolving jobs from the container and instead creates them with `ActivatorUtilities` (i.e. job dependencies are resolved from the container, the job is newed up).

Job types should no longer be registered in the container. `ScheduleJob` extension is changed to no longer register the job type.

This change fixes double disposal of `IDisposable` jobs (#1120). Prior to this change, `IDisposable` jobs were disposed twice: by the container as well as by the job factory (`ScopedJob`). And when there was no scope (`CreateScope=false`), the container kept all job instances until the container itself was disposed, creating a resource leak.
 
`AllowDefaultConstructor` option is now redundant and has been removed.

Fixes #1120 