### PR TITLE
remove outdated Info about TriggerUtils

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -28,8 +28,6 @@ values from the JobDataMap on found on the JobExecutionContext, rather than dire
 
 TriggerUtils:
 
-* Offers a simpler way to create triggers (schedules)
-* Has various methods for creating triggers with schedules that meet particular descriptions, as opposed to directly instantiating triggers of a specific type (i.e. SimpleTrigger, CronTrigger, etc.) and then invoking various setter methods to configure them
 * Offers a simple way to create Dates (for start/end dates)
 * Offers helpers for analyzing triggers (e.g. calculating future fire times)
 


### PR DESCRIPTION
I got a little confused when browsing the docs.
As far as I can tell TriggerUtils used to be able to create commonly used Triggers in a short way.
Currently it seems you are supposed to use the TriggerBuilder DSL.