### PR TITLE
Fix for JobDataMap, TryGetValue return false when key is null/doesn't exist

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 [http://www.quartz-scheduler.net](http://www.quartz-scheduler.net)
 
+## Future Release, TBA
+
+* CHANGES
+  * `TryGetNullableString` method added to JobDataMap (#2125)
+
+* FIXES
+  * JobDataMap `TryGetXXX` methods will now correctly return true/false if a key value can be retrieved (or not) (#2125)
+  * JobDataMap `GetXXX` methods with throw KeyNotFoundException if the key does not exist on the JobDataMap (#2125)
+  * JobDataMap `GetXXX` methods with throw InvalidCastException if null value for non nullable types is found. (#2125)
+
 ## Release 3.7.0, Aug 4 2023
 
 * CHANGES

--- a/changelog.md
+++ b/changelog.md
@@ -9,8 +9,8 @@
 
 * FIXES
   * JobDataMap `TryGetXXX` methods will now correctly return true/false if a key value can be retrieved (or not) (#2125)
-  * JobDataMap `GetXXX` methods with throw KeyNotFoundException if the key does not exist on the JobDataMap (#2125)
-  * JobDataMap `GetXXX` methods with throw InvalidCastException if null value for non nullable types is found. (#2125)
+  * JobDataMap `GetXXX` methods throw KeyNotFoundException if the key does not exist on the JobDataMap (#2125)
+  * JobDataMap `GetXXX` methods throw InvalidCastException if null value for non nullable types is found. (#2125)
 
 ## Release 3.7.0, Aug 4 2023
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ## Future Release, TBA
 
 * CHANGES
-  * `TryGetNullableString` method added to JobDataMap (#2125)
+  * `TryGetString` method added to JobDataMap (#2125)
 
 * FIXES
   * JobDataMap `TryGetXXX` methods will now correctly return true/false if a key value can be retrieved (or not) (#2125)

--- a/src/Quartz.Jobs/Job/SendMailJob.cs
+++ b/src/Quartz.Jobs/Job/SendMailJob.cs
@@ -165,8 +165,9 @@ namespace Quartz.Job
 
         protected virtual string? GetOptionalParameter(JobDataMap data, string propertyName)
         {
-            var value = data.GetString(propertyName);
-            return string.IsNullOrEmpty(value) ? null : value;
+            if (data.TryGetNullableString(propertyName, out var value))
+                return string.IsNullOrEmpty(value) ? null : value;
+            return null;
         }
 
         protected virtual void Send(MailInfo mailInfo)

--- a/src/Quartz.Jobs/Job/SendMailJob.cs
+++ b/src/Quartz.Jobs/Job/SendMailJob.cs
@@ -165,7 +165,7 @@ namespace Quartz.Job
 
         protected virtual string? GetOptionalParameter(JobDataMap data, string propertyName)
         {
-            if (data.TryGetNullableString(propertyName, out var value))
+            if (data.TryGetString(propertyName, out var value))
                 return string.IsNullOrEmpty(value) ? null : value;
             return null;
         }

--- a/src/Quartz.Jobs/Job/SendMailJob.cs
+++ b/src/Quartz.Jobs/Job/SendMailJob.cs
@@ -165,9 +165,7 @@ namespace Quartz.Job
 
         protected virtual string? GetOptionalParameter(JobDataMap data, string propertyName)
         {
-            if (data.TryGetString(propertyName, out var value))
-                return string.IsNullOrEmpty(value) ? null : value;
-            return null;
+            return data.TryGetString(propertyName, out var value) ? value : null;
         }
 
         protected virtual void Send(MailInfo mailInfo)

--- a/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,9 +81,9 @@ namespace Quartz.Plugin.Interrupt
                     // Get the MaxRuntime from MergedJobDataMap if NOT available use MaxRunTime from Plugin Configuration
                     var jobDataDelay = DefaultMaxRunTime;
 
-                    if (context.MergedJobDataMap.GetString(JobDataMapKeyMaxRunTime) != null)
+                    if (context.MergedJobDataMap.TryGetLongValueFromString(JobDataMapKeyMaxRunTime, out var val))
                     {
-                        jobDataDelay = TimeSpan.FromMilliseconds(context.MergedJobDataMap.GetLongValueFromString(JobDataMapKeyMaxRunTime));
+                        jobDataDelay = TimeSpan.FromMilliseconds(val);
                     }
 
                     monitorPlugin.ScheduleJobInterruptMonitor(context.FireInstanceId, context.JobDetail.Key, jobDataDelay);

--- a/src/Quartz.Tests.Unit/JobDataMapTest.cs
+++ b/src/Quartz.Tests.Unit/JobDataMapTest.cs
@@ -78,6 +78,18 @@ namespace Quartz.Tests.Unit
             map.TryGetNullableGuid("key-not-found", out var nullable).Should().BeTrue();
             nullable.Should().Be(null);
         }
+        
+        [TestCase(null, true)] //nullable string is valid
+        [TestCase("string", true)]
+        public void TryGetString_ParseResult(object val, bool resultOutcome)
+        {
+            var map = new JobDataMap
+            {
+                ["key"] = val
+            };
+            var result = map.TryGetString("key", out _);
+            result.Should().Be(resultOutcome);
+        }
 
         [TestCase(null, false)]
         [TestCase(1, true)]
@@ -165,6 +177,13 @@ namespace Quartz.Tests.Unit
         public void TryGetFloatValue_NonExistentKey()
         {
             var result = new JobDataMap().TryGetFloatValue("key", out _);
+            result.Should().BeFalse();
+        }
+        
+        [Test]
+        public void TryGetString_NonExistentKey()
+        {
+            var result = new JobDataMap().TryGetString("key", out _);
             result.Should().BeFalse();
         }
     }

--- a/src/Quartz.Tests.Unit/JobDataMapTest.cs
+++ b/src/Quartz.Tests.Unit/JobDataMapTest.cs
@@ -78,5 +78,94 @@ namespace Quartz.Tests.Unit
             map.TryGetNullableGuid("key-not-found", out var nullable).Should().BeTrue();
             nullable.Should().Be(null);
         }
+
+        [TestCase(null, false)]
+        [TestCase(1, true)]
+        public void TryGetIntValue_ParseResult(object val, bool resultOutcome)
+        {
+            var map = new JobDataMap
+            {
+                ["key"] = val
+            };
+            var result = map.TryGetIntValue("key", out _);
+            result.Should().Be(resultOutcome);
+        }
+
+        [TestCase(null, false)]
+        [TestCase(1, true)]
+        public void TryGetLongValue_ParseResult(object val, bool resultOutcome)
+        {
+            var map = new JobDataMap
+            {
+                ["key"] = val
+            };
+            var result = map.TryGetLongValue("key", out _);
+            result.Should().Be(resultOutcome);
+        }
+
+        [TestCase(null, false)]
+        [TestCase(1, true)]
+        public void TryGetFloatValue_ParseResult(object val, bool resultOutcome)
+        {
+            var map = new JobDataMap
+            {
+                ["key"] = val
+            };
+            var result = map.TryGetFloatValue("key", out _);
+            result.Should().Be(resultOutcome);
+        }
+
+        [TestCase(null, false)]
+        [TestCase(1, true)]
+        public void TryGetDoubleValue_ParseResult(object val, bool resultOutcome)
+        {
+            var map = new JobDataMap
+            {
+                ["key"] = val
+            };
+            var result = map.TryGetDoubleValue("key", out _);
+            result.Should().Be(resultOutcome);
+        }
+
+        [TestCase(null, false)]
+        [TestCase(true, true)]
+        [TestCase(false, true)]
+        public void TryGetBooleanValue_ParseResult(object val, bool resultOutcome)
+        {
+            var map = new JobDataMap
+            {
+                ["key"] = val
+            };
+            var result = map.TryGetBooleanValue("key", out _);
+            result.Should().Be(resultOutcome);
+        }
+
+        [Test]
+        public void TryGetValBoolean_NonExistentKey()
+        {
+            var result = new JobDataMap().TryGetBooleanValue("key", out _);
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void TryGetIntValue_NonExistentKey()
+        {
+            var result = new JobDataMap().TryGetIntValue("key", out _);
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void TryGetLongValue_NonExistentKey()
+        {
+            var result = new JobDataMap().TryGetLongValue("key", out _);
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void TryGetFloatValue_NonExistentKey()
+        {
+            var result = new JobDataMap().TryGetFloatValue("key", out _);
+            result.Should().BeFalse();
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/Plugin/Interrupt/AutoInterruptableJobTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/Interrupt/AutoInterruptableJobTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,7 +42,7 @@ namespace Quartz.Tests.Unit.Plugin.Interrupt
             }
         }
 
-        [Test]
+        [Test, Timeout(5000)]
         public async Task TestJobAutoInterruption()
         {
             var scheduler = await CreateScheduler<TestInterruptableJob>();

--- a/src/Quartz/Util/StringKeyDirtyFlagMap.cs
+++ b/src/Quartz/Util/StringKeyDirtyFlagMap.cs
@@ -208,8 +208,16 @@ namespace Quartz.Util
         /// </summary>
         public virtual int GetInt(string key)
         {
-            var obj = this[key];
+            if (!this.ContainsKey(key))
+            {
+                throw new KeyNotFoundException($"Key {key} not found");
+            }
 
+            var obj = this[key];
+            if (obj is null)
+            {
+                throw new InvalidCastException("Identified object is not an Integer.");
+            }
             try
             {
                 return Convert.ToInt32(obj);
@@ -225,8 +233,16 @@ namespace Quartz.Util
         /// </summary>
         public virtual long GetLong(string key)
         {
-            var obj = this[key];
+            if (!this.ContainsKey(key))
+            {
+                throw new KeyNotFoundException($"Key {key} not found");
+            }
 
+            var obj = this[key];
+            if (obj is null)
+            {
+                throw new InvalidCastException("Identified object is not a Long.");
+            }
             try
             {
                 return Convert.ToInt64(obj);
@@ -242,8 +258,16 @@ namespace Quartz.Util
         /// </summary>
         public virtual float GetFloat(string key)
         {
-            var obj = this[key];
+            if (!this.ContainsKey(key))
+            {
+                throw new KeyNotFoundException($"Key {key} not found");
+            }
 
+            var obj = this[key];
+            if (obj is null)
+            {
+                throw new InvalidCastException("Identified object is not a Float.");
+            }
             try
             {
                 return Convert.ToSingle(obj);
@@ -259,8 +283,17 @@ namespace Quartz.Util
         /// </summary>
         public virtual double GetDouble(string key)
         {
+            if (!this.ContainsKey(key))
+            {
+                throw new KeyNotFoundException($"Key {key} not found");
+            }
+
             var obj = this[key];
 
+            if (obj is null)
+            {
+                throw new InvalidCastException("Identified object is not a Double.");
+            }
             try
             {
                 return Convert.ToDouble(obj);
@@ -276,8 +309,16 @@ namespace Quartz.Util
         /// </summary>
         public virtual bool GetBoolean(string key)
         {
+            if (!this.ContainsKey(key))
+            {
+                throw new KeyNotFoundException($"Key {key} not found");
+            }
             var obj = this[key];
-
+            
+            if (obj is null)
+            {
+                throw new InvalidCastException("Identified object is not a Boolean.");
+            }
             try
             {
                 return Convert.ToBoolean(obj);
@@ -293,8 +334,16 @@ namespace Quartz.Util
         /// </summary>
         public virtual char GetChar(string key)
         {
-            var obj = this[key];
+            if (!this.ContainsKey(key))
+            {
+                throw new KeyNotFoundException($"Key {key} not found");
+            }
 
+            var obj = this[key];
+            if (obj is null)
+            {
+                throw new InvalidCastException("Identified object is not a Character.");
+            }
             try
             {
                 return Convert.ToChar(obj);
@@ -310,8 +359,16 @@ namespace Quartz.Util
         /// </summary>
         public virtual string? GetString(string key)
         {
+            if (!this.ContainsKey(key))
+            {
+                throw new KeyNotFoundException($"Key {key} not found");
+            }
             var obj = this[key];
 
+            if (obj is null)
+            {
+                throw new InvalidCastException("Identified object is not a String.");
+            }
             try
             {
                 return (string?) obj;
@@ -327,8 +384,16 @@ namespace Quartz.Util
         /// </summary>
         public virtual DateTime GetDateTime(string key)
         {
-            var obj = this[key];
+            if (!this.ContainsKey(key))
+            {
+                throw new KeyNotFoundException($"Key {key} not found");
+            }
 
+            var obj = this[key];
+            if (obj is null)
+            {
+                throw new InvalidCastException("Identified object is not a DateTime.");
+            }
             try
             {
                 return

--- a/src/Quartz/Util/StringKeyDirtyFlagMap.cs
+++ b/src/Quartz/Util/StringKeyDirtyFlagMap.cs
@@ -356,11 +356,7 @@ namespace Quartz.Util
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
-
-            if (obj is null)
-            {
-                throw new InvalidCastException("Identified object is not a String.");
-            }
+          
             try
             {
                 return (string?) obj;
@@ -607,7 +603,7 @@ namespace Quartz.Util
         /// <summary>
         /// Try to retrieve the identified <see cref="string" /> value from the <see cref="JobDataMap" />.
         /// </summary>
-        public virtual bool TryGetNullableString(string key, out string? value)
+        public virtual bool TryGetString(string key, out string? value)
         {
             try
             {

--- a/src/Quartz/Util/StringKeyDirtyFlagMap.cs
+++ b/src/Quartz/Util/StringKeyDirtyFlagMap.cs
@@ -208,12 +208,11 @@ namespace Quartz.Util
         /// </summary>
         public virtual int GetInt(string key)
         {
-            if (!this.ContainsKey(key))
+            if (!this.TryGetValue(key, out var obj))
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
 
-            var obj = this[key];
             if (obj is null)
             {
                 throw new InvalidCastException("Identified object is not an Integer.");
@@ -233,12 +232,11 @@ namespace Quartz.Util
         /// </summary>
         public virtual long GetLong(string key)
         {
-            if (!this.ContainsKey(key))
+            if (!this.TryGetValue(key, out var obj))
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
 
-            var obj = this[key];
             if (obj is null)
             {
                 throw new InvalidCastException("Identified object is not a Long.");
@@ -258,12 +256,11 @@ namespace Quartz.Util
         /// </summary>
         public virtual float GetFloat(string key)
         {
-            if (!this.ContainsKey(key))
+            if (!this.TryGetValue(key, out var obj))
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
 
-            var obj = this[key];
             if (obj is null)
             {
                 throw new InvalidCastException("Identified object is not a Float.");
@@ -283,12 +280,10 @@ namespace Quartz.Util
         /// </summary>
         public virtual double GetDouble(string key)
         {
-            if (!this.ContainsKey(key))
+            if (!this.TryGetValue(key, out var obj))
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
-
-            var obj = this[key];
 
             if (obj is null)
             {
@@ -309,11 +304,10 @@ namespace Quartz.Util
         /// </summary>
         public virtual bool GetBoolean(string key)
         {
-            if (!this.ContainsKey(key))
+            if (!this.TryGetValue(key, out var obj))
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
-            var obj = this[key];
             
             if (obj is null)
             {
@@ -334,12 +328,11 @@ namespace Quartz.Util
         /// </summary>
         public virtual char GetChar(string key)
         {
-            if (!this.ContainsKey(key))
+            if (!this.TryGetValue(key, out var obj))
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
 
-            var obj = this[key];
             if (obj is null)
             {
                 throw new InvalidCastException("Identified object is not a Character.");
@@ -359,11 +352,10 @@ namespace Quartz.Util
         /// </summary>
         public virtual string? GetString(string key)
         {
-            if (!this.ContainsKey(key))
+            if (!this.TryGetValue(key, out var obj))
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
-            var obj = this[key];
 
             if (obj is null)
             {
@@ -384,12 +376,11 @@ namespace Quartz.Util
         /// </summary>
         public virtual DateTime GetDateTime(string key)
         {
-            if (!this.ContainsKey(key))
+            if (!this.TryGetValue(key, out var obj))
             {
                 throw new KeyNotFoundException($"Key {key} not found");
             }
 
-            var obj = this[key];
             if (obj is null)
             {
                 throw new InvalidCastException("Identified object is not a DateTime.");

--- a/src/Quartz/Util/StringKeyDirtyFlagMap.cs
+++ b/src/Quartz/Util/StringKeyDirtyFlagMap.cs
@@ -605,6 +605,23 @@ namespace Quartz.Util
         }
 
         /// <summary>
+        /// Try to retrieve the identified <see cref="string" /> value from the <see cref="JobDataMap" />.
+        /// </summary>
+        public virtual bool TryGetNullableString(string key, out string? value)
+        {
+            try
+            {
+                value = GetString(key);
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Try to retrieve the identified <see cref="char" /> value from the <see cref="JobDataMap" />.
         /// </summary>
         public virtual bool TryGetChar(string key, out char value)


### PR DESCRIPTION
When a Key in JobDataMap does not exist/or is null, `TryGetXXXValue` will return false.

Presently, it will return true, due to `Convert.ToInt(null)`  (and other types) returning 0

The follow changes were also done, to adapt to this change:

+ Add `TryGetString` to match other method.
+ Refactor `JobInterruptMonitor` and `SendMailJob` to change to use Try methods now that Gets may throw `KeyNotFoundException`.
+ add a release note for change