### PR TITLE
Optimize notify of trigger listeners by only locking and allocating w…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,13 @@
     **ListenerManager** on **QuartzScheduler** allows more control over the events that a **IJobListener** will
     receive.
 
+  * To improve performance and reduce allocations, `IListenerManager.GetTriggerListeners()` now returns (a shallow copy of)
+    the registered **ITriggerListener** instances as an array instead of an **IReadOnlyCollection<ITriggerListener>**.
+
+  * **QuartzScheduler** no longer defines properties and methods for accessing or manipulating internal trigger listeners.
+    **ListenerManager** on **QuartzScheduler** allows more control over the events that a **ITriggerListener** will
+    receive.
+
 ## Release 3.4.0, Mar 27 2022
 
 This release has Quartz jobs start executing only after application startup completes successfully, unless QuartzHostedServiceOptions are used to specify otherwise.

--- a/src/Quartz.Benchmark/Directory.Build.props
+++ b/src/Quartz.Benchmark/Directory.Build.props
@@ -1,7 +1,0 @@
-<Project>
-  <Import Project="..\Directory.Build.props" />
-
-  <PropertyGroup>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-  </PropertyGroup>
-</Project>

--- a/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
@@ -16,9 +16,9 @@ namespace Quartz.Benchmark
     /// |           |    job    | scheduler |  trigger  |    job    | scheduler |  trigger  |
     /// | --------- | --------- | --------- | --------- | --------- | --------- | --------- |
     /// |     1     |     1     |     0     |     0     |     0     |     0     |     0     |
-    /// |     2     |     1     |     1     |     1     |     1     |     0     |     0     |
+    /// |     2     |     1     |     1     |     0     |     1     |     0     |     0     |
     /// |     3     |     1     |     0     |     0     |     1     |     1     |     1     |
-    /// |     4     |     1     |     1     |     1     |     2     |     1     |     1     |
+    /// |     4     |     1     |     1     |     0     |     2     |     1     |     2     |
     /// 
     /// Note:
     /// -----
@@ -43,7 +43,6 @@ namespace Quartz.Benchmark
             _quartzScheduler2 = CreateQuartzScheduler("#2", "#2", 5);
             _quartzScheduler2.ListenerManager.AddJobListener(new NoOpListener("GlobalJob1"));
             _quartzScheduler2.AddInternalSchedulerListener(new NoOpListener("InternalScheduler1"));
-            _quartzScheduler2.AddInternalTriggerListener(new NoOpListener("InternalTrigger1"));
 
             _quartzScheduler3 = CreateQuartzScheduler("#3", "#3", 5);
             _quartzScheduler3.ListenerManager.AddJobListener(new NoOpListener("GlobalJob1"), EverythingMatcher<JobKey>.AllJobs());
@@ -52,11 +51,11 @@ namespace Quartz.Benchmark
 
             _quartzScheduler4 = CreateQuartzScheduler("#4", "#4", 5);
             _quartzScheduler4.AddInternalSchedulerListener(new NoOpListener("InternalScheduler1"));
-            _quartzScheduler4.AddInternalTriggerListener(new NoOpListener("InternalTrigger1"));
             _quartzScheduler4.ListenerManager.AddJobListener(new NoOpListener("GlobalJob1"));
             _quartzScheduler4.ListenerManager.AddJobListener(new NoOpListener("GlobalJob2"), EverythingMatcher<JobKey>.AllJobs());
             _quartzScheduler4.ListenerManager.AddSchedulerListener(new NoOpListener("GlobalScheduler1"));
             _quartzScheduler4.ListenerManager.AddTriggerListener(new NoOpListener("GlobalTrigger1"));
+            _quartzScheduler4.ListenerManager.AddTriggerListener(new NoOpListener("GlobalTrigger2"), EverythingMatcher<TriggerKey>.AllTriggers());
 
             _basicScheduler = new StdScheduler(_quartzScheduler1);
 

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <!-- Necessary to run benchmarks on .NET 6.0+ -->
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
@@ -12,7 +12,6 @@ namespace Quartz.Tests.Unit.Core
     /// <summary>
     /// Tests for <see cref="ListenerManagerImpl" />. 
     /// </summary>
-    [TestFixture]
     public class ListenerManagerTest
     {
         private ListenerManagerImpl _manager;
@@ -47,7 +46,61 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ArrayOfMatcherIsNull_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        public void AddJobListener_ArrayOfMatcher_JobListenerIsNull()
+        {
+            const IJobListener jobListener = null;
+            var matchers = Array.Empty<IMatcher<JobKey>>();
+
+            try
+            {
+                _manager.AddJobListener(jobListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddJobListener_ArrayOfMatcher_NameOfJobListenerIsNull()
+        {
+            var jobListener = new TestJobListener(null);
+            var matchers = Array.Empty<IMatcher<JobKey>>();
+
+            try
+            { 
+                _manager.AddJobListener(jobListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddJobListener_ArrayOfMatcher_NameOfJobListenerIsEmpty()
+        {
+            var jobListener = new TestJobListener(String.Empty);
+            var matchers = Array.Empty<IMatcher<JobKey>>();
+
+            try
+            {
+                _manager.AddJobListener(jobListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddJobListener_ArrayOfMatcher_MatchersIsNull_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
         {
             const IMatcher<JobKey>[] setMatchers = null;
 
@@ -68,7 +121,7 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ArrayOfMatcherIsNull_JobListenerDoesntAlreadyExist()
+        public void AddJobListener_ArrayOfMatcher_MatchersIsNull_JobListenerDoesntAlreadyExist()
         {
             const IMatcher<JobKey>[] setMatchers = null;
 
@@ -86,7 +139,7 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ArrayOfMatcherIsEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        public void AddJobListener_ArrayOfMatcher_MatchersIsEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
         {
             var tl1a = new TestJobListener("tl1");
             var tl1b = new TestJobListener("tl1");
@@ -106,7 +159,7 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ArrayOfMatcherIsEmpty_JobListenerDoesntAlreadyExist()
+        public void AddJobListener_ArrayOfMatcher_MatchersIsEmpty_JobListenerDoesntAlreadyExist()
         {
             var tl1 = new TestJobListener("tl1");
             var setMatchers = Array.Empty<IMatcher<JobKey>>();
@@ -123,7 +176,7 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ArrayOfMatcherIsNotEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        public void AddJobListener_ArrayOfMatcher_MatchersIsNotEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
         {
             var tl1a = new TestJobListener("tl1");
             var tl1b = new TestJobListener("tl1");
@@ -148,7 +201,7 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ArrayOfMatcherIsNotEmpty_JobListenerDoesntAlreadyExist()
+        public void AddJobListener_ArrayOfMatcher_MatchersIsNotEmpty_JobListenerDoesntAlreadyExist()
         {
             var tl1 = new TestJobListener("tl1");
             var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
@@ -168,7 +221,61 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ReadOnlyCollectionOfMatcherIsNull_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        public void AddJobListener_ReadOnlyCollectionOfMatcher_JobListenerIsNull()
+        {
+            const IJobListener jobListener = null;
+            IReadOnlyCollection<IMatcher<JobKey>> matchers = Array.Empty<IMatcher<JobKey>>();
+
+            try
+            {
+                _manager.AddJobListener(jobListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddJobListener_ReadOnlyCollectionOfMatcher_NameOfJobListenerIsNull()
+        {
+            var jobListener = new TestJobListener(null);
+            IReadOnlyCollection<IMatcher<JobKey>> matchers = Array.Empty<IMatcher<JobKey>>();
+
+            try
+            {
+                _manager.AddJobListener(jobListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddJobListener_ReadOnlyCollectionOfMatcher_NameOfJobListenerIsEmpty()
+        {
+            var jobListener = new TestJobListener(String.Empty);
+            IReadOnlyCollection<IMatcher<JobKey>> matchers = Array.Empty<IMatcher<JobKey>>();
+
+            try
+            {
+                _manager.AddJobListener(jobListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddJobListener_ReadOnlyCollectionOfMatcher_MatchersIsNull_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
         {
             const IReadOnlyCollection<IMatcher<JobKey>> setMatchers = null;
 
@@ -189,7 +296,7 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ReadOnlyCollectionOfMatcherIsEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        public void AddJobListener_ReadOnlyCollectionOfMatcher_MatchersIsEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
         {
             var tl1a = new TestJobListener("tl1");
             var tl1b = new TestJobListener("tl1");
@@ -211,7 +318,7 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void AddJobListener_ReadOnlyCollectionOfMatcherIsNotEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        public void AddJobListener_ReadOnlyCollectionOfMatcher_MatchersIsNotEmpty_JobListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
         {
             var tl1a = new TestJobListener("tl1");
             var tl1b = new TestJobListener("tl1");
@@ -700,26 +807,764 @@ namespace Quartz.Tests.Unit.Core
         }
 
         [Test]
-        public void testManagementOfTriggerListeners()
+        public void AddTriggerListener_ArrayOfMatcher_TriggerListenerIsNull()
+        {
+            const ITriggerListener triggerListener = null;
+            var matchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            try
+            {
+                _manager.AddTriggerListener(triggerListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddTriggerListener_ArrayOfMatcher_NameOfTriggerListenerIsNull()
+        {
+            var triggerListener = new TestTriggerListener(null);
+            var matchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            try
+            {
+                _manager.AddTriggerListener(triggerListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddTriggerListener_ArrayOfMatcher_NameOfTriggerListenerIsEmpty()
+        {
+            var triggerListener = new TestTriggerListener(String.Empty);
+            var matchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            try
+            {
+                _manager.AddTriggerListener(triggerListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddTriggerListener_ArrayOfMatcher_MatchersIsNull_TriggerListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            const IMatcher<TriggerKey>[] setMatchers = null;
+
+            var tl1a = new TestTriggerListener("tl1");
+            var tl1b = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+
+            _manager.AddTriggerListener(tl1a, groupMatcher);
+            _manager.AddTriggerListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddTriggerListener_ArrayOfMatcher_MatchersIsNull_TriggerListenerDoesntAlreadyExist()
+        {
+            const IMatcher<TriggerKey>[] setMatchers = null;
+
+            var tl1 = new TestTriggerListener("tl1");
+
+            _manager.AddTriggerListener(tl1, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddTriggerListener_ArrayOfMatcher_MatchersIsEmpty_TriggerListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            var tl1a = new TestTriggerListener("tl1");
+            var tl1b = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var setMatchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            _manager.AddTriggerListener(tl1a, groupMatcher);
+            _manager.AddTriggerListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddTriggerListener_ArrayOfMatcher_MatchersIsEmpty_TriggerListenerDoesntAlreadyExist()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var setMatchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            _manager.AddTriggerListener(tl1, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddTriggerListener_ArrayOfMatcher_MatchersIsNotEmpty_TriggerListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            var tl1a = new TestTriggerListener("tl1");
+            var tl1b = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+
+            _manager.AddTriggerListener(tl1a, groupMatcher);
+
+            var setMatchers = new IMatcher<TriggerKey>[] { nameMatcher };
+
+            _manager.AddTriggerListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }));
+        }
+
+        [Test]
+        public void AddTriggerListener_ArrayOfMatcher_MatchersIsNotEmpty_TriggerListenerDoesntAlreadyExist()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+            var setMatchers = new IMatcher<TriggerKey>[] { nameMatcher };
+
+            _manager.AddTriggerListener(tl1, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }));
+        }
+
+        [Test]
+        public void AddTriggerListener_ReadOnlyCollectionOfMatcher_TriggerListenerIsNull()
+        {
+            const ITriggerListener triggerListener = null;
+            IReadOnlyCollection<IMatcher<TriggerKey>> matchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            try
+            {
+                _manager.AddTriggerListener(triggerListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddTriggerListener_ReadOnlyCollectionOfMatcher_NameOfTriggerListenerIsNull()
+        {
+            var triggerListener = new TestTriggerListener(null);
+            IReadOnlyCollection<IMatcher<TriggerKey>> matchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            try
+            {
+                _manager.AddTriggerListener(triggerListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddTriggerListener_ReadOnlyCollectionOfMatcher_NameOfTriggerListenerIsEmpty()
+        {
+            var triggerListener = new TestTriggerListener(String.Empty);
+            IReadOnlyCollection<IMatcher<TriggerKey>> matchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            try
+            {
+                _manager.AddTriggerListener(triggerListener, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddTriggerListener_ReadOnlyCollectionOfMatcher_MatchersIsNull_TriggerListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            const IReadOnlyCollection<IMatcher<TriggerKey>> setMatchers = null;
+
+            var tl1a = new TestTriggerListener("tl1");
+            var tl1b = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+
+            _manager.AddTriggerListener(tl1a, groupMatcher);
+            _manager.AddTriggerListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddTriggerListener_ReadOnlyCollectionOfMatcher_MatchersIsEmpty_TriggerListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            var tl1a = new TestTriggerListener("tl1");
+            var tl1b = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+
+            _manager.AddTriggerListener(tl1a, groupMatcher);
+
+            IReadOnlyCollection<IMatcher<TriggerKey>> setMatchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            _manager.AddTriggerListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
+            Assert.IsNull(matchers);
+        }
+
+        [Test]
+        public void AddTriggerListener_ReadOnlyCollectionOfMatcher_MatchersIsNotEmpty_TriggerListenerWithSameNameAlreadyExistsWithOneOrMoreMatchers()
+        {
+            var tl1a = new TestTriggerListener("tl1");
+            var tl1b = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+
+            _manager.AddTriggerListener(tl1a, groupMatcher);
+
+            IReadOnlyCollection<IMatcher<TriggerKey>> setMatchers = new IMatcher<TriggerKey>[] { nameMatcher };
+
+            _manager.AddTriggerListener(tl1b, setMatchers);
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1b, jobListeners[0]);
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }));
+        }
+
+        [Test]
+        public void AddTriggerListenerMatcher_ListenerNameIsNull()
+        {
+            const string listenerName = null;
+
+            var matcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+
+            try
+            {
+                _manager.AddTriggerListenerMatcher(listenerName, matcher);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddTriggerListenerMatcher_MatcherIsNull()
+        {
+            const IMatcher<TriggerKey> matcher = null;
+
+            try
+            {
+                _manager.AddTriggerListenerMatcher("A", matcher);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(matcher), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void AddTriggerListenerMatcher_ListenerWasFirstRegisteredWithoutMatchers()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+
+            _manager.AddTriggerListener(tl1);
+            Assert.IsTrue(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher));
+            Assert.IsTrue(_manager.AddTriggerListenerMatcher(tl1.Name, nameMatcher));
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(2, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher }));
+        }
+
+        [Test]
+        public void AddTriggerListenerMatcher_ListenerWasFirstRegisteredWithMatchers()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+
+            _manager.AddTriggerListener(tl1, nameMatcher);
+            Assert.IsTrue(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher));
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(2, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher, groupMatcher }));
+        }
+
+        [Test]
+        public void GetTriggerListener_ShouldThrowKeyNotFoundExceptionWhenNoTriggerListenerExistsWithSpecifiedName()
+        {
+            const string name = "A";
+
+            Assert.Throws<KeyNotFoundException>(() => _manager.GetTriggerListener(name));
+
+            _manager.AddTriggerListener(new TestTriggerListener("B"));
+
+            Assert.Throws<KeyNotFoundException>(() => _manager.GetTriggerListener(name));
+        }
+
+        [Test]
+        public void GetTriggerListener_ShouldThrowArgumentNullExceptionWhenNameIsNull()
+        {
+            const string name = null;
+
+            try
+            {
+                _manager.GetTriggerListener(name);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(name), ex.ParamName);
+            }
+
+            _manager.AddTriggerListener(new TestTriggerListener("B"));
+
+            try
+            {
+                _manager.GetTriggerListener(name);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(name), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void GetTriggerListeners_ShouldReturnShallowClone()
         {
             var tl1 = new TestTriggerListener("tl1");
             var tl2 = new TestTriggerListener("tl2");
 
-            // test adding listener without matcher
             _manager.AddTriggerListener(tl1);
-            Assert.AreEqual(1, _manager.GetTriggerListeners().Length, "Unexpected size of listener list");
 
-            // test adding listener with matcher
-            _manager.AddTriggerListener(tl2, GroupMatcher<TriggerKey>.GroupEquals("foo"));
-            Assert.AreEqual(2, _manager.GetTriggerListeners().Length, "Unexpected size of listener list");
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
 
-            // test removing a listener
-            _manager.RemoveTriggerListener("tl1");
-            Assert.AreEqual(1, _manager.GetTriggerListeners().Length, "Unexpected size of listener list");
+            jobListeners[0] = tl2;
 
-            // test adding a matcher
-            _manager.AddTriggerListenerMatcher("tl2", NameMatcher<TriggerKey>.NameContains("foo"));
-            Assert.AreEqual(2, _manager.GetTriggerListenerMatchers("tl2").Count, "Unexpected size of listener's matcher list");
+            jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+        }
+
+        [Test]
+        public void GetTriggerListeners_ShouldReturnEmptyArrayWhenNoTriggerListenersHaveBeenAdded()
+        {
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.AreSame(Array.Empty<ITriggerListener>(), jobListeners);
+        }
+
+        [Test]
+        public void GetTriggerListenerMatchers_ListenerNameIsNull()
+        {
+            const string listenerName = null;
+
+            try
+            {
+                _manager.GetTriggerListenerMatchers(listenerName);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void RemoveTriggerListener_NameIsNull()
+        {
+            const string name = null;
+
+            try
+            {
+                _manager.RemoveTriggerListener(name);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(name), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void RemoveTriggerListener_NoMatchersRegisteredForSpecifiedTriggerListener()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var tl2 = new TestTriggerListener("tl2");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+
+            _manager.AddTriggerListener(tl1, groupMatcher);
+            _manager.AddTriggerListener(tl2);
+
+            Assert.IsTrue(_manager.RemoveTriggerListener(tl2.Name));
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
+            Assert.IsNull(matchersTl2);
+
+            var matchersTl1 = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchersTl1);
+            Assert.IsTrue(matchersTl1.SequenceEqual(new[] { groupMatcher }));
+        }
+
+        [Test]
+        public void RemoveTriggerListener_MatchersRegisteredForSpecifiedTriggerListener()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var tl2 = new TestTriggerListener("tl2");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+
+            _manager.AddTriggerListener(tl1, groupMatcher);
+            _manager.AddTriggerListener(tl2, nameMatcher);
+
+            Assert.IsTrue(_manager.RemoveTriggerListener(tl2.Name));
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+
+            var matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
+            Assert.IsNull(matchersTl2);
+
+            var matchersTl1 = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchersTl1);
+            Assert.IsTrue(matchersTl1.SequenceEqual(new[] { groupMatcher }));
+
+            // Ensure adding back the listener without matchers does not "magically" recover the
+            // matchers that were registered before we removed the listener
+            _manager.AddTriggerListener(tl2);
+
+            jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(2, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+            Assert.AreSame(tl2, jobListeners[1]);
+
+            matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
+            Assert.IsNull(matchersTl2);
+        }
+
+        [Test]
+        public void RemoveTriggerListener_NoTriggerListenerRegisteredWithSpecifiedName()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var tl2 = new TestTriggerListener("tl2");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+
+            _manager.AddTriggerListener(tl1, groupMatcher);
+
+            Assert.IsFalse(_manager.RemoveTriggerListener(tl2.Name));
+
+            var jobListeners = _manager.GetTriggerListeners();
+            Assert.IsNotNull(jobListeners);
+            Assert.AreEqual(1, jobListeners.Length);
+            Assert.AreSame(tl1, jobListeners[0]);
+        }
+
+        [Test]
+        public void RemoveTriggerListenerMatcher_ListenerNameIsNull()
+        {
+            const string listenerName = null;
+
+            var matcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+
+            try
+            {
+                _manager.RemoveTriggerListenerMatcher(listenerName, matcher);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void RemoveTriggerListenerMatcher_MatcherIsNull()
+        {
+            const IMatcher<TriggerKey> matcher = null;
+
+            try
+            {
+                _manager.RemoveTriggerListenerMatcher("A", matcher);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(matcher), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void RemoveTriggerListenerMatcher_MatcherWasAddedForSpecifiedListener()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+
+            _manager.AddTriggerListener(tl1, groupMatcher, nameMatcher);
+
+            Assert.IsTrue(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher));
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new[] { nameMatcher }));
+
+            Assert.IsTrue(_manager.RemoveTriggerListenerMatcher(tl1.Name, nameMatcher));
+            Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void RemoveTriggerListenerMatcher_MatcherWasNotAddedForSpecifiedListener()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+
+            _manager.AddTriggerListener(tl1);
+
+            Assert.False(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher));
+            Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+
+            _manager.AddTriggerListenerMatcher(tl1.Name, nameMatcher);
+
+            Assert.False(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher));
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(1, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(new[] { nameMatcher }));
+        }
+
+        [Test]
+        public void RemoveTriggerListenerMatcher_TriggerListenerIsNotRegistered()
+        {
+            const string listenerName = "A";
+
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+
+            Assert.False(_manager.RemoveTriggerListenerMatcher(listenerName, groupMatcher));
+            Assert.IsNull(_manager.GetTriggerListenerMatchers(listenerName));
+        }
+
+        [Test]
+        public void SetTriggerListenerMatchers_ListenerNameIsNull()
+        {
+            const string listenerName = null;
+
+            var matchers = new[] { GroupMatcher<TriggerKey>.GroupEquals("foo") };
+
+            try
+            {
+                _manager.SetTriggerListenerMatchers(listenerName, matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void SetTriggerListenerMatchers_MatchersIsNull()
+        {
+            const IReadOnlyCollection<IMatcher<TriggerKey>> matchers = null;
+
+            try
+            {
+                _manager.SetTriggerListenerMatchers("A", matchers);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsNull(ex.InnerException);
+                Assert.AreEqual(nameof(matchers), ex.ParamName);
+            }
+        }
+
+        [Test]
+        public void SetTriggerListenerMatchers_MatchersIsEmpty_ListenerDoesNotExist()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var setMatchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            Assert.IsFalse(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
+            Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void SetTriggerListenerMatchers_MatchersIsEmpty_ListenerHasNoMatchers()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var setMatchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            _manager.AddTriggerListener(tl1);
+
+            Assert.IsTrue(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
+            Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void SetTriggerListenerMatchers_MatchersIsEmpty_ListenerHasMatchers()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var setMatchers = Array.Empty<IMatcher<TriggerKey>>();
+
+            _manager.AddTriggerListener(tl1, groupMatcher);
+
+            Assert.IsTrue(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
+            Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void SetTriggerListenerMatchers_MatchersIsNotEmpty_ListenerDoesNotExist()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+            var setMatchers = new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher };
+
+            Assert.IsFalse(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
+            Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        }
+
+        [Test]
+        public void SetTriggerListenerMatchers_MatchersIsNotEmpty_ListenerHasNoMatchers()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+            var setMatchers = new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher };
+
+            _manager.AddTriggerListener(tl1);
+
+            Assert.IsTrue(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(setMatchers.Length, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(setMatchers));
+        }
+
+        [Test]
+        public void SetTriggerListenerMatchers_MatchersIsNotEmpty_ListenerHasMatchers()
+        {
+            var tl1 = new TestTriggerListener("tl1");
+
+            var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
+            var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
+            var setMatchers = new IMatcher<TriggerKey>[] { nameMatcher };
+
+            _manager.AddTriggerListener(tl1, groupMatcher);
+
+            Assert.IsTrue(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
+
+            var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
+            Assert.IsNotNull(matchers);
+            Assert.AreEqual(setMatchers.Length, matchers.Count);
+            Assert.IsTrue(matchers.SequenceEqual(setMatchers));
         }
 
         [Test]

--- a/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
@@ -707,15 +707,15 @@ namespace Quartz.Tests.Unit.Core
 
             // test adding listener without matcher
             _manager.AddTriggerListener(tl1);
-            Assert.AreEqual(1, _manager.GetTriggerListeners().Count, "Unexpected size of listener list");
+            Assert.AreEqual(1, _manager.GetTriggerListeners().Length, "Unexpected size of listener list");
 
             // test adding listener with matcher
             _manager.AddTriggerListener(tl2, GroupMatcher<TriggerKey>.GroupEquals("foo"));
-            Assert.AreEqual(2, _manager.GetTriggerListeners().Count, "Unexpected size of listener list");
+            Assert.AreEqual(2, _manager.GetTriggerListeners().Length, "Unexpected size of listener list");
 
             // test removing a listener
             _manager.RemoveTriggerListener("tl1");
-            Assert.AreEqual(1, _manager.GetTriggerListeners().Count, "Unexpected size of listener list");
+            Assert.AreEqual(1, _manager.GetTriggerListeners().Length, "Unexpected size of listener list");
 
             // test adding a matcher
             _manager.AddTriggerListenerMatcher("tl2", NameMatcher<TriggerKey>.NameContains("foo"));

--- a/src/Quartz/Core/ListenerManagerImpl.cs
+++ b/src/Quartz/Core/ListenerManagerImpl.cs
@@ -30,9 +30,14 @@ namespace Quartz.Core
 
         public void AddJobListener(IJobListener jobListener, IReadOnlyCollection<IMatcher<JobKey>> matchers)
         {
+            if (jobListener == null)
+            {
+                throw new ArgumentNullException(nameof(jobListener));
+            }
+
             if (string.IsNullOrEmpty(jobListener.Name))
             {
-                throw new ArgumentException($"{nameof(jobListener.Name)} cannot be empty.", nameof(jobListener));
+                throw new ArgumentException($"{nameof(jobListener.Name)} cannot be null or empty.", nameof(jobListener));
             }
 
             lock (globalJobListenerLock)
@@ -261,6 +266,11 @@ namespace Quartz.Core
 
         public void AddTriggerListener(ITriggerListener triggerListener, IReadOnlyCollection<IMatcher<TriggerKey>> matchers)
         {
+            if (triggerListener == null)
+            {
+                throw new ArgumentNullException(nameof(triggerListener));
+            }
+
             if (string.IsNullOrEmpty(triggerListener.Name))
             {
                 throw new ArgumentException($"{nameof(triggerListener.Name)} cannot be empty.", nameof(triggerListener));
@@ -281,7 +291,7 @@ namespace Quartz.Core
                 else
                 {
                     // Remove any registered matchers for the trigger listener
-                    RemoveJobListenerMatchers(triggerListener.Name);
+                    RemoveTriggerListenerMatchers(triggerListener.Name);
                 }
             }
         }
@@ -300,7 +310,7 @@ namespace Quartz.Core
 
             if (string.IsNullOrEmpty(triggerListener.Name))
             {
-                throw new ArgumentException($"{nameof(triggerListener.Name)} cannot be empty.", nameof(triggerListener));
+                throw new ArgumentException($"{nameof(triggerListener.Name)} cannot be null or empty.", nameof(triggerListener));
             }
 
             lock (globalTriggerListenerLock)

--- a/src/Quartz/IListenerManager.cs
+++ b/src/Quartz/IListenerManager.cs
@@ -164,7 +164,7 @@ namespace Quartz
         IJobListener GetJobListener(string name);
 
         /// <summary>
-        /// Add the given <see cref="ITriggerListener" /> to the<see cref="IScheduler" />,
+        /// Add the given <see cref="ITriggerListener" /> to the <see cref="IScheduler" />,
         /// and register it to receive events for Triggers that are matched by ANY of the
         /// given Matchers.
         /// </summary>
@@ -176,7 +176,7 @@ namespace Quartz
         void AddTriggerListener(ITriggerListener triggerListener, params IMatcher<TriggerKey>[] matchers);
 
         /// <summary>
-        /// Add the given <see cref="ITriggerListener" /> to the<see cref="IScheduler" />,
+        /// Add the given <see cref="ITriggerListener" /> to the <see cref="IScheduler" />,
         /// and register it to receive events for Triggers that are matched by ANY of the
         /// given Matchers.
         /// </summary>
@@ -232,7 +232,7 @@ namespace Quartz
         IReadOnlyCollection<IMatcher<TriggerKey>>? GetTriggerListenerMatchers(string listenerName);
 
         /// <summary>
-        /// Remove the identified <see cref="ITriggerListener" /> from the<see cref="IScheduler" />.
+        /// Removes the identified <see cref="ITriggerListener" /> from the <see cref="IScheduler" />.
         /// </summary>
         /// <remarks>
         /// </remarks>
@@ -241,10 +241,12 @@ namespace Quartz
         bool RemoveTriggerListener(string name);
 
         /// <summary>
-        /// Get a List containing all of the <see cref="ITriggerListener" />s
-        /// in the<see cref="IScheduler" />.
+        /// Gets all of the <see cref="ITriggerListener" /> instances in the <see cref="IScheduler" />.
         /// </summary>
-        IReadOnlyCollection<ITriggerListener> GetTriggerListeners();
+        /// <returns>
+        /// A shallow copy of all <see cref="ITriggerListener" /> instances that are registered.
+        /// </returns>
+        ITriggerListener[] GetTriggerListeners();
 
         /// <summary>
         /// Get the <see cref="ITriggerListener" /> that has the given name.
@@ -268,7 +270,7 @@ namespace Quartz
 
         /// <summary>
         /// Get a List containing all of the <see cref="ISchedulerListener" />s
-        /// registered with the<see cref="IScheduler" />.
+        /// registered with the <see cref="IScheduler" />.
         /// </summary>
         IReadOnlyCollection<ISchedulerListener> GetSchedulerListeners();
     }


### PR DESCRIPTION
Optimize notify of trigger listeners by only locking and allocating when non-global trigger listeners have been added.
No longer define properties and methods for accessing or manipulating internal trigger listeners.

**.NET 4.8**

|                                                      Method | Branch |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------------------------------------------ |-------:|-----------|----------:|----------:|-------:|----------:|
| Success_NoTriggerListenersAndSingleJobListener_MayFireAgain | main   |  1322  ns | 2.62 ns   | 2.45 ns   | 0.1163 |     489 B |
| Success_NoTriggerListenersAndSingleJobListener_MayFireAgain | pr     |  936.7 ns | 3.30 ns   | 2.76 ns   | 0.0858 |     361 B |

**.NET 6.0**

|                                                      Method | Branch |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------------------------------------------ |-------:|-----------|----------:|----------:|-------:|----------:|
| Success_NoTriggerListenersAndSingleJobListener_MayFireAgain | main   | 902.0 ns  | 3.47 ns   | 3.24 ns   | 0.0668 |     280 B |
| Success_NoTriggerListenersAndSingleJobListener_MayFireAgain | pr     | 617.6 ns  | 1.12 ns   | 0.99 ns   | 0.0362 |     152 B |
