### PR TITLE
RAMJobStore: improve performance and reduce allocations

### DIFF
--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1609,7 +1609,7 @@ namespace Quartz.Simpl
 
                 while (true)
                 {
-                    var tw = timeTriggers.FirstOrDefault();
+                    var tw = timeTriggers.Min;
                     if (tw == null)
                     {
                         break;

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -104,7 +104,7 @@ namespace Quartz.Simpl
         protected virtual string GetFiredTriggerRecordId()
         {
             long value = Interlocked.Increment(ref ftrCtr);
-            return Convert.ToString(value, CultureInfo.InvariantCulture);
+            return value.ToString(CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -989,7 +989,7 @@ namespace Quartz.Simpl
         {
             lock (lockObject)
             {
-                HashSet<TriggerKey>? outList = null;
+                HashSet<TriggerKey> outList = new HashSet<TriggerKey>();
                 StringOperator op = matcher.CompareWithOperator;
                 string compareToValue = matcher.CompareToValue;
 
@@ -998,8 +998,6 @@ namespace Quartz.Simpl
                     triggersByGroup.TryGetValue(compareToValue, out var grpMap);
                     if (grpMap != null)
                     {
-                        outList = new HashSet<TriggerKey>();
-
                         foreach (TriggerWrapper tw in grpMap.Values)
                         {
                             if (tw != null)
@@ -1015,10 +1013,6 @@ namespace Quartz.Simpl
                     {
                         if (op.Evaluate(entry.Key, compareToValue) && entry.Value != null)
                         {
-                            if (outList == null)
-                            {
-                                outList = new HashSet<TriggerKey>();
-                            }
                             foreach (TriggerWrapper triggerWrapper in entry.Value.Values)
                             {
                                 if (triggerWrapper != null)
@@ -1029,7 +1023,7 @@ namespace Quartz.Simpl
                         }
                     }
                 }
-                return outList ?? new HashSet<TriggerKey>();
+                return outList;
             }
         }
 

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1782,8 +1782,12 @@ namespace Quartz.Simpl
 
                     if (job.ConcurrentExecutionDisallowed)
                     {
-                        foreach (TriggerWrapper ttw in GetTriggerWrappersForJobInternal(job.Key))
+                        var triggerWrappersForJob = GetTriggerWrappersForJobInternal(job.Key);
+
+                        for (var i = 0; i < triggerWrappersForJob.Count; i++)
                         {
+                            var ttw = triggerWrappersForJob[i];
+
                             if (ttw.state == InternalTriggerState.Waiting)
                             {
                                 ttw.state = InternalTriggerState.Blocked;
@@ -1792,6 +1796,7 @@ namespace Quartz.Simpl
                             {
                                 ttw.state = InternalTriggerState.PausedAndBlocked;
                             }
+
                             timeTriggers.Remove(ttw);
                         }
                         blockedJobs.Add(job.Key);
@@ -1851,8 +1856,12 @@ namespace Quartz.Simpl
                     {
                         blockedJobs.Remove(jd.Key);
 
-                        foreach (TriggerWrapper ttw in GetTriggerWrappersForJobInternal(jd.Key))
+                        var triggerWrappersForJob = GetTriggerWrappersForJobInternal(jd.Key);
+
+                        for (var i = 0; i < triggerWrappersForJob.Count; i++)
                         {
+                            var ttw = triggerWrappersForJob[i];
+
                             if (ttw.state == InternalTriggerState.Blocked)
                             {
                                 ttw.state = InternalTriggerState.Waiting;
@@ -1965,8 +1974,12 @@ namespace Quartz.Simpl
         /// </remarks>
         protected virtual void SetAllTriggersOfJobToState(JobKey jobKey, InternalTriggerState state)
         {
-            foreach (TriggerWrapper tw in GetTriggerWrappersForJobInternal(jobKey))
+            var triggerWrappersForJob = GetTriggerWrappersForJobInternal(jobKey);
+
+            for (var i = 0; i < triggerWrappersForJob.Count; i++)
             {
+                var tw = triggerWrappersForJob[i];
+
                 tw.state = state;
                 if (state != InternalTriggerState.Waiting)
                 {

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1619,10 +1619,7 @@ namespace Quartz.Simpl
                     // we need to remove it before we apply the misfire. It not, after having updated the trigger,
                     // we'd attempt to remove the trigger with the new next fire time which would no longer match
                     // the trigger in the 'timeTriggers' set.
-                    if (!timeTriggers.Remove(tw))
-                    {
-                        break;
-                    }
+                    timeTriggers.Remove(tw);
 
                     // When the trigger is not scheduled to fire, continue with the next trigger.
                     if (tw.Trigger.GetNextFireTimeUtc() == null)

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1670,20 +1670,23 @@ namespace Quartz.Simpl
                     tw.Trigger.FireInstanceId = GetFiredTriggerRecordId();
                     IOperableTrigger trig = (IOperableTrigger) tw.Trigger.Clone();
 
-                    if (result.Count == 0)
+                    result.Add(trig);
+
+                    if (result.Count == maxCount)
+                    {
+                        break;
+                    }
+
+                    // Use the next fire time of the first acquired trigger to update the maximum next fire
+                    // time that we accept for this batch. We only perform this update if we want to acquire
+                    // more than one trigger.
+                    if (result.Count == 1)
                     {
                         var now = SystemTime.UtcNow();
                         var nextFireTime = tnft.GetValueOrDefault();
                         var max = now > nextFireTime ? now : nextFireTime;
 
                         batchEnd = max + timeWindow;
-                    }
-
-                    result.Add(trig);
-
-                    if (result.Count == maxCount)
-                    {
-                        break;
                     }
                 }
 
@@ -1695,6 +1698,7 @@ namespace Quartz.Simpl
                         timeTriggers.Add(excludedTrigger);
                     }
                 }
+
                 return Task.FromResult<IReadOnlyCollection<IOperableTrigger>>(result);
             }
         }

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -73,10 +73,14 @@ namespace Quartz.Simpl
         }
 
         /// <summary>
-        /// The time span by which a trigger must have missed its
-        /// next-fire-time, in order for it to be considered "misfired" and thus
-        /// have its misfire instruction applied.
+        /// Gets or sets the time by which a trigger must have missed its next-fire-time, in order for it to
+        /// be considered "misfired" and thus have its misfire instruction applied.
         /// </summary>
+        /// <value>
+        /// The time by which a trigger must have missed its next-fire-time, in order for it to be considered
+        /// "misfired" and thus have its misfire instruction applied. The default is <c>5</c> seconds.
+        /// </value>
+        /// <exception cref="ArgumentException"><paramref name="value"/> represents less than one millisecond.</exception>
         [TimeSpanParseRule(TimeSpanParseRule.Milliseconds)]
         public virtual TimeSpan MisfireThreshold
         {

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1543,7 +1543,7 @@ namespace Quartz.Simpl
             DateTimeOffset misfireTime = SystemTime.UtcNow();
             if (MisfireThreshold > TimeSpan.Zero)
             {
-                misfireTime = misfireTime.AddMilliseconds(-1 * MisfireThreshold.TotalMilliseconds);
+                misfireTime = misfireTime.AddTicks(-1 * MisfireThreshold.Ticks);
             }
 
             DateTimeOffset? tnft = tw.Trigger.GetNextFireTimeUtc();

--- a/src/Quartz/Util/SortedSetExtensions.cs
+++ b/src/Quartz/Util/SortedSetExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Quartz.Util
@@ -9,30 +9,5 @@ namespace Quartz.Util
         {
             return set.GetViewBetween(value, 9999999);
         }
-
-        /// <summary>
-        /// Returns the first element of the specified <see cref="SortedSet{TSource}"/>, or a default
-        /// value if no element is found.
-        /// </summary>
-        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-        /// <param name="source">The <see cref="SortedSet{TSource}"/> to return the first element of.</param>
-        /// <returns>
-        /// The default value for <typeparamref name="TSource"/> if <paramref name="source"/> is empty;
-        /// otherwise, the first element in <paramref name="source"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        internal static TSource? FirstOrDefault<TSource>(this SortedSet<TSource> source) where TSource : class
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-
-            using var enumerator = source.GetEnumerator();
-            if (!enumerator.MoveNext())
-            {
-                return null;
-            }
-
-            return enumerator.Current;
-        }
-    }
+   }
 }


### PR DESCRIPTION
* Document default value of **MisfireThreshold**, and exception that is thrown.
* Avoid extra indirection in `GetFiredTriggerRecordId()` as `Convert.ToString(long, IFormatProvider)` in turn calls `long.ToString(IFormatProvider)` anyway.
* Update `GetTriggerKeysInternal(...)` to immediately initialize 'outList' as that is what we end up doing anyway.
* In `ApplyMisfire(TriggerWrapper tw)`, use `AddTicks(...)` instead of `AddMilliseconds(...)` to compute 'misfireTime' as a micro-optimization.
* Apply optimizations In AcquireNext(...):
  * Use **SortedSet\<T>.Min** to get first item instead of using our extension method.
  * No need to check return value of `timeTriggers.Remove(...)` as we just obtained the trigger from that list, and this while holding the instance-level lock.
  * Avoid interface calls where possible.
  * Only recalculate 'batchEnd' if more than one triggers is requested.
* Use indexer instead of enumerator to improve performance.

<details>
<summary>Benchmark results</summary>

|                                                                                                             Method | Branch |         Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------------------------------------------------------------------------------------------------- |--------|-------------:|----------:|----------:|-------:|----------:|
|                                                  TriggeredJobComplete_ConcurrentExecutionDisallowed_TriggersForJob | master |    172.55 ns |  0.767 ns |  0.718 ns | 0.0303 |     128 B |
|                                                  TriggeredJobComplete_ConcurrentExecutionDisallowed_TriggersForJob | PR     |    166.92 ns |  2.431 ns |  2.155 ns | 0.0303 |     128 B |
|                                                TriggeredJobComplete_ConcurrentExecutionDisallowed_NoTriggersForJob | master |    131.87 ns |  1.231 ns |  1.151 ns | 0.0382 |     160 B |
|                                                TriggeredJobComplete_ConcurrentExecutionDisallowed_NoTriggersForJob | PR     |    128.64 ns |  0.262 ns |  0.232 ns | 0.0382 |     160 B |
|                                        AcquireNextTriggers_MaxCountIsOneAndAtLeastOneMatchingTimerTriggerAvailable | master |    499.18 ns |  4.834 ns |  4.521 ns | 0.1925 |     808 B |
|                                        AcquireNextTriggers_MaxCountIsOneAndAtLeastOneMatchingTimerTriggerAvailable | PR     |    311.16 ns |  0.519 ns |  0.434 ns | 0.1717 |     720 B |
|                                        AcquireNextTriggers_MultipleTimeTriggersForJobThatAllowsConcurrentExecution | master |  4,693.05 ns | 45.691 ns | 42.739 ns | 1.3667 |   5,728 B |
|                                        AcquireNextTriggers_MultipleTimeTriggersForJobThatAllowsConcurrentExecution | PR     |  3,815.43 ns | 11.832 ns |  9.881 ns | 1.0833 |   4,536 B |
|                                           AcquireAndRelease_MultipleTriggersForJobThatDisallowsConcurrentExecution | master |  1,777.23 ns | 23.331 ns | 21.823 ns | 0.4700 |   1,976 B |
|                                           AcquireAndRelease_MultipleTriggersForJobThatDisallowsConcurrentExecution | PR     |  1,480.68 ns |  3.539 ns |  3.310 ns | 0.3700 |   1,560 B |
|                                                                                            AcquireAndFire_Misfires | master | 10,362.66 ns |170.108 ns |159.119 ns | 1.5833 |   6,632 B |
|                                                                                            AcquireAndFire_Misfires | PR     |  9,152.53 ns | 14.891 ns | 11.626 ns | 1.1533 |   4,832 B |
| AcquireAndRelease_OneTriggerForJobsThatDisallowConcurrentExecutionAndOneTriggerForJobThatAllowsConcurrentExecution | master |    890.32 ns |  5.639 ns |  5.275 ns | 0.3333 |   1,400 B |
| AcquireAndRelease_OneTriggerForJobsThatDisallowConcurrentExecutionAndOneTriggerForJobThatAllowsConcurrentExecution | PR     |    768.37 ns |  1.277 ns |  1.195 ns | 0.2922 |   1,224 B |
|                                   AcquireAndFireAndComplete_MultipleTriggersForJobsThatDisallowConcurrentExecution | master |  4,418.43 ns | 50.970 ns | 47.677 ns | 0.9967 |   4,176 B |
|                                   AcquireAndFireAndComplete_MultipleTriggersForJobsThatDisallowConcurrentExecution | PR     |  3,942.90 ns | 10.961 ns | 10.253 ns | 0.8367 |   3,512 B |
</details>

I split the changes in multiple commit for easier review.