### PR TITLE
Fix for deserializing CronExpression using Json Serializer throwing exception on GetNextValidTimeAfter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -69,6 +69,13 @@
 
   * Add Cron parser support for 'L' and 'LW' in expression combinations for daysOfMonth (#1939) (#1288)
 
+* FIXES
+
+  * Fix for deserializing CronExpression using Json Serializer throwing error calling `GetNextValidTimeAfter`.  (#1996)
+    `IDeserializationCallback` interface was removed from class `CronExpression` and the deserialization logic 
+    added to the constructor `CronExpression(SerializationInfo info, StreamingContext context)`.
+  
+
 ## Release 3.6.1, Feb 25 2023
 
 This bug fix release contains an important fix to anyone configuring jobs using job builder's `DisallowConcurrentExecution()`

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -23,6 +23,8 @@ using System.Diagnostics;
 
 using FluentAssertions;
 
+using Newtonsoft.Json;
+
 using NUnit.Framework;
 
 using Quartz.Simpl;
@@ -266,6 +268,19 @@ namespace Quartz.Tests.Unit
         {
             Action act = () => new CronExpression($"0 0 * * * ?{allowedChar}");
             act.Should().NotThrow();
+        }
+
+
+        [Test]
+        public void CanGetNextTimeAfterExternal_From_JsonDeserializedExpression()
+        {
+            // Scenario where external serialization occurrs outside of the provided Quartz Serializers.
+            var cronExpression = new CronExpression("0 15 23 * * ?");
+            var cal = new DateTime(2005, 6, 1, 23, 16, 0).ToUniversalTime();
+            var nextExpectedFireTime = new DateTime(2005, 6, 2, 23, 15, 0).ToUniversalTime();
+            var jsonCronExpression = JsonConvert.SerializeObject(cronExpression);
+            var deSerializedCron = JsonConvert.DeserializeObject<CronExpression>(jsonCronExpression);
+            deSerializedCron.GetNextValidTimeAfter(cal).Value.Should().Be(nextExpectedFireTime);
         }
 
         [Test]

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -207,7 +207,7 @@ namespace Quartz
     /// <author>Refactoring from CronTrigger to CronExpression by Aaron Craven</author>
     /// <author>Marko Lahma (.NET)</author>
     [Serializable]
-    public class CronExpression : IDeserializationCallback, ISerializable
+    public class CronExpression : ISerializable
     {
         private static readonly Dictionary<string, int> monthMap = new Dictionary<string, int>(20);
         private static readonly Dictionary<string, int> dayMap = new Dictionary<string, int>(60);
@@ -378,6 +378,7 @@ namespace Quartz
                     ThrowHelper.ThrowNotSupportedException($"Unknown serialization version {version}");
                     break;
             }
+            BuildExpression(CronExpressionString);
         }
 
         [System.Security.SecurityCritical]
@@ -2151,11 +2152,6 @@ namespace Quartz
             var copy = new CronExpression(CronExpressionString);
             copy.TimeZone = TimeZone;
             return copy;
-        }
-
-        public void OnDeserialization(object? sender)
-        {
-            BuildExpression(CronExpressionString);
         }
 
         /// <summary>


### PR DESCRIPTION
## Fix

When deserializing a CronExpression outside of builtin Quartz Serializers (for example to store in a custom store). Then calling `GetNextValidTimeAfter` will throw a NullReferenceException

This is due to `BuildExpression` not being called

Resolves #1996
