### PR TITLE
Fix for #1948 Ambiguous references 

### DIFF
--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Quartz.NET ASP.NET Core integration; $(Description)</Description>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Quartz</RootNamespace>
+    <RootNamespace>Quartz.AspNetCore</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Lewis Zou, Marko Lahma, Quartz.NET</Authors>
   </PropertyGroup>

--- a/src/Quartz.AspNetCore/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz.AspNetCore/QuartzServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -12,7 +12,7 @@ using Quartz.AspNetCore.HttpApi;
 using Quartz.AspNetCore.HttpApi.Endpoints;
 using Quartz.AspNetCore.HttpApi.Util;
 
-namespace Quartz;
+namespace Quartz.AspNetCore;
 
 public static class QuartzServiceCollectionExtensions
 {

--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -15,6 +15,7 @@ using NSwag.Generation.Processors.Security;
 
 using OpenTelemetry.Trace;
 
+using Quartz.AspNetCore;
 using Quartz.Impl.AdoJobStore.Common;
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Matchers;

--- a/src/Quartz.Tests.AspNetCore/Program.cs
+++ b/src/Quartz.Tests.AspNetCore/Program.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
+
+using Quartz.AspNetCore;
 
 namespace Quartz.Tests.AspNetCore;
 


### PR DESCRIPTION
namespace changed to Quartz.AspNetCore