### PR TITLE
Add CRON support for DayOfWeek and DayOfMonth to be set together (inclusive rules)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,7 @@ charset = utf-8
 # XML project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
 indent_size = 2
+csharp_prefer_braces = true:suggestion
 
 # XML config files
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]

--- a/Quartz.sln.DotSettings
+++ b/Quartz.sln.DotSettings
@@ -73,7 +73,11 @@
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cron/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jambula/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lahma/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Marko/@EntryIndexedValue">True</s:Boolean>	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nthday/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=progressor/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Progressors/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=quartznet/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serialization/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sharada/@EntryIndexedValue">True</s:Boolean>

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ## Release 4.0.0, T.B.D
 
-* BREAKING CHANGES
+### BREAKING CHANGES
 
   * netstandard2.0 build no longer reference System.Configuration.ConfigurationManager and thus there's no support for Full Framework style .config files
   * **JobKey** and **TriggerKey** now throw an **ArgumentNullException** when you specify **null** for _name_ or _group_ (#1359)
@@ -65,13 +65,16 @@
   
   * IJobExecutionContext.RecoveringTriggerKey now returns null if IJobExecutionContext.Recovering is false instead of throwing exception.
 
-* NEW FEATURES
+### NEW FEATURES
+
+#### Cron Parser
 
   * Add cron parser support for 'L' and 'LW' in expression combinations for daysOfMonth (#1939) (#1288)
   * Add cron parser support for `LW-<OFFSET>`. i.e. `LW-2` (calculate the Last weekday then offset by -2) (#1287)
     If the calculated day would cross a month boundary it will be reset to the 1st of the month. (e.g. LW-30 in Feb will be 1st Feb)
-
-* FIXES
+  * Add cron parser support for day-of-month and day-of-week together. (#1543)
+  
+### FIXES
 
   * Fix for deserializing CronExpression using Json Serializer throwing error calling `GetNextValidTimeAfter`.  (#1996)
     `IDeserializationCallback` interface was removed from class `CronExpression` and the deserialization logic 
@@ -88,7 +91,6 @@ without having the attribute `DisallowConcurrentExecutionAttribute` on type itse
     * Add missing "disallow concurrency" materialization for jobs (#1923)
     * Allow accessing the wrapped scoped job instance from job execution context (#1917)
     * JobDiagnosticsWriter can throw error when writing context data (#1191)
-
 
 ## Release 3.6.0, Jan 29 2023
 

--- a/docs/documentation/quartz-4.x/tutorial/crontrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontrigger.md
@@ -74,38 +74,32 @@ The legal characters and the names of months and days of the week are not case s
 
 Here are some full examples:
 
-| **Expression**    | **Meaning**
-|:--------------------------|:----------------------------------------------------------------------|
-| 0 0 12 ** ?    | Fire at 12pm (noon) every day|
-| 0 15 10 ? **    | Fire at 10:15am every day|
-| 0 15 10 ** ?    | Fire at 10:15am every day|
-| 0 15 10 ** ? *   | Fire at 10:15am every day|
-| 0 15 10 ** ? 2005   | Fire at 10:15am every day during the year 2005|
-| 0 *14* * ?    | Fire every minute starting at 2pm and ending at 2:59pm, every day|
-| 0 0/5 14 ** ?   | Fire every 5 minutes starting at 2pm and ending at 2:55pm, every day|
-| 0 0/5 14,18 ** ?   | Fire every 5 minutes starting at 2pm and ending at 2:55pm, AND fire every 5 minutes starting at 6pm and ending at 6:55pm, every day|
-| 0 0-5 14 ** ?   | Fire every minute starting at 2pm and ending at 2:05pm, every day|
-| 0 10,44 14 ? 3 WED  | Fire at 2:10pm and at 2:44pm every Wednesday in the month of March.|
-| 0 15 10 ? * MON-FRI  | Fire at 10:15am every Monday, Tuesday, Wednesday, Thursday and Friday|
-| 0 15 10 15 * ?   | Fire at 10:15am on the 15th day of every month|
-| 0 15 10 L * ?    | Fire at 10:15am on the last day of every month|
-| 0 15 10 L-2 * ?   | Fire at 10:15am on the 2nd-to-last last day of every month|
-| 0 15 10 ? * 6L   | Fire at 10:15am on the last Friday of every month|
-| 0 15 10 ? * 6L   | Fire at 10:15am on the last Friday of every month|
-| 0 15 10 ? * 6L 2002-2005 | Fire at 10:15am on every last Friday of every month during the years 2002, 2003, 2004 and 2005|
-| 0 15 10 ? * 6#3   | Fire at 10:15am on the third Friday of every month|
-| 0 0 12 1/5 * ?   | Fire at 12pm (noon) every 5 days every month, starting on the first day of the month.|
-| 0 11 11 11 11 ?   | Fire every November 11th at 11:11am.|
-
-::: tip
-Pay attention to the effects of '?' and '*' in the day-of-week and day-of-month fields!
-:::
+| **Expression**             | **Meaning**                                                                                                                         |
+|--:-------------------------|--:----------------------------------------------------------------------------------------------------------------------------------|
+| `0 0 12 ** ?`              | Fire at 12pm (noon) every day                                                                                                       |
+| `0 15 10 ? **`             | Fire at 10:15am every day                                                                                                           |
+| `0 15 10 ** ?`             | Fire at 10:15am every day                                                                                                           |
+| `0 15 10 ** ? *`           | Fire at 10:15am every day                                                                                                           |
+| `0 15 10 ** ? 2005`        | Fire at 10:15am every day during the year 2005                                                                                      |
+| `0 *14* * ?`               | Fire every minute starting at 2pm and ending at 2:59pm, every day                                                                   |
+| `0 0/5 14 ** ?`            | Fire every 5 minutes starting at 2pm and ending at 2:55pm, every day                                                                |
+| `0 0/5 14,18 ** ?`         | Fire every 5 minutes starting at 2pm and ending at 2:55pm, AND fire every 5 minutes starting at 6pm and ending at 6:55pm, every day |
+| `0 0-5 14 ** ?`            | Fire every minute starting at 2pm and ending at 2:05pm, every day                                                                   |
+| `0 10,44 14 ? 3 WED`       | Fire at 2:10pm and at 2:44pm every Wednesday in the month of March.                                                                 |
+| `0 15 10 ? * MON-FRI`      | Fire at 10:15am every Monday, Tuesday, Wednesday, Thursday and Friday                                                               |
+| `0 15 10 15 * ?`           | Fire at 10:15am on the 15th day of every month                                                                                      |
+| `0 15 10 L * ?`            | Fire at 10:15am on the last day of every month                                                                                      |
+| `0 15 10 L-2 * ?`          | Fire at 10:15am on the 2nd-to-last last day of every month                                                                          |
+| `0 15 10 ? * 6L`           | Fire at 10:15am on the last Friday of every month                                                                                   |
+| `0 15 10 ? * 6L`           | Fire at 10:15am on the last Friday of every month                                                                                   |
+| `0 15 10 ? * 6L 2002-2005` | Fire at 10:15am on every last Friday of every month during the years 2002, 2003, 2004 and 2005                                      |
+| `0 15 10 ? * 6#3`          | Fire at 10:15am on the third Friday of every month                                                                                  |
+| `0 0 12 1/5 * ?`           | Fire at 12pm (noon) every 5 days every month, starting on the first day of the month.                                               |
+| `0 11 11 11 11 ?`          | Fire every November 11th at 11:11am.                                                                                                |
+| `0 15 10 1,2,3 * MON,FRI`  | Fire at 10:15am on the 1st, 2nd, 3rd of the month, and every Monday and Friday                                                      |
 
 ## Notes
 
-::: warning
-Support for specifying both a day-of-week and a day-of-month value is not complete (you must currently use the '?' character in one of these fields).
-:::
 ::: warning
 Be careful when setting fire times between the hours of the morning when "daylight savings" changes occur in your locale (for US locales, this would typically be the hour before and after 2:00 AM - because the time shift can cause a skip or a repeat depending on whether the time moves back or jumps forward. You may find this Wikipedia entry helpful in determining the specifics to your locale:
 [https://secure.wikimedia.org/wikipedia/en/wiki/Daylight_saving_time_around_the_world](https://secure.wikimedia.org/wikipedia/en/wiki/Daylight_saving_time_around_the_world)

--- a/docs/documentation/quartz-4.x/tutorial/crontriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontriggers.md
@@ -34,6 +34,8 @@ For easy generation of cron intervals using UI you can use some of these service
 
 - [Cron Expression Generator & Explainer](https://www.freeformatter.com/cron-expression-generator-quartz.html)
 - [CronMaker](http://www.cronmaker.com/)
+
+NOTE: There are many cron standards/implementations. The results from some generators may not always be correct for Quartz.NET
 :::
 
 An example of a complete cron-expression is the string `0 0 12 ? * WED` - which means "every Wednesday at 12:00 pm".
@@ -164,7 +166,7 @@ ITrigger trigger = TriggerBuilder.Create()
 ## CronTrigger Misfire Instructions
 
 The following instructions can be used to inform Quartz what it should do when a misfire occurs for CronTrigger.
-(Misfire situations were introduced in the More About Triggers section of this tutorial). These instructions are defined in  as
+(Misfire situations were introduced in the More About Triggers section of this tutorial). These instructions are defined in as
 constants (and API documentation has description for their behavior). The instructions include:
 
 - `MisfireInstruction.IgnoreMisfirePolicy`

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -153,6 +153,43 @@ namespace Quartz.Tests.Unit
             }
         }
 
+        private int[] CreateArrayOfDays(int year, int month)
+        {
+            var daysInMonth = DateTime.DaysInMonth(year, month);
+            var numbers = new List<int>();
+            for (var i = 0; i < daysInMonth; i++)
+            {
+                numbers.Add(i + 1);
+            }
+
+            return numbers.ToArray();
+        }
+
+        [TestCase("0 15 10 5/5 * MON 2010", new int[] { 4,11,18,25,5,10,15,20,25,30 }, "10:15am every 5th day of the month from 5 to 31, and on Mondays in October 2010")]
+        [TestCase("0 15 10 3 * MON,THU,FRI 2010", new int[] { 1,3,4,11,18,25,7,14,21,28,8,15,22,29 }, "10:15am 3rd of month and every mon,thu,fri October 2010")]
+        [TestCase("0 15 10 1,2,3,4,5,6 * MON,THU,FRI 2010", new int[] { 1, 2, 3, 4, 5, 6, 11, 18, 25, 7, 14, 21, 28, 8, 15, 22, 29 }, "10:15am 1-6th of mon and every Mon,Thu,Fri October 2010")]
+        [TestCase("0 15 10 * * MON,THU,FRI 2010", new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,31 }, "10:15am EveryDay of Month October 2010, Wildcard specified")]
+        [TestCase("0 15 10 1 * * 2010", new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 }, "10:15am Every Day of Month October 2010, Wildcard specified")]
+        public void CanUse_DayOfMonth_And_DayOfWeek_Together(string cronExpression, int[] expectedDays,string scenario = "")
+        {
+            var expr = new CronExpression(cronExpression);
+            var templateDate = new DateTime(2010, 10, 1, 10, 15, 0).ToUniversalTime();
+
+            foreach (var day in expectedDays)
+            {
+                var date = new DateTime(templateDate.Year, templateDate.Month, day, templateDate.Hour, templateDate.Minute, templateDate.Second, templateDate.Kind);
+                expr.IsSatisfiedBy(date).Should().BeTrue($"expected day of {day}, {scenario}");
+            }
+
+            var invalidDays = CreateArrayOfDays(2010,10).Except(expectedDays);
+
+            foreach (var day in invalidDays)
+            {
+                var date = new DateTime(templateDate.Year, templateDate.Month, day, templateDate.Hour, templateDate.Minute, templateDate.Second, templateDate.Kind);
+                expr.IsSatisfiedBy(date).Should().BeFalse($"invalid day of {day}, {scenario}");
+            }
+        }
+
         [TestCase("0 15 10 LW-2 * ? 2010", 27, "31 Oct 2010 is Sunday, last-weekday (LW) is 29 (FRI) -2 Offset")]
         [TestCase("0 15 10 LW-5 * ? 2010", 24, "31 Oct 2010 is Sunday, last-weekday (LW) is 29 (FRI) -5 Offset")]
         [TestCase("0 15 10 LW-7 * ? 2010", 22, "31 Oct 2010 is Sunday, last-weekday (LW) is 29 (FRI) -7 Offset")]
@@ -216,7 +253,6 @@ namespace Quartz.Tests.Unit
                 act.Should().Throw<FormatException>();
             }
         }
-
 
         [TestCase("0 15 10 6,15,LW * ? 2010")]
         [TestCase("0 15 10 6,15,L * ? 2010")]
@@ -283,7 +319,6 @@ namespace Quartz.Tests.Unit
             Action act = () => new CronExpression($"0 0 * * * ?{allowedChar}");
             act.Should().NotThrow();
         }
-
 
         [Test]
         public void CanGetNextTimeAfterExternal_From_JsonDeserializedExpression()
@@ -462,24 +497,6 @@ namespace Quartz.Tests.Unit
 
             // check that all fired
             Assert.IsTrue(correctFireDays.Count == 0, $"CronExpression did not evaluate true for all expected days (count: {correctFireDays.Count}).");
-        }
-
-        [Test]
-        public void TestFormatExceptionWildCardDayOfMonthAndDayOfWeek()
-        {
-            Assert.Throws<FormatException>(() => new CronExpression("0 0 * * * *"), "Support for specifying both a day-of-week AND a day-of-month parameter is not implemented.");
-        }
-
-        [Test]
-        public void TestFormatExceptionSpecifiedDayOfMonthAndWildCardDayOfWeek()
-        {
-            Assert.Throws<FormatException>(() => new CronExpression("0 0 * 4 * *"), "Support for specifying both a day-of-week AND a day-of-month parameter is not implemented.");
-        }
-
-        [Test]
-        public void TestFormatExceptionWildCardDayOfMonthAndSpecifiedDayOfWeek()
-        {
-            Assert.Throws<FormatException>(() => new CronExpression("0 0 * * * 4"), "Support for specifying both a day-of-week AND a day-of-month parameter is not implemented.");
         }
 
         [Test]

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -321,6 +321,8 @@ namespace Quartz
 
         private static readonly char[] splitSeparators = { ' ', '\t', '\r', '\n' };
         private static readonly char[] commaSeparator = { ',' };
+        private static Regex regex = new Regex("^L(-\\d{1,2})?(W(-\\d{1,2})?)?$", RegexOptions.Compiled); //e.g. LW L-0W L-4 L-12W LW-4 LW-12
+        private static Regex offsetRegex = new Regex("LW-(?<offset>[0-9]+)", RegexOptions.Compiled);
 
         static CronExpression()
         {
@@ -680,7 +682,7 @@ namespace Quartz
                                 {
                                     nearestWeekday = true;
                                 }
-                                var offsetRegex = new Regex("LW-(?<offset>[0-9]+)",RegexOptions.Compiled);
+                                
                                 if (offsetRegex.IsMatch(s))
                                 {
                                     var offSetGroup = offsetRegex.Match(s).Groups["offset"];
@@ -840,8 +842,6 @@ namespace Quartz
             {
                 return;
             }
-
-            var regex = new Regex("^L(-\\d{1,2})?(W(-\\d{1,2})?)?$", RegexOptions.Compiled); //e.g. LW L-0W L-4 L-12W LW-4 LW-12
 
             switch (s[i])
             {


### PR DESCRIPTION
## Feature

- CronExpression support DayOfMonth and DayOfWeek together (inclusive values)
resolves #1543

## Refactors

Outdated tests removed, condition no longer valid.

```text
public void TestFormatExceptionWildCardDayOfMonthAndDayOfWeek()
public void TestFormatExceptionSpecifiedDayOfMonthAndWildCardDayOfWeek()
public void TestFormatExceptionWildCardDayOfMonthAndSpecifiedDayOfWeek()
```

Below changes were reverted for performance reasons
~~`monthMap` and `dayMap` changed to `IReadOnlyDictionary`~~
~~protected fields initialised instead of null~~

## Note

~~Branched from #1972 - https://github.com/jafin/quartznet/tree/refactor-cron-expressions~~
EDIT: Rebased on main



