### PR TITLE
Reduce the C/I warning display for postgres

### DIFF
--- a/database/tables/tables_postgres.sql
+++ b/database/tables/tables_postgres.sql
@@ -1,3 +1,4 @@
+set client_min_messages = WARNING;
 DROP TABLE IF EXISTS qrtz_fired_triggers;
 DROP TABLE IF EXISTS qrtz_paused_trigger_grps;
 DROP TABLE IF EXISTS qrtz_scheduler_state;
@@ -9,7 +10,7 @@ DROP TABLE IF EXISTS qrtz_blob_triggers;
 DROP TABLE IF EXISTS qrtz_triggers;
 DROP TABLE IF EXISTS qrtz_job_details;
 DROP TABLE IF EXISTS qrtz_calendars;
-
+set client_min_messages = NOTICE;
 
 CREATE TABLE qrtz_job_details
   (


### PR DESCRIPTION
## Change
Postgres fencing DROP TABLES statements with `client_min_messages = WARNING`
Reset to NOTICE after done.

## ISSUE
Logs for integration tests are showing warnings for DROP TABLES when they really aren't, adding to noise.
![image](https://user-images.githubusercontent.com/127927/227775045-8ae02e3c-7bf8-42a7-8403-9f356f266a79.png)
