### PR TITLE
Fix StartDelay delaying the start of other hosted services

### DIFF
--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -103,9 +103,9 @@ namespace Quartz.Tests.Unit.Core
             var sf = new StdSchedulerFactory(properties);
 
             IScheduler sched = await sf.GetScheduler();
-            var task = sched.StartDelayed(TimeSpan.FromSeconds(2));
+            await sched.StartDelayed(TimeSpan.FromMilliseconds(100));
             Assert.IsFalse(sched.IsStarted);
-            await task;
+            await Task.Delay(200);
             Assert.IsTrue(sched.IsStarted);
         }
 

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -105,7 +105,7 @@ namespace Quartz.Tests.Unit.Core
             IScheduler sched = await sf.GetScheduler();
             await sched.StartDelayed(TimeSpan.FromMilliseconds(100));
             Assert.IsFalse(sched.IsStarted);
-            await Task.Delay(500);
+            await Task.Delay(1000);
             Assert.IsTrue(sched.IsStarted);
         }
 

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -105,7 +105,7 @@ namespace Quartz.Tests.Unit.Core
             IScheduler sched = await sf.GetScheduler();
             await sched.StartDelayed(TimeSpan.FromMilliseconds(100));
             Assert.IsFalse(sched.IsStarted);
-            await Task.Delay(200);
+            await Task.Delay(500);
             Assert.IsTrue(sched.IsStarted);
         }
 

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -394,7 +394,7 @@ namespace Quartz.Core
                 throw new SchedulerException(
                     "The Scheduler cannot be restarted after Shutdown() has been called.");
             }
-            return Task.Run(async () =>
+            Task.Run(async () =>
             {
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 
@@ -407,6 +407,8 @@ namespace Quartz.Core
                     log.ErrorException("Unable to start scheduler after startup delay.", se);
                 }
             }, cancellationToken);
+
+            return Task.CompletedTask;
         }
 
         /// <summary>


### PR DESCRIPTION
QuartzScheduler.StartDelay is changed not to wait on the background Task anymore.  Returning a task is preserved so that the API does not change.

Update TestStartDelayed test to take less time. This test is more non-deterministic now.

Fixes #1313