### PR TITLE
Remove redundant DI job registration from AddJob

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -133,7 +133,6 @@ namespace Quartz
             {
                 x.jobDetails.Add(jobDetail);
             });
-            options.Services.TryAddTransient(jobDetail.JobType);
 
             return options;
         }


### PR DESCRIPTION
This removes redundant DI job registration which was missed in #1127 .