### PR TITLE
RAMJobStore: Improve performance of StoreTrigger(Internal) by avoiding clone of job

### DIFF
--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -455,7 +455,7 @@ namespace Quartz.Simpl
                     RemoveTriggerInternal(newTrigger.Key, removeOrphanedJob: false);
                 }
 
-                if (RetrieveJobInternal(newTrigger.JobKey) == null)
+                if (!CheckExistsInternal(newTrigger.JobKey))
                 {
                     throw new JobPersistenceException("The job (" + newTrigger.JobKey +
                                                       ") referenced by the trigger does not exist.");
@@ -684,6 +684,19 @@ namespace Quartz.Simpl
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult(jobsByKey.ContainsKey(jobKey));
+        }
+
+        /// <summary>
+        /// Determine whether a <see cref="IJob"/> with the given identifier already
+        /// exists within the scheduler.
+        /// </summary>
+        /// <param name="jobKey">the identifier to check for</param>
+        /// <returns>
+        /// <see langword="true"/> if a job exists with the given identifier; otherwise <see langword="false"/>.
+        /// </returns>
+        private bool CheckExistsInternal(JobKey jobKey)
+        {
+            return jobsByKey.ContainsKey(jobKey);
         }
 
         /// <summary>


### PR DESCRIPTION
We currently use `RetrieveJobInternal(JobKey jobKey)` in `StoreTriggerInternal(IOperableTrigger newTrigger, bool replaceExisting)` to check if the job of the trigger exists.

This comes with an extra cost as we also clone the job In `RetrieveJobInternal(JobKey jobKey)`.

I introduced a `CheckExistsInternal(JobKey jobKey)` method that only check if a job exists with the specified key, and use it in `StoreTriggerInternal(IOperableTrigger newTrigger, bool replaceExisting)`.

Let me know if you want me to:
* also use that method in `CheckExists(JobKey jobKey)`.
-or-
* remove the `CheckExistsInternal(JobKey jobKey)` method, and just use `jobsByKey.ContainsKey(jobKey)` directly in `StoreTriggerInternal(IOperableTrigger newTrigger, bool replaceExisting)`.

Benchmark results:

|                                      Method | Branch |       Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------------------- | -------|-----------:|--------:|--------:|-------:|------:|------:|----------:|
| StoreTrigger_ReplaceExisting_SingleThreaded | main |   853.6 ns | 1.96 ns | 1.74 ns | 0.2060 |     - |     - |     864 B |
|  StoreTrigger_ReplaceExisting_SingleThreaded| PR     |   789.0 ns | 3.02 ns | 2.36 ns | 0.1717 |     - |     - |     720 B |
|  StoreTrigger_ReplaceExisting_MultiThreaded | main  | 1,045.3 ns | 3.91 ns | 3.27 ns | 0.2067 |     - |     - |     864 B |
|   StoreTrigger_ReplaceExisting_MultiThreaded| PR     |   969.7 ns | 4.26 ns | 3.78 ns | 0.1717 |     - |     - |     720 B |

<details>
<summary>Benchmark code:</summary>

```cs
using BenchmarkDotNet.Attributes;
using Quartz.Job;
using Quartz.Simpl;
using Quartz.Spi;
using System.Linq;
using System.Threading;
using System.Threading.Tasks;

namespace Quartz.Benchmark
{
    [MemoryDiagnoser]
    public class RAMJobStoreBenchmark
    {
        private RAMJobStore _ramJobStore;
        private IOperableTrigger _trigger;
        private IJobDetail _job;

        public RAMJobStoreBenchmark()
        {
            _ramJobStore = new RAMJobStore();

            _job = JobBuilder.Create<NoOpJob>().Build();
            _ramJobStore.StoreJob(_job, false);

            _trigger = (IOperableTrigger)TriggerBuilder.Create().ForJob(_job).WithSimpleSchedule().StartNow().Build();
        }

        [Benchmark]
        public void StoreTrigger_ReplaceExisting_SingleThreaded()
        {
            _ramJobStore.StoreTrigger(_trigger, true);
        }

        [Benchmark(OperationsPerInvoke = 200_000)]
        public void StoreTrigger_ReplaceExisting_MultiThreaded()
        {
            ManualResetEvent start = new ManualResetEvent(false);

            var tasks = Enumerable.Range(0, 20).Select(i =>
            {
                return Task.Run(() =>
                {
                    start.WaitOne();

                    for (var i = 0; i < 10_000; i++)
                    {
                        _ramJobStore.StoreTrigger(_trigger, true);
                    }
                });
            }).ToArray();

            start.Set();

            Task.WaitAll(tasks);
        }
    }
}
```
</details>

Contributes to resolving #1347.

**Note:**
You talked about wanting to seal **RAMJobStore**, but unable to do so because it's an extension point.
From an extensibility point-of-view, **RAMJobStore** is already broken.
You could for example override `GetTriggerKeys(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)`, but it would not have the desired effect because internally in **RAMJobStore** we use `GetTriggerKeysInternal(GroupMatcher<TriggerKey> matcher)`.
