### PR TITLE
V3: return PersistJobDataAfterExecution flag in SelectJobDetail.fixed not…

### DIFF
--- a/src/Quartz.Tests.Integration/Core/RecoverJobsTest.cs
+++ b/src/Quartz.Tests.Integration/Core/RecoverJobsTest.cs
@@ -80,7 +80,7 @@ namespace Quartz.Tests.Integration.Core
                     // check that trigger is blocked after fail over situation
                     Assert.AreEqual("BLOCKED", triggerState);
 
-                    command.CommandText = "SELECT count(*) from QRTZ_FIRED_TRIGGERS";
+                    command.CommandText = $"SELECT count(*) from QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = '{scheduler.SchedulerName}' AND TRIGGER_NAME='test'";
                     int count = Convert.ToInt32(command.ExecuteScalar());
 
                     // check that fired trigger remains after fail over situation

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -123,7 +123,7 @@ namespace Quartz.Tests.Unit
         {
             Action act = () => new CronExpression(null);
             act.Should().Throw<ArgumentException>()
-                .WithMessage("cronExpression cannot be null (Parameter 'cronExpression')");
+                .WithMessage($"cronExpression cannot be null*");
         }
 
         [TestCase('h')]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -253,6 +253,8 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore
                 .Returns(true);
             A.CallTo(() => dataReader[AdoConstants.ColumnIsNonConcurrent])
                 .Returns(true);
+            A.CallTo(() => dataReader[AdoConstants.ColumnIsUpdateData])
+                .Returns(true);
 
             var command = A.Fake<StubCommand>();
 
@@ -312,7 +314,8 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore
                 + "IS_DURABLE,"
                 + "REQUESTS_RECOVERY,"
                 + "JOB_DATA,"
-                + "IS_NONCONCURRENT "
+                + "IS_NONCONCURRENT,"
+                + "IS_UPDATE_DATA "
                 + "FROM QRTZ_JOB_DETAILS "
                 + "WHERE SCHED_NAME = @schedulerName "
                 + "AND JOB_NAME = @jobName "

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -65,9 +65,9 @@ namespace Quartz.Tests.Unit.Simpl
         public async Task TestAcquireNextTrigger()
         {
             DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
-            IOperableTrigger trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(200), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(50), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger3 = new SimpleTriggerImpl("trigger1", "triggerGroup2", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(100), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(200), d.AddSeconds(400), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(50), d.AddSeconds(250), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger3 = new SimpleTriggerImpl("trigger1", "triggerGroup2", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(100), d.AddSeconds(300), 2, TimeSpan.FromSeconds(2));
 
             trigger1.ComputeFirstFireTimeUtc(null);
             trigger2.ComputeFirstFireTimeUtc(null);
@@ -94,12 +94,12 @@ namespace Quartz.Tests.Unit.Simpl
         {
             DateTimeOffset d = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(1));
 
-            IOperableTrigger early = new SimpleTriggerImpl("early", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d, d.AddMilliseconds(5), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(200000), d.AddMilliseconds(200005), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(210000), d.AddMilliseconds(210005), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger3 = new SimpleTriggerImpl("trigger3", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(220000), d.AddMilliseconds(220005), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger4 = new SimpleTriggerImpl("trigger4", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(230000), d.AddMilliseconds(230005), 2, TimeSpan.FromSeconds(2));
-            IOperableTrigger trigger10 = new SimpleTriggerImpl("trigger10", "triggerGroup2", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(500000), d.AddMilliseconds(700000), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger early = new SimpleTriggerImpl("early", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d, d.AddMilliseconds(220000), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(190000), d.AddMilliseconds(570000), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(229000), d.AddMilliseconds(610050), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger3 = new SimpleTriggerImpl("trigger3", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(240000), d.AddMilliseconds(620050), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger4 = new SimpleTriggerImpl("trigger4", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(240000), d.AddMilliseconds(630050), 2, TimeSpan.FromSeconds(2));
+            IOperableTrigger trigger10 = new SimpleTriggerImpl("trigger10", "triggerGroup2", fJobDetail.Name, fJobDetail.Group, d.AddMilliseconds(5000000), d.AddMilliseconds(7000000), 2, TimeSpan.FromSeconds(2));
 
             early.ComputeFirstFireTimeUtc(null);
             early.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
@@ -117,13 +117,14 @@ namespace Quartz.Tests.Unit.Simpl
             await fJobStore.StoreTrigger(trigger10, false);
 
             DateTimeOffset firstFireTime = trigger1.GetNextFireTimeUtc().Value;
-
+            DateTimeOffset firstFireTime2 = early.GetNextFireTimeUtc().Value;
             List<IOperableTrigger> acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromSeconds(1))).ToList();
             Assert.AreEqual(1, acquiredTriggers.Count);
             Assert.AreEqual(early.Key, acquiredTriggers[0].Key);
             await fJobStore.ReleaseAcquiredTrigger(early);
+            
 
-            acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromMilliseconds(205000))).ToList();
+            acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromMilliseconds(200000))).ToList();
             Assert.AreEqual(2, acquiredTriggers.Count);
             Assert.AreEqual(early.Key, acquiredTriggers[0].Key);
             Assert.AreEqual(trigger1.Key, acquiredTriggers[1].Key);
@@ -132,7 +133,7 @@ namespace Quartz.Tests.Unit.Simpl
 
             await fJobStore.RemoveTrigger(early.Key);
 
-            acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 5, TimeSpan.FromMilliseconds(100000))).ToList();
+            acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 5, TimeSpan.FromMilliseconds(300000))).ToList();
             Assert.AreEqual(4, acquiredTriggers.Count);
             Assert.AreEqual(trigger1.Key, acquiredTriggers[0].Key);
             Assert.AreEqual(trigger2.Key, acquiredTriggers[1].Key);
@@ -143,7 +144,7 @@ namespace Quartz.Tests.Unit.Simpl
             await fJobStore.ReleaseAcquiredTrigger(trigger3);
             await fJobStore.ReleaseAcquiredTrigger(trigger4);
 
-            acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 6, TimeSpan.FromMilliseconds(100000))).ToList();
+            acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 6, TimeSpan.FromMilliseconds(300000))).ToList();
 
             Assert.AreEqual(4, acquiredTriggers.Count);
             Assert.AreEqual(trigger1.Key, acquiredTriggers[0].Key);
@@ -162,7 +163,7 @@ namespace Quartz.Tests.Unit.Simpl
 
             await fJobStore.ReleaseAcquiredTrigger(trigger1);
 
-            acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(250), 5, TimeSpan.FromMilliseconds(19999L))).ToList();
+            acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(250), 5, TimeSpan.FromMilliseconds(40000))).ToList();
             Assert.AreEqual(2, acquiredTriggers.Count);
             Assert.AreEqual(trigger1.Key, acquiredTriggers[0].Key);
             Assert.AreEqual(trigger2.Key, acquiredTriggers[1].Key);
@@ -366,7 +367,7 @@ namespace Quartz.Tests.Unit.Simpl
             // Test acquire one trigger at a time
             for (int i = 0; i < 10; i++)
             {
-                DateTimeOffset noLaterThan = startTime0.AddMinutes(i);
+                DateTimeOffset noLaterThan = startTime0.AddMinutes(i + 2);
                 int maxCount = 1;
                 TimeSpan timeWindow = TimeSpan.Zero;
                 var triggers = await store.AcquireNextTriggers(noLaterThan, maxCount, timeWindow);
@@ -429,7 +430,7 @@ namespace Quartz.Tests.Unit.Simpl
                 "triggerGroup1",
                 fJobDetail.Name,
                 fJobDetail.Group,
-                baseFireTimeDate.AddMilliseconds(200000),
+                baseFireTimeDate,
                 baseFireTimeDate.AddMilliseconds(200000),
                 2,
                 TimeSpan.FromMilliseconds(2000));

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -147,7 +147,7 @@ namespace Quartz.Impl.AdoJobStore
             $"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName AND {ColumnRequestsRecovery} = @requestsRecovery";
 
         public static readonly string SqlSelectJobDetail =
-            $"SELECT {ColumnJobName},{ColumnJobGroup},{ColumnDescription},{ColumnJobClass},{ColumnIsDurable},{ColumnRequestsRecovery},{ColumnJobDataMap},{ColumnIsNonConcurrent} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
+            $"SELECT {ColumnJobName},{ColumnJobGroup},{ColumnDescription},{ColumnJobClass},{ColumnIsDurable},{ColumnRequestsRecovery},{ColumnJobDataMap},{ColumnIsNonConcurrent},{ColumnIsUpdateData} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";
 
         public static readonly string SqlSelectJobExecutionCount =
             $"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup";

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -154,7 +154,7 @@ namespace Quartz.Impl.AdoJobStore
                     requestsRecovery: GetBooleanFromDbValue(rs[ColumnRequestsRecovery]),
                     jobDataMap: jobDataMap,
                     disallowConcurrentExecution: GetBooleanFromDbValue(rs[ColumnIsNonConcurrent]),
-                    persistJobDataAfterExecution: null);
+                    persistJobDataAfterExecution: GetBooleanFromDbValue(rs[ColumnIsUpdateData]));
             }
 
             return job;

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -557,9 +557,9 @@ namespace Quartz.Impl.Triggers
         /// </returns>
         public override DateTimeOffset? ComputeFirstFireTimeUtc(ICalendar? cal)
         {
-            nextFireTimeUtc = StartTimeUtc;
+            nextFireTimeUtc = GetFireTimeAfter(StartTimeUtc.AddSeconds(-1));
 
-            while (cal != null && !cal.IsTimeIncluded(nextFireTimeUtc.Value))
+            while (nextFireTimeUtc != null && cal != null && !cal.IsTimeIncluded(nextFireTimeUtc.Value))
             {
                 nextFireTimeUtc = GetFireTimeAfter(nextFireTimeUtc);
 

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -557,16 +557,9 @@ namespace Quartz.Impl.Triggers
         /// </returns>
         public override DateTimeOffset? ComputeFirstFireTimeUtc(ICalendar? cal)
         {
-            if (RepeatInterval.Ticks > 0)
-            {
-                nextFireTimeUtc = GetFireTimeAfter(StartTimeUtc);
-            }
-            else
-            {
-                nextFireTimeUtc = StartTimeUtc;
-            }
-            
-            while (nextFireTimeUtc != null && cal != null && !cal.IsTimeIncluded(nextFireTimeUtc.Value))
+            nextFireTimeUtc = StartTimeUtc;
+
+            while (cal != null && !cal.IsTimeIncluded(nextFireTimeUtc.Value))
             {
                 nextFireTimeUtc = GetFireTimeAfter(nextFireTimeUtc);
 
@@ -654,7 +647,7 @@ namespace Quartz.Impl.Triggers
                 return startMillis;
             }
 
-            long numberOfTimesExecuted = ((afterMillis - startMillis).Ticks / repeatInterval.Ticks);
+            long numberOfTimesExecuted = ((afterMillis - startMillis).Ticks / repeatInterval.Ticks) + 1;
 
             if (numberOfTimesExecuted > repeatCount &&
                 repeatCount != RepeatIndefinitely)
@@ -662,7 +655,7 @@ namespace Quartz.Impl.Triggers
                 return null;
             }
 
-            DateTimeOffset time = startMillis.AddTicks((numberOfTimesExecuted + 1) * repeatInterval.Ticks);
+            DateTimeOffset time = startMillis.AddTicks(numberOfTimesExecuted * repeatInterval.Ticks);
 
             if (endMillis <= time)
             {

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -557,8 +557,15 @@ namespace Quartz.Impl.Triggers
         /// </returns>
         public override DateTimeOffset? ComputeFirstFireTimeUtc(ICalendar? cal)
         {
-            nextFireTimeUtc = GetFireTimeAfter(StartTimeUtc);
-
+            if (RepeatInterval.Ticks > 0)
+            {
+                nextFireTimeUtc = GetFireTimeAfter(StartTimeUtc);
+            }
+            else
+            {
+                nextFireTimeUtc = StartTimeUtc;
+            }
+            
             while (nextFireTimeUtc != null && cal != null && !cal.IsTimeIncluded(nextFireTimeUtc.Value))
             {
                 nextFireTimeUtc = GetFireTimeAfter(nextFireTimeUtc);

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -557,7 +557,7 @@ namespace Quartz.Impl.Triggers
         /// </returns>
         public override DateTimeOffset? ComputeFirstFireTimeUtc(ICalendar? cal)
         {
-            nextFireTimeUtc = GetFireTimeAfter(StartTimeUtc.AddSeconds(-1));
+            nextFireTimeUtc = GetFireTimeAfter(StartTimeUtc);
 
             while (nextFireTimeUtc != null && cal != null && !cal.IsTimeIncluded(nextFireTimeUtc.Value))
             {

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -654,7 +654,7 @@ namespace Quartz.Impl.Triggers
                 return startMillis;
             }
 
-            long numberOfTimesExecuted = ((afterMillis - startMillis).Ticks / repeatInterval.Ticks) + 1;
+            long numberOfTimesExecuted = ((afterMillis - startMillis).Ticks / repeatInterval.Ticks);
 
             if (numberOfTimesExecuted > repeatCount &&
                 repeatCount != RepeatIndefinitely)
@@ -662,7 +662,7 @@ namespace Quartz.Impl.Triggers
                 return null;
             }
 
-            DateTimeOffset time = startMillis.AddTicks(numberOfTimesExecuted * repeatInterval.Ticks);
+            DateTimeOffset time = startMillis.AddTicks((numberOfTimesExecuted + 1) * repeatInterval.Ticks);
 
             if (endMillis <= time)
             {


### PR DESCRIPTION
return PersistJobDataAfterExecution flag in SelectJobDetail.fixed not persisting jobData to database.

fixed incorrect exception message in CronExpression_Throw_Error_Contructed_With_Null
fixed incorrect nextFireTimeUtc in ComputeFirstFireTimeUtc when using SimpleTriggerImpl
fixed ComputeFirstFireTimeUtc for the trigger that will fire once
fixed incorrect time setting in TestAcquireNextTrigger.
fixed incorrect time setting in TestAcquireNextTriggerBatch.
fixed incorrect time setting in TestAcquireTriggers.
fixed incorrect time setting in TestResetErrorTrigger.
fixed incorrect repeatCount  when using RepeatSecondlyForTotalCount and fixed incorrect FireCount in TestTriggerFinalized.
