### PR TITLE
Optimize notify of job listeners

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,19 @@
     * SyncRoot
     * IsSynchronized
 
+  * A **IJobStore** that implements **IJobListener** no longer automatically receives all events. You should
+    instead register it as job listener using the **ListenerManager** of the **QuartzScheduler**.
+
+  * **QuartzScheduler** no longer defines a default protected ctor. You should use ctor((QuartzSchedulerResources resources)
+    to initialize the **QuartzScheduler**.
+
+  * To improve performance and reduce allocations, `IListenerManager.GetJobListeners()` now returns (a shallow copy of)
+    the registered **IJobListener** instances as an array instead of an **IReadOnlyCollection<IJobListener>**.
+
+  * **QuartzScheduler** no longer defines properties and methods for accessing or manipulating internal job listeners.
+    **ListenerManager** on **QuartzScheduler** allows more control over the events that a **IJobListener** will
+    receive.
+
 ## Release 3.4.0, Mar 27 2022
 
 This release has Quartz jobs start executing only after application startup completes successfully, unless QuartzHostedServiceOptions are used to specify otherwise.

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -45,11 +45,14 @@ namespace Quartz.Benchmark
 
         private static QuartzScheduler CreateQuartzScheduler(string name, string instanceId, int threadCount)
         {
+            var threadPool = new DefaultThreadPool { MaxConcurrency = threadCount };
+            threadPool.Initialize();
+
             QuartzSchedulerResources res = new QuartzSchedulerResources
             {
                 Name = name,
                 InstanceId = instanceId,
-                ThreadPool = new DefaultThreadPool { MaxConcurrency = threadCount },
+                ThreadPool = threadPool,
                 JobStore = new NoOpJobStore(),
                 IdleWaitTime = TimeSpan.FromSeconds(30),
                 MaxBatchSize = threadCount,

--- a/src/Quartz.Benchmark/SchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/SchedulerBenchmark.cs
@@ -19,11 +19,13 @@ namespace Quartz.Benchmark
         private IScheduler? _scheduler;
 
         [Benchmark(OperationsPerInvoke = 450_000)]
-        public void DisableConcurrent_15Threads_15Jobs_1TriggerPerJob()
+        public void DisableConcurrent_15Threads_15Jobs_1TriggersPerJob()
         {
             RunDisableConcurrent(operationsPerRun: 450_000,
                                  threadCount: 15,
                                  jobCount: 15,
+                                 disableConcurrentExecution: true,
+                                 persistJobDataAfterExecution: false,
                                  triggersPerJob: 1,
                                  maxBatchSize: 16,
                                  idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
@@ -38,39 +40,77 @@ namespace Quartz.Benchmark
             RunDisableConcurrent(operationsPerRun: 150_000,
                                  threadCount: 50,
                                  jobCount: 15,
+                                 disableConcurrentExecution: true,
+                                 persistJobDataAfterExecution: false,
                                  triggersPerJob: 5,
                                  maxBatchSize: 16,
                                  idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
-                                 repeatInterval: TimeSpan.FromTicks(1000L),
+                                 repeatInterval: TimeSpan.FromTicks(1L),
                                  repeatCount: 1_999,
                                  misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
         }
 
         [Benchmark(OperationsPerInvoke = 450_000)]
-        public void DisableConcurrent_15Threads_30Jobs_1TriggerPerJob()
+        public void DisableConcurrent_15Threads_30Jobs_1TriggersPerJob()
         {
             RunDisableConcurrent(operationsPerRun: 450_000,
                                  threadCount: 15,
                                  jobCount: 30,
+                                 disableConcurrentExecution: true,
+                                 persistJobDataAfterExecution: false,
                                  triggersPerJob: 1,
                                  maxBatchSize: 16,
                                  idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
-                                 repeatInterval: TimeSpan.FromTicks(1000L),
+                                 repeatInterval: TimeSpan.FromTicks(1L),
                                  repeatCount: 14_999,
                                  misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
         }
 
         [Benchmark(OperationsPerInvoke = 225_000)]
-        public void DisableConcurrent_2Threads_15Jobs_2TriggerPerJob()
+        public void DisableConcurrent_2Threads_15Jobs_2TriggersPerJob()
         {
             RunDisableConcurrent(operationsPerRun: 225_000,
                                  threadCount: 2,
                                  jobCount: 15,
+                                 disableConcurrentExecution: true,
+                                 persistJobDataAfterExecution: false,
                                  triggersPerJob: 2,
                                  maxBatchSize: 16,
                                  idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
-                                 repeatInterval: TimeSpan.FromTicks(1000L),
+                                 repeatInterval: TimeSpan.FromTicks(1L),
                                  repeatCount: 7_499,
+                                 misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [Benchmark(OperationsPerInvoke = 450_000)]
+        public void DisableConcurrent_50Threads_15Jobs_2TriggersPerJob()
+        {
+            RunDisableConcurrent(operationsPerRun: 450_000,
+                                 threadCount: 50,
+                                 jobCount: 15,
+                                 disableConcurrentExecution: true,
+                                 persistJobDataAfterExecution: false,
+                                 triggersPerJob: 2,
+                                 maxBatchSize: 16,
+                                 idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                                 repeatInterval: TimeSpan.FromTicks(1L),
+                                 repeatCount: 14_999,
+                                 misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [Benchmark(OperationsPerInvoke = 450_000)]
+        public void DisableConcurrent_50Threads_30Jobs_1TriggersPerJob()
+        {
+            RunDisableConcurrent(operationsPerRun: 450_000,
+                                 threadCount: 50,
+                                 jobCount: 30,
+                                 disableConcurrentExecution: true,
+                                 persistJobDataAfterExecution: false,
+                                 triggersPerJob: 1,
+                                 maxBatchSize: 16,
+                                 idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                                 repeatInterval: TimeSpan.FromTicks(1L),
+                                 repeatCount: 14_999,
                                  misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
         }
 
@@ -78,8 +118,10 @@ namespace Quartz.Benchmark
         public void DisableConcurrent_50Threads_30Jobs_3TriggersPerJob()
         {
             RunDisableConcurrent(operationsPerRun: 450_000,
-                                 threadCount: 30,
+                                 threadCount: 50,
                                  jobCount: 30,
+                                 disableConcurrentExecution: true,
+                                 persistJobDataAfterExecution: false,
                                  triggersPerJob: 3,
                                  maxBatchSize: 16,
                                  idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
@@ -88,69 +130,15 @@ namespace Quartz.Benchmark
                                  misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
         }
 
-        [Benchmark(OperationsPerInvoke = 450_000)]
-        public void Concurrent_15Threads_15Jobs_1TriggerPerJob()
-        {
-            RunConcurrent(operationsPerRun: 450_000,
-                          threadCount: 15,
-                          jobCount: 15,
-                          triggersPerJob: 1,
-                          maxBatchSize: 16,
-                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
-                          repeatInterval: TimeSpan.FromTicks(1L),
-                          repeatCount: 29_999,
-                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
-        }
-
-        [Benchmark(OperationsPerInvoke = 450_000)]
-        public void Concurrent_15Thread_30Jobs_1TriggerPerJob()
-        {
-            RunConcurrent(operationsPerRun: 450_000,
-                          threadCount: 15,
-                          jobCount: 30,
-                          triggersPerJob: 1,
-                          maxBatchSize: 16,
-                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
-                          repeatInterval: TimeSpan.FromTicks(1000L),
-                          repeatCount: 14_999,
-                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
-        }
-
-        [Benchmark(OperationsPerInvoke = 450_000)]
-        public void Concurrent_50Threads_15Jobs_2TriggersPerJob()
-        {
-            RunConcurrent(operationsPerRun: 450_000,
-                          threadCount: 50,
-                          jobCount: 15,
-                          triggersPerJob: 2,
-                          maxBatchSize: 16,
-                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
-                          repeatInterval: TimeSpan.FromTicks(1000L),
-                          repeatCount: 14_999,
-                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
-        }
-
-        [Benchmark(OperationsPerInvoke = 450_000)]
-        public void Concurrent_50Threads_30Jobs_1TriggerPerJob()
-        {
-            RunConcurrent(operationsPerRun: 450_000,
-                          threadCount: 50,
-                          jobCount: 30,
-                          triggersPerJob: 1,
-                          maxBatchSize: 16,
-                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
-                          repeatInterval: TimeSpan.FromTicks(1L),
-                          repeatCount: 14_999,
-                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
-        }
-
-        [IterationSetup(Target = nameof(Concurrent_30Threads_15Jobs_1TriggerPerJob_RepeatCountZero))]
-        public void IterationSetup_Concurrent_30Threads_15Jobs_1TriggerPerJob_RepeatCountZero()
+        [IterationSetup(Target = nameof(DisableConcurrent_30Threads_15Jobs_1TriggersPerJob_RepeatCountZero))]
+        public void IterationSetup_DisableConcurrent_30Threads_15Jobs_1TriggersPerJob_RepeatCountZero()
         {
             _scheduler = CreateAndConfigureScheduler<ConcurrentJob>(name: "A",
                                                                     instanceId: "1",
                                                                     threadCount: 30,
                                                                     jobCount: 15,
+                                                                    disableConcurrentExecution: true,
+                                                                    persistJobDataAfterExecution: false,
                                                                     triggersPerJob: 1,
                                                                     maxBatchSize: 16,
                                                                     idleWaitTime: TimeSpan.FromMinutes(1),
@@ -167,7 +155,7 @@ namespace Quartz.Benchmark
         /// 3. Wait for 'idleWaitTime', which should be interrupted by either signal change or shutdown of the scheduler.
         /// </summary>
         [Benchmark(OperationsPerInvoke = 15)]
-        public void Concurrent_30Threads_15Jobs_1TriggerPerJob_RepeatCountZero()
+        public void DisableConcurrent_30Threads_15Jobs_1TriggersPerJob_RepeatCountZero()
         {
             ConcurrentJob.Initialize(15);
 
@@ -179,13 +167,15 @@ namespace Quartz.Benchmark
             ConcurrentJob.Reset();
         }
 
-        [IterationSetup(Target = nameof(Concurrent_30Threads_15Jobs_2TriggerPerJob_RepeatCountZero))]
-        public void IterationSetup_Concurrent_30Threads_15Jobs_2TriggerPerJob_RepeatCountZero()
+        [IterationSetup(Target = nameof(DisableConcurrent_30Threads_15Jobs_2TriggersPerJob_RepeatCountZero))]
+        public void IterationSetup_DisableConcurrent_30Threads_15Jobs_2TriggersPerJob_RepeatCountZero()
         {
             _scheduler = CreateAndConfigureScheduler<ConcurrentJob>(name: "A",
                                                                     instanceId: "1",
                                                                     threadCount: 30,
                                                                     jobCount: 15,
+                                                                    disableConcurrentExecution: true,
+                                                                    persistJobDataAfterExecution: false,
                                                                     triggersPerJob: 2,
                                                                     maxBatchSize: 16,
                                                                     idleWaitTime: TimeSpan.FromSeconds(1),
@@ -202,7 +192,193 @@ namespace Quartz.Benchmark
         /// 3. Wait for 'idleWaitTime', which should be interrupted by either signal change or shutdown of the scheduler.
         /// </summary>
         [Benchmark(OperationsPerInvoke = 30)]
-        public void Concurrent_30Threads_15Jobs_2TriggerPerJob_RepeatCountZero()
+        public void DisableConcurrent_30Threads_15Jobs_2TriggersPerJob_RepeatCountZero()
+        {
+            ConcurrentJob.Initialize(30);
+
+            _scheduler!.Start();
+
+            ConcurrentJob.Wait();
+
+            _scheduler.Shutdown(false).GetAwaiter().GetResult();
+            ConcurrentJob.Reset();
+        }
+
+        [Benchmark(OperationsPerInvoke = 450_000)]
+        public void Concurrent_15Threads_15Jobs_1TriggersPerJob()
+        {
+            RunConcurrent(operationsPerRun: 450_000,
+                          threadCount: 15,
+                          jobCount: 15,
+                          disableConcurrentExecution: false,
+                          persistJobDataAfterExecution: false,
+                          triggersPerJob: 1,
+                          maxBatchSize: 16,
+                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                          repeatInterval: TimeSpan.FromTicks(1L),
+                          repeatCount: 29_999,
+                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [Benchmark(OperationsPerInvoke = 150_000)]
+        public void Concurrent_15Threads_15Jobs_5TriggersPerJob()
+        {
+            RunConcurrent(operationsPerRun: 150_000,
+                          threadCount: 15,
+                          jobCount: 15,
+                          disableConcurrentExecution: false,
+                          persistJobDataAfterExecution: false,
+                          triggersPerJob: 5,
+                          maxBatchSize: 16,
+                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                          repeatInterval: TimeSpan.FromTicks(1L),
+                          repeatCount: 1_999,
+                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [Benchmark(OperationsPerInvoke = 450_000)]
+        public void Concurrent_15Threads_30Jobs_1TriggersPerJob()
+        {
+            RunConcurrent(operationsPerRun: 450_000,
+                          threadCount: 15,
+                          jobCount: 30,
+                          disableConcurrentExecution: false,
+                          persistJobDataAfterExecution: false,
+                          triggersPerJob: 1,
+                          maxBatchSize: 16,
+                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                          repeatInterval: TimeSpan.FromTicks(1L),
+                          repeatCount: 14_999,
+                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [Benchmark(OperationsPerInvoke = 450_000)]
+        public void Concurrent_50Threads_15Jobs_2TriggersPerJob()
+        {
+            RunConcurrent(operationsPerRun: 450_000,
+                          threadCount: 50,
+                          jobCount: 15,
+                          disableConcurrentExecution: false,
+                          persistJobDataAfterExecution: false,
+                          triggersPerJob: 2,
+                          maxBatchSize: 16,
+                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                          repeatInterval: TimeSpan.FromTicks(1L),
+                          repeatCount: 14_999,
+                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [Benchmark(OperationsPerInvoke = 450_000)]
+        public void Concurrent_50Threads_30Jobs_1TriggersPerJob()
+        {
+            RunConcurrent(operationsPerRun: 450_000,
+                          threadCount: 50,
+                          jobCount: 30,
+                          disableConcurrentExecution: false,
+                          persistJobDataAfterExecution: false,
+                          triggersPerJob: 1,
+                          maxBatchSize: 16,
+                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                          repeatInterval: TimeSpan.FromTicks(1L),
+                          repeatCount: 14_999,
+                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [Benchmark(OperationsPerInvoke = 450_000)]
+        public void Concurrent_50Threads_30Jobs_3TriggersPerJob()
+        {
+            RunConcurrent(operationsPerRun: 450_000,
+                          threadCount: 50,
+                          jobCount: 30,
+                          disableConcurrentExecution: false,
+                          persistJobDataAfterExecution: false,
+                          triggersPerJob: 3,
+                          maxBatchSize: 16,
+                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                          repeatInterval: TimeSpan.FromTicks(1L),
+                          repeatCount: 4_999,
+                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [Benchmark(OperationsPerInvoke = 225_000)]
+        public void Concurrent_2Threads_15Jobs_2TriggersPerJob()
+        {
+            RunConcurrent(operationsPerRun: 225_000,
+                          threadCount: 2,
+                          jobCount: 15,
+                          disableConcurrentExecution: false,
+                          persistJobDataAfterExecution: false,
+                          triggersPerJob: 2,
+                          maxBatchSize: 16,
+                          idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+                          repeatInterval: TimeSpan.FromTicks(1L),
+                          repeatCount: 7_499,
+                          misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
+        }
+
+        [IterationSetup(Target = nameof(Concurrent_30Threads_15Jobs_1TriggersPerJob_RepeatCountZero))]
+        public void IterationSetup_Concurrent_30Threads_15Jobs_1TriggersPerJob_RepeatCountZero()
+        {
+            _scheduler = CreateAndConfigureScheduler<ConcurrentJob>(name: "A",
+                                                                    instanceId: "1",
+                                                                    threadCount: 30,
+                                                                    jobCount: 15,
+                                                                    disableConcurrentExecution: false,
+                                                                    persistJobDataAfterExecution: false,
+                                                                    triggersPerJob: 1,
+                                                                    maxBatchSize: 16,
+                                                                    idleWaitTime: TimeSpan.FromMinutes(1),
+                                                                    repeatInterval: TimeSpan.FromMilliseconds(1),
+                                                                    repeatCount: 0,
+                                                                    misfireInstruction: MisfireInstruction.SimpleTrigger.FireNow);
+        }
+
+        /// <summary>
+        /// Primary goal of this benchmark is to measure allocations.
+        /// With this benchmark we should:
+        /// 1. Acquire 15 triggers.
+        /// 2. Acquire 0 triggers.
+        /// 3. Wait for 'idleWaitTime', which should be interrupted by either signal change or shutdown of the scheduler.
+        /// </summary>
+        [Benchmark(OperationsPerInvoke = 15)]
+        public void Concurrent_30Threads_15Jobs_1TriggersPerJob_RepeatCountZero()
+        {
+            ConcurrentJob.Initialize(15);
+
+            _scheduler!.Start();
+
+            ConcurrentJob.Wait();
+
+            _scheduler.Shutdown(false).GetAwaiter().GetResult();
+            ConcurrentJob.Reset();
+        }
+
+        [IterationSetup(Target = nameof(Concurrent_30Threads_15Jobs_2TriggersPerJob_RepeatCountZero))]
+        public void IterationSetup_Concurrent_30Threads_15Jobs_2TriggersPerJob_RepeatCountZero()
+        {
+            _scheduler = CreateAndConfigureScheduler<ConcurrentJob>(name: "A",
+                                                                    instanceId: "1",
+                                                                    threadCount: 30,
+                                                                    jobCount: 15,
+                                                                    disableConcurrentExecution: false,
+                                                                    persistJobDataAfterExecution: false,
+                                                                    triggersPerJob: 2,
+                                                                    maxBatchSize: 16,
+                                                                    idleWaitTime: TimeSpan.FromSeconds(1),
+                                                                    repeatInterval: TimeSpan.Zero, // we're not repeating a trigger
+                                                                    repeatCount: 0, // we only want a given trigger to fire once
+                                                                    misfireInstruction: MisfireInstruction.SimpleTrigger.FireNow);
+        }
+
+        /// <summary>
+        /// Primary goal of this benchmark is to measure allocations.
+        /// With this benchmark we should:
+        /// 1. Acquire 15 triggers.
+        /// 2. Acquire 15 triggers.
+        /// 3. Wait for 'idleWaitTime', which should be interrupted by either signal change or shutdown of the scheduler.
+        /// </summary>
+        [Benchmark(OperationsPerInvoke = 30)]
+        public void Concurrent_30Threads_15Jobs_2TriggersPerJob_RepeatCountZero()
         {
             ConcurrentJob.Initialize(30);
 
@@ -223,6 +399,8 @@ namespace Quartz.Benchmark
         public static void RunDisableConcurrent(int operationsPerRun,
                                                 int threadCount,
                                                 int jobCount,
+                                                bool disableConcurrentExecution,
+                                                bool persistJobDataAfterExecution,
                                                 int triggersPerJob,
                                                 int maxBatchSize,
                                                 TimeSpan idleWaitTime,
@@ -236,6 +414,8 @@ namespace Quartz.Benchmark
                                                                               "1",
                                                                               threadCount,
                                                                               jobCount,
+                                                                              disableConcurrentExecution,
+                                                                              persistJobDataAfterExecution,
                                                                               triggersPerJob,
                                                                               maxBatchSize,
                                                                               idleWaitTime,
@@ -267,6 +447,8 @@ namespace Quartz.Benchmark
         public static void RunConcurrent(int operationsPerRun,
                                          int threadCount,
                                          int jobCount,
+                                         bool disableConcurrentExecution,
+                                         bool persistJobDataAfterExecution,
                                          int triggersPerJob,
                                          int maxBatchSize,
                                          TimeSpan idleWaitTime,
@@ -280,6 +462,8 @@ namespace Quartz.Benchmark
                                                                        "1",
                                                                        threadCount,
                                                                        jobCount,
+                                                                       disableConcurrentExecution,
+                                                                       persistJobDataAfterExecution,
                                                                        triggersPerJob,
                                                                        maxBatchSize,
                                                                        idleWaitTime,
@@ -309,6 +493,8 @@ namespace Quartz.Benchmark
         public static void RunDelayedConcurrent(int operationsPerRun,
                                                 int threadCount,
                                                 int jobCount,
+                                                bool disableConcurrentExecution,
+                                                bool persistJobDataAfterExecution,
                                                 int triggersPerJob,
                                                 int maxBatchSize,
                                                 TimeSpan idleWaitTime,
@@ -322,6 +508,8 @@ namespace Quartz.Benchmark
                                                                               "1",
                                                                               threadCount,
                                                                               jobCount,
+                                                                              disableConcurrentExecution,
+                                                                              persistJobDataAfterExecution,
                                                                               triggersPerJob,
                                                                               maxBatchSize,
                                                                               idleWaitTime,
@@ -347,6 +535,8 @@ namespace Quartz.Benchmark
                                                                  string instanceId,
                                                                  int threadCount,
                                                                  int jobCount,
+                                                                 bool disableConcurrentExecution,
+                                                                 bool persistJobDataAfterExecution,
                                                                  int triggersPerJob,
                                                                  int maxBatchSize,
                                                                  TimeSpan idleWaitTime,
@@ -376,7 +566,7 @@ namespace Quartz.Benchmark
 
             for (var i = 0; i < jobCount; i++)
             {
-                var job = CreateJobDetail(typeof(SchedulerBenchmark).Name, typeof(T));
+                var job = CreateJobDetail(typeof(SchedulerBenchmark).Name, typeof(T), disableConcurrentExecution, persistJobDataAfterExecution);
 
                 var triggers = new ITrigger[triggersPerJob];
                 for (var j = 0; j < triggersPerJob; j++)
@@ -403,9 +593,13 @@ namespace Quartz.Benchmark
                                  .Build();
         }
 
-        private static IJobDetail CreateJobDetail(string group, Type jobType)
+        private static IJobDetail CreateJobDetail(string group, Type jobType, bool disableConcurrentExecution, bool persistJobDataAfterExecution)
         {
-            return JobBuilder.Create(jobType).WithIdentity(Guid.NewGuid().ToString(), group).Build();
+            return JobBuilder.Create(jobType)
+                             .WithIdentity(Guid.NewGuid().ToString(), group)
+                             .DisallowConcurrentExecution(disableConcurrentExecution)
+                             .PersistJobDataAfterExecution(persistJobDataAfterExecution)
+                             .Build();
         }
 
         [DisallowConcurrentExecution]

--- a/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
@@ -3,6 +3,9 @@ using NUnit.Framework;
 using Quartz.Core;
 using Quartz.Impl.Matchers;
 using Quartz.Listener;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Quartz.Tests.Unit.Core
 {
@@ -12,6 +15,8 @@ namespace Quartz.Tests.Unit.Core
     [TestFixture]
     public class ListenerManagerTest
     {
+        private ListenerManagerImpl _manager;
+
         private class TestJobListener : JobListenerSupport
         {
             public TestJobListener(string name)
@@ -35,75 +40,705 @@ namespace Quartz.Tests.Unit.Core
         {
         }
 
-        [Test]
-        public void TestManagementOfJobListeners()
+        [SetUp]
+        public void SetUp()
         {
-            TestJobListener tl1 = new TestJobListener("tl1");
-            TestJobListener tl2 = new TestJobListener("tl2");
+            _manager = new ListenerManagerImpl();
+        }
 
-            ListenerManagerImpl manager = new ListenerManagerImpl();
+        [Test]
+        public void AddJobListener_ArrayOfMatcherIsNull_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            const IMatcher<JobKey>[] setMatchers = null;
 
-            // test adding listener without matcher
-            manager.AddJobListener(tl1);
-            Assert.AreEqual(1, manager.GetJobListeners().Count, "Unexpected size of listener list");
+            var tl1a = new TestJobListener("tl1");
+            var tl1b = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
 
-            // test adding listener with matcher
-            manager.AddJobListener(tl2, GroupMatcher<JobKey>.GroupEquals("foo"));
-            Assert.AreEqual(2, manager.GetJobListeners().Count, "Unexpected size of listener list");
+            _manager.AddJobListener(tl1a, groupMatcher);
+            _manager.AddJobListener(tl1b, setMatchers);
 
-            // test removing a listener
-            manager.RemoveJobListener("tl1");
-            Assert.AreEqual(1, manager.GetJobListeners().Count, "Unexpected size of listener list");
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
 
-            // test adding a matcher
-            manager.AddJobListenerMatcher("tl2", NameMatcher<JobKey>.NameContains("foo"));
-            Assert.AreEqual(2, manager.GetJobListenerMatchers("tl2").Count, "Unexpected size of listener's matcher list");
+            var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddJobListener_ArrayOfMatcherIsNull_JobListenerDoesntAlreadyExist()
+        {
+            const IMatcher<JobKey>[] setMatchers = null;
+
+            var tl1 = new TestJobListener("tl1");
+
+            _manager.AddJobListener(tl1, setMatchers);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddJobListener_ArrayOfMatcherIsEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            var tl1a = new TestJobListener("tl1");
+            var tl1b = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var setMatchers = Array.Empty<IMatcher<JobKey>>();
+
+            _manager.AddJobListener(tl1a, groupMatcher);
+            _manager.AddJobListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddJobListener_ArrayOfMatcherIsEmpty_JobListenerDoesntAlreadyExist()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var setMatchers = Array.Empty<IMatcher<JobKey>>();
+
+            _manager.AddJobListener(tl1, setMatchers);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddJobListener_ArrayOfMatcherIsNotEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            var tl1a = new TestJobListener("tl1");
+            var tl1b = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+
+            _manager.AddJobListener(tl1a, groupMatcher);
+
+            var setMatchers = new IMatcher<JobKey>[] { nameMatcher };
+
+            _manager.AddJobListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }));
+        }
+
+        [Test]
+        public void AddJobListener_ArrayOfMatcherIsNotEmpty_JobListenerDoesntAlreadyExist()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+            var setMatchers = new IMatcher<JobKey>[] { nameMatcher };
+
+            _manager.AddJobListener(tl1, setMatchers);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }));
+        }
+
+        [Test]
+        public void AddJobListener_ReadOnlyCollectionOfMatcherIsNull_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            const IReadOnlyCollection<IMatcher<JobKey>> setMatchers = null;
+
+            var tl1a = new TestJobListener("tl1");
+            var tl1b = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+
+            _manager.AddJobListener(tl1a, groupMatcher);
+            _manager.AddJobListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddJobListener_ReadOnlyCollectionOfMatcherIsEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            var tl1a = new TestJobListener("tl1");
+            var tl1b = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+
+            _manager.AddJobListener(tl1a, groupMatcher);
+
+            IReadOnlyCollection<IMatcher<JobKey>> setMatchers = Array.Empty<IMatcher<JobKey>>();
+
+            _manager.AddJobListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddJobListener_ReadOnlyCollectionOfMatcherIsNotEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            var tl1a = new TestJobListener("tl1");
+            var tl1b = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+
+            _manager.AddJobListener(tl1a, groupMatcher);
+
+            IReadOnlyCollection<IMatcher<JobKey>> setMatchers = new IMatcher<JobKey>[] { nameMatcher };
+
+            _manager.AddJobListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }));
+        }
+
+        [Test]
+        public void AddJobListenerMatcher_ListenerNameIsNull()
+        {
+            const string listenerName = null;
+
+            var matcher = GroupMatcher<JobKey>.GroupEquals("foo");
+
+            try
+            {
+                _manager.AddJobListenerMatcher(listenerName, matcher);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddJobListenerMatcher_MatcherIsNull()
+        {
+            const IMatcher<JobKey> matcher = null;
+
+            try
+            {
+                _manager.AddJobListenerMatcher("A", matcher);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(matcher), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddJobListenerMatcher_ListenerWasFirstRegisteredWithoutMatchers()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+
+            _manager.AddJobListener(tl1);
+            Assert.IsTrue(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher));
+            Assert.IsTrue(_manager.AddJobListenerMatcher(tl1.Name, nameMatcher));
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(2, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { groupMatcher, nameMatcher }));
+        }
+
+        [Test]
+        public void AddJobListenerMatcher_ListenerWasFirstRegisteredWithMatchers()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+
+            _manager.AddJobListener(tl1, nameMatcher);
+            Assert.IsTrue(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher));
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(2, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher, groupMatcher }));
+        }
+
+        [Test]
+        public void GetJobListener_ShouldThrowKeyNotFoundExceptionWhenNoJobListenerExistsWithSpecifiedName()
+        {
+            const string name = "A";
+
+            Assert.Throws<KeyNotFoundException>(() => _manager.GetJobListener(name));
+
+            _manager.AddJobListener(new TestJobListener("B"));
+
+            Assert.Throws<KeyNotFoundException>(() => _manager.GetJobListener(name));
+        }
+
+        [Test]
+        public void GetJobListener_ShouldThrowArgumentNullExceptionWhenNameIsNull()
+        {
+            const string name = null;
+
+            try
+            {
+                _manager.GetJobListener(name);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(name), ex.ParamName);
+            }
+
+            _manager.AddJobListener(new TestJobListener("B"));
+
+            try
+            {
+                _manager.GetJobListener(name);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(name), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void GetJobListeners_ShouldReturnShallowClone()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var tl2 = new TestJobListener("tl2");
+
+            _manager.AddJobListener(tl1);
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            jobListeners[0] = tl2;
+
+            jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+        }
+
+        [Test]
+        public void GetJobListeners_ShouldReturnEmptyArrayWhenNoJobListenersHaveBeenAdded()
+        {
+            var jobListeners = _manager.GetJobListeners();
+            Assert.AreSame(Array.Empty<IJobListener>(), jobListeners);
+        }
+
+        [Test]
+        public void GetJobListenerMatchers_ListenerNameIsNull()
+        {
+            const string listenerName = null;
+
+            try
+            {
+                _manager.GetJobListenerMatchers(listenerName);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void RemoveJobListener_NameIsNull()
+        {
+            const string name = null;
+
+            try
+            {
+                _manager.RemoveJobListener(name);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(name), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void RemoveJobListener_NoMatchersRegisteredForSpecifiedJobListener()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var tl2 = new TestJobListener("tl2");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+
+            _manager.AddJobListener(tl1, groupMatcher);
+            _manager.AddJobListener(tl2);
+
+            Assert.IsTrue(_manager.RemoveJobListener(tl2.Name));
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
+            Assert.IsNull(matchersTl2);
+
+            var matchersTl1 = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchersTl1);
+            Assert.IsTrue(matchersTl1.SequenceEqual(new[] { groupMatcher }));
+        }
+
+        [Test]
+        public void RemoveJobListener_MatchersRegisteredForSpecifiedJobListener()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var tl2 = new TestJobListener("tl2");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+
+            _manager.AddJobListener(tl1, groupMatcher);
+            _manager.AddJobListener(tl2, nameMatcher);
+
+            Assert.IsTrue(_manager.RemoveJobListener(tl2.Name));
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
+            Assert.IsNull(matchersTl2);
+
+            var matchersTl1 = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchersTl1);
+            Assert.IsTrue(matchersTl1.SequenceEqual(new[] { groupMatcher }));
+
+            // Ensure adding back the listener without matchers does not "magically" recover the
+            // matchers that were registered before we removed the listener
+            _manager.AddJobListener(tl2);
+
+            jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(2, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+            Assert.AreSame(tl2, jobListeners[1]);
+
+            matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
+            Assert.IsNull(matchersTl2);
+        }
+
+        [Test]
+        public void RemoveJobListener_NoJobListenerRegisteredWithSpecifiedName()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var tl2 = new TestJobListener("tl2");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+
+            _manager.AddJobListener(tl1, groupMatcher);
+
+            Assert.IsFalse(_manager.RemoveJobListener(tl2.Name));
+
+            var jobListeners = _manager.GetJobListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+        }
+
+        [Test]
+        public void RemoveJobListenerMatcher_ListenerNameIsNull()
+        {
+            const string listenerName = null;
+
+            var matcher = GroupMatcher<JobKey>.GroupEquals("foo");
+
+            try
+            {
+                _manager.RemoveJobListenerMatcher(listenerName, matcher);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void RemoveJobListenerMatcher_MatcherIsNull()
+        {
+            const IMatcher<JobKey> matcher = null;
+
+            try
+            {
+                _manager.RemoveJobListenerMatcher("A", matcher);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(matcher), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void RemoveJobListenerMatcher_MatcherWasAddedForSpecifiedListener()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+
+            _manager.AddJobListener(tl1, groupMatcher, nameMatcher);
+
+            Assert.IsTrue(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher));
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new[] { nameMatcher }));
+
+            Assert.IsTrue(_manager.RemoveJobListenerMatcher(tl1.Name, nameMatcher));
+            Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void RemoveJobListenerMatcher_MatcherWasNotAddedForSpecifiedListener()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+
+            _manager.AddJobListener(tl1);
+
+            Assert.False(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher));
+            Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+
+            _manager.AddJobListenerMatcher(tl1.Name, nameMatcher);
+
+            Assert.False(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher));
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new[] { nameMatcher }));
+        }
+
+        [Test]
+        public void RemoveJobListenerMatcher_JobListenerIsNotRegistered()
+        {
+            const string listenerName = "A";
+
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+
+            Assert.False(_manager.RemoveJobListenerMatcher(listenerName, groupMatcher));
+            Assert.IsNull(_manager.GetJobListenerMatchers(listenerName));
+        }
+
+        [Test]
+        public void SetJobListenerMatchers_ListenerNameIsNull()
+        {
+            const string listenerName = null;
+
+            var matchers = new[] { GroupMatcher<JobKey>.GroupEquals("foo") };
+
+            try
+            {
+                _manager.SetJobListenerMatchers(listenerName, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void SetJobListenerMatchers_MatchersIsNull()
+        {
+            const IReadOnlyCollection<IMatcher<JobKey>> matchers = null;
+
+            try
+            {
+                _manager.SetJobListenerMatchers("A", matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(matchers), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void SetJobListenerMatchers_MatchersIsEmpty_ListenerDoesNotExist()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var setMatchers = Array.Empty<IMatcher<JobKey>>();
+
+            Assert.IsFalse(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
+            Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void SetJobListenerMatchers_MatchersIsEmpty_ListenerHasNoMatchers()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var setMatchers = Array.Empty<IMatcher<JobKey>>();
+
+            _manager.AddJobListener(tl1);
+
+            Assert.IsTrue(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
+            Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void SetJobListenerMatchers_MatchersIsEmpty_ListenerHasMatchers()
+        {
+            var tl1 = new TestJobListener("tl1");
+
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var setMatchers = Array.Empty<IMatcher<JobKey>>();
+
+            _manager.AddJobListener(tl1, groupMatcher);
+
+            Assert.IsTrue(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
+            Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void SetJobListenerMatchers_MatchersIsNotEmpty_ListenerDoesNotExist()
+        {
+            var tl1 = new TestJobListener("tl1");
+
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+            var setMatchers = new IMatcher<JobKey>[] { groupMatcher, nameMatcher };
+
+            Assert.IsFalse(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
+            Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void SetJobListenerMatchers_MatchersIsNotEmpty_ListenerHasNoMatchers()
+        {
+            var tl1 = new TestJobListener("tl1");
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+            var setMatchers = new IMatcher<JobKey>[] { groupMatcher, nameMatcher };
+
+            _manager.AddJobListener(tl1);
+
+            Assert.IsTrue(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(setMatchers.Length, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(setMatchers));
+        }
+
+        [Test]
+        public void SetJobListenerMatchers_MatchersIsNotEmpty_ListenerHasMatchers()
+        {
+            var tl1 = new TestJobListener("tl1");
+
+            var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
+            var setMatchers = new IMatcher<JobKey>[] { nameMatcher };
+
+            _manager.AddJobListener(tl1, groupMatcher);
+
+            Assert.IsTrue(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
+
+            var matchers = _manager.GetJobListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(setMatchers.Length, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(setMatchers));
         }
 
         [Test]
         public void testManagementOfTriggerListeners()
         {
-            TestTriggerListener tl1 = new TestTriggerListener("tl1");
-            TestTriggerListener tl2 = new TestTriggerListener("tl2");
-
-            ListenerManagerImpl manager = new ListenerManagerImpl();
+            var tl1 = new TestTriggerListener("tl1");
+            var tl2 = new TestTriggerListener("tl2");
 
             // test adding listener without matcher
-            manager.AddTriggerListener(tl1);
-            Assert.AreEqual(1, manager.GetTriggerListeners().Count, "Unexpected size of listener list");
+            _manager.AddTriggerListener(tl1);
+            Assert.AreEqual(1, _manager.GetTriggerListeners().Count, "Unexpected size of listener list");
 
             // test adding listener with matcher
-            manager.AddTriggerListener(tl2, GroupMatcher<TriggerKey>.GroupEquals("foo"));
-            Assert.AreEqual(2, manager.GetTriggerListeners().Count, "Unexpected size of listener list");
+            _manager.AddTriggerListener(tl2, GroupMatcher<TriggerKey>.GroupEquals("foo"));
+            Assert.AreEqual(2, _manager.GetTriggerListeners().Count, "Unexpected size of listener list");
 
             // test removing a listener
-            manager.RemoveTriggerListener("tl1");
-            Assert.AreEqual(1, manager.GetTriggerListeners().Count, "Unexpected size of listener list");
+            _manager.RemoveTriggerListener("tl1");
+            Assert.AreEqual(1, _manager.GetTriggerListeners().Count, "Unexpected size of listener list");
 
             // test adding a matcher
-            manager.AddTriggerListenerMatcher("tl2", NameMatcher<TriggerKey>.NameContains("foo"));
-            Assert.AreEqual(2, manager.GetTriggerListenerMatchers("tl2").Count, "Unexpected size of listener's matcher list");
+            _manager.AddTriggerListenerMatcher("tl2", NameMatcher<TriggerKey>.NameContains("foo"));
+            Assert.AreEqual(2, _manager.GetTriggerListenerMatchers("tl2").Count, "Unexpected size of listener's matcher list");
         }
 
         [Test]
         public void TestManagementOfSchedulerListeners()
         {
-            TestSchedulerListener tl1 = new TestSchedulerListener();
-            TestSchedulerListener tl2 = new TestSchedulerListener();
-
-            ListenerManagerImpl manager = new ListenerManagerImpl();
+            var tl1 = new TestSchedulerListener();
+            var tl2 = new TestSchedulerListener();
 
             // test adding listener without matcher
-            manager.AddSchedulerListener(tl1);
-            Assert.AreEqual(1, manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
+            _manager.AddSchedulerListener(tl1);
+            Assert.AreEqual(1, _manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
 
             // test adding listener with matcher
-            manager.AddSchedulerListener(tl2);
-            Assert.AreEqual(2, manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
+            _manager.AddSchedulerListener(tl2);
+            Assert.AreEqual(2, _manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
 
             // test removing a listener
-            manager.RemoveSchedulerListener(tl1);
-            Assert.AreEqual(1, manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
+            _manager.RemoveSchedulerListener(tl1);
+            Assert.AreEqual(1, _manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
         }
     }
 }

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -20,9 +20,9 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,6 +34,7 @@ using Quartz.Core;
 using Quartz.Impl;
 using Quartz.Impl.Triggers;
 using Quartz.Job;
+using Quartz.Simpl;
 using Quartz.Spi;
 
 namespace Quartz.Tests.Unit.Core
@@ -142,6 +143,158 @@ namespace Quartz.Tests.Unit.Core
             // expect unschedule and schedule
             A.CallTo(() => listener.JobUnscheduled(new TriggerKey(TriggerName, TriggerGroup), A<CancellationToken>._)).MustHaveHappened();
             A.CallTo(() => listener.JobScheduled(jobTrigger, A<CancellationToken>._)).MustHaveHappened();
+        }
+
+        [Test]
+        [Ignore("Flaky in CI")]
+        public void CurrentlyExecutingJobs()
+        {
+            IReadOnlyCollection<IJobExecutionContext> executingJobs;
+
+            var scheduler = CreateQuartzScheduler("A", "B", 5);
+
+            executingJobs = scheduler.CurrentlyExecutingJobs;
+            Assert.AreEqual(0, executingJobs.Count);
+
+            scheduler.Start().GetAwaiter().GetResult();
+
+            executingJobs = scheduler.CurrentlyExecutingJobs;
+            Assert.AreEqual(0, executingJobs.Count);
+
+            ScheduleJobs<DelayedJob>(scheduler, 3, true, false, 1, TimeSpan.FromMilliseconds(1), 1);
+            ScheduleJobs<DelayedJob>(scheduler, 1, true, false, 1, TimeSpan.FromMilliseconds(1), 0);
+
+            Thread.Sleep(150);
+
+            executingJobs = scheduler.CurrentlyExecutingJobs;
+            Assert.AreEqual(4, executingJobs.Count);
+
+            Thread.Sleep(150);
+
+            executingJobs = scheduler.CurrentlyExecutingJobs;
+            Assert.AreEqual(3, executingJobs.Count);
+
+            Thread.Sleep(300);
+
+            executingJobs = scheduler.CurrentlyExecutingJobs;
+            Assert.AreEqual(0, executingJobs.Count);
+
+            scheduler.Shutdown(true).GetAwaiter().GetResult();
+        }
+
+        [Test]
+        [Ignore("Flaky in CI")]
+        public void NumJobsExecuted()
+        {
+            var scheduler = CreateQuartzScheduler("A", "B", 5);
+
+            Assert.AreEqual(0, scheduler.NumJobsExecuted);
+
+            scheduler.Start().GetAwaiter().GetResult();
+
+            Assert.AreEqual(0, scheduler.NumJobsExecuted);
+
+            ScheduleJobs<DelayedJob>(scheduler, 3, true, false, 1, TimeSpan.FromMilliseconds(1), 1);
+            ScheduleJobs<DelayedJob>(scheduler, 1, true, false, 1, TimeSpan.FromMilliseconds(1), 0);
+
+            Thread.Sleep(150);
+
+            Assert.AreEqual(4, scheduler.NumJobsExecuted);
+
+            Thread.Sleep(150);
+
+            Assert.AreEqual(7, scheduler.NumJobsExecuted);
+
+            Thread.Sleep(200);
+
+            Assert.AreEqual(7, scheduler.NumJobsExecuted);
+
+            scheduler.Shutdown(true).GetAwaiter().GetResult();
+        }
+
+        private static void ScheduleJobs<T>(QuartzScheduler scheduler,
+                                            int jobCount,
+                                            bool disableConcurrentExecution,
+                                            bool persistJobDataAfterExecution,
+                                            int triggersPerJob,
+                                            TimeSpan repeatInterval,
+                                            int repeatCount)
+        {
+            var triggersByJob = new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>>();
+
+            for (var i = 0; i < jobCount; i++)
+            {
+                var job = CreateJobDetail(typeof(QuartzSchedulerTest).Name,
+                                          typeof(T),
+                                          disableConcurrentExecution,
+                                          persistJobDataAfterExecution);
+
+                var triggers = new ITrigger[triggersPerJob];
+                for (var j = 0; j < triggersPerJob; j++)
+                {
+                    triggers[j] = CreateTrigger(job, repeatInterval, repeatCount);
+                }
+
+                triggersByJob.Add(job, triggers);
+            }
+
+            scheduler.ScheduleJobs(triggersByJob, false).GetAwaiter().GetResult();
+        }
+
+
+        private static QuartzScheduler CreateQuartzScheduler(string name, string instanceId, int threadCount)
+        {
+            var threadPool = new DefaultThreadPool { MaxConcurrency = threadCount };
+            threadPool.Initialize();
+
+            QuartzSchedulerResources res = new QuartzSchedulerResources
+            {
+                Name = name,
+                InstanceId = instanceId,
+                ThreadPool = threadPool,
+                JobRunShellFactory = new StdJobRunShellFactory(),
+                JobStore = new RAMJobStore(),
+                IdleWaitTime = TimeSpan.FromMilliseconds(10),
+                MaxBatchSize = threadCount,
+                BatchTimeWindow = TimeSpan.FromMilliseconds(10)
+            };
+
+            var scheduler = new QuartzScheduler(res);
+            scheduler.JobFactory = new SimpleJobFactory();
+            return scheduler;
+        }
+
+        private static ITrigger CreateTrigger(IJobDetail job, TimeSpan repeatInterval, int repeatCount)
+        {
+            return TriggerBuilder.Create()
+                                 .ForJob(job)
+                                 .WithSimpleSchedule(
+                                     sb => sb.WithRepeatCount(repeatCount)
+                                             .WithInterval(repeatInterval)
+                                             .WithMisfireHandlingInstruction(MisfireInstruction.IgnoreMisfirePolicy))
+                                 .Build();
+        }
+
+        private static IJobDetail CreateJobDetail(string group,
+                                                  Type jobType,
+                                                  bool disableConcurrentExecution,
+                                                  bool persistJobDataAfterExecution)
+        {
+            return JobBuilder.Create(jobType)
+                             .WithIdentity(Guid.NewGuid().ToString(), group)
+                             .DisallowConcurrentExecution(disableConcurrentExecution)
+                             .PersistJobDataAfterExecution(persistJobDataAfterExecution)
+                             .Build();
+        }
+
+        public class DelayedJob : IJob
+        {
+            private static TimeSpan _delay = TimeSpan.FromMilliseconds(200);
+
+            public async Task Execute(IJobExecutionContext context)
+            {
+                await Task.Delay(_delay).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Quartz/Collections/OrderedDictionary.ValueCollection.cs
+++ b/src/Quartz/Collections/OrderedDictionary.ValueCollection.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -103,6 +103,26 @@ namespace Quartz.Collections
                 {
                     array[i + arrayIndex] = entries[i].Value;
                 }
+            }
+
+            public TValue[] ToArray()
+            {
+                var count = Count;
+
+                if (count == 0)
+                {
+                    return Array.Empty<TValue>();
+                }
+
+                var entries = _orderedDictionary._entries;
+                var array = new TValue[count];
+
+                for (int i = 0; i < count; ++i)
+                {
+                    array[i] = entries[i].Value;
+                }
+
+                return array;
             }
 
             bool ICollection<TValue>.Remove(TValue item) => throw new NotSupportedException();

--- a/src/Quartz/Core/ListenerManagerImpl.cs
+++ b/src/Quartz/Core/ListenerManagerImpl.cs
@@ -11,11 +11,13 @@ namespace Quartz.Core
     /// </summary>
     public class ListenerManagerImpl : IListenerManager
     {
-        private readonly OrderedDictionary<string, IJobListener> globalJobListeners = new OrderedDictionary<string, IJobListener>(10);
+        private readonly object globalJobListenerLock = new object();
+
+        private OrderedDictionary<string, IJobListener>? globalJobListeners;
 
         private readonly OrderedDictionary<string, ITriggerListener> globalTriggerListeners = new OrderedDictionary<string, ITriggerListener>(10);
 
-        private readonly Dictionary<string, List<IMatcher<JobKey>>> globalJobListenersMatchers = new Dictionary<string, List<IMatcher<JobKey>>>(10);
+        private Dictionary<string, List<IMatcher<JobKey>>>? globalJobListenersMatchers;
 
         private readonly Dictionary<string, List<IMatcher<TriggerKey>>> globalTriggerListenersMatchers = new Dictionary<string, List<IMatcher<TriggerKey>>>(10);
 
@@ -23,7 +25,9 @@ namespace Quartz.Core
 
         public void AddJobListener(IJobListener jobListener, params IMatcher<JobKey>[] matchers)
         {
-            AddJobListener(jobListener, new List<IMatcher<JobKey>>(matchers));
+            IReadOnlyCollection<IMatcher<JobKey>> matchersCollection = matchers;
+
+            AddJobListener(jobListener, matchersCollection);
         }
 
         public void AddJobListener(IJobListener jobListener, IReadOnlyCollection<IMatcher<JobKey>> matchers)
@@ -33,37 +37,56 @@ namespace Quartz.Core
                 throw new ArgumentException("JobListener name cannot be empty.");
             }
 
-            lock (globalJobListeners)
+            lock (globalJobListenerLock)
             {
+                globalJobListeners ??= new OrderedDictionary<string, IJobListener>();
                 globalJobListeners[jobListener.Name] = jobListener;
 
-                List<IMatcher<JobKey>> matchersL = new List<IMatcher<JobKey>>();
                 if (matchers != null && matchers.Count > 0)
                 {
-                    matchersL.AddRange(matchers);
+                    // Add or replace matchers for the job listener
+                    globalJobListenersMatchers ??= new Dictionary<string, List<IMatcher<JobKey>>>();
+                    globalJobListenersMatchers[jobListener.Name] = new List<IMatcher<JobKey>>(matchers);
                 }
                 else
                 {
-                    matchersL.Add(EverythingMatcher<JobKey>.AllJobs());
+                    // Remove any registered matchers for the job listener
+                    RemoveJobListenerMatchers(jobListener.Name);
                 }
-
-                globalJobListenersMatchers[jobListener.Name] = matchersL;
             }
         }
 
         public bool AddJobListenerMatcher(string listenerName, IMatcher<JobKey> matcher)
         {
-            if (matcher == null)
+            if (listenerName == null)
             {
-                throw new ArgumentException("Non-null value not acceptable.");
+                throw new ArgumentNullException(nameof(listenerName));
             }
 
-            lock (globalJobListeners)
+            if (matcher == null)
             {
-                if (!globalJobListenersMatchers.TryGetValue(listenerName, out var matchers))
+                throw new ArgumentNullException(nameof(matcher));
+            }
+
+            lock (globalJobListenerLock)
+            {
+                if (globalJobListenersMatchers == null || !globalJobListenersMatchers.TryGetValue(listenerName, out var matchers))
                 {
-                    return false;
+                    // Return false if no job listener is registered with the specified name
+                    if (globalJobListeners == null || !globalJobListeners.ContainsKey(listenerName))
+                    {
+                        return false;
+                    }
+
+                    // We may be adding the first matcher for any job listener, so make sure globalJobListenersMatchers
+                    // is initialized
+                    globalJobListenersMatchers ??= new Dictionary<string, List<IMatcher<JobKey>>>();
+
+                    // We're adding the first matcher for the specified job listener
+                    matchers = new List<IMatcher<JobKey>>();
+                    globalJobListenersMatchers.Add(listenerName, matchers);
                 }
+
                 matchers.Add(matcher);
                 return true;
             }
@@ -71,26 +94,54 @@ namespace Quartz.Core
 
         public bool RemoveJobListenerMatcher(string listenerName, IMatcher<JobKey> matcher)
         {
-            if (matcher == null)
+            if (listenerName == null)
             {
-                throw new ArgumentException("Non-null value not acceptable.");
+                throw new ArgumentNullException(nameof(listenerName));
             }
 
-            lock (globalJobListeners)
+            if (matcher == null)
             {
-                if (!globalJobListenersMatchers.TryGetValue(listenerName, out var matchers))
+                throw new ArgumentNullException(nameof(matcher));
+            }
+
+            if (globalJobListenersMatchers == null)
+            {
+                return false;
+            }
+
+            lock (globalJobListenerLock)
+            {
+                if (globalJobListenersMatchers == null || !globalJobListenersMatchers.TryGetValue(listenerName, out var matchers))
                 {
                     return false;
                 }
-                return matchers.Remove(matcher);
+
+                var removed = matchers.Remove(matcher);
+
+                if (removed && matchers.Count == 0)
+                {
+                    RemoveJobListenerMatchers(listenerName);
+                }
+
+                return removed;
             }
         }
 
         public IReadOnlyCollection<IMatcher<JobKey>>? GetJobListenerMatchers(string listenerName)
         {
-            lock (globalJobListeners)
+            if (listenerName == null)
             {
-                if (!globalJobListenersMatchers.TryGetValue(listenerName, out var matchers))
+                throw new ArgumentNullException(nameof(listenerName));
+            }
+
+            if (globalJobListenersMatchers == null)
+            {
+                return null;
+            }
+
+            lock (globalJobListenerLock)
+            {
+                if (globalJobListenersMatchers == null || !globalJobListenersMatchers.TryGetValue(listenerName, out var matchers))
                 {
                     return null;
                 }
@@ -101,46 +152,103 @@ namespace Quartz.Core
 
         public bool SetJobListenerMatchers(string listenerName, IReadOnlyCollection<IMatcher<JobKey>> matchers)
         {
-            if (matchers == null)
+            if (listenerName == null)
             {
-                throw new ArgumentException("Non-null value not acceptable.");
+                throw new ArgumentNullException(nameof(listenerName));
             }
 
-            lock (globalJobListeners)
+            if (matchers == null)
             {
-                if (!globalJobListenersMatchers.TryGetValue(listenerName, out _))
+                throw new ArgumentNullException(nameof(matchers));
+            }
+
+            lock (globalJobListenerLock)
+            {
+                if (globalJobListeners == null || !globalJobListeners.ContainsKey(listenerName))
                 {
                     return false;
                 }
 
-                globalJobListenersMatchers[listenerName] = new List<IMatcher<JobKey>>(matchers);
+                if (matchers.Count == 0)
+                {
+                    RemoveJobListenerMatchers(listenerName);
+                }
+                else
+                {
+                    globalJobListenersMatchers ??= new Dictionary<string, List<IMatcher<JobKey>>>();
+                    globalJobListenersMatchers[listenerName] = new List<IMatcher<JobKey>>(matchers);
+                }
+
                 return true;
             }
         }
 
         public bool RemoveJobListener(string name)
         {
-            lock (globalJobListeners)
+            if (name == null)
             {
-                return globalJobListeners.Remove(name);
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (globalJobListeners == null)
+            {
+                return false;
+            }
+
+            lock (globalJobListenerLock)
+            {
+                if (globalJobListeners == null)
+                {
+                    return false;
+                }
+
+                var removed = globalJobListeners.Remove(name);
+
+                // When we've removed a job listener, make sure to also remove associated matchers
+                if (removed)
+                {
+                    RemoveJobListenerMatchers(name);
+
+                    if (globalJobListeners.Count == 0)
+                    {
+                        globalJobListeners = null;
+                    }
+                }
+
+                return removed;
             }
         }
 
-        public IReadOnlyCollection<IJobListener> GetJobListeners()
+        public IJobListener[] GetJobListeners()
         {
-            lock (globalJobListeners)
+            if (globalJobListeners == null)
             {
-                return globalJobListeners.Count > 0 
-                    ? new List<IJobListener>(globalJobListeners.Values) 
-                    : EmptyReadOnlyCollection<IJobListener>.Instance;
+                return Array.Empty<IJobListener>();
+            }
+
+            lock (globalJobListenerLock)
+            {
+                return globalJobListeners != null ? globalJobListeners.Values.ToArray()
+                                                  : Array.Empty<IJobListener>();
             }
         }
 
         public IJobListener GetJobListener(string name)
         {
-            lock (globalJobListeners)
+            if (name == null)
             {
-                return globalJobListeners[name];
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            lock (globalJobListenerLock)
+            {
+                // Avoid initializing globalJobListeners when no job listeners have been added
+                if (globalJobListeners == null || !globalJobListeners.TryGetValue(name, out var jobListener))
+                {
+                    throw new KeyNotFoundException();
+                }
+
+                return jobListener;
             }
         }
 
@@ -189,7 +297,7 @@ namespace Quartz.Core
             lock (globalTriggerListeners)
             {
                 globalTriggerListeners[triggerListener.Name] = triggerListener;
-                var matchers = new List<IMatcher<TriggerKey>> {matcher};
+                var matchers = new List<IMatcher<TriggerKey>> { matcher };
                 globalTriggerListenersMatchers[triggerListener.Name] = matchers;
             }
         }
@@ -305,9 +413,25 @@ namespace Quartz.Core
         {
             lock (schedulerListeners)
             {
-                return schedulerListeners.Count > 0 
+                return schedulerListeners.Count > 0
                     ? new List<ISchedulerListener>(schedulerListeners)
                     : EmptyReadOnlyCollection<ISchedulerListener>.Instance;
+            }
+        }
+
+        private void RemoveJobListenerMatchers(string listenerName)
+        {
+            if (globalJobListenersMatchers == null)
+            {
+                return;
+            }
+
+            // If we're removing the last matcher of the only job listener with matchers, then
+            // reset globalJobListenersMatchers to null to avoid having to lock in subsequent calls
+            // to GetJobListenerMatchers(string listenerName)
+            if (globalJobListenersMatchers.Remove(listenerName) && globalJobListenersMatchers.Count == 0)
+            {
+                globalJobListenersMatchers = null;
             }
         }
     }


### PR DESCRIPTION
This is a draft PR that mostly aims to gather feedback on the changes that I applied as I'm sure some (most? :p) of these changes will probably be considered controversial.

There are two parts to this PR:
* Optimize the job listener part of ListenerManagerImpl.
* Optimize the job listener part of QuartzScheduler.

**ListenerManagerImpl**
Optimize the way we deal with job listeners by:
* eliminating locking in GetJobListenerMatchers when no matchers were were added.
* eliminating locking in GetJobListeners when no job listeners were added.
* lazily initializing globalJobListeners and globalJobListenersMatchers dictionaries.
* not adding a EverythingMatcher for a job listener when no matchers were specified.

<details>
<summary>Benchmark results</summary>

|                                                        Method | Branch |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------------------------------------------------------------- |--------|---------:|---------:|---------:|-------:|----------:|
| NotifyJobListenersToBeExecuted_QuartScheduler1_SingleThreaded | v4     | 402.6 ns |  3.26 ns |  2.72 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartScheduler1_SingleThreaded | pr     | 350.2 ns |  0.67 ns |  0.63 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler1_MultiThreaded | v4     | 467.0 ns |  6.56 ns |  5.81 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler1_MultiThreaded | pr     | 473.5 ns |  4.97 ns |  4.65 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartScheduler2_SingleThreaded | v4     | 398.1 ns |  0.69 ns |  0.64 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartScheduler2_SingleThreaded | pr     | 348.3 ns |  1.14 ns |  1.01 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler2_MultiThreaded | v4     | 472.5 ns |  9.17 ns |  9.42 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler2_MultiThreaded | pr     | 474.7 ns |  3.21 ns |  3.00 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartScheduler3_SingleThreaded | v4     | 792.0 ns |  3.59 ns |  3.18 ns | 0.1068 |     449 B |
| NotifyJobListenersToBeExecuted_QuartScheduler3_SingleThreaded | pr     | 713.3 ns | 14.24 ns | 13.32 ns | 0.0896 |     377 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler3_MultiThreaded | v4     | 765.7 ns | 15.00 ns | 20.53 ns | 0.1075 |     451 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler3_MultiThreaded | pr     | 611.3 ns |  9.01 ns | 12.63 ns | 0.0900 |     379 B |
| NotifyJobListenersToBeExecuted_QuartScheduler4_SingleThreaded | v4     | 789.2 ns |  2.64 ns |  2.47 ns | 0.1068 |     449 B |
| NotifyJobListenersToBeExecuted_QuartScheduler4_SingleThreaded | pr     | 702.4 ns |  5.84 ns |  4.56 ns | 0.0896 |     377 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler4_MultiThreaded | v4     | 737.1 ns | 14.70 ns | 20.61 ns | 0.1075 |     452 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler4_MultiThreaded | pr     | 581.9 ns | 11.61 ns | 20.64 ns | 0.0900 |     379 B |
</details>

_Conclusion:_
This part of the PR leads to nice improvements, but nothing too spectacular.

**QuartzScheduler**
Optimize notify of job listeners by:
* only special casing ExecutingJobsManager as "internal" job listener.
* no longer checking for matchers in case of ExecutingJobsManager.
* removing methods to add, remove or get internal job listeners.
* no longer add the job store as internal listener if it implements IJobListener.

I also removed the protected ctor of **QuartzScheduler**, but that can easily be reverted.

<details>
<summary>Benchmark results</summary>

|                                                        Method | Branch |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|-------------------------------------------------------------- |--------|---------:|--------:|--------:|-------:|----------:|
| NotifyJobListenersToBeExecuted_QuartScheduler1_SingleThreaded | v4     | 402.6 ns | 3.26 ns |  2.72 ns| 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartScheduler1_SingleThreaded | pr     | 105.3 ns | 0.26 ns | 0.23 ns | 0.0114 |      48 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler1_MultiThreaded | v4     | 467.0 ns | 6.56 ns |  5.81 ns| 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler1_MultiThreaded | pr     | 143.5 ns | 1.27 ns | 1.19 ns | 0.0114 |      48 B |
| NotifyJobListenersToBeExecuted_QuartScheduler2_SingleThreaded | v4     | 398.1 ns | 0.69 ns |  0.64 ns| 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartScheduler2_SingleThreaded | pr     | 130.9 ns | 0.70 ns | 0.59 ns | 0.0114 |      48 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler2_MultiThreaded | v4     | 472.5 ns | 9.17 ns |  9.42 ns| 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler2_MultiThreaded | pr     | 142.8 ns | 1.20 ns | 1.12 ns | 0.0114 |      48 B |
| NotifyJobListenersToBeExecuted_QuartScheduler3_SingleThreaded | v4     | 792.0 ns | 3.59 ns |  3.18 ns| 0.1068 |     449 B |
| NotifyJobListenersToBeExecuted_QuartScheduler3_SingleThreaded | pr     | 372.7 ns | 0.99 ns | 0.77 ns | 0.0381 |     160 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler3_MultiThreaded | v4     | 765.7 ns |15.00 ns | 20.53 ns| 0.1075 |     451 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler3_MultiThreaded | pr     | 328.1 ns | 3.46 ns | 3.06 ns | 0.0381 |     161 B |
| NotifyJobListenersToBeExecuted_QuartScheduler4_SingleThreaded | v4     | 789.2 ns | 2.64 ns |  2.47 ns| 0.1068 |     449 B |
| NotifyJobListenersToBeExecuted_QuartScheduler4_SingleThreaded | pr     | 371.5 ns | 1.10 ns | 0.92 ns | 0.0381 |     160 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler4_MultiThreaded | v4     | 737.1 ns |14.70 ns | 20.61 ns| 0.1075 |     452 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler4_MultiThreaded | pr     | 322.1 ns | 3.31 ns | 2.76 ns | 0.0381 |     161 B |
</details>

_Conclusion:_
If we combine the changes to **ListenerManagerImpl** and **QuartzScheduler**, we get great improvements on both performance and allocations. 
