### PR TITLE
Cron support for 'L' and 'LW' in expression daysOfMonth

### DIFF
--- a/Quartz.sln.DotSettings
+++ b/Quartz.sln.DotSettings
@@ -71,6 +71,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cron/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=quartznet/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Simpl/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unschedule/@EntryIndexedValue">True</s:Boolean>

--- a/changelog.md
+++ b/changelog.md
@@ -29,12 +29,12 @@
     overridden in pair with `Equals(object? obj)` and `GetHashCode()`.
 
   * The **Quartz.Util.DictionaryExtensions** type was removed.
-    
+
   * The 'Get(TKey key)' method of **DirtyFlagMap<TKey,TValue>** has been removed. You can instead use the
     this[TKey key] indexer or `TryGetValue(TKey key, out TValue value)` to obtain the value for a given key.
-    
+
   * (Logging): `LibLog` has been removed and replaced with `Microsoft.Logging.Abstractions` (#1480).
-      
+
   * The following properties of **DirtyFlagMap<TKey,TValue>** are now explicit interface implementations:
     * IsReadOnly
     * IsFixedSize
@@ -63,6 +63,9 @@
 
   * Introduce JobType to allow storing job's type information without actual Type instance (#1610)
 
+* NEW FEATURES
+
+  * Add Cron parser support for 'L' and 'LW' in expression combinations for daysOfMonth (#1939) (#1288)
 
 ## Release 3.6.1, Feb 25 2023
 

--- a/docs/documentation/quartz-4.x/tutorial/crontrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontrigger.md
@@ -48,16 +48,20 @@ You can also specify `/` after the "character - in this case" is equivalent to h
 For example, the value `L` in the day-of-month field means "the last day of the month" - day 31 for January, day 28 for February on non-leap years.
 If used in the day-of-week field by itself, it simply means "7" or "SAT". But if used in the day-of-week field after another value, it means "the last xxx day of the month" -
 for example `6L` means "the last Friday of the month". You can also specify an offset from the last day of the month, such as `L-3` which
-would mean the third-to-last day of the calendar month. When using the `L` option, it is important not to specify lists, or ranges of values,
-as you'll get confusing/unexpected results.
+would mean the third-to-last day of the calendar month.
+The `L` option can be used in a list, but there can only be one occurrence of the `L`.
+For example `1,15,L` would mean trigger on the 1st, 15th and Last Day of the month.
+
 * `W` ("weekday") - used to specify the weekday (Monday-Friday) nearest the given day.
 As an example, if you were to specify `15W` as the value for the day-of-month field, the meaning is: "the nearest weekday to the 15th of the month".
 So if the 15th is a Saturday, the trigger will fire on Friday the 14th. If the 15th is a Sunday, the trigger will fire on Monday the 16th. If the 15th is a Tuesday,
 then it will fire on Tuesday the 15th. However if you specify `1W` as the value for day-of-month, and the 1st is a Saturday, the trigger will fire on Monday the 3rd,
 as it will not 'jump' over the boundary of a month's days. The `W` character can only be specified when the day-of-month is a single day, not a range or list of days.
+
 ::: tip
- The `L` and `W` characters can also be combined in the day-of-month field to yield `LW`, which translates to *"last weekday of the month".
+ The `L` and `W` characters can also be combined in the day-of-month field to yield `LW`, which translates to *"last weekday of the month".  This field can also be used in a list, for example `1,15,LW` meaning 1st, 15th and Last Weekday of the month.
 :::
+
 * `#` - used to specify "the nth" XXX day of the month. For example, the value of `6#3` in the day-of-week field means
 "the third Friday of the month" (day 6 = Friday and "#3" = the 3rd one in the month).
 Other examples: `2#1` = the first Monday of the month and `4#5` = the fifth Wednesday of the month.

--- a/docs/documentation/quartz-4.x/tutorial/crontriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontriggers.md
@@ -47,7 +47,7 @@ Wild-cards (the `*` character) can be used to say "every" possible value of this
 All of the fields have a set of valid values that can be specified. These values should be fairly obvious - such as the numbers
 0 to 59 for seconds and minutes, and the values 0 to 23 for hours. Day-of-Month can be any value 1-31, but you need to be careful
 about how many days are in a given month! Months can be specified as values between 1 and 12, or by using the strings
-JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV and DEC. Days-of-Week can be specified as vaules between 1 and 7 (1 = Sunday)
+JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV and DEC. Days-of-Week can be specified as values between 1 and 7 (1 = Sunday)
 or by using the strings SUN, MON, TUE, WED, THU, FRI and SAT.
 
 The '/' character can be used to specify increments to values. For example, if you put '0/15' in the Minutes field, it means 'every 15 minutes,
@@ -62,8 +62,7 @@ The 'L' character is allowed for the day-of-month and day-of-week fields. This c
 but it has different meaning in each of the two fields. For example, the value "L" in the day-of-month field means
 "the last day of the month" - day 31 for January, day 28 for February on non-leap years. If used in the day-of-week field by itself,
 it simply means "7" or "SAT". But if used in the day-of-week field after another value, it means "the last xxx day of the month" -
-for example "6L" or "FRIL" both mean "the last friday of the month". When using the 'L' option, it is important not to specify lists,
-or ranges of values, as you'll get confusing results.
+for example "6L" or "FRIL" both mean "the last Friday of the month".
 
 The 'W' is used to specify the weekday (Monday-Friday) nearest the given day. As an example, if you were to specify "15W" as the value for the day-of-month field, the meaning is: "the nearest weekday to the 15th of the month".
 

--- a/src/Quartz/Util/SerializationInfoExtensions.cs
+++ b/src/Quartz/Util/SerializationInfoExtensions.cs
@@ -1,0 +1,9 @@
+using System.Runtime.Serialization;
+
+namespace Quartz.Util
+{
+    internal static class SerializationInfoExtensions
+    {
+        public static T? GetValue<T>(this SerializationInfo info, string name) => (T?)info.GetValue(name, typeof(T));
+    }
+}


### PR DESCRIPTION
- Add cron parser support for `'L'` and `'LW'` in expression combinations daysOfMonth (#1939) (#1288)
- There is a limit of only one 'L' in the expression.  ie 
`"0 15 10 7,15,L,L-2 * ?"` will fail  but 
`"0 15 10 7,15,L-2 * ? "` will pass.
