### PR TITLE
Simplity calculation of 'timeUntilContinue'

### DIFF
--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -461,9 +461,7 @@ namespace Quartz.Core
                         // while (!halted)
                     }
 
-                    DateTimeOffset utcNow = SystemTime.UtcNow();
-                    DateTimeOffset waitTime = utcNow.Add(GetRandomizedIdleWaitTime());
-                    TimeSpan timeUntilContinue = waitTime - utcNow;
+                    TimeSpan timeUntilContinue = GetRandomizedIdleWaitTime();
                     lock (sigLock)
                     {
                         if (!halted)


### PR DESCRIPTION
When we acquired zero triggers, we calculate a randomized wait time.
For some reason we were:
1. getting the current time.
1. calculating the randomized wait time.
1. adding that randomized wait time to the time we obtained in **1**.
1. subtracting the time we obtained in **1** from the result of **3**.

This actually gives us the randomized wait time that we calculated in **2**, so we now use that directly.
