### PR TITLE
Add TryGet functions to JobDataMap and StringKeyDirtyFlagMap

### DIFF
--- a/src/Quartz/JobDataMap.cs
+++ b/src/Quartz/JobDataMap.cs
@@ -472,5 +472,301 @@ namespace Quartz
 
             return GetNullableGuid(key);
         }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="int" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetIntValueFromString(string key, out int value)
+        {
+            try
+            {
+                value = GetIntValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="bool" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetBooleanValueFromString(string key, out bool value)
+        {
+            try
+            {
+                value = GetBooleanValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="double" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDoubleValueFromString(string key, out double value)
+        {
+            try
+            {
+                value = GetDoubleValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="float" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetFloatValueFromString(string key, out float value)
+        {
+            try
+            {
+                value = GetFloatValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="long" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetLongValueFromString(string key, out long value)
+        {
+            try
+            {
+                value = GetLongValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="DateTime" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDateTimeValueFromString(string key, out DateTime value)
+        {
+            try
+            {
+                value = GetDateTimeValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="DateTimeOffset" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDateTimeOffsetValueFromString(string key, out DateTimeOffset value)
+        {
+            try
+            {
+                value = GetDateTimeOffsetValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="TimeSpan" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetTimeSpanValueFromString(string key, out TimeSpan value)
+        {
+            try
+            {
+                value = GetTimeSpanValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="Guid" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetGuidValueFromString(string key, out Guid value)
+        {
+            try
+            {
+                value = GetGuidValueFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="int" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetIntValue(string key, out int value)
+        {
+            var result = TryGetIntValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetInt(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="bool" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetBooleanValue(string key, out bool value)
+        {
+            var result = TryGetBooleanValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetBoolean(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="double" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDoubleValue(string key, out double value)
+        {
+            var result = TryGetDoubleValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetDouble(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="float" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetFloatValue(string key, out float value)
+        {
+            var result = TryGetFloatValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetFloat(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="long" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetLongValue(string key, out long value)
+        {
+            var result = TryGetLongValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetLong(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="DateTime" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDateTimeValue(string key, out DateTime value)
+        {
+            var result = TryGetDateTimeValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetDateTime(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="DateTimeOffset" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDateTimeOffsetValue(string key, out DateTimeOffset value)
+        {
+            var result = TryGetDateTimeOffsetValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetDateTimeOffset(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="TimeSpan" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetTimeSpanValue(string key, out TimeSpan value)
+        {
+            var result = TryGetTimeSpanValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetTimeSpan(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="Guid" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetGuidValue(string key, out int value)
+        {
+            var result = TryGetIntValueFromString(key, out value);
+            if (!result)
+            {
+                result = TryGetInt(key, out value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="char" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetCharFromString(string key, out char value)
+        {
+            try
+            {
+                value = GetCharFromString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
     }
 }

--- a/src/Quartz/Util/StringKeyDirtyFlagMap.cs
+++ b/src/Quartz/Util/StringKeyDirtyFlagMap.cs
@@ -377,5 +377,192 @@ namespace Quartz.Util
             var obj = this[key];
             return (Guid?) obj;
         }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="int" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetInt(string key, out int value)
+        {
+            try
+            {
+                value = GetInt(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="bool" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetBoolean(string key, out bool value)
+        {
+            try
+            {
+                value = GetBoolean(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="double" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDouble(string key, out double value)
+        {
+            try
+            {
+                value = GetDouble(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="float" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetFloat(string key, out float value)
+        {
+            try
+            {
+                value = GetFloat(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="long" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetLong(string key, out long value)
+        {
+            try
+            {
+                value = GetLong(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="DateTime" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDateTime(string key, out DateTime value)
+        {
+            try
+            {
+                value = GetDateTime(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="DateTimeOffset" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetDateTimeOffset(string key, out DateTimeOffset value)
+        {
+            try
+            {
+                value = GetDateTimeOffset(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="TimeSpan" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetTimeSpan(string key, out TimeSpan value)
+        {
+            try
+            {
+                value = GetTimeSpan(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="Guid" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetGuid(string key, out Guid value)
+        {
+            try
+            {
+                value = GetGuid(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified Nullable <see cref="Guid" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetNullableGuid(string key, out Guid? value)
+        {
+            try
+            {
+                value = GetNullableGuid(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve the identified <see cref="char" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetChar(string key, out char value)
+        {
+            try
+            {
+                value = GetChar(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Added `TryGet` versions for `GetXxx`, `GetXxxValueFromString`, and `GetXxxValue` methods.

*   I was tempted to refactor many of the existing `GetXxx` and `GetXxxValue` methods, because most of each group follows the same pattern. I left them alone for now, and I similarly used a repetitive pattern for the new methods instead of refactoring.
*   Two of the types don't have the standard complement of three methods. I assumed there was a reason for this and did not add missing methods.
    *   `char` has `GetCharFromString` (only method named `GetXxxFromString`) and `GetChar`, but it does not have `GetCharValueFromString` or `GetCharValue`
    *   `Guid?` does not have `GetNullableGuidFromString`
*   There were no unit tests for the existing methods, so I did not add any for the new ones.
*   I'm happy to revise as needed.

#1582