### PR TITLE
Remove unused `HashHelpers.PowerOf2` function

### DIFF
--- a/src/Quartz/Collections/HashHelpers.cs
+++ b/src/Quartz/Collections/HashHelpers.cs
@@ -8,14 +8,6 @@ namespace Quartz.Collections
 {
     internal static partial class HashHelpers
     {
-        internal static int PowerOf2(int v)
-        {
-            if ((v & (v - 1)) == 0) return v;
-            int i = 2;
-            while (i < v) i <<= 1;
-            return i;
-        }
-
         // must never be written to
         internal static readonly int[] SizeOneIntArray = new int[1];
 


### PR DESCRIPTION
I found this unused internal function and have put up a PR to remove it. It doesn't appear to be used in the containing assembly or the assemblies referenced via `InternalsVisibleTo`. I don't know the history of it but I'm guessing it may've been from a previous resizing strategy.