### PR TITLE
Add support for creating HttpScheduler with StdSchedulerFactory

### DIFF
--- a/src/Quartz.Examples.HttpClient/Program.cs
+++ b/src/Quartz.Examples.HttpClient/Program.cs
@@ -1,5 +1,27 @@
-﻿using Quartz.HttpClient;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
+using Quartz;
+using Quartz.Simpl;
+
+// Using HttpClientFactory with host builder
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
+    {
+        services.AddHttpClient("QuartzHttpClient", client =>
+        {
+            client.BaseAddress = new Uri("http://localhost:5000/quartz-api/");
+            client.DefaultRequestHeaders.Add("X-Quartz-ApiKey", "MySuperSecretApiKey");
+        });
+
+        // You can also use AddQuartzHttpClient(schedulerName, HttpClient) override if you do not want to use HttpClientFactory (AddHttpClient method call above)
+        services.AddQuartzHttpClient("Quartz ASP.NET Core Sample Scheduler", "QuartzHttpClient");
+    })
+    .Build();
+
+var httpScheduler = host.Services.GetRequiredService<IScheduler>();
+
+/* Simply instantiating new HttpScheduler
 using var httpClient = new HttpClient
 {
     BaseAddress = new Uri("http://localhost:5000/quartz-api/"),
@@ -9,7 +31,20 @@ using var httpClient = new HttpClient
     }
 };
 
-var httpScheduler = new HttpScheduler("Quartz ASP.NET Core Sample Scheduler", httpClient);
+var httpScheduler = new Quartz.HttpClient.HttpScheduler("Quartz ASP.NET Core Sample Scheduler", httpClient);
+*/
+
+/* Using SchedulerBuilder. This does not allow configuring HttpClient used by HttpScheduler. For this example to work, authentication needs to be removed from Quartz.Examples.AspNetCore
+var httpScheduler = await SchedulerBuilder.Create()
+    .WithName("Quartz ASP.NET Core Sample Scheduler")
+    .ProxyToRemoteScheduler<HttpSchedulerProxyFactory>("http://localhost:5000/quartz-api/")
+    .BuildScheduler();*/
+
+/*/ Using SchedulerBuilder with custom ProxyFactory
+var httpScheduler = await SchedulerBuilder.Create()
+    .WithName("Quartz ASP.NET Core Sample Scheduler")
+    .ProxyToRemoteScheduler<MyHttpSchedulerProxyFactory>("http://localhost:5000/quartz-api/")
+    .BuildScheduler();*/
 
 while (true)
 {
@@ -29,5 +64,15 @@ while (true)
     catch (Exception e)
     {
         Console.WriteLine(e.Message);
+    }
+}
+
+internal class MyHttpSchedulerProxyFactory : HttpSchedulerProxyFactory
+{
+    protected override HttpClient CreateHttpClient(string address)
+    {
+        var client = base.CreateHttpClient(address);
+        client.DefaultRequestHeaders.Add("X-Quartz-ApiKey", "MySuperSecretApiKey");
+        return client;
     }
 }

--- a/src/Quartz.Examples.HttpClient/Quartz.Examples.HttpClient.csproj
+++ b/src/Quartz.Examples.HttpClient/Quartz.Examples.HttpClient.csproj
@@ -8,7 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Quartz.HttpClient\Quartz.HttpClient.csproj"/>
+    <ProjectReference Include="..\Quartz.HttpClient\Quartz.HttpClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Quartz.HttpClient/HttpClient/HttpClientExtensions.cs
+++ b/src/Quartz.HttpClient/HttpClient/HttpClientExtensions.cs
@@ -117,7 +117,17 @@ internal static class HttpClientExtensions
             return true;
         }
 
-        var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>(serializerOptions, cancellationToken).ConfigureAwait(false);
+        ProblemDetails? problemDetails = null;
+
+        try
+        {
+            problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>(serializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignored because we can have responses which are not json 
+        }
+
         if (problemDetails?.Detail == null || string.IsNullOrWhiteSpace(problemDetails.Detail))
         {
             // When Web API returns error response it is always problem details, so let HTTP client throw if we do not have problem details

--- a/src/Quartz.HttpClient/HttpClientOptions.cs
+++ b/src/Quartz.HttpClient/HttpClientOptions.cs
@@ -1,0 +1,46 @@
+﻿using System.Text.Json;
+
+namespace Quartz;
+
+public class HttpClientOptions
+{
+    /// <summary>
+    /// Name of the scheduler, must be same as the remote scheduler.
+    /// </summary>
+    public string SchedulerName { get; set; } = null!;
+
+    /// <summary>
+    /// If given, IHttpClientFactory is used to fetch HttpClient with this name.
+    /// </summary>
+    /// <remarks>
+    /// Either this or HttpClient must be given
+    /// </remarks>
+    public string? HttpClientName { get; set; }
+
+    /// <summary>
+    /// If given this HttpClient will be used
+    /// </summary>
+    /// <remarks>
+    /// Either this or HttpClientName must be given
+    /// </remarks>
+    public System.Net.Http.HttpClient? HttpClient { get; set; }
+
+    /// <summary>
+    /// Optional json serializer options to be used by the HTTP scheduler
+    /// </summary>
+    public JsonSerializerOptions? JsonSerializerOptions { get; set; }
+
+    internal void AssertValid()
+    {
+        if (string.IsNullOrWhiteSpace(SchedulerName))
+        {
+            throw new ArgumentException("Scheduler name required");
+        }
+
+        if ((string.IsNullOrWhiteSpace(HttpClientName) && HttpClient == null) ||
+            (!string.IsNullOrWhiteSpace(HttpClientName) && HttpClient != null))
+        {
+            throw new ArgumentException("Either http client name or http client instance required");
+        }
+    }
+}

--- a/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
+++ b/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System.Text.Json;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.HttpClient;
+using Quartz.Impl;
+
+namespace Quartz;
+
+public static class QuartzHttpClientServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register IScheduler which will call remote scheduler over HTTP
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="schedulerName">Name of the scheduler, must be same as the remote scheduler</param>
+    /// <param name="httpClient">HttpClient to be used</param>
+    /// <param name="jsonSerializerOptions">Optional json serializer options to be used by the HTTP scheduler</param>
+    /// <returns></returns>
+    public static IServiceCollection AddQuartzHttpClient(
+        this IServiceCollection services,
+        string schedulerName,
+        System.Net.Http.HttpClient httpClient,
+        JsonSerializerOptions? jsonSerializerOptions = null)
+    {
+        return services.AddQuartzHttpClient(options =>
+        {
+            options.SchedulerName = schedulerName;
+            options.HttpClient = httpClient;
+            options.JsonSerializerOptions = jsonSerializerOptions;
+        });
+    }
+
+    /// <summary>
+    /// Register IScheduler which will call remote scheduler over HTTP
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="schedulerName">Name of the scheduler, must be same as the remote scheduler</param>
+    /// <param name="httpClientName">Name of the HttpClient, which will be fetched from IHttpClientFactory</param>
+    /// <param name="jsonSerializerOptions">Optional json serializer options to be used by the HTTP scheduler</param>
+    /// <returns></returns>
+    public static IServiceCollection AddQuartzHttpClient(
+        this IServiceCollection services,
+        string schedulerName,
+        string httpClientName,
+        JsonSerializerOptions? jsonSerializerOptions = null)
+    {
+        return services.AddQuartzHttpClient(options =>
+        {
+            options.SchedulerName = schedulerName;
+            options.HttpClientName = httpClientName;
+            options.JsonSerializerOptions = jsonSerializerOptions;
+        });
+    }
+
+    /// <summary>
+    /// Register IScheduler which will call remote scheduler over HTTP
+    /// </summary>
+    /// <returns></returns>
+    public static IServiceCollection AddQuartzHttpClient(
+        this IServiceCollection services,
+        Action<HttpClientOptions> configure)
+    {
+        var options = new HttpClientOptions();
+        configure(options);
+
+        options.AssertValid();
+
+        services.AddSingleton<IScheduler>(serviceProvider =>
+        {
+            var httpClient = options.HttpClient ?? serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(options.HttpClientName!);
+
+            var scheduler = new HttpScheduler(options.SchedulerName, httpClient);
+            SchedulerRepository.Instance.Bind(scheduler);
+
+            return scheduler;
+        });
+
+        return services;
+    }
+}

--- a/src/Quartz.HttpClient/Simpl/HttpSchedulerProxyFactory.cs
+++ b/src/Quartz.HttpClient/Simpl/HttpSchedulerProxyFactory.cs
@@ -1,0 +1,43 @@
+﻿using System.Text.Json;
+
+using Quartz.HttpClient;
+using Quartz.Spi;
+
+namespace Quartz.Simpl;
+
+/// <summary>
+/// A <see cref="IRemotableSchedulerProxyFactory" /> implementation that creates
+/// connection to remote scheduler using HTTP.
+/// </summary>
+public class HttpSchedulerProxyFactory : IRemotableSchedulerProxyFactory
+{
+    /// <summary>
+    /// Gets or sets the remote scheduler address.
+    /// </summary>
+    /// <value>The remote scheduler address.</value>
+    public string? Address { private get; set; }
+
+    /// <summary>
+    /// Returns a client proxy to a remote <see cref="IScheduler" />.
+    /// </summary>
+    public IScheduler GetProxy(string schedulerName, string schedulerInstanceId)
+    {
+        if (string.IsNullOrWhiteSpace(Address))
+        {
+            ThrowHelper.ThrowInvalidOperationException("Address hasn't been configured");
+        }
+
+        var scheduler = new HttpScheduler(schedulerName, CreateHttpClient(Address!), CreateJsonSerializerOptions());
+        return scheduler;
+    }
+
+    protected virtual System.Net.Http.HttpClient CreateHttpClient(string address)
+    {
+        return new System.Net.Http.HttpClient
+        {
+            BaseAddress = new Uri(address)
+        };
+    }
+
+    protected virtual JsonSerializerOptions? CreateJsonSerializerOptions() => null;
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
@@ -3,7 +3,6 @@ using System.Data.SQLite;
 using System.Diagnostics;
 
 using Microsoft.Data.Sqlite;
-using Microsoft.Extensions.Logging;
 
 using NUnit.Framework;
 

--- a/src/Quartz/Impl/DirectSchedulerFactory.cs
+++ b/src/Quartz/Impl/DirectSchedulerFactory.cs
@@ -119,6 +119,7 @@ namespace Quartz.Impl
 			CreateScheduler(threadPool, jobStore);
 		}
 
+#if REMOTING
 		/// <summary>
 		/// Creates a proxy to a remote scheduler. This scheduler can be retrieved
 		/// via <see cref="DirectSchedulerFactory.GetScheduler(CancellationToken)" />.
@@ -140,16 +141,15 @@ namespace Quartz.Impl
 		/// <throws>  SchedulerException </throws>
 		protected virtual void CreateRemoteScheduler(string schedulerName, string schedulerInstanceId, string proxyAddress)
 		{
-			string uid = QuartzSchedulerResources.GetUniqueIdentifier(schedulerName, schedulerInstanceId);
-
 		    var proxyBuilder = new RemotingSchedulerProxyFactory();
 		    proxyBuilder.Address = proxyAddress;
-		    RemoteScheduler remoteScheduler = new RemoteScheduler(uid, proxyBuilder);
+            IScheduler remoteScheduler = proxyBuilder.GetProxy(schedulerName, schedulerInstanceId);
 
             SchedulerRepository schedRep = SchedulerRepository.Instance;
 			schedRep.Bind(remoteScheduler);
 		    initialized = true;
 		}
+#endif // REMOTING
 
         /// <summary>
         /// Creates a scheduler using the specified thread pool and job store, and with an idle wait time of

--- a/src/Quartz/Impl/RemoteScheduler.cs
+++ b/src/Quartz/Impl/RemoteScheduler.cs
@@ -19,13 +19,14 @@
 
 #endregion
 
+#if REMOTING
+
+using System.Runtime.Remoting;
+
 using Quartz.Core;
 using Quartz.Impl.Matchers;
 using Quartz.Simpl;
 using Quartz.Spi;
-#if REMOTING
-using System.Runtime.Remoting;
-#endif // REMOTING
 
 namespace Quartz.Impl
 {
@@ -42,13 +43,13 @@ namespace Quartz.Impl
     {
         private IRemotableQuartzScheduler? rsched;
         private readonly string schedId;
-        private readonly IRemotableSchedulerProxyFactory proxyFactory;
+        private readonly Func<IRemotableQuartzScheduler> proxyFactory;
 
         /// <summary>
         /// Construct a <see cref="RemoteScheduler" /> instance to proxy the given
         /// RemoteableQuartzScheduler instance.
         /// </summary>
-        public RemoteScheduler(string schedId, IRemotableSchedulerProxyFactory proxyFactory)
+        public RemoteScheduler(string schedId, Func<IRemotableQuartzScheduler> proxyFactory)
         {
             this.schedId = schedId;
             this.proxyFactory = proxyFactory;
@@ -252,11 +253,7 @@ namespace Quartz.Impl
                 SchedulerRepository.Instance.Remove(schedulerName);
                 return Task.CompletedTask;
             }
-#if REMOTING
             catch (RemotingException re)
-#else // REMOTING
-            catch (Exception re) // TODO (NetCore Port): Determine the correct exception type
-#endif // REMOTING
             {
                 throw InvalidateHandleCreateException("Error communicating with remote scheduler.", re);
             }
@@ -649,11 +646,7 @@ namespace Quartz.Impl
                 ThrowHelper.ThrowUnableToInterruptJobException(se);
                 return Task.FromResult(false);
             }
-#if REMOTING
             catch (RemotingException re)
-#else // REMOTING
-            catch (Exception re) // TODO (NetCore Port): Determine the correct exception type
-#endif // REMOTING
             {
                 ThrowHelper.ThrowUnableToInterruptJobException(InvalidateHandleCreateException("Error communicating with remote scheduler.", re));
                 return Task.FromResult(false);
@@ -673,11 +666,7 @@ namespace Quartz.Impl
                 ThrowHelper.ThrowUnableToInterruptJobException(se);
                 return Task.FromResult(false);
             }
-#if REMOTING
             catch (RemotingException re)
-#else // REMOTING
-            catch (Exception re) // TODO (NetCore Port): Determine the correct exception type
-#endif // REMOTING
             {
                 ThrowHelper.ThrowUnableToInterruptJobException(InvalidateHandleCreateException("Error communicating with remote scheduler.", re));
                 return Task.FromResult(false);
@@ -691,11 +680,7 @@ namespace Quartz.Impl
                 action(GetRemoteScheduler());
                 return Task.CompletedTask;
             }
-#if REMOTING
             catch (RemotingException re)
-#else // REMOTING
-            catch (Exception re) // TODO (NetCore Port): Determine the correct exception type
-#endif // REMOTING
             {
                 throw InvalidateHandleCreateException("Error communicating with remote scheduler.", re);
             }
@@ -707,11 +692,7 @@ namespace Quartz.Impl
             {
                 return Task.FromResult(func(GetRemoteScheduler()));
             }
-#if REMOTING
             catch (RemotingException re)
-#else // REMOTING
-            catch (Exception re) // TODO (NetCore Port): Determine the correct exception type
-#endif // REMOTING
             {
                 throw InvalidateHandleCreateException("Error communicating with remote scheduler.", re);
             }
@@ -723,11 +704,7 @@ namespace Quartz.Impl
             {
                 return action(GetRemoteScheduler());
             }
-#if REMOTING
             catch (RemotingException re)
-#else // REMOTING
-            catch (Exception re) // TODO (NetCore Port): Determine the correct exception type
-#endif // REMOTING
             {
                 throw InvalidateHandleCreateException("Error communicating with remote scheduler.", re);
             }
@@ -742,7 +719,7 @@ namespace Quartz.Impl
 
             try
             {
-                rsched = proxyFactory.GetProxy();
+                rsched = proxyFactory();
             }
             catch (Exception e)
             {
@@ -762,3 +739,5 @@ namespace Quartz.Impl
         }
     }
 }
+
+#endif // REMOTING

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -424,7 +424,11 @@ Please add configuration to your application config file to correctly initialize
                     schedInstId = DefaultInstanceId;
                 }
 
-                var proxyType = loadHelper.LoadType(cfg.GetStringProperty(PropertySchedulerProxyType)) ?? typeof(RemotingSchedulerProxyFactory);
+                var proxyType = loadHelper.LoadType(cfg.GetStringProperty(PropertySchedulerProxyType));
+#if REMOTING
+                proxyType ??= typeof(RemotingSchedulerProxyFactory);
+#endif
+
                 IRemotableSchedulerProxyFactory factory;
                 try
                 {
@@ -437,9 +441,7 @@ Please add configuration to your application config file to correctly initialize
                     throw initException;
                 }
 
-                string uid = QuartzSchedulerResources.GetUniqueIdentifier(schedName, schedInstId);
-
-                RemoteScheduler remoteScheduler = new RemoteScheduler(uid, factory);
+                var remoteScheduler = factory.GetProxy(schedName, schedInstId);
 
                 schedRep.Bind(remoteScheduler);
 

--- a/src/Quartz/SPI/IRemotableSchedulerProxyFactory.cs
+++ b/src/Quartz/SPI/IRemotableSchedulerProxyFactory.cs
@@ -1,15 +1,13 @@
-﻿using Quartz.Simpl;
-
-namespace Quartz.Spi
+﻿namespace Quartz.Spi
 {
     /// <summary>
-    /// Client Proxy to a IRemotableQuartzScheduler
+    /// Client Proxy to a IScheduler
     /// </summary>
     public interface IRemotableSchedulerProxyFactory
     {
         /// <summary>
-        /// Returns a client proxy to a remote <see cref="IRemotableQuartzScheduler" />.
+        /// Returns a client proxy to a remote <see cref="IScheduler" />.
         /// </summary>
-        IRemotableQuartzScheduler? GetProxy();
+        IScheduler GetProxy(string schedulerName, string schedulerInstanceId);
     }
 }

--- a/src/Quartz/SchedulerBuilder.cs
+++ b/src/Quartz/SchedulerBuilder.cs
@@ -206,6 +206,7 @@ namespace Quartz
             return this;
         }
 
+#if REMOTING
         /// <summary>
         /// Makes this scheduler a proxy that calls another scheduler instance via remote invocation
         /// using the default mechanism (for full .NET Framework it's remoting, otherwise unsupported).
@@ -215,6 +216,7 @@ namespace Quartz
         {
             return ProxyToRemoteScheduler<RemotingSchedulerProxyFactory>(address);
         }
+#endif // REMOTING
 
         /// <summary>
         /// Makes this scheduler a proxy that calls another scheduler instance via remote invocation

--- a/src/Quartz/Simpl/RemotingSchedulerExporter.cs
+++ b/src/Quartz/Simpl/RemotingSchedulerExporter.cs
@@ -54,9 +54,7 @@ namespace Quartz.Simpl
         public RemotingSchedulerExporter()
         {
             ChannelType = ChannelTypeTcp;
-#if REMOTING
             TypeFilterLevel = TypeFilterLevel.Full;
-#endif // REMOTING
             ChannelName = DefaultChannelName;
             BindName = DefaultBindName;
             Log = LogProvider.CreateLogger<RemotingSchedulerExporter>();
@@ -68,8 +66,6 @@ namespace Quartz.Simpl
             {
                 ThrowHelper.ThrowArgumentNullException(nameof(scheduler));
             }
-
-#if REMOTING
             if (!(scheduler is MarshalByRefObject))
             {
                 ThrowHelper.ThrowArgumentException("Exported scheduler must be of type MarshallByRefObject", nameof(scheduler));
@@ -94,9 +90,6 @@ namespace Quartz.Simpl
             {
                 Log.LogError(ex,"Exception during Bind");
             }
-#else // REMOTING
-            // TODO (NetCore Port): Replace with HTTP communication
-#endif // REMOTING
         }
 
         /// <summary>
@@ -110,7 +103,6 @@ namespace Quartz.Simpl
                 // try remoting bind
                 var props = CreateConfiguration();
 
-#if REMOTING
                 // use binary formatter
                 var formatProviderProps = ExtractFormatProviderConfiguration(props);
                 var formatprovider = new BinaryServerFormatterSinkProvider(formatProviderProps, null);
@@ -153,9 +145,6 @@ namespace Quartz.Simpl
                 ChannelServices.RegisterChannel(chan, false);
 
                 registeredChannels.Add(channelRegistrationKey, new object());
-#else // REMOTING
-                // TODO (NetCore Port): Replace with HTTP communication
-#endif // REMOTING
                 Log.LogInformation("Remoting channel registered successfully");
             }
             else
@@ -202,21 +191,15 @@ namespace Quartz.Simpl
             {
                 ThrowHelper.ThrowArgumentNullException(nameof(scheduler));
             }
-#if REMOTING
             if (!(scheduler is MarshalByRefObject))
             {
                 ThrowHelper.ThrowArgumentException("Exported scheduler must be of type MarshallByRefObject", nameof(scheduler));
             }
-#endif // REMOTING
 
             try
             {
-#if REMOTING
                 RemotingServices.Disconnect((MarshalByRefObject)scheduler);
                 Log.LogInformation("Successfully disconnected remotable scheduler");
-#else // REMOTING
-                // TODO (NetCore Port): Replace with HTTP communication
-#endif // REMOTING
             }
             catch (ArgumentException ex)
             {


### PR DESCRIPTION
This PR adds support for creating `HttpScheduler` using `StdSchedulerFactory`.

I changed the `IRemotableSchedulerProxyFactory` to return `IScheduler` instead of `IRemotableQuartzScheduler` and implemented `HttpSchedulerProxyFactory` which creates `HttpScheduler`. If the default implementation is used through `StdSchedulerFactory`, only base address can be configured for the `HttpClient`. However, one can inherit their own implementation from `HttpSchedulerProxyFactory` which can configure the `HttpClient`. I added examples for both of these cases into `Quartz.Examples.HttpClient`.

I also added extension methods to register `HttpScheduler` into service collection. As it is registered as `IScheduler`, only single scheduler can be added this way. There is also example about this in `Quartz.Examples.HttpClient`.

I also found a bug in the error handling of `HttpScheduler` and fixed it also in this PR. I can split the change into separate PR if that is better. The issue was that JSON deserialization exception was thrown if HTTP response with non OK status code did not have JSON body. Now in these cases exception by `HttpClient` is thrown which contains details about the error (e.g. HTTP status code of the response).