### PR TITLE
Add missing "disallow concurrency" materialization for jobs

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -153,7 +153,7 @@ namespace Quartz.Impl.AdoJobStore
                     isDurable: GetBooleanFromDbValue(rs[ColumnIsDurable]),
                     requestsRecovery: GetBooleanFromDbValue(rs[ColumnRequestsRecovery]),
                     jobDataMap: jobDataMap,
-                    disallowConcurrentExecution: null,
+                    disallowConcurrentExecution: GetBooleanFromDbValue(rs[ColumnIsNonConcurrent]),
                     persistJobDataAfterExecution: null);
             }
 

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -141,21 +141,20 @@ namespace Quartz.Impl.AdoJobStore
 
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                job = new JobDetailImpl();
-
-                job.Name = rs.GetString(ColumnJobName)!;
-                job.Group = rs.GetString(ColumnJobGroup)!;
-                job.Description = rs.GetString(ColumnDescription);
-                job.JobType = loadHelper.LoadType(rs.GetString(ColumnJobClass)!)!;
-                job.Durable = GetBooleanFromDbValue(rs[ColumnIsDurable]);
-                job.RequestsRecovery = GetBooleanFromDbValue(rs[ColumnRequestsRecovery]);
-
                 var map = await ReadMapFromReader(rs, 6).ConfigureAwait(false);
+                var jobDataMap = map != null ? new JobDataMap(map) : null;
 
-                if (map != null)
-                {
-                    job.JobDataMap = new JobDataMap(map);
-                }
+                job = new JobDetailImpl(
+                    new JobKey(
+                        rs.GetString(ColumnJobName)!,
+                        rs.GetString(ColumnJobGroup)),
+                    jobType: loadHelper.LoadType(rs.GetString(ColumnJobClass)!)!,
+                    description: rs.GetString(ColumnDescription),
+                    isDurable: GetBooleanFromDbValue(rs[ColumnIsDurable]),
+                    requestsRecovery: GetBooleanFromDbValue(rs[ColumnRequestsRecovery]),
+                    jobDataMap: jobDataMap,
+                    disallowConcurrentExecution: null,
+                    persistJobDataAfterExecution: null);
             }
 
             return job;

--- a/src/Quartz/JobKey.cs
+++ b/src/Quartz/JobKey.cs
@@ -66,7 +66,7 @@ namespace Quartz
         {
         }
 
-        public JobKey(string name, string group) : base(name, group)
+        public JobKey(string name, string? group) : base(name, group)
         {
         }
 
@@ -75,7 +75,7 @@ namespace Quartz
             return new JobKey(name);
         }
 
-        public static JobKey Create(string name, string group)
+        public static JobKey Create(string name, string? group)
         {
             return new JobKey(name, group);
         }

--- a/src/Quartz/Util/Key.cs
+++ b/src/Quartz/Util/Key.cs
@@ -57,7 +57,7 @@ namespace Quartz.Util
         /// </summary>
         /// <param name="name">the name</param>
         /// <param name="group">the group</param>
-        public Key(string name, string group)
+        public Key(string name, string? group)
         {
             this.name = name ?? throw new ArgumentNullException(nameof(name), "Name cannot be null.");
             this.group = group ?? DefaultGroup;


### PR DESCRIPTION
Here's the [discussion](https://github.com/quartznet/quartznet/discussions/1921). This is a PR for `3.x`-branch.

> one option is to add `internal` setter for the property

I've managed without adding new setters and just use existing internal ctor which suits me just well.