### PR TITLE
ScheduleJob(trigger => trigger.WithIdentity()): Set job identity to match

### DIFF
--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,113 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Quartz.Tests.Unit.Extensions.DependencyInjection
+{
+    [TestFixture()]
+    public class ServiceCollectionExtensionsTests
+    {
+        [Test]
+        public void ScheduleJob_WithJobIdentity_ShouldHonorIt()
+        {
+            var services = new ServiceCollection();
+
+            // Go through AddQuartz(), because the IServiceCollectionQuartzConfigurator interface refuses mocking or implementation, due to an internal default-implemented property
+            services.AddQuartz(quartz => quartz.ScheduleJob<DummyJob>(
+                trigger => trigger.WithIdentity("TriggerName", "TriggerGroup"),
+                job => job.WithIdentity("JobName", "JobGroup")));
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var quartzOptions = serviceProvider.GetRequiredService<IOptions<QuartzOptions>>().Value;
+
+            Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
+            Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+
+            var trigger = quartzOptions.Triggers.Single();
+            var job = quartzOptions.JobDetails.Single();
+
+            // The trigger key should have its own manual configuration
+            Assert.AreEqual("TriggerName", trigger.Key.Name);
+            Assert.AreEqual("TriggerGroup", trigger.Key.Group);
+
+            // The job key should have its own manual configuration
+            Assert.AreEqual("JobName", job.Key.Name);
+            Assert.AreEqual("JobGroup", job.Key.Group);
+
+            // Also validate that the trigger knows the correct job key
+            Assert.AreEqual(job.Key.Name, trigger.JobKey.Name);
+            Assert.AreEqual(job.Key.Group, trigger.JobKey.Group);
+        }
+
+        [Test]
+        public void ScheduleJob_WithoutJobIdentityWithoutTriggerIdentity_ShouldCopyFromTriggerIdentity()
+        {
+            var services = new ServiceCollection();
+
+            // Go through AddQuartz(), because the IServiceCollectionQuartzConfigurator interface refuses mocking or implementation, due to an internal default-implemented property
+            services.AddQuartz(quartz => quartz.ScheduleJob<DummyJob>(
+                trigger => { }));
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var quartzOptions = serviceProvider.GetRequiredService<IOptions<QuartzOptions>>().Value;
+
+            Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
+            Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+
+            var trigger = quartzOptions.Triggers.Single();
+            var job = quartzOptions.JobDetails.Single();
+
+            // The job's key should match the trigger's (auto-generated) key
+            Assert.AreEqual(trigger.Key.Name, job.Key.Name);
+            Assert.AreEqual(trigger.Key.Group, job.Key.Group);
+
+            // Also validate that the trigger knows the correct job key
+            Assert.AreEqual(job.Key.Name, trigger.JobKey.Name);
+            Assert.AreEqual(job.Key.Group, trigger.JobKey.Group);
+        }
+
+        [Test]
+        public void ScheduleJob_WithoutJobIdentityWithTriggerIdentity_ShouldCopyFromTriggerIdentity()
+        {
+            var services = new ServiceCollection();
+
+            // Go through AddQuartz(), because the IServiceCollectionQuartzConfigurator interface refuses mocking or implementation, due to an internal default-implemented property
+            services.AddQuartz(quartz => quartz.ScheduleJob<DummyJob>(
+                trigger => trigger.WithIdentity("TriggerName", "TriggerGroup")));
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var quartzOptions = serviceProvider.GetRequiredService<IOptions<QuartzOptions>>().Value;
+
+            Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
+            Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+
+            var trigger = quartzOptions.Triggers.Single();
+            var job = quartzOptions.JobDetails.Single();
+
+            // The trigger key should have its own manual configuration
+            Assert.AreEqual("TriggerName", trigger.Key.Name);
+            Assert.AreEqual("TriggerGroup", trigger.Key.Group);
+
+            // The job's key should match the trigger's (auto-generated) key
+            Assert.AreEqual(trigger.Key.Name, job.Key.Name);
+            Assert.AreEqual(trigger.Key.Group, job.Key.Group);
+
+            // Also validate that the trigger knows the correct job key
+            Assert.AreEqual(job.Key.Name, trigger.JobKey.Name);
+            Assert.AreEqual(job.Key.Group, trigger.JobKey.Group);
+        }
+
+        private sealed class DummyJob : IJob
+        {
+            public Task Execute(IJobExecutionContext context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -19,11 +19,13 @@
     <PackageReference Include="FakeItEasy" Version="6.2.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Quartz.Extensions.DependencyInjection\Quartz.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
     <ProjectReference Include="..\Quartz.Jobs\Quartz.Jobs.csproj" />
     <ProjectReference Include="..\Quartz.Plugins\Quartz.Plugins.csproj" />

--- a/src/Quartz/JobBuilder.cs
+++ b/src/Quartz/JobBuilder.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 
 /* 
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -72,6 +72,11 @@ namespace Quartz
         private bool shouldRecover;
 
         private JobDataMap jobDataMap = new JobDataMap();
+
+        /// <summary>
+        /// The key that identifies the job uniquely.
+        /// </summary>
+        internal JobKey? Key => key;
 
         protected JobBuilder()
         {


### PR DESCRIPTION
Implements https://github.com/quartznet/quartznet/issues/1211.

`ScheduleJob(trigger => trigger.WithIdentity(...))`, without a job configurator, now sets the job identity to match the trigger's (instead of `"DEFAULT-[UUID]"`).