### PR TITLE
Change QuartzServiceCollectionExtensions namespace to Quartz.AspNetCore in Quartz.AspNetCore project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ _dotCover*/
 # Other
 /src/Quartz/Quartz.xml
 /src/Quartz.Serialization.Json/Quartz.Serialization.Json.xml
+.nuke/
 
 *.ReSharper
 *.dotCover

--- a/src/Quartz.AspNetCore/AspNetCore/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/QuartzServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Quartz.AspNetCore.HealthChecks;
 #endif
 
-namespace Quartz
+namespace Quartz.AspNetCore
 {
     public static class QuartzServiceCollectionExtensions
     {

--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using OpenTelemetry.Trace;
-
+using Quartz.AspNetCore;
 using Quartz.Impl.AdoJobStore.Common;
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Matchers;


### PR DESCRIPTION
fixes #1948

namespace changed to `Quartz.AspNetCore`