### PR TITLE
Verify scheduler configudation values, validate IdleWaitTime

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,10 +13,16 @@
       * JobName
       * JobGroup
       * FullName
-
     * Triggers can no longer be constructed with a **null** group name (#1359)
-
     * The *endUtc* argument of **SimpleTriggerImpl** is no longer nullable.
+    * If a value is explicitly specified for "IdleWaitTime", we will no longer silently ignore the value (and use 
+      a default value of 30 seconds instead) if it's less than or equal to **zero**.
+    * If you use **StdSchedulerFactory** to create a scheduler, we will no longer reject an **IdleWaitTime** that
+      is greater than **zero** but less than **1000 milliseconds**.
+    * An negative value for **IdleWaitTime** or **BatchTimeWindow** will no longer be accepted.
+    * For **MaxBatchSize**, a value less than or equal to **zero** will be rejected.
+    * The ctor for **QuartzScheduler** no longer takes an **idleWaitTime** argument. This value
+      is now obtained from a newly introduced **IdleWaitTime** property on **QuartzSchedulerResources**.
 
 ## Release 3.3.3, Aug 1 2021
 

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -51,11 +51,12 @@ namespace Quartz.Benchmark
                 InstanceId = instanceId,
                 ThreadPool = new DefaultThreadPool { MaxConcurrency = threadCount },
                 JobStore = new NoOpJobStore(),
+                IdleWaitTime = TimeSpan.FromSeconds(30),
                 MaxBatchSize = threadCount,
                 BatchTimeWindow = TimeSpan.Zero
             };
 
-            return new QuartzScheduler(res, TimeSpan.Zero);
+            return new QuartzScheduler(res);
         }
 
         private TriggerFiredBundle CreateTriggerFiredBundle()

--- a/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
@@ -395,11 +395,12 @@ namespace Quartz.Benchmark
                 InstanceId = instanceId,
                 ThreadPool = new DefaultThreadPool { MaxConcurrency = threadCount },
                 JobStore = new RAMJobStore(),
+                IdleWaitTime = TimeSpan.FromSeconds(30),
                 MaxBatchSize = threadCount,
                 BatchTimeWindow = TimeSpan.Zero
             };
 
-            return new QuartzScheduler(res, TimeSpan.Zero);
+            return new QuartzScheduler(res);
         }
 
         private JobExecutionContextImpl CreateJobExecutionContext(IScheduler scheduler, IOperableTrigger trigger)

--- a/src/Quartz.Benchmark/SchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/SchedulerBenchmark.cs
@@ -130,7 +130,7 @@ namespace Quartz.Benchmark
                                                             threadPool,
                                                             store,
                                                             null,
-                                                            TimeSpan.Zero,
+                                                            TimeSpan.FromSeconds(30),
                                                             threadCount,
                                                             TimeSpan.Zero,
                                                             null);

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerResourcesTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerResourcesTest.cs
@@ -1,0 +1,145 @@
+using NUnit.Framework;
+using Quartz.Core;
+using System;
+using System.Collections.Generic;
+
+namespace Quartz.Tests.Unit.Core
+{
+    [TestFixture]
+    public class QuartzSchedulerResourcesTest
+    {
+        private QuartzSchedulerResources _resources;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _resources = new QuartzSchedulerResources();
+        }
+
+        [Test]
+        public void DefaultCtor()
+        {
+            var resources = new QuartzSchedulerResources();
+            Assert.AreEqual(TimeSpan.Zero, resources.BatchTimeWindow);
+            Assert.IsNull(resources.InstanceId);
+            Assert.IsFalse(resources.InterruptJobsOnShutdown);
+            Assert.IsFalse(resources.InterruptJobsOnShutdownWithWait);
+            Assert.IsNull(resources.JobRunShellFactory);
+            Assert.IsNull(resources.JobStore);
+            Assert.IsFalse(resources.MakeSchedulerThreadDaemon);
+            Assert.AreEqual(1, resources.MaxBatchSize);
+            Assert.IsNull(resources.Name);
+            Assert.IsNull(resources.SchedulerExporter);
+            Assert.IsNotNull(resources.SchedulerPlugins);
+            Assert.IsEmpty(resources.SchedulerPlugins);
+            Assert.IsNull(resources.ThreadName);
+            Assert.IsNull(resources.ThreadPool);
+        }
+
+        [Test]
+        public void IdleWaitTime_ValidValues([ValueSource(nameof(ValidIdleWaitTimes))] TimeSpan idleWaitTime)
+        {
+            _resources.IdleWaitTime = idleWaitTime;
+            Assert.AreEqual(idleWaitTime, _resources.IdleWaitTime);
+        }
+
+        [Test]
+        public void IdleWaitTime_InvalidValues([ValueSource(nameof(InvalidIdleWaitTimes))] TimeSpan idleWaitTime)
+        {
+            try
+            {
+                _resources.IdleWaitTime = idleWaitTime;
+                Assert.Fail();
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                Assert.AreEqual("value", ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void BatchTimeWindow_ValidValues([ValueSource(nameof(ValidBatchTimeWindows))] TimeSpan batchTimeWindow)
+        {
+            _resources.BatchTimeWindow = batchTimeWindow;
+            Assert.AreEqual(batchTimeWindow, _resources.BatchTimeWindow);
+        }
+
+        [Test]
+        public void BatchTimeWindow_InvalidValues([ValueSource(nameof(InvalidBatchTimeWindows))] TimeSpan batchTimeWindow)
+        {
+            try
+            {
+                _resources.BatchTimeWindow = batchTimeWindow;
+                Assert.Fail();
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                Assert.AreEqual("value", ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void MaxBatchSize_ValidValues([ValueSource(nameof(ValidMaxBatchSizes))] int maxBatchSize)
+        {
+            _resources.MaxBatchSize = maxBatchSize;
+            Assert.AreEqual(maxBatchSize, _resources.MaxBatchSize);
+        }
+
+        [Test]
+        public void MaxBatchSize_InvalidValues([ValueSource(nameof(InvalidMaxBatchSizes))] int maxBatchSize)
+        {
+            try
+            {
+                _resources.MaxBatchSize = maxBatchSize;
+                Assert.Fail();
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                Assert.AreEqual("value", ex.ParamName);
+            }
+        }
+
+        internal static IEnumerable<TimeSpan> ValidIdleWaitTimes()
+        {
+            yield return TimeSpan.Zero;
+            yield return TimeSpan.FromTicks(1);
+            yield return TimeSpan.MaxValue;
+        }
+
+        internal static IEnumerable<TimeSpan> InvalidIdleWaitTimes()
+        {
+            yield return TimeSpan.FromTicks(-1);
+            yield return TimeSpan.FromDays(-30);
+            yield return TimeSpan.MinValue;
+        }
+
+        internal static IEnumerable<int> ValidMaxBatchSizes()
+        {
+            yield return 1;
+            yield return 8;
+            yield return int.MaxValue;
+        }
+
+        internal static IEnumerable<int> InvalidMaxBatchSizes()
+        {
+            yield return 0;
+            yield return -1;
+            yield return int.MinValue;
+        }
+
+        internal static IEnumerable<TimeSpan> ValidBatchTimeWindows()
+        {
+            yield return TimeSpan.Zero;
+            yield return TimeSpan.FromTicks(1);
+            yield return TimeSpan.FromDays(30);
+        }
+
+        internal static IEnumerable<TimeSpan> InvalidBatchTimeWindows()
+        {
+            yield return TimeSpan.FromTicks(-1);
+            yield return TimeSpan.FromDays(-30);
+            yield return TimeSpan.MinValue;
+        }
+
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using Quartz.Core;
+using System;
+using System.Collections.Generic;
+
+namespace Quartz.Tests.Unit.Core
+{
+    [TestFixture]
+    public class QuartzSchedulerThreadTest
+    {
+        [Test]
+        public void Ctor_SchedulerAndResources([ValueSource(nameof(ValidIdleWaitTimes))] TimeSpan idleWaitTime)
+        {
+            QuartzSchedulerResources resources = new QuartzSchedulerResources
+                {
+                    IdleWaitTime = idleWaitTime
+                };
+            QuartzScheduler scheduler = new QuartzScheduler(resources);
+
+            var thread = new QuartzSchedulerThread(scheduler, resources);
+            Assert.IsTrue(thread.Paused);
+            Assert.IsFalse(thread.Halted);
+            Assert.AreEqual((int) (idleWaitTime.TotalMilliseconds * 0.2), thread.IdleWaitVariableness);
+        }
+
+        private static IEnumerable<TimeSpan> ValidIdleWaitTimes()
+        {
+            return QuartzSchedulerResourcesTest.ValidIdleWaitTimes();
+        }
+    }
+}

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -65,9 +65,9 @@ namespace Quartz.Core
         private readonly ILog log;
         private static readonly Version version;
 
-        private readonly QuartzSchedulerResources resources = null!;
+        internal readonly QuartzSchedulerResources resources = null!;
 
-        private readonly QuartzSchedulerThread schedThread = null!;
+        internal readonly QuartzSchedulerThread schedThread = null!;
 
         private readonly ConcurrentDictionary<string, IJobListener> internalJobListeners = new ConcurrentDictionary<string, IJobListener>();
         private readonly ConcurrentDictionary<string, ITriggerListener> internalTriggerListeners = new ConcurrentDictionary<string, ITriggerListener>();
@@ -264,7 +264,7 @@ namespace Quartz.Core
         /// properties.
         /// </summary>
         /// <seealso cref="QuartzSchedulerResources" />
-        public QuartzScheduler(QuartzSchedulerResources resources, TimeSpan idleWaitTime) : this()
+        public QuartzScheduler(QuartzSchedulerResources resources) : this()
         {
             this.resources = resources;
 
@@ -275,11 +275,6 @@ namespace Quartz.Core
 
             schedThread = new QuartzSchedulerThread(this, resources);
             schedThread.Start();
-
-            if (idleWaitTime > TimeSpan.Zero)
-            {
-                schedThread.IdleWaitTime = idleWaitTime;
-            }
 
             jobMgr = new ExecutingJobsManager();
             AddInternalJobListener(jobMgr);

--- a/src/Quartz/ExceptionHelper.cs
+++ b/src/Quartz/ExceptionHelper.cs
@@ -22,5 +22,12 @@ namespace Quartz
         {
             throw new ArgumentException(message, paramName);
         }
+
+        [DoesNotReturn]
+        public static void ThrowArgumentOutOfRangeException(string message, string paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, message);
+        }
+
     }
 }

--- a/src/Quartz/Impl/DirectSchedulerFactory.cs
+++ b/src/Quartz/Impl/DirectSchedulerFactory.cs
@@ -74,8 +74,6 @@ namespace Quartz.Impl
 	{
 		public const string DefaultInstanceId = "SIMPLE_NON_CLUSTERED";
         public const string DefaultSchedulerName = "SimpleQuartzScheduler";
-        private const int DefaultBatchMaxSize = 1;
-        private readonly TimeSpan DefaultBatchTimeWindow = TimeSpan.Zero;
 
         private bool initialized;
 
@@ -156,68 +154,64 @@ namespace Quartz.Impl
 		    initialized = true;
 		}
 
-		/// <summary>
-		/// Creates a scheduler using the specified thread pool and job store. This
-		/// scheduler can be retrieved via DirectSchedulerFactory#GetScheduler()
-		/// </summary>
-		/// <param name="threadPool">
-		/// The thread pool for executing jobs
-		/// </param>
-		/// <param name="jobStore">
-		/// The type of job store
-		/// </param>
-		/// <throws>  SchedulerException </throws>
-		/// <summary>           if initialization failed
-		/// </summary>
-		public virtual void CreateScheduler(IThreadPool threadPool, IJobStore jobStore)
+        /// <summary>
+        /// Creates a scheduler using the specified thread pool and job store, and with an idle wait time of
+        /// <c>30</c> seconds. This scheduler can be retrieved via <see cref="GetScheduler(CancellationToken)"/>.
+        /// </summary>
+        /// <param name="threadPool">The thread pool for executing jobs</param>
+        /// <param name="jobStore">The type of job store</param>
+        /// <exception cref="SchedulerException">Initialization failed.</exception>
+        public virtual void CreateScheduler(IThreadPool threadPool, IJobStore jobStore)
 		{
 			CreateScheduler(DefaultSchedulerName, DefaultInstanceId, threadPool, jobStore);
-			initialized = true;
 		}
 
-		/// <summary>
-		/// Same as DirectSchedulerFactory#createScheduler(ThreadPool threadPool, JobStore jobStore),
-		/// with the addition of specifying the scheduler name and instance ID. This
-		/// scheduler can only be retrieved via DirectSchedulerFactory#getScheduler(String)
-		/// </summary>
-		/// <param name="schedulerName">The name for the scheduler.</param>
-		/// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
-		/// <param name="threadPool">The thread pool for executing jobs</param>
-		/// <param name="jobStore">The type of job store</param>
-		public virtual void CreateScheduler(string schedulerName, string schedulerInstanceId, IThreadPool threadPool,
+        /// <summary>
+        /// Same as <see cref="DirectSchedulerFactory.CreateScheduler(IThreadPool, IJobStore)" />,
+        /// with the addition of specifying the scheduler name and instance ID. This
+        /// scheduler can only be retrieved via <see cref="GetScheduler(string, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="schedulerName">The name for the scheduler.</param>
+        /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
+        /// <param name="threadPool">The thread pool for executing jobs</param>
+        /// <param name="jobStore">The type of job store</param>
+        /// <exception cref="SchedulerException">Initialization failed.</exception>
+        public virtual void CreateScheduler(string schedulerName, string schedulerInstanceId, IThreadPool threadPool,
 		                                    IJobStore jobStore)
 		{
-			CreateScheduler(schedulerName, schedulerInstanceId, threadPool, jobStore, TimeSpan.Zero);
+			CreateScheduler(schedulerName, schedulerInstanceId, threadPool, jobStore, QuartzSchedulerResources.DefaultIdleWaitTime);
 		}
 
-	    /// <summary>
-	    /// Creates a scheduler using the specified thread pool and job store and
-	    /// binds it for remote access.
-	    /// </summary>
-	    /// <param name="schedulerName">The name for the scheduler.</param>
-	    /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
-	    /// <param name="threadPool">The thread pool for executing jobs</param>
-	    /// <param name="jobStore">The type of job store</param>
-	    /// <param name="idleWaitTime">The idle wait time. You can specify "-1" for
-	    /// the default value, which is currently 30000 ms.</param>
-	    public virtual void CreateScheduler(string schedulerName, string schedulerInstanceId, IThreadPool threadPool,
+        /// <summary>
+        /// Creates a scheduler using the specified thread pool and job store and
+        /// binds it for remote access.
+        /// </summary>
+        /// <param name="schedulerName">The name for the scheduler.</param>
+        /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
+        /// <param name="threadPool">The thread pool for executing jobs</param>
+        /// <param name="jobStore">The type of job store</param>
+        /// <param name="idleWaitTime">The idle wait time.</param>
+        /// <exception cref="SchedulerException">Initialization failed.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="idleWaitTime"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        public virtual void CreateScheduler(string schedulerName, string schedulerInstanceId, IThreadPool threadPool,
                                             IJobStore jobStore, TimeSpan idleWaitTime)
         {
             CreateScheduler(schedulerName, schedulerInstanceId, threadPool, jobStore, null, idleWaitTime);
         }
 
-	    /// <summary>
-	    /// Creates a scheduler using the specified thread pool and job store and
-	    /// binds it for remote access.
-	    /// </summary>
-	    /// <param name="schedulerName">The name for the scheduler.</param>
-	    /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
-	    /// <param name="threadPool">The thread pool for executing jobs</param>
-	    /// <param name="jobStore">The type of job store</param>
-	    /// <param name="schedulerPluginMap"></param>
-	    /// <param name="idleWaitTime">The idle wait time. You can specify TimeSpan.Zero for
-	    ///     the default value, which is currently 30000 ms.</param>
-	    public virtual void CreateScheduler(
+        /// <summary>
+        /// Creates a scheduler using the specified thread pool and job store, and
+        /// binds it for remote access.
+        /// </summary>
+        /// <param name="schedulerName">The name for the scheduler.</param>
+        /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
+        /// <param name="threadPool">The thread pool for executing jobs</param>
+        /// <param name="jobStore">The type of job store</param>
+        /// <param name="schedulerPluginMap"></param>
+        /// <param name="idleWaitTime">The idle wait time.</param>
+        /// <exception cref="SchedulerException">Initialization failed.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="idleWaitTime"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        public virtual void CreateScheduler(
 		    string schedulerName,
 		    string schedulerInstanceId,
 		    IThreadPool threadPool,
@@ -232,24 +226,27 @@ namespace Quartz.Impl
                 jobStore,
                 schedulerPluginMap,
                 idleWaitTime,
-                DefaultBatchMaxSize,
-                DefaultBatchTimeWindow);
+                QuartzSchedulerResources.DefaultMaxBatchSize,
+                QuartzSchedulerResources.DefaultBatchTimeWindow);
 		}
 
-	    /// <summary>
-	    /// Creates a scheduler using the specified thread pool and job store and
-	    /// binds it for remote access.
-	    /// </summary>
-	    /// <param name="schedulerName">The name for the scheduler.</param>
-	    /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
-	    /// <param name="threadPool">The thread pool for executing jobs</param>
-	    /// <param name="jobStore">The type of job store</param>
-	    /// <param name="schedulerPluginMap"></param>
-	    /// <param name="idleWaitTime">The idle wait time. You can specify TimeSpan.Zero for
-	    ///     the default value, which is currently 30000 ms.</param>
-	    /// <param name="maxBatchSize">The maximum batch size of triggers, when acquiring them</param>
-	    /// <param name="batchTimeWindow">The time window for which it is allowed to "pre-acquire" triggers to fire</param>
-	    public virtual void CreateScheduler(
+        /// <summary>
+        /// Creates a scheduler using the specified thread pool and job store and
+        /// binds it for remote access.
+        /// </summary>
+        /// <param name="schedulerName">The name for the scheduler.</param>
+        /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
+        /// <param name="threadPool">The thread pool for executing jobs</param>
+        /// <param name="jobStore">The type of job store</param>
+        /// <param name="schedulerPluginMap"></param>
+        /// <param name="idleWaitTime">The idle wait time.</param>
+        /// <param name="maxBatchSize">The maximum batch size of triggers, when acquiring them</param>
+        /// <param name="batchTimeWindow">The time window for which it is allowed to "pre-acquire" triggers to fire</param>
+        /// <exception cref="SchedulerException">Initialization failed.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="idleWaitTime"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxBatchSize"/> is less than <c>1</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="batchTimeWindow"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        public virtual void CreateScheduler(
 		    string schedulerName,
 		    string schedulerInstanceId,
 		    IThreadPool threadPool,
@@ -271,21 +268,23 @@ namespace Quartz.Impl
 		        null);
 	    }
 
-	    /// <summary>
-	    /// Creates a scheduler using the specified thread pool and job store and
-	    /// binds it for remote access.
-	    /// </summary>
-	    /// <param name="schedulerName">The name for the scheduler.</param>
-	    /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
-	    /// <param name="threadPool">The thread pool for executing jobs</param>
-	    /// <param name="jobStore">The type of job store</param>
-	    /// <param name="schedulerPluginMap"></param>
-	    /// <param name="idleWaitTime">The idle wait time. You can specify TimeSpan.Zero for
-	    ///     the default value, which is currently 30000 ms.</param>
-	    /// <param name="maxBatchSize">The maximum batch size of triggers, when acquiring them</param>
-	    /// <param name="batchTimeWindow">The time window for which it is allowed to "pre-acquire" triggers to fire</param>
-	    /// <param name="schedulerExporter">The scheduler exporter to use</param>
-	    public virtual void CreateScheduler(
+        /// <summary>
+        /// Creates a scheduler using the specified thread pool and job store and
+        /// binds it for remote access.
+        /// </summary>
+        /// <param name="schedulerName">The name for the scheduler.</param>
+        /// <param name="schedulerInstanceId">The instance ID for the scheduler.</param>
+        /// <param name="threadPool">The thread pool for executing jobs</param>
+        /// <param name="jobStore">The type of job store</param>
+        /// <param name="schedulerPluginMap"></param>
+        /// <param name="idleWaitTime">The idle wait time.</param>
+        /// <param name="maxBatchSize">The maximum batch size of triggers, when acquiring them</param>
+        /// <param name="batchTimeWindow">The time window for which it is allowed to "pre-acquire" triggers to fire</param>
+        /// <param name="schedulerExporter">The scheduler exporter to use</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="idleWaitTime"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxBatchSize"/> is less than <c>1</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="batchTimeWindow"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        public virtual void CreateScheduler(
 		    string schedulerName,
 		    string schedulerInstanceId,
 		    IThreadPool threadPool,
@@ -296,6 +295,21 @@ namespace Quartz.Impl
 		    TimeSpan batchTimeWindow,
 		    ISchedulerExporter? schedulerExporter)
         {
+            if (idleWaitTime < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(idleWaitTime), $"Cannot be less than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}.");
+            }
+
+            if (maxBatchSize < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxBatchSize), "Cannot be less than 1.");
+            }
+
+            if (batchTimeWindow < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(batchTimeWindow), $"Cannot be less than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}.");
+            }
+
             // Currently only one run-shell factory is available...
             IJobRunShellFactory jrsf = new StdJobRunShellFactory();
 
@@ -309,10 +323,10 @@ namespace Quartz.Impl
 
             qrs.Name = schedulerName;
             qrs.InstanceId = schedulerInstanceId;
-
             qrs.JobRunShellFactory = jrsf;
             qrs.ThreadPool = threadPool;
             qrs.JobStore = jobStore;
+            qrs.IdleWaitTime = idleWaitTime;
             qrs.MaxBatchSize = maxBatchSize;
             qrs.BatchTimeWindow = batchTimeWindow;
             qrs.SchedulerExporter = schedulerExporter;
@@ -326,7 +340,7 @@ namespace Quartz.Impl
                 }
             }
 
-            QuartzScheduler qs = new QuartzScheduler(qrs, idleWaitTime);
+            QuartzScheduler qs = new QuartzScheduler(qrs);
 
             ITypeLoadHelper cch = new SimpleTypeLoadHelper();
             cch.Initialize();


### PR DESCRIPTION
We now verify whether valid values are specified for **IdleWaitTime**, **MaxBatchSize** and **BatchTimeoutWindow**, and no longer replace **TimeSpan.Zero** with a default of **30 seconds** if explicitly set.

This last modification is to allow for scenarios where someone wants a very low latency and precise scheduler.
We should not implicitly / silently change the configuration specified by a user.

<details>
<summary>Detailed changes</summary>
&nbsp;

**StdSchedulerFactory**
* Use default value of **30 seconds** for idle wait time if not explicitly set
* No longer reject value greater than **zero** and less than **1000 milliseconds** for idle wait time.

**DirectSchedulerFactory**
* Throw **ArgumentOutOfRangeException** if **idleWaitTime** is less than **TimeSpan.Zero**, **maxBatchSize** is less than **one** or **batchTimeWindow** is less than **TimeSpan.Zero**.
* Set **IdleWaitTime** property on **QuartzSchedulerResources** instead of passing value in ctor of **QuartzScheduler**.
* Document exceptions.

**ExceptionHelper**
* Add `ThrowArgumentOutOfRangeException(...)` method.

**QuartzScheduler**
* Make **resources** and **schedThread** fields internal for unit testing purposes.
* Remove **idleWaitTime** argument from ctor.

**QuartzSchedulerResources**
* Add **IdleWaitTime** property.
* Throw **ArgumentOutOfRangeException** if value for **BatchTimeWindow** is less than **TimeSpan.Zero**.
* Throw **ArgumentOutOfRangeException** if value for **MaxBatchSize** is less than **one**.

**QuartzSchedulerThread**
* Remove **IdleWaitTime** property, and instead use the **IdleWaitTime** on **QuartzSchedulerResources**.

Update benchmarks to explicitly specifiy 30 seconds for idle wait time, and update for **QuartzScheduler** ctor that no longer takes **idleWaitTime** argument.
Add unit tests.
</details>

Fixes #1394.