### PR TITLE
Fix persistence of extended properties when the trigger type is changed (v3)

### DIFF
--- a/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 using Quartz.Impl;
 using Quartz.Impl.Matchers;
+using Quartz.Impl.Triggers;
 
 namespace Quartz.Tests.Integration
 {
@@ -239,6 +240,113 @@ namespace Quartz.Tests.Integration
 
             Assert.That(jobKeys.Count, Is.EqualTo(1), "Number of jobs expected in default group was 1 "); // job should have been left in place, because it is non-durable
             Assert.That(triggerKeys, Is.Empty, "Number of triggers expected in default group was 0 ");
+
+            await sched.Shutdown();
+        }
+
+        [Test]
+        [Category("db-sqlserver")]
+        public async Task TestUpdatingTriggerTypes()
+        {
+            var sched = await CreateScheduler("testUpdatingTriggerTypes", 2);
+            await sched.Clear();
+
+            // test basic storage functions of scheduler...
+            var job = JobBuilder.Create<TestJob>()
+                .WithIdentity("j1")
+                .StoreDurably()
+                .Build();
+
+            var trigger = TriggerBuilder.Create()
+                .WithIdentity("t1")
+                .ForJob(job)
+                .StartNow()
+                .WithSimpleSchedule(x => x
+                    .RepeatForever()
+                    .WithIntervalInSeconds(5))
+                .Build();
+
+            await sched.ScheduleJob(job, trigger);
+
+            trigger = await sched.GetTrigger(new TriggerKey("t1"));
+
+            Assert.That(trigger, Is.Not.Null);
+            Assert.That(trigger, Is.InstanceOf<SimpleTriggerImpl>());
+            var simpleTrigger = (SimpleTriggerImpl) trigger;
+            Assert.That(simpleTrigger.RepeatCount, Is.EqualTo(-1));
+            Assert.That(simpleTrigger.RepeatInterval, Is.EqualTo(TimeSpan.FromSeconds(5)));
+
+
+            trigger = TriggerBuilder.Create()
+                .WithIdentity("t1")
+                .ForJob(job)
+                .StartNow()
+                .WithCronSchedule("0/5 * * * * ?")
+                .Build();
+
+            await sched.ScheduleJob(job, new[] { trigger }, true);
+
+            trigger = await sched.GetTrigger(new TriggerKey("t1"));
+
+            Assert.That(trigger, Is.Not.Null);
+            Assert.That(trigger, Is.InstanceOf<CronTriggerImpl>());
+            var cronTrigger = (CronTriggerImpl) trigger;
+            Assert.That(cronTrigger.CronExpressionString, Is.EqualTo("0/5 * * * * ?"));
+
+
+            var blobTrigger = new TestBlobCronTriggerImpl
+            {
+                StartTimeUtc = DateTimeOffset.UtcNow,
+                Key = new TriggerKey("t1"),
+                CronExpression = new CronExpression("0/10 * * * * ?")
+            };
+
+            await sched.ScheduleJob(job, new[] { blobTrigger }, true);
+
+            trigger = await sched.GetTrigger(new TriggerKey("t1"));
+
+            Assert.That(trigger, Is.Not.Null);
+            Assert.That(trigger, Is.InstanceOf<TestBlobCronTriggerImpl>());
+            blobTrigger = (TestBlobCronTriggerImpl) trigger;
+            Assert.That(blobTrigger.CronExpressionString, Is.EqualTo("0/10 * * * * ?"));
+
+
+            trigger = TriggerBuilder.Create()
+                .WithIdentity("t1")
+                .ForJob(job)
+                .StartNow()
+                .WithCalendarIntervalSchedule(x =>
+                    x.WithInterval(5, IntervalUnit.Day))
+                .Build();
+
+            await sched.ScheduleJob(job, new[] { trigger }, true);
+
+            trigger = await sched.GetTrigger(new TriggerKey("t1"));
+
+            Assert.That(trigger, Is.Not.Null);
+            Assert.That(trigger, Is.InstanceOf<CalendarIntervalTriggerImpl>());
+            var calendarTrigger = (CalendarIntervalTriggerImpl) trigger;
+            Assert.That(calendarTrigger.RepeatInterval, Is.EqualTo(5));
+            Assert.That(calendarTrigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Day));
+
+
+            trigger = TriggerBuilder.Create()
+                .WithIdentity("t1")
+                .ForJob(job)
+                .StartNow()
+                .WithDailyTimeIntervalSchedule(x =>
+                    x.WithInterval(30, IntervalUnit.Minute))
+                .Build();
+
+            await sched.ScheduleJob(job, new[] { trigger }, true);
+
+            trigger = await sched.GetTrigger(new TriggerKey("t1"));
+
+            Assert.That(trigger, Is.Not.Null);
+            Assert.That(trigger, Is.InstanceOf<DailyTimeIntervalTriggerImpl>());
+            var dailyTimeIntervalTrigger = (DailyTimeIntervalTriggerImpl) trigger;
+            Assert.That(dailyTimeIntervalTrigger.RepeatInterval, Is.EqualTo(30));
+            Assert.That(dailyTimeIntervalTrigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Minute));
 
             await sched.Shutdown();
         }
@@ -478,6 +586,11 @@ namespace Quartz.Tests.Integration
         protected string CreateSchedulerName(string name)
         {
             return $"{name}_Scheduler_{provider}_{serializerType}";
+        }
+
+        public class TestBlobCronTriggerImpl : CronTriggerImpl
+        {
+            public override bool HasAdditionalProperties => true;
         }
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -291,6 +291,9 @@ namespace Quartz.Impl.AdoJobStore
         public static readonly string SqlSelectTriggersInState =
             $"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state";
 
+        public static readonly string SqlSelectTriggerType =
+            $"SELECT {ColumnTriggerType} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+
         // UPDATE
 
         public static readonly string SqlUpdateBlobTrigger =

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -346,20 +346,17 @@ namespace Quartz.Impl.AdoJobStore
             IJobDetail jobDetail,
             CancellationToken cancellationToken = default)
         {
+            var existingType = await SelectTriggerType(conn, trigger.Key, cancellationToken).ConfigureAwait(false);
+
+            // No need to continue if the trigger type is not found - there's nothing to update.
+            if (existingType == null) return 0;
+
             // save some clock cycles by unnecessarily writing job data blob ...
             var updateJobData = trigger.JobDataMap.Dirty;
             var jobData = updateJobData ? SerializeJobData(trigger.JobDataMap) : null;
 
-            DbCommand cmd;
-
-            if (updateJobData)
-            {
-                cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTrigger));
-            }
-            else
-            {
-                cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerSkipData));
-            }
+            var sqlUpdate = updateJobData ? SqlUpdateTrigger : SqlUpdateTriggerSkipData;
+            using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sqlUpdate));
 
             AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "triggerJobName", trigger.JobKey.Name);
@@ -399,18 +396,43 @@ namespace Quartz.Impl.AdoJobStore
                 AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
             }
 
-            int insertResult = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            var updateResult = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
-            if (tDel == null)
+            if (type == existingType)
             {
-                await UpdateBlobTrigger(conn, trigger, cancellationToken).ConfigureAwait(false);
+                if (tDel == null)
+                {
+                    await UpdateBlobTrigger(conn, trigger, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await tDel.UpdateExtendedTriggerProperties(conn, trigger, state, jobDetail, cancellationToken).ConfigureAwait(false);
+                }
             }
             else
             {
-                await tDel.UpdateExtendedTriggerProperties(conn, trigger, state, jobDetail, cancellationToken).ConfigureAwait(false);
+                var existingDel = FindTriggerPersistenceDelegate(existingType);
+
+                if (existingDel == null)
+                {
+                    await DeleteBlobTrigger(conn, trigger.Key, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await existingDel.DeleteExtendedTriggerProperties(conn, trigger.Key, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (tDel == null)
+                {
+                    await InsertBlobTrigger(conn, trigger, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await tDel.InsertExtendedTriggerProperties(conn, trigger, state, jobDetail, cancellationToken).ConfigureAwait(false);
+                }
             }
 
-            return insertResult;
+            return updateResult;
         }
 
         /// <inheritdoc />
@@ -846,6 +868,24 @@ namespace Quartz.Impl.AdoJobStore
             }
 
             return status;
+        }
+
+        private async Task<string?> SelectTriggerType(
+            ConnectionAndTransactionHolder conn,
+            TriggerKey triggerKey,
+            CancellationToken cancellationToken = default)
+        {
+            using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerType));
+            AddCommandParameter(cmd, "schedulerName", schedName);
+            AddCommandParameter(cmd, "triggerName", triggerKey.Name);
+            AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+
+            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return rs.GetString(ColumnTriggerType)!;
+            }
+            return null;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This is the fix from #2039 backported to the 3.x branch. Please see the other PR for details.