### PR TITLE
Introduce an Unwrapped JobInstance property

### DIFF
--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -207,7 +207,18 @@ namespace Quartz.Impl
         /// interfaces.
         /// </para>
         /// </summary>
-        public virtual IJob JobInstance => (jobInstance as IJobWrapper)?.Target ?? jobInstance;
+        public virtual IJob JobInstance => jobInstance;
+
+        /// <summary>
+        /// Get the instance of the <see cref="IJob" /> that was created for this
+        /// execution.  If the job is wrapped in an IJobWrapper this will unwrap that
+        /// job and return the original job
+        /// <para>
+        /// Note: The Job instance is not available through remote scheduler
+        /// interfaces.
+        /// </para>
+        /// </summary>
+        public virtual IJob JobInstanceUnwrapped => (jobInstance as IJobWrapper)?.Target ?? jobInstance;
 
         /// <summary>
         /// The actual time the trigger fired. For instance the scheduled time may


### PR DESCRIPTION
 this allows us to satisf the requirements of the original PR that introduced the bug( #1581 ) and fix the problem by putting the original JobInstance property back to the correct state. See bug report https://github.com/quartznet/quartznet/issues/1954

@nstdspace you will be interested in this as your code will have to look at the new property.

