### PR TITLE
Serialized field for Job Type to enable maintenance on Jobs that cannot be constructed to their Type

### DIFF
--- a/src/Quartz.Tests.Integration/JobMaintenanceTests.cs
+++ b/src/Quartz.Tests.Integration/JobMaintenanceTests.cs
@@ -1,0 +1,81 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Data.SqlClient;
+
+using NUnit.Framework;
+
+using Quartz.Tests.Integration.TestHelpers;
+
+namespace Quartz.Tests.Integration;
+
+[TestFixture]
+public class JobMaintenanceTests : IntegrationTest
+{
+    [Test]
+    public async Task CanUnscheduleNonConstructableTypeJobs()
+    {
+        var scheduler = await GetACleanScheduler();
+
+        const string jobKey = "CanDeleteUnknownTypeJobs";
+        const string triggerKey = "CanDeleteUnknownTypeJobsTrigger";
+        var jobDetail = JobBuilder.Create<KnownJobType>()
+            .WithIdentity(jobKey)
+            .UsingJobData("jfoo", "bar")
+            .Build();
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity(triggerKey)
+            .WithCronSchedule("0 0 0 * * ?")
+            .UsingJobData("tfoo", "bar")
+            .Build();
+
+        await scheduler.ScheduleJob(jobDetail, trigger);
+
+        RenameJobClass("Quartz.Tests.Integration.JobMaintenanceTests+UnKnownJobType");
+
+        // assert job is stored
+        var storedJobDetail = await scheduler.GetJobDetail(new JobKey(jobKey));
+        var storedJobMap = storedJobDetail.JobDataMap;
+        Assert.That(storedJobMap.Dirty, Is.False);
+
+        var storedTrigger = await scheduler.GetTrigger(new TriggerKey(triggerKey));
+        var storedTriggerMap = storedTrigger.JobDataMap;
+        Assert.That(storedTriggerMap.Dirty, Is.False);
+
+        // assert can unSchedule
+        var unscheduleResponse = await scheduler.UnscheduleJob(new TriggerKey(triggerKey), CancellationToken.None);
+        unscheduleResponse.Should().BeTrue();
+    }
+
+    private async Task<IScheduler> GetACleanScheduler()
+    {
+        var scheduler = await SchedulerHelper.CreateScheduler(nameof(JobMaintenanceTests));
+        await scheduler.Clear();
+        return scheduler;
+    }
+
+    // Rename the Job Type ClassName
+    private static void RenameJobClass(string jobClassName)
+    {
+        using var dbConnection = new SqlConnection(TestConstants.SqlServerConnectionString);
+
+        var sql = $@"
+update {SchedulerHelper.TablePrefix}JOB_DETAILS
+set JOB_CLASS_NAME = '{jobClassName}'
+where SCHED_NAME = 'JobMaintenanceTestsScheduler'";
+        dbConnection.Open();
+        using var command = new SqlCommand(sql, dbConnection);
+        command.ExecuteNonQuery();
+    }
+
+    public class KnownJobType : IJob
+    {
+        public Task Execute(IJobExecutionContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/JobMaintenanceTests.cs
+++ b/src/Quartz.Tests.Integration/JobMaintenanceTests.cs
@@ -11,7 +11,6 @@ using Quartz.Tests.Integration.TestHelpers;
 
 namespace Quartz.Tests.Integration;
 
-[TestFixture]
 public class JobMaintenanceTests : IntegrationTest
 {
     [Test]

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -39,7 +39,4 @@
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="19.7.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="TestHelpers\" />
-  </ItemGroup>
 </Project>

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.0-alpha" PrivateAssets="all" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="8.5.4" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="MELT" Version="0.8.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
     <PackageReference Include="Microsoft.Data.SQLite" Version="3.1.6" />
@@ -37,5 +38,8 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="19.7.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="TestHelpers\" />
   </ItemGroup>
 </Project>

--- a/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using NUnit.Framework;
 
+using Quartz.Impl;
 using Quartz.Impl.Matchers;
 
 namespace Quartz.Tests.Integration
@@ -360,7 +361,9 @@ namespace Quartz.Tests.Integration
         [Test]
         public async Task TestDurableStorageFunctions()
         {
-            IScheduler sched = await CreateScheduler("testDurableStorageFunctions", 2);
+            const string schedulerName = "testDurableStorageFunctions";
+            SchedulerRepository.Instance.Remove(schedulerName + "Scheduler"); // workaround prior test cleanup - relates to issue in #1453
+            IScheduler sched = await CreateScheduler(schedulerName, 2);
             await sched.Clear();
 
             // test basic storage functions of scheduler...

--- a/src/Quartz.Tests.Integration/TestHelpers/SchedulerHelper.cs
+++ b/src/Quartz.Tests.Integration/TestHelpers/SchedulerHelper.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Simpl;
+using Quartz.Util;
+
+namespace Quartz.Tests.Integration.TestHelpers;
+
+public class SchedulerHelper
+{
+    public const string TablePrefix = "QRTZ_";
+
+    public static Task<IScheduler> CreateScheduler(string name)
+    {
+        DBConnectionManager.Instance.AddConnectionProvider("default", new DbProvider(TestConstants.DefaultSqlServerProvider, TestConstants.SqlServerConnectionString));
+
+        var serializer = new JsonObjectSerializer();
+        serializer.Initialize();
+        var jobStore = new JobStoreTX
+        {
+            DataSource = "default",
+            TablePrefix = TablePrefix,
+            InstanceId = "AUTO",
+            DriverDelegateType = typeof(SqlServerDelegate).AssemblyQualifiedName,
+            ObjectSerializer = serializer
+        };
+
+        DirectSchedulerFactory.Instance.CreateScheduler(name + "Scheduler", "AUTO", new DefaultThreadPool(), jobStore);
+        return SchedulerRepository.Instance.Lookup(name + "Scheduler");
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/JobType/JobTypeTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/JobType/JobTypeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 using FluentAssertions;
 
@@ -11,13 +12,49 @@ public class JobTypeTests
     [Test]
     public void JobTypeMustImplementIJob()
     {
-        Action act = () => new Quartz.Impl.JobType(typeof(ClassDoesNotImplementIJobType));
+        Action act = () => new Quartz.Impl.JobType(typeof(ClassDoesNotImplementIJob));
 
         act.Should().Throw<ArgumentException>()
             .WithMessage("Job class must implement Quartz.IJob interface.");
     }
 
-    public class ClassDoesNotImplementIJobType
+    [Test]
+    public void ConstructUnknownJobTypeName()
+    {
+        const string jobTypeFullName = "Library.UnknownType";
+        var jobType = new Quartz.Impl.JobType(jobTypeFullName);
+        jobType.FullName.Should().Be(jobTypeFullName);
+    }
+
+    [Test]
+    public void ConstructUnknownJobTypeByName_WillThrowOnTypeResolve()
+    {
+        const string jobTypeFullName = "Library.UnknownType";
+        var jobType = new Quartz.Impl.JobType(jobTypeFullName);
+        jobType.FullName.Should().Be(jobTypeFullName);
+
+        jobType.Invoking(jt => jt.Type)
+            .Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
+    public void ConstructWithNameWillReturnType()
+    {
+        var typeFullName = typeof(LoggerJob).AssemblyQualifiedName;
+        var jobType = new Quartz.Impl.JobType(typeFullName);
+        jobType.Type.FullName.Should().Be(typeof(LoggerJob).FullName);
+    }
+
+    public sealed class LoggerJob : IJob
+    {
+        public Task Execute(IJobExecutionContext context)
+        {
+            Console.WriteLine("TestJobExecuted");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class ClassDoesNotImplementIJob
     {
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/JobType/JobTypeTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/JobType/JobTypeTests.cs
@@ -1,0 +1,23 @@
+using System;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace Quartz.Tests.Unit.Impl.JobType;
+
+public class JobTypeTests
+{
+    [Test]
+    public void JobTypeMustImplementIJob()
+    {
+        Action act = () => new Quartz.Impl.JobType(typeof(ClassDoesNotImplementIJobType));
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Job class must implement Quartz.IJob interface.");
+    }
+
+    public class ClassDoesNotImplementIJobType
+    {
+    }
+}

--- a/src/Quartz.Tests.Unit/JobBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/JobBuilderTest.cs
@@ -1,5 +1,7 @@
 using System.Threading.Tasks;
 
+using FluentAssertions;
+
 using NUnit.Framework;
 
 namespace Quartz.Tests.Unit
@@ -57,8 +59,7 @@ namespace Quartz.Tests.Unit
             Assert.IsFalse(job.RequestsRecovery, "Expected requestsRecovery == false ");
             Assert.IsFalse(job.ConcurrentExecutionDisallowed, "Expected isConcurrentExecutionDisallowed == false ");
             Assert.IsFalse(job.PersistJobDataAfterExecution, "Expected isPersistJobDataAfterExecution == false ");
-            Assert.IsTrue(job.JobType.Equals(typeof (TestJob)), "Unexpected job class: " + job.JobType)
-                ;
+            job.JobType.Type.Should().Be(typeof(TestJob));
 
             job = JobBuilder.Create()
                 .OfType<TestAnnotatedJob>()

--- a/src/Quartz.Tests.Unit/JobDetailTest.cs
+++ b/src/Quartz.Tests.Unit/JobDetailTest.cs
@@ -55,7 +55,7 @@ namespace Quartz.Tests.Unit
         [Test]
         public void TestClone()
         {
-            JobDetailImpl jobDetail = new JobDetailImpl();
+            JobDetailImpl jobDetail = new JobDetailImpl("test",typeof(NoOpJob));
             JobDetailImpl clonedJobDetail = (JobDetailImpl) jobDetail.Clone();
 
             Assert.AreEqual(jobDetail, clonedJobDetail);
@@ -78,7 +78,7 @@ namespace Quartz.Tests.Unit
         [Test]
         public void SettingKeyShouldAlsoSetNameAndGroup()
         {
-            JobDetailImpl detail = new JobDetailImpl();
+            JobDetailImpl detail = new JobDetailImpl(nameof(SettingKeyShouldAlsoSetNameAndGroup), typeof(NoOpJob));
             detail.Key = new JobKey("name", "group");
 
             Assert.That(detail.Name, Is.EqualTo("name"));
@@ -104,8 +104,8 @@ namespace Quartz.Tests.Unit
             var type = typeof(GenericJob<string>);
             var job = new JobDetailImpl("name", "group", type, true, true);
             
-            job.JobType.Should().Be(type);
-            job.JobTypeWithStorage.StorableTypeName.Should().Be(type.AssemblyQualifiedNameWithoutVersion());
+            job.JobType.Type.Should().Be(type);
+            job.JobType.FullName.Should().Be(type.AssemblyQualifiedNameWithoutVersion());
         }
 
         public class GenericJob<T> : IJob

--- a/src/Quartz.Tests.Unit/JobDetailTest.cs
+++ b/src/Quartz.Tests.Unit/JobDetailTest.cs
@@ -21,6 +21,8 @@
 
 using System.Threading.Tasks;
 
+using FluentAssertions;
+
 using NUnit.Framework;
 
 using Quartz.Impl;
@@ -94,6 +96,16 @@ namespace Quartz.Tests.Unit
 
             Assert.That(loadedType, Is.Not.Null);
             Assert.That(loadedType, Is.EqualTo(type));
+        }
+
+        [Test]
+        public void CanConstructJobAndReadJobType()
+        {
+            var type = typeof(GenericJob<string>);
+            var job = new JobDetailImpl("name", "group", type, true, true);
+            
+            job.JobType.Should().Be(type);
+            job.JobTypeWithStorage.StorableTypeName.Should().Be(type.AssemblyQualifiedNameWithoutVersion());
         }
 
         public class GenericJob<T> : IJob

--- a/src/Quartz/IJobDetail.cs
+++ b/src/Quartz/IJobDetail.cs
@@ -19,8 +19,6 @@
 
 #endregion
 
-using System;
-
 using Quartz.Impl;
 namespace Quartz
 {
@@ -62,14 +60,9 @@ namespace Quartz
         string? Description { get; }
 
         /// <summary>
-        /// Get or sets the instance of <see cref="IJob" /> that will be executed.
+        /// Get the instance of <see cref="IJob" /> that will be executed.
         /// </summary>
-        Type JobType { get; }
-
-        /// <summary>
-        /// JobType type in serialized format.
-        /// </summary>
-        JobType JobTypeWithStorage { get; }
+        JobType JobType { get; }
 
         /// <summary>
         /// Get or set the <see cref="JobDataMap" /> that is associated with the <see cref="IJob" />.

--- a/src/Quartz/IJobDetail.cs
+++ b/src/Quartz/IJobDetail.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /* 
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -21,6 +21,7 @@
 
 using System;
 
+using Quartz.Impl;
 namespace Quartz
 {
     /// <summary>
@@ -64,6 +65,11 @@ namespace Quartz
         /// Get or sets the instance of <see cref="IJob" /> that will be executed.
         /// </summary>
         Type JobType { get; }
+
+        /// <summary>
+        /// JobType type in serialized format.
+        /// </summary>
+        JobType JobTypeWithStorage { get; }
 
         /// <summary>
         /// Get or set the <see cref="JobDataMap" /> that is associated with the <see cref="IJob" />.

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -17,15 +17,7 @@ namespace Quartz.Impl.AdoJobStore
 {
     public partial class StdAdoDelegate
     {
-        protected virtual string GetStorableJobTypeName(Type jobType)
-        {
-            if (jobType.AssemblyQualifiedName == null)
-            {
-                throw new ArgumentException("Cannot determine job type name when type's AssemblyQualifiedName is null");
-            }
 
-            return jobType.AssemblyQualifiedNameWithoutVersion();
-        }
 
         /// <inheritdoc />
         public virtual async Task<int> UpdateJobDetail(
@@ -38,7 +30,7 @@ namespace Quartz.Impl.AdoJobStore
             using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateJobDetail));
             AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "jobDescription", job.Description);
-            AddCommandParameter(cmd, "jobType", GetStorableJobTypeName(job.JobType));
+            AddCommandParameter(cmd, "jobType", job.JobTypeWithStorage.StorableTypeName);
             AddCommandParameter(cmd, "jobDurable", GetDbBooleanValue(job.Durable));
             AddCommandParameter(cmd, "jobVolatile", GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
             AddCommandParameter(cmd, "jobStateful", GetDbBooleanValue(job.PersistJobDataAfterExecution));
@@ -47,9 +39,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "jobName", job.Key.Name);
             AddCommandParameter(cmd, "jobGroup", job.Key.Group);
 
-            int insertResult = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-
-            return insertResult;
+            return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -147,7 +137,7 @@ namespace Quartz.Impl.AdoJobStore
                 var jobBuilder = JobBuilder.Create()
                     .WithIdentity(new JobKey(rs.GetString(ColumnJobName)!, rs.GetString(ColumnJobGroup)!))
                     .WithDescription(rs.GetString(ColumnDescription))
-                    .OfType(loadHelper.LoadType(rs.GetString(ColumnJobClass)!)!)
+                    .WithJobTypeSerialized(rs.GetString(ColumnJobClass))
                     .RequestRecovery(GetBooleanFromDbValue(rs[ColumnRequestsRecovery]))
                     .StoreDurably(GetBooleanFromDbValue(rs[ColumnIsDurable]));
 
@@ -225,6 +215,7 @@ namespace Quartz.Impl.AdoJobStore
                 var jobBuilder = JobBuilder.Create()
                     .WithIdentity(new JobKey(rs.GetString(ColumnJobName)!, rs.GetString(ColumnJobGroup)!))
                     .RequestRecovery(GetBooleanFromDbValue(rs[ColumnRequestsRecovery]))
+                    .WithJobTypeSerialized(rs.GetString(ColumnJobClass))
                     .StoreDurably(GetBooleanFromDbValue(rs[ColumnIsDurable]));
 
                 if (loadJobType)
@@ -329,7 +320,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "jobName", job.Key.Name);
             AddCommandParameter(cmd, "jobGroup", job.Key.Group);
             AddCommandParameter(cmd, "jobDescription", job.Description);
-            AddCommandParameter(cmd, "jobType", GetStorableJobTypeName(job.JobType));
+            AddCommandParameter(cmd, "jobType", job.JobTypeWithStorage.StorableTypeName);
             AddCommandParameter(cmd, "jobDurable", GetDbBooleanValue(job.Durable));
             AddCommandParameter(cmd, "jobVolatile", GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
             AddCommandParameter(cmd, "jobStateful", GetDbBooleanValue(job.PersistJobDataAfterExecution));

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -30,7 +30,7 @@ namespace Quartz.Impl.AdoJobStore
             using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateJobDetail));
             AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "jobDescription", job.Description);
-            AddCommandParameter(cmd, "jobType", job.JobTypeWithStorage.StorableTypeName);
+            AddCommandParameter(cmd, "jobType", job.JobType.FullName);
             AddCommandParameter(cmd, "jobDurable", GetDbBooleanValue(job.Durable));
             AddCommandParameter(cmd, "jobVolatile", GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
             AddCommandParameter(cmd, "jobStateful", GetDbBooleanValue(job.PersistJobDataAfterExecution));
@@ -137,7 +137,7 @@ namespace Quartz.Impl.AdoJobStore
                 var jobBuilder = JobBuilder.Create()
                     .WithIdentity(new JobKey(rs.GetString(ColumnJobName)!, rs.GetString(ColumnJobGroup)!))
                     .WithDescription(rs.GetString(ColumnDescription))
-                    .WithJobTypeSerialized(rs.GetString(ColumnJobClass))
+                    .OfType(rs.GetString(ColumnJobClass))
                     .RequestRecovery(GetBooleanFromDbValue(rs[ColumnRequestsRecovery]))
                     .StoreDurably(GetBooleanFromDbValue(rs[ColumnIsDurable]));
 
@@ -215,7 +215,7 @@ namespace Quartz.Impl.AdoJobStore
                 var jobBuilder = JobBuilder.Create()
                     .WithIdentity(new JobKey(rs.GetString(ColumnJobName)!, rs.GetString(ColumnJobGroup)!))
                     .RequestRecovery(GetBooleanFromDbValue(rs[ColumnRequestsRecovery]))
-                    .WithJobTypeSerialized(rs.GetString(ColumnJobClass))
+                    .OfType(rs.GetString(ColumnJobClass))
                     .StoreDurably(GetBooleanFromDbValue(rs[ColumnIsDurable]));
 
                 if (loadJobType)
@@ -320,7 +320,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "jobName", job.Key.Name);
             AddCommandParameter(cmd, "jobGroup", job.Key.Group);
             AddCommandParameter(cmd, "jobDescription", job.Description);
-            AddCommandParameter(cmd, "jobType", job.JobTypeWithStorage.StorableTypeName);
+            AddCommandParameter(cmd, "jobType", job.JobType.FullName);
             AddCommandParameter(cmd, "jobDurable", GetDbBooleanValue(job.Durable));
             AddCommandParameter(cmd, "jobVolatile", GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
             AddCommandParameter(cmd, "jobStateful", GetDbBooleanValue(job.PersistJobDataAfterExecution));

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
@@ -137,7 +137,7 @@ namespace Quartz.Impl.AdoJobStore
                 var jobBuilder = JobBuilder.Create()
                     .WithIdentity(new JobKey(rs.GetString(ColumnJobName)!, rs.GetString(ColumnJobGroup)!))
                     .WithDescription(rs.GetString(ColumnDescription))
-                    .OfType(rs.GetString(ColumnJobClass))
+                    .OfType(rs.GetString(ColumnJobClass)!)
                     .RequestRecovery(GetBooleanFromDbValue(rs[ColumnRequestsRecovery]))
                     .StoreDurably(GetBooleanFromDbValue(rs[ColumnIsDurable]));
 
@@ -215,7 +215,7 @@ namespace Quartz.Impl.AdoJobStore
                 var jobBuilder = JobBuilder.Create()
                     .WithIdentity(new JobKey(rs.GetString(ColumnJobName)!, rs.GetString(ColumnJobGroup)!))
                     .RequestRecovery(GetBooleanFromDbValue(rs[ColumnRequestsRecovery]))
-                    .OfType(rs.GetString(ColumnJobClass))
+                    .OfType(rs.GetString(ColumnJobClass)!)
                     .StoreDurably(GetBooleanFromDbValue(rs[ColumnIsDurable]));
 
                 if (loadJobType)

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -106,20 +106,6 @@ namespace Quartz.Impl
         private JobKey key = null!;
 
         /// <summary>
-        /// Create a <see cref="IJobDetail" /> with no specified name or group, and
-        /// the default settings of all the other properties.
-        /// <para>
-        /// Note that the <see cref="Name" />,<see cref="Group" /> and
-        /// <see cref="JobType" /> properties must be set before the job can be
-        /// placed into a <see cref="IScheduler" />.
-        /// </para>
-        /// </summary>
-        public JobDetailImpl()
-        {
-            // do nothing...
-        }
-
-        /// <summary>
         /// Create a <see cref="IJobDetail" /> with the given name, default group, and
         /// the default settings of all the other properties.
         /// If <see langword="null" />, SchedulerConstants.DefaultGroup will be used.
@@ -143,7 +129,7 @@ namespace Quartz.Impl
         {
             Name = name;
             Group = group;
-            JobTypeWithStorage = new JobType(jobType);
+            this.JobType = new JobType(jobType);
         }
 
         /// <summary>
@@ -162,7 +148,7 @@ namespace Quartz.Impl
         {
             Name = name;
             Group = group;
-            JobTypeWithStorage = new JobType(jobType);
+            this.JobType = new JobType(jobType);
             Durable = isDurable;
             RequestsRecovery = requestsRecovery;
         }
@@ -172,7 +158,7 @@ namespace Quartz.Impl
         /// the given settings of all the other properties.
         /// </summary>
         /// <param name="key">The key of the job.</param>
-        /// <param name="jobTypeWithStorage">Type of the job.</param>
+        /// <param name="jobType">Type of the job.</param>
         /// <param name="description">The description given to the <see cref="IJob" /> instance by its creator.</param>
         /// <param name="isDurable">if set to <c>true</c>, job will be durable.</param>
         /// <param name="requestsRecovery">if set to <c>true</c>, job will request recovery.</param>
@@ -181,7 +167,7 @@ namespace Quartz.Impl
         /// <param name="persistJobDataAfterExecution">Indicates whether or not job data should re-stored when execution of the job completes.</param>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
         internal JobDetailImpl(JobKey key,
-                               JobType jobTypeWithStorage,
+                               JobType jobType,
                                string? description,
                                bool isDurable,
                                bool requestsRecovery,
@@ -190,7 +176,7 @@ namespace Quartz.Impl
                                bool? persistJobDataAfterExecution)
         {
             Key = key;
-            JobTypeWithStorage = jobTypeWithStorage;
+            JobType = jobType;
             Description = description;
             Durable = isDurable;
             RequestsRecovery = requestsRecovery;
@@ -302,10 +288,8 @@ namespace Quartz.Impl
             private set => description = value;
         }
 
-        public JobType JobTypeWithStorage { get; set; } = new ();
-
-        public virtual Type JobType => JobTypeWithStorage.Type!;
-
+        public JobType JobType { get; set; }
+    
         /// <summary>
         /// Get or set the <see cref="JobDataMap" /> that is associated with the <see cref="IJob" />.
         /// </summary>
@@ -450,7 +434,7 @@ namespace Quartz.Impl
         {
             //doesn't consider job's saved data,
             //durability etc
-            return detail != null && detail.Name == Name && detail.Group == Group && detail.JobType == JobType;
+            return detail != null && detail.Name == Name && detail.Group == Group && detail.JobType.Equals(JobType);
         }
 
         /// <summary>
@@ -495,7 +479,7 @@ namespace Quartz.Impl
 
         public virtual JobBuilder GetJobBuilder()
         {
-            JobBuilder b = JobBuilder.Create()
+            return JobBuilder.Create()
                                      .OfType(JobType)
                                      .RequestRecovery(RequestsRecovery)
                                      .StoreDurably(Durable)
@@ -504,8 +488,6 @@ namespace Quartz.Impl
                                      .PersistJobDataAfterExecution(PersistJobDataAfterExecution)
                                      .WithDescription(description)
                                      .WithIdentity(Key);
-
-            return b;
         }
     }
 }

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -49,7 +49,7 @@ namespace Quartz.Impl
         /// </summary>
         /// <param name="jobType">The type for which information will be searched</param>
         /// <returns>
-        /// An <see cref="JobTypeInformation"/> object that describe specified type 
+        /// An <see cref="JobTypeInformation"/> object that describe specified type
         /// </returns>
         public static JobTypeInformation GetOrCreate(Type jobType)
         {
@@ -129,7 +129,7 @@ namespace Quartz.Impl
         {
             Name = name;
             Group = group;
-            this.JobType = new JobType(jobType);
+            JobType = new JobType(jobType);
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Quartz.Impl
         {
             Name = name;
             Group = group;
-            this.JobType = new JobType(jobType);
+            JobType = new JobType(jobType);
             Durable = isDurable;
             RequestsRecovery = requestsRecovery;
         }
@@ -288,8 +288,8 @@ namespace Quartz.Impl
             private set => description = value;
         }
 
-        public JobType JobType { get; set; }
-    
+        public JobType JobType { get; private set; }
+
         /// <summary>
         /// Get or set the <see cref="JobDataMap" /> that is associated with the <see cref="IJob" />.
         /// </summary>

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -22,7 +22,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
-using System.Reflection;
 
 using Quartz.Util;
 
@@ -144,7 +143,7 @@ namespace Quartz.Impl
         {
             Name = name;
             Group = group;
-            JobType = jobType;
+            JobTypeWithStorage = new JobType(jobType);
         }
 
         /// <summary>
@@ -163,7 +162,7 @@ namespace Quartz.Impl
         {
             Name = name;
             Group = group;
-            JobType = jobType;
+            JobTypeWithStorage = new JobType(jobType);
             Durable = isDurable;
             RequestsRecovery = requestsRecovery;
         }
@@ -173,16 +172,16 @@ namespace Quartz.Impl
         /// the given settings of all the other properties.
         /// </summary>
         /// <param name="key">The key of the job.</param>
-        /// <param name="jobType">Type of the job.</param>
+        /// <param name="jobTypeWithStorage">Type of the job.</param>
         /// <param name="description">The description given to the <see cref="IJob" /> instance by its creator.</param>
         /// <param name="isDurable">if set to <c>true</c>, job will be durable.</param>
         /// <param name="requestsRecovery">if set to <c>true</c>, job will request recovery.</param>
         /// <param name="jobDataMap">The data that is associated with the <see cref="IJob" />.</param>
-        /// <param name="disallowConcurrentExecution">Indicates whether or not concurrent exection of the job should be disallowed.</param>
+        /// <param name="disallowConcurrentExecution">Indicates whether or not concurrent execution of the job should be disallowed.</param>
         /// <param name="persistJobDataAfterExecution">Indicates whether or not job data should re-stored when execution of the job completes.</param>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
         internal JobDetailImpl(JobKey key,
-                               Type? jobType,
+                               JobType jobTypeWithStorage,
                                string? description,
                                bool isDurable,
                                bool requestsRecovery,
@@ -191,7 +190,7 @@ namespace Quartz.Impl
                                bool? persistJobDataAfterExecution)
         {
             Key = key;
-            JobType = jobType!;
+            JobTypeWithStorage = jobTypeWithStorage;
             Description = description;
             Durable = isDurable;
             RequestsRecovery = requestsRecovery;
@@ -303,30 +302,9 @@ namespace Quartz.Impl
             private set => description = value;
         }
 
-        /// <summary>
-        /// Get or sets the instance of <see cref="IJob" /> that will be executed.
-        /// </summary>
-        /// <exception cref="ArgumentException">
-        /// if jobType is null or the class is not a <see cref="IJob" />.
-        /// </exception>
-        public virtual Type JobType
-        {
-            get => jobType;
-            private set
-            {
-                if (value == null)
-                {
-                    throw new ArgumentException("Job class cannot be null.");
-                }
+        public JobType JobTypeWithStorage { get; set; } = new ();
 
-                if (!typeof(IJob).IsAssignableFrom(value))
-                {
-                    throw new ArgumentException("Job class must implement the Job interface.");
-                }
-
-                jobType = value;
-            }
-        }
+        public virtual Type JobType => JobTypeWithStorage.Type!;
 
         /// <summary>
         /// Get or set the <see cref="JobDataMap" /> that is associated with the <see cref="IJob" />.
@@ -339,6 +317,7 @@ namespace Quartz.Impl
                 {
                     jobDataMap = new JobDataMap();
                 }
+
                 return jobDataMap;
             }
 

--- a/src/Quartz/Impl/JobType.cs
+++ b/src/Quartz/Impl/JobType.cs
@@ -5,7 +5,7 @@ using Quartz.Util;
 namespace Quartz.Impl;
 
 /// <summary>
-/// Store the Job Type and storable backing field name for serialization
+/// Store the Job Type and backing field name for serialization
 /// </summary>
 public class JobType
 {

--- a/src/Quartz/Impl/JobType.cs
+++ b/src/Quartz/Impl/JobType.cs
@@ -12,6 +12,12 @@ public sealed class JobType
 {
     private Lazy<Type> type = new(() => throw new InvalidOperationException("Type not defined"));
 
+    /// <summary>
+    /// Construct a Job Type specifying the Assembly Qualified NameWithout Version.
+    /// There is no check on construction this type is valid.
+    /// </summary>
+    /// <param name="fullName">Type full name</param>
+    /// <exception cref="ArgumentNullException">Cannot be null</exception>
     public JobType(string? fullName)
     {
         SetWithFullName(fullName ?? throw new ArgumentNullException(nameof(fullName)));

--- a/src/Quartz/Impl/JobType.cs
+++ b/src/Quartz/Impl/JobType.cs
@@ -1,0 +1,75 @@
+using System;
+
+using Quartz.Util;
+
+namespace Quartz.Impl;
+
+/// <summary>
+/// Store the Job Type and storable backing field name for serialization
+/// </summary>
+public class JobType
+{
+    private string storableTypeName = string.Empty;
+    private Lazy<Type> lazyType = new(() => throw new InvalidOperationException("Type not defined"));
+
+    public JobType()
+    {
+    }
+
+    public JobType(string? typeStorageName)
+    {
+        this.StorableTypeName = typeStorageName ?? throw new ArgumentNullException(nameof(typeStorageName));
+    }
+
+    /// <summary>
+    /// Job Type declaration
+    /// </summary>
+    public JobType(Type type)
+    {
+        Type = type;
+    }
+
+    /// <summary>
+    /// Type as a string represented storable name.
+    /// </summary>
+    public string StorableTypeName
+    {
+        get => storableTypeName;
+        set
+        {
+            storableTypeName = value;
+            lazyType = new Lazy<Type>(() =>
+                Type.GetType(value) ?? throw new InvalidOperationException("Job class Type cannot be resolved."));
+        }
+    }
+
+    public virtual Type Type
+    {
+        get => string.IsNullOrEmpty(StorableTypeName) ? null! : lazyType.Value;
+        private set
+        {
+            if (value == null)
+            {
+                throw new ArgumentException("Job class cannot be null.");
+            }
+
+            if (!typeof(IJob).IsAssignableFrom(value))
+            {
+                throw new ArgumentException("Job class must implement the Job interface.");
+            }
+
+            lazyType = new Lazy<Type>(() => value);
+            storableTypeName = GetStorableJobTypeName(value);
+        }
+    }
+
+    private string GetStorableJobTypeName(Type jobType)
+    {
+        if (jobType.AssemblyQualifiedName == null)
+        {
+            throw new ArgumentException("Cannot determine job type name when type's AssemblyQualifiedName is null");
+        }
+
+        return jobType.AssemblyQualifiedNameWithoutVersion();
+    }
+}

--- a/src/Quartz/Impl/JobType.cs
+++ b/src/Quartz/Impl/JobType.cs
@@ -18,7 +18,7 @@ public sealed class JobType
     /// </summary>
     /// <param name="fullName">Type full name</param>
     /// <exception cref="ArgumentNullException">Cannot be null</exception>
-    public JobType(string? fullName)
+    public JobType(string fullName)
     {
         SetWithFullName(fullName ?? throw new ArgumentNullException(nameof(fullName)));
     }
@@ -38,7 +38,7 @@ public sealed class JobType
 
     private void SetWithFullName(string fullName)
     {
-        this.FullName = fullName;
+        FullName = fullName;
         type = new Lazy<Type>(() =>
             Type.GetType(fullName) ?? throw new InvalidOperationException($"Job class Type {fullName} cannot be resolved."));
     }
@@ -60,7 +60,7 @@ public sealed class JobType
             throw new ArgumentException("Job class must implement Quartz.IJob interface.");
         }
 
-        this.type = new Lazy<Type>(() => jobType);
+        type = new Lazy<Type>(() => jobType);
         FullName = GetFullName(jobType);
     }
 
@@ -78,7 +78,7 @@ public sealed class JobType
 
     public static implicit operator Type(JobType jobType) => jobType.Type;
 
-    public static implicit operator JobType(string? fullName) => new(fullName);
+    public static implicit operator JobType(string fullName) => new(fullName);
 
     private bool Equals(JobType other)
     {

--- a/src/Quartz/JobBuilder.cs
+++ b/src/Quartz/JobBuilder.cs
@@ -22,6 +22,7 @@
 using System;
 
 using Quartz.Impl;
+using Quartz.Util;
 
 namespace Quartz
 {
@@ -68,6 +69,7 @@ namespace Quartz
         private JobKey? key;
         private string? description;
         private Type? jobType;
+        private string? jobTypeSerialized;
         private bool durability;
         private bool shouldRecover;
         private bool? _concurrentExecutionDisallowed;
@@ -157,7 +159,7 @@ namespace Quartz
             }
 
             return new JobDetailImpl(Key ?? new JobKey(Guid.NewGuid().ToString()),
-                                     jobType,
+                                     new JobType(jobTypeSerialized),
                                      description,
                                      durability,
                                      shouldRecover,
@@ -270,6 +272,17 @@ namespace Quartz
         }
 
         /// <summary>
+        /// Set the JobType Serialized name
+        /// </summary>
+        /// <param name="jobTypeSerialized">the serialized job Type</param>
+        /// /// <returns>the updated JobBuilder</returns>
+        public JobBuilder WithJobTypeSerialized(string? jobTypeSerialized)
+        {
+            this.jobTypeSerialized = jobTypeSerialized;
+            return this;
+        }
+
+        /// <summary>
         /// Set the class which will be instantiated and executed when a
         /// Trigger fires that is associated with this JobDetail.
         /// </summary>
@@ -289,6 +302,7 @@ namespace Quartz
         public JobBuilder OfType(Type type)
         {
             jobType = type;
+            jobTypeSerialized = type.AssemblyQualifiedNameWithoutVersion();
             return this;
         }
 

--- a/src/Quartz/JobBuilder.cs
+++ b/src/Quartz/JobBuilder.cs
@@ -69,7 +69,7 @@ namespace Quartz
         private JobKey? key;
         private string? description;
         private Type? jobType;
-        private string? jobTypeSerialized;
+        private string? jobTypeName;
         private bool durability;
         private bool shouldRecover;
         private bool? _concurrentExecutionDisallowed;
@@ -159,7 +159,7 @@ namespace Quartz
             }
 
             return new JobDetailImpl(Key ?? new JobKey(Guid.NewGuid().ToString()),
-                                     new JobType(jobTypeSerialized),
+                                     jobTypeName,
                                      description,
                                      durability,
                                      shouldRecover,
@@ -272,13 +272,13 @@ namespace Quartz
         }
 
         /// <summary>
-        /// Set the JobType Serialized name
+        /// Set the JobType by name
         /// </summary>
-        /// <param name="jobTypeSerialized">the serialized job Type</param>
-        /// /// <returns>the updated JobBuilder</returns>
-        public JobBuilder WithJobTypeSerialized(string? jobTypeSerialized)
+        /// <param name="typeName">the Type name</param>
+        /// <returns>the updated JobBuilder</returns>
+        public JobBuilder OfType(string? typeName)
         {
-            this.jobTypeSerialized = jobTypeSerialized;
+            this.jobTypeName = typeName;
             return this;
         }
 
@@ -302,7 +302,7 @@ namespace Quartz
         public JobBuilder OfType(Type type)
         {
             jobType = type;
-            jobTypeSerialized = type.AssemblyQualifiedNameWithoutVersion();
+            jobTypeName = type.AssemblyQualifiedNameWithoutVersion();
             return this;
         }
 

--- a/src/Quartz/JobBuilder.cs
+++ b/src/Quartz/JobBuilder.cs
@@ -1,20 +1,20 @@
 #region License
 
-/* 
+/*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
- * use this file except in compliance with the License. You may obtain a copy 
- * of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
- * 
+ *
  */
 
 #endregion
@@ -31,7 +31,7 @@ namespace Quartz
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The builder will always try to keep itself in a valid state, with 
+    /// The builder will always try to keep itself in a valid state, with
     /// reasonable defaults set for calling Build() at any point.  For instance
     /// if you do not invoke <i>WithIdentity(..)</i> a job name will be generated
     /// for you.
@@ -51,13 +51,13 @@ namespace Quartz
     ///         IJobDetail job = JobBuilder.Create&lt;MyJob&gt;()
     ///             .WithIdentity("myJob")
     ///             .Build();
-    ///             
-    ///         ITrigger trigger = TriggerBuilder.Create() 
+    ///
+    ///         ITrigger trigger = TriggerBuilder.Create()
     ///             .WithIdentity("myTrigger", "myTriggerGroup")
     ///             .WithSimpleSchedule(x => x.WithIntervalInHours(1).RepeatForever())
     ///             .StartAt(DateBuilder.FutureDate(10, IntervalUnit.Minute))
     ///             .Build();
-    ///         
+    ///
     ///         scheduler.scheduleJob(job, trigger);
     /// </code>
     /// </remarks>
@@ -68,8 +68,7 @@ namespace Quartz
     {
         private JobKey? key;
         private string? description;
-        private Type? jobType;
-        private string? jobTypeName;
+        private JobType? jobType;
         private bool durability;
         private bool shouldRecover;
         private bool? _concurrentExecutionDisallowed;
@@ -139,27 +138,33 @@ namespace Quartz
         /// <returns>the defined JobDetail.</returns>
         public IJobDetail Build()
         {
+            if (jobType is null)
+            {
+                throw new InvalidOperationException("Job type has not been set");
+            }
+
             var concurrentExecutionDisallowed = _concurrentExecutionDisallowed;
             var persistJobDataAfterExecution = _persistJobDataAfterExecution;
 
             // When the user specified a job type, we can deduce the values for
             // ConcurrentExecutionDisallowed and PersistJobDataAfterExecution if
             // no explicit values were specified
-            if (jobType != null)
+            var resolvedJobType = Type.GetType(jobType.FullName);
+            if (resolvedJobType != null)
             {
                 if (!_concurrentExecutionDisallowed.HasValue)
                 {
-                    concurrentExecutionDisallowed = JobTypeInformation.GetOrCreate(jobType).ConcurrentExecutionDisallowed;
+                    concurrentExecutionDisallowed = JobTypeInformation.GetOrCreate(resolvedJobType).ConcurrentExecutionDisallowed;
                 }
 
                 if (!persistJobDataAfterExecution.HasValue)
                 {
-                    persistJobDataAfterExecution = JobTypeInformation.GetOrCreate(jobType).PersistJobDataAfterExecution;
+                    persistJobDataAfterExecution = JobTypeInformation.GetOrCreate(resolvedJobType).PersistJobDataAfterExecution;
                 }
             }
 
             return new JobDetailImpl(Key ?? new JobKey(Guid.NewGuid().ToString()),
-                                     jobTypeName,
+                                     jobType,
                                      description,
                                      durability,
                                      shouldRecover,
@@ -215,7 +220,7 @@ namespace Quartz
         /// </remarks>
         /// <param name="name">the name element for the Job's JobKey</param>
         /// <returns>the updated JobBuilder</returns>
-        /// <seealso cref="JobKey" /> 
+        /// <seealso cref="JobKey" />
         /// <seealso cref="IJobDetail.Key" />
         public JobBuilder WithIdentity(string name)
         {
@@ -276,9 +281,9 @@ namespace Quartz
         /// </summary>
         /// <param name="typeName">the Type name</param>
         /// <returns>the updated JobBuilder</returns>
-        public JobBuilder OfType(string? typeName)
+        public JobBuilder OfType(string typeName)
         {
-            this.jobTypeName = typeName;
+            jobType = typeName;
             return this;
         }
 
@@ -301,8 +306,7 @@ namespace Quartz
         /// <seealso cref="IJobDetail.JobType" />
         public JobBuilder OfType(Type type)
         {
-            jobType = type;
-            jobTypeName = type.AssemblyQualifiedNameWithoutVersion();
+            jobType = new JobType(type);
             return this;
         }
 
@@ -427,7 +431,7 @@ namespace Quartz
         }
 
         /// <summary>
-        /// Add all the data from the given <see cref="JobDataMap" /> to the 
+        /// Add all the data from the given <see cref="JobDataMap" /> to the
         /// <see cref="IJobDetail" />'s <see cref="JobDataMap" />.
         /// </summary>
         ///<returns>the updated JobBuilder</returns>

--- a/src/Quartz/JobDataMap.cs
+++ b/src/Quartz/JobDataMap.cs
@@ -51,7 +51,7 @@ namespace Quartz
     /// </para>
     /// <para>
     /// Update since 2.4.2 - We keep an dirty flag for this map so that whenever you modify(add/delete) any of the entries,
-    /// it will set to "true". However if you create new instance using an exising map with constructor, then
+    /// it will set to "true". However if you create new instance using an existing map with constructor, then
     /// the dirty flag will NOT be set to "true" until you modify the instance.
     /// </para>
     /// </remarks>

--- a/src/Quartz/Util/ObjectExtensions.cs
+++ b/src/Quartz/Util/ObjectExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Quartz.Util


### PR DESCRIPTION
Reduce the need to construct the stored job `Type` , allowing maintenance tasks such as `UnschduleJob` to operate when the stored job Type can no longer be constructed.
JobTypeSerialized is stored and can be retrieved as Type still via a Lazy getter

It should be a `Non-breaking change`, but if external code depended on exceptions being thrown for invalid job type retrieval this might introduce unexpected results

Should resolve #1560  - (V4) Error in JobDetailImpl due to null JobType being passed

fixes #1560