### PR TITLE
Add support for the ISchedulerFactory.StartDelayed in the QuartzHostedService

### DIFF
--- a/src/Quartz.Examples.Worker/Program.cs
+++ b/src/Quartz.Examples.Worker/Program.cs
@@ -83,6 +83,9 @@ namespace Quartz.Examples.Worker
                     {
                         // when shutting down we want jobs to complete gracefully
                         options.WaitForJobsToComplete = true;
+
+                        // when we need to init another IHostedServices first
+                        options.StartDelay = TimeSpan.FromSeconds(10);
                     });
                 });
     }

--- a/src/Quartz.Extensions.Hosting/QuartzHostedService.cs
+++ b/src/Quartz.Extensions.Hosting/QuartzHostedService.cs
@@ -23,7 +23,15 @@ namespace Quartz
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             scheduler = await schedulerFactory.GetScheduler(cancellationToken);
-            await scheduler.Start(cancellationToken);
+
+            if (options.Value.StartDelay.HasValue)
+            {
+                await scheduler.StartDelayed(options.Value.StartDelay.Value, cancellationToken);
+            }
+            else
+            {
+                await scheduler.Start(cancellationToken);
+            }
         }
 
         public async Task StopAsync(CancellationToken cancellationToken)

--- a/src/Quartz.Extensions.Hosting/QuartzHostedServiceOptions.cs
+++ b/src/Quartz.Extensions.Hosting/QuartzHostedServiceOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Quartz
 {
     public class QuartzHostedServiceOptions
@@ -7,5 +9,10 @@ namespace Quartz
         /// to return until all currently executing jobs have completed.
         /// </summary>
         public bool WaitForJobsToComplete { get; set; }
+
+        /// <summary>
+        /// if not <see langword="null" /> the scheduler will start after specified delay.
+        /// </summary>
+        public TimeSpan? StartDelay { get; set; }
     }
 }


### PR DESCRIPTION
Hi, this PR adds support for the already existing `ISchedulerFactory.StartDelayed` when using pre-prepared `AddQuartzHostedService`.