### PR TITLE
Ability to specify an offset from the last weekday of the month (#1287)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -67,7 +67,9 @@
 
 * NEW FEATURES
 
-  * Add Cron parser support for 'L' and 'LW' in expression combinations for daysOfMonth (#1939) (#1288)
+  * Add cron parser support for 'L' and 'LW' in expression combinations for daysOfMonth (#1939) (#1288)
+  * Add cron parser support for `LW-<OFFSET>`. i.e. `LW-2` (calculate the Last weekday then offset by -2) (#1287)
+    If the calculated day would cross a month boundary it will be reset to the 1st of the month. (e.g. LW-30 in Feb will be 1st Feb)
 
 ## Release 3.6.1, Feb 25 2023
 

--- a/docs/documentation/quartz-4.x/tutorial/crontrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontrigger.md
@@ -59,7 +59,7 @@ then it will fire on Tuesday the 15th. However if you specify `1W` as the value 
 as it will not 'jump' over the boundary of a month's days. The `W` character can only be specified when the day-of-month is a single day, not a range or list of days.
 
 ::: tip
- The `L` and `W` characters can also be combined in the day-of-month field to yield `LW`, which translates to *"last weekday of the month".  This field can also be used in a list, for example `1,15,LW` meaning 1st, 15th and Last Weekday of the month.
+ The `L` and `W` characters can also be combined in the day-of-month field to yield `LW`, which translates to *"last weekday of the month"*.  This field can also be used in a list, for example `1,15,LW` meaning 1st, 15th and Last Weekday of the month.  `LW` supports an offset value, which will be calculated by first identifying last weekday, then subtracting the offset. for example `LW-2`
 :::
 
 * `#` - used to specify "the nth" XXX day of the month. For example, the value of `6#3` in the day-of-week field means


### PR DESCRIPTION
## Feature
- Ability to specify an offset from the last weekday of the month  resolves #1287
  For Example `LW-2`
- If final day value will cross month boundary, ie LW-30 in February would result in possible -2 day. The value for day will reset to 1.  This was preferred over throwing an exception at runtime 

~~NOTE: PR Branch is built on top of #1972~~
EDIT: Rebased on main