### PR TITLE
Create IJobWrapper interface and let ScopedJob implement it

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
@@ -67,7 +67,7 @@ namespace Quartz.Simpl
             (job as IDisposable)?.Dispose();
         }
 
-        private sealed class ScopedJob : IJob, IDisposable
+        private sealed class ScopedJob : IJob, IJobWrapper, IDisposable
         {
             private readonly IServiceScope scope;
             private readonly bool canDispose;
@@ -80,6 +80,7 @@ namespace Quartz.Simpl
             }
             
             internal IJob InnerJob { get; }
+            public IJob Target => InnerJob;
 
             public void Dispose()
             {

--- a/src/Quartz/IJobWrapper.cs
+++ b/src/Quartz/IJobWrapper.cs
@@ -1,6 +1,6 @@
 namespace Quartz;
 
-public interface IJobWrapper
+internal interface IJobWrapper
 {
     IJob Target { get; }
 }

--- a/src/Quartz/IJobWrapper.cs
+++ b/src/Quartz/IJobWrapper.cs
@@ -1,0 +1,6 @@
+namespace Quartz;
+
+public interface IJobWrapper
+{
+    IJob Target { get; }
+}

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -210,7 +210,7 @@ namespace Quartz.Impl
         /// interfaces.
         /// </para>
         /// </summary>
-        public virtual IJob JobInstance => jobInstance;
+        public virtual IJob JobInstance => (jobInstance as IJobWrapper)?.Target ?? jobInstance;
 
         /// <summary>
         /// The actual time the trigger fired. For instance the scheduled time may


### PR DESCRIPTION
Allows to access the `InnerJob` of a `MicrosoftDependencyInjectionJobFactory#ScopedJob`. 

See discussion at https://github.com/quartznet/quartznet/discussions/1578/
