### PR TITLE
Optimize reading blobs on SQL Server

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -236,14 +236,35 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore
             var jobName = $"TestJobName-{Guid.NewGuid()}";
             A.CallTo(() => dataReader[AdoConstants.ColumnJobName])
                 .Returns(jobName);
+            A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnJobName))
+                .Returns(0);
+            A.CallTo(() => dataReader.GetString(0))
+                .Returns(jobName);
+
             var jobGroup = $"TestGroup-{Guid.NewGuid()}";
             A.CallTo(() => dataReader[AdoConstants.ColumnJobGroup])
                 .Returns(jobGroup);
+            A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnJobGroup))
+                .Returns(1);
+            A.CallTo(() => dataReader.GetString(1))
+                .Returns(jobGroup);
+
             var jobDescription = $"TestDescription-{Guid.NewGuid()}";
             A.CallTo(() => dataReader[AdoConstants.ColumnDescription])
                 .Returns(jobDescription);
+            A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnDescription))
+                .Returns(2);
+            A.CallTo(() => dataReader.GetString(2))
+                .Returns(jobDescription);
+
+            var jobClass = typeof(TestJob).AssemblyQualifiedNameWithoutVersion();
             A.CallTo(() => dataReader[AdoConstants.ColumnJobClass])
-                .Returns(typeof(TestJob).AssemblyQualifiedNameWithoutVersion());
+                .Returns(jobClass);
+            A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnJobClass))
+                .Returns(3);
+            A.CallTo(() => dataReader.GetString(3))
+                .Returns(jobClass);
+
             A.CallTo(() => dataReader[AdoConstants.ColumnRequestsRecovery])
                 .Returns(true);
             A.CallTo(() => dataReader[AdoConstants.ColumnIsDurable])

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -236,35 +236,14 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore
             var jobName = $"TestJobName-{Guid.NewGuid()}";
             A.CallTo(() => dataReader[AdoConstants.ColumnJobName])
                 .Returns(jobName);
-            A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnJobName))
-                .Returns(0);
-            A.CallTo(() => dataReader.GetString(0))
-                .Returns(jobName);
-
             var jobGroup = $"TestGroup-{Guid.NewGuid()}";
             A.CallTo(() => dataReader[AdoConstants.ColumnJobGroup])
                 .Returns(jobGroup);
-            A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnJobGroup))
-                .Returns(1);
-            A.CallTo(() => dataReader.GetString(1))
-                .Returns(jobGroup);
-
             var jobDescription = $"TestDescription-{Guid.NewGuid()}";
             A.CallTo(() => dataReader[AdoConstants.ColumnDescription])
                 .Returns(jobDescription);
-            A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnDescription))
-                .Returns(2);
-            A.CallTo(() => dataReader.GetString(2))
-                .Returns(jobDescription);
-
-            var jobClass = typeof(TestJob).AssemblyQualifiedNameWithoutVersion();
             A.CallTo(() => dataReader[AdoConstants.ColumnJobClass])
-                .Returns(jobClass);
-            A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnJobClass))
-                .Returns(3);
-            A.CallTo(() => dataReader.GetString(3))
-                .Returns(jobClass);
-
+                .Returns(typeof(TestJob).AssemblyQualifiedNameWithoutVersion());
             A.CallTo(() => dataReader[AdoConstants.ColumnRequestsRecovery])
                 .Returns(true);
             A.CallTo(() => dataReader[AdoConstants.ColumnIsDurable])

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System.Data;
 
 namespace Quartz.Impl.AdoJobStore
 {
@@ -64,7 +65,7 @@ namespace Quartz.Impl.AdoJobStore
             using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectCalendar));
             AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "calendarName", calendarName);
-            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var rs = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             ICalendar? cal = null;
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using System.Data;
 
 namespace Quartz.Impl.AdoJobStore
 {
@@ -65,7 +64,7 @@ namespace Quartz.Impl.AdoJobStore
             using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectCalendar));
             AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "calendarName", calendarName);
-            using var rs = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+            using var rs = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             ICalendar? cal = null;
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using System.Data.Common;
 using System.Runtime.Serialization;
 
@@ -125,7 +124,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "jobName", jobKey.Name);
             AddCommandParameter(cmd, "jobGroup", jobKey.Group);
-            using var rs = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+            using var rs = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             IJobDetail? job = null;
 
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Data;
 using System.Data.Common;
 using System.Globalization;
 
@@ -712,7 +711,7 @@ namespace Quartz.Impl.AdoJobStore
                 AddCommandParameter(cmd2, "schedulerName", schedName);
                 AddCommandParameter(cmd2, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd2, "triggerGroup", triggerKey.Group);
-                using var rs2 = await cmd2.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+                using var rs2 = await cmd2.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
                 if (await rs2.ReadAsync(cancellationToken).ConfigureAwait(false))
                 {
                     trigger = await GetObjectFromBlob<IOperableTrigger>(rs2, 0, cancellationToken).ConfigureAwait(false);
@@ -809,7 +808,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "triggerName", triggerKey.Name);
             AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
-            using var rs = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+            using var rs = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 var map = await ReadMapFromReader(rs, 0).ConfigureAwait(false);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Data;
 using System.Data.Common;
 using System.Globalization;
 
@@ -300,7 +301,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "triggerCalendarName", trigger.CalendarName);
             AddCommandParameter(cmd, "triggerMisfireInstruction", trigger.MisfireInstruction);
             AddCommandParameter(cmd, "triggerJobJobDataMap", jobData, DbProvider.Metadata.DbBinaryType);
-            
+
             AddCommandParameter(cmd, "triggerPriority", trigger.Priority);
 
             int insertResult = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -343,7 +344,7 @@ namespace Quartz.Impl.AdoJobStore
             CancellationToken cancellationToken = default)
         {
             var existingType = await SelectTriggerType(conn, trigger.Key, cancellationToken).ConfigureAwait(false);
- 
+
             // No need to continue if the trigger type is not found - there's nothing to update.
             if (existingType == null) return 0;
 
@@ -694,7 +695,7 @@ namespace Quartz.Impl.AdoJobStore
                     previousFireTimeUtc = GetDateTimeFromDbValue(rs[ColumnPreviousFireTime]);
                     startTimeUtc = GetDateTimeFromDbValue(rs[ColumnStartTime]) ?? DateTimeOffset.MinValue;
                     endTimeUtc = GetDateTimeFromDbValue(rs[ColumnEndTime]);
-                    
+
                     // check if we access fast path
                     if (triggerType.Equals(TriggerTypeCron) || triggerType.Equals(TriggerTypeSimple))
                     {
@@ -711,7 +712,7 @@ namespace Quartz.Impl.AdoJobStore
                 AddCommandParameter(cmd2, "schedulerName", schedName);
                 AddCommandParameter(cmd2, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd2, "triggerGroup", triggerKey.Group);
-                using var rs2 = await cmd2.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                using var rs2 = await cmd2.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
                 if (await rs2.ReadAsync(cancellationToken).ConfigureAwait(false))
                 {
                     trigger = await GetObjectFromBlob<IOperableTrigger>(rs2, 0, cancellationToken).ConfigureAwait(false);
@@ -808,7 +809,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "triggerName", triggerKey.Name);
             AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
-            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var rs = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 var map = await ReadMapFromReader(rs, 0).ConfigureAwait(false);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -578,23 +578,21 @@ namespace Quartz.Impl.AdoJobStore
             return obj;
         }
 
-        protected virtual async ValueTask<byte[]?> ReadBytesFromBlob(
+        protected virtual ValueTask<byte[]?> ReadBytesFromBlob(
             IDataReader dr,
             int colIndex,
             CancellationToken cancellationToken)
         {
             if (dr.IsDBNull(colIndex))
             {
-                return null;
+                return new ValueTask<byte[]?>();
             }
 
             // If you pass a buffer that is null, GetBytes returns the length of the entire field in bytes, not the remaining size based on the buffer offset parameter.
             var length = dr.GetBytes(colIndex, 0, null!, 0, int.MaxValue);
             byte[] outbyte = new byte[length];
             dr.GetBytes(colIndex, 0, outbyte, 0, outbyte.Length);
-            using MemoryStream stream = new MemoryStream();
-            await stream.WriteAsync(outbyte, 0, outbyte.Length, cancellationToken).ConfigureAwait(false);
-            return outbyte;
+            return new ValueTask<byte[]?>(outbyte);
         }
 
         public virtual DbCommand PrepareCommand(ConnectionAndTransactionHolder cth, string commandText)


### PR DESCRIPTION
Fixes #2054

Use `CommandBehavior.SequentialAccess` to work around performance issues with SqlClient when reading blobs (SQL Server specific), and remove unnecessary copying to `MemoryStream` (All ADO.NET delegates).