### PR TITLE
Detect invalid CRON expression character trailing a '?'

### DIFF
--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -23,6 +23,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using FluentAssertions;
+
 using NUnit.Framework;
 
 using Quartz.Simpl;
@@ -114,6 +116,32 @@ namespace Quartz.Tests.Unit
 
             cal = new DateTime(2010, 10, 29, 10, 15, 0).ToUniversalTime(); // nearest weekday to last day - 1 (29th is a friday in 2010)
             Assert.IsTrue(cronExpression.IsSatisfiedBy(cal));
+        }
+
+        [Test]
+        public void CronExpression_Throw_Error_Contructed_With_Null()
+        {
+            Action act = () => new CronExpression(null);
+            act.Should().Throw<ArgumentException>()
+                .WithMessage("cronExpression cannot be null (Parameter 'cronExpression')");
+        }
+
+        [TestCase('h')]
+        [TestCase('?')]
+        [TestCase('*')]
+        public void Should_Throw_Error_When_Extra_NonWhitespace_Character_After_QuestionMark(char invalidChar)
+        {
+            Action act = () => new CronExpression($"0 0 * * * ?{invalidChar}");
+            act.Should().Throw<FormatException>()
+                .WithMessage("Illegal character after '?':*");
+        }
+
+        [TestCase(' ')]
+        [TestCase('\t')]
+        public void QuestionMark_With_ExtraWhitespace_Should_Be_Valid(char allowedChar)
+        {
+            Action act = () => new CronExpression($"0 0 * * * ?{allowedChar}");
+            act.Should().NotThrow();
         }
 
         [Test]

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -391,7 +391,7 @@ namespace Quartz
         {
             if (cronExpression == null)
             {
-                throw new ArgumentException("cronExpression cannot be null");
+                throw new ArgumentException("cronExpression cannot be null", nameof(cronExpression));
             }
 
             CronExpressionString = CultureInfo.InvariantCulture.TextInfo.ToUpper(cronExpression);
@@ -799,7 +799,7 @@ namespace Quartz
             if (c == '?')
             {
                 i++;
-                if (i + 1 < s.Length && s[i] != ' ' && s[i + 1] != '\t')
+                if (i + 1 <= s.Length && s[i] != ' ' && s[i] != '\t')
                 {
                     throw new FormatException("Illegal character after '?': "
                                               + s[i]);


### PR DESCRIPTION
Fix to detect invalid cron expression character trailing a '?'  (resolves #1953)