### PR TITLE
Remove use of GetTypeInfo()

### DIFF
--- a/src/Quartz.Examples/Program.cs
+++ b/src/Quartz.Examples/Program.cs
@@ -41,7 +41,7 @@ namespace Quartz.Examples
                 var logRepository = log4net.LogManager.GetRepository(Assembly.GetEntryAssembly());
                 log4net.Config.XmlConfigurator.Configure(logRepository, new System.IO.FileInfo("log4net.config"));
 
-                Assembly asm = typeof(Program).GetTypeInfo().Assembly;
+                Assembly asm = typeof(Program).Assembly;
                 Type[] types = asm.GetTypes();
 
                 IDictionary<int, Type> typeMap = new Dictionary<int, Type>();

--- a/src/Quartz.Serialization.Json/Converters/StringKeyDirtyFlagMapConverter.cs
+++ b/src/Quartz.Serialization.Json/Converters/StringKeyDirtyFlagMapConverter.cs
@@ -25,7 +25,7 @@ namespace Quartz.Converters
 
         public override bool CanConvert(Type objectType)
         {
-            return typeof(StringKeyDirtyFlagMap).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+            return typeof(StringKeyDirtyFlagMap).IsAssignableFrom(objectType);
         }
     }
 }

--- a/src/Quartz.Tests.Integration/TestAssemblySetup.cs
+++ b/src/Quartz.Tests.Integration/TestAssemblySetup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 
@@ -14,7 +14,7 @@ namespace Quartz.Tests.Integration
         {
             // set default directory to make sure file loading works
             // (https://youtrack.jetbrains.com/issue/RSRP-451142) 
-            string codeBase = GetType().GetTypeInfo().Assembly.Location;
+            string codeBase = GetType().Assembly.Location;
             string pathToUse = codeBase;
             if (!codeBase.StartsWith("/"))
             {

--- a/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
@@ -308,7 +308,7 @@ namespace Quartz.Tests.Integration.Xml
         private static Stream ReadJobXmlFromEmbeddedResource(string resourceName)
         {
             string fullName = "Quartz.Tests.Integration.Xml.TestData." + resourceName;
-            Stream stream = typeof(XMLSchedulingDataProcessorTest).GetTypeInfo().Assembly.GetManifestResourceStream(fullName);
+            Stream stream = typeof(XMLSchedulingDataProcessorTest).Assembly.GetManifestResourceStream(fullName);
             Assert.That(stream, Is.Not.Null, "resource " + resourceName + " not found");
             return new StreamReader(stream).BaseStream;
         }

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -45,7 +45,7 @@ namespace Quartz.Tests.Unit.Core
         [Test]
         public void TestVersionInfo()
         {
-            var versionInfo = typeof(QuartzScheduler).GetTypeInfo().Assembly.GetName().Version;
+            var versionInfo = typeof(QuartzScheduler).Assembly.GetName().Version;
             Assert.AreEqual(versionInfo.Major.ToString(CultureInfo.InvariantCulture), QuartzScheduler.VersionMajor);
             Assert.AreEqual(versionInfo.Minor.ToString(CultureInfo.InvariantCulture), QuartzScheduler.VersionMinor);
             Assert.AreEqual(versionInfo.Build.ToString(CultureInfo.InvariantCulture), QuartzScheduler.VersionIteration);

--- a/src/Quartz.Tests.Unit/QualityTest.cs
+++ b/src/Quartz.Tests.Unit/QualityTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -17,8 +17,8 @@ namespace Quartz.Tests.Unit
         [Test]
         public void EnsureNoAsyncVoidMethods()
         {
-            AssertNoAsyncVoidMethods(GetType().GetTypeInfo().Assembly);
-            AssertNoAsyncVoidMethods(typeof (IJob).GetTypeInfo().Assembly);
+            AssertNoAsyncVoidMethods(GetType().Assembly);
+            AssertNoAsyncVoidMethods(typeof (IJob).Assembly);
             // AssertNoAsyncVoidMethods(typeof (TriggersController).Assembly);
         }
 

--- a/src/Quartz.Tests.Unit/SerializationTestSupport.cs
+++ b/src/Quartz.Tests.Unit/SerializationTestSupport.cs
@@ -79,7 +79,7 @@ namespace Quartz.Tests.Unit
         [Test]
         public void WriteJobDataFile()
         {
-            Assembly asm = GetType().GetTypeInfo().Assembly;
+            Assembly asm = GetType().Assembly;
             Version info = asm.GetName().Version;
 
             string version = info.ToString();

--- a/src/Quartz.Tests.Unit/TestAssemblySetup.cs
+++ b/src/Quartz.Tests.Unit/TestAssemblySetup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 
@@ -14,7 +14,7 @@ namespace Quartz.Tests.Unit
         {
             // set default directory to make sure file loading works
             // (https://youtrack.jetbrains.com/issue/RSRP-451142) 
-            string codeBase = GetType().GetTypeInfo().Assembly.Location;
+            string codeBase = GetType().Assembly.Location;
             string pathToUse = codeBase;
             if (!codeBase.StartsWith("/"))
             {

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -87,7 +87,7 @@ namespace Quartz.Core
         /// </summary>
         static QuartzScheduler()
         {
-            var asm = typeof (QuartzScheduler).GetTypeInfo().Assembly;
+            var asm = typeof (QuartzScheduler).Assembly;
             version = asm.GetName().Version!;
         }
 

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -255,7 +255,7 @@ namespace Quartz.Impl
                     throw new ArgumentException("Job class cannot be null.");
                 }
 
-                if (!typeof(IJob).IsAssignableFrom(value.GetType()))
+                if (!typeof(IJob).IsAssignableFrom(value))
                 {
                     throw new ArgumentException("Job class must implement the Job interface.");
                 }

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -255,7 +255,7 @@ namespace Quartz.Impl
                     throw new ArgumentException("Job class cannot be null.");
                 }
 
-                if (!typeof(IJob).GetTypeInfo().IsAssignableFrom(value.GetTypeInfo()))
+                if (!typeof(IJob).IsAssignableFrom(value.GetType()))
                 {
                     throw new ArgumentException("Job class must implement the Job interface.");
                 }

--- a/src/Quartz/Simpl/PropertySettingJobFactory.cs
+++ b/src/Quartz/Simpl/PropertySettingJobFactory.cs
@@ -169,7 +169,7 @@ namespace Quartz.Simpl
 
 			    paramType = prop.PropertyType;
 
-			    if (o == null && (paramType.GetTypeInfo().IsPrimitive || paramType.GetTypeInfo().IsEnum))
+			    if (o == null && (paramType.IsPrimitive || paramType.IsEnum))
 			    {
 				    // cannot set null to these
 				    HandleError($"Cannot set null to property on Job class {job.GetType()} for property '{name}'");

--- a/src/Quartz/Util/ObjectExtensions.cs
+++ b/src/Quartz/Util/ObjectExtensions.cs
@@ -14,7 +14,7 @@ namespace Quartz.Util
         private static readonly Regex cleanup = new Regex(", (Version|Culture|PublicKeyToken)=[0-9.\\w]+", RegexOptions.Compiled);
         
         public static string AssemblyQualifiedNameWithoutVersion(this Type type)
-            => assemblyQualifiedNameCache.GetOrAdd(type, x => GetTypeString(x) + ", " + x.GetType().Assembly.GetName().Name);
+            => assemblyQualifiedNameCache.GetOrAdd(type, x => GetTypeString(x) + ", " + x.Assembly.GetName().Name);
 
         public static string? GetTypeString(Type type)
             => type.IsGenericType

--- a/src/Quartz/Util/ObjectExtensions.cs
+++ b/src/Quartz/Util/ObjectExtensions.cs
@@ -14,7 +14,7 @@ namespace Quartz.Util
         private static readonly Regex cleanup = new Regex(", (Version|Culture|PublicKeyToken)=[0-9.\\w]+", RegexOptions.Compiled);
         
         public static string AssemblyQualifiedNameWithoutVersion(this Type type)
-            => assemblyQualifiedNameCache.GetOrAdd(type, x => GetTypeString(x) + ", " + x.GetTypeInfo().Assembly.GetName().Name);
+            => assemblyQualifiedNameCache.GetOrAdd(type, x => GetTypeString(x) + ", " + x.GetType().Assembly.GetName().Name);
 
         public static string? GetTypeString(Type type)
             => type.IsGenericType

--- a/src/Quartz/Util/ObjectUtils.cs
+++ b/src/Quartz/Util/ObjectUtils.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2009- Marko Lahma
@@ -69,7 +69,7 @@ namespace Quartz.Util
                 {
                     return Type.GetType(newValue.ToString()!, true);
                 }
-                if (newValue.GetType().GetTypeInfo().IsEnum)
+                if (newValue.GetType().IsEnum)
                 {
                     // If we couldn't convert the type, but it's an enum type, try convert it as an int
                     return ConvertValueIfNecessary(requiredType, Convert.ChangeType(newValue, Convert.GetTypeCode(newValue), null));
@@ -90,7 +90,7 @@ namespace Quartz.Util
                 throw new NotSupportedException($"{newValue} is no a supported value for a target of type {requiredType}");
             }
 
-            if (requiredType.GetTypeInfo().IsValueType)
+            if (requiredType.IsValueType)
             {
                 return Activator.CreateInstance(requiredType);
             }
@@ -247,7 +247,7 @@ namespace Quartz.Util
 
         public static bool IsAttributePresent(Type typeToExamine, Type attributeType)
         {
-            return typeToExamine.GetTypeInfo().GetCustomAttributes(attributeType, true).Any();
+            return typeToExamine.GetCustomAttributes(attributeType, true).Any();
         }
 
         public static bool IsAnyInterfaceAttributePresent(Type typeToExamine, Type attributeType)

--- a/src/Quartz/Util/PropertiesParser.cs
+++ b/src/Quartz/Util/PropertiesParser.cs
@@ -658,7 +658,7 @@ namespace Quartz.Util
         /// <returns></returns>
         public static PropertiesParser ReadFromEmbeddedAssemblyResource(string resourceName)
          {
-	         var stream = typeof(IScheduler).GetTypeInfo().Assembly.GetManifestResourceStream(resourceName);
+	         var stream = typeof(IScheduler).Assembly.GetManifestResourceStream(resourceName);
 	         return ReadFromStream(stream ?? throw new ArgumentException("cannot find resource " + resourceName));
          }
 


### PR DESCRIPTION
Remove use of `Type.GetTypeInfo()` that dates back to early days of .NET Core.