### PR TITLE
Remove unnecessary null check from TriggerWrapperComparator.GetHashCode()

### DIFF
--- a/src/Quartz/Simpl/TriggerWrapperComparator.cs
+++ b/src/Quartz/Simpl/TriggerWrapperComparator.cs
@@ -41,7 +41,7 @@ namespace Quartz.Simpl
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()
         {
-            return ttc?.GetHashCode() ?? 0;
+            return ttc.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
Removes unnecessary null check from `TriggerWrapperComparator.GetHashCode()` as the **ttc** field is readonly and always initialized.