### PR TITLE
Optimize CronExpression and small reduction on allocation

### DIFF
--- a/src/Quartz.Benchmark/CronExpressionBenchmark.cs
+++ b/src/Quartz.Benchmark/CronExpressionBenchmark.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Quartz.Benchmark;
+
+[MemoryDiagnoser]
+public class CronExpressionBenchmark
+{
+    [ParamsSource(nameof(DateValues))]
+    public DateTime Date { get; set; }
+
+    public IEnumerable<DateTime> DateValues => new[]
+    {
+        new DateTime(2005, 6, 1, 22, 15, 0),
+        new DateTime(2005, 12, 31, 23, 59, 59),
+    };
+
+    [ParamsSource(nameof(CronExpressionValues))]
+    public string CronExpression { get; set; } = "";
+
+    public IEnumerable<string> CronExpressionValues => new[]
+    {
+        "0 15 10 6,15 * ? *",
+        "0 0/5 10 6,15 * ? *",
+        "0 15 10 15 * ? *",
+        "0 15 10 15,31 * ? *",
+        "0 15 10 6,15,LW * ? *",
+        "0 15 10 6,15,L * ? *",
+        "0 15 10 15,L * ? *",
+        "0 15 10 15,31 * ? *",
+        "0 15 10 15,L-2 * ? *",
+        "0 15 10 1,3,6,15,L * ? *",
+        "0 15 10 1,2,3,4,5,6,7,8,9,10,15,L * ? *",
+        "0 15 10 15,LW-2 * ? *",
+        "0 15 10 ? * 6#3 *"
+    };
+
+    [Benchmark]
+    public void CreateExpressionsAndCalculateFireTimeAfter()
+    {
+        var expression = new CronExpression(CronExpression);
+        expression.GetNextValidTimeAfter(Date);
+    }
+}

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -23,7 +23,6 @@ using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
-
 using Quartz.Util;
 
 namespace Quartz
@@ -1411,8 +1410,8 @@ namespace Quartz
         protected virtual ValueSet GetValue(int v, string s, int i)
         {
             var c = s[i];
-            var s1 = new StringBuilder(v.ToString(CultureInfo.InvariantCulture));
-            while (c >= '0' && c <= '9')
+            var s1 = new StringBuilder(v.ToString(CultureInfo.InvariantCulture),s.Length);
+            while (c is >= '0' and <= '9')
             {
                 s1.Append(c);
                 i++;
@@ -1422,7 +1421,12 @@ namespace Quartz
                 }
                 c = s[i];
             }
-            var val = new ValueSet();
+
+            var val = new ValueSet
+            {
+                theValue = Convert.ToInt32(s1.ToString(), CultureInfo.InvariantCulture)
+            };
+
             if (i < s.Length)
             {
                 val.pos = i;
@@ -1431,7 +1435,6 @@ namespace Quartz
             {
                 val.pos = i + 1;
             }
-            val.theValue = Convert.ToInt32(s1.ToString(), CultureInfo.InvariantCulture);
             return val;
         }
 
@@ -1529,11 +1532,11 @@ namespace Quartz
             var st = seconds.TailSet(sec);
             if (st.Count > 0)
             {
-                sec = st.First();
+                sec = st.Min;
             }
             else
             {
-                sec = seconds.First();
+                sec = seconds.Min;
                 d = d.AddMinutes(1);
             }
 
@@ -1554,11 +1557,11 @@ namespace Quartz
             if (st.Count > 0)
             {
                 t = min;
-                min = st.First();
+                min = st.Min;
             }
             else
             {
-                min = minutes.First();
+                min = minutes.Min;
                 hr++;
             }
 
@@ -1586,11 +1589,11 @@ namespace Quartz
             if (st.Count > 0)
             {
                 t = d.Hour;
-                hour = st.First();
+                hour = st.Min;
             }
             else
             {
-                hour = hours.First();
+                hour = hours.Min;
                 day++;
             }
 
@@ -1651,7 +1654,7 @@ namespace Quartz
             }
             else if (nearestWeekday) //AND not lastDay
             {
-                var day = daysOfMonth.First();
+                var day = daysOfMonth.Min;
                 var tcal = new DateTimeOffset(dt.Year, dt.Month, day, 0, 0, 0, dt.Offset);
                 var lastDayOfMonth = GetLastDayOfMonth(dt.Month, dt.Year);
                 var dayOfWeek = tcal.DayOfWeek;
@@ -1695,13 +1698,13 @@ namespace Quartz
             if (found)
             {
                 t = day;
-                day = tailDays.First();
+                day = tailDays.Min;
 
                 // make sure we don't over-run a short month, such as february
                 var lastDay = GetLastDayOfMonth(mon, d.Year);
                 if (day > lastDay)
                 {
-                    day = daysOfMonthCalculated.First();
+                    day = daysOfMonthCalculated.Min;
                     mon++;
                 }
             }
@@ -1709,11 +1712,11 @@ namespace Quartz
             {
                 if (lastdayOfMonth)
                 {
-                    day = daysOfMonthCalculated.First(); //for lastDayOfMonth use calculated fields
+                    day = daysOfMonthCalculated.Min; //for lastDayOfMonth use calculated fields
                 }
                 else
                 {
-                    day = daysOfMonth.First(); //if not then initial set of days uncalculated (to avoid issue with stale weekday in wrong month value)
+                    day = daysOfMonth.Min; //if not then initial set of days uncalculated (to avoid issue with stale weekday in wrong month value)
                 }
 
                 mon++;
@@ -1755,7 +1758,7 @@ namespace Quartz
             {
                 // are we looking for the last XXX day of
                 // the month?
-                var dow = daysOfWeek.First(); // desired
+                var dow = daysOfWeek.Min; // desired
                                               // d-o-w
                 var cDow = (int)d.DayOfWeek + 1; // current d-o-w
                 var daysToAdd = 0;
@@ -1806,7 +1809,7 @@ namespace Quartz
             else if (nthdayOfWeek != 0)
             {
                 // are we looking for the Nth XXX day in the month?
-                var dow = daysOfWeek.First(); // desired
+                var dow = daysOfWeek.Min; // desired
                                               // d-o-w
                 var cDow = (int)d.DayOfWeek + 1; // current d-o-w
                 var daysToAdd = 0;
@@ -1854,12 +1857,12 @@ namespace Quartz
             else if (everyNthWeek != 0)
             {
                 var cDow = (int)d.DayOfWeek + 1; // current d-o-w
-                var dow = daysOfWeek.First(); // desired
+                var dow = daysOfWeek.Min; // desired
                                               // d-o-w
                 var tailDays = daysOfWeek.TailSet(cDow);
                 if (tailDays.Count > 0)
                 {
-                    dow = tailDays.First();
+                    dow = tailDays.Min;
                 }
 
                 var daysToAdd = 0;
@@ -1884,12 +1887,12 @@ namespace Quartz
             else
             {
                 var cDow = (int)d.DayOfWeek + 1; // current d-o-w
-                var dow = daysOfWeek.First(); // desired
+                var dow = daysOfWeek.Min; // desired
                                               // d-o-w
                 var tailDays = daysOfWeek.TailSet(cDow);
                 if (tailDays.Count > 0)
                 {
-                    dow = tailDays.First();
+                    dow = tailDays.Min;
                 }
 
                 var daysToAdd = 0;
@@ -1985,11 +1988,11 @@ namespace Quartz
             if (st.Count > 0)
             {
                 t = mon;
-                mon = st.First();
+                mon = st.Min;
             }
             else
             {
-                mon = months.First();
+                mon = months.Min;
                 year++;
             }
 
@@ -2010,7 +2013,7 @@ namespace Quartz
             if (st.Count > 0)
             {
                 t = year;
-                year = st.First();
+                year = st.Min;
             }
             else
             {


### PR DESCRIPTION
Micro performance optimization in CronExpression

**4.x with this change:**

|            Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|------------------ |---------:|---------:|---------:|-------:|----------:|
| CreateExpressions | 35.96 us | 0.505 us | 0.518 us | 3.4180 |  55.93 KB |

4.x before change:  0c9ba23189c85223917d1ecbebbf2a951b891044

|            Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|------------------ |---------:|---------:|---------:|-------:|----------:|
| CreateExpressions | 50.90 us | 0.981 us | 1.008 us | 5.0049 |  82.08 KB |

3.x 9d136a8d26122f0ff087f7ff67705673c1742ce8

|            Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|------------------ |---------:|---------:|---------:|-------:|----------:|
| CreateExpressions | 41.09 us | 0.783 us | 0.837 us | 4.5776 |  75.13 KB |


~~Branched from #1980, will rebase if/when PR 1980 is committed.~~

EDIT:

Benchmark now parameterised, example result below:

|                                     Method |                Date |       CronExpression |     Mean |    Error |   StdDev |   Gen0 |   Gen1 | Allocated |
|------------------------------------------- |-------------------- |--------------------- |---------:|---------:|---------:|-------:|-------:|----------:|
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 |  0 0/5 10 6,15 * ? * | 13.12 us | 0.217 us | 0.203 us | 0.8392 | 0.0153 |  13.88 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 | 0 15 (...)* ? * [39] | 12.27 us | 0.118 us | 0.105 us | 0.8087 | 0.0153 |  13.29 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 | 0 15 (...)* ? * [24] | 13.68 us | 0.273 us | 0.464 us | 0.9003 | 0.0153 |  14.84 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 |     0 15 10 15 * ? * | 13.06 us | 0.249 us | 0.306 us | 0.8545 | 0.0153 |  14.15 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 |  0 15 10 15,31 * ? * | 13.16 us | 0.259 us | 0.425 us | 0.8850 |      - |  14.53 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 |  0 15 10 15,31 * ? * | 13.35 us | 0.265 us | 0.284 us | 0.8850 | 0.0153 |  14.53 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 |   0 15 10 15,L * ? * | 13.07 us | 0.212 us | 0.188 us | 0.8545 | 0.0153 |  14.19 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 | 0 15 10 15,L-2 * ? * | 13.08 us | 0.258 us | 0.297 us | 0.8698 | 0.0153 |  14.31 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 | 0 15 (...)* ? * [21] | 13.74 us | 0.272 us | 0.373 us | 0.8850 | 0.0153 |   14.6 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 |   0 15 10 6,15 * ? * | 12.89 us | 0.202 us | 0.189 us | 0.8698 | 0.0153 |  14.41 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 | 0 15 10 6,15,L * ? * | 12.89 us | 0.197 us | 0.184 us | 0.8698 | 0.0153 |  14.43 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 | 0 15 (...)* ? * [21] | 12.95 us | 0.236 us | 0.242 us | 0.8698 | 0.0153 |  14.44 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 06/01/2005 22:15:00 |    0 15 10 ? * 6#3 * | 12.57 us | 0.145 us | 0.129 us | 0.7935 | 0.0153 |  13.13 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 |  0 0/5 10 6,15 * ? * | 13.03 us | 0.256 us | 0.342 us | 0.8240 | 0.0153 |  13.62 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 | 0 15 (...)* ? * [39] | 12.74 us | 0.250 us | 0.411 us | 0.8240 | 0.0153 |  13.55 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 | 0 15 (...)* ? * [24] | 11.96 us | 0.238 us | 0.284 us | 0.7477 | 0.0153 |   12.4 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 |     0 15 10 15 * ? * | 13.02 us | 0.169 us | 0.158 us | 0.8698 | 0.0153 |  14.41 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 |  0 15 10 15,31 * ? * | 13.35 us | 0.238 us | 0.223 us | 0.9003 | 0.0153 |   14.8 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 |  0 15 10 15,31 * ? * | 13.07 us | 0.218 us | 0.204 us | 0.9003 | 0.0153 |   14.8 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 |   0 15 10 15,L * ? * | 12.90 us | 0.172 us | 0.161 us | 0.8698 | 0.0153 |  14.45 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 | 0 15 10 15,L-2 * ? * | 13.16 us | 0.158 us | 0.140 us | 0.8850 | 0.0153 |  14.58 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 | 0 15 (...)* ? * [21] | 13.50 us | 0.254 us | 0.260 us | 0.9003 | 0.0153 |  14.87 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 |   0 15 10 6,15 * ? * | 13.04 us | 0.200 us | 0.187 us | 0.8850 | 0.0153 |  14.68 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 | 0 15 10 6,15,L * ? * | 13.09 us | 0.106 us | 0.099 us | 0.8850 | 0.0153 |   14.7 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 | 0 15 (...)* ? * [21] | 13.49 us | 0.258 us | 0.286 us | 0.8850 | 0.0153 |   14.7 KB |
| CreateExpressionsAndCalculateFireTimeAfter | 12/31/2005 23:59:59 |    0 15 10 ? * 6#3 * | 12.54 us | 0.109 us | 0.102 us | 0.8087 | 0.0153 |  13.39 KB |
