### PR TITLE
Reduce allocations when notifying job listeners.

### DIFF
--- a/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
@@ -1,0 +1,175 @@
+using BenchmarkDotNet.Attributes;
+using Quartz.Core;
+using Quartz.Impl;
+using Quartz.Simpl;
+using Quartz.Spi;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Quartz.Benchmark
+{
+    [MemoryDiagnoser]
+    public class QuartSchedulerBenchmark
+    {
+        private QuartzScheduler _basicQuartzScheduler;
+        private StdScheduler _basicScheduler;
+        private JobExecutionContextImpl _jobExecutionContext;
+
+        public QuartSchedulerBenchmark()
+        {
+            _basicQuartzScheduler = CreateQuartzScheduler("basic", "basic", 5);
+            _basicScheduler = new StdScheduler(_basicQuartzScheduler);
+            _jobExecutionContext = CreateJobExecutionContext(_basicScheduler);
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            _basicQuartzScheduler.Shutdown(true).GetAwaiter().GetResult();
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersFired_SingleThreaded()
+        {
+            _basicQuartzScheduler.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersFired_MultiThreaded()
+        {
+            Execute(_basicQuartzScheduler, 20, 10_000, (scheduler) =>
+            {
+                _basicQuartzScheduler.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
+            });
+        }
+
+        [Benchmark]
+        public void NotifySchedulerListenersStarted_SingleThreaded()
+        {
+            _basicQuartzScheduler.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifySchedulerListenersStarted_MultiThreaded()
+        {
+            Execute(_basicQuartzScheduler, 20, 10_000, (scheduler) =>
+            {
+                scheduler.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+            });
+        }
+
+        [Benchmark]
+        public void NotifyJobListenersToBeExecuted_SingleThreaded()
+        {
+            _basicQuartzScheduler.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyJobListenersToBeExecuted_MultiThreaded()
+        {
+            Execute(_basicQuartzScheduler, 20, 10_000, (scheduler) =>
+            {
+                scheduler.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+            });
+        }
+
+        private static QuartzScheduler CreateQuartzScheduler(string name, string instanceId, int threadCount)
+        {
+            QuartzSchedulerResources res = new QuartzSchedulerResources
+            {
+                Name = name,
+                InstanceId = instanceId,
+                ThreadPool = new DefaultThreadPool { MaxConcurrency = threadCount },
+                JobStore = new RAMJobStore(),
+                MaxBatchSize = threadCount,
+                BatchTimeWindow = TimeSpan.Zero
+            };
+
+            return new QuartzScheduler(res, TimeSpan.Zero);
+        }
+
+        private JobExecutionContextImpl CreateJobExecutionContext(IScheduler scheduler)
+        {
+            var job = new Job();
+            var jobDetail = CreateJobDetail("A", job.GetType());
+            var trigger = (IOperableTrigger)CreateTrigger(TimeSpan.Zero);
+            trigger.FireInstanceId = Guid.NewGuid().ToString();
+
+            var triggerFiredBundle = new TriggerFiredBundle(jobDetail, trigger, null, false, DateTimeOffset.Now, null, null, null);
+
+            return new JobExecutionContextImpl(scheduler, triggerFiredBundle, job);
+        }
+
+        private static ITrigger CreateTrigger(TimeSpan repeatInterval)
+        {
+            return TriggerBuilder.Create()
+                                 .WithSimpleSchedule(
+                                     sb => sb.RepeatForever()
+                                             .WithInterval(repeatInterval)
+                                             .WithMisfireHandlingInstructionFireNow())
+                                 .Build();
+        }
+
+        private static IJobDetail CreateJobDetail(string group, Type jobType)
+        {
+            return JobBuilder.Create(jobType).WithIdentity(Guid.NewGuid().ToString(), group).Build();
+        }
+
+        private static void Execute(QuartzScheduler scheduler, int threadCount, int iterationsPerThread, Action<QuartzScheduler> action)
+        {
+            ManualResetEvent start = new ManualResetEvent(false);
+
+            var tasks = Enumerable.Range(0, threadCount).Select(i =>
+            {
+                return Task.Run(() =>
+                {
+                    start.WaitOne();
+
+                    for (var i = 0; i < iterationsPerThread; i++)
+                    {
+                        action(scheduler);
+                    }
+                });
+            }).ToArray();
+
+            start.Set();
+
+            Task.WaitAll(tasks);
+        }
+
+        [DisallowConcurrentExecution]
+        public class Job : IJob
+        {
+            private static readonly ManualResetEvent Done = new ManualResetEvent(false);
+            private static int RunCount = 0;
+            private static int _operationsPerRun;
+
+            public Task Execute(IJobExecutionContext context)
+            {
+                if (Interlocked.Increment(ref RunCount) == _operationsPerRun)
+                {
+                    Done.Set();
+                }
+                return Task.CompletedTask;
+            }
+
+            public static void Initialize(int operationsPerRun)
+            {
+                _operationsPerRun = operationsPerRun;
+            }
+
+            public static void Wait()
+            {
+                Done.WaitOne();
+            }
+
+            public static void Reset()
+            {
+                Done.Reset();
+                RunCount = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reduce allocations when notifying job listeners by avoiding captures.

**QuartSchedulerBenchmark**

|                                         Method | Branch |    Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------------------- |--------|--------:|--------:|--------:|-------:|------:|------:|----------:|
|  NotifyJobListenersToBeExecuted_SingleThreaded | v4     |334.3 ns | 0.65 ns | 0.58 ns | 0.0648 |     - |     - |     272 B |
|  NotifyJobListenersToBeExecuted_SingleThreaded | PR     |307.9 ns | 0.77 ns | 0.72 ns | 0.0305 |     - |     - |     128 B |
|   NotifyJobListenersToBeExecuted_MultiThreaded | v4     |475.5 ns | 0.77 ns | 0.68 ns | 0.0650 |     - |     - |     272 B |
|   NotifyJobListenersToBeExecuted_MultiThreaded | PR     |391.5 ns | 4.88 ns | 4.57 ns | 0.0307 |     - |     - |     128 B |

**SchedulerBenchmark**

|                                         Method | Branch |       Mean |        Error |       StdDev |      Gen 0 |  Gen 1 | Gen 2 |  Allocated |
|----------------------------------------------- |--------|-----------:|-------------:|-------------:|-----------:|-------:|------:|-----------:|
|                                         Run_15 | v4     |   6,668 ns |       0.6 ns |       0.5 ns |     0.9500 |      - |     - |     3952 B |
|                                         Run_15 | PR     | 6,667.7 ns |      1.04 ns |      0.81 ns |     0.9050 |      - |     - |     3760 B |
|                                         Run_50 | v4     |   4,000 ns |      75.2 ns |      80,4 ns |     0.9350 | 0.0050 |     - |     3880 B |
|                                         Run_50 | PR     | 3,915.4 ns |     70.16 ns |     65.63 ns |     0.8650 | 0.0100 |     - |     3586 B |
