### PR TITLE
*NOMERGE* Stabilize flaky tests playground

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -100,6 +100,7 @@ namespace System {
             DotNetTest(s => s
                 .EnableNoRestore()
                 .EnableNoBuild()
+                .AddLoggers("console;verbosity=normal")
                 .SetProjectFile(Solution.GetProject("Quartz.Tests.Unit"))
                 .SetConfiguration(Configuration)
                 .SetFramework(framework)

--- a/src/Quartz.Benchmark/JobExecutionContextImplBenchmark.cs
+++ b/src/Quartz.Benchmark/JobExecutionContextImplBenchmark.cs
@@ -103,7 +103,7 @@ namespace Quartz.Benchmark
                     BatchTimeWindow = TimeSpan.Zero
                 };
 
-            return new QuartzScheduler(res, TimeSpan.Zero);
+            return new QuartzScheduler(res);
         }
     }
 }

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -91,11 +91,10 @@ namespace Quartz.Tests.Unit
             await scheduler.ScheduleJob(job, trigger);
 
             trigger = await scheduler.GetTrigger(trigger.Key);
+            var nextFireTime = trigger.GetNextFireTimeUtc();
 
-            // Console.WriteLine("testScheduleInMiddleOfDailyInterval: currTime = " + currTime);
-            // Console.WriteLine("testScheduleInMiddleOfDailyInterval: computed first fire time = " + trigger.GetNextFireTimeUtc());
-
-            Assert.That(trigger.GetNextFireTimeUtc() > currTime, "First fire time is not after now!");
+            Assert.That(nextFireTime, Is.Not.Null);
+            Assert.That(nextFireTime > currTime, $"First fire time is not after now: nextFireTime = {nextFireTime.GetValueOrDefault()} ({nextFireTime.GetValueOrDefault().Ticks}), currTime = {currTime} ({currTime.Ticks})");
 
             DateTimeOffset startTime = DateBuilder.TodayAt(2, 15, 0);
 
@@ -110,11 +109,10 @@ namespace Quartz.Tests.Unit
             await scheduler.ScheduleJob(job, trigger);
 
             trigger = await scheduler.GetTrigger(trigger.Key);
+            nextFireTime = trigger.GetNextFireTimeUtc();
 
-            // Console.WriteLine("testScheduleInMiddleOfDailyInterval: startTime = " + startTime);
-            // Console.WriteLine("testScheduleInMiddleOfDailyInterval: computed first fire time = " + trigger.GetNextFireTimeUtc());
-
-            Assert.That(trigger.GetNextFireTimeUtc() == startTime);
+            Assert.That(nextFireTime, Is.Not.Null);
+            Assert.That(nextFireTime, Is.EqualTo(startTime));
 
             await scheduler.Shutdown();
         }

--- a/src/Quartz.Tests.Unit/DisallowConcurrentJobExecutionTest.cs
+++ b/src/Quartz.Tests.Unit/DisallowConcurrentJobExecutionTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Threading;
@@ -98,9 +98,7 @@ namespace Quartz.Tests.Unit
             await scheduler.Shutdown(true);
 
             Assert.AreEqual(2, jobExecDates.Count);
-            
-            // there can be some jitter
-            Assert.Greater((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, jobBlockTime.TotalMilliseconds - 1);
+            Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5d));
         }
 
         /** QTZ-202 */

--- a/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
+++ b/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Quartz.Impl;
 using Quartz.Listener;
 using System;
@@ -113,7 +113,7 @@ namespace Quartz.Tests.Unit
             await scheduler.Shutdown(true);
 
             Assert.AreEqual(2, jobExecDates.Count);
-            Assert.Greater((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, jobBlockTime.TotalMilliseconds - 1);
+            Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5d));
         }
 
         /** QTZ-202 */

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -318,6 +318,7 @@ namespace Quartz.Tests.Unit
             Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5), result);
             Assert.That(completed.WaitOne(0), Is.True, result);
 
+            /// FIRE CI AGAIN
             //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -360,9 +360,6 @@ namespace Quartz.Tests.Unit
             Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50), result + " => " + stopwatch.ElapsedMilliseconds);
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
-
-            // TRY TO BREAK
-            //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 
         [Test]

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -359,6 +359,7 @@ namespace Quartz.Tests.Unit
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
 
+            // TRY TO BREAK
             //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -359,7 +359,7 @@ namespace Quartz.Tests.Unit
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
 
-            // F*K ASYNC
+            // F*K ASYNC 2
 
             //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -14,6 +14,7 @@ using Quartz.Spi;
 
 using System.IO;
 using System.Threading;
+using Quartz.Simpl;
 
 namespace Quartz.Tests.Unit
 {
@@ -308,10 +309,10 @@ namespace Quartz.Tests.Unit
 
             var stopwatch = Stopwatch.StartNew();
 
-            await scheduler.Shutdown(true);
+            var result = await scheduler.Shutdown(true);
 
-            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5));
-            Assert.That(completed.WaitOne(0), Is.True);
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5), result);
+            Assert.That(completed.WaitOne(0), Is.True, result);
         }
 
         [Test]
@@ -345,12 +346,12 @@ namespace Quartz.Tests.Unit
 
             var stopwatch = Stopwatch.StartNew();
 
-            await scheduler.Shutdown(false);
+            var result = await scheduler.Shutdown(false);
 
             // Shutdown should be fast since we're not waiting for tasks to complete
-            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50));
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50), result);
             // The task should still be executing
-            Assert.That(completed.WaitOne(0), Is.False);
+            Assert.That(completed.WaitOne(0), Is.False, result);
         }
 
         [Test]

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -359,6 +359,8 @@ namespace Quartz.Tests.Unit
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
 
+            // F*K ASYNC
+
             //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -355,7 +355,7 @@ namespace Quartz.Tests.Unit
             stopwatch.Stop();
 
             // Shutdown should be fast since we're not waiting for tasks to complete
-            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50), result);
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50), result + " => " + stopwatch.ElapsedMilliseconds);
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
 

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -339,7 +339,7 @@ namespace Quartz.Tests.Unit
                                 .UsingJobData(TestJobWithDelay.CreateJobDataMap(executing, completed))
                                 .Build();
             IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMilliseconds(1)).RepeatForever())
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever())
                 .ForJob(job)
                 .StartNow()
                 .Build();

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -89,6 +89,7 @@ namespace Quartz.Tests.Unit
             }
         }
 
+        /*
         [SetUp]
         protected async Task SetUp()
         {
@@ -103,6 +104,7 @@ namespace Quartz.Tests.Unit
             var crontTriggers = input.Split('|').Select(x => x.Trim()).Select(cronExpression => TriggerBuilder.Create().WithCronSchedule(cronExpression).Build());
             await scheduler.ScheduleJob(job, new List<ITrigger>(crontTriggers), replace: false);
         }
+        */
 
         [Test]
         public async Task TestBasicStorageFunctions()

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -359,7 +359,7 @@ namespace Quartz.Tests.Unit
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
 
-            // F*K ASYNC 2
+            // F*K ASYNC
 
             //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -318,7 +318,7 @@ namespace Quartz.Tests.Unit
             Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5), result);
             Assert.That(completed.WaitOne(0), Is.True, result);
 
-            /// FIRE CI AGAIN
+            /// FIRE CI AGAIN 1
             //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -320,7 +320,7 @@ namespace Quartz.Tests.Unit
         }
 
         [Test]
-        public async Task TestShutdownWithoutWaitShouldNotBlockUntilAllTasksHaveCompleted()
+        public void TestShutdownWithoutWaitShouldNotBlockUntilAllTasksHaveCompleted()
         {
             var schedulerName = Guid.NewGuid().ToString();
             var executing = new ManualResetEvent(false);
@@ -332,8 +332,8 @@ namespace Quartz.Tests.Unit
                     ["quartz.threadPool.threadCount"] = "2"
                 };
             ISchedulerFactory factory = new StdSchedulerFactory(properties);
-            IScheduler scheduler = await factory.GetScheduler();
-            await scheduler.Start();
+            IScheduler scheduler = factory.GetScheduler().GetAwaiter().GetResult();
+            scheduler.Start().GetAwaiter().GetResult();
 
             var job = JobBuilder.Create<TestJobWithDelay>()
                                 .UsingJobData(TestJobWithDelay.CreateJobDataMap(executing, completed))
@@ -343,14 +343,14 @@ namespace Quartz.Tests.Unit
                 .ForJob(job)
                 .StartNow()
                 .Build();
-            await scheduler.ScheduleJob(job, trigger);
+            scheduler.ScheduleJob(job, trigger).GetAwaiter().GetResult();
 
             // Wait for job to start executing
             executing.WaitOne();
 
             var stopwatch = Stopwatch.StartNew();
 
-            var result = await scheduler.Shutdown(false);
+            var result = scheduler.Shutdown(false).GetAwaiter().GetResult();
 
             stopwatch.Stop();
 

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -311,8 +311,12 @@ namespace Quartz.Tests.Unit
 
             var result = await scheduler.Shutdown(true);
 
+            stopwatch.Stop();
+
             Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5), result);
             Assert.That(completed.WaitOne(0), Is.True, result);
+
+            Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 
         [Test]
@@ -348,12 +352,14 @@ namespace Quartz.Tests.Unit
 
             var result = await scheduler.Shutdown(false);
 
+            stopwatch.Stop();
+
             // Shutdown should be fast since we're not waiting for tasks to complete
             Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50), result);
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
 
-            Assert.Fail(result);
+            Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 
         [Test]

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -293,7 +293,6 @@ namespace Quartz.Tests.Unit
         }
 
         [Test]
-        [Platform(Exclude="Linux")]  // TODO seems that we have some trouble on Linux with this
         public async Task ReschedulingTriggerShouldKeepOriginalNextFireTime()
         {
             NameValueCollection properties = new NameValueCollection();
@@ -302,26 +301,32 @@ namespace Quartz.Tests.Unit
             IScheduler scheduler = await factory.GetScheduler();
             await scheduler.Start();
 
+            // Delay starting the trigger by a second as we do not expect it to get triggered
+            var triggerStartTime = DateTimeOffset.UtcNow.AddSeconds(1);
+
             var job = JobBuilder.Create<NoOpJob>().Build();
             IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
                 .WithSimpleSchedule(x => x.WithIntervalInHours(1).RepeatForever())
                 .ForJob(job)
-                .StartNow()
+                .StartAt(triggerStartTime)
                 .Build();
 
             await scheduler.ScheduleJob(job, trigger);
 
             trigger = (IOperableTrigger) await scheduler.GetTrigger(trigger.Key);
+            Assert.That(trigger.StartTimeUtc, Is.EqualTo(triggerStartTime));
+            Assert.That(trigger.GetNextFireTimeUtc(), Is.EqualTo(triggerStartTime));
             Assert.That(trigger.GetPreviousFireTimeUtc(), Is.EqualTo(null));
 
-            var previousFireTimeUtc = DateTimeOffset.UtcNow.AddDays(1);
+            var previousFireTimeUtc = triggerStartTime.AddDays(1);
             trigger.SetPreviousFireTimeUtc(previousFireTimeUtc);
             trigger.SetNextFireTimeUtc(trigger.GetFireTimeAfter(previousFireTimeUtc));
 
             await scheduler.RescheduleJob(trigger.Key, trigger);
 
             trigger = (IOperableTrigger) await scheduler.GetTrigger(trigger.Key);
-            Assert.That(trigger.GetNextFireTimeUtc().Value.UtcDateTime, Is.EqualTo(previousFireTimeUtc.AddHours(1).UtcDateTime).Within(TimeSpan.FromSeconds(5)));
+            Assert.That(trigger.GetNextFireTimeUtc(), Is.Not.Null);
+            Assert.That(trigger.GetNextFireTimeUtc(), Is.EqualTo(previousFireTimeUtc.AddHours(1)));
 
             await scheduler.Shutdown(true);
         }

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -341,7 +341,7 @@ namespace Quartz.Tests.Unit
                                 .UsingJobData(TestJobWithDelay.CreateJobDataMap(executing, completed))
                                 .Build();
             IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever())
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMilliseconds(1)).RepeatForever())
                 .ForJob(job)
                 .StartNow()
                 .Build();

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -294,6 +294,8 @@ namespace Quartz.Tests.Unit
             IScheduler scheduler = await factory.GetScheduler();
             await scheduler.Start();
 
+            var stopwatch = Stopwatch.StartNew();
+
             var job = JobBuilder.Create<TestJobWithDelay>().Build();
             IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
                 .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMilliseconds(1)).RepeatForever())
@@ -302,12 +304,19 @@ namespace Quartz.Tests.Unit
                 .Build();
             await scheduler.ScheduleJob(job, trigger);
 
+            Console.WriteLine("#1:" + stopwatch.ElapsedMilliseconds);
+
             // Wait for job to start executing
             TestJobWithDelay.Executing.WaitOne();
 
-            var stopwatch = Stopwatch.StartNew();
+            Console.WriteLine("#2:" + stopwatch.ElapsedMilliseconds);
+
+            stopwatch.Reset();
+            stopwatch.Start();
 
             await scheduler.Shutdown(false);
+
+            Console.WriteLine("#3:" + stopwatch.ElapsedMilliseconds);
 
             // Shutdown should be fast since we're not waiting for tasks to complete
             Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(40));

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -339,7 +339,7 @@ namespace Quartz.Tests.Unit
                                 .UsingJobData(TestJobWithDelay.CreateJobDataMap(executing, completed))
                                 .Build();
             IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever())
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMilliseconds(1)).RepeatForever())
                 .ForJob(job)
                 .StartNow()
                 .Build();

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -290,7 +290,7 @@ namespace Quartz.Tests.Unit
                     ["quartz.threadPool.threadCount"] = "2"
                 };
             ISchedulerFactory factory = new StdSchedulerFactory(properties);
-            var scheduler = await factory.GetScheduler(schedulerName);
+            var scheduler = await factory.GetScheduler();
             await scheduler.Start();
 
             var job = JobBuilder.Create<TestJobWithDelay>()
@@ -327,7 +327,7 @@ namespace Quartz.Tests.Unit
                     ["quartz.threadPool.threadCount"] = "2"
                 };
             ISchedulerFactory factory = new StdSchedulerFactory(properties);
-            IScheduler scheduler = await factory.GetScheduler(schedulerName);
+            IScheduler scheduler = await factory.GetScheduler();
             await scheduler.Start();
 
             var job = JobBuilder.Create<TestJobWithDelay>()

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -319,7 +319,7 @@ namespace Quartz.Tests.Unit
             Assert.That(completed.WaitOne(0), Is.True, result);
 
             /// FIRE CI AGAIN
-            //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
+            Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 
         [Test]

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -310,7 +310,7 @@ namespace Quartz.Tests.Unit
 
             await scheduler.Shutdown(true);
 
-            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5), sb.ToString());
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5));
             Assert.That(completed.WaitOne(0), Is.True);
         }
 

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -316,7 +316,7 @@ namespace Quartz.Tests.Unit
             Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5), result);
             Assert.That(completed.WaitOne(0), Is.True, result);
 
-            Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
+            //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 
         [Test]
@@ -359,7 +359,7 @@ namespace Quartz.Tests.Unit
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
 
-            Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
+            //Assert.Fail("SUCCESS: " + stopwatch.ElapsedMilliseconds + " | " + result);
         }
 
         [Test]

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -352,6 +352,8 @@ namespace Quartz.Tests.Unit
             Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50), result);
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False, result);
+
+            Assert.Fail(result);
         }
 
         [Test]

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -43,7 +43,7 @@ namespace Quartz.Tests.Unit
             public const string ExecutingWaitHandleKey = "ExecutingWaitHandle";
             public const string CompletedWaitHandleKey = "CompletedWaitHandle";
 
-            public static TimeSpan Delay = TimeSpan.FromMilliseconds(100);
+            public static TimeSpan Delay = TimeSpan.FromMilliseconds(200);
 
             public static JobDataMap CreateJobDataMap(ManualResetEvent executing, ManualResetEvent completed)
             {
@@ -348,7 +348,7 @@ namespace Quartz.Tests.Unit
             await scheduler.Shutdown(false);
 
             // Shutdown should be fast since we're not waiting for tasks to complete
-            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(40));
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50));
             // The task should still be executing
             Assert.That(completed.WaitOne(0), Is.False);
         }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -558,6 +558,8 @@ namespace Quartz.Core
 
             log.Info($"Scheduler {resources.GetUniqueIdentifier()} Shutdown complete.");
 
+            sb.AppendLine("Final " + resources.GetUniqueIdentifier());
+
             return sb.ToString();
         }
 

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -558,7 +558,7 @@ namespace Quartz.Core
 
             log.Info($"Scheduler {resources.GetUniqueIdentifier()} Shutdown complete.");
 
-            sb.AppendLine("Final " + resources.GetUniqueIdentifier());
+            sb.AppendLine("Final " + resources.GetUniqueIdentifier() + " = " + sw.ElapsedMilliseconds);
 
             return sb.ToString();
         }

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -303,7 +303,7 @@ namespace Quartz
         /// </param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <seealso cref="Shutdown(CancellationToken)" /> 
-        Task Shutdown(bool waitForJobsToComplete, CancellationToken cancellationToken = default);
+        Task<string> Shutdown(bool waitForJobsToComplete, CancellationToken cancellationToken = default);
 
 
         /// <summary>

--- a/src/Quartz/Impl/RemoteScheduler.cs
+++ b/src/Quartz/Impl/RemoteScheduler.cs
@@ -270,11 +270,15 @@ namespace Quartz.Impl
         /// <summary>
         /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
         /// </summary>
-        public virtual Task Shutdown(
+        public virtual Task<string> Shutdown(
             bool waitForJobsToComplete,
             CancellationToken cancellationToken = default)
         {
-            return CallInGuard(x => x.Shutdown(waitForJobsToComplete));
+            return CallInGuard(x =>
+            {
+                x.Shutdown(waitForJobsToComplete);
+                return "";
+            });
         }
 
         /// <summary>

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -235,7 +235,7 @@ namespace Quartz.Impl
         /// <summary>
         /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
         /// </summary>
-        public virtual Task Shutdown(
+        public virtual Task<string> Shutdown(
             bool waitForJobsToComplete,
             CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Stabilize the following tests:
* Quartz.Tests.Unit.JobExecutionAttributesInterfaceInheritanceTest.TestNoConcurrentExecOnSameJob(): add a small tolerance as **DateTime.(Utc)Now** does not have a high precision.
* Quartz.Tests.Unit.DisallowConcurrentExecutionJobTest.TestNoConcurrentExecOnSameJob(): add a small tolerance as **DateTime.(Utc)Now** does not have a high precision.
* Quartz.Tests.Unit.SchedulerTest.ReschedulingTriggerShouldKeepOriginalNextFireTime(): Ensure trigger does not immediately fire. Enable test on Linux.

Re-enable shutdown test in **Quartz.Tests.Unit.SchedulerTest**, and add test to verify that we do not wait for tasks to complete when **waitForJobsToComplete** is **false**.