### PR TITLE
Change a few properties of DirtyFlagMap<TKey,TValue>to explicit inter…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,12 @@
     * The 'Get(TKey key)' method of **DirtyFlagMap<TKey,TValue>** has been removed. You can instead use the
       this[TKey key] indexer or ´TryGetValue(TKey key, out TValue value)` to obtain the value for a given key.
 
+    * The following properties of **DirtyFlagMap<TKey,TValue>** are now explicit interface implementations:
+      * IsReadOnly
+      * IsFixedSize
+      * SyncRoot
+      * IsSynchronized
+
 ## Release 3.3.3, Aug 1 2021
 
 This is a maintenance release mostly fixing some smaller bugs and improving DI API story.

--- a/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
@@ -1818,6 +1818,59 @@ namespace Quartz.Tests.Unit.Utils
             Assert.IsTrue(dirtyFlagMap.Dirty);
         }
 
+        [Test]
+        public void ICollection_SyncRoot()
+        {
+            var dirtyFlagMap1 = new DirtyFlagMap<string, string>();
+            var collection1 = (ICollection) dirtyFlagMap1;
+
+            var syncRoot1 = collection1.SyncRoot;
+            Assert.IsNotNull(syncRoot1);
+            Assert.AreSame(syncRoot1, collection1.SyncRoot);
+            Assert.AreEqual(typeof(object), syncRoot1.GetType());
+
+            var dirtyFlagMap2 = new DirtyFlagMap<string, string>();
+            var collection2 = (ICollection) dirtyFlagMap2;
+
+            var syncRoot2 = collection2.SyncRoot;
+            Assert.IsNotNull(syncRoot2);
+            Assert.AreSame(syncRoot2, collection2.SyncRoot);
+            Assert.AreEqual(typeof(object), syncRoot2.GetType());
+            Assert.AreNotSame(syncRoot1, syncRoot2);
+        }
+
+        [Test]
+        public void ICollectionKeyValuePairOfTKeyAndTValue_IsReadOnly()
+        {
+            var dirtyFlagMap = new DirtyFlagMap<string, string>();
+            var collection = (ICollection<KeyValuePair<string,string>>) dirtyFlagMap;
+            Assert.IsFalse(collection.IsReadOnly);
+        }
+
+        [Test]
+        public void IDictionary_IsReadOnly()
+        {
+            var dirtyFlagMap = new DirtyFlagMap<string, string>();
+            var dictionary = (IDictionary) dirtyFlagMap;
+            Assert.IsFalse(dictionary.IsReadOnly);
+        }
+
+        [Test]
+        public void IDictionary_IsSynchronized()
+        {
+            var dirtyFlagMap = new DirtyFlagMap<string, string>();
+            var dictionary = (IDictionary) dirtyFlagMap;
+            Assert.IsFalse(dictionary.IsSynchronized);
+        }
+
+        [Test]
+        public void IDictionary_IsFixedSize()
+        {
+            var dirtyFlagMap = new DirtyFlagMap<string, string>();
+            var dictionary = (IDictionary) dirtyFlagMap;
+            Assert.IsFalse(dictionary.IsFixedSize);
+        }
+
         //[Test]
         //[Ignore]
         //public void TestEntrySetRemove() 

--- a/src/Quartz/Util/DirtyFlagMap.cs
+++ b/src/Quartz/Util/DirtyFlagMap.cs
@@ -386,33 +386,53 @@ namespace Quartz.Util
         public virtual ICollection<TKey> Keys => map.Keys;
 
         /// <summary>
-        /// When implemented by a class, gets a value indicating whether the <see cref="T:System.Collections.IDictionary"/>
-        /// is read-only.
+        /// Gets a value indicating whether the <see cref="DirtyFlagMap{TKey,TValue}"/> is read-only.
         /// </summary>
-        /// <value></value>
-        public virtual bool IsReadOnly => false;
+        /// <value>
+        /// <see langword="true"/> if the <see cref="DirtyFlagMap{TKey,TValue}"/> is read-only; otherwise, <see langword="false"/>.
+        /// In the default implementation of <see cref="DirtyFlagMap{TKey,TValue}"/>, this property always returns
+        /// <see langword="false"/>.
+        /// </value>
+        bool IDictionary.IsReadOnly => false;
 
         /// <summary>
-        /// When implemented by a class, gets a value indicating whether the <see cref="T:System.Collections.IDictionary"/>
-        /// has a fixed size.
+        /// Gets a value indicating whether the <see cref="DirtyFlagMap{TKey,TValue}"/> is read-only.
         /// </summary>
-        /// <value></value>
-        public virtual bool IsFixedSize => false;
+        /// <value>
+        /// <see langword="true"/> if the <see cref="DirtyFlagMap{TKey,TValue}"/> is read-only; otherwise, <see langword="false"/>.
+        /// In the default implementation of <see cref="DirtyFlagMap{TKey,TValue}"/>, this property always returns
+        /// <see langword="false"/>.
+        /// </value>
+        bool ICollection<KeyValuePair<TKey,TValue>>.IsReadOnly => false;
 
         /// <summary>
-        /// When implemented by a class, gets an object that
-        /// can be used to synchronize access to the <see cref="T:System.Collections.ICollection"/>.
+        /// Gets a value indicating whether the <see cref="DirtyFlagMap{TKey,TValue}"/> has a fixed size.
         /// </summary>
-        /// <value></value>
-        public virtual object SyncRoot { get; } = new object();
+        /// <value>
+        /// <see langword="true"/> if the <see cref="DirtyFlagMap{TKey,TValue}"/> has a fixed size;
+        /// otherwise, <see langword="false"/>. In the default implementation of <see cref="DirtyFlagMap{TKey,TValue}"/>,
+        /// this property always returns <see langword="false"/>.
+        /// </value>
+        bool IDictionary.IsFixedSize => false;
 
         /// <summary>
-        /// When implemented by a class, gets a value
-        /// indicating whether access to the <see cref="T:System.Collections.ICollection"/> is synchronized
+        /// Gets an object that can be used to synchronize access to the <see cref="DirtyFlagMap{TKey,TValue}"/>.
+        /// </summary>
+        /// <value>
+        /// An object that can be used to synchronize access to the <see cref="DirtyFlagMap{TKey,TValue}"/>.
+        /// </value>
+        object ICollection.SyncRoot { get; } = new object();
+
+        /// <summary>
+        /// Gets a value indicating whether access to the <see cref="DirtyFlagMap{TKey,TValue}"/> is synchronized
         /// (thread-safe).
         /// </summary>
-        /// <value></value>
-        public virtual bool IsSynchronized => false;
+        /// <value>
+        /// <see langword="true"/> if access to the <see cref="DirtyFlagMap{TKey,TValue}"/> is synchronized (thread safe);
+        /// otherwise, <see langword="false"/>. In the default implementation of <see cref="DirtyFlagMap{TKey,TValue}"/>,
+        /// this property always returns <see langword="false"/>.
+        /// </value>
+        bool ICollection.IsSynchronized => false;
 
         #endregion
 


### PR DESCRIPTION
* Changed the following properties of **DirtyFlagMap<TKey,TValue>** to be explicit interface implementations:
  * IsReadOnly
  * IsFixedSize
  * SyncRoot
  * IsSynchronized
* Added unit tests.

Resolves item 13 of issue #1417.