### PR TITLE
Stabilize tests

### DIFF
--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -42,6 +42,7 @@ namespace Quartz.Tests.Unit
     /// </summary>
     /// <author>Zemian Deng saltnlight5@gmail.com</author>
     /// <author>Nuno Maia (.NET)</author>
+    [TestFixture]
     public class DailyTimeIntervalScheduleBuilderTest
     {
         [Test]
@@ -91,11 +92,10 @@ namespace Quartz.Tests.Unit
             await scheduler.ScheduleJob(job, trigger);
 
             trigger = await scheduler.GetTrigger(trigger.Key);
+            var nextFireTime = trigger.GetNextFireTimeUtc();
 
-            // Console.WriteLine("testScheduleInMiddleOfDailyInterval: currTime = " + currTime);
-            // Console.WriteLine("testScheduleInMiddleOfDailyInterval: computed first fire time = " + trigger.GetNextFireTimeUtc());
-
-            Assert.That(trigger.GetNextFireTimeUtc() > currTime, "First fire time is not after now!");
+            Assert.That(nextFireTime, Is.Not.Null);
+            Assert.That(nextFireTime, Is.GreaterThan(currTime));
 
             DateTimeOffset startTime = DateBuilder.TodayAt(2, 15, 0);
 
@@ -110,11 +110,10 @@ namespace Quartz.Tests.Unit
             await scheduler.ScheduleJob(job, trigger);
 
             trigger = await scheduler.GetTrigger(trigger.Key);
+            nextFireTime = trigger.GetNextFireTimeUtc();
 
-            // Console.WriteLine("testScheduleInMiddleOfDailyInterval: startTime = " + startTime);
-            // Console.WriteLine("testScheduleInMiddleOfDailyInterval: computed first fire time = " + trigger.GetNextFireTimeUtc());
-
-            Assert.That(trigger.GetNextFireTimeUtc() == startTime);
+            Assert.That(nextFireTime, Is.Not.Null);
+            Assert.That(nextFireTime, Is.EqualTo(startTime));
 
             await scheduler.Shutdown();
         }

--- a/src/Quartz.Tests.Unit/DisallowConcurrentJobExecutionTest.cs
+++ b/src/Quartz.Tests.Unit/DisallowConcurrentJobExecutionTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Threading;
@@ -98,9 +98,7 @@ namespace Quartz.Tests.Unit
             await scheduler.Shutdown(true);
 
             Assert.AreEqual(2, jobExecDates.Count);
-            
-            // there can be some jitter
-            Assert.Greater((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, jobBlockTime.TotalMilliseconds - 1);
+            Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5d));
         }
 
         /** QTZ-202 */

--- a/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
+++ b/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Quartz.Impl;
 using Quartz.Listener;
 using System;
@@ -113,7 +113,7 @@ namespace Quartz.Tests.Unit
             await scheduler.Shutdown(true);
 
             Assert.AreEqual(2, jobExecDates.Count);
-            Assert.Greater((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, jobBlockTime.TotalMilliseconds - 1);
+            Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5d));
         }
 
         /** QTZ-202 */


### PR DESCRIPTION
Attempt to stabilize more tests:
* `Quartz.Tests.Unit.DailyTimeIntervalScheduleBuilderTest.TestScheduleInMiddleOfDailyInterval()`: provide more meaningful information when asserts fail.
* `Quartz.Tests.Unit.JobExecutionAttributesInterfaceInheritanceTest.TestNoConcurrentExecOnSameJob()`: add a small tolerance as **DateTime.(Utc)Now** does not have a high precision.
* `Quartz.Tests.Unit.DisallowConcurrentExecutionJobTest.TestNoConcurrentExecOnSameJob()`: add a small tolerance as **DateTime.(Utc)Now** does not have a high precision.
* `Quartz.Tests.Unit.SchedulerTest.ReschedulingTriggerShouldKeepOriginalNextFireTime()`: Ensure trigger does not immediately fire. Enable test on Linux.

Re-enable shutdown test in **Quartz.Tests.Unit.SchedulerTest**, and add test to verify that we do not wait for tasks to complete when **waitForJobsToComplete** is **false**.
I had to make both tests synchronous to get them stable. I cannot explain this though.

Replaces #1458. I'm keeping that one open to play around with some async weirdness.