### PR TITLE
Refactor CronExpression, add guards for invalid usage, add tests

### DIFF
--- a/Quartz.sln.DotSettings
+++ b/Quartz.sln.DotSettings
@@ -72,7 +72,11 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cron/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jambula/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nthday/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=quartznet/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serialization/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sharada/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Simpl/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unschedule/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/src/Quartz/CronExpressionConstants.cs
+++ b/src/Quartz/CronExpressionConstants.cs
@@ -1,0 +1,59 @@
+namespace Quartz;
+
+internal static class CronExpressionConstants
+{
+    /// <summary>
+    /// Field specification for second.
+    /// </summary>
+    public const int Second = 0;
+
+    /// <summary>
+    /// Field specification for minute.
+    /// </summary>
+    public const int Minute = 1;
+
+    /// <summary>
+    /// Field specification for hour.
+    /// </summary>
+    public const int Hour = 2;
+
+    /// <summary>
+    /// Field specification for day of month.
+    /// </summary>
+    public const int DayOfMonth = 3;
+
+    /// <summary>
+    /// Field specification for month.
+    /// </summary>
+    public const int Month = 4;
+
+    /// <summary>
+    /// Field specification for day of week.
+    /// </summary>
+    public const int DayOfWeek = 5;
+
+    /// <summary>
+    /// Field specification for year.
+    /// </summary>
+    public const int Year = 6;
+
+    /// <summary>
+    /// Field specification for all wildcard value '*'.
+    /// </summary>
+    public const int AllSpecInt = 99; // '*'
+
+    /// <summary>
+    /// Field specification for not specified value '?'.
+    /// </summary>
+    public const int NoSpecInt = 98; // '?'
+
+    /// <summary>
+    /// Field specification for wildcard '*'.
+    /// </summary>
+    public const int AllSpec = AllSpecInt;
+
+    /// <summary>
+    /// Field specification for no specification at all '?'.
+    /// </summary>
+    public const int NoSpec = NoSpecInt;
+}

--- a/src/Quartz/CronExpressionSummary.cs
+++ b/src/Quartz/CronExpressionSummary.cs
@@ -1,0 +1,130 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Globalization;
+using System.Text;
+
+namespace Quartz
+{
+    internal struct CronExpressionSummary
+    {
+        public CronExpressionSummary(SortedSet<int> seconds, SortedSet<int> minutes, SortedSet<int> hours, SortedSet<int> daysOfMonth,
+            SortedSet<int> months, SortedSet<int> daysOfWeek, bool lastDayOfWeek, bool nearestWeekday, int nthDayOfWeek,
+            bool lastDayOfMonth, bool calendarDayOfWeek, bool calendarDayOfMonth, SortedSet<int> years)
+        {
+            Seconds = seconds;
+            Minutes = minutes;
+            Hours = hours;
+            DaysOfMonth = daysOfMonth;
+            Months = months;
+            DaysOfWeek = daysOfWeek;
+            LastDayOfWeek = lastDayOfWeek;
+            NearestWeekday = nearestWeekday;
+            NthDayOfWeek = nthDayOfWeek;
+            LastDayOfMonth = lastDayOfMonth;
+            CalendarDayOfWeek = calendarDayOfWeek;
+            CalendarDayOfMonth = calendarDayOfMonth;
+            Years = years;
+        }
+
+        public SortedSet<int> Seconds { get; set; }
+        public SortedSet<int> Minutes { get; set; }
+        public SortedSet<int> Hours { get; set; }
+        public SortedSet<int> DaysOfMonth { get; set; }
+        public SortedSet<int> Months { get; set; }
+        public SortedSet<int> DaysOfWeek { get; set; }
+        public bool LastDayOfWeek { get; set; }
+        public bool NearestWeekday { get; set; }
+        public int NthDayOfWeek { get; set; }
+        public bool LastDayOfMonth { get; set; }
+        public bool CalendarDayOfWeek { get; set; }
+        public bool CalendarDayOfMonth { get; set; }
+        public SortedSet<int> Years { get; set; }
+
+        /// <summary>
+        /// Gets the expression set summary.
+        /// </summary>
+        /// <param name="data">The data.</param>
+        /// <returns></returns>
+        private string GetExpressionSetSummary(ICollection<int> data)
+        {
+            if (data.Contains(CronExpressionConstants.NoSpec))
+            {
+                return "?";
+            }
+
+            if (data.Contains(CronExpressionConstants.AllSpec))
+            {
+                return "*";
+            }
+
+            var buf = new StringBuilder();
+
+            var first = true;
+            foreach (var iVal in data)
+            {
+                var val = iVal.ToString(CultureInfo.InvariantCulture);
+                if (!first)
+                {
+                    buf.Append(",");
+                }
+
+                buf.Append(val);
+                first = false;
+            }
+
+            return buf.ToString();
+        }
+
+        public override string ToString()
+        {
+            var buf = new StringBuilder();
+
+            buf.Append("seconds: ");
+            buf.AppendLine(GetExpressionSetSummary(Seconds));
+            buf.Append("minutes: ");
+            buf.AppendLine(GetExpressionSetSummary(Minutes));
+            buf.Append("hours: ");
+            buf.AppendLine(GetExpressionSetSummary(Hours));
+            buf.Append("daysOfMonth: ");
+            buf.AppendLine(GetExpressionSetSummary(DaysOfMonth));
+            buf.Append("months: ");
+            buf.AppendLine(GetExpressionSetSummary(Months));
+            buf.Append("daysOfWeek: ");
+            buf.AppendLine(GetExpressionSetSummary(DaysOfWeek));
+            buf.Append("lastdayOfWeek: ");
+            buf.AppendLine(LastDayOfWeek.ToString());
+            buf.Append("nearestWeekday: ");
+            buf.AppendLine(NearestWeekday.ToString());
+            buf.Append("NthDayOfWeek: ");
+            buf.AppendLine(NthDayOfWeek.ToString());
+            buf.Append("lastdayOfMonth: ");
+            buf.AppendLine(LastDayOfMonth.ToString());
+            buf.Append("calendardayOfWeek: ");
+            buf.AppendLine(CalendarDayOfWeek.ToString());
+            buf.Append("calendardayOfMonth: ");
+            buf.AppendLine(CalendarDayOfMonth.ToString());
+            buf.Append("years: ");
+            buf.AppendLine(GetExpressionSetSummary(Years));
+            return buf.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## Features
- Add guard for invalid `L` token location.
- Add guard for `DayOfWeek` on `L` token being out of range
- Add guards for `nthDayOfWeek` being out of range
- Increase test coverage on CronExpression class

## Refactors
- (CronExpression) Extract CronExpressionSummary & CronExpressionConstants.
- (CronExpression) `StoreExpressionVals` refactored 
- (CronExpression) Remove `GetDaysOfMonth`, was refactored out into other methods and is unused.
- (CronExpression) `CheckNext` return values are unused, changed to return void

## Minor (breaking?) change
- CronExpression.GetExpressionSummary() emits `\r\n` for newlines via AppendLine, previously was `\n`  ( I doubt this would cause any concern)