### PR TITLE
Added a configuration point to the private Scope of MicrosoftDependencyInjectionJobFactory

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
@@ -30,14 +30,16 @@ namespace Quartz.Simpl
             //  Generate a scope for the job, this allows the job to be registered
             //	using .AddScoped<T>() which means we can use scoped dependencies 
             //	e.g. database contexts
-            var scope = ConfigureScope(bundle, scheduler);
+            var scope = serviceProvider.CreateScope();
+            ConfigureScope(scope, bundle, scheduler);
             var (job, fromContainer) = CreateJob(bundle, scope.ServiceProvider);
             return new ScopedJob(scope, job, canDispose: !fromContainer);
         }
 
-        protected virtual IServiceScope ConfigureScope(TriggerFiredBundle bundle, IScheduler scheduler)
+        protected virtual void ConfigureScope(IServiceScope scope, TriggerFiredBundle bundle, IScheduler scheduler)
         {
-            return serviceProvider.CreateScope();
+            // Configuration point for Services that are Scoped and need
+            // the ambiente context of a Job
         }
 
         public override void SetObjectProperties(object obj, JobDataMap data)

--- a/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -30,9 +30,14 @@ namespace Quartz.Simpl
             //  Generate a scope for the job, this allows the job to be registered
             //	using .AddScoped<T>() which means we can use scoped dependencies 
             //	e.g. database contexts
-            var scope = serviceProvider.CreateScope();
+            var scope = ConfigureScope(bundle, scheduler);
             var (job, fromContainer) = CreateJob(bundle, scope.ServiceProvider);
             return new ScopedJob(scope, job, canDispose: !fromContainer);
+        }
+
+        protected virtual IServiceScope ConfigureScope(TriggerFiredBundle bundle, IScheduler scheduler)
+        {
+            return serviceProvider.CreateScope();
         }
 
         public override void SetObjectProperties(object obj, JobDataMap data)


### PR DESCRIPTION
This PR aims to enable a configuration point to the private `IServiceScope` created by the `MicrosoftDependencyInjectionJobFactory`

With that solution in place we could inherit the `MicrosoftDependencyInjectionJobFactory` and configure scoped types based on Job Data or another property from the ambient context.