### PR TITLE
Revert documentation changes in v4 relating to ValueTask

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -11,37 +11,6 @@ If you are a new user starting with the latest version, you don't need to follow
 
 ## Migrating from Version 3.x to 4.x
 
-### Tasks changed to ValueTask
-
-In a majority of interfaces that previously returned or took a `Task` or `Task<T>` parameter, have been changed to a `ValueTask` or `ValueTask<T>`
-
-In most cases, all you will need to do is adjust the signature from a `Task` to be a `ValueTask`
-
-::: info
-Note the following restrictions when working with ValueTask:
-:::
-
-> The following operations should never be performed on a `ValueTask<TResult>` instance:
->
-> * Awaiting the instance multiple times.
-> * Calling AsTask multiple times.
-> * Using `.Result` or `.GetAwaiter().GetResult()` when the operation hasn't yet completed, or using them multiple times.
-> * Using more than one of these techniques to consume the instance.
-
-For example, to migrate jobs:
-
-```csharp
-public async Task Execute(IJobExecutionContext context)
-```
-
-becomes:
-
-```csharp
-public async ValueTask Execute(IJobExecutionContext context)
-```
-
-For more information on `ValueTasks` please see [Microsoft](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.valuetask-1?view=net-7.0)
-
 ### Logging
 
 LibLog has been replaced with the Microsoft.Logging.Abstraction library.

--- a/docs/documentation/quartz-4.x/tutorial/jobs-and-triggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/jobs-and-triggers.md
@@ -65,7 +65,7 @@ namespace Quartz
 {
     public interface IJob
     {
-        ValueTask Execute(JobExecutionContext context);
+        Task Execute(JobExecutionContext context);
     }
 }
 ```

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -42,7 +42,7 @@ Now consider the job class __HelloJob__  defined as such:
 ```csharp
 public class HelloJob : IJob
 {
- public async ValueTask Execute(IJobExecutionContext context)
+ public async Task Execute(IJobExecutionContext context)
  {
   await Console.Out.WriteLineAsync("HelloJob is executing.");
  }
@@ -85,7 +85,7 @@ __Getting Values from a JobDataMap__
 ```csharp
 public class DumbJob : IJob
 {
- public async ValueTask Execute(IJobExecutionContext context)
+ public async Task Execute(IJobExecutionContext context)
  {
   JobKey key = context.JobDetail.Key;
 
@@ -124,7 +124,7 @@ Here's a quick example of getting data from the JobExecutionContext's merged Job
 ```csharp
 public class DumbJob : IJob
 {
- public async ValueTask Execute(IJobExecutionContext context)
+ public async Task Execute(IJobExecutionContext context)
  {
   JobKey key = context.JobDetail.Key;
 
@@ -148,7 +148,7 @@ public class DumbJob : IJob
  public string JobSays { private get; set; }
  public float FloatValue { private get; set; }
 
- public async ValueTask Execute(IJobExecutionContext context)
+ public async Task Execute(IJobExecutionContext context)
  {
   JobKey key = context.JobDetail.Key;
 

--- a/docs/documentation/quartz-4.x/tutorial/scheduler-listeners.md
+++ b/docs/documentation/quartz-4.x/tutorial/scheduler-listeners.md
@@ -19,23 +19,23 @@ __The ISchedulerListener Interface__
 ```csharp
 public interface ISchedulerListener
 {
- ValueTask JobScheduled(Trigger trigger);
+ Task JobScheduled(Trigger trigger);
 
- ValueTask JobUnscheduled(string triggerName, string triggerGroup);
+ Task JobUnscheduled(string triggerName, string triggerGroup);
 
- ValueTask TriggerFinalized(Trigger trigger);
+ Task TriggerFinalized(Trigger trigger);
 
- ValueTask TriggersPaused(string triggerName, string triggerGroup);
+ Task TriggersPaused(string triggerName, string triggerGroup);
 
- ValueTask TriggersResumed(string triggerName, string triggerGroup);
+ Task TriggersResumed(string triggerName, string triggerGroup);
 
- ValueTask JobsPaused(string jobName, string jobGroup);
+ Task JobsPaused(string jobName, string jobGroup);
 
- ValueTask JobsResumed(string jobName, string jobGroup);
+ Task JobsResumed(string jobName, string jobGroup);
 
- ValueTask SchedulerError(string msg, SchedulerException cause);
+ Task SchedulerError(string msg, SchedulerException cause);
 
- ValueTask SchedulerShutdown();
+ Task SchedulerShutdown();
 } 
 ```
 

--- a/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
+++ b/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
@@ -21,13 +21,13 @@ public interface ITriggerListener
 {
   string Name { get; }
   
-  ValueTask TriggerFired(ITrigger trigger, IJobExecutionContext context);
+  Task TriggerFired(ITrigger trigger, IJobExecutionContext context);
   
-  ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context);
+  Task<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context);
   
-  ValueTask TriggerMisfired(ITrigger trigger);
+  Task TriggerMisfired(ITrigger trigger);
   
-  ValueTask TriggerComplete(ITrigger trigger, IJobExecutionContext context, int triggerInstructionCode);
+  Task TriggerComplete(ITrigger trigger, IJobExecutionContext context, int triggerInstructionCode);
 }
 ```
 
@@ -40,11 +40,11 @@ public interface IJobListener
 {
  string Name { get; }
 
- ValueTask JobToBeExecuted(IJobExecutionContext context);
+ Task JobToBeExecuted(IJobExecutionContext context);
 
- ValueTask JobExecutionVetoed(IJobExecutionContext context);
+ Task JobExecutionVetoed(IJobExecutionContext context);
 
- ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException jobException);
+ Task JobWasExecuted(IJobExecutionContext context, JobExecutionException jobException);
 } 
 ```
 


### PR DESCRIPTION
This reverts documentation changes made in #1967 that were part of PR #1964 and should not be part of main yet, (relating to ValueTask changes which have not been merged yet)

NOTE: If #1964 is reviewed first and approved, this PR should be trashed as superceded.
