### PR TITLE
RAMJobStore: Improve performance and reduce allocations of GetTriggersForJobInternal

### DIFF
--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -547,7 +547,7 @@ namespace Quartz.Simpl
                     {
                         JobWrapper jw = jobsByKey[tw.JobKey];
                         var trigs = GetTriggersForJobInternal(tw.JobKey);
-                        if ((trigs == null || trigs.Count == 0) && !jw.JobDetail.Durable)
+                        if (trigs.Length == 0 && !jw.JobDetail.Durable)
                         {
                             if (RemoveJobInternal(jw.Key))
                             {
@@ -1051,25 +1051,25 @@ namespace Quartz.Simpl
             JobKey jobKey,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(GetTriggersForJobInternal(jobKey));
+            return Task.FromResult<IReadOnlyCollection<IOperableTrigger>>(GetTriggersForJobInternal(jobKey));
         }
 
-        private IReadOnlyCollection<IOperableTrigger> GetTriggersForJobInternal(JobKey jobKey)
+        private IOperableTrigger[] GetTriggersForJobInternal(JobKey jobKey)
         {
             lock (lockObject)
             {
                 if (triggersByJob.TryGetValue(jobKey, out var jobList))
                 {
-                    var trigList = new List<IOperableTrigger>(jobList.Count);
-                    foreach (var tw in jobList)
+                    var trigList = new IOperableTrigger[jobList.Count];
+                    for (var i = 0; i < jobList.Count; i++)
                     {
-                        trigList.Add((IOperableTrigger) tw.Trigger.Clone());
+                        trigList[i] = (IOperableTrigger) jobList[i].Trigger.Clone();
                     }
                     return trigList;
                 }
             }
 
-            return new List<IOperableTrigger>();
+            return Array.Empty<IOperableTrigger>();
         }
 
         /// <summary>


### PR DESCRIPTION
Improve performance and reduce allocations of `GetTriggersForJobInternal(JobKey jobKey)` by having it return an array instead of a **IReadOnlyCollection\<IOperableTrigger>**.

This makes iterating the triggers more efficient (no enumerator is used), eliminates virtual method calls and removes all allocations (for this method) when there are no triggers for a given job.

<details>
<summary>Benchmark result</summary>

|                                      Method |       Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------------------------------- |-----------:|---------:|---------:|-------:|-------:|------:|----------:|
|     StoreAndRemoveJob_NoTriggersExistForJob |   459.3 ns |  1.47 ns |  1.37 ns | 0.1109 | 0.0009 |     - |     464 B |
|       StoreAndRemoveJob_TriggersExistForJob | 1,606.7 ns |  9.74 ns |  9.11 ns | 0.3625 |      - |     - |    1520 B |
| StoreAndRemoveJob_NoTriggersExistForJob_New |   445.4 ns |  1.68 ns |  1.49 ns | 0.0933 | 0.0008 |     - |     392 B |
|   StoreAndRemoveJob_TriggersExistForJob_New | 1,539.6 ns | 12.73 ns | 11.91 ns | 0.3200 |      - |     - |    1344 B |
</details>

<details>
<summary>Benchmark code:</summary>

```cs
using BenchmarkDotNet.Attributes;
using Quartz.Job;
using Quartz.Simpl;
using Quartz.Spi;

namespace Quartz.Benchmark
{
    [MemoryDiagnoser]
    public class RAMJobStoreBenchmark
    {
        private IOperableTrigger _trigger1;
        private IOperableTrigger _trigger2;
        private IJobDetail _job;

        public RAMJobStoreBenchmark()
        {
            _job = JobBuilder.Create<NoOpJob>().Build();

            var triggerBuilder = TriggerBuilder.Create();
            _trigger1 = (IOperableTrigger)triggerBuilder.ForJob(_job).WithSimpleSchedule().StartNow().Build();
            _trigger2 = (IOperableTrigger)triggerBuilder.ForJob(_job).WithSimpleSchedule().StartNow().Build();
        }

        [Benchmark(OperationsPerInvoke =100_000)]
        public void StoreAndRemoveJob_NoTriggersExistForJob()
        {
            var ramJobStore = new RAMJobStore();

            for (var i = 0; i < 100_000; i++)
            {
                ramJobStore.StoreJob(_job, true);
                ramJobStore.RemoveJob(_job.Key);
            }
        }

        [Benchmark(OperationsPerInvoke = 100_000)]
        public void StoreAndRemoveJob_TriggersExistForJob()
        {
            var ramJobStore = new RAMJobStore();

            for (var i = 0; i < 100_000; i++)
            {
                ramJobStore.StoreJob(_job, true);
                ramJobStore.StoreTrigger(_trigger1, true);
                ramJobStore.StoreTrigger(_trigger2, true);
                ramJobStore.RemoveJob(_job.Key);
            }
        }
    }
}
```
</details>

Contributes to resolving #1347.