### PR TITLE
Use JobBuilder to create IJobDetail instances

### DIFF
--- a/src/Quartz.Plugins/Plugin/Xml/XMLSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Xml/XMLSchedulingDataProcessorPlugin.cs
@@ -184,11 +184,9 @@ namespace Quartz.Plugin.Xml
                             trig.RepeatCount = SimpleTriggerImpl.RepeatIndefinitely;
                             trig.RepeatInterval = ScanInterval;
 
-                            // TODO: convert to use builder
-                            JobDetailImpl job = new JobDetailImpl(
-                                jobTriggerName,
-                                JobInitializationPluginName,
-                                typeof (FileScanJob));
+                            var job = JobBuilder.Create<FileScanJob>()
+                                                .WithIdentity(new JobKey(jobTriggerName, JobInitializationPluginName))
+                                                .Build();
 
                             job.JobDataMap.Put(FileScanJob.FileName, jobFile.FilePath);
                             job.JobDataMap.Put(FileScanJob.FileScanListenerName, JobInitializationPluginName + '_' + Name);

--- a/src/Quartz.Tests.Integration/ExceptionPolicy/ExceptionJobTest.cs
+++ b/src/Quartz.Tests.Integration/ExceptionPolicy/ExceptionJobTest.cs
@@ -32,8 +32,13 @@ namespace Quartz.Tests.Integration.ExceptionPolicy
             await sched.Start();
             string jobName = "ExceptionPolicyUnscheduleFiringTrigger";
             string jobGroup = "ExceptionPolicyUnscheduleFiringTriggerGroup";
-            JobDetailImpl myDesc = new JobDetailImpl(jobName, jobGroup, typeof(ExceptionJob));
-            myDesc.Durable = true;
+
+            var myDesc = JobBuilder.Create()
+                                   .OfType<ExceptionJob>()
+                                   .WithIdentity(new JobKey(jobName, jobGroup))
+                                   .StoreDurably(true)
+                                   .Build();
+
             await sched.AddJob(myDesc, false);
             string trigGroup = "ExceptionPolicyFiringTriggerGroup";
             IOperableTrigger trigger = new CronTriggerImpl("trigName", trigGroup, "0/2 * * * * ?");
@@ -113,8 +118,11 @@ namespace Quartz.Tests.Integration.ExceptionPolicy
         {
             await sched.Start();
             JobKey jobKey = new JobKey("ExceptionPolicyNoRestartJob", "ExceptionPolicyNoRestartGroup");
-            JobDetailImpl exceptionJob = new JobDetailImpl(jobKey.Name, jobKey.Group, typeof(ExceptionJob));
-            exceptionJob.Durable = true;
+            var exceptionJob = JobBuilder.Create()
+                                         .OfType<ExceptionJob>()
+                                         .WithIdentity(jobKey)
+                                         .StoreDurably(true)
+                                         .Build();
             await sched.AddJob(exceptionJob, false);
 
             ExceptionJob.ThrowsException = true;

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
@@ -266,8 +266,11 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
             IScheduler sched = await sf.GetScheduler();
             await sched.Clear();
 
-            JobDetailImpl jobWithData = new JobDetailImpl("datajob", "jobgroup", typeof(NoOpJob));
-            jobWithData.JobDataMap["testkey"] = "testvalue";
+            var jobWithData = JobBuilder.Create<NoOpJob>()
+                                        .WithIdentity(new JobKey("datajob", "jobgroup"))
+                                        .UsingJobData("testkey", "testvalue")
+                                        .Build();
+
             IOperableTrigger triggerWithData = new SimpleTriggerImpl("datatrigger", "triggergroup", 20, TimeSpan.FromSeconds(5));
             triggerWithData.JobDataMap.Add("testkey", "testvalue");
             triggerWithData.EndTimeUtc = DateTime.UtcNow.AddYears(10);
@@ -342,7 +345,9 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
                     for (int i = 0; i < 100000; ++i)
                     {
                         ITrigger trigger = new SimpleTriggerImpl("calendarsTrigger", "test", SimpleTriggerImpl.RepeatIndefinitely, TimeSpan.FromSeconds(1));
-                        JobDetailImpl jd = new JobDetailImpl("testJob", "test", typeof(NoOpJob));
+                        var jd = JobBuilder.Create<NoOpJob>()
+                                           .WithIdentity(new JobKey("testJob", "test"))
+                                           .Build();
                         await sched.ScheduleJob(jd, trigger);
                     }
                 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
@@ -485,15 +485,22 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
             {
                 await sched.Clear();
 
-                JobDetailImpl lonelyJob = new JobDetailImpl("lonelyJob", "lonelyGroup", typeof(SimpleRecoveryJob));
-                lonelyJob.Durable = true;
-                lonelyJob.RequestsRecovery = true;
+                var lonelyJob = JobBuilder.Create()
+                                          .OfType<SimpleRecoveryJob>()
+                                          .WithIdentity(new JobKey("lonelyJob", "lonelyGroup"))
+                                          .StoreDurably(true)
+                                          .RequestRecovery(true)
+                                          .Build();
+
                 await sched.AddJob(lonelyJob, false);
                 await sched.AddJob(lonelyJob, true);
 
                 string schedId = sched.SchedulerInstanceId;
 
-                JobDetailImpl job = new JobDetailImpl("job_to_use", schedId, typeof(SimpleRecoveryJob));
+                var job = JobBuilder.Create()
+                                    .OfType<SimpleRecoveryJob>()
+                                    .WithIdentity(new JobKey("job_to_use", schedId))
+                                    .Build();
 
                 for (int i = 0; i < 100000; ++i)
                 {

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -75,9 +75,13 @@ namespace Quartz.Tests.Integration.Impl
 
                     Assert.IsNotNull(await scheduler.GetCalendar("annualCalendar"));
 
-                    JobDetailImpl lonelyJob = new JobDetailImpl("lonelyJob", "lonelyGroup", typeof (SimpleRecoveryJob));
-                    lonelyJob.Durable = true;
-                    lonelyJob.RequestsRecovery = true;
+                    var lonelyJob = JobBuilder.Create()
+                                              .OfType<SimpleRecoveryJob>()
+                                              .WithIdentity(new JobKey("lonelyJob", "lonelyGroup"))
+                                              .StoreDurably(true)
+                                              .RequestRecovery(true)
+                                              .Build();
+
                     await scheduler.AddJob(lonelyJob, false);
                     await scheduler.AddJob(lonelyJob, true);
 
@@ -85,11 +89,13 @@ namespace Quartz.Tests.Integration.Impl
 
                     int count = 1;
 
-                    JobDetailImpl job = new JobDetailImpl("job_" + count, schedId, typeof (SimpleRecoveryJob));
-
+                    var job = JobBuilder.Create()
+                                        .OfType<SimpleRecoveryJob>()
+                                        .WithIdentity(new JobKey("job_" + count, schedId))
+                                        .RequestRecovery(true)
+                                        .Build();
                     // ask scheduler to re-Execute this job if it was in progress when
                     // the scheduler went down...
-                    job.RequestsRecovery = true;
                     IOperableTrigger trigger = new SimpleTriggerImpl("trig_" + count, schedId, 20, TimeSpan.FromSeconds(5));
                     trigger.JobDataMap.Add("key", "value");
                     trigger.EndTimeUtc = DateTime.UtcNow.AddYears(10);
@@ -103,48 +109,60 @@ namespace Quartz.Tests.Integration.Impl
                     Assert.IsTrue(persisted is SimpleTriggerImpl);
 
                     count++;
-                    job = new JobDetailImpl("job_" + count, schedId, typeof (SimpleRecoveryJob));
+                    job = JobBuilder.Create()
+                                    .OfType<SimpleRecoveryJob>()
+                                    .WithIdentity(new JobKey("job_" + count, schedId))
+                                    .RequestRecovery(true)
+                                    .Build();
                     // ask scheduler to re-Execute this job if it was in progress when
                     // the scheduler went down...
-                    job.RequestsRecovery = true;
                     trigger = new SimpleTriggerImpl("trig_" + count, schedId, 20, TimeSpan.FromSeconds(5));
-
                     trigger.StartTimeUtc = DateTime.Now.AddMilliseconds(2000L);
                     await scheduler.ScheduleJob(job, trigger);
 
                     count++;
-                    job = new JobDetailImpl("job_" + count, schedId, typeof (SimpleRecoveryStatefulJob));
+                    job = JobBuilder.Create()
+                                    .OfType<SimpleRecoveryStatefulJob>()
+                                    .WithIdentity(new JobKey("job_" + count, schedId))
+                                    .RequestRecovery(true)
+                                    .Build();
                     // ask scheduler to re-Execute this job if it was in progress when
                     // the scheduler went down...
-                    job.RequestsRecovery = true;
                     trigger = new SimpleTriggerImpl("trig_" + count, schedId, 20, TimeSpan.FromSeconds(3));
-
                     trigger.StartTimeUtc = DateTime.Now.AddMilliseconds(1000L);
                     await scheduler.ScheduleJob(job, trigger);
 
                     count++;
-                    job = new JobDetailImpl("job_" + count, schedId, typeof (SimpleRecoveryJob));
+                    job = JobBuilder.Create()
+                                    .OfType<SimpleRecoveryJob>()
+                                    .WithIdentity(new JobKey("job_" + count, schedId))
+                                    .RequestRecovery(true)
+                                    .Build();
                     // ask scheduler to re-Execute this job if it was in progress when
                     // the scheduler went down...
-                    job.RequestsRecovery = true;
                     trigger = new SimpleTriggerImpl("trig_" + count, schedId, 20, TimeSpan.FromSeconds(4));
-
                     trigger.StartTimeUtc = DateTime.Now.AddMilliseconds(1000L);
                     await scheduler.ScheduleJob(job, trigger);
 
                     count++;
-                    job = new JobDetailImpl("job_" + count, schedId, typeof (SimpleRecoveryJob));
+                    job = JobBuilder.Create()
+                                    .OfType<SimpleRecoveryJob>()
+                                    .WithIdentity(new JobKey("job_" + count, schedId))
+                                    .RequestRecovery(true)
+                                    .Build();
                     // ask scheduler to re-Execute this job if it was in progress when
                     // the scheduler went down...
-                    job.RequestsRecovery = true;
                     trigger = new SimpleTriggerImpl("trig_" + count, schedId, 20, TimeSpan.FromMilliseconds(4500));
                     await scheduler.ScheduleJob(job, trigger);
 
                     count++;
-                    job = new JobDetailImpl("job_" + count, schedId, typeof (SimpleRecoveryJob));
+                    job = JobBuilder.Create()
+                                    .OfType<SimpleRecoveryJob>()
+                                    .WithIdentity(new JobKey("job_" + count, schedId))
+                                    .RequestRecovery(true)
+                                    .Build();
                     // ask scheduler to re-Execute this job if it was in progress when
                     // the scheduler went down...
-                    job.RequestsRecovery = true;
                     IOperableTrigger ct = new CronTriggerImpl("cron_trig_" + count, schedId, "0/10 * * * * ?");
                     ct.JobDataMap.Add("key", "value");
                     ct.StartTimeUtc = DateTime.Now.AddMilliseconds(1000);
@@ -152,10 +170,13 @@ namespace Quartz.Tests.Integration.Impl
                     await scheduler.ScheduleJob(job, ct);
 
                     count++;
-                    job = new JobDetailImpl("job_" + count, schedId, typeof (SimpleRecoveryJob));
+                    job = JobBuilder.Create()
+                                    .OfType<SimpleRecoveryJob>()
+                                    .WithIdentity(new JobKey("job_" + count, schedId))
+                                    .RequestRecovery(true)
+                                    .Build();
                     // ask scheduler to re-Execute this job if it was in progress when
                     // the scheduler went down...
-                    job.RequestsRecovery = true;
 
                     var timeZone1 = TimeZoneUtil.FindTimeZoneById("Central European Standard Time");
                     var timeZone2 = TimeZoneUtil.FindTimeZoneById("Mountain Standard Time");
@@ -200,7 +221,6 @@ namespace Quartz.Tests.Integration.Impl
                     Assert.That(triggerFromDb.EndTimeOfDay.Minute, Is.EqualTo(3));
                     Assert.That(triggerFromDb.EndTimeOfDay.Second, Is.EqualTo(4));
 
-                    job.RequestsRecovery = true;
                     CalendarIntervalTriggerImpl intervalTrigger = new CalendarIntervalTriggerImpl(
                         "calint_trig_" + count,
                         schedId,

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -48,7 +48,9 @@ namespace Quartz.Tests.Integration.Impl
                     IOperableTrigger calendarsTrigger = new SimpleTriggerImpl("calendarsTrigger", "test", 20, TimeSpan.FromMilliseconds(5));
                     calendarsTrigger.CalendarName = "annualCalendar";
 
-                    JobDetailImpl jd = new JobDetailImpl("testJob", "test", typeof (NoOpJob));
+                    var jd = JobBuilder.Create<NoOpJob>()
+                                       .WithIdentity(new JobKey("testJob", "test"))
+                                       .Build();
                     await scheduler.ScheduleJob(jd, calendarsTrigger);
 
                     // QRTZNET-93
@@ -262,7 +264,9 @@ namespace Quartz.Tests.Integration.Impl
 
                     // bulk operations
                     var info = new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>>();
-                    IJobDetail detail = new JobDetailImpl("job_" + count, schedId, typeof (SimpleRecoveryJob));
+                    IJobDetail detail = JobBuilder.Create<SimpleRecoveryJob>()
+                                                  .WithIdentity(new JobKey("job_" + count, schedId))
+                                                  .Build();
                     ITrigger simple = new SimpleTriggerImpl("trig_" + count, schedId, 20, TimeSpan.FromMilliseconds(4500));
                     var triggers = new List<ITrigger>();
                     triggers.Add(simple);

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -64,7 +64,9 @@ namespace Quartz.Tests.Unit.Core
             DateTime runTime = DateTime.Now.AddMinutes(10);
 
             // define the job and tie it to our HelloJob class
-            JobDetailImpl job = new JobDetailImpl("job1", "group1", typeof(NoOpJob));
+            var job = JobBuilder.Create<NoOpJob>()
+                                .WithIdentity(new JobKey("job1", "group1"))
+                                .Build();
 
             // Trigger the job to run on the next round minute
             IOperableTrigger trigger = new SimpleTriggerImpl("trigger1", "group1", runTime);
@@ -122,7 +124,9 @@ namespace Quartz.Tests.Unit.Core
             ISchedulerFactory sf = new StdSchedulerFactory(properties);
             IScheduler scheduler = await sf.GetScheduler();
             DateTime startTimeUtc = DateTime.UtcNow.AddSeconds(2);
-            JobDetailImpl jobDetail = new JobDetailImpl(JobName, JobGroup, typeof(NoOpJob));
+            var jobDetail = JobBuilder.Create<NoOpJob>()
+                                      .WithIdentity(new JobKey(JobName, JobGroup))
+                                      .Build();
             SimpleTriggerImpl jobTrigger = new SimpleTriggerImpl(TriggerName, TriggerGroup, JobName, JobGroup, startTimeUtc, null, 1, TimeSpan.FromMilliseconds(1000));
 
             ISchedulerListener listener = A.Fake<ISchedulerListener>();

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -224,7 +224,9 @@ namespace Quartz.Tests.Unit.Simpl
         {
             string jobName = "StoreTriggerReplacesTrigger";
             string jobGroup = "StoreTriggerReplacesTriggerGroup";
-            JobDetailImpl detail = new JobDetailImpl(jobName, jobGroup, typeof(NoOpJob));
+            var detail = JobBuilder.Create<NoOpJob>()
+                                   .WithIdentity(new JobKey(jobName, jobGroup))
+                                   .Build();
             await fJobStore.StoreJob(detail, false);
 
             string trName = "StoreTriggerReplacesTrigger";

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -45,7 +45,7 @@ namespace Quartz.Tests.Unit.Simpl
     public class RAMJobStoreTest
     {
         private IJobStore fJobStore;
-        private JobDetailImpl fJobDetail;
+        private IJobDetail fJobDetail;
         private SampleSignaler fSignaler;
 
         [SetUp]
@@ -56,8 +56,12 @@ namespace Quartz.Tests.Unit.Simpl
             fJobStore.Initialize(null, fSignaler);
             fJobStore.SchedulerStarted();
 
-            fJobDetail = new JobDetailImpl("job1", "jobGroup1", typeof(NoOpJob));
-            fJobDetail.Durable = true;
+            fJobDetail = JobBuilder.Create()
+                                   .OfType<NoOpJob>()
+                                   .WithIdentity(new JobKey("job1", "jobGroup1"))
+                                   .StoreDurably(true)
+                                   .Build();
+
             fJobStore.StoreJob(fJobDetail, false);
         }
 
@@ -65,9 +69,9 @@ namespace Quartz.Tests.Unit.Simpl
         public async Task TestAcquireNextTrigger()
         {
             DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
-            IOperableTrigger trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(200), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(50), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger3 = new SimpleTriggerImpl("trigger1", "triggerGroup2", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(100), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddSeconds(200), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddSeconds(50), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger3 = new SimpleTriggerImpl("trigger1", "triggerGroup2", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddSeconds(100), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
 
             trigger1.ComputeFirstFireTimeUtc(null);
             trigger2.ComputeFirstFireTimeUtc(null);
@@ -94,12 +98,12 @@ namespace Quartz.Tests.Unit.Simpl
         {
             DateTimeOffset d = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(1));
 
-            IOperableTrigger early = new SimpleTriggerImpl("early", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d, d.AddMilliseconds(5), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(200000), d.AddMilliseconds(200005), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(210000), d.AddMilliseconds(210005), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger3 = new SimpleTriggerImpl("trigger3", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(220000), d.AddMilliseconds(220005), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger4 = new SimpleTriggerImpl("trigger4", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(230000), d.AddMilliseconds(230005), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger10 = new SimpleTriggerImpl("trigger10", "triggerGroup2", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(500000), d.AddMilliseconds(700000), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger early = new SimpleTriggerImpl("early", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, d, d.AddMilliseconds(5), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddMilliseconds(200000), d.AddMilliseconds(200005), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddMilliseconds(210000), d.AddMilliseconds(210005), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger3 = new SimpleTriggerImpl("trigger3", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddMilliseconds(220000), d.AddMilliseconds(220005), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger4 = new SimpleTriggerImpl("trigger4", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddMilliseconds(230000), d.AddMilliseconds(230005), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger10 = new SimpleTriggerImpl("trigger10", "triggerGroup2", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddMilliseconds(500000), d.AddMilliseconds(700000), 2, TimeSpan.FromSeconds(2));
 
             early.ComputeFirstFireTimeUtc(null);
             early.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
@@ -181,7 +185,7 @@ namespace Quartz.Tests.Unit.Simpl
         [Test]
         public async Task TestTriggerStates()
         {
-            IOperableTrigger trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, DateTimeOffset.Now.AddSeconds(100), DateTimeOffset.Now.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, DateTimeOffset.Now.AddSeconds(100), DateTimeOffset.Now.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
             trigger.ComputeFirstFireTimeUtc(null);
             Assert.AreEqual(TriggerState.None, await fJobStore.GetTriggerState(trigger.Key));
             await fJobStore.StoreTrigger(trigger, false);
@@ -206,7 +210,7 @@ namespace Quartz.Tests.Unit.Simpl
         {
             // QRTZNET-29
 
-            IOperableTrigger trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, DateTimeOffset.Now.AddSeconds(100), DateTimeOffset.Now.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, DateTimeOffset.Now.AddSeconds(100), DateTimeOffset.Now.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
             trigger.ComputeFirstFireTimeUtc(null);
             ICalendar cal = new MonthlyCalendar();
             fJobStore.StoreTrigger(trigger, false);
@@ -256,13 +260,18 @@ namespace Quartz.Tests.Unit.Simpl
             string jobName1 = "PauseJobGroupPausesNewJob";
             string jobName2 = "PauseJobGroupPausesNewJob2";
             string jobGroup = "PauseJobGroupPausesNewJobGroup";
-            JobDetailImpl detail = new JobDetailImpl(jobName1, jobGroup, typeof(NoOpJob));
-            detail.Durable = true;
+
+            var detail = JobBuilder.Create<NoOpJob>()
+                                   .WithIdentity(new JobKey(jobName1, jobGroup))
+                                   .StoreDurably(true)
+                                   .Build();
             await fJobStore.StoreJob(detail, false);
             await fJobStore.PauseJobs(GroupMatcher<JobKey>.GroupEquals(jobGroup));
 
-            detail = new JobDetailImpl(jobName2, jobGroup, typeof(NoOpJob));
-            detail.Durable = true;
+            detail = JobBuilder.Create<NoOpJob>()
+                               .WithIdentity(new JobKey(jobName2, jobGroup))
+                               .StoreDurably(true)
+                               .Build();
             await fJobStore.StoreJob(detail, false);
 
             string trName = "PauseJobGroupPausesNewJobTrigger";

--- a/src/Quartz.Tests.Unit/TestUtil.cs
+++ b/src/Quartz.Tests.Unit/TestUtil.cs
@@ -53,7 +53,10 @@ namespace Quartz.Tests.Unit
         /// <returns>Minimal TriggerFiredBundle</returns>
         public static TriggerFiredBundle CreateMinimalFiredBundleWithTypedJobDetail(Type jobType, IOperableTrigger trigger)
         {
-            JobDetailImpl jd = new JobDetailImpl("jobName", "jobGroup", jobType);
+            var jd = JobBuilder.Create()
+                               .OfType(jobType)
+                               .WithIdentity(new JobKey("jobName", "jobGroup"))
+                               .Build();
             TriggerFiredBundle bundle = new TriggerFiredBundle(jd, trigger, null, false, DateTimeOffset.UtcNow, null, null, null);
             return bundle;
         }
@@ -70,7 +73,9 @@ namespace Quartz.Tests.Unit
 
 		private static TriggerFiredBundle NewMinimalTriggerFiredBundle(bool isRecovering)
 		{
-			IJobDetail jd = new JobDetailImpl("jobName", "jobGroup", typeof(NoOpJob));
+            IJobDetail jd = JobBuilder.Create<NoOpJob>()
+                                      .WithIdentity(new JobKey("jobName", "jobGroup"))
+                                      .Build();
 			IOperableTrigger trigger = new SimpleTriggerImpl("triggerName", "triggerGroup");
 			TriggerFiredBundle retValue = new TriggerFiredBundle(jd, trigger, null, isRecovering, DateTimeOffset.UtcNow, null, null, null);
 


### PR DESCRIPTION
We should give preference to using **JobBuilder** to create a **IJobDetail** instance over directly initializing a **JobDetailImpl**.