### PR TITLE
DirtyFlagMap: Update Put(TKey key, TValue val) to only set dirty flag if successful

### DIFF
--- a/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
@@ -612,8 +612,7 @@ namespace Quartz.Tests.Unit.Utils
                 Assert.AreEqual("key", ex.ParamName);
             }
 
-            // #1417: this should return false
-            Assert.IsTrue(dirtyFlagMap.Dirty);
+            Assert.IsFalse(dirtyFlagMap.Dirty);
         }
 
         [Test]
@@ -751,8 +750,7 @@ namespace Quartz.Tests.Unit.Utils
                 Assert.AreEqual("key", ex.ParamName);
             }
 
-            // #1417: this should return false
-            Assert.IsTrue(dirtyFlagMap.Dirty);
+            Assert.IsFalse(dirtyFlagMap.Dirty);
         }
 
         [Test]
@@ -1803,8 +1801,7 @@ namespace Quartz.Tests.Unit.Utils
                 Assert.AreEqual(nameof(key), ex.ParamName);
             }
 
-            // #1417: should return false
-            Assert.IsTrue(dirtyFlagMap.Dirty);
+            Assert.IsFalse(dirtyFlagMap.Dirty);
         }
 
         [Test]

--- a/src/Quartz/Util/DirtyFlagMap.cs
+++ b/src/Quartz/Util/DirtyFlagMap.cs
@@ -532,9 +532,9 @@ namespace Quartz.Util
         /// <returns></returns>
         public virtual object? Put(TKey key, TValue val)
         {
-            dirty = true;
             map.TryGetValue(key, out var tempObject);
             map[key] = val;
+            dirty = true;
             return tempObject;
         }
 


### PR DESCRIPTION
Update `DirtyFlagMap.Put(TKey key, TValue val)`to only set the dirty flaw when we know that we managed to add or update an entry in the underlying dictionary.

Fixes first part of issue 14 in #1417