### PR TITLE
Cleanup JobTemplate docs

### DIFF
--- a/docs/documentation/quartz-3.x/how-tos/job-template.md
+++ b/docs/documentation/quartz-3.x/how-tos/job-template.md
@@ -8,7 +8,7 @@ This page tries to pull together a variety of common recommendations listed thro
 into one page can be easily referenced.
 
 ```csharp
-public class ASampleJob : IJob
+public class SampleJob : IJob
 {
     public static readonly JobKey Key = new JobKey("sample-job", "examples");
 
@@ -17,7 +17,7 @@ public class ASampleJob : IJob
         try 
         {
             // get data out of the MergedJobDataMap
-            var value = context.MergedJobDataMap.GetString("some-vaule");
+            var value = context.MergedJobDataMap.GetString("some-value");
             
             // ... do work
         } catch (Exception ex) {


### PR DESCRIPTION
Noticed the typo + the prefix of the class.

C# standard typically uses `A` prefix for abstract classes and I think as a standard (based on other jobs created) `SampleJob` is a cleaner name.