### PR TITLE
Lazy initialize some properties of JobExecutionContextImpl

### DIFF
--- a/src/Quartz.Benchmark/JobExecutionContextImplBenchmark.cs
+++ b/src/Quartz.Benchmark/JobExecutionContextImplBenchmark.cs
@@ -1,0 +1,109 @@
+#nullable disable
+
+using System;
+
+using BenchmarkDotNet.Attributes;
+
+using Quartz.Core;
+using Quartz.Impl;
+using Quartz.Job;
+using Quartz.Simpl;
+using Quartz.Spi;
+
+namespace Quartz.Benchmark
+{
+    [MemoryDiagnoser]
+    public class JobExecutionContextImplBenchmark
+    {
+        private IJobDetail _jobDetailDataMapEmpty;
+        private IJobDetail _jobDetailDataMapNotEmpty;
+        private IOperableTrigger _triggerDataMapEmpty;
+        private IOperableTrigger _triggerDataMapNotEmpty;
+        private TriggerFiredBundle _triggerFiredBundleJobDataMapEmptyAndTriggerDataMapEmpty;
+        private TriggerFiredBundle _triggerFiredBundleJobDataMapNotEmptyAndTriggerDataMapEmpty;
+        private TriggerFiredBundle _triggerFiredBundleJobDataMapNotEmptyAndTriggerDataMapNotEmpty;
+        private TriggerFiredBundle _triggerFiredBundleJobDataMapEmptyAndTriggerDataMapNotEmpty;
+        private StdScheduler _scheduler;
+        private NoOpJob _job;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var triggerBuilder = TriggerBuilder.Create();
+            var jobBuilder = JobBuilder.Create();
+
+            _jobDetailDataMapEmpty = jobBuilder.OfType<NoOpJob>()
+                                               .WithIdentity("Empty")
+                                               .Build();
+            _jobDetailDataMapNotEmpty = jobBuilder.OfType<NoOpJob>()
+                                                  .WithIdentity("NotEmpty")
+                                                  .UsingJobData("Mutex", "Yes")
+                                                  .UsingJobData("LongRunning", "No")
+                                                  .Build();
+            _triggerDataMapEmpty = (IOperableTrigger) triggerBuilder.WithIdentity("Empty").Build();
+            _triggerDataMapNotEmpty = (IOperableTrigger) triggerBuilder.WithIdentity("NotEmpty")
+                                                                       .UsingJobData("Foo", "Bar")
+                                                                       .UsingJobData("Bar", "Foo")
+                                                                       .Build();
+
+            _triggerFiredBundleJobDataMapEmptyAndTriggerDataMapEmpty = CreateTriggerFiredBundle(_jobDetailDataMapEmpty, _triggerDataMapEmpty);
+            _triggerFiredBundleJobDataMapEmptyAndTriggerDataMapNotEmpty = CreateTriggerFiredBundle(_jobDetailDataMapEmpty, _triggerDataMapNotEmpty);
+            _triggerFiredBundleJobDataMapNotEmptyAndTriggerDataMapEmpty = CreateTriggerFiredBundle(_jobDetailDataMapNotEmpty, _triggerDataMapEmpty);
+            _triggerFiredBundleJobDataMapNotEmptyAndTriggerDataMapNotEmpty = CreateTriggerFiredBundle(_jobDetailDataMapNotEmpty, _triggerDataMapNotEmpty);
+
+            _scheduler = new StdScheduler(CreateQuartzScheduler("x", "1", 5));
+            _job = new NoOpJob();
+        }
+
+        [Benchmark]
+        public JobExecutionContextImpl Ctor_JobDataMapEmpty_TriggerDataMapEmpty()
+        {
+            return new JobExecutionContextImpl(_scheduler, _triggerFiredBundleJobDataMapEmptyAndTriggerDataMapEmpty, _job);
+        }
+
+        [Benchmark]
+        public JobExecutionContextImpl Ctor_JobDataMapEmpty_TriggerDataMapNotEmpty()
+        {
+            return new JobExecutionContextImpl(_scheduler, _triggerFiredBundleJobDataMapEmptyAndTriggerDataMapNotEmpty, _job);
+        }
+
+        [Benchmark]
+        public JobExecutionContextImpl Ctor_JobDataMapNotEmpty_TriggerDataMapEmpty()
+        {
+            return new JobExecutionContextImpl(_scheduler, _triggerFiredBundleJobDataMapNotEmptyAndTriggerDataMapEmpty, _job);
+        }
+
+        [Benchmark]
+        public JobExecutionContextImpl Ctor_JobDataMapNotEmpty_TriggerDataMapNotEmpty()
+        {
+            return new JobExecutionContextImpl(_scheduler, _triggerFiredBundleJobDataMapNotEmptyAndTriggerDataMapNotEmpty, _job);
+        }
+
+        private static TriggerFiredBundle CreateTriggerFiredBundle(IJobDetail jobDetail, IOperableTrigger trigger)
+        {
+            return new TriggerFiredBundle(jobDetail,
+                                          trigger,
+                                          null,
+                                          false,
+                                          DateTimeOffset.Now,
+                                          DateTimeOffset.Now,
+                                          DateTimeOffset.Now,
+                                          DateTimeOffset.Now);
+        }
+
+        private static QuartzScheduler CreateQuartzScheduler(string name, string instanceId, int threadCount)
+        {
+            QuartzSchedulerResources res = new QuartzSchedulerResources
+                {
+                    Name = name,
+                    InstanceId = instanceId,
+                    ThreadPool = new DefaultThreadPool { MaxConcurrency = threadCount },
+                    JobStore = new RAMJobStore(),
+                    MaxBatchSize = threadCount,
+                    BatchTimeWindow = TimeSpan.Zero
+                };
+
+            return new QuartzScheduler(res, TimeSpan.Zero);
+        }
+    }
+}

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -76,8 +76,6 @@ namespace Quartz.Impl
         private JobDataMap? jobDataMap;
         [NonSerialized]
         private readonly IScheduler scheduler;
-        [NonSerialized]
-        private CancellationToken cancellationToken;
 
         private int numRefires;
         private TimeSpan? jobRunTime;
@@ -352,24 +350,7 @@ namespace Quartz.Impl
         /// </summary>
         public string FireInstanceId => ((IOperableTrigger) trigger).FireInstanceId;
 
-        public CancellationToken CancellationToken
-        {
-            get
-            {
-                if (cancellationToken == null)
-                {
-                    lock (lazyInitLock)
-                    {
-                        if (cancellationToken == null)
-                        {
-                            cancellationToken = CancellationTokenSource.Token;
-                        }
-                    }
-                }
-
-                return cancellationToken;
-            }
-        }
+        public CancellationToken CancellationToken => CancellationTokenSource.Token;
 
         /// <summary>
         /// Lazily initializes the <see cref="CancellationTokenSource"/>.


### PR DESCRIPTION
Lazy initialize cancellationTokenSource, cancellationToken, data and jobDataMap.
This has quite a positive impact on both performance and memory allocations.

**To be discussed:**
* Does this lazy init have to be threadsafe?
  If it is, we'll need to introduce a lock field.
* Is it correct to lazy init **jobDataMap**?
  I think it's not, because I assume we want the "state" of both the job and trigger data at the time we create the **JobExecutionContextImpl**.

<details>
<summary>Benchmark results</summary>

|                                                       Method | Branch |    Mean |     Error |    StdDev |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|------------------------------------------------------------- |-------:|--------:|----------:|----------:|-------:|-------:|-------:|----------:|
| Concurrent_MaxThreads_30Jobs_30TriggersPerJob_MaxBatchSize30 | main   |8.379 us | 0.1643 us | 0.1956 us | 0.5780 | 0.2480 | 0.0860 |    3.1 KB |
| Concurrent_MaxThreads_30Jobs_30TriggersPerJob_MaxBatchSize30 | PR     |7.206 us | 0.1417 us | 0.1687 us | 0.4520 | 0.1820 | 0.0700 |   2.42 KB |
</details>