### PR TITLE
Set test [category] for vendor database integration tests

### DIFF
--- a/src/Quartz.Tests.Integration/AdoSchedulerTest.cs
+++ b/src/Quartz.Tests.Integration/AdoSchedulerTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
@@ -12,7 +12,7 @@ using Quartz.Util;
 
 namespace Quartz.Tests.Integration
 {
-    [Category("sqlserver")]
+    [Category("db-sqlserver")]
     [TestFixture(typeof(BinaryObjectSerializer))]
     [TestFixture(typeof(JsonObjectSerializer))]
     public class AdoSchedulerTest : AbstractSchedulerTest

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
@@ -57,7 +57,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public Task TestSqlServer(string serializerType)
         {
@@ -69,7 +69,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public Task TestSqlServerMemoryOptimizedTables(string serializerType)
         {
@@ -82,6 +82,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
+        [Category("db-postgres")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public Task TestPostgreSql(string serializerType)
         {
@@ -91,6 +92,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
+        [Category("db-mysql")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public Task TestMySql(string serializerType)
         {
@@ -100,6 +102,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
+        [Category("db-sqlite")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public async Task TestSQLiteMicrosoft(string serializerType)
         {
@@ -127,6 +130,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
+        [Category("db-firebird")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public Task TestFirebird(string serializerType)
         {
@@ -136,6 +140,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
+        [Category("db-oracle")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public Task TestOracleODPManaged(string serializerType)
         {
@@ -145,6 +150,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
+        [Category("db-sqlite")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public async Task TestSQLite(string serializerType)
         {
@@ -244,7 +250,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task ShouldBeAbleToUseMixedProperties()
         {
             NameValueCollection properties = new NameValueCollection();
@@ -301,6 +307,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
 
         [Test]
         [Explicit]
+        [Category("db-sqlserver")]
         [TestCaseSource(nameof(GetSerializerTypes))]
         public async Task TestSqlServerStress(string serializerType)
         {
@@ -357,7 +364,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task TestGetTriggerKeysWithLike()
         {
             var sched = await CreateScheduler(null);
@@ -366,7 +373,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task TestGetTriggerKeysWithEquals()
         {
             var sched = await CreateScheduler(null);
@@ -375,7 +382,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task TestGetJobKeysWithLike()
         {
             var sched = await CreateScheduler(null);
@@ -384,7 +391,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task TestGetJobKeysWithEquals()
         {
             var sched = await CreateScheduler(null);
@@ -393,7 +400,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore
         }
 
         [Test]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task JobTypeNotFoundShouldNotBlock()
         {
             NameValueCollection properties = new NameValueCollection();

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbMetadataTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbMetadataTest.cs
@@ -30,18 +30,21 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore.Common
     public class DbMetadataTest
     {
         [Test]
+        [Category("db-sqlserver")]
         public void TestDbMetadataSqlServer20()
         {
             TestDbMetadata(TestConstants.DefaultSqlServerProvider);
         }
 
         [Test]
+        [Category("db-firebird")]
         public void TestDbMetadataFirebird()
         {
             TestDbMetadata("Firebird", hashCustomBinaryType: false);
         }
 
         [Test]
+        [Category("db-mysql")]
         public void TestDbMetadataMySql()
         {
             TestDbMetadata("MySqlConnector");
@@ -50,12 +53,14 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore.Common
 #if !NETCORE
         
         [Test]
+        [Category("db-oracle")]
         public void TestDbMetadataOracleODP()
         {
             TestDbMetadata("OracleODP");
         }
 
         [Test]
+        [Category("db-oracle")]
         public void TestDbMetadataOracleODPManaged()
         {
             var provider = TestDbMetadata("OracleODPManaged");

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/DeleteNonExistsJobTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/DeleteNonExistsJobTest.cs
@@ -14,7 +14,7 @@ using Quartz.Util;
 namespace Quartz.Tests.Integration.Impl.AdoJobStore
 {
     [TestFixture]
-    [Category("sqlserver")]
+    [Category("db-sqlserver")]
     public class DeleteNonExistsJobTest
     {
         private static readonly ILogger<DeleteNonExistsJobTest> logger = LogProvider.CreateLogger<DeleteNonExistsJobTest>();

--- a/src/Quartz.Tests.Integration/JobDataMapStorageTest.cs
+++ b/src/Quartz.Tests.Integration/JobDataMapStorageTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 using NUnit.Framework;
 
@@ -15,6 +15,7 @@ namespace Quartz.Tests.Integration
     public class JobDataMapStorageTest : IntegrationTest
     {
         [Test]
+        [Category("db-sqlserver")]
         public async Task TestJobDataMapDirtyFlag()
         {
             IScheduler scheduler = await CreateScheduler("testBasicStorageFunctions");

--- a/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
@@ -71,6 +71,7 @@ namespace Quartz.Tests.Integration
         protected abstract Task<IScheduler> CreateScheduler(string name, int threadPoolSize);
 
         [Test]
+        [Category("db-sqlserver")]
         public async Task TestBasicStorageFunctions()
         {
             IScheduler sched = await CreateScheduler("testBasicStorageFunctions", 2);

--- a/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
@@ -287,7 +287,7 @@ namespace Quartz.Tests.Integration.Xml
 
         [Test]
         [Category("database")]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task TestSimpleTriggerNoRepeat()
         {
             IScheduler scheduler = await CreateDbBackedScheduler();
@@ -318,7 +318,7 @@ namespace Quartz.Tests.Integration.Xml
 
         [Test]
         [Category("database")]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task TestRemoveJobTypeNotFound()
         {
             var scheduler = await CreateDbBackedScheduler();
@@ -385,7 +385,7 @@ namespace Quartz.Tests.Integration.Xml
 
         [Test]
         [Category("database")]
-        [Category("sqlserver")]
+        [Category("db-sqlserver")]
         public async Task TestOverwriteJobTypeNotFound()
         {
             IScheduler scheduler = await CreateDbBackedScheduler();


### PR DESCRIPTION
Set test `[category]` against database integration tests, enabling easier exclusion per db in development.
Existing category `sqlserver` was prefixed with `db-` 
For example, https://www.jetbrains.com/help/resharper/Test_Categories.html#ignore