### PR TITLE
Fix and improve performance of TriggerTimeComparator

### DIFF
--- a/src/Quartz.Benchmark/TriggerTimeComparatorBenchmark.cs
+++ b/src/Quartz.Benchmark/TriggerTimeComparatorBenchmark.cs
@@ -1,0 +1,331 @@
+using BenchmarkDotNet.Attributes;
+using Quartz.Spi;
+using System;
+using System.Collections.Generic;
+
+namespace Quartz.Benchmark
+{
+    [MemoryDiagnoser]
+    public class TriggerTimeComparatorBenchmark
+    {
+        private TriggerKey _triggerKeyA;
+        private TriggerKey _triggerKeyB;
+        private TriggerTimeComparator _comparerNew;
+        private TriggerTimeComparatorLegacy _comparerLegacy;
+        private MutableTrigger _triggerAPrio1NextFireTimeMinValue;
+        private MutableTrigger _triggerAPrio1NextFireTimeMaxValue;
+        private MutableTrigger _triggerAPrio1NextFireTimeNull;
+        private MutableTrigger _triggerBPrio1NextFireTimeNull;
+        private MutableTrigger _triggerBPrio2NextFireTimeNull;
+        private MutableTrigger _triggerBPrio1NextFireTimeMinValue;
+        private MutableTrigger _triggerBPrio2NextFireTimeMinValue;
+
+        public TriggerTimeComparatorBenchmark()
+        {
+            _triggerKeyA = new TriggerKey("A");
+            _triggerKeyB = new TriggerKey("B");
+
+            _comparerNew = new TriggerTimeComparator();
+            _comparerLegacy = new TriggerTimeComparatorLegacy();
+
+            _triggerAPrio1NextFireTimeMinValue = new MutableTrigger(_triggerKeyA, JobKey.Create("B"), 1, DateTimeOffset.MinValue);
+            _triggerAPrio1NextFireTimeMaxValue = new MutableTrigger(_triggerKeyA, JobKey.Create("B"), 1, DateTimeOffset.MaxValue);
+            _triggerAPrio1NextFireTimeNull = new MutableTrigger(_triggerKeyA, JobKey.Create("B"), 1, null);
+            _triggerBPrio1NextFireTimeNull = new MutableTrigger(_triggerKeyB, JobKey.Create("B"), 1, null);
+            _triggerBPrio2NextFireTimeNull = new MutableTrigger(_triggerKeyB, JobKey.Create("B"), 2, null);
+            _triggerBPrio1NextFireTimeMinValue = new MutableTrigger(_triggerKeyB, JobKey.Create("B"), 1, DateTimeOffset.MinValue);
+            _triggerBPrio2NextFireTimeMinValue = new MutableTrigger(_triggerKeyB, JobKey.Create("B"), 2, DateTimeOffset.MinValue);
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_ReferenceEquality_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerAPrio1NextFireTimeMaxValue, _triggerAPrio1NextFireTimeMaxValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeOfOtherIsNull_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerAPrio1NextFireTimeMinValue, _triggerAPrio1NextFireTimeNull);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeOfOtherIsLess_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerAPrio1NextFireTimeMaxValue, _triggerAPrio1NextFireTimeMinValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeOfOtherIsGreater_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerAPrio1NextFireTimeMinValue, _triggerAPrio1NextFireTimeMaxValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsEqual_PriorityOfOtherIsLess_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerBPrio2NextFireTimeMinValue, _triggerBPrio1NextFireTimeMinValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsEqual_PriorityOfOtherIsGreater_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerBPrio1NextFireTimeMinValue, _triggerBPrio2NextFireTimeMinValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsEqual_PriorityIsEqual_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerAPrio1NextFireTimeMinValue, _triggerBPrio1NextFireTimeMinValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsNull_PriorityOfOtherIsLess_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerBPrio2NextFireTimeNull, _triggerBPrio1NextFireTimeNull);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsNull_PriorityOfOtherIsGreater_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerBPrio1NextFireTimeNull, _triggerBPrio2NextFireTimeNull);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsNull_PriorityIsEqual_New()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerNew.Compare(_triggerAPrio1NextFireTimeNull, _triggerBPrio1NextFireTimeNull);
+            }
+        }
+        
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_ReferenceEquality_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerAPrio1NextFireTimeMaxValue, _triggerAPrio1NextFireTimeMaxValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeOfOtherIsNull_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerAPrio1NextFireTimeMinValue, _triggerAPrio1NextFireTimeNull);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeOfOtherIsLess_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerAPrio1NextFireTimeMaxValue, _triggerAPrio1NextFireTimeMinValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeOfOtherIsGreater_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerAPrio1NextFireTimeMinValue, _triggerAPrio1NextFireTimeMaxValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsEqual_PriorityOfOtherIsLess_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerBPrio2NextFireTimeMinValue, _triggerBPrio1NextFireTimeMinValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsEqual_PriorityOfOtherIsGreater_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerBPrio1NextFireTimeMinValue, _triggerBPrio2NextFireTimeMinValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsEqual_PriorityIsEqual_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerAPrio1NextFireTimeMinValue, _triggerBPrio1NextFireTimeMinValue);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsNull_PriorityOfOtherIsLess_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerBPrio2NextFireTimeNull, _triggerBPrio1NextFireTimeNull);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsNull_PriorityOfOtherIsGreater_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerBPrio1NextFireTimeNull, _triggerBPrio2NextFireTimeNull);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 300_000)]
+        public void CompareTo_NextFireTimeIsNull_PriorityIsEqual_Old()
+        {
+            for (var i = 0; i < 300_000; i++)
+            {
+                _comparerLegacy.Compare(_triggerAPrio1NextFireTimeNull, _triggerBPrio1NextFireTimeNull);
+            }
+        }
+
+        [Serializable]
+        public class TriggerTimeComparatorLegacy : IComparer<ITrigger>
+        {
+            public int Compare(ITrigger? trig1, ITrigger? trig2)
+            {
+                if (trig1 == null && trig2 == null)
+                {
+                    return 0;
+                }
+
+                var t1 = trig1!.GetNextFireTimeUtc();
+                var t2 = trig2!.GetNextFireTimeUtc();
+
+                if (t1 != null || t2 != null)
+                {
+                    if (t1 == null)
+                    {
+                        return 1;
+                    }
+
+                    if (t2 == null)
+                    {
+                        return -1;
+                    }
+
+                    if (t1 < t2)
+                    {
+                        return -1;
+                    }
+
+                    if (t1 > t2)
+                    {
+                        return 1;
+                    }
+                }
+
+                int comp = trig2.Priority - trig1.Priority;
+                if (comp != 0)
+                {
+                    return comp;
+                }
+
+                return trig1.Key.CompareTo(trig2.Key);
+            }
+        }
+
+        private class MutableTrigger : IMutableTrigger
+        {
+            private readonly DateTimeOffset? _nextFireTimeUtc;
+
+            public MutableTrigger(TriggerKey key, JobKey jobKey, int priority, DateTimeOffset? nextFireTimeUtc)
+            {
+                Key = key;
+                JobKey = jobKey;
+                Priority = priority;
+                _nextFireTimeUtc = nextFireTimeUtc;
+            }
+
+            public TriggerKey Key { get; set; }
+            public JobKey JobKey { get; set; }
+            public string? Description { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public string? CalendarName { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public JobDataMap JobDataMap { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public int Priority { get; set; }
+            public DateTimeOffset StartTimeUtc { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DateTimeOffset? EndTimeUtc { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public int MisfireInstruction { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DateTimeOffset? FinalFireTimeUtc => throw new NotImplementedException();
+            public bool HasMillisecondPrecision => throw new NotImplementedException();
+
+            public ITrigger Clone()
+            {
+                throw new NotImplementedException();
+            }
+
+            public int CompareTo(ITrigger? other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public DateTimeOffset? GetFireTimeAfter(DateTimeOffset? afterTime)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool GetMayFireAgain()
+            {
+                throw new NotImplementedException();
+            }
+
+            public DateTimeOffset? GetNextFireTimeUtc()
+            {
+                return _nextFireTimeUtc;
+            }
+
+            public DateTimeOffset? GetPreviousFireTimeUtc()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IScheduleBuilder GetScheduleBuilder()
+            {
+                throw new NotImplementedException();
+            }
+
+            public TriggerBuilder GetTriggerBuilder()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Quartz/TriggerTimeComparator.cs
+++ b/src/Quartz/TriggerTimeComparator.cs
@@ -15,13 +15,23 @@ namespace Quartz
     {
         public int Compare(ITrigger? trig1, ITrigger? trig2)
         {
-            if (trig1 == null && trig2 == null)
+            if (ReferenceEquals(trig1, trig2))
             {
                 return 0;
             }
-            
-            var t1 = trig1!.GetNextFireTimeUtc();
-            var t2 = trig2!.GetNextFireTimeUtc();
+
+            if (trig1 == null)
+            {
+                return 1;
+            }
+
+            if (trig2 == null)
+            {
+                return -1;
+            }
+
+            var t1 = trig1.GetNextFireTimeUtc();
+            var t2 = trig2.GetNextFireTimeUtc();
 
             if (t1 != null || t2 != null)
             {
@@ -29,20 +39,19 @@ namespace Quartz
                 {
                     return 1;
                 }
-
+                
                 if (t2 == null)
                 {
                     return -1;
                 }
 
-                if (t1 < t2)
+                // Use GetValueOrDefault() to avoid going through expensive Nullable<T>.Value.
+                // In .NET 6.0, the JIT has been improved but since we also support other and
+                // older CLRs...
+                var result = t1.GetValueOrDefault().CompareTo(t2.GetValueOrDefault());
+                if (result != 0)
                 {
-                    return -1;
-                }
-
-                if (t1 > t2)
-                {
-                    return 1;
+                    return result;
                 }
             }
 


### PR DESCRIPTION
Fix case where one of the triggers, but not both, is null.
Improve performance when comparing a trigger against itself, and when comparing next fire time.
Add corresponding benchmarks.

<details>
<summary>Benchmark results</summary>

|                                                 Method | Branch |      Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------------------------- |--------|----------:|----------:|----------:|------:|------:|------:|----------:|
|                            CompareTo_ReferenceEquality | master | 30.200 ns | 0.0282 ns | 0.0235 ns |     - |     - |     - |         - |
|                            CompareTo_ReferenceEquality | PR     |  1.914 ns | 0.0014 ns | 0.0013 ns |     - |     - |     - |         - |
|                    CompareTo_NextFireTimeOfOtherIsNull | master |  6.438 ns | 0.0505 ns | 0.0472 ns |     - |     - |     - |         - |
|                    CompareTo_NextFireTimeOfOtherIsNull | PR     |  6.135 ns | 0.0446 ns | 0.0395 ns |     - |     - |     - |         - |
|                    CompareTo_NextFireTimeOfOtherIsLess | master | 25.378 ns | 0.0367 ns | 0.0343 ns |     - |     - |     - |         - |
|                    CompareTo_NextFireTimeOfOtherIsLess | PR     | 14.364 ns | 0.0193 ns | 0.0171 ns |     - |     - |     - |         - |
|                 CompareTo_NextFireTimeOfOtherIsGreater | master | 15.571 ns | 0.0252 ns | 0.0236 ns |     - |     - |     - |         - |
|                 CompareTo_NextFireTimeOfOtherIsGreater | PR     | 14.379 ns | 0.0330 ns | 0.0309 ns |     - |     - |     - |         - |
|    CompareTo_NextFireTimeIsEqual_PriorityOfOtherIsLess | master | 27.115 ns | 0.0347 ns | 0.0307 ns |     - |     - |     - |         - |
|    CompareTo_NextFireTimeIsEqual_PriorityOfOtherIsLess | PR     | 16.266 ns | 0.0129 ns | 0.0108 ns |     - |     - |     - |         - |
| CompareTo_NextFireTimeIsEqual_PriorityOfOtherIsGreater | master | 27.099 ns | 0.0205 ns | 0.0192 ns |     - |     - |     - |         - |
| CompareTo_NextFireTimeIsEqual_PriorityOfOtherIsGreater | PR     | 16.566 ns | 0.0314 ns | 0.0278 ns |     - |     - |     - |         - |
|          CompareTo_NextFireTimeIsEqual_PriorityIsEqual | master | 65.847 ns | 0.1826 ns | 0.1708 ns |     - |     - |     - |         - |
|          CompareTo_NextFireTimeIsEqual_PriorityIsEqual | PR     | 58.928 ns | 0.1790 ns | 0.1674 ns |     - |     - |     - |         - |
|     CompareTo_NextFireTimeIsNull_PriorityOfOtherIsLess | master | 10.428 ns | 0.0074 ns | 0.0062 ns |     - |     - |     - |         - |
|     CompareTo_NextFireTimeIsNull_PriorityOfOtherIsLess | PR     |  8.826 ns | 0.0127 ns | 0.0106 ns |     - |     - |     - |         - |
|  CompareTo_NextFireTimeIsNull_PriorityOfOtherIsGreater | master | 10.442 ns | 0.0280 ns | 0.0262 ns |     - |     - |     - |         - |
|  CompareTo_NextFireTimeIsNull_PriorityOfOtherIsGreater | PR     |  8.835 ns | 0.0098 ns | 0.0082 ns |     - |     - |     - |         - |
|           CompareTo_NextFireTimeIsNull_PriorityIsEqual | master | 53.588 ns | 0.0954 ns | 0.0846 ns |     - |     - |     - |         - |
|           CompareTo_NextFireTimeIsNull_PriorityIsEqual | PR     | 53.540 ns | 1.0639 ns | 1.4563 ns |     - |     - |     - |         - |
</details>

The `Compare(ITrigger? trig1, ITrigger? trig2)` method is invoked between **2** and **2,5** million times if you run the **ScheduleBenchmark**. In about 10% of the calls, we're comparing a trigger with itself.

Contributes to #1363.