### PR TITLE
Set NextFireTime of the replaced trigger relative to the old trigger's StartTime if the old trigger's PreviousFireTime is null

### DIFF
--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -949,7 +949,9 @@ namespace Quartz.Xml
                 var oldTriggerPreviousFireTime = oldTrigger.GetPreviousFireTimeUtc();
                 trigger.StartTimeUtc = oldTrigger.StartTimeUtc;
                 ((IOperableTrigger)trigger).SetPreviousFireTimeUtc(oldTriggerPreviousFireTime);
-                ((IOperableTrigger)trigger).SetNextFireTimeUtc(trigger.GetFireTimeAfter(oldTriggerPreviousFireTime));
+                // if oldTriggerPreviousFireTime is null then NextFireTime should be set relative to oldTrigger.StartTimeUtc 
+                // to be able to handle misfiring for an existing trigger that has never been executed before.
+                ((IOperableTrigger)trigger).SetNextFireTimeUtc(trigger.GetFireTimeAfter(oldTriggerPreviousFireTime ?? oldTrigger.StartTimeUtc));
             }
 
             return sched.RescheduleJob(trigger.Key, trigger, cancellationToken);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/74782503/153388208-aee831df-df6c-4a97-8e74-10b8cbccdb63.png)

I had the following problem with the replacement of an existing CronTrigger in a PersistentJobStorage: I configured the Trigger to run a Job in an Asp.Net Core app every night at 1 am using PersistentJobStore. Unfortunately my app was always down at 1 am. I configured the following:

```
options.Scheduling.ScheduleTriggerRelativeToReplacedTrigger = true;
options.Scheduling.OverWriteExistingData = true;
```

When my application started again in the morning it updated the trigger and set the trigger's NextFireTime to 1 am in the next night which caused that my trigger was not executed. I figured out that this problem only occurs when the trigger never had been executed before and it's PreviousFireTime is null.

When "ScheduleTriggerRelativeToReplacedTrigger" is enabled the NextFireTime of the replaced trigger is set relative to the PreviousFireTime of the old trigger, which is usually fine. But for the case that the PreviousFireTime is null the NextFireTime is set relative to the current date and time. Therefore my trigger's NextFireTime was always set to 1 am in the next night and never has been executed.

I changed it like this, that if the PreviousFireTime is null the NextFireTime is not set relative to the current date and time but to the old trigger's StartTime. Like this, if the PreviousFireTime is null, the trigger will be treated like never executed since it's StartTime. Then the trigger will be executed depending on the configured misfiring options.

`((IOperableTrigger)trigger).SetNextFireTimeUtc(trigger.GetFireTimeAfter(oldTriggerPreviousFireTime));`
to
`((IOperableTrigger)trigger).SetNextFireTimeUtc(trigger.GetFireTimeAfter(oldTriggerPreviousFireTime ?? oldTrigger.StartTimeUtc));`