### PR TITLE
JobInterruptMonitor Plugin: Read MaxRunTime from MergedJobDataMap

### DIFF
--- a/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
@@ -78,12 +78,12 @@ namespace Quartz.Plugin.Interrupt
                 if (context.JobDetail.JobDataMap.GetBoolean(JobDataMapKeyAutoInterruptable))
                 {
                     JobInterruptMonitorPlugin monitorPlugin = (JobInterruptMonitorPlugin) context.Scheduler.Context.Get(JobInterruptMonitorKey);
-                    // Get the MaxRuntime from Job Data if NOT available use MaxRunTime from Plugin Configuration
+                    // Get the MaxRuntime from MergedJobDataMap if NOT available use MaxRunTime from Plugin Configuration
                     var jobDataDelay = DefaultMaxRunTime;
 
-                    if (context.JobDetail.JobDataMap.GetString(JobDataMapKeyMaxRunTime) != null)
+                    if (context.MergedJobDataMap.GetString(JobDataMapKeyMaxRunTime) != null)
                     {
-                        jobDataDelay = TimeSpan.FromMilliseconds(context.JobDetail.JobDataMap.GetLongValueFromString(JobDataMapKeyMaxRunTime));
+                        jobDataDelay = TimeSpan.FromMilliseconds(context.MergedJobDataMap.GetLongValueFromString(JobDataMapKeyMaxRunTime));
                     }
 
                     monitorPlugin.ScheduleJobInterruptMonitor(context.FireInstanceId, context.JobDetail.Key, jobDataDelay);


### PR DESCRIPTION
**Change:**
Reading MaxRuntime from the MergedDataMap instead of JobDataMap.
This allows to set the MaxRunTime also in the trigger configuration. Before this change only configure a 'gracefully' interrupt in JobDetails was possible.

**Reason for change:**
I have the situation to have several (long running) jobs that start at different times with same parameters and need to be finished 'gracefully'  after a different time
This would also work with multiple jobs with one trigger each, but made the configuration bigger.
