### PR TITLE
Improve performance, reduce allocations and reduce contention in TaskSchedulingThreadPool 

### DIFF
--- a/src/Quartz.Benchmark/DefaultThreadPoolBenchmark.cs
+++ b/src/Quartz.Benchmark/DefaultThreadPoolBenchmark.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using Quartz.Simpl;
+
+namespace Quartz.Benchmark
+{
+    [MemoryDiagnoser]
+    public class DefaultThreadPoolBenchmark
+    {
+        [Benchmark(OperationsPerInvoke = 500_000)]
+        public void RunInThread_CompletedTask_MaxConcurrencyIsMaxValue_SingleThreaded()
+        {
+            var threadPool = new DefaultThreadPool
+                {
+                    MaxConcurrency = int.MaxValue
+                };
+            threadPool.Initialize();
+
+            for (var i = 0; i < 500_000; i++)
+            {
+                threadPool!.RunInThread(() => Task.CompletedTask);
+            }
+
+            threadPool.Shutdown(true);
+        }
+
+        [Benchmark(OperationsPerInvoke = 1_000_000)]
+        public void RunInThread_CompletedTask_MaxConcurrencyIsMaxValue_MultiThreaded()
+        {
+            var threadPool = new DefaultThreadPool
+                {
+                    MaxConcurrency = int.MaxValue
+                };
+            threadPool.Initialize();
+
+            Execute(threadPool, 20, 50_000, (tp) => tp.RunInThread(() => Task.CompletedTask));
+
+            threadPool.Shutdown(true);
+        }
+
+        [Benchmark(OperationsPerInvoke = 500_000)]
+        public void RunInThread_CompletedTask_MaxConcurrencyIsSixteen_SingleThreaded()
+        {
+            var threadPool = new DefaultThreadPool
+                {
+                    MaxConcurrency = 16
+                };
+            threadPool.Initialize();
+
+            for (var i = 0; i < 500_000; i++)
+            {
+                threadPool!.RunInThread(() => Task.CompletedTask);
+            }
+
+            threadPool.Shutdown(true);
+        }
+
+        [Benchmark(OperationsPerInvoke = 1_000_000)]
+        public void RunInThread_CompletedTask_MaxConcurrencyIsSixteen_MultiThreaded()
+        {
+            var threadPool = new DefaultThreadPool
+                {
+                    MaxConcurrency = 16
+                };
+            threadPool.Initialize();
+
+            Execute(threadPool, 20, 50_000, (tp) => tp.RunInThread(() => Task.CompletedTask));
+
+            threadPool.Shutdown(true);
+        }
+
+        /// <summary>
+        /// The primary goal of this benchamrk is to measure memory allocations.
+        /// </summary>
+        /// <remarks>
+        /// Note that this includes the allocations for initializing the threadpool itself.
+        /// </remarks>
+        [Benchmark]
+        public void RunInThread_OneShot()
+        {
+            var threadPool = new DefaultThreadPool();
+            threadPool.MaxConcurrency = int.MaxValue;
+            threadPool.Initialize();
+            threadPool.RunInThread(() => Task.CompletedTask);
+            threadPool.Shutdown(true);
+        }
+
+        private static void Execute(DefaultThreadPool scheduler, int threadCount, int iterationsPerThread, Action<DefaultThreadPool> action)
+        {
+            ManualResetEvent start = new ManualResetEvent(false);
+
+            var tasks = new Task[threadCount];
+
+            for (var i = 0; i < threadCount; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                    {
+                        start.WaitOne();
+
+                        for (var j = 0; j < iterationsPerThread; j++)
+                        {
+                            action(scheduler);
+                        }
+                    });
+            }
+
+            start.Set();
+
+            Task.WaitAll(tasks);
+        }
+    }
+}


### PR DESCRIPTION
Improve performance, reduce allocations and reduce contention of **TaskSchedulingThreadPool** by:
* Setting continuation on the wrapper task insteaad of the unwrapped task.
* Using a **CountDownEvent** instead of a **List\<Task>** to keep track of the (number of) running tasks and wait until all tasks have completed.
* Caching the delegate that we use to mark the task complete.

The biggest impact on allocations and certainly contention/locking comes from the usage of **CountDownEvent**.

<details>
<summary>Benchmark results</summary>

|                                                           Method | Branch |    Mean  |    Error |   StdDev |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|----------------------------------------------------------------- |--------|---------:|---------:|---------:|-------:|-------:|-------:|----------:|
| RunInThread_CompletedTask_MaxConcurrencyIsMaxValue_MultiThreaded | main   | 184.6 us | 10.96 us | 32.15 us | 0.0800 | 0.0300 | 0.0100 |     426 B |
| RunInThread_CompletedTask_MaxConcurrencyIsMaxValue_MultiThreaded | PR     | 575.1 ns | 11.37 ns | 14.38 ns | 0.0430 | 0.0170 | 0.0050 |     259 B |
</details>

Note that the time unit for **main** is microseconds, while the unit for the **PR** is nanoseconds.
For this benchmark, the new threadpool implementation is **320** times faster.

I had to temporarily reduce the number of tasks that are created in that benchmark from 1 million to 100.000 in order to get results for **main**. If not, it would take ages to complete.
