### PR TITLE
Reduce out-of-the-box memory usage of RAMJobStore

### DIFF
--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -57,7 +57,7 @@ namespace Quartz.Simpl
         private readonly Dictionary<string, Dictionary<TriggerKey, TriggerWrapper>> triggersByGroup = new Dictionary<string, Dictionary<TriggerKey, TriggerWrapper>>();
         private readonly SortedSet<TriggerWrapper> timeTriggers = new SortedSet<TriggerWrapper>(new TriggerWrapperComparator());
         private readonly Dictionary<string, ICalendar> calendarsByName = new Dictionary<string, ICalendar>();
-        private readonly Dictionary<JobKey, List<TriggerWrapper>> triggersByJob = new Dictionary<JobKey, List<TriggerWrapper>>(1000);
+        private readonly Dictionary<JobKey, List<TriggerWrapper>> triggersByJob = new Dictionary<JobKey, List<TriggerWrapper>>();
         private readonly HashSet<string> pausedTriggerGroups = new HashSet<string>();
         private readonly HashSet<string> pausedJobGroups = new HashSet<string>();
         private readonly HashSet<JobKey> blockedJobs = new HashSet<JobKey>();


### PR DESCRIPTION
We currently initialize the `triggersByJob` dictionary with an initial capacity of **1000**.
I'm not sure where this default comes from, but I don't see why we would want this.

For short-lived lists and dictionaries it's important to specify a good estimate of the required capacity (and where possible the exact capacity that you'll need), but here I don't see why we would want to pre-allocate that much capacity (or any capacity at all).

Alternatively, we could add a **capacity** argument to the ctor and leave it up to the "client" to decide.  But then the question is whether we'd want to apply that capacity for all dictionaries and sets. I don't think it makes sense for **pausedTriggerGroups**, **pausedJobGroups** and **blockedJobs**.

Personally, I wouldn't preallocate anything.