### PR TITLE
Use concrete array to enumerate job listeners

### DIFF
--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1687,7 +1687,7 @@ namespace Quartz.Core
 
             static Task NotifyAllJobListeners(IListenerManager listenerManager,
                                               ExecutingJobsManager jobManager,
-                                              IReadOnlyCollection<IJobListener> listeners,
+                                              IJobListener[] listeners,
                                               Func<IJobListener, IJobExecutionContext, JobExecutionException?, CancellationToken, Task> notifyAction,
                                               IJobExecutionContext jec,
                                               JobExecutionException? je,
@@ -1698,7 +1698,7 @@ namespace Quartz.Core
 
             static async Task NotifyAwaited(IListenerManager listenerManager,
                                             ExecutingJobsManager jobManager,
-                                            IReadOnlyCollection<IJobListener> listeners,
+                                            IJobListener[] listeners,
                                             Func<IJobListener, IJobExecutionContext, JobExecutionException?, CancellationToken, Task> notifyAction,
                                             IJobExecutionContext jec,
                                             JobExecutionException? je,

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1623,7 +1623,7 @@ namespace Quartz.Core
             IJobExecutionContext jec,
             CancellationToken cancellationToken = default)
         {
-            return NotifyJobListeners((jl, jec, je, cancellationToken) => jl.JobToBeExecuted(jec, cancellationToken),
+            return NotifyJobListeners(static (jl, jec, je, cancellationToken) => jl.JobToBeExecuted(jec, cancellationToken),
                                       jec,
                                       null,
                                       cancellationToken);
@@ -1638,7 +1638,7 @@ namespace Quartz.Core
             IJobExecutionContext jec,
             CancellationToken cancellationToken = default)
         {
-            return NotifyJobListeners((jl, jec, je, cancellationToken) => jl.JobExecutionVetoed(jec, cancellationToken),
+            return NotifyJobListeners(static (jl, jec, je, cancellationToken) => jl.JobExecutionVetoed(jec, cancellationToken),
                                       jec,
                                       null,
                                       cancellationToken);
@@ -1655,7 +1655,7 @@ namespace Quartz.Core
             JobExecutionException? je,
             CancellationToken cancellationToken = default)
         {
-            return NotifyJobListeners((jl, jec, je, cancellationToken) => jl.JobWasExecuted(jec, je, cancellationToken),
+            return NotifyJobListeners(static (jl, jec, je, cancellationToken) => jl.JobWasExecuted(jec, je, cancellationToken),
                                       jec,
                                       je,
                                       cancellationToken);


### PR DESCRIPTION
Minor performance improvement and reduced allocations in case global job listeners are registered.

**Before:**

|                                                        Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|-------------------------------------------------------------- |---------:|--------:|--------:|-------:|----------:|
| NotifyJobListenersToBeExecuted_QuartScheduler1_SingleThreaded | 102.1 ns | 0.21 ns | 0.18 ns | 0.0114 |      48 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler1_MultiThreaded | 144.5 ns | 1.58 ns | 1.40 ns | 0.0114 |      48 B |
| NotifyJobListenersToBeExecuted_QuartScheduler2_SingleThreaded | 356.3 ns | 2.32 ns | 1.94 ns | 0.0267 |     112 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler2_MultiThreaded | 313.9 ns | 1.84 ns | 1.63 ns | 0.0269 |     113 B |
| NotifyJobListenersToBeExecuted_QuartScheduler3_SingleThreaded | 415.8 ns | 1.70 ns | 1.42 ns | 0.0439 |     185 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler3_MultiThreaded | 432.0 ns | 7.94 ns | 7.43 ns | 0.0433 |     185 B |
| NotifyJobListenersToBeExecuted_QuartScheduler4_SingleThreaded | 544.4 ns | 1.66 ns | 1.47 ns | 0.0458 |     193 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler4_MultiThreaded | 641.7 ns | 4.84 ns | 4.53 ns | 0.0460 |     193 B |

**After:**

|                                                        Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|-------------------------------------------------------------- |---------:|--------:|--------:|-------:|----------:|
| NotifyJobListenersToBeExecuted_QuartScheduler1_SingleThreaded | 100.8 ns | 0.27 ns | 0.24 ns | 0.0114 |      48 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler1_MultiThreaded | 139.7 ns | 1.03 ns | 0.96 ns | 0.0114 |      48 B |
| NotifyJobListenersToBeExecuted_QuartScheduler2_SingleThreaded | 330.6 ns | 0.35 ns | 0.29 ns | 0.0191 |      80 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler2_MultiThreaded | 296.9 ns | 1.47 ns | 1.37 ns | 0.0189 |      81 B |
| NotifyJobListenersToBeExecuted_QuartScheduler3_SingleThreaded | 390.5 ns | 1.01 ns | 0.84 ns | 0.0362 |     152 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler3_MultiThreaded | 418.9 ns | 5.28 ns | 4.94 ns | 0.0358 |     154 B |
| NotifyJobListenersToBeExecuted_QuartScheduler4_SingleThreaded | 509.0 ns | 0.44 ns | 0.39 ns | 0.0381 |     160 B |
| NotifyJobListenersToBeExecuted_QuartzScheduler4_MultiThreaded | 562.3 ns | 7.32 ns | 6.85 ns | 0.0380 |     161 B |

