### PR TITLE
Fix persistence of extended properties when the trigger type is changed

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateTriggerTest.cs
@@ -72,10 +72,25 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore
             cronTriggerImpl.JobKey = new JobKey("JobKey", "JobKeyGroup");
             cronTriggerImpl.Priority = 1;
 
+            // Support getting the existing trigger type.
+            var selectTypeReader = A.Fake<DbDataReader>();
+            A.CallTo(() => selectTypeReader.ReadAsync(CancellationToken.None))
+                .Returns(true);
+            A.CallTo(() => selectTypeReader[AdoConstants.ColumnTriggerType])
+                .Returns(AdoConstants.TriggerTypeCron);
+
+            var selectTypeCommand = A.Fake<DbCommand>();
+            A.CallTo(selectTypeCommand)
+                .Where(x => x.Method.Name == "ExecuteDbDataReaderAsync")
+                .WithReturnType<Task<DbDataReader>>()
+                .Returns(selectTypeReader);
+
             var dbProvider = A.Fake<IDbProvider>();
             var dbCommand = A.Fake<DbCommand>();
+            A.CallTo(() => dbProvider.CreateCommand()).ReturnsNextFromSequence(selectTypeCommand, dbCommand);
+
             var dataParameterCollection = A.Fake<DbParameterCollection>();
-            A.CallTo(() => dbProvider.CreateCommand()).Returns(dbCommand);
+
             Func<DbParameter> dataParam = () => new SqlParameter();
             A.CallTo(dbProvider)
                 .Where(x => x.Method.Name == "CreateDbParameter")

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -291,6 +291,9 @@ namespace Quartz.Impl.AdoJobStore
         public static readonly string SqlSelectTriggersInState =
             $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state";
 
+        public static readonly string SqlSelectTriggerType =
+            $"SELECT {ColumnTriggerType} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+
         // UPDATE
 
         public static readonly string SqlUpdateBlobTrigger =


### PR DESCRIPTION
When using JobStoreTX (ADO.NET), changing the type of a trigger (by calling `ScheduleJob` with `replace` set to `true`) will corrupt the trigger state in the database. The extended properties relating to the old state will be left unchanged. Extended properties relating to the new type will not be written to the database. Once the next fire time for the updated trigger is reached, the trigger will fail to be loaded from the database and the scheduler will stop executing _all_ jobs.

This is an issue with version 3.6.2 and the latest code in the main branch.

RAMJobStore works correctly.

Here's an example that will reproduce the problem:

```c#
public class Test
{
    public static async Task Execute()
    {
        var factory = new StdSchedulerFactory();
        var scheduler = await factory.GetScheduler();
        await scheduler.Start();	

        var regularJob = JobBuilder
            .Create<TestJob>()
            .WithIdentity("Regular", "Test")
            .Build();
        var regularTrigger = TriggerBuilder
            .Create()
            .WithIdentity("Regular", "Test").StartNow()
            .WithSimpleSchedule(b => b.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever())
            .Build();
        await scheduler.ScheduleJob(regularJob, regularTrigger);

        var problemJob = JobBuilder
            .Create<TestJob>()
            .WithIdentity("Problem", "Test")
            .Build();
        var problemTrigger = TriggerBuilder
            .Create()
            .WithIdentity("Problem", "Test")
            .StartAt(DateTime.UtcNow.AddSeconds(40))
            .WithSimpleSchedule(b => b.WithRepeatCount(0))
            .Build();
        await scheduler.ScheduleJob(problemJob, problemTrigger);

        await Task.Delay(TimeSpan.FromSeconds(11));

        var changedProblemJob = JobBuilder
            .Create<TestJob>()
            .WithIdentity("Problem", "Test")
            .Build();
        var changedProblemTrigger = TriggerBuilder
            .Create()
            .WithIdentity("Problem", "Test")
            .StartNow()
            .WithCronSchedule("0/15 * * * * ?")
            .Build();
        await scheduler.ScheduleJob(changedProblemJob, new[] { changedProblemTrigger }, true);

        await Task.Delay(TimeSpan.FromMinutes(1));

        await scheduler.Shutdown();
    }
}

public class TestJob : IJob
{
    public Task Execute(IJobExecutionContext context)
    {
        Console.WriteLine("[" + DateTime.Now.ToLongTimeString() + "] Executing " + context.JobDetail.Key);
        return Task.CompletedTask;
    }
}
```

Calling `Test.Execute()` sets up a job Test.Regular job that's triggered once every 10 seconds. It then sets up a second Test.Problem job that is initially set to execute once, but will never reach the start time. After 11 seconds Test.Problem is changed to use a cron schedule. Once Test.Problem becomes due to execute, a `Quartz.JobPersistenceException` is thrown when acquiring the trigger. Test.Regular is not executed again.

The exception details (from version 3.6.2) are:

```
Quartz.JobPersistenceException:

Couldn't acquire next trigger: Couldn't retrieve trigger: cronExpression cannot be null
Parameter name: cronExpression

   at Quartz.Impl.AdoJobStore.JobStoreSupport.<AcquireNextTrigger>d__240.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Quartz.Impl.AdoJobStore.JobStoreSupport.<ExecuteInNonManagedTXLock>d__275`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Quartz.Impl.AdoJobStore.JobStoreSupport.<ExecuteInNonManagedTXLock>d__275`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Quartz.Core.QuartzSchedulerThread.<Run>d__28.MoveNext()
```

This PR changes `StdAdoDelegate.UpdateTrigger()` to check if the type of the trigger is changing. If the type has changed, the old extended properties are deleted and the new extended properties are inserted.

This also includes a change to dispose the `DbCommand` used to update the trigger.