### PR TITLE
RAMJobStore: Improve performance and reduce allocations of GetJobKeysInternal

### DIFF
--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -898,14 +898,14 @@ namespace Quartz.Simpl
             GroupMatcher<JobKey> matcher,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(GetJobKeysInternal(matcher));
+            return Task.FromResult<IReadOnlyCollection<JobKey>>(GetJobKeysInternal(matcher));
         }
 
-        private IReadOnlyCollection<JobKey> GetJobKeysInternal(GroupMatcher<JobKey> matcher)
+        private HashSet<JobKey> GetJobKeysInternal(GroupMatcher<JobKey> matcher)
         {
             lock (lockObject)
             {
-                HashSet<JobKey>? outList = null;
+                HashSet<JobKey> outList = new HashSet<JobKey>();
                 StringOperator op = matcher.CompareWithOperator;
                 string compareToValue = matcher.CompareToValue;
 
@@ -914,8 +914,6 @@ namespace Quartz.Simpl
                     jobsByGroup.TryGetValue(compareToValue, out var grpMap);
                     if (grpMap != null)
                     {
-                        outList = new HashSet<JobKey>();
-
                         foreach (JobWrapper jw in grpMap.Values)
                         {
                             if (jw != null)
@@ -931,10 +929,6 @@ namespace Quartz.Simpl
                     {
                         if (op.Evaluate(entry.Key, compareToValue) && entry.Value != null)
                         {
-                            if (outList == null)
-                            {
-                                outList = new HashSet<JobKey>();
-                            }
                             foreach (JobWrapper jobWrapper in entry.Value.Values)
                             {
                                 if (jobWrapper != null)
@@ -945,7 +939,7 @@ namespace Quartz.Simpl
                         }
                     }
                 }
-                return outList ?? new HashSet<JobKey>();
+                return outList;
             }
         }
 


### PR DESCRIPTION
Improve performance and reduce allocations of `GetJobKeysInternal(GroupMatcher<JobKey> matcher)` by returning concrete **HashSet\<JobKey>** instead of **IReadOnlyCollection\<JobKey>**.

Immediately initialize 'outList' as the method always initializes a new **HashSet\<JobKey>** anyway.

<details>
<summary>Benchmark results</summary>

|                                                                           Method | Branch   |    Mean |   Error |  StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|--------------------------------------------------------------------------------- |----------|--------:|--------:|--------:|-------:|-------:|------:|----------:|
|         ResumeJobs_EqualsMatch_NoMatchingPausedGroupsAndNoMatchingPausedTriggers | master   |202.3 ns | 1.02 ns | 0.95 ns | 0.1050 | 0.0009 |     - |     440 B |
|     ResumeJobs_EqualsMatch_NoMatchingPausedGroupsAndNoMatchingPausedTriggers_New | PR       |185.5 ns | 0.70 ns | 0.66 ns | 0.0956 | 0.0009 |     - |     400 B |
|     ResumeJobs_StartsWithMatch_NoMatchingPausedGroupsAndNoMatchingPausedTriggers | master   |210.1 ns | 0.75 ns | 0.66 ns | 0.1050 | 0.0009 |     - |     440 B |
| ResumeJobs_StartsWithMatch_NoMatchingPausedGroupsAndNoMatchingPausedTriggers_New | PR       |191.4 ns | 0.91 ns | 0.81 ns | 0.0956 | 0.0009 |     - |     400 B |

</details>

<details>
<summary>Benchmark code</summary>

```cs
using BenchmarkDotNet.Attributes;
using Quartz.Impl.Matchers;
using Quartz.Job;
using Quartz.Simpl;

namespace Quartz.Benchmark
{
    [MemoryDiagnoser]
    public class RAMJobStoreBenchmark
    {
        private IJobDetail _job;

        public RAMJobStoreBenchmark()
        {
            _job = JobBuilder.Create<NoOpJob>().WithIdentity("Job1", "Group1").Build();
        }

        [Benchmark(OperationsPerInvoke = 100_000)]
        public void ResumeJobs_EqualsMatch_NoMatchingPausedGroupsAndNoMatchingPausedTriggers()
        {
            var ramJobStore = new RAMJobStore();
            ramJobStore.StoreJob(_job, true);

            var matcher = GroupMatcher<JobKey>.GroupEquals(_job.Key.Group);

            for (var i = 0; i < 100_000; i++)
            {
                ramJobStore.ResumeJobs(matcher);
            }
        }

        [Benchmark(OperationsPerInvoke = 100_000)]
        public void ResumeJobs_StartsWithMatch_NoMatchingPausedGroupsAndNoMatchingPausedTriggers()
        {
            var ramJobStore = new RAMJobStore();
            ramJobStore.StoreJob(_job, true);

            var matcher = GroupMatcher<JobKey>.GroupStartsWith(_job.Key.Group);

            for (var i = 0; i < 100_000; i++)
            {
                ramJobStore.ResumeJobs(matcher);
            }
        }
    }
}
```
</details>

Contributes to resolving #1347.