### PR TITLE
Update nuget packages (this was update hell)

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.3.0" />
+    <PackageReference Include="Nuke.Common" Version="7.0.2" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.7.0]" />
   </ItemGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,65 +3,65 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' ">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="NLog.Extensions.Logging" Version="5.2.1" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="6.0.4" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.4" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.4" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageVersion Include="FakeItEasy" Version="7.3.1" />
-    <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="8.5.4" />
-    <PackageVersion Include="FluentAssertions" Version="6.10.0" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="5.2.3" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="6.0.5" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageVersion Include="FakeItEasy" Version="7.4.0" />
+    <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="9.1.1" />
+    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
     <PackageVersion Include="MELT" Version="0.8.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
-    <PackageVersion Include="Microsoft.Data.SQLite" Version="3.1.6" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageVersion Include="MySqlConnector" Version="2.1.8" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="13.18.0" />
+    <PackageVersion Include="Microsoft.Data.SQLite" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageVersion Include="MySqlConnector" Version="2.2.6" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="Npgsql" Version="6.0.3" />
-    <PackageVersion Include="OpenTelemetry" Version="1.3.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Npgsql" Version="7.0.4" />
+    <PackageVersion Include="OpenTelemetry" Version="1.4.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.4.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.4.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.1" />
     <PackageVersion Include="OpenTracing" Version="0.12.1" />
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="19.7.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="2.19.70" />
     <PackageVersion Include="Serilog" Version="2.12.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="4.2.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.46.0" />
-    <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.115.5" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
-    <PackageVersion Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.47.0" />
+    <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.117" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+    <PackageVersion Include="System.Net.Http.Json" Version="7.0.1" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
-    <PackageVersion Include="System.Text.Json" Version="5.0.0" />
-    <PackageVersion Include="TimeZoneConverter" Version="5.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.2" />
+    <PackageVersion Include="TimeZoneConverter" Version="6.1.0" />
     <PackageVersion Include="Topshelf" Version="4.3.0" />
     <PackageVersion Include="log4net" Version="2.0.15" />
   </ItemGroup>

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -14,4 +14,26 @@
     <ProjectReference Include="..\Quartz.HttpClient\Quartz.HttpClient.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -15,4 +15,26 @@
   <ItemGroup>
     <ProjectReference Include="..\Quartz.Jobs\Quartz.Jobs.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz.Examples.AspNetCore/CustomSqlServerConnectionProvider.cs
+++ b/src/Quartz.Examples.AspNetCore/CustomSqlServerConnectionProvider.cs
@@ -1,10 +1,7 @@
-using System;
 using System.Data;
 using System.Data.Common;
 
 using Microsoft.Data.SqlClient;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 using Quartz.Impl.AdoJobStore.Common;
 
@@ -53,7 +50,7 @@ public class CustomSqlServerConnectionProvider : IDbProvider
         return new SqlConnection(ConnectionString);
     }
 
-    public string ConnectionString
+    public string? ConnectionString
     {
         get => configuration.GetConnectionString("Quartz");
         set => throw new NotImplementedException();

--- a/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
+++ b/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
@@ -27,4 +27,26 @@
       <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="GitHubActionsTestLogger">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageVersion Update="PolySharp" Version="1.13.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="PolySharp">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -49,21 +49,23 @@ namespace Quartz.Examples.AspNetCore
                 loggingBuilder.AddSerilog(dispose: true);
             });
 
-            services.AddOpenTelemetryTracing(builder =>
-            {
-                builder
-                    .AddQuartzInstrumentation()
-                    .AddZipkinExporter(o =>
-                    {
-                        o.Endpoint = new Uri("http://localhost:9411/api/v2/spans");
-                    })
-                    .AddJaegerExporter(o =>
-                    {
-                        // these are the defaults
-                        o.AgentHost = "localhost";
-                        o.AgentPort = 6831;
-                    });
-            });
+            // TODO : Fix me !!!
+
+            //services.AddOpenTelemetryTracing(builder =>
+            //{
+            //    builder
+            //        .AddQuartzInstrumentation()
+            //        .AddZipkinExporter(o =>
+            //        {
+            //            o.Endpoint = new Uri("http://localhost:9411/api/v2/spans");
+            //        })
+            //        .AddJaegerExporter(o =>
+            //        {
+            //            // these are the defaults
+            //            o.AgentHost = "localhost";
+            //            o.AgentPort = 6831;
+            //        });
+            //});
 
             services.AddRazorPages();
 

--- a/src/Quartz.Examples.HttpClient/Quartz.Examples.HttpClient.csproj
+++ b/src/Quartz.Examples.HttpClient/Quartz.Examples.HttpClient.csproj
@@ -15,4 +15,26 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Examples.Worker/Quartz.Examples.Worker.csproj
+++ b/src/Quartz.Examples.Worker/Quartz.Examples.Worker.csproj
@@ -15,4 +15,26 @@
     <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="Serilog.Sinks.Console" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz.Examples/Quartz.Examples.csproj
+++ b/src/Quartz.Examples/Quartz.Examples.csproj
@@ -30,4 +30,22 @@
   <ItemGroup>
     <None Update="*.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj
+++ b/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj
@@ -18,4 +18,26 @@
       <ProjectReference Include="..\Quartz\Quartz.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="GitHubActionsTestLogger">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageVersion Update="PolySharp" Version="1.13.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="PolySharp">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/src/Quartz.Extensions.DependencyInjection/QuartzConfiguration.cs
+++ b/src/Quartz.Extensions.DependencyInjection/QuartzConfiguration.cs
@@ -7,7 +7,7 @@ namespace Quartz
     /// </summary>
     internal sealed class QuartzConfiguration : IPostConfigureOptions<QuartzOptions>
     {
-        public void PostConfigure(string name, QuartzOptions options)
+        public void PostConfigure(string? name, QuartzOptions options)
         {
         }
     }

--- a/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj
+++ b/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj
@@ -16,4 +16,26 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.HttpClient/Quartz.HttpClient.csproj
+++ b/src/Quartz.HttpClient/Quartz.HttpClient.csproj
@@ -20,4 +20,26 @@
     <ProjectReference Include="..\Quartz.Serialization.SystemTextJson\Quartz.Serialization.SystemTextJson.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Jobs/Quartz.Jobs.csproj
+++ b/src/Quartz.Jobs/Quartz.Jobs.csproj
@@ -8,4 +8,22 @@
   <ItemGroup>
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz.OpenTelemetry.Instrumentation/Quartz.OpenTelemetry.Instrumentation.csproj
+++ b/src/Quartz.OpenTelemetry.Instrumentation/Quartz.OpenTelemetry.Instrumentation.csproj
@@ -8,9 +8,28 @@
     <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" VersionOverride="0.6.0-beta.1" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Quartz.OpenTelemetry.Instrumentation/QuartzJobInstrumentation.cs
+++ b/src/Quartz.OpenTelemetry.Instrumentation/QuartzJobInstrumentation.cs
@@ -10,8 +10,7 @@ namespace Quartz.OpenTelemetry.Instrumentation
     {
         private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
 
-        public QuartzJobInstrumentation(ActivitySourceAdapter activitySource)
-            : this(activitySource, new QuartzInstrumentationOptions())
+        public QuartzJobInstrumentation(ActivitySourceAdapter activitySource) : this(activitySource, new QuartzInstrumentationOptions())
         {
         }
 

--- a/src/Quartz.OpenTracing/Quartz.OpenTracing.csproj
+++ b/src/Quartz.OpenTracing/Quartz.OpenTracing.csproj
@@ -20,4 +20,26 @@
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
+++ b/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
@@ -13,4 +13,22 @@
   <ItemGroup>
     <ProjectReference Include="..\Quartz.Plugins\Quartz.Plugins.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz.Plugins/Quartz.Plugins.csproj
+++ b/src/Quartz.Plugins/Quartz.Plugins.csproj
@@ -8,4 +8,22 @@
   <ItemGroup>
     <ProjectReference Include="..\Quartz.Jobs\Quartz.Jobs.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz.Serialization.Json/Quartz.Serialization.Json.csproj
+++ b/src/Quartz.Serialization.Json/Quartz.Serialization.Json.csproj
@@ -15,4 +15,26 @@
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Serialization.SystemTextJson/Quartz.Serialization.SystemTextJson.csproj
+++ b/src/Quartz.Serialization.SystemTextJson/Quartz.Serialization.SystemTextJson.csproj
@@ -15,4 +15,26 @@
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Server/Quartz.Server.csproj
+++ b/src/Quartz.Server/Quartz.Server.csproj
@@ -23,4 +23,22 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Topshelf" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
+++ b/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
@@ -26,4 +26,26 @@
     <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -38,4 +38,22 @@
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Oracle.ManagedDataAccess" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -37,4 +37,22 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Quartz/Impl/AdoJobStore/Common/DbProvider.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/DbProvider.cs
@@ -70,7 +70,7 @@ namespace Quartz.Impl.AdoJobStore.Common
         /// </summary>
         /// <param name="dbProviderName">Name of the db provider.</param>
         /// <param name="connectionString">The connection string.</param>
-        public DbProvider(string dbProviderName, string connectionString)
+        public DbProvider(string dbProviderName, string? connectionString)
         {
             ConnectionString = connectionString;
             Metadata = GetDbMetadata(dbProviderName);
@@ -168,7 +168,7 @@ namespace Quartz.Impl.AdoJobStore.Common
         }
 
         /// <inheritdoc />
-        public string ConnectionString { get; set; }
+        public string? ConnectionString { get; set; }
 
         /// <inheritdoc />
         public DbMetadata Metadata { get; }

--- a/src/Quartz/Impl/AdoJobStore/Common/IDbProvider.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/IDbProvider.cs
@@ -51,7 +51,7 @@ namespace Quartz.Impl.AdoJobStore.Common
         /// <summary>
         /// Connection string used to create connections.
         /// </summary>
-        string ConnectionString { set; get; }
+        string? ConnectionString { set; get; }
 
         DbMetadata Metadata { get; }
 

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -24,4 +24,26 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="GitHubActionsTestLogger" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Update="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- I updated all the nuget packages to the latest versions where possible. Some I just could not update because there were not supported anymore on .NET 4.7.2

The only thing I could nog get fixed was the `Quartz.OpenTelemetry.Instrumentation` project. Classes you used in there are internal in the latest version of `OpenTelemetry` and because I just don't know how this tool works I also have no idea how to fix this. I hope that you can look into this.

This pull request fixes the issue I have with `System.Diagnostics.DiagnosticSource` 7.0.0.0 or higher. The reason why it did not work anymore was because there was a version conflict in your code.

I hope you can merge this pull request so that we can go on with the latest nuget versions. Also one tip... please try to update the nuget packages more often because it took me about 2 hours to solve all the dependencies the package had on each other. I had to figure out the correct order in how to update them to avoid errors like ... this package depends on version x.x.x.x .... etc....