### PR TITLE
Replace SortedSet.TailSet with separate CronField container

### DIFF
--- a/src/Quartz.Benchmark/CronExpressionBenchmark.cs
+++ b/src/Quartz.Benchmark/CronExpressionBenchmark.cs
@@ -5,15 +5,6 @@ namespace Quartz.Benchmark;
 [MemoryDiagnoser]
 public class CronExpressionBenchmark
 {
-    [ParamsSource(nameof(DateValues))]
-    public DateTime Date { get; set; }
-
-    public IEnumerable<DateTime> DateValues => new[]
-    {
-        new DateTime(2005, 6, 1, 22, 15, 0),
-        new DateTime(2005, 12, 31, 23, 59, 59),
-    };
-
     [ParamsSource(nameof(CronExpressionValues))]
     public string CronExpression { get; set; } = "";
 
@@ -38,6 +29,7 @@ public class CronExpressionBenchmark
     public void CreateExpressionsAndCalculateFireTimeAfter()
     {
         var expression = new CronExpression(CronExpression);
-        expression.GetNextValidTimeAfter(Date);
+        expression.GetNextValidTimeAfter(new DateTime(2005, 6, 1, 22, 15, 0));
+        expression.GetNextValidTimeAfter(new DateTime(2005, 12, 31, 23, 59, 59));
     }
 }

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -583,8 +583,8 @@ namespace Quartz.Tests.Unit
         {
             try
             {
-                SimpleCronExpression cronExpression = new SimpleCronExpression(expression);
-                ICollection<int> set = cronExpression.GetSetPublic(constant);
+                var cronExpression = new CronExpression(expression);
+                var set = cronExpression.GetSet(constant);
                 if (set.Count == 0)
                 {
                     Assert.Fail("Empty field [" + constant + "] returned for " + expression);
@@ -902,19 +902,6 @@ namespace Quartz.Tests.Unit
         public void TestHourRangeAndSlash()
         {
             CronExpression.ValidateExpression("0 0 18-21/1 ? * MON,TUE,WED,THU,FRI,SAT,SUN");
-        }
-
-        private class SimpleCronExpression : CronExpression
-        {
-            public SimpleCronExpression(string cronExpression)
-                : base(cronExpression)
-            {
-            }
-
-            public ISet<int> GetSetPublic(int constant)
-            {
-                return GetSet(constant);
-            }
         }
 
         [Test]

--- a/src/Quartz.Tests.Unit/CronFieldTest.cs
+++ b/src/Quartz.Tests.Unit/CronFieldTest.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace Quartz.Tests.Unit;
+
+public class CronFieldTest
+{
+    [Test]
+    public void BasicOperationsShouldWork()
+    {
+        var field = new CronField();
+        field.Should().BeEmpty();
+
+        field.Add(1);
+        field.Should().HaveCount(1);
+
+        field.Should().Contain(1);
+        field.Should().NotContain(2);
+
+        field.Add(2);
+        field.Should().HaveCount(2);
+        field.Should().Contain(1);
+        field.Should().Contain(2);
+
+        field.Clear();
+        field.Should().BeEmpty();
+        field.Should().NotContain(1);
+        field.Should().NotContain(2);
+    }
+
+    [Test]
+    public void ShouldSupportAllSpec()
+    {
+        var field = new CronField();
+        field.Add(CronExpressionConstants.AllSpec);
+        field.Contains(1).Should().BeTrue();
+        field.Contains(2023).Should().BeTrue();
+        field.Contains(CronExpressionConstants.AllSpec).Should().BeTrue();
+        field.Contains(CronExpressionConstants.NoSpec).Should().BeFalse();
+
+        field.Clear();
+
+        field.Add(1);
+        field.Add(CronExpressionConstants.AllSpec);
+        field.Contains(1).Should().BeTrue();
+        field.Contains(2023).Should().BeTrue();
+        field.Contains(CronExpressionConstants.AllSpec).Should().BeTrue();
+        field.Contains(CronExpressionConstants.NoSpec).Should().BeFalse();
+    }
+
+    [Test]
+    public void ShouldSupportNoSpec()
+    {
+        var field = new CronField();
+        field.Add(CronExpressionConstants.NoSpec);
+        field.Contains(CronExpressionConstants.NoSpec).Should().BeTrue();
+        field.Contains(CronExpressionConstants.AllSpec).Should().BeFalse();
+
+        field.Clear();
+
+        field.Add(1);
+        field.Add(CronExpressionConstants.AllSpec);
+        field.Contains(1).Should().BeTrue();
+        field.Contains(2023).Should().BeTrue();
+        field.Contains(CronExpressionConstants.AllSpec).Should().BeTrue();
+    }
+
+    [Test]
+    public void ShouldSupportFoo()
+    {
+        var field = new CronField();
+
+        field.TryGetMinValueStartingFrom(0, out var min).Should().BeFalse();
+
+        field.Add(0);
+        field.TryGetMinValueStartingFrom(0, out min).Should().BeTrue();
+        min.Should().Be(0);
+
+        field.Clear();
+        field.Add(15);
+        field.TryGetMinValueStartingFrom(0, out min).Should().BeTrue();
+        min.Should().Be(15);
+        field.TryGetMinValueStartingFrom(30, out min).Should().BeFalse();
+
+        field.Clear();
+        field.Add(CronExpressionConstants.AllSpec);
+        field.TryGetMinValueStartingFrom(0, out min).Should().BeTrue();
+        min.Should().Be(0);
+        field.TryGetMinValueStartingFrom(2023, out min).Should().BeTrue();
+        min.Should().Be(2023);
+    }
+}

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -19,10 +19,12 @@
 
 #endregion
 
+using System.Collections;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
+
 using Quartz.Util;
 
 namespace Quartz
@@ -240,37 +242,37 @@ namespace Quartz
         /// <summary>
         /// Seconds.
         /// </summary>
-        [NonSerialized] protected SortedSet<int> seconds = null!;
+        [NonSerialized] private CronField seconds = new();
 
         /// <summary>
         /// minutes.
         /// </summary>
-        [NonSerialized] protected SortedSet<int> minutes = null!;
+        [NonSerialized] private CronField minutes = new();
 
         /// <summary>
         /// Hours.
         /// </summary>
-        [NonSerialized] protected SortedSet<int> hours = null!;
+        [NonSerialized] private CronField hours = new();
 
         /// <summary>
         /// Days of month.
         /// </summary>
-        [NonSerialized] protected SortedSet<int> daysOfMonth = null!;
+        [NonSerialized] private CronField daysOfMonth = new();
 
         /// <summary>
         /// Months.
         /// </summary>
-        [NonSerialized] protected SortedSet<int> months = null!;
+        [NonSerialized] private CronField months = new();
 
         /// <summary>
         /// Days of week.
         /// </summary>
-        [NonSerialized] protected SortedSet<int> daysOfWeek = null!;
+        [NonSerialized] private CronField daysOfWeek = new();
 
         /// <summary>
         /// Years.
         /// </summary>
-        [NonSerialized] protected SortedSet<int> years = null!;
+        [NonSerialized] private CronField years = new();
 
         /// <summary>
         /// Last day of week.
@@ -522,13 +524,13 @@ namespace Quartz
         {
             try
             {
-                seconds ??= new();
-                minutes ??= new();
-                hours ??= new();
-                daysOfMonth ??= new();
-                months ??= new();
-                daysOfWeek ??= new();
-                years ??= new();
+                seconds.Clear();
+                minutes.Clear();
+                hours.Clear();
+                daysOfMonth.Clear();
+                months.Clear();
+                daysOfWeek.Clear();
+                years.Clear();
 
                 var exprOn = CronExpressionConstants.Second;
 
@@ -594,20 +596,18 @@ namespace Quartz
             }
             if (type != CronExpressionConstants.DayOfWeek && type != CronExpressionConstants.DayOfMonth)
             {
-                ThrowHelper.ThrowFormatException(
-                    "'?' can only be specified for Day-of-Month or Day-of-Week.");
+                ThrowHelper.ThrowFormatException("'?' can only be specified for Day-of-Month or Day-of-Week.");
             }
             if (type == CronExpressionConstants.DayOfWeek && !lastdayOfMonth)
             {
                 var val = daysOfMonth.LastOrDefault();
-                if (val == CronExpressionConstants.NoSpecInt)
+                if (val == CronExpressionConstants.NoSpec)
                 {
-                    ThrowHelper.ThrowFormatException(
-                        "'?' can only be specified for Day-of-Month -OR- Day-of-Week.");
+                    ThrowHelper.ThrowFormatException("'?' can only be specified for Day-of-Month -OR- Day-of-Week.");
                 }
             }
 
-            AddToSet(CronExpressionConstants.NoSpecInt, -1, 0, type);
+            AddToSet(CronExpressionConstants.NoSpec, -1, 0, type);
         }
 
         private void StoreExpressionStarOrSlash(int type, string s, int i)
@@ -617,7 +617,7 @@ namespace Quartz
             var startsWithAsterisk = c == '*';
             if (startsWithAsterisk && i + 1 >= s.Length)
             {
-                AddToSet(CronExpressionConstants.AllSpecInt, -1, incr, type);
+                AddToSet(CronExpressionConstants.AllSpec, -1, incr, type);
                 return;
             }
             if (c == '/' && (i + 1 >= s.Length || s[i + 1] == ' ' || s[i + 1] == '\t'))
@@ -650,7 +650,7 @@ namespace Quartz
                 incr = 1;
             }
 
-            AddToSet(CronExpressionConstants.AllSpecInt, -1, incr, type);
+            AddToSet(CronExpressionConstants.AllSpec, -1, incr, type);
         }
 
         private void StoreExpressionL(int type, string s, int i)
@@ -681,7 +681,7 @@ namespace Quartz
                                 {
                                     nearestWeekday = true;
                                 }
-                                
+
                                 if (offsetRegex.IsMatch(s))
                                 {
                                     var offSetGroup = offsetRegex.Match(s).Groups["offset"];
@@ -1192,43 +1192,43 @@ namespace Quartz
 
             if (type == CronExpressionConstants.Second || type == CronExpressionConstants.Minute)
             {
-                if ((val < 0 || val > 59 || end > 59) && val != CronExpressionConstants.AllSpecInt)
+                if ((val < 0 || val > 59 || end > 59) && val != CronExpressionConstants.AllSpec)
                 {
                     ThrowHelper.ThrowFormatException("Minute and CronExpressionConstants.Second values must be between 0 and 59");
                 }
             }
             else if (type == CronExpressionConstants.Hour)
             {
-                if ((val < 0 || val > 23 || end > 23) && val != CronExpressionConstants.AllSpecInt)
+                if ((val < 0 || val > 23 || end > 23) && val != CronExpressionConstants.AllSpec)
                 {
                     ThrowHelper.ThrowFormatException("Hour values must be between 0 and 23");
                 }
             }
             else if (type == CronExpressionConstants.DayOfMonth)
             {
-                if ((val < 1 || val > 31 || end > 31) && val != CronExpressionConstants.AllSpecInt
-                                                      && val != CronExpressionConstants.NoSpecInt)
+                if ((val < 1 || val > 31 || end > 31) && val != CronExpressionConstants.AllSpec
+                                                      && val != CronExpressionConstants.NoSpec)
                 {
                     ThrowHelper.ThrowFormatException("Day of month values must be between 1 and 31");
                 }
             }
             else if (type == CronExpressionConstants.Month)
             {
-                if ((val < 1 || val > 12 || end > 12) && val != CronExpressionConstants.AllSpecInt)
+                if ((val < 1 || val > 12 || end > 12) && val != CronExpressionConstants.AllSpec)
                 {
                     ThrowHelper.ThrowFormatException("Month values must be between 1 and 12");
                 }
             }
             else if (type == CronExpressionConstants.DayOfWeek)
             {
-                if ((val == 0 || val > 7 || end > 7) && val != CronExpressionConstants.AllSpecInt
-                                                     && val != CronExpressionConstants.NoSpecInt)
+                if ((val == 0 || val > 7 || end > 7) && val != CronExpressionConstants.AllSpec
+                                                     && val != CronExpressionConstants.NoSpec)
                 {
                     ThrowHelper.ThrowFormatException("Day-of-Week values must be between 1 and 7");
                 }
             }
 
-            if ((incr == 0 || incr == -1) && val != CronExpressionConstants.AllSpecInt)
+            if ((incr == 0 || incr == -1) && val != CronExpressionConstants.AllSpec)
             {
                 data.Add(val != -1 ? val : CronExpressionConstants.NoSpec);
                 return;
@@ -1237,10 +1237,11 @@ namespace Quartz
             var startAt = val;
             var stopAt = end;
 
-            if (val == CronExpressionConstants.AllSpecInt && incr <= 0)
+            if (val == CronExpressionConstants.AllSpec && incr <= 0)
             {
-                incr = 1;
-                data.Add(CronExpressionConstants.AllSpec); // put in a marker, but also fill values
+                data.Add(CronExpressionConstants.AllSpec);
+                // skip adding other data, we check this wildcard in TryGetMinValueStartingFrom
+                return;
             }
 
             if (type == CronExpressionConstants.Second || type == CronExpressionConstants.Minute)
@@ -1249,7 +1250,7 @@ namespace Quartz
                 {
                     stopAt = 59;
                 }
-                if (startAt == -1 || startAt == CronExpressionConstants.AllSpecInt)
+                if (startAt == -1 || startAt == CronExpressionConstants.AllSpec)
                 {
                     startAt = 0;
                 }
@@ -1260,7 +1261,7 @@ namespace Quartz
                 {
                     stopAt = 23;
                 }
-                if (startAt == -1 || startAt == CronExpressionConstants.AllSpecInt)
+                if (startAt == -1 || startAt == CronExpressionConstants.AllSpec)
                 {
                     startAt = 0;
                 }
@@ -1271,7 +1272,7 @@ namespace Quartz
                 {
                     stopAt = 31;
                 }
-                if (startAt == -1 || startAt == CronExpressionConstants.AllSpecInt)
+                if (startAt == -1 || startAt == CronExpressionConstants.AllSpec)
                 {
                     startAt = 1;
                 }
@@ -1282,7 +1283,7 @@ namespace Quartz
                 {
                     stopAt = 12;
                 }
-                if (startAt == -1 || startAt == CronExpressionConstants.AllSpecInt)
+                if (startAt == -1 || startAt == CronExpressionConstants.AllSpec)
                 {
                     startAt = 1;
                 }
@@ -1293,7 +1294,7 @@ namespace Quartz
                 {
                     stopAt = 7;
                 }
-                if (startAt == -1 || startAt == CronExpressionConstants.AllSpecInt)
+                if (startAt == -1 || startAt == CronExpressionConstants.AllSpec)
                 {
                     startAt = 1;
                 }
@@ -1304,7 +1305,7 @@ namespace Quartz
                 {
                     stopAt = MaxYear;
                 }
-                if (startAt == -1 || startAt == CronExpressionConstants.AllSpecInt)
+                if (startAt is -1 or CronExpressionConstants.AllSpec)
                 {
                     startAt = 1970;
                 }
@@ -1359,8 +1360,8 @@ namespace Quartz
                     var i2 = i % max;
 
                     // 1-indexed ranges should not include 0, and should include their max
-                    if (i2 == 0 && (type == CronExpressionConstants.Month 
-                                    || type == CronExpressionConstants.DayOfWeek 
+                    if (i2 == 0 && (type == CronExpressionConstants.Month
+                                    || type == CronExpressionConstants.DayOfWeek
                                     || type == CronExpressionConstants.DayOfMonth))
                     {
                         i2 = max;
@@ -1374,9 +1375,7 @@ namespace Quartz
         /// <summary>
         /// Gets the set of given type.
         /// </summary>
-        /// <param name="type">The type of set to get.</param>
-        /// <returns></returns>
-        protected virtual SortedSet<int> GetSet(int type)
+        internal CronField GetSet(int type)
         {
             switch (type)
             {
@@ -1400,13 +1399,6 @@ namespace Quartz
             }
         }
 
-        /// <summary>
-        /// Gets the value.
-        /// </summary>
-        /// <param name="v">The v.</param>
-        /// <param name="s">The s.</param>
-        /// <param name="i">The i.</param>
-        /// <returns></returns>
         protected virtual ValueSet GetValue(int v, string s, int i)
         {
             var c = s[i];
@@ -1525,14 +1517,12 @@ namespace Quartz
         /// <summary>
         /// Progress next fire time seconds
         /// </summary>
-        /// <param name="d">NextFireTimeCheck</param>
         private NextFireTimeCursor ProgressNextFireTimeSecond(DateTimeOffset d)
         {
             var sec = d.Second;
-            var st = seconds.TailSet(sec);
-            if (st.Count > 0)
+            if (seconds.TryGetMinValueStartingFrom(sec, out var min))
             {
-                sec = st.Min;
+                sec = min;
             }
             else
             {
@@ -1549,30 +1539,29 @@ namespace Quartz
         /// <param name="d">NextFireTimeCheck</param>
         private NextFireTimeCursor ProgressNextFireTimeMinute(DateTimeOffset d)
         {
-            var min = d.Minute;
+            var minute = d.Minute;
             var hr = d.Hour;
             var t = -1;
 
-            var st = minutes.TailSet(min);
-            if (st.Count > 0)
+            if (minutes.TryGetMinValueStartingFrom(minute, out var min))
             {
-                t = min;
-                min = st.Min;
+                t = minute;
+                minute = min;
             }
             else
             {
-                min = minutes.Min;
+                minute = minutes.Min;
                 hr++;
             }
 
-            if (min != t)
+            if (minute != t)
             {
-                d = new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, min, 0, d.Millisecond, d.Offset);
+                d = new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, minute, 0, d.Millisecond, d.Offset);
                 d = SetCalendarHour(d, hr);
                 return new NextFireTimeCursor(true, d);
             }
 
-            return new NextFireTimeCursor(false, new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, min, d.Second, d.Millisecond, d.Offset));
+            return new NextFireTimeCursor(false, new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, minute, d.Second, d.Millisecond, d.Offset));
         }
 
         /// <summary>
@@ -1585,11 +1574,10 @@ namespace Quartz
             var day = d.Day;
             var t = -1;
 
-            var st = hours.TailSet(d.Hour);
-            if (st.Count > 0)
+            if (hours.TryGetMinValueStartingFrom(d.Hour, out var min))
             {
                 t = d.Hour;
-                hour = st.Min;
+                hour = min;
             }
             else
             {
@@ -1644,7 +1632,7 @@ namespace Quartz
                     {
                         calculatedLastDayWithOffset = 1;
                     }
-                        
+
                     results.Add(calculatedLastDayWithOffset);
                 }
                 else
@@ -1693,12 +1681,10 @@ namespace Quartz
 
             // get day by day of month rule
             var daysOfMonthCalculated = CalculateDaysOfMonth(d);
-            var tailDays = daysOfMonthCalculated.TailSet(d.Day);
-            var found = tailDays.Count > 0;
-            if (found)
+            if (daysOfMonthCalculated.TryGetMinValueStartingFrom(d.Day, out var min))
             {
                 t = day;
-                day = tailDays.Min;
+                day = min;
 
                 // make sure we don't over-run a short month, such as february
                 var lastDay = GetLastDayOfMonth(mon, d.Year);
@@ -1857,12 +1843,10 @@ namespace Quartz
             else if (everyNthWeek != 0)
             {
                 var cDow = (int)d.DayOfWeek + 1; // current d-o-w
-                var dow = daysOfWeek.Min; // desired
-                                              // d-o-w
-                var tailDays = daysOfWeek.TailSet(cDow);
-                if (tailDays.Count > 0)
+                var dow = daysOfWeek.Min; // desired d-o-w
+                if (daysOfWeek.TryGetMinValueStartingFrom(cDow, out var min))
                 {
-                    dow = tailDays.Min;
+                    dow = min;
                 }
 
                 var daysToAdd = 0;
@@ -1887,12 +1871,10 @@ namespace Quartz
             else
             {
                 var cDow = (int)d.DayOfWeek + 1; // current d-o-w
-                var dow = daysOfWeek.Min; // desired
-                                              // d-o-w
-                var tailDays = daysOfWeek.TailSet(cDow);
-                if (tailDays.Count > 0)
+                var dow = daysOfWeek.Min; // desired d-o-w
+                if (daysOfWeek.TryGetMinValueStartingFrom(cDow, out var min))
                 {
-                    dow = tailDays.Min;
+                    dow = min;
                 }
 
                 var daysToAdd = 0;
@@ -1984,11 +1966,10 @@ namespace Quartz
             var year = d.Year;
             var t = -1;
 
-            var st = months.TailSet(mon);
-            if (st.Count > 0)
+            if (months.TryGetMinValueStartingFrom(mon, out var min))
             {
                 t = mon;
-                mon = st.Min;
+                mon = min;
             }
             else
             {
@@ -1996,8 +1977,8 @@ namespace Quartz
                 year++;
             }
 
-            return mon != t 
-                ? new NextFireTimeCursor(true, new DateTimeOffset(year, mon, 1, 0, 0, 0, d.Offset)) 
+            return mon != t
+                ? new NextFireTimeCursor(true, new DateTimeOffset(year, mon, 1, 0, 0, 0, d.Offset))
                 : new NextFireTimeCursor(false, new DateTimeOffset(d.Year, mon, d.Day, d.Hour, d.Minute, d.Second, d.Offset));
         }
 
@@ -2008,12 +1989,11 @@ namespace Quartz
         private NextFireTimeCursor ProgressNextFireTimeYear(DateTimeOffset d)
         {
             var year = d.Year;
-            var st = years.TailSet(d.Year);
             int t;
-            if (st.Count > 0)
+            if (years.TryGetMinValueStartingFrom(d.Year, out var min))
             {
                 t = year;
-                year = st.Min;
+                year = min;
             }
             else
             {
@@ -2260,5 +2240,177 @@ namespace Quartz
         /// NextFireDate calculated progress result
         /// </summary>
         public DateTimeOffset? Date { get; set; }
+    }
+
+    /// <summary>
+    /// Optimized structure to hold either one value or multiple.
+    /// </summary>
+    internal sealed class CronField : IEnumerable<int>
+    {
+        // null == not set, all spec or individual value
+        private int? singleValue;
+        private SortedSet<int>? values;
+        private bool hasAllOrNoSpec;
+
+        public CronField()
+        {
+            Clear();
+        }
+
+        internal int Count
+        {
+            get
+            {
+                if (singleValue is not null)
+                {
+                    return 1;
+                }
+
+                return values?.Count ?? 0;
+            }
+        }
+
+        internal int Min
+        {
+            get
+            {
+                if (singleValue is not null)
+                {
+                    return hasAllOrNoSpec  ? 0 : singleValue.Value;
+                }
+
+                if (values is not null)
+                {
+                    return hasAllOrNoSpec ? 0 : values.Min;
+                }
+
+                return 0;
+            }
+        }
+
+        internal void Clear()
+        {
+            singleValue = null;
+            values = null;
+            hasAllOrNoSpec = false;
+        }
+
+        internal bool TryGetMinValueStartingFrom(int start, out int min)
+        {
+            min = 0;
+
+            if (singleValue == CronExpressionConstants.AllSpec)
+            {
+                min = start;
+                return true;
+            }
+
+            if (singleValue != null)
+            {
+                if (singleValue >= start)
+                {
+                    min = singleValue.Value;
+                    return true;
+                }
+
+                // didn't match
+                return false;
+            }
+
+            var set = values;
+
+            if (set == null)
+            {
+                return false;
+            }
+
+            min = set.Min;
+
+            if (set.Contains(start))
+            {
+                min = start;
+                return true;
+            }
+
+            if (set.Count == 0 || set.Max < start)
+            {
+                return false;
+            }
+
+            if (set.Min >= start)
+            {
+                // value is contained and would be returned from view
+                return true;
+            }
+
+            // slow path
+            var view = set.GetViewBetween(start, int.MaxValue);
+            if (view.Count > 0)
+            {
+                min = view.Min;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Add(int value)
+        {
+            hasAllOrNoSpec = value is CronExpressionConstants.AllSpec or CronExpressionConstants.NoSpec;
+
+            if (singleValue is null)
+            {
+                if (values is null)
+                {
+                    singleValue = value;
+                }
+                else
+                {
+                    values.Add(value);
+                }
+            }
+            else if (singleValue != value)
+            {
+                values = new SortedSet<int>
+                {
+                    singleValue.Value,
+                    value
+                };
+                singleValue = null;
+            }
+        }
+
+        public bool Contains(int value)
+        {
+            if (singleValue == value
+                || (value != CronExpressionConstants.AllSpec && value != CronExpressionConstants.NoSpec && hasAllOrNoSpec))
+            {
+                return true;
+            }
+
+            return values != null && values.Contains(value);
+        }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            if (singleValue is not null)
+            {
+                yield return singleValue.Value;
+                yield break;
+            }
+
+            if (values is not null)
+            {
+                foreach (var value in values)
+                {
+                    yield return value;
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/src/Quartz/CronExpressionConstants.cs
+++ b/src/Quartz/CronExpressionConstants.cs
@@ -38,22 +38,12 @@ internal static class CronExpressionConstants
     public const int Year = 6;
 
     /// <summary>
-    /// Field specification for all wildcard value '*'.
-    /// </summary>
-    public const int AllSpecInt = 99; // '*'
-
-    /// <summary>
-    /// Field specification for not specified value '?'.
-    /// </summary>
-    public const int NoSpecInt = 98; // '?'
-
-    /// <summary>
     /// Field specification for wildcard '*'.
     /// </summary>
-    public const int AllSpec = AllSpecInt;
+    public const int AllSpec = 99;
 
     /// <summary>
     /// Field specification for no specification at all '?'.
     /// </summary>
-    public const int NoSpec = NoSpecInt;
+    public const int NoSpec = 98;
 }

--- a/src/Quartz/CronExpressionSummary.cs
+++ b/src/Quartz/CronExpressionSummary.cs
@@ -24,11 +24,11 @@ using System.Text;
 
 namespace Quartz
 {
-    internal struct CronExpressionSummary
+    internal readonly struct CronExpressionSummary
     {
-        public CronExpressionSummary(SortedSet<int> seconds, SortedSet<int> minutes, SortedSet<int> hours, SortedSet<int> daysOfMonth,
-            SortedSet<int> months, SortedSet<int> daysOfWeek, bool lastDayOfWeek, bool nearestWeekday, int nthDayOfWeek,
-            bool lastDayOfMonth, bool calendarDayOfWeek, bool calendarDayOfMonth, SortedSet<int> years)
+        public CronExpressionSummary(CronField seconds, CronField minutes, CronField hours, CronField daysOfMonth,
+            CronField months, CronField daysOfWeek, bool lastDayOfWeek, bool nearestWeekday, int nthDayOfWeek,
+            bool lastDayOfMonth, bool calendarDayOfWeek, bool calendarDayOfMonth, CronField years)
         {
             Seconds = seconds;
             Minutes = minutes;
@@ -45,26 +45,24 @@ namespace Quartz
             Years = years;
         }
 
-        public SortedSet<int> Seconds { get; set; }
-        public SortedSet<int> Minutes { get; set; }
-        public SortedSet<int> Hours { get; set; }
-        public SortedSet<int> DaysOfMonth { get; set; }
-        public SortedSet<int> Months { get; set; }
-        public SortedSet<int> DaysOfWeek { get; set; }
-        public bool LastDayOfWeek { get; set; }
-        public bool NearestWeekday { get; set; }
-        public int NthDayOfWeek { get; set; }
-        public bool LastDayOfMonth { get; set; }
-        public bool CalendarDayOfWeek { get; set; }
-        public bool CalendarDayOfMonth { get; set; }
-        public SortedSet<int> Years { get; set; }
+        public CronField Seconds { get; }
+        public CronField Minutes { get; }
+        public CronField Hours { get; }
+        public CronField DaysOfMonth { get; }
+        public CronField Months { get; }
+        public CronField DaysOfWeek { get; }
+        public bool LastDayOfWeek { get; }
+        public bool NearestWeekday { get; }
+        public int NthDayOfWeek { get; }
+        public bool LastDayOfMonth { get; }
+        public bool CalendarDayOfWeek { get; }
+        public bool CalendarDayOfMonth { get; }
+        public CronField Years { get; }
 
         /// <summary>
         /// Gets the expression set summary.
         /// </summary>
-        /// <param name="data">The data.</param>
-        /// <returns></returns>
-        private string GetExpressionSetSummary(ICollection<int> data)
+        private static string GetExpressionSetSummary(CronField data)
         {
             if (data.Contains(CronExpressionConstants.NoSpec))
             {

--- a/src/Quartz/Util/SortedSetExtensions.cs
+++ b/src/Quartz/Util/SortedSetExtensions.cs
@@ -1,10 +1,36 @@
-﻿namespace Quartz.Util
+﻿namespace Quartz.Util;
+
+internal static class SortedSetExtensions
 {
-    internal static class SortedSetExtensions
+    internal static bool TryGetMinValueStartingFrom(this SortedSet<int> set, int start, out int min)
     {
-        internal static SortedSet<int> TailSet(this SortedSet<int> set, int value)
+        min = set.Min;
+
+        if (set.Contains(CronExpressionConstants.AllSpec) || set.Contains(start))
         {
-            return set.GetViewBetween(value, 9999999);
+            min = start;
+            return true;
         }
-   }
+
+        if (set.Count == 0 || set.Max < start)
+        {
+            return false;
+        }
+
+        if (set.Min >= start)
+        {
+            // value is contained and would be returned from view
+            return true;
+        }
+
+        // slow path
+        var view = set.GetViewBetween(start, int.MaxValue);
+        if (view.Count > 0)
+        {
+            min = view.Min;
+            return true;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
* don't store individual values when AllSpec in use
* remove AllSpecInt and NoSpecInt

## Quartz.Benchmark.CronExpressionBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |CreateExpressionsAndCalculateFireTimeAfter|17.58 μs|0.223 μs|18.75 KB|
| **New** |	| **5.769 μs (-67%)** | **0.0163 μs** | **4.73 KB (-75%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|16.37 μs|0.099 μs|17.51 KB|
| **New** |	| **5.519 μs (-66%)** | **0.0603 μs** | **5.45 KB (-69%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|16.88 μs|0.107 μs|18.7 KB|
| **New** |	| **6.242 μs (-63%)** | **0.0120 μs** | **4.45 KB (-76%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|17.97 μs|0.312 μs|20.28 KB|
| **New** |	| **6.054 μs (-66%)** | **0.0081 μs** | **3.24 KB (-84%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|18.76 μs|0.062 μs|20.8 KB|
| **New** |	| **6.598 μs (-65%)** | **0.0091 μs** | **4.16 KB (-80%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|18.33 μs|0.049 μs|20.8 KB|
| **New** |	| **6.552 μs (-64%)** | **0.0258 μs** | **4.16 KB (-80%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|18.29 μs|0.071 μs|20.4 KB|
| **New** |	| **6.319 μs (-65%)** | **0.0141 μs** | **3.43 KB (-83%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|18.07 μs|0.087 μs|20.52 KB|
| **New** |	| **6.380 μs (-65%)** | **0.0187 μs** | **3.55 KB (-83%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|18.81 μs|0.116 μs|20.81 KB|
| **New** |	| **6.746 μs (-64%)** | **0.0125 μs** | **3.84 KB (-82%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|18.42 μs|0.204 μs|20.69 KB|
| **New** |	| **6.493 μs (-65%)** | **0.0151 μs** | **4.04 KB (-80%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|18.42 μs|0.099 μs|20.78 KB|
| **New** |	| **6.914 μs (-62%)** | **0.0178 μs** | **4.12 KB (-80%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|18.36 μs|0.068 μs|20.79 KB|
| **New** |	| **7.151 μs (-61%)** | **0.0562 μs** | **4.13 KB (-80%)** |
| Old |CreateExpressionsAndCalculateFireTimeAfter|17.84 μs|0.066 μs|18.34 KB|
| **New** |	| **5.883 μs (-67%)** | **0.0155 μs** | **2.46 KB (-87%)** |


/cc @jafin 