### PR TITLE
Try and clarify WithDailyTimeIntervalSchedule for #1152

### DIFF
--- a/src/Quartz/Configuration/TriggerExtensions.cs
+++ b/src/Quartz/Configuration/TriggerExtensions.cs
@@ -2,11 +2,45 @@ namespace Quartz;
 
 public static class TriggerExtensions
 {
+    /// <summary>
+    /// Sets up a daily schedule with a default interval of *every-minute* unless overridden by the action
+    /// by calling WithInterval / WithIntervalInHours / WithIntervalInMinutes.
+    ///
+    /// For the sake of clarity, you probably want to use WithDailyConfiguredTimeIntervalSchedule instead.
+    /// </summary>
+    [Obsolete("Use WithDailyConfiguredTimeIntervalSchedule with default interval params instead.")]
     public static ITriggerConfigurator WithDailyTimeIntervalSchedule(
         this ITriggerConfigurator triggerBuilder,
         Action<DailyTimeIntervalScheduleBuilder>? action = null)
     {
         DailyTimeIntervalScheduleBuilder builder = DailyTimeIntervalScheduleBuilder.Create();
+        action?.Invoke(builder);
+        triggerBuilder.WithSchedule(builder);
+        return triggerBuilder;
+    }
+    
+    /// <summary>
+    /// Sets up a trigger schedule for one or more occurrences every day.
+    /// With parameter defaults, sets up a daily interval of every 12h.
+    /// </summary>
+    /// <remarks>
+    /// You need to configure the interval for when the trigger fires the job. If you only want one execution per day,
+    /// call EndingDailyAfterCount(1) or set the interval accordingly.
+    /// </remarks>
+    /// <param name="triggerBuilder"></param>
+    /// <param name="action"></param>
+    /// <param name="defaultInterval">The interval count to configure on the builder initially , e.g. 12*hours</param>
+    /// <param name="defaultIntervalUnit">The unit for the defaultInterval count. Defaults to hours.</param>
+    /// <seealso cref="DailyTimeIntervalScheduleBuilder.EndingDailyAfterCount"/>
+    /// <seealso cref="DailyTimeIntervalScheduleBuilder.EndingDailyAt"/>
+    /// <seealso cref="WithCronSchedule(Quartz.ITriggerConfigurator,string,System.Action{Quartz.CronScheduleBuilder}?)"/>
+    /// <returns>Mutated trigger configurator</returns>
+    public static ITriggerConfigurator WithDailyConfiguredTimeIntervalSchedule(
+        this ITriggerConfigurator triggerBuilder,
+        Action<DailyTimeIntervalScheduleBuilder>? action = null, int defaultInterval=12, IntervalUnit defaultIntervalUnit=IntervalUnit.Hour)
+    {
+        DailyTimeIntervalScheduleBuilder builder = DailyTimeIntervalScheduleBuilder.Create();
+        builder.WithInterval(defaultInterval, defaultIntervalUnit);
         action?.Invoke(builder);
         triggerBuilder.WithSchedule(builder);
         return triggerBuilder;


### PR DESCRIPTION
Previously the WithDailyTimeIntervalSchedule name was confusing, the method lacked inline documentation, and the default interval at 1 minute has led to a non-trivial number of developers accidentally running tasks every minute of every day (when they really meant every day).

I, along with many others, interpreted "daily time interval" as meaning a time interval of 24h. So, I wrote code like this:

```csharp
q.AddTrigger(t => t
    .WithIdentity("process_csv_report_trigger")
    .WithDescription("Generate CSV and upload to upstream SFTP server")
    .ForJob("process_csv_report_trigger")
    .WithDailyTimeIntervalSchedule(DailyTimeIntervalScheduleBuilder.Create().StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(2, 0)).OnEveryDay())
);
```

I then had the horror of experiencing this happen every 60 seconds (yeah I know, it could've been tested a bit more locally). To make matters worse, the SFTP creds were wrong so it's probably generated about 2,500 authentication failure log lines. I'm surprised we didn't get our IP address blocked, to be honest.

Further discussion here: https://github.com/quartznet/quartznet/issues/1152#issue-852435242

StackOverflow confusion (41 upvotes):

![image](https://github.com/quartznet/quartznet/assets/2552726/7ccfa6b7-3bb8-4866-830b-01a09b5e13e7)

![image](https://github.com/quartznet/quartznet/assets/2552726/7aa48c0d-8ae5-4e54-bab2-cf52973f60cc)

I've added some pointers with `<seealso>` here to try and reduce confusion too. Frankly, I'd say the Quartz.CronScheduleBuilder.DailyAtHourAndMinute method is much more ergonomic to use and developers would probably be better served by using this API for simple daily tasks. I've tried to make the change backwards-compatible, whilst nudging developers to think about their use of this method carefully.
