### PR TITLE
Fix a typo in the multiple triggers docs

### DIFF
--- a/docs/documentation/quartz-3.x/how-tos/multiple-triggers.md
+++ b/docs/documentation/quartz-3.x/how-tos/multiple-triggers.md
@@ -71,11 +71,11 @@ public Task DoSomething(IScheduler schedule, CancellationToken ct)
 
     // Trigger 1
     var jobData1 = new JobDataMap { { "CustomerId", 1 } };
-    await scheduler.TriggerJob(HelloJob.Key), jobData1, ct);
+    await scheduler.TriggerJob(HelloJob.Key, jobData1, ct);
 
     // Trigger 2
     var jobData2 = new JobDataMap { { "CustomerId", 2 } };
-    await scheduler.TriggerJob(HelloJob.Key), jobData2, ct);
+    await scheduler.TriggerJob(HelloJob.Key, jobData2, ct);
 }
 ```
 


### PR DESCRIPTION
Fixes a the parentheses on the ` await scheduler.TriggerJob` call 