### PR TITLE
Fix SchedulerBenchmark

### DIFF
--- a/src/Quartz.Benchmark/SchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/SchedulerBenchmark.cs
@@ -33,14 +33,6 @@ namespace Quartz.Benchmark
         public void Run()
         {
             Run(OperationsPerRun);
-
-            var scheduler = CreateAndConfigureScheduler("A", "1", 15);
-            scheduler.Start();
-
-            Job.Wait();
-
-            scheduler.Shutdown(true).GetAwaiter().GetResult();
-            Job.Reset();
         }
 
         /// <summary>


### PR DESCRIPTION
Remove left-over from manual test which caused the same benchmark code to actually twice in the same iteration :(