### PR TITLE
Allow benchmarks to run against .NET 6.0

### DIFF
--- a/src/Quartz.Benchmark/Directory.Build.props
+++ b/src/Quartz.Benchmark/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+</Project>

--- a/src/Quartz.Tests.Unit/Collections/OrderedDictionaryTest.cs
+++ b/src/Quartz.Tests.Unit/Collections/OrderedDictionaryTest.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using Quartz.Collections;
+using System;
+
+namespace Quartz.Tests.Unit.Collections
+{
+    [TestFixture]
+    internal class OrderedDictionaryTest
+    {
+        [Test]
+        public void Values_Empty_ToArray()
+        {
+            var dictionary = new OrderedDictionary<string, int>();
+            var valuesCollection = dictionary.Values;
+
+            var valuesArray = valuesCollection.ToArray();
+            Assert.AreSame(Array.Empty<int>(), valuesArray);
+        }
+
+        [Test]
+        public void Values_NotEmpty_ToArray()
+        {
+            var dictionary = new OrderedDictionary<string, int>();
+            dictionary.Add("A", 5);
+            dictionary.Add("Z", 2);
+
+            var valuesCollection = dictionary.Values;
+
+            var valuesArray = valuesCollection.ToArray();
+            Assert.IsNotNull(valuesArray);
+            Assert.AreEqual(2, valuesArray.Length);
+            Assert.AreEqual(5, valuesArray[0]);
+            Assert.AreEqual(2, valuesArray[1]);
+        }
+    }
+}


### PR DESCRIPTION
If I do not set **ProduceReferenceAssembly** to **false**, I get the following error when I attempt to run our benchmarks against .NET 6.0:

> CSC : error CS0006: Metadata file 'C:\development\quartznet\src\Quartz.Benchmark\bin\Release\net6.0\ref\Quartz.Benchmark.dll' could not be found [C:\development\quartznet\src\Quartz.Benchmark\bin\release\net6.0\eabb1d91-56a8-446e-b662-2e305185d641\BenchmarkDotNet.Autogenerated.csproj]
Build FAILED.
> CSC : error CS0006: Metadata file 'C:\development\quartznet\src\Quartz.Benchmark\bin\Release\net6.0\ref\Quartz.Benchmark.dll' could not be found [C:\development\quartznet\src\Quartz.Benchmark\bin\release\net6.0\eabb1d91-56a8-446e-b662-2e305185d641\BenchmarkDotNet.Autogenerated.csproj]

I also added a test that I forgot to commit in my previous PR.