### PR TITLE
Fix XSD schema

### DIFF
--- a/src/Quartz/Xml/job_scheduling_data_2_0.xsd
+++ b/src/Quartz/Xml/job_scheduling_data_2_0.xsd
@@ -105,10 +105,8 @@
       <xs:element name="group" type="xs:string" minOccurs="0" />
       <xs:element name="description" type="xs:string" minOccurs="0" />
       <xs:element name="job-type" type="xs:string" />
-      <xs:sequence minOccurs="0">
-        <xs:element name="durable" type="xs:boolean" />
-        <xs:element name="recover" type="xs:boolean" />
-      </xs:sequence>
+      <xs:element name="durable" type="xs:boolean" minOccurs="0" />
+      <xs:element name="recover" type="xs:boolean" minOccurs="0" />
       <xs:element name="job-data-map" type="job-data-mapType" minOccurs="0" />
     </xs:sequence>
   </xs:complexType>


### PR DESCRIPTION
Fix XSD schema to remove the dependency between `durable` and `recover` parameters according to the issue #1128