### PR TITLE
Use job and trigger listeners without configurations

### DIFF
--- a/src/Quartz.Examples.AspNetCore/SecondSampleJobListener.cs
+++ b/src/Quartz.Examples.AspNetCore/SecondSampleJobListener.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Listener;
+
+namespace Quartz.Examples.AspNetCore
+{
+    public class SecondSampleJobListener : JobListenerSupport
+    {
+        private readonly ILogger<SecondSampleJobListener> logger;
+
+        public SecondSampleJobListener(ILogger<SecondSampleJobListener> logger)
+        {
+            this.logger = logger;
+        }
+
+        public override string Name => "Second Sample Job Listener";
+
+        public override Task JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("Job {JobName} executed", context.JobDetail.Key);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Quartz.Examples.AspNetCore/SecondSampleTriggerListener.cs
+++ b/src/Quartz.Examples.AspNetCore/SecondSampleTriggerListener.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Listener;
+
+namespace Quartz.Examples.AspNetCore
+{
+    public class SecondSampleTriggerListener : TriggerListenerSupport
+    {
+        private readonly ILogger<SecondSampleTriggerListener> logger;
+        private readonly string exampleValue;
+
+        public SecondSampleTriggerListener(ILogger<SecondSampleTriggerListener> logger, string exampleValue)
+        {
+            this.logger = logger;
+            this.exampleValue = exampleValue;
+        }
+
+        public override string Name => "Second Sample Trigger Listener";
+
+        public override Task TriggerComplete(ITrigger trigger, IJobExecutionContext context, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("Trigger {TriggerKey} fired (example value '{ExampleValue}')", trigger.Key, exampleValue);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -212,8 +212,16 @@ namespace Quartz.Examples.AspNetCore
             });
 
             // we can use options pattern to support hooking your own configuration with Quartz's
-            // because we don't use service registration api, we need to manally ensure the job is present in DI
+            // because we don't use service registration api, we need to manually ensure the job is present in DI
             services.AddTransient<ExampleJob>();
+
+            // if there is no need to use key matchers, job and trigger listeners can be added to services and Quartz will automatically use these
+            services.AddSingleton<IJobListener, SecondSampleJobListener>();
+            services.AddSingleton<ITriggerListener>(serviceProvider =>
+            {
+                var logger = serviceProvider.GetRequiredService<ILogger<SecondSampleTriggerListener>>();
+                return new SecondSampleTriggerListener(logger, "Example value");
+            });
 
             services.Configure<SampleOptions>(Configuration.GetSection("Sample"));
             services.AddOptions<QuartzOptions>()

--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
@@ -69,17 +69,19 @@ namespace Quartz
             }
 
             var jobListeners = serviceProvider.GetServices<IJobListener>();
-            foreach (var configuration in serviceProvider.GetServices<JobListenerConfiguration>())
+            var jobListenerConfigurations = serviceProvider.GetServices<JobListenerConfiguration>().ToArray();
+            foreach (var listener in jobListeners)
             {
-                var listener = jobListeners.First(x => x.GetType() == configuration.ListenerType);
-                scheduler.ListenerManager.AddJobListener(listener, configuration.Matchers);
+                var configuration = jobListenerConfigurations.SingleOrDefault(x => x.ListenerType == listener.GetType());
+                scheduler.ListenerManager.AddJobListener(listener, configuration?.Matchers ?? Array.Empty<IMatcher<JobKey>>());
             }
 
             var triggerListeners = serviceProvider.GetServices<ITriggerListener>();
-            foreach (var configuration in serviceProvider.GetServices<TriggerListenerConfiguration>())
+            var triggerListenerConfigurations = serviceProvider.GetServices<TriggerListenerConfiguration>().ToArray();
+            foreach (var listener in triggerListeners)
             {
-                var listener = triggerListeners.First(x => x.GetType() == configuration.ListenerType);
-                scheduler.ListenerManager.AddTriggerListener(listener, configuration.Matchers);
+                var configuration = triggerListenerConfigurations.SingleOrDefault(x => x.ListenerType == listener.GetType());
+                scheduler.ListenerManager.AddTriggerListener(listener, configuration?.Matchers ?? Array.Empty<IMatcher<TriggerKey>>());
             }
 
             var calendars = serviceProvider.GetServices<CalendarConfiguration>();


### PR DESCRIPTION
Quartz will resolve job and trigger listeners from service provider only if there exists listener configuration class also in the service provider. This is added when IServiceCollectionQuartzConfigurator's add-methods are called. These add methods does not provide all the same overloads as service collection to add listeners and thus limits the possible ways to register listeners.

This PR changes the way Quartz resolves job and trigger listeners from service provider. All the listeners that are added to service collection will be used. If no configuration class is found, defaults are used.