### PR TITLE
fix: (Config) Use configuration value quartz.jobStore.dbRetryInterval to set DbRetryInterval

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -60,6 +60,11 @@
     **ListenerManager** on **QuartzScheduler** allows more control over the events that a **ITriggerListener** will
     receive.
 
+* FIXES
+  * Configuration property `quartz.jobStore.dbRetryInterval` will be correctly set when constructing the Scheduler JobStore.
+    If you previously had configuration with the key `quartz.scheduler.dbFailureRetryInterval` please change to the above mentioned key. 
+  
+
 ## Release 3.4.0, Mar 27 2022
 
 This release has Quartz jobs start executing only after application startup completes successfully, unless QuartzHostedServiceOptions are used to specify otherwise.

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -29,13 +29,13 @@ These properties configure the identification of the scheduler, and various othe
 
 |Property Name                                                | Required |    Type |  Default Value                                  |
 |-------------------------------------------------------------|----------|---------|-------------------------------------------------|
+|quartz.jobStore.dbRetryInterval                              | no       | long    | 15000   (15 seconds)                            |
 |quartz.scheduler.instanceName                                | no       | string  |'QuartzScheduler'                                |
 |quartz.scheduler.instanceId                                  | no       | string  | 'NON_CLUSTERED'                                 |
 |quartz.scheduler.instanceIdGenerator.type                    | no       | string  | Quartz.Simpl.SimpleInstanceIdGenerator, Quartz  |
 |quartz.scheduler.threadName                                  | no       | string  | instanceName + '_QuartzSchedulerThread'         |
 |quartz.scheduler.makeSchedulerThreadDaemon                   | no       | boolean | false                                           |
 |quartz.scheduler.idleWaitTime                                | no       | long    | 30000                                           |
-|quartz.scheduler.dbFailureRetryInterval                      | no       | long    | 15000                                           |
 |quartz.scheduler.typeLoadHelper.type                         | no       | string  | Quartz.Simpl.SimpleTypeLoadHelper               |
 |quartz.scheduler.jobFactory.type                             | no       | string  | Quartz.Simpl.PropertySettingJobFactory          |
 |quartz.context.key.SOME_KEY                                  | no       | string  | none                                            |
@@ -77,10 +77,11 @@ Is the amount of time in milliseconds that the scheduler will wait before re-que
 Normally you should not have to 'tune' this parameter, unless you’re using XA transactions, and are having problems with delayed firings of triggers that should fire immediately.
 Values less than 5000 ms are not recommended as it will cause excessive database querying. Values less than 1000 are not legal.
 
-### `quartz.scheduler.dbFailureRetryInterval`
+### `quartz.jobStore.dbRetryInterval`
 
 Is the amount of time in milliseconds that the scheduler will wait between re-tries when it has detected a loss of connectivity within the JobStore (e.g. to the database).
 This parameter is obviously not very meaningful when using RamJobStore.
+It is also used in a Job misfire scenario, if a Job fails, and there is a configured retry value (default of 4) then this is the amount of time to wait between retries.
 
 ### `quartz.scheduler.typeLoadHelper.type`
 

--- a/src/Quartz.Tests.Unit/SchedulerBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerBuilderTest.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Data.Common;
 
 using NUnit.Framework;
 
+using Quartz.Impl;
 using Quartz.Impl.AdoJobStore;
 using Quartz.Impl.AdoJobStore.Common;
 using Quartz.Plugin.TimeZoneConverter;
@@ -54,7 +55,7 @@ namespace Quartz.Tests.Unit
             Assert.That(config.Properties["quartz.jobStore.tablePrefix"], Is.EqualTo("QRTZ2019_"));
             Assert.That(config.Properties["quartz.jobStore.clusterCheckinInterval"], Is.EqualTo("10000"));
             Assert.That(config.Properties["quartz.jobStore.clusterCheckinMisfireThreshold"], Is.EqualTo("15000"));
-            Assert.That(config.Properties["quartz.jobStore.dbRetryInterval"], Is.EqualTo("20000"));
+            Assert.That(config.Properties[StdSchedulerFactory.PropertyJobStoreDbRetryInterval], Is.EqualTo("20000"));
 
             Assert.That(config.Properties["quartz.dataSource.default.connectionProvider.type"], Is.EqualTo("Quartz.Tests.Unit.SchedulerBuilderTest+CustomConnectionProvider, Quartz.Tests.Unit"));
         }

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -97,7 +97,6 @@ namespace Quartz.Impl
         public const string PropertySchedulerProxy = "quartz.scheduler.proxy";
         public const string PropertySchedulerProxyType = "quartz.scheduler.proxy.type";
         public const string PropertySchedulerIdleWaitTime = "quartz.scheduler.idleWaitTime";
-        public const string PropertySchedulerDbFailureRetryInterval = "quartz.scheduler.dbFailureRetryInterval";
         public const string PropertySchedulerMakeSchedulerThreadDaemon = "quartz.scheduler.makeSchedulerThreadDaemon";
         public const string PropertySchedulerTypeLoadHelperType = "quartz.scheduler.typeLoadHelper.type";
         public const string PropertySchedulerJobFactoryType = "quartz.scheduler.jobFactory.type";
@@ -107,6 +106,7 @@ namespace Quartz.Impl
         public const string PropertySchedulerContextPrefix = "quartz.context.key";
         public const string PropertyThreadPoolPrefix = "quartz.threadPool";
         public const string PropertyThreadPoolType = "quartz.threadPool.type";
+        public const string PropertyJobStoreDbRetryInterval = "quartz.jobStore.dbRetryInterval";
         public const string PropertyJobStorePrefix = "quartz.jobStore";
         public const string PropertyJobStoreLockHandlerPrefix = PropertyJobStorePrefix + ".lockHandler";
         public const string PropertyJobStoreLockHandlerType = PropertyJobStoreLockHandlerPrefix + ".type";
@@ -390,10 +390,10 @@ Please add configuration to your application config file to correctly initialize
 
             Type? typeLoadHelperType = LoadType(cfg.GetStringProperty(PropertySchedulerTypeLoadHelperType));
 
-            dbFailureRetry = cfg.GetTimeSpanProperty(PropertySchedulerDbFailureRetryInterval, dbFailureRetry);
+            dbFailureRetry = cfg.GetTimeSpanProperty(PropertyJobStoreDbRetryInterval, dbFailureRetry);
             if (dbFailureRetry < TimeSpan.Zero)
             {
-                throw new SchedulerException(PropertySchedulerDbFailureRetryInterval + " of less than 0 ms is not legal.");
+                throw new SchedulerException(PropertyJobStoreDbRetryInterval + " of less than 0 ms is not legal.");
             }
 
             bool makeSchedulerThreadDaemon = cfg.GetBooleanProperty(PropertySchedulerMakeSchedulerThreadDaemon);

--- a/src/Quartz/SchedulerBuilder.cs
+++ b/src/Quartz/SchedulerBuilder.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -357,14 +357,14 @@ namespace Quartz
             }
 
             /// <summary>
-            /// Gets or sets the database retry interval.
+            /// Sets the database retry interval.
             /// </summary>
             /// <remarks>
             /// Defaults to 15 seconds.
             /// </remarks>
             public TimeSpan RetryInterval
             {
-                set => SetProperty("quartz.jobStore.dbRetryInterval", ((int) value.TotalMilliseconds).ToString());
+                set => SetProperty(StdSchedulerFactory.PropertyJobStoreDbRetryInterval, ((int) value.TotalMilliseconds).ToString());
             }
 
             /// <summary>


### PR DESCRIPTION
Use configuration value `quartz.jobStore.dbRetryInterval` instead of deprecated `quartz.scheduler.dbFailureRetryInterval`, which is not used to set the property  of `DbRetryInterval` in JobStoreSupport

Resolves #1623 