### PR TITLE
Change QuartzOptions to inherit from Dictionary<string, string?>

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,8 @@
   * Configuration property `quartz.jobStore.dbRetryInterval` will be correctly set when constructing the Scheduler JobStore.
      * If you previously had configuration with the key `quartz.scheduler.dbFailureRetryInterval` please change to the above mentioned key.
   * DailyCalendar doesn't include first and last millisecond of day in checks (#1665)
-  * StdSchedulerFactory and derived factories are not thread-safe #1587
+  * StdSchedulerFactory and derived factories are not thread-safe (#1587)
+  * Change QuartzOptions to inherit from Dictionary<string, string?> instead of NameValueCollection to fix Microsoft.Extensions.Hosting 7 RC integration (#1748)
 
 
 ## Release 3.4.0, Mar 27 2022

--- a/src/Quartz.Extensions.DependencyInjection/QuartzOptions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/QuartzOptions.cs
@@ -4,116 +4,87 @@ using System.Collections.Specialized;
 
 using Quartz.Impl;
 
-namespace Quartz
+namespace Quartz;
+
+public class QuartzOptions : Dictionary<string, string?>
 {
-    public class QuartzOptions : NameValueCollection, IDictionary<string, string>
+    internal readonly List<IJobDetail> jobDetails = new();
+    internal readonly List<ITrigger> triggers = new();
+
+    public string? SchedulerId
     {
-        internal readonly List<IJobDetail> jobDetails = new List<IJobDetail>();
-        internal readonly List<ITrigger> triggers = new List<ITrigger>();
-
-        public string? SchedulerId
+        get
         {
-            get => this[StdSchedulerFactory.PropertySchedulerInstanceId];
-            set => this[StdSchedulerFactory.PropertySchedulerInstanceId] = value;
+            TryGetValue(StdSchedulerFactory.PropertySchedulerInstanceId, out var schedulerId);
+            return schedulerId;
         }
+        set => this[StdSchedulerFactory.PropertySchedulerInstanceId] = value;
+    }
 
-        public string? SchedulerName
+    public string? SchedulerName
+    {
+        get
         {
-            get => this[StdSchedulerFactory.PropertySchedulerName];
-            set => this[StdSchedulerFactory.PropertySchedulerName] = value;
+            TryGetValue(StdSchedulerFactory.PropertySchedulerName, out var schedulerName);
+            return schedulerName;
         }
+        set => this[StdSchedulerFactory.PropertySchedulerName] = value;
+    }
 
-        public TimeSpan? MisfireThreshold
+    public TimeSpan? MisfireThreshold
+    {
+        get
         {
-            get
+            if (!TryGetValue("quartz.jobStore.misfireThreshold", out var value) || string.IsNullOrWhiteSpace(value))
             {
-                var value = this["quartz.jobStore.misfireThreshold"];
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    return null;
-                }
-                return TimeSpan.FromMilliseconds(int.Parse(value)); 
+                return null;
             }
-            set => this["quartz.jobStore.misfireThreshold"] =  value != null ? ((int) value.Value.TotalMilliseconds).ToString() : "";
+
+            return TimeSpan.FromMilliseconds(int.Parse(value));
         }
+        set => this["quartz.jobStore.misfireThreshold"] = value != null ? ((int) value.Value.TotalMilliseconds).ToString() : "";
+    }
 
-        public SchedulingOptions Scheduling { get; set; } = new SchedulingOptions();
+    public SchedulingOptions Scheduling { get; set; } = new();
 
-        public JobFactoryOptions JobFactory { get; set; } = new JobFactoryOptions();
+    public JobFactoryOptions JobFactory { get; set; } = new();
 
-        public IReadOnlyList<IJobDetail> JobDetails => jobDetails;
+    public IReadOnlyList<IJobDetail> JobDetails => jobDetails;
 
-        public IReadOnlyList<ITrigger> Triggers => triggers;
+    public IReadOnlyList<ITrigger> Triggers => triggers;
 
-        public QuartzOptions AddJob(Type jobType, Action<JobBuilder> configure)
+    public QuartzOptions AddJob(Type jobType, Action<JobBuilder> configure)
+    {
+        var builder = JobBuilder.Create(jobType);
+        configure(builder);
+        jobDetails.Add(builder.Build());
+        return this;
+    }
+
+    public QuartzOptions AddJob<T>(Action<JobBuilder> configure) where T : IJob
+    {
+        var builder = JobBuilder.Create<T>();
+        configure(builder);
+        jobDetails.Add(builder.Build());
+        return this;
+    }
+
+    public QuartzOptions AddTrigger(Action<TriggerBuilder> configure)
+    {
+        var builder = TriggerBuilder.Create();
+        configure(builder);
+        triggers.Add(builder.Build());
+        return this;
+    }
+
+    public NameValueCollection ToNameValueCollection()
+    {
+        var collection = new NameValueCollection(Count);
+        foreach (var pair in this)
         {
-            var builder = JobBuilder.Create(jobType);
-            configure(builder);
-            jobDetails.Add(builder.Build());
-            return this;
+            collection[pair.Key] = pair.Value;
         }
 
-        public QuartzOptions AddJob<T>(Action<JobBuilder> configure) where T : IJob
-        {
-            var builder = JobBuilder.Create<T>();
-            configure(builder);
-            jobDetails.Add(builder.Build());
-            return this;
-        }
-
-        public QuartzOptions AddTrigger(Action<TriggerBuilder> configure)
-        {
-            var builder = TriggerBuilder.Create();
-            configure(builder);
-            triggers.Add(builder.Build());
-            return this;
-        }
-
-        IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
-
-        void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> item)
-        {
-            throw new NotImplementedException();
-        }
-
-        bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> item)
-        {
-            throw new NotImplementedException();
-        }
-
-        void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
-        {
-            throw new NotImplementedException();
-        }
-
-        bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> item)
-        {
-            throw new NotImplementedException();
-        }
-
-        bool ICollection<KeyValuePair<string, string>>.IsReadOnly => false;
-
-        bool IDictionary<string, string>.ContainsKey(string key)
-        {
-            return this[key] is not null;
-        }
-
-        bool IDictionary<string, string>.Remove(string key)
-        {
-            throw new NotImplementedException();
-        }
-
-        bool IDictionary<string, string>.TryGetValue(string key, out string value)
-        {
-            value = this[key];
-            return value is not null;
-        }
-
-        ICollection<string> IDictionary<string, string>.Keys => throw new NotImplementedException();
-
-        ICollection<string> IDictionary<string, string>.Values => throw new NotImplementedException();
+        return collection;
     }
 }

--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
@@ -43,18 +43,20 @@ namespace Quartz
                     // check if logging provider configured and let if configure
                     serviceProvider.GetService<MicrosoftLoggingProvider>();
 
-                    base.Initialize(options.Value);
+                    base.Initialize(options.Value.ToNameValueCollection());
                 }
-                
+
                 var scheduler = await base.GetScheduler(cancellationToken);
-                
+
                 // The base method may produce a new scheduler in the event that the original scheduler was stopped
-                if(Object.ReferenceEquals(scheduler, initializedScheduler))
+                if (ReferenceEquals(scheduler, initializedScheduler))
+                {
                     return scheduler;
-                
+                }
+
                 await InitializeScheduler(scheduler, cancellationToken);
                 initializedScheduler = scheduler;
-                
+
                 return scheduler;
             }
             finally


### PR DESCRIPTION
So this seems to be never-ending battle against the Options binder. Now they expect that if you implement `IDictionary<,>`, the type must be of type (or inherit from) `Dictionary<,>`. Changing `QuartzOptions` to inherit from `Dictionary<string, string?>` instead of `NameValueCollection `seems to resolve the problem.

Slightly API-breaking but said to be in progress...

fixes #1748