### PR TITLE
Simplify TaskExtensions.IsCompletedSuccessfully(this Task t)

### DIFF
--- a/src/Quartz.Tests.Unit/TaskExtensionsTest.cs
+++ b/src/Quartz.Tests.Unit/TaskExtensionsTest.cs
@@ -1,0 +1,107 @@
+using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Quartz.Tests.Unit
+{
+    [TestFixture]
+    public class TaskExtensionsTest
+    {
+        [Test]
+        public void IsCompletedSuccessfully_Created()
+        {
+            var task = new Task(() => Task.Delay(300));
+
+            Assert.False(task.IsCompletedSuccessfully());
+            Assert.AreEqual(TaskStatus.Created, task.Status);
+        }
+
+        [Test]
+        public void IsCompletedSuccessfully_WaitingToRun()
+        {
+            var task = new Task(() => Thread.Sleep(300));
+            task.Start();
+
+            Assert.False(task.IsCompletedSuccessfully());
+            Assert.AreEqual(TaskStatus.WaitingToRun, task.Status);
+        }
+
+        [Test]
+        public void IsCompletedSuccessfully_Running()
+        {
+            var task = new Task(() => Thread.Sleep(300));
+            task.Start();
+
+            task.Wait(50);
+
+            Assert.False(task.IsCompletedSuccessfully());
+            Assert.AreEqual(TaskStatus.Running, task.Status);
+        }
+
+        [Test]
+        public void IsCompletedSuccessfully_WaitingForActivation()
+        {
+            var task = Task.Run(() => Task.Delay(300));
+
+            Assert.False(task.IsCompletedSuccessfully());
+            Assert.AreEqual(TaskStatus.WaitingForActivation, task.Status);
+        }
+
+        [Test]
+        public void IsCompletedSuccessfully_Canceled()
+        {
+            var tokenSource = new CancellationTokenSource();
+            CancellationToken ct = tokenSource.Token;
+
+            var task = Task.Run(() =>
+                {
+
+                    while (true)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                    }
+                }, ct);
+
+            tokenSource.Cancel();
+
+            try
+            {
+                task.GetAwaiter().GetResult();
+                Assert.Fail();
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.False(task.IsCompletedSuccessfully());
+                Assert.AreEqual(TaskStatus.Canceled, task.Status);
+            }
+        }
+
+        [Test]
+        public void IsCompletedSuccessfully_Faulted()
+        {
+            var task = Task.Run(() => throw new ApplicationException());
+
+            try
+            {
+                task.GetAwaiter().GetResult();
+                Assert.Fail();
+            }
+            catch (ApplicationException)
+            {
+                Assert.False(task.IsCompletedSuccessfully());
+                Assert.AreEqual(TaskStatus.Faulted, task.Status);
+            }
+        }
+
+        [Test]
+        public void IsCompletedSuccessfully_RanToCompletion()
+        {
+            var task = Task.Run(() => { });
+            task.Wait(30);
+
+            Assert.True(task.IsCompletedSuccessfully());
+            Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
+        }
+    }
+}

--- a/src/Quartz/TaskExtensions.cs
+++ b/src/Quartz/TaskExtensions.cs
@@ -8,7 +8,11 @@ namespace Quartz
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsCompletedSuccessfully(this Task t)
         {
-            return t.Status == TaskStatus.RanToCompletion && !t.IsFaulted && !t.IsCanceled;
-        }   
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+            return t.IsCompletedSuccessfully;
+#else
+            return t.Status == TaskStatus.RanToCompletion;
+#endif
+        }
     }
 }


### PR DESCRIPTION
In `TaskExtensions.IsCompletedSuccessfully(this Task t)` we currently consider the task to be completed successfully if all of the following conditions are met:
* **Status** is **RanToCompletion**.
* **IsFaulted** is **false**.
* **IsCanceled** is **false**.

These last two conditions are not necessary as **Status** is only **RanToCompletion** if the task completed successfully.

I added unit tests for `TaskExtensions.IsCompletedSuccessfully(this Task t)`, but they may require a little tuning to get them to produce stable results.