### PR TITLE
Fix bug in ServiceCollectionSchedulerFactory.GetNamedConnectionString

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
@@ -94,7 +94,7 @@ namespace Quartz
                 return connectionString;
             }
 
-            return base.GetNamedConnectionString(connectionString);
+            return base.GetNamedConnectionString(connectionStringName);
         }
 
         protected override T InstantiateType<T>(Type? implementationType)


### PR DESCRIPTION
Step to reproduce:
1. .Net Framework 4.8 project
2. Libraries:
* Microsoft.Extensions.DependencyInjection
* Quartz.net 3.6.0
* Quartz.Extensions.DependencyInjection 3.6.0
3. Configuration in app.config

Exception
```
System.NullReferenceException: Object reference not set to an instance of an object.
at Quartz.Impl.StdSchedulerFactory.GetNamedConnectionString(String dsConnectionStringName)
at Quartz.Impl.StdSchedulerFactory.<Instantiate>d__65.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Quartz.Impl.StdSchedulerFactory.<GetScheduler>d__71.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Quartz.ServiceCollectionSchedulerFactory.<GetScheduler>d__6.MoveNext()
```