### PR TITLE
Fix pathname in job-stores documentation.

### DIFF
--- a/docs/documentation/quartz-3.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-3.x/tutorial/job-stores.md
@@ -38,7 +38,7 @@ Because of this it is a bit more complicated to configure than `RAMJobStore`, an
 However, the performance draw-back is not terribly bad, especially if you build the database tables with indexes on the primary keys. 
 
 To use AdoJobStore, you must first create a set of database tables for Quartz.NET to use. 
-You can find table-creation SQL scripts in the "database/dbtables" directory of the Quartz.NET distribution. 
+You can find table-creation SQL scripts in the "database/tables" directory of the Quartz.NET distribution. 
 If there is not already a script for your database type, just look at one of the existing ones, and modify it in any way necessary for your DB. 
 One thing to note is that in these scripts, all the the tables start with the prefix `QRTZ_` 
 (such as the tables `QRTZ_TRIGGERS`, and `QRTZ_JOB_DETAIL`). This prefix can actually be anything you'd like, as long as you inform AdoJobStore


### PR DESCRIPTION
The path in the section about the ADO storage is not correct. This fixes it.