### PR TITLE
Fix integer overflow in `QuartzRandom.Next(int, int)`

### DIFF
--- a/src/Quartz.Tests.Unit/Core/QuartzRandomTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzRandomTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using Quartz.Core;
-using System.Globalization;
 
 namespace Quartz.Tests.Unit.Core
 {
@@ -27,7 +26,6 @@ namespace Quartz.Tests.Unit.Core
             Assert.LessOrEqual(result, -2);
         }
 
-
         [Test]
         public void TestNextValidatesPositiveNegativeRange()
         {
@@ -46,6 +44,14 @@ namespace Quartz.Tests.Unit.Core
 
             Assert.GreaterOrEqual(result, -1);
             Assert.LessOrEqual(result, int.MaxValue);
+        }
+
+        [Test]
+        public void TestMinimumGreaterThanMaximum()
+        {
+            var rand = new QuartzRandom();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => rand.Next(3, 2));
         }
     }
 }

--- a/src/Quartz.Tests.Unit/Core/QuartzRandomTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzRandomTest.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using Quartz.Core;
+using System.Globalization;
+
+namespace Quartz.Tests.Unit.Core
+{
+    [TestFixture]
+    public class QuartzRandomTest
+    {
+        [Test]
+        public void TestNextValidatesPositiveRange()
+        {
+            var rand = new QuartzRandom();
+            var result = rand.Next(2, 6);
+
+            Assert.GreaterOrEqual(result, 2);
+            Assert.LessOrEqual(result, 6);
+        }
+
+        [Test]
+        public void TestNextValidatesNegativeRange()
+        {
+            var rand = new QuartzRandom();
+            var result = rand.Next(-6, -2);
+
+            Assert.GreaterOrEqual(result, -6);
+            Assert.LessOrEqual(result, -2);
+        }
+
+
+        [Test]
+        public void TestNextValidatesPositiveNegativeRange()
+        {
+            var rand = new QuartzRandom();
+            var result = rand.Next(-6, 6);
+
+            Assert.GreaterOrEqual(result, -6);
+            Assert.LessOrEqual(result, 6);
+        }
+
+        [Test]
+        public void TestNextDoesntIntegerOverflow()
+        {
+            var rand = new QuartzRandom();
+            var result = rand.Next(-1, int.MaxValue);
+
+            Assert.GreaterOrEqual(result, -1);
+            Assert.LessOrEqual(result, int.MaxValue);
+        }
+    }
+}

--- a/src/Quartz/Core/QuartzRandom.cs
+++ b/src/Quartz/Core/QuartzRandom.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 
 namespace Quartz.Core
 {
@@ -48,7 +48,7 @@ namespace Quartz.Core
                 ThrowHelper.ThrowArgumentOutOfRangeException(nameof(maxValue), "maxValue must be larger then minValue");
             }
 
-            long range = maxValue - minValue;
+            long range = (long)maxValue - minValue;
             return (int) Math.Floor(NextDouble() * range) + minValue;
         }
     }


### PR DESCRIPTION
An integer overflow is possible in the `Next(int minValue, int maxValue)` if the difference between those two values is greater than 2^31. It doesn't looks like this can happen in the library itself since all usages have hard-coded safe values, but since the class is public it's possible someone else may hit this.

I've also added a few other tests to validate the happy path of this function