### PR TITLE
SendMailJob to throw JobExecutionException on BuildMessage construction failure due to missing mandatory params.

### DIFF
--- a/src/Quartz.Jobs/Job/SendMailJob.cs
+++ b/src/Quartz.Jobs/Job/SendMailJob.cs
@@ -84,9 +84,17 @@ namespace Quartz.Job
         /// <param name="context">The job execution context.</param>
         public virtual Task Execute(IJobExecutionContext context)
         {
-            JobDataMap data = context.MergedJobDataMap;
+            var data = context.MergedJobDataMap;
+            MailMessage message;
 
-            MailMessage message = BuildMessageFromParameters(data);
+            try
+            {
+                message = BuildMessageFromParameters(data);
+            }
+            catch (Exception ex)
+            {
+                throw new JobExecutionException($"Could not build message: {ex.Message}", ex, false);
+            }
 
             try
             {

--- a/src/Quartz.Tests.Unit/Job/SendMailJobTest.cs
+++ b/src/Quartz.Tests.Unit/Job/SendMailJobTest.cs
@@ -19,7 +19,10 @@
 
 #endregion
 
+using System;
 using System.Net.Mail;
+
+using FluentAssertions;
 
 using NUnit.Framework;
 
@@ -56,6 +59,23 @@ namespace Quartz.Tests.Unit.Job
             expectedMail.IsEqualTo(job.actualMailSent);
             Assert.AreEqual("someserver", job.actualSmtpHost);
         }
+
+        [Test]
+        public void JobShouldCatchExceptionIfRequiredParamsAreNotSet()
+        {
+            // setup mail job omitting mandatory properties.
+            var job = new TestSendMailJob();
+
+            var context = TestUtil.NewJobExecutionContextFor(job);
+            context.MergedJobDataMap.Put("smtp_host", "someserver");
+
+            // When
+            Action act = () => job.Execute(context);
+
+            // Then
+            act.Should().Throw<JobExecutionException>();
+        }
+
 
         [Test]
         public void ShouldSendMailWithOptionalProperties()
@@ -156,7 +176,7 @@ namespace Quartz.Tests.Unit.Job
 
     internal class TestSendMailJob : SendMailJob
     {
-        public MailMessage actualMailSent = new MailMessage();
+        public MailMessage actualMailSent = new ();
         public string actualSmtpHost = "ad";
         public string actualSmtpUserName;
         public string actualSmtpPassword;


### PR DESCRIPTION
When a `SendMailJob` fails to construct message from missing parameters, it should throw a `JobExecutionException`.

Branched from #2125