### PR TITLE
Fix build on Linux

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -37,6 +37,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <PolySharpExcludeGeneratedTypes>System.Runtime.CompilerServices.IsExternalInit</PolySharpExcludeGeneratedTypes>
+
   </PropertyGroup>
 
   <!--

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,6 +35,7 @@
 
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 
   </PropertyGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,18 +2,12 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' ">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="2.1.1" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' ">
-    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[6.0.14]" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -76,11 +76,6 @@
     <GlobalPackageReference Include="Meziantou.Analyzer" Version="1.0.756"/>
     -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <GlobalPackageReference Include="PolySharp" Version="1.8.1" />
-    <GlobalPackageReference Include="Nullable" Version="1.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </GlobalPackageReference>
-    
+    <GlobalPackageReference Include="PolySharp" Version="1.12.1" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,12 +2,18 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' ">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="2.1.1" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' ">
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[6.0.14]" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
@@ -71,7 +77,10 @@
     -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <GlobalPackageReference Include="PolySharp" Version="1.8.1" />
-    <GlobalPackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" />
-    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[5.0.0]" />
+    <GlobalPackageReference Include="Nullable" Version="1.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </GlobalPackageReference>
+    
   </ItemGroup>
 </Project>

--- a/src/Quartz/Impl/AdoJobStore/CalendarIntervalTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/CalendarIntervalTriggerPersistenceDelegate.cs
@@ -69,7 +69,7 @@ namespace Quartz.Impl.AdoJobStore
                 // we moved to use separate column in v 2.6
                 tzId = props.String2;
             }
-            if (!string.IsNullOrEmpty(tzId))
+            if (!string.IsNullOrEmpty(tzId) && tzId != null)
             {
                 tz = TimeZoneUtil.FindTimeZoneById(tzId);
             }

--- a/src/Quartz/Impl/AdoJobStore/DailyTimeIntervalTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/DailyTimeIntervalTriggerPersistenceDelegate.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -106,7 +106,7 @@ namespace Quartz.Impl.AdoJobStore
                 .WithInterval(interval, intervalUnit)
                 .WithRepeatCount(repeatCount);
 
-            if (!string.IsNullOrEmpty(props.TimeZoneId))
+            if (!string.IsNullOrEmpty(props.TimeZoneId) && props.TimeZoneId != null)
             {
                 scheduleBuilder.InTimeZone(TimeZoneUtil.FindTimeZoneById(props.TimeZoneId));
             }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -77,7 +77,7 @@ namespace Quartz.Impl.AdoJobStore
 
             AddDefaultTriggerPersistenceDelegates();
 
-            if (!string.IsNullOrEmpty(args.InitString))
+            if (!string.IsNullOrEmpty(args.InitString) && args.InitString != null)
             {
                 string[] settings = args.InitString.Split('\\', '|');
 

--- a/src/Quartz/Impl/SchedulerRepository.cs
+++ b/src/Quartz/Impl/SchedulerRepository.cs
@@ -81,8 +81,10 @@ namespace Quartz.Impl
 			lock (syncRoot)
 			{
 				schedulers.TryGetValue(schedName, out var retValue);
-				return Task.FromResult(retValue);
-			}
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
+                return Task.FromResult(retValue);
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
+            }
 		}
 
 	    /// <summary>

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -213,7 +213,7 @@ namespace Quartz.Impl
         {
             var props = Util.Configuration.GetSection(ConfigurationSectionName);
             var requestedFile = QuartzEnvironment.GetEnvironmentVariable(PropertiesFile);
-            string propFileName = !string.IsNullOrWhiteSpace(requestedFile) ? requestedFile : "~/quartz.config";
+            string propFileName = (requestedFile != null && !string.IsNullOrWhiteSpace(requestedFile)) ? requestedFile : "~/quartz.config";
 
             // check for specials
             propFileName = FileUtil.ResolveFile(propFileName) ?? "quartz.config";
@@ -582,7 +582,7 @@ Please add configuration to your application config file to correctly initialize
                     var dsConnectionString = pp.GetStringProperty(PropertyDataSourceConnectionString, null);
                     var dsConnectionStringName = pp.GetStringProperty(PropertyDataSourceConnectionStringName, null);
 
-                    if (dsConnectionString == null && !string.IsNullOrEmpty(dsConnectionStringName))
+                    if (dsConnectionString == null && !string.IsNullOrEmpty(dsConnectionStringName) && dsConnectionStringName != null)
                     {
                         var connectionString = GetNamedConnectionString(dsConnectionStringName);
                         if (string.IsNullOrWhiteSpace(connectionString))

--- a/src/Quartz/SchedulerBuilder.cs
+++ b/src/Quartz/SchedulerBuilder.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System.Collections.Specialized;
+using System.Diagnostics;
 
 using Quartz.Impl;
 using Quartz.Impl.AdoJobStore;
@@ -56,12 +57,12 @@ namespace Quartz
         public static SchedulerBuilder Create(string? id, string? name)
         {
             var builder = Create();
-            if (!string.IsNullOrWhiteSpace(id))
+            if (!string.IsNullOrWhiteSpace(id) && id != null)
             {
                 builder.SchedulerId = id;
             }
 
-            if (!string.IsNullOrWhiteSpace(name))
+            if (!string.IsNullOrWhiteSpace(name) && name != null)
             {
                 builder.SchedulerName = name;
             }

--- a/src/Quartz/Simpl/SimpleTypeLoadHelper.cs
+++ b/src/Quartz/Simpl/SimpleTypeLoadHelper.cs
@@ -40,7 +40,7 @@ namespace Quartz.Simpl
 		/// <inheritdoc />
 		public virtual Type? LoadType(string? name)
 		{
-            if (string.IsNullOrEmpty(name))
+            if (string.IsNullOrEmpty(name) || name == null)
             {
                 return null;
             }

--- a/src/Quartz/Util/DirtyFlagMap.cs
+++ b/src/Quartz/Util/DirtyFlagMap.cs
@@ -190,7 +190,9 @@ namespace Quartz.Util
         /// <see langword="true"/> if the <see cref="DirtyFlagMap{TKey, TValue}"/>contains an element with the specified key;
         /// otherwise, <see langword="false"/>.
         /// </returns>
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
         {
             return map.TryGetValue(key, out value);
         }

--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -232,7 +232,7 @@ namespace Quartz.Xml
                         foreach (string s in command.deletejobsingroup)
                         {
                             var deleteJobGroup = s.NullSafeTrim();
-                            if (!string.IsNullOrEmpty(deleteJobGroup))
+                            if (!string.IsNullOrEmpty(deleteJobGroup) && deleteJobGroup != null)
                             {
                                 jobGroupsToDelete.Add(deleteJobGroup);
                             }
@@ -244,7 +244,7 @@ namespace Quartz.Xml
                         foreach (string s in command.deletetriggersingroup)
                         {
                             var deleteTriggerGroup = s.NullSafeTrim();
-                            if (!string.IsNullOrEmpty(deleteTriggerGroup))
+                            if (!string.IsNullOrEmpty(deleteTriggerGroup) && deleteTriggerGroup != null)
                             {
                                 triggerGroupsToDelete.Add(deleteTriggerGroup);
                             }
@@ -542,7 +542,7 @@ namespace Quartz.Xml
 
         protected virtual IntervalUnit ParseDateIntervalTriggerIntervalUnit(string? intervalUnit)
         {
-            if (string.IsNullOrEmpty(intervalUnit))
+            if (string.IsNullOrEmpty(intervalUnit) || intervalUnit == null)
             {
                 return IntervalUnit.Day;
             }


### PR DESCRIPTION
## Issue 
Ubuntu Build is generating warnings for NU1505.

```
  Error: /home/runner/work/quartznet/quartznet/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj : error NU1505: Warning As Error: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Microsoft.NETCore.App.Ref [5.0.0], Microsoft.NETCore.App.Ref [6.0.14]. [TargetFramework=net6.0]
  00:38:03 [ERR] /home/runner/work/quartznet/quartznet/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj : error NU1505: Warning As Error: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Microsoft.NETCore.App.Ref [5.0.0], Microsoft.NETCore.App.Ref [6.0.14]. [TargetFramework=net6.0]
  Error: /home/runner/work/quartznet/quartznet/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj : error NU1505: Warning As Error: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Microsoft.NETCore.App.Ref [5.0.0], Microsoft.NETCore.App.Ref [6.0.14]. [TargetFramework=net6.0]
  00:38:03 [ERR] /home/runner/work/quartznet/quartznet/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj : error NU1505: Warning As Error: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Microsoft.NETCore.App.Ref [5.0.0], Microsoft.NETCore.App.Ref [6.0.14]. [TargetFramework=net6.0]
  Error: /home/runner/work/quartznet/quartznet/src/Quartz.HttpClient/Quartz.HttpClient.csproj : error NU1505: Warning As Error: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Microsoft.NETCore.App.Ref [5.0.0], Microsoft.NETCore.App.Ref [6.0.14]. [TargetFramework=net6.0]
  00:38:03 [ERR] /home/runner/work/quartznet/quartznet/src/Quartz.HttpClient/Quartz.HttpClient.csproj : error NU1505: Warning As Error: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Microsoft.NETCore.App.Ref [5.0.0], Microsoft.NETCore.App.Ref [6.0.14]. [TargetFramework=net6.0]
```

Seen in log for PR #1956

## Proposal

- Replace TunnelVisions lib with [Nullable](https://github.com/manuelroemer/Nullable). (due to challenges with consistent build on linux without the Nuget error [related](https://github.com/tunnelvisionlabs/ReferenceAssemblyAnnotator/issues/92))
- Update PackageDownload ref to `Microsoft.NETCore.App.Ref" Version="[6.0.0]]`  (from 5.0) and only target specific frameworks.
- Add guards where exists `String.IsNullOrWhitespace` checks with additional `!= null` due to `CS8601 - Possible null reference`
(I'm guessing because this is not from the later BCL version in NET472 target, that has a signature with a nullable -> ISNullOrWhitespace(value?))