### PR TITLE
Restore System.Data.SqlClient support on .NET Core

### DIFF
--- a/docs/documentation/quartz-3.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-3.x/tutorial/job-stores.md
@@ -103,7 +103,8 @@ Currently following database providers are supported:
 * `SqlServer` - SQL Server driver
     * For full framework this is by default System.Data.SqlClient (except in Quartz 3.1)
     * From Quartz 3.2 onwards for .NET Core this is by default Microsoft.Data.SqlClient
-* `MicrosoftDataSqlClient` - Available separately on on full framework (default for .NET Core)
+* `SystemDataSqlClient` - Available separately on .NET Core (default for full framework)
+* `MicrosoftDataSqlClient` - Available separately on full framework (default for .NET Core)
 * `OracleODP` - Oracle's Oracle Driver
 * `OracleODPManaged` - Oracle's managed driver for Oracle 11
 * `MySql` - MySQL Connector/.NET

--- a/src/Quartz/Impl/AdoJobStore/Common/dbproviders.netstandard.properties
+++ b/src/Quartz/Impl/AdoJobStore/Common/dbproviders.netstandard.properties
@@ -1,4 +1,6 @@
 # SQL SERVER
+
+# the default is Microsoft.Data.SqlClient
 quartz.dbprovider.SqlServer.productName=Microsoft SQL Server Core
 quartz.dbprovider.SqlServer.assemblyName=System.Data
 quartz.dbprovider.SqlServer.connectionType=Microsoft.Data.SqlClient.SqlConnection, Microsoft.Data.SqlClient
@@ -11,6 +13,34 @@ quartz.dbprovider.SqlServer.exceptionType=Microsoft.Data.SqlClient.SqlException,
 quartz.dbprovider.SqlServer.useParameterNamePrefixInParameterCollection=true
 quartz.dbprovider.SqlServer.bindByName=true
 quartz.dbprovider.SqlServer.dbBinaryTypeName=VarBinary
+
+# alias for System.Data.SqlClient
+quartz.dbprovider.SystemDataSqlClient.productName=Microsoft SQL Server Core
+quartz.dbprovider.SystemDataSqlClient.assemblyName=System.Data, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+quartz.dbprovider.SystemDataSqlClient.connectionType=System.Data.SqlClient.SqlConnection, System.Data.SqlClient, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+quartz.dbprovider.SystemDataSqlClient.commandType=System.Data.SqlClient.SqlCommand, System.Data.SqlClient, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+quartz.dbprovider.SystemDataSqlClient.parameterType=System.Data.SqlClient.SqlParameter, System.Data.SqlClient, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+quartz.dbprovider.SystemDataSqlClient.parameterDbType=System.Data.SqlDbType, System.Data.SqlClient, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+quartz.dbprovider.SystemDataSqlClient.parameterDbTypePropertyName=SqlDbType
+quartz.dbprovider.SystemDataSqlClient.parameterNamePrefix=@
+quartz.dbprovider.SystemDataSqlClient.exceptionType=System.Data.SqlClient.SqlException, System.Data.SqlClient, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+quartz.dbprovider.SystemDataSqlClient.useParameterNamePrefixInParameterCollection=true
+quartz.dbprovider.SystemDataSqlClient.bindByName=true
+quartz.dbprovider.SystemDataSqlClient.dbBinaryTypeName=VarBinary
+
+# alias for Microsoft.Data.SqlClient
+quartz.dbprovider.MicrosoftDataSqlClient.productName=Microsoft SQL Server Core
+quartz.dbprovider.MicrosoftDataSqlClient.assemblyName=System.Data
+quartz.dbprovider.MicrosoftDataSqlClient.connectionType=Microsoft.Data.SqlClient.SqlConnection, Microsoft.Data.SqlClient
+quartz.dbprovider.MicrosoftDataSqlClient.commandType=Microsoft.Data.SqlClient.SqlCommand, Microsoft.Data.SqlClient
+quartz.dbprovider.MicrosoftDataSqlClient.parameterType=Microsoft.Data.SqlClient.SqlParameter, Microsoft.Data.SqlClient
+quartz.dbprovider.MicrosoftDataSqlClient.parameterDbType=System.Data.SqlDbType, System.Data.Common
+quartz.dbprovider.MicrosoftDataSqlClient.parameterDbTypePropertyName=SqlDbType
+quartz.dbprovider.MicrosoftDataSqlClient.parameterNamePrefix=@
+quartz.dbprovider.MicrosoftDataSqlClient.exceptionType=Microsoft.Data.SqlClient.SqlException, Microsoft.Data.SqlClient
+quartz.dbprovider.MicrosoftDataSqlClient.useParameterNamePrefixInParameterCollection=true
+quartz.dbprovider.MicrosoftDataSqlClient.bindByName=true
+quartz.dbprovider.MicrosoftDataSqlClient.dbBinaryTypeName=VarBinary
 
 # PostgreSQL Npgsql
 quartz.dbprovider.Npgsql.productName=Npgsql


### PR DESCRIPTION
Added the ability to optionally use `System.Data.SqlClient` on .NET Core (https://github.com/quartznet/quartznet/discussions/950#discussioncomment-415731)

If we want to use `System.Data.SqlServer` in .NET Core we can specify it explicitly with this parameter
`quartz.dataSource.myDS.provider = SystemDataSqlClient`