### PR TITLE
Remove allocations from captures when notifying trigger listeners

### DIFF
--- a/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
@@ -10,69 +10,381 @@ using System.Threading.Tasks;
 
 namespace Quartz.Benchmark
 {
+    /// <summary>
+    /// | scheduler |              internal             |              global               |
+    /// |           |    job    | scheduler |  trigger  |    job    | scheduler |  trigger  |
+    /// | --------- | --------- | --------- | --------- | --------- | --------- | --------- |
+    /// |     1     |     1     |     0     |     0     |     0     |     0     |     0     |
+    /// |     2     |     2     |     1     |     1     |     0     |     0     |     0     |
+    /// |     3     |     1     |     0     |     0     |     1     |     1     |     1     |
+    /// |     4     |     2     |     1     |     1     |     1     |     1     |     1     |
+    /// 
+    /// Note:
+    /// -----
+    /// There's always one internal job listener, which is Quartz.Core.ExecutingJobsManager.
+    /// 
+    /// </summary>
     [MemoryDiagnoser]
     public class QuartSchedulerBenchmark
     {
-        private QuartzScheduler _basicQuartzScheduler;
+        private QuartzScheduler _quartzScheduler1;
+        private QuartzScheduler _quartzScheduler2;
+        private QuartzScheduler _quartzScheduler3;
+        private QuartzScheduler _quartzScheduler4;
         private StdScheduler _basicScheduler;
+        private IOperableTrigger _trigger;
         private JobExecutionContextImpl _jobExecutionContext;
 
         public QuartSchedulerBenchmark()
         {
-            _basicQuartzScheduler = CreateQuartzScheduler("basic", "basic", 5);
-            _basicScheduler = new StdScheduler(_basicQuartzScheduler);
-            _jobExecutionContext = CreateJobExecutionContext(_basicScheduler);
+            _quartzScheduler1 = CreateQuartzScheduler("#1", "#1", 5);
+
+            _quartzScheduler2 = CreateQuartzScheduler("#2", "#2", 5);
+            _quartzScheduler2.AddInternalJobListener(new NoOpListener("InternalJob1"));
+            _quartzScheduler2.AddInternalSchedulerListener(new NoOpListener("InternalScheduler1"));
+            _quartzScheduler2.AddInternalTriggerListener(new NoOpListener("InternalTrigger1"));
+
+            _quartzScheduler3 = CreateQuartzScheduler("#3", "#3", 5);
+            _quartzScheduler3.ListenerManager.AddJobListener(new NoOpListener("GlobalJob1"));
+            _quartzScheduler3.ListenerManager.AddSchedulerListener(new NoOpListener("GlobalScheduler1"));
+            _quartzScheduler3.ListenerManager.AddTriggerListener(new NoOpListener("GlobalTrigger1"));
+
+            _quartzScheduler4 = CreateQuartzScheduler("#4", "#4", 5);
+            _quartzScheduler4.AddInternalJobListener(new NoOpListener("InternalJob1"));
+            _quartzScheduler4.AddInternalSchedulerListener(new NoOpListener("InternalScheduler1"));
+            _quartzScheduler4.AddInternalTriggerListener(new NoOpListener("InternalTrigger1"));
+            _quartzScheduler4.ListenerManager.AddJobListener(new NoOpListener("GlobalJob1"));
+            _quartzScheduler4.ListenerManager.AddSchedulerListener(new NoOpListener("GlobalScheduler1"));
+            _quartzScheduler4.ListenerManager.AddTriggerListener(new NoOpListener("GlobalTrigger1"));
+
+            _basicScheduler = new StdScheduler(_quartzScheduler1);
+
+            _trigger = (IOperableTrigger)CreateTrigger(TimeSpan.Zero);
+            _trigger.FireInstanceId = Guid.NewGuid().ToString();
+
+            _jobExecutionContext = CreateJobExecutionContext(_basicScheduler, _trigger);
         }
 
         [GlobalCleanup]
         public void GlobalCleanup()
         {
-            _basicQuartzScheduler.Shutdown(true).GetAwaiter().GetResult();
+            _quartzScheduler1.Shutdown(true).GetAwaiter().GetResult();
         }
 
         [Benchmark]
-        public void NotifyTriggerListenersFired_SingleThreaded()
+        public void NotifyTriggerListenersFired_QuartScheduler1_SingleThreaded()
         {
-            _basicQuartzScheduler.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
+            _quartzScheduler1.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
         }
 
         [Benchmark(OperationsPerInvoke = 200_000)]
-        public void NotifyTriggerListenersFired_MultiThreaded()
+        public void NotifyTriggerListenersFired_QuartScheduler1_MultiThreaded()
         {
-            Execute(_basicQuartzScheduler, 20, 10_000, (scheduler) =>
-            {
-                _basicQuartzScheduler.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
-            });
+            Execute(_quartzScheduler1, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
+                });
         }
 
         [Benchmark]
-        public void NotifySchedulerListenersStarted_SingleThreaded()
+        public void NotifyTriggerListenersFired_QuartScheduler2_SingleThreaded()
         {
-            _basicQuartzScheduler.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+            _quartzScheduler2.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
         }
 
         [Benchmark(OperationsPerInvoke = 200_000)]
-        public void NotifySchedulerListenersStarted_MultiThreaded()
+        public void NotifyTriggerListenersFired_QuartScheduler2_MultiThreaded()
         {
-            Execute(_basicQuartzScheduler, 20, 10_000, (scheduler) =>
-            {
-                scheduler.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
-            });
+            Execute(_quartzScheduler2, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
+                });
         }
 
         [Benchmark]
-        public void NotifyJobListenersToBeExecuted_SingleThreaded()
+        public void NotifyTriggerListenersFired_QuartScheduler3_SingleThreaded()
         {
-            _basicQuartzScheduler.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+            _quartzScheduler3.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
         }
 
         [Benchmark(OperationsPerInvoke = 200_000)]
-        public void NotifyJobListenersToBeExecuted_MultiThreaded()
+        public void NotifyTriggerListenersFired_QuartScheduler3_MultiThreaded()
         {
-            Execute(_basicQuartzScheduler, 20, 10_000, (scheduler) =>
-            {
-                scheduler.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
-            });
+            Execute(_quartzScheduler3, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersFired_QuartScheduler4_SingleThreaded()
+        {
+            _quartzScheduler4.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersFired_QuartScheduler4_MultiThreaded()
+        {
+            Execute(_quartzScheduler4, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersFired(_jobExecutionContext).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersMisfired_QuartzScheduler1_SingleThreaded()
+        {
+            _quartzScheduler1.NotifyTriggerListenersMisfired(_trigger).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersMisfired_QuartzScheduler1_MultiThreaded()
+        {
+            Execute(_quartzScheduler1, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersMisfired(_trigger).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersMisfired_QuartzScheduler2_SingleThreaded()
+        {
+            _quartzScheduler2.NotifyTriggerListenersMisfired(_trigger).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersMisfired_QuartzScheduler2_MultiThreaded()
+        {
+            Execute(_quartzScheduler2, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersMisfired(_trigger).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersMisfired_QuartzScheduler3_SingleThreaded()
+        {
+            _quartzScheduler3.NotifyTriggerListenersMisfired(_trigger).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersMisfired_QuartzScheduler3_MultiThreaded()
+        {
+            Execute(_quartzScheduler3, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersMisfired(_trigger).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersMisfired_QuartzScheduler4_SingleThreaded()
+        {
+            _quartzScheduler4.NotifyTriggerListenersMisfired(_trigger).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersMisfired_QuartzScheduler4_MultiThreaded()
+        {
+            Execute(_quartzScheduler4, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersMisfired(_trigger).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersComplete_QuartzScheduler1_SingleThreaded()
+        {
+            _quartzScheduler1.NotifyTriggerListenersComplete(_jobExecutionContext, SchedulerInstruction.NoInstruction)
+                             .GetAwaiter()
+                             .GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersComplete_QuartzScheduler1_MultiThreaded()
+        {
+            Execute(_quartzScheduler1, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersComplete(_jobExecutionContext, SchedulerInstruction.NoInstruction)
+                             .GetAwaiter()
+                             .GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersComplete_QuartzScheduler2_SingleThreaded()
+        {
+            _quartzScheduler2.NotifyTriggerListenersComplete(_jobExecutionContext, SchedulerInstruction.NoInstruction)
+                             .GetAwaiter()
+                             .GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersComplete_QuartzScheduler2_MultiThreaded()
+        {
+            Execute(_quartzScheduler2, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersComplete(_jobExecutionContext, SchedulerInstruction.NoInstruction)
+                             .GetAwaiter()
+                             .GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersComplete_QuartzScheduler3_SingleThreaded()
+        {
+            _quartzScheduler3.NotifyTriggerListenersComplete(_jobExecutionContext, SchedulerInstruction.NoInstruction)
+                             .GetAwaiter()
+                             .GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersComplete_QuartzScheduler3_MultiThreaded()
+        {
+            Execute(_quartzScheduler3, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersComplete(_jobExecutionContext, SchedulerInstruction.NoInstruction)
+                             .GetAwaiter()
+                             .GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyTriggerListenersComplete_QuartzScheduler4_SingleThreaded()
+        {
+            _quartzScheduler4.NotifyTriggerListenersComplete(_jobExecutionContext, SchedulerInstruction.NoInstruction)
+                             .GetAwaiter()
+                             .GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyTriggerListenersComplete_QuartzScheduler4_MultiThreaded()
+        {
+            Execute(_quartzScheduler4, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyTriggerListenersComplete(_jobExecutionContext, SchedulerInstruction.NoInstruction)
+                             .GetAwaiter()
+                             .GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifySchedulerListenersStarted_QuartzScheduler1_SingleThreaded()
+        {
+            _quartzScheduler1.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifySchedulerListenersStarted_QuartzScheduler1_MultiThreaded()
+        {
+            Execute(_quartzScheduler1, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifySchedulerListenersStarted_QuartzScheduler2_SingleThreaded()
+        {
+            _quartzScheduler2.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifySchedulerListenersStarted_QuartzScheduler2_MultiThreaded()
+        {
+            Execute(_quartzScheduler2, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifySchedulerListenersStarted_QuartzScheduler3_SingleThreaded()
+        {
+            _quartzScheduler3.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifySchedulerListenersStarted_QuartzScheduler3_MultiThreaded()
+        {
+            Execute(_quartzScheduler3, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifySchedulerListenersStarted_QuartzScheduler4_SingleThreaded()
+        {
+            _quartzScheduler4.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifySchedulerListenersStarted_QuartzScheduler4_MultiThreaded()
+        {
+            Execute(_quartzScheduler4, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifySchedulerListenersStarted().GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyJobListenersToBeExecuted_QuartScheduler1_SingleThreaded()
+        {
+            _quartzScheduler1.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyJobListenersToBeExecuted_QuartzScheduler1_MultiThreaded()
+        {
+            Execute(_quartzScheduler1, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyJobListenersToBeExecuted_QuartScheduler2_SingleThreaded()
+        {
+            _quartzScheduler2.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyJobListenersToBeExecuted_QuartzScheduler2_MultiThreaded()
+        {
+            Execute(_quartzScheduler2, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyJobListenersToBeExecuted_QuartScheduler3_SingleThreaded()
+        {
+            _quartzScheduler3.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyJobListenersToBeExecuted_QuartzScheduler3_MultiThreaded()
+        {
+            Execute(_quartzScheduler3, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+                });
+        }
+
+        [Benchmark]
+        public void NotifyJobListenersToBeExecuted_QuartScheduler4_SingleThreaded()
+        {
+            _quartzScheduler4.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+        }
+
+        [Benchmark(OperationsPerInvoke = 200_000)]
+        public void NotifyJobListenersToBeExecuted_QuartzScheduler4_MultiThreaded()
+        {
+            Execute(_quartzScheduler4, 20, 10_000, (scheduler) =>
+                {
+                    scheduler.NotifyJobListenersToBeExecuted(_jobExecutionContext).GetAwaiter().GetResult();
+                });
         }
 
         private static QuartzScheduler CreateQuartzScheduler(string name, string instanceId, int threadCount)
@@ -90,13 +402,10 @@ namespace Quartz.Benchmark
             return new QuartzScheduler(res, TimeSpan.Zero);
         }
 
-        private JobExecutionContextImpl CreateJobExecutionContext(IScheduler scheduler)
+        private JobExecutionContextImpl CreateJobExecutionContext(IScheduler scheduler, IOperableTrigger trigger)
         {
             var job = new Job();
             var jobDetail = CreateJobDetail("A", job.GetType());
-            var trigger = (IOperableTrigger)CreateTrigger(TimeSpan.Zero);
-            trigger.FireInstanceId = Guid.NewGuid().ToString();
-
             var triggerFiredBundle = new TriggerFiredBundle(jobDetail, trigger, null, false, DateTimeOffset.Now, null, null, null);
 
             return new JobExecutionContextImpl(scheduler, triggerFiredBundle, job);
@@ -105,10 +414,9 @@ namespace Quartz.Benchmark
         private static ITrigger CreateTrigger(TimeSpan repeatInterval)
         {
             return TriggerBuilder.Create()
-                                 .WithSimpleSchedule(
-                                     sb => sb.RepeatForever()
-                                             .WithInterval(repeatInterval)
-                                             .WithMisfireHandlingInstructionFireNow())
+                                 .WithSimpleSchedule(sb => sb.RepeatForever()
+                                                             .WithInterval(repeatInterval)
+                                                             .WithMisfireHandlingInstructionFireNow())
                                  .Build();
         }
 
@@ -127,7 +435,7 @@ namespace Quartz.Benchmark
                 {
                     start.WaitOne();
 
-                    for (var i = 0; i < iterationsPerThread; i++)
+                    for (var j = 0; j < iterationsPerThread; j++)
                     {
                         action(scheduler);
                     }
@@ -169,6 +477,156 @@ namespace Quartz.Benchmark
             {
                 Done.Reset();
                 RunCount = 0;
+            }
+        }
+
+        private class NoOpListener : IJobListener, ITriggerListener, ISchedulerListener
+        {
+            public NoOpListener(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; }
+
+            public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SchedulerError(string msg, SchedulerException cause, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SchedulerInStandbyMode(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SchedulerShutdown(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SchedulerShuttingdown(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SchedulerStarted(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SchedulerStarting(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SchedulingDataCleared(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task TriggerComplete(ITrigger trigger, IJobExecutionContext context, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task TriggerFired(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task TriggerResumed(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task TriggersPaused(string? triggerGroup, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task TriggersResumed(string? triggerGroup, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(false);
+            }
+
+            public Task JobAdded(IJobDetail jobDetail, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobDeleted(JobKey jobKey, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobPaused(JobKey jobKey, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobResumed(JobKey jobKey, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobScheduled(ITrigger trigger, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobsPaused(string jobGroup, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task JobsResumed(string jobGroup, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
             }
         }
     }

--- a/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
+++ b/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using Quartz.Impl.Matchers;
 using Quartz.Job;
 using Quartz.Simpl;
@@ -48,7 +48,7 @@ namespace Quartz.Benchmark
                 {
                     start.WaitOne();
 
-                    for (var i = 0; i < 10_000; i++)
+                    for (var j = 0; j < 10_000; j++)
                     {
                         _ramJobStore.StoreTrigger(_trigger1, true);
                     }


### PR DESCRIPTION
Remove allocations from captures when notifying trigger listeners.
Document **ConcurrentDictionary\<TKey,TValue>** 'trick' to check if dictionary is empty.
Add more scenarios to **QuartSchedulerBenchmark**.

<details>
<summary>Benchmark results</summary>

|                                                     Method | Branch |    Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------------------------------- |--------|--------:|--------:|--------:|-------:|------:|------:|----------:|
| NotifyTriggerListenersFired_QuartScheduler1_SingleThreaded | main   |145.2 ns | 0.24 ns | 0.20 ns | 0.0439 |     - |     - |     184 B |
| NotifyTriggerListenersFired_QuartScheduler1_SingleThreaded | PR     |124.7 ns | 0.35 ns | 0.33 ns | 0.0324 |     - |     - |     136 B |
|  NotifyTriggerListenersFired_QuartScheduler1_MultiThreaded | main   |100.9 ns | 1.97 ns | 1.84 ns | 0.0441 |     - |     - |     184 B |
|  NotifyTriggerListenersFired_QuartScheduler1_MultiThreaded | PR     |100.4 ns | 1.85 ns | 1.74 ns | 0.0325 |     - |     - |     136 B |
| NotifyTriggerListenersFired_QuartScheduler2_SingleThreaded | main   |396.2 ns | 0.78 ns | 0.69 ns | 0.0935 |     - |     - |     392 B |
| NotifyTriggerListenersFired_QuartScheduler2_SingleThreaded | PR     |406.3 ns | 1.03 ns | 0.91 ns | 0.0820 |     - |     - |     344 B |
|  NotifyTriggerListenersFired_QuartScheduler2_MultiThreaded | main   |407.1 ns | 3.84 ns | 3.60 ns | 0.0936 |     - |     - |     392 B |
|  NotifyTriggerListenersFired_QuartScheduler2_MultiThreaded | PR     |370.5 ns | 4.38 ns | 4.09 ns | 0.0821 |     - |     - |     344 B |
| NotifyTriggerListenersFired_QuartScheduler3_SingleThreaded | main   |396.0 ns | 1.20 ns | 1.06 ns | 0.1202 |     - |     - |     504 B |
| NotifyTriggerListenersFired_QuartScheduler3_SingleThreaded | PR     |388.2 ns | 6.53 ns | 6.11 ns | 0.1087 |     - |     - |     456 B |
|  NotifyTriggerListenersFired_QuartScheduler3_MultiThreaded | main   |456.4 ns | 0.65 ns | 0.57 ns | 0.1208 |     - |     - |     504 B |
|  NotifyTriggerListenersFired_QuartScheduler3_MultiThreaded | PR     |377.7 ns | 7.32 ns | 6.85 ns | 0.1093 |     - |     - |     456 B |
| NotifyTriggerListenersFired_QuartScheduler4_SingleThreaded | main   |494.3 ns | 7.36 ns | 6.89 ns | 0.1507 |     - |     - |     632 B |
| NotifyTriggerListenersFired_QuartScheduler4_SingleThreaded | PR     |465.9 ns | 1.76 ns | 1.47 ns | 0.1392 |     - |     - |     584 B |
|  NotifyTriggerListenersFired_QuartScheduler4_MultiThreaded | main   |436.7 ns | 5.05 ns | 4.73 ns | 0.1517 |     - |     - |     632 B |
|  NotifyTriggerListenersFired_QuartScheduler4_MultiThreaded | PR     |428.7 ns | 5.16 ns | 4.83 ns | 0.1400 |     - |     - |     584 B |

</details>