### PR TITLE
Make StdSchedulerFactory and ServiceCollectionSchedulerFactories threadsafe

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
@@ -20,8 +20,8 @@ namespace Quartz
         private readonly IServiceProvider serviceProvider;
         private readonly IOptions<QuartzOptions> options;
         private readonly ContainerConfigurationProcessor processor;
-        private bool initialized;
         private readonly SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+        private IScheduler? initializedScheduler;
 
         public ServiceCollectionSchedulerFactory(
             IServiceProvider serviceProvider,
@@ -31,27 +31,29 @@ namespace Quartz
             this.serviceProvider = serviceProvider;
             this.options = options;
             this.processor = processor;
+            this.initializedScheduler = null;
         }
 
         public override async Task<IScheduler> GetScheduler(CancellationToken cancellationToken = default)
         {
-            if(initialized)
-                return await base.GetScheduler(cancellationToken);
-        
             await semaphore.WaitAsync(cancellationToken);
             try
             {
-                if(initialized)
-                    return await base.GetScheduler(cancellationToken);
-                    
-                // check if logging provider configured and let if configure
-                serviceProvider.GetService<MicrosoftLoggingProvider>();
+                if(initializedScheduler == null) {
+                    // check if logging provider configured and let if configure
+                    serviceProvider.GetService<MicrosoftLoggingProvider>();
 
-                base.Initialize(options.Value);
+                    base.Initialize(options.Value);
+                }
+                
                 var scheduler = await base.GetScheduler(cancellationToken);
                 
+                // The base method may produce a new scheduler in the event that the original scheduler was stopped
+                if(Object.ReferenceEquals(scheduler, initializedScheduler))
+                    return scheduler;
+                
                 await InitializeScheduler(scheduler, cancellationToken);
-                initialized = true;
+                initializedScheduler = scheduler;
                 
                 return scheduler;
             }

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -369,8 +369,6 @@ Please add configuration to your application config file to correctly initialize
             TimeSpan idleWaitTime = TimeSpan.Zero;
             TimeSpan dbFailureRetry = TimeSpan.FromSeconds(15);
 
-            SchedulerRepository schedRep = SchedulerRepository.Instance;
-
             // Get Scheduler Properties
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -450,8 +448,6 @@ Please add configuration to your application config file to correctly initialize
                 string uid = QuartzSchedulerResources.GetUniqueIdentifier(schedName, schedInstId);
 
                 RemoteScheduler remoteScheduler = new RemoteScheduler(uid, factory);
-
-                schedRep.Bind(remoteScheduler);
 
                 return remoteScheduler;
             }
@@ -1016,15 +1012,11 @@ Please add configuration to your application config file to correctly initialize
 
                 log.Info("Quartz scheduler version: {0}".FormatInvariant(qs.Version));
 
-                // prevents the repository from being garbage collected
-                qs.AddNoGCObject(schedRep);
                 // prevents the db manager from being garbage collected
                 if (dbMgr != null)
                 {
                     qs.AddNoGCObject(dbMgr);
                 }
-
-                schedRep.Bind(sched);
 
                 return sched;
             }
@@ -1120,6 +1112,7 @@ Please add configuration to your application config file to correctly initialize
                 }
 
                 sched = await Instantiate().ConfigureAwait(false);
+                SchedulerRepository.Instance.Bind(sched);
 
                 return sched;
             } finally {

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -131,6 +131,8 @@ namespace Quartz.Impl
 
         public const string SystemPropertyAsInstanceId = "SYS_PROP";
 
+        private readonly SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+
         private SchedulerException? initException;
 
         private PropertiesParser cfg = null!;
@@ -1093,30 +1095,36 @@ Please add configuration to your application config file to correctly initialize
         /// </remarks>
         public virtual async Task<IScheduler> GetScheduler(CancellationToken cancellationToken = default)
         {
-            if (cfg == null)
-            {
-                Initialize();
-            }
-
-            SchedulerRepository schedRep = SchedulerRepository.Instance;
-
-            IScheduler? sched = await schedRep.Lookup(SchedulerName, cancellationToken).ConfigureAwait(false);
-
-            if (sched != null)
-            {
-                if (sched.IsShutdown)
+            // We always need to guarantee exclusivity because of the possible sequence of interactions with
+            // the SchedulerRepository.
+            if(!semaphore.Wait(0, cancellationToken))
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try {
+                if (cfg == null)
                 {
-                    schedRep.Remove(SchedulerName);
+                    Initialize();
                 }
-                else
+
+                IScheduler? sched = await SchedulerRepository.Instance.Lookup(SchedulerName, cancellationToken).ConfigureAwait(false);
+
+                if (sched != null)
                 {
-                    return sched;
+                    if (sched.IsShutdown)
+                    {
+                        SchedulerRepository.Instance.Remove(SchedulerName);
+                    }
+                    else
+                    {
+                        return sched;
+                    }
                 }
+
+                sched = await Instantiate().ConfigureAwait(false);
+
+                return sched;
+            } finally {
+                semaphore.Release();
             }
-
-            sched = await Instantiate().ConfigureAwait(false);
-
-            return sched!;
         }
 
         /// <summary> <para>

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -1020,11 +1020,6 @@ Please add configuration to your application config file to correctly initialize
 
                 return sched;
             }
-            catch (SchedulerException)
-            {
-                await ShutdownFromInstantiateException(tp, qs, tpInited, qsInited).ConfigureAwait(false);
-                throw;
-            }
             catch
             {
                 await ShutdownFromInstantiateException(tp, qs, tpInited, qsInited).ConfigureAwait(false);


### PR DESCRIPTION
fixes #1587

I moved the call to SchedulerRepository.Bind to GetScheduler, as this makes the registration process clearer.

You can't write tests against this as it would pollute the SchedulerRepository singleton as noted in #1453.