### PR TITLE
Add explicit netcoreapp3.1 and net6.0 targets to MS integration projects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@
 
 ## Release 3.5.1, xxx xx 2022
 
+This release contains mostly bug fixes and refinement of package dependencies/targets.
+
+* NEW FEATURES
+
+  * Add explicit netcoreapp3.1 and net6.0 targets to MS integration projects (#1879)
+  * Use IHostApplicationLifetime instead of IApplicationLifetime in >= netcoreapp3.1 Hosting targets (#1593)
+
+
 * FIXES
  
   * Fix named connection string resolution when using MS DI and its configuration system (#1839)

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Quartz.NET ASP.NET Core integration; $(Description)</Description>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Lewis Zou, Marko Lahma, Quartz.NET</Authors>
@@ -17,11 +17,16 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_HEALTH_CHECKS</DefineConstants>
   </PropertyGroup>
 

--- a/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj
+++ b/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj
@@ -2,16 +2,28 @@
 
     <PropertyGroup>
         <Description>Quartz.NET Microsoft.Extensions.DependencyInjection integration; $(Description)</Description>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net6.0;netstandard2.0</TargetFrameworks>
         <RootNamespace>Quartz</RootNamespace>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <Authors>Facundo Glaeser, Marko Lahma, Quartz.NET</Authors>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -34,7 +34,7 @@ namespace Quartz
             Action<IServiceCollectionQuartzConfigurator>? configure = null)
         {
             services.AddOptions();
-            services.TryAddSingleton<MicrosoftLoggingProvider?>(serviceProvider =>
+            services.TryAddSingleton<MicrosoftLoggingProvider>(serviceProvider =>
             {
                 var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
 
@@ -45,7 +45,7 @@ namespace Quartz
 
                 LogContext.SetCurrentLogProvider(loggerFactory);
 
-                return LogProvider.CurrentLogProvider as MicrosoftLoggingProvider;
+                return (LogProvider.CurrentLogProvider as MicrosoftLoggingProvider)!;
             });
 
             var schedulerBuilder = SchedulerBuilder.Create(properties);
@@ -72,7 +72,10 @@ namespace Quartz
             {
                 foreach (var key in schedulerBuilder.Properties.AllKeys)
                 {
-                    options[key] = schedulerBuilder.Properties[key];
+                    if (key is not null)
+                    {
+                        options[key] = schedulerBuilder.Properties[key];
+                    }
                 }
             });
 
@@ -212,7 +215,7 @@ namespace Quartz
             return options;
         }
 
-      
+
 
         private static IJobDetail ConfigureAndBuildJobDetail(
             Type type,

--- a/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj
+++ b/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj
@@ -2,14 +2,22 @@
 
   <PropertyGroup>
     <Description>Quartz.NET Generic Host integration; $(Description)</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Andrew Lock, Marko Lahma, Quartz.NET</Authors>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Extensions.Hosting/QuartzHostedService.cs
+++ b/src/Quartz.Extensions.Hosting/QuartzHostedService.cs
@@ -4,11 +4,17 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
+#if NETCOREAPP3_1_OR_GREATER
+using Lifetime = Microsoft.Extensions.Hosting.IHostApplicationLifetime;
+#else
+using Lifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
+#endif
+
 namespace Quartz
 {
     internal class QuartzHostedService : IHostedService
     {
-        private readonly IApplicationLifetime applicationLifetime;
+        private readonly Lifetime applicationLifetime;
         private readonly ISchedulerFactory schedulerFactory;
         private readonly IOptions<QuartzHostedServiceOptions> options;
         private IScheduler? scheduler;
@@ -16,7 +22,7 @@ namespace Quartz
         private bool schedulerWasStarted;
 
         public QuartzHostedService(
-            IApplicationLifetime applicationLifetime,
+            Lifetime applicationLifetime,
             ISchedulerFactory schedulerFactory,
             IOptions<QuartzHostedServiceOptions> options)
         {

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -2,18 +2,23 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Quartz.Impl.Matchers;
 using Quartz.Spi;
+
+#if NETCOREAPP3_1_OR_GREATER
+using Lifetime = Microsoft.Extensions.Hosting.IHostApplicationLifetime;
+#else
+using Lifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
+#endif
 
 namespace Quartz.Tests.Unit
 {
     [TestFixture]
     public class QuartzHostedServiceTests
     {
-        private sealed class MockApplicationLifetime : IApplicationLifetime
+        private sealed class MockApplicationLifetime : Lifetime
         {
             public CancellationTokenSource StartedSource { get; } = new CancellationTokenSource();
             public CancellationTokenSource StoppingSource { get; } = new CancellationTokenSource();


### PR DESCRIPTION
* use 2.1 packages for netstandard2.0
* use 3.1.0 packages for netcoreapp3.1
* use 6.0.0 packages for net6.0

fixes #1593