### PR TITLE
Add support for registering multiple HttpSchedulers

### DIFF
--- a/src/Quartz.HttpClient/Quartz.HttpClient.csproj
+++ b/src/Quartz.HttpClient/Quartz.HttpClient.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
+++ b/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Quartz.HttpClient;
 using Quartz.Impl;
+using Quartz.Simpl;
 
 namespace Quartz;
 
@@ -23,12 +24,7 @@ public static class QuartzHttpClientServiceCollectionExtensions
         System.Net.Http.HttpClient httpClient,
         JsonSerializerOptions? jsonSerializerOptions = null)
     {
-        return services.AddQuartzHttpClient(options =>
-        {
-            options.SchedulerName = schedulerName;
-            options.HttpClient = httpClient;
-            options.JsonSerializerOptions = jsonSerializerOptions;
-        });
+        return services.AddQuartzHttpClient<IScheduler>(schedulerName, httpClient, jsonSerializerOptions);
     }
 
     /// <summary>
@@ -45,12 +41,7 @@ public static class QuartzHttpClientServiceCollectionExtensions
         string httpClientName,
         JsonSerializerOptions? jsonSerializerOptions = null)
     {
-        return services.AddQuartzHttpClient(options =>
-        {
-            options.SchedulerName = schedulerName;
-            options.HttpClientName = httpClientName;
-            options.JsonSerializerOptions = jsonSerializerOptions;
-        });
+        return services.AddQuartzHttpClient<IScheduler>(schedulerName, httpClientName, jsonSerializerOptions);
     }
 
     /// <summary>
@@ -61,19 +52,82 @@ public static class QuartzHttpClientServiceCollectionExtensions
         this IServiceCollection services,
         Action<HttpClientOptions> configure)
     {
+        return services.AddQuartzHttpClient<IScheduler>(configure);
+    }
+
+    /// <summary>
+    /// Register scheduler of given type which will call remote scheduler over HTTP
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="schedulerName">Name of the scheduler, must be same as the remote scheduler</param>
+    /// <param name="httpClient">HttpClient to be used</param>
+    /// <param name="jsonSerializerOptions">Optional json serializer options to be used by the HTTP scheduler</param>
+    /// <typeparam name="TScheduler">Interface for the scheduler to be registered. Must inherit directly from IScheduler</typeparam>
+    /// <returns></returns>
+    public static IServiceCollection AddQuartzHttpClient<TScheduler>(
+        this IServiceCollection services,
+        string schedulerName,
+        System.Net.Http.HttpClient httpClient,
+        JsonSerializerOptions? jsonSerializerOptions = null) where TScheduler : class, IScheduler
+    {
+        return services.AddQuartzHttpClient<TScheduler>(options =>
+        {
+            options.SchedulerName = schedulerName;
+            options.HttpClient = httpClient;
+            options.JsonSerializerOptions = jsonSerializerOptions;
+        });
+    }
+
+    /// <summary>
+    /// Register scheduler of given type which will call remote scheduler over HTTP
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="schedulerName">Name of the scheduler, must be same as the remote scheduler</param>
+    /// <param name="httpClientName">Name of the HttpClient, which will be fetched from IHttpClientFactory</param>
+    /// <param name="jsonSerializerOptions">Optional json serializer options to be used by the HTTP scheduler</param>
+    /// <typeparam name="TScheduler">Interface for the scheduler to be registered. Must inherit directly from IScheduler</typeparam>
+    /// <returns></returns>
+    public static IServiceCollection AddQuartzHttpClient<TScheduler>(
+        this IServiceCollection services,
+        string schedulerName,
+        string httpClientName,
+        JsonSerializerOptions? jsonSerializerOptions = null) where TScheduler : class, IScheduler
+    {
+        return services.AddQuartzHttpClient<TScheduler>(options =>
+        {
+            options.SchedulerName = schedulerName;
+            options.HttpClientName = httpClientName;
+            options.JsonSerializerOptions = jsonSerializerOptions;
+        });
+    }
+
+    /// <summary>
+    /// Register scheduler of given type which will call remote scheduler over HTTP
+    /// </summary>
+    /// <typeparam name="TScheduler">Interface for the scheduler to be registered. Must inherit directly from IScheduler</typeparam>
+    /// <returns></returns>
+    public static IServiceCollection AddQuartzHttpClient<TScheduler>(
+        this IServiceCollection services,
+        Action<HttpClientOptions> configure) where TScheduler : class, IScheduler
+    {
         var options = new HttpClientOptions();
         configure(options);
 
         options.AssertValid();
 
-        services.AddSingleton<IScheduler>(serviceProvider =>
+        services.AddSingleton<TScheduler>(serviceProvider =>
         {
             var httpClient = options.HttpClient ?? serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(options.HttpClientName!);
+            IScheduler scheduler = new HttpScheduler(options.SchedulerName, httpClient, options.JsonSerializerOptions);
 
-            var scheduler = new HttpScheduler(options.SchedulerName, httpClient, options.JsonSerializerOptions);
+            if (typeof(TScheduler) != typeof(IScheduler))
+            {
+                var schedulerType = SchedulerTypeBuilder.Create<TScheduler>();
+                scheduler = (IScheduler)Activator.CreateInstance(schedulerType, scheduler);
+            }
+
             SchedulerRepository.Instance.Bind(scheduler);
-
-            return scheduler;
+            return (TScheduler)scheduler;
         });
 
         return services;

--- a/src/Quartz.HttpClient/Simpl/SchedulerTypeBuilder.cs
+++ b/src/Quartz.HttpClient/Simpl/SchedulerTypeBuilder.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using Quartz.Impl;
+
+namespace Quartz.Simpl;
+
+/// <summary>
+/// Creates dynamic IScheduler types with custom marker interface.
+/// </summary>
+/// <remarks>
+/// This implementation is based on BusInstanceBuilder from MassTransit:
+/// https://github.com/MassTransit/MassTransit/blob/master/src/MassTransit/DependencyInjection/DependencyInjection/BusInstanceBuilder.cs
+/// </remarks>
+internal static class SchedulerTypeBuilder
+{
+    private const string AssemblyName = "Quartz.SchedulerInstances";
+
+    private static readonly ModuleBuilder moduleBuilder = CreateModuleBuilder();
+    private static readonly ConcurrentDictionary<string, Type> createdTypes = new();
+
+    private static ModuleBuilder CreateModuleBuilder()
+    {
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(AssemblyName), AssemblyBuilderAccess.RunAndCollect);
+        var builder = assemblyBuilder.DefineDynamicModule(AssemblyName);
+
+        return builder;
+    }
+
+    public static Type Create<TScheduler>() where TScheduler : class, IScheduler
+    {
+        return Create(typeof(TScheduler));
+    }
+
+    public static Type Create(Type interfaceType)
+    {
+        var result = createdTypes.GetOrAdd(interfaceType.FullName, _ => DoCreate(interfaceType));
+        return result;
+
+        static Type DoCreate(Type interfaceType)
+        {
+            AssertInterfaceType(interfaceType);
+            var schedulerType = CreateTypeForInterface(interfaceType);
+            return schedulerType;
+        }
+    }
+
+    private static void AssertInterfaceType(Type interfaceType)
+    {
+        if (!interfaceType.IsInterface)
+        {
+            throw new ArgumentException($"Scheduler type {interfaceType.FullName} is not interface", nameof(interfaceType));
+        }
+
+        if (!interfaceType.IsPublic)
+        {
+            throw new ArgumentException($"Scheduler type {interfaceType.FullName} is not public", nameof(interfaceType));
+        }
+
+        if (interfaceType.IsGenericType)
+        {
+            throw new ArgumentException($"Scheduler type {interfaceType.FullName} is generic", nameof(interfaceType));
+        }
+
+        if (!typeof(IScheduler).IsAssignableFrom(interfaceType))
+        {
+            throw new ArgumentException($"Scheduler type {interfaceType.FullName} does not implement IScheduler", nameof(interfaceType));
+        }
+
+        if (interfaceType.IsNested)
+        {
+            throw new ArgumentException($"Scheduler type {interfaceType.FullName} is nested type", nameof(interfaceType));
+        }
+
+        if (interfaceType.GetInterfaces().Any(x => x != typeof(IScheduler)))
+        {
+            throw new ArgumentException($"Scheduler type {interfaceType.FullName} implements other interfaces than {nameof(IScheduler)}", nameof(interfaceType));
+        }
+    }
+
+    private static Type CreateTypeForInterface(Type interfaceType)
+    {
+        var typeName = interfaceType.Namespace != null ?
+            $"{AssemblyName}.{interfaceType.Namespace}.{interfaceType.Name}Instance" :
+            $"{AssemblyName}.{interfaceType.Name}Instance";
+
+        try
+        {
+            var parentType = typeof(DelegatingScheduler);
+
+            var typeBuilder = moduleBuilder.DefineType(
+                name: typeName,
+                attr: TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed,
+                parent: parentType,
+                interfaces: new[] { interfaceType }
+            );
+
+            var parameterTypes = new[] { typeof(IScheduler) };
+
+            var ctorParent = parentType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, parameterTypes, null)!;
+            var ctorBuilder = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, parameterTypes);
+
+            var il = ctorBuilder.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, ctorParent);
+            il.Emit(OpCodes.Ret);
+
+            return typeBuilder.CreateTypeInfo()!.AsType();
+        }
+        catch (Exception ex)
+        {
+            var message = $"Exception creating scheduler instance ({typeName}) for {interfaceType.FullName}";
+            throw new InvalidOperationException(message, ex);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/QuartzHttpClientServiceCollectionExtensionsTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/QuartzHttpClientServiceCollectionExtensionsTest.cs
@@ -1,0 +1,141 @@
+﻿using FakeItEasy;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+using Quartz;
+using Quartz.HttpClient;
+using Quartz.Impl;
+
+using QuartzHttpClientServiceCollectionExtensionsTestTypes;
+
+namespace Quartz.Tests.Unit.Extensions.DependencyInjection
+{
+    public class QuartzHttpClientServiceCollectionExtensionsTest
+    {
+        private System.Net.Http.HttpClient testClient;
+
+        [SetUp]
+        public void SetUp()
+        {
+            testClient = new System.Net.Http.HttpClient
+            {
+                BaseAddress = new Uri("http://localhost:8080")
+            };
+        }
+
+        [TearDown]
+        public async Task TearDown()
+        {
+            testClient?.Dispose();
+            testClient = null;
+
+            await ClearSchedulerRepository();
+        }
+
+        [Test]
+        public void ShouldBeAbelToRegisterSchedulerUsingHttpClient()
+        {
+            var services = new ServiceCollection();
+            services.AddQuartzHttpClient("Scheduler", testClient);
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var scheduler = serviceProvider.GetRequiredService<IScheduler>();
+            scheduler.Should().NotBeNull();
+            scheduler.Should().BeOfType<HttpScheduler>();
+            scheduler.SchedulerName.Should().Be("Scheduler");
+        }
+
+        [Test]
+        public void ShouldBeAbelToRegisterSchedulerUsingHttpClientAndMarkerInterface()
+        {
+            var services = new ServiceCollection();
+            services.AddQuartzHttpClient<IMyScheduler>("Scheduler", testClient);
+            services.AddQuartzHttpClient<IMySecondScheduler>("SecondScheduler", testClient);
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            IScheduler scheduler = serviceProvider.GetRequiredService<IMyScheduler>();
+            scheduler.Should().NotBeNull();
+            scheduler.Should().BeAssignableTo<DelegatingScheduler>();
+            scheduler.SchedulerName.Should().Be("Scheduler");
+
+            scheduler = serviceProvider.GetRequiredService<IMySecondScheduler>();
+            scheduler.Should().NotBeNull();
+            scheduler.Should().BeAssignableTo<DelegatingScheduler>();
+            scheduler.SchedulerName.Should().Be("SecondScheduler");
+
+            scheduler = serviceProvider.GetService<IScheduler>();
+            scheduler.Should().BeNull();
+        }
+
+        [Test]
+        public void ShouldBeAbelToRegisterSchedulerUsingHttpClientFactor()
+        {
+            var httpClientFactory = A.Fake<IHttpClientFactory>();
+            A.CallTo(() => httpClientFactory.CreateClient("MyHttpClient")).Returns(testClient);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(httpClientFactory);
+            services.AddQuartzHttpClient("Scheduler", "MyHttpClient");
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var scheduler = serviceProvider.GetRequiredService<IScheduler>();
+            scheduler.Should().NotBeNull();
+            scheduler.Should().BeOfType<HttpScheduler>();
+            scheduler.SchedulerName.Should().Be("Scheduler");
+        }
+
+        [Test]
+        public void ShouldBeAbelToRegisterSchedulerUsingHttpClientFactorAndMarkerInterface()
+        {
+            var httpClientFactory = A.Fake<IHttpClientFactory>();
+            A.CallTo(() => httpClientFactory.CreateClient("MyHttpClient")).Returns(testClient);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(httpClientFactory);
+            services.AddQuartzHttpClient<IMyScheduler>("Scheduler", "MyHttpClient");
+            services.AddQuartzHttpClient<IMySecondScheduler>("SecondScheduler", "MyHttpClient");
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            IScheduler scheduler = serviceProvider.GetRequiredService<IMyScheduler>();
+            scheduler.Should().NotBeNull();
+            scheduler.Should().BeAssignableTo<DelegatingScheduler>();
+            scheduler.SchedulerName.Should().Be("Scheduler");
+
+            scheduler = serviceProvider.GetRequiredService<IMySecondScheduler>();
+            scheduler.Should().NotBeNull();
+            scheduler.Should().BeAssignableTo<DelegatingScheduler>();
+            scheduler.SchedulerName.Should().Be("SecondScheduler");
+
+            scheduler = serviceProvider.GetService<IScheduler>();
+            scheduler.Should().BeNull();
+        }
+
+        private static async Task ClearSchedulerRepository()
+        {
+            var allSchedulers = await SchedulerRepository.Instance.LookupAll();
+            foreach (var scheduler in allSchedulers)
+            {
+                SchedulerRepository.Instance.Remove(scheduler.SchedulerName);
+            }
+        }
+    }
+}
+
+namespace QuartzHttpClientServiceCollectionExtensionsTestTypes
+{
+    public interface IMyScheduler : IScheduler
+    {
+    }
+
+    public interface IMySecondScheduler : IScheduler
+    {
+    }
+}

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\Quartz.Extensions.DependencyInjection\Quartz.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\Quartz.Extensions.Hosting\Quartz.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
+    <ProjectReference Include="..\Quartz.HttpClient\Quartz.HttpClient.csproj" />
     <ProjectReference Include="..\Quartz.Jobs\Quartz.Jobs.csproj" />
     <ProjectReference Include="..\Quartz.Plugins\Quartz.Plugins.csproj" />
     <ProjectReference Include="..\Quartz.Plugins.TimeZoneConverter\Quartz.Plugins.TimeZoneConverter.csproj" />

--- a/src/Quartz.Tests.Unit/Simpl/SchedulerTypeBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/SchedulerTypeBuilderTest.cs
@@ -1,0 +1,120 @@
+﻿using FluentAssertions;
+
+using NUnit.Framework;
+
+using Quartz;
+using Quartz.Impl;
+using Quartz.Simpl;
+
+using SchedulerTypeBuilderTestTypes;
+
+namespace Quartz.Tests.Unit.Simpl
+{
+    public class SchedulerTypeBuilderTest
+    {
+        [Test]
+        public void ShouldBeAbleToCreateTypeForInterface()
+        {
+            RunTest<IMyScheduler>();
+
+            // Should be able to create same type multiple times
+            RunTest(typeof(IMyScheduler));
+        }
+
+        [Test]
+        public void ShouldBeAbleToCreateTypeForInterfaceWithoutNameSpace()
+        {
+            RunTest<IMySchedulerWithoutNameSpace>();
+        }
+
+        [Test]
+        public void ShouldBeAbleToCreateTypeForInterfacesWithSameNameInDifferentNamespaces()
+        {
+            RunTest<IMyScheduler>();
+            RunTest<SchedulerTypeBuilderTestTypesB.IMyScheduler>();
+        }
+
+        [Test]
+        public void ShouldValidateGivenInterface()
+        {
+            AssertThrows(typeof(DummyClass));
+            AssertThrows(typeof(INonPublicInterface));
+            AssertThrows(typeof(IGenericInterface<int>));
+            AssertThrows(typeof(IDummyInterface));
+            AssertThrows(typeof(INestedInterface));
+            AssertThrows(typeof(IInterfaceWhichImplementMultipleInterfaces));
+
+            static void AssertThrows(Type type)
+            {
+                Assert.Throws<ArgumentException>(() => SchedulerTypeBuilder.Create(type))!.ParamName.Should().Be("interfaceType");
+            }
+        }
+
+        private static void RunTest<TScheduler>() where TScheduler : class, IScheduler
+        {
+            var cratedType = SchedulerTypeBuilder.Create<TScheduler>();
+            AssertCreatedType(cratedType, typeof(TScheduler));
+        }
+
+        private static void RunTest(Type type)
+        {
+            var cratedType = SchedulerTypeBuilder.Create(type);
+            AssertCreatedType(cratedType, type);
+        }
+
+        private static void AssertCreatedType(Type schedulerType, Type interfaceType)
+        {
+            schedulerType.Should().NotBeNull();
+
+            var dummyScheduler = new DelegatingScheduler(null!);
+            var scheduler = Activator.CreateInstance(schedulerType, dummyScheduler);
+
+            scheduler.Should().NotBeNull();
+            scheduler.Should().BeAssignableTo<IScheduler>();
+            scheduler.Should().BeAssignableTo(interfaceType);
+        }
+
+        // ReSharper disable once MemberCanBePrivate.Global
+        public interface INestedInterface : IScheduler
+        {
+        }
+    }
+}
+
+namespace SchedulerTypeBuilderTestTypes
+{
+    public interface IMyScheduler : IScheduler
+    {
+    }
+
+    public class DummyClass
+    {
+    }
+
+    public interface IDummyInterface
+    {
+    }
+
+    public interface IGenericInterface<T> : IScheduler
+    {
+    }
+
+    public interface IInterfaceWhichImplementMultipleInterfaces : IScheduler, ICalendar
+    {
+    }
+
+    internal interface INonPublicInterface : IScheduler
+    {
+    }
+}
+
+namespace SchedulerTypeBuilderTestTypesB
+{
+    public interface IMyScheduler : IScheduler
+    {
+    }
+}
+
+public interface IMySchedulerWithoutNameSpace : IScheduler
+{
+}

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -1,0 +1,282 @@
+﻿using Quartz.Impl.Matchers;
+using Quartz.Spi;
+
+namespace Quartz.Impl;
+
+public class DelegatingScheduler : IScheduler
+{
+    private readonly IScheduler scheduler;
+
+    public DelegatingScheduler(IScheduler scheduler)
+    {
+        this.scheduler = scheduler;
+    }
+
+    public Task<bool> IsJobGroupPaused(string groupName, CancellationToken cancellationToken = default)
+    {
+        return scheduler.IsJobGroupPaused(groupName, cancellationToken);
+    }
+
+    public Task<bool> IsTriggerGroupPaused(string groupName, CancellationToken cancellationToken = default)
+    {
+        return scheduler.IsTriggerGroupPaused(groupName, cancellationToken);
+    }
+
+    public string SchedulerName => scheduler.SchedulerName;
+    public string SchedulerInstanceId => scheduler.SchedulerInstanceId;
+    public SchedulerContext Context => scheduler.Context;
+    public bool InStandbyMode => scheduler.InStandbyMode;
+    public bool IsShutdown => scheduler.IsShutdown;
+
+    public Task<SchedulerMetaData> GetMetaData(CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetMetaData(cancellationToken);
+    }
+
+    public Task<IReadOnlyCollection<IJobExecutionContext>> GetCurrentlyExecutingJobs(CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetCurrentlyExecutingJobs(cancellationToken);
+    }
+
+    public IJobFactory JobFactory
+    {
+        set => scheduler.JobFactory = value;
+    }
+
+    public IListenerManager ListenerManager => scheduler.ListenerManager;
+
+    public Task<IReadOnlyCollection<string>> GetJobGroupNames(CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetJobGroupNames(cancellationToken);
+    }
+
+    public Task<IReadOnlyCollection<string>> GetTriggerGroupNames(CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetTriggerGroupNames(cancellationToken);
+    }
+
+    public Task<IReadOnlyCollection<string>> GetPausedTriggerGroups(CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetPausedTriggerGroups(cancellationToken);
+    }
+
+    public Task Start(CancellationToken cancellationToken = default)
+    {
+        return scheduler.Start(cancellationToken);
+    }
+
+    public Task StartDelayed(TimeSpan delay, CancellationToken cancellationToken = default)
+    {
+        return scheduler.StartDelayed(delay, cancellationToken);
+    }
+
+    public bool IsStarted
+    {
+        get { return scheduler.IsStarted; }
+    }
+
+    public Task Standby(CancellationToken cancellationToken = default)
+    {
+        return scheduler.Standby(cancellationToken);
+    }
+
+    public Task Shutdown(CancellationToken cancellationToken = default)
+    {
+        return scheduler.Shutdown(cancellationToken);
+    }
+
+    public Task Shutdown(bool waitForJobsToComplete, CancellationToken cancellationToken = default)
+    {
+        return scheduler.Shutdown(waitForJobsToComplete, cancellationToken);
+    }
+
+    public Task<DateTimeOffset> ScheduleJob(IJobDetail jobDetail, ITrigger trigger, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ScheduleJob(jobDetail, trigger, cancellationToken);
+    }
+
+    public Task<DateTimeOffset> ScheduleJob(ITrigger trigger, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ScheduleJob(trigger, cancellationToken);
+    }
+
+    public Task ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<ITrigger>> triggersAndJobs, bool replace, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ScheduleJobs(triggersAndJobs, replace, cancellationToken);
+    }
+
+    public Task ScheduleJob(IJobDetail jobDetail, IReadOnlyCollection<ITrigger> triggersForJob, bool replace, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ScheduleJob(jobDetail, triggersForJob, replace, cancellationToken);
+    }
+
+    public Task<bool> UnscheduleJob(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.UnscheduleJob(triggerKey, cancellationToken);
+    }
+
+    public Task<bool> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+    {
+        return scheduler.UnscheduleJobs(triggerKeys, cancellationToken);
+    }
+
+    public Task<DateTimeOffset?> RescheduleJob(TriggerKey triggerKey, ITrigger newTrigger, CancellationToken cancellationToken = default)
+    {
+        return scheduler.RescheduleJob(triggerKey, newTrigger, cancellationToken);
+    }
+
+    public Task AddJob(IJobDetail jobDetail, bool replace, CancellationToken cancellationToken = default)
+    {
+        return scheduler.AddJob(jobDetail, replace, cancellationToken);
+    }
+
+    public Task AddJob(IJobDetail jobDetail, bool replace, bool storeNonDurableWhileAwaitingScheduling, CancellationToken cancellationToken = default)
+    {
+        return scheduler.AddJob(jobDetail, replace, storeNonDurableWhileAwaitingScheduling, cancellationToken);
+    }
+
+    public Task<bool> DeleteJob(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.DeleteJob(jobKey, cancellationToken);
+    }
+
+    public Task<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+    {
+        return scheduler.DeleteJobs(jobKeys, cancellationToken);
+    }
+
+    public Task TriggerJob(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.TriggerJob(jobKey, cancellationToken);
+    }
+
+    public Task TriggerJob(JobKey jobKey, JobDataMap data, CancellationToken cancellationToken = default)
+    {
+        return scheduler.TriggerJob(jobKey, data, cancellationToken);
+    }
+
+    public Task PauseJob(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.PauseJob(jobKey, cancellationToken);
+    }
+
+    public Task PauseJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return scheduler.PauseJobs(matcher, cancellationToken);
+    }
+
+    public Task PauseTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.PauseTrigger(triggerKey, cancellationToken);
+    }
+
+    public Task PauseTriggers(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return scheduler.PauseTriggers(matcher, cancellationToken);
+    }
+
+    public Task ResumeJob(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ResumeJob(jobKey, cancellationToken);
+    }
+
+    public Task ResumeJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ResumeJobs(matcher, cancellationToken);
+    }
+
+    public Task ResumeTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ResumeTrigger(triggerKey, cancellationToken);
+    }
+
+    public Task ResumeTriggers(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ResumeTriggers(matcher, cancellationToken);
+    }
+
+    public Task PauseAll(CancellationToken cancellationToken = default)
+    {
+        return scheduler.PauseAll(cancellationToken);
+    }
+
+    public Task ResumeAll(CancellationToken cancellationToken = default)
+    {
+        return scheduler.ResumeAll(cancellationToken);
+    }
+
+    public Task<IReadOnlyCollection<JobKey>> GetJobKeys(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetJobKeys(matcher, cancellationToken);
+    }
+
+    public Task<IReadOnlyCollection<ITrigger>> GetTriggersOfJob(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetTriggersOfJob(jobKey, cancellationToken);
+    }
+
+    public Task<IReadOnlyCollection<TriggerKey>> GetTriggerKeys(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetTriggerKeys(matcher, cancellationToken);
+    }
+
+    public Task<IJobDetail?> GetJobDetail(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetJobDetail(jobKey, cancellationToken);
+    }
+
+    public Task<ITrigger?> GetTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetTrigger(triggerKey, cancellationToken);
+    }
+
+    public Task<TriggerState> GetTriggerState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetTriggerState(triggerKey, cancellationToken);
+    }
+
+    public Task AddCalendar(string calName, ICalendar calendar, bool replace, bool updateTriggers, CancellationToken cancellationToken = default)
+    {
+        return scheduler.AddCalendar(calName, calendar, replace, updateTriggers, cancellationToken);
+    }
+
+    public Task<bool> DeleteCalendar(string calName, CancellationToken cancellationToken = default)
+    {
+        return scheduler.DeleteCalendar(calName, cancellationToken);
+    }
+
+    public Task<ICalendar?> GetCalendar(string calName, CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetCalendar(calName, cancellationToken);
+    }
+
+    public Task<IReadOnlyCollection<string>> GetCalendarNames(CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetCalendarNames(cancellationToken);
+    }
+
+    public Task<bool> Interrupt(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.Interrupt(jobKey, cancellationToken);
+    }
+
+    public Task<bool> Interrupt(string fireInstanceId, CancellationToken cancellationToken = default)
+    {
+        return scheduler.Interrupt(fireInstanceId, cancellationToken);
+    }
+
+    public Task<bool> CheckExists(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.CheckExists(jobKey, cancellationToken);
+    }
+
+    public Task<bool> CheckExists(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.CheckExists(triggerKey, cancellationToken);
+    }
+
+    public Task Clear(CancellationToken cancellationToken = default)
+    {
+        return scheduler.Clear(cancellationToken);
+    }
+}


### PR DESCRIPTION
Current implementation of `services.AddQuartzHttpClient()` will register the `HttpScheduler` as `IScheduler` and thus only single client can be added.

This PR adds support for using marker interfaces to register multiple `HttpScheduler`s by using `services.AddQuartzHttpClient<IMyScheduler>()`. Quartz will dynamically create implementation for the given interface and register it into the service collection. The code to generate the dynamic types is based on code from MassTransit.

I tested the implementation only by using the tests and examples included in this PR. So, there might be some corner cases where the current implementation will not work, but we can fix those as they come up.