### PR TITLE
Do not use BOM for source files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ indent_style = space
 # Code files
 [*.cs]
 indent_size = 4
-charset = utf-8-bom
+charset = utf-8
 
 # XML project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]


### PR DESCRIPTION
All the source files are in UTF-8 **without** BOM, but in our .editorconfig it was for some reason configured as UTF-8 **with** BOM.