### PR TITLE
[3.x] Optimize reading blobs on SQL Server

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -69,7 +70,7 @@ namespace Quartz.Impl.AdoJobStore
             using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectCalendar));
             AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "calendarName", calendarName);
-            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var rs = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             ICalendar? cal = null;
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.IO;
 using System.Runtime.Serialization;
@@ -136,25 +137,31 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "jobName", jobKey.Name);
             AddCommandParameter(cmd, "jobGroup", jobKey.Group);
-            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var rs = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             JobDetailImpl? job = null;
 
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
+                // Due to CommandBehavior.SequentialAccess, columns must be read in order.
+                var jobName = rs.GetString(ColumnJobName)!;
+                var jobGroup = rs.GetString(ColumnJobGroup);
+                var description = rs.GetString(ColumnDescription);
+                var jobType = loadHelper.LoadType(rs.GetString(ColumnJobClass)!)!;
+                var isDurable = GetBooleanFromDbValue(rs[ColumnIsDurable]);
+                var requestsRecovery = GetBooleanFromDbValue(rs[ColumnRequestsRecovery]);
                 var map = await ReadMapFromReader(rs, 6).ConfigureAwait(false);
                 var jobDataMap = map != null ? new JobDataMap(map) : null;
+                var disallowConcurrentExecution = GetBooleanFromDbValue(rs[ColumnIsNonConcurrent]);
 
                 job = new JobDetailImpl(
-                    new JobKey(
-                        rs.GetString(ColumnJobName)!,
-                        rs.GetString(ColumnJobGroup)),
-                    jobType: loadHelper.LoadType(rs.GetString(ColumnJobClass)!)!,
-                    description: rs.GetString(ColumnDescription),
-                    isDurable: GetBooleanFromDbValue(rs[ColumnIsDurable]),
-                    requestsRecovery: GetBooleanFromDbValue(rs[ColumnRequestsRecovery]),
+                    new JobKey(jobName, jobGroup),
+                    description: description,
+                    jobType: jobType,
+                    isDurable: isDurable,
+                    requestsRecovery: requestsRecovery,
                     jobDataMap: jobDataMap,
-                    disallowConcurrentExecution: GetBooleanFromDbValue(rs[ColumnIsNonConcurrent]),
-                    persistJobDataAfterExecution: GetBooleanFromDbValue(rs[ColumnIsUpdateData]));
+                    disallowConcurrentExecution: disallowConcurrentExecution,
+                    persistJobDataAfterExecution: null);
             }
 
             return job;

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -152,6 +152,7 @@ namespace Quartz.Impl.AdoJobStore
                 var map = await ReadMapFromReader(rs, 6).ConfigureAwait(false);
                 var jobDataMap = map != null ? new JobDataMap(map) : null;
                 var disallowConcurrentExecution = GetBooleanFromDbValue(rs[ColumnIsNonConcurrent]);
+                var persistJobDataAfterExecution = GetBooleanFromDbValue(rs[ColumnIsUpdateData]);
 
                 job = new JobDetailImpl(
                     new JobKey(jobName, jobGroup),
@@ -161,7 +162,7 @@ namespace Quartz.Impl.AdoJobStore
                     requestsRecovery: requestsRecovery,
                     jobDataMap: jobDataMap,
                     disallowConcurrentExecution: disallowConcurrentExecution,
-                    persistJobDataAfterExecution: null);
+                    persistJobDataAfterExecution: persistJobDataAfterExecution);
             }
 
             return job;

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.Threading;
@@ -304,7 +305,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "triggerCalendarName", trigger.CalendarName);
             AddCommandParameter(cmd, "triggerMisfireInstruction", trigger.MisfireInstruction);
             AddCommandParameter(cmd, "triggerJobJobDataMap", jobData, DbProvider.Metadata.DbBinaryType);
-            
+
             AddCommandParameter(cmd, "triggerPriority", trigger.Priority);
 
             int insertResult = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -698,7 +699,7 @@ namespace Quartz.Impl.AdoJobStore
                     previousFireTimeUtc = GetDateTimeFromDbValue(rs[ColumnPreviousFireTime]);
                     startTimeUtc = GetDateTimeFromDbValue(rs[ColumnStartTime]) ?? DateTimeOffset.MinValue;
                     endTimeUtc = GetDateTimeFromDbValue(rs[ColumnEndTime]);
-                    
+
                     // check if we access fast path
                     if (triggerType.Equals(TriggerTypeCron) || triggerType.Equals(TriggerTypeSimple))
                     {
@@ -715,7 +716,7 @@ namespace Quartz.Impl.AdoJobStore
                 AddCommandParameter(cmd2, "schedulerName", schedName);
                 AddCommandParameter(cmd2, "triggerName", triggerKey.Name);
                 AddCommandParameter(cmd2, "triggerGroup", triggerKey.Group);
-                using var rs2 = await cmd2.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                using var rs2 = await cmd2.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
                 if (await rs2.ReadAsync(cancellationToken).ConfigureAwait(false))
                 {
                     trigger = await GetObjectFromBlob<IOperableTrigger>(rs2, 0, cancellationToken).ConfigureAwait(false);
@@ -812,7 +813,7 @@ namespace Quartz.Impl.AdoJobStore
             AddCommandParameter(cmd, "triggerName", triggerKey.Name);
             AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
-            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var rs = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 var map = await ReadMapFromReader(rs, 0).ConfigureAwait(false);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -580,23 +580,21 @@ namespace Quartz.Impl.AdoJobStore
             return obj;
         }
 
-        protected virtual async Task<byte[]?> ReadBytesFromBlob(
+        protected virtual Task<byte[]?> ReadBytesFromBlob(
             IDataReader dr,
             int colIndex,
             CancellationToken cancellationToken)
         {
             if (dr.IsDBNull(colIndex))
             {
-                return null;
+                return Task.FromResult<byte[]?>(null);
             }
 
             // If you pass a buffer that is null, GetBytes returns the length of the entire field in bytes, not the remaining size based on the buffer offset parameter.
             var length = dr.GetBytes(colIndex, 0, null!, 0, int.MaxValue);
             byte[] outbyte = new byte[length];
             dr.GetBytes(colIndex, 0, outbyte, 0, outbyte.Length);
-            using MemoryStream stream = new MemoryStream();
-            await stream.WriteAsync(outbyte, 0, outbyte.Length, cancellationToken).ConfigureAwait(false);
-            return outbyte;
+            return Task.FromResult<byte[]?>(outbyte);
         }
 
         public virtual DbCommand PrepareCommand(ConnectionAndTransactionHolder cth, string commandText)


### PR DESCRIPTION
Backport of #2060 to version 3.x

Fixes #2054

Use `CommandBehavior.SequentialAccess` to work around performance issues with SqlClient when reading blobs (SQL Server specific), and remove unnecessary copying to `MemoryStream` (All ADO.NET delegates).