### PR TITLE
Add NET 8.0 targeting

### DIFF
--- a/Quartz.sln
+++ b/Quartz.sln
@@ -42,8 +42,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quartz.Examples.AspNetCore"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{FCD766DA-FF68-4A60-9130-07A56C2480F0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quartz.OpenTelemetry.Instrumentation", "src\Quartz.OpenTelemetry.Instrumentation\Quartz.OpenTelemetry.Instrumentation.csproj", "{5B99035A-3623-4584-9AFA-C6D77F5704BD}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quartz.Examples.Worker", "src\Quartz.Examples.Worker\Quartz.Examples.Worker.csproj", "{2BB03F5A-7736-42E9-A572-5D60336A9BFF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quartz.Benchmark", "src\Quartz.Benchmark\Quartz.Benchmark.csproj", "{23DEAB6E-D12C-40F6-A50E-6584FEAA389C}"
@@ -123,10 +121,6 @@ Global
 		{5224231E-7678-4EC6-B18A-FA302D9553E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5224231E-7678-4EC6-B18A-FA302D9553E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5224231E-7678-4EC6-B18A-FA302D9553E3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5B99035A-3623-4584-9AFA-C6D77F5704BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5B99035A-3623-4584-9AFA-C6D77F5704BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5B99035A-3623-4584-9AFA-C6D77F5704BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5B99035A-3623-4584-9AFA-C6D77F5704BD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2BB03F5A-7736-42E9-A572-5D60336A9BFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2BB03F5A-7736-42E9-A572-5D60336A9BFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2BB03F5A-7736-42E9-A572-5D60336A9BFF}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -127,7 +127,7 @@ partial class Build : NukeBuild
             var framework = "";
             if (!IsRunningOnWindows)
             {
-                framework = "net6.0";
+                framework = "net8.0";
             }
 
             var testProjects = new[] { "Quartz.Tests.Unit", "Quartz.Tests.AspNetCore" };
@@ -154,7 +154,7 @@ partial class Build : NukeBuild
 
             static void RunAsPostgresUser(string parameters)
             {
-                // Warn: Be careful refactoring this to concatenation. 
+                // Warn: Be careful refactoring this to concatenation.
                 ProcessTasks.StartProcess("sudo", "-u postgres " + parameters, workingDirectory: Path.GetTempPath()).AssertZeroExitCode();
             }
 

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,17 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
     <IsPackable>false</IsPackable>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="7.0.2" />
+    <PackageReference Include="Nuke.Common" Version="7.0.6" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.7.0]" />
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,58 +3,56 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' ">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.0" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="6.0.5" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageVersion Include="FakeItEasy" Version="7.4.0" />
-    <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="8.5.4" />
-    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
-    <PackageVersion Include="MELT" Version="0.8.0" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.5" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="7.0.2" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="7.1.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="7.0.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageVersion Include="FakeItEasy" Version="8.0.0" />
+    <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="10.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="MELT" Version="0.9.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.18" />
-    <PackageVersion Include="Microsoft.Data.SQLite" Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Data.SQLite" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageVersion Include="MySqlConnector" Version="2.1.13" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
-    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="MySqlConnector" Version="2.3.1" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="14.0.0-preview010" />
+    <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Npgsql" Version="6.0.9" />
+    <PackageVersion Include="Npgsql" Version="7.0.6" />
     <PackageVersion Include="OpenTelemetry" Version="1.3.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.6.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.3" />
     <PackageVersion Include="OpenTracing" Version="0.12.1" />
-    <PackageVersion Include="Oracle.ManagedDataAccess" Version="19.19.0" />
-    <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="2.19.190" />
-    <PackageVersion Include="Serilog" Version="2.12.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="4.2.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageVersion Include="Oracle.ManagedDataAccess" Version="21.12.0" />
+    <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="3.21.120" />
+    <PackageVersion Include="Serilog" Version="3.1.1" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.0" />
     <PackageVersion Include="Spectre.Console" Version="0.47.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.118" />
@@ -67,9 +65,9 @@
     <PackageVersion Include="log4net" Version="2.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <GlobalPackageReference Include="Meziantou.Analyzer" Version="2.0.80" />
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <GlobalPackageReference Include="PolySharp" Version="1.12.1" />
+    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+    <GlobalPackageReference Include="Meziantou.Analyzer" Version="2.0.110" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <GlobalPackageReference Include="PolySharp" Version="1.13.2" />
   </ItemGroup>
 </Project>

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/NotFoundException.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/NotFoundException.cs
@@ -1,5 +1,3 @@
-using System.Runtime.Serialization;
-
 namespace Quartz.AspNetCore.HttpApi.Util;
 
 internal sealed class NotFoundException : Exception
@@ -9,10 +7,6 @@ internal sealed class NotFoundException : Exception
     }
 
     public NotFoundException(string? message, Exception? innerException) : base(message, innerException)
-    {
-    }
-
-    public NotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Quartz.NET ASP.NET Core integration; $(Description)</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Lewis Zou, Marko Lahma, Quartz.NET</Authors>

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <!-- Necessary to run benchmarks on .NET 6.0+ -->
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>

--- a/src/Quartz.Benchmark/SchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/SchedulerBenchmark.cs
@@ -543,7 +543,8 @@ public class SchedulerBenchmark
 
         var threadPool = new DefaultThreadPool { MaxConcurrency = threadCount };
 
-        DirectSchedulerFactory.Instance.CreateScheduler(name,
+        DirectSchedulerFactory.Instance.CreateScheduler(
+            name,
             instanceId,
             threadPool,
             store,
@@ -551,7 +552,7 @@ public class SchedulerBenchmark
             idleWaitTime,
             maxBatchSize,
             TimeSpan.Zero,
-            null);
+            null).GetAwaiter().GetResult();
 
 
         var scheduler = DirectSchedulerFactory.Instance.GetScheduler(name).ConfigureAwait(false).GetAwaiter().GetResult();

--- a/src/Quartz.Examples.AspNetCore/ApiKeyAuthenticationOptions.cs
+++ b/src/Quartz.Examples.AspNetCore/ApiKeyAuthenticationOptions.cs
@@ -6,5 +6,5 @@ public class ApiKeyAuthenticationOptions : AuthenticationSchemeOptions
 {
     public const string Scheme = "api-key";
 
-    public string AllowedApiKey { get; set; } = null!;
+    public string? AllowedApiKey { get; set; }
 }

--- a/src/Quartz.Examples.AspNetCore/CustomSqlServerConnectionProvider.cs
+++ b/src/Quartz.Examples.AspNetCore/CustomSqlServerConnectionProvider.cs
@@ -52,7 +52,7 @@ public class CustomSqlServerConnectionProvider : IDbProvider
 
     public string ConnectionString
     {
-        get => configuration.GetConnectionString("Quartz");
+        get => configuration.GetConnectionString("Quartz")!;
         set => throw new NotImplementedException();
     }
 

--- a/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
+++ b/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
     <NoWarn>$(NoWarn);MA0004</NoWarn>
+    <!-- https://github.com/dotnet/aspnetcore/issues/50836 -->
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,6 +22,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="NSwag.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/src/Quartz.Examples.HttpClient/Quartz.Examples.HttpClient.csproj
+++ b/src/Quartz.Examples.HttpClient/Quartz.Examples.HttpClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
     <NoWarn>$(NoWarn);MA0047</NoWarn>

--- a/src/Quartz.Examples.Worker/Quartz.Examples.Worker.csproj
+++ b/src/Quartz.Examples.Worker/Quartz.Examples.Worker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
     <NoWarn>$(NoWarn);MA0004</NoWarn>

--- a/src/Quartz.Examples/Quartz.Examples.csproj
+++ b/src/Quartz.Examples/Quartz.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);MA0004</NoWarn>

--- a/src/Quartz.HttpClient/Quartz.HttpClient.csproj
+++ b/src/Quartz.HttpClient/Quartz.HttpClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Quartz.NET HTTP client</AssemblyTitle>
-    <TargetFrameworks>netstandard2.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;</TargetFrameworks>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Quartz.OpenTelemetry.Instrumentation/Quartz.OpenTelemetry.Instrumentation.csproj
+++ b/src/Quartz.OpenTelemetry.Instrumentation/Quartz.OpenTelemetry.Instrumentation.csproj
@@ -8,7 +8,7 @@
     <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" VersionOverride="0.6.0-beta.1" />
+    <PackageReference Include="OpenTelemetry" VersionOverride="1.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quartz\Quartz.csproj" />

--- a/src/Quartz.OpenTracing/QuartzDiagnostic.cs
+++ b/src/Quartz.OpenTracing/QuartzDiagnostic.cs
@@ -131,7 +131,7 @@ internal sealed class QuartzDiagnostic : IObserver<DiagnosticListener>, IObserve
             { LogFields.ErrorKind, exception.GetType().Name },
             { LogFields.ErrorObject, options.IncludeExceptionDetails
                 ? exception
-                : (object)$"{nameof(QuartzDiagnosticOptions.IncludeExceptionDetails)} is disabled" }
+                : $"{nameof(QuartzDiagnosticOptions.IncludeExceptionDetails)} is disabled" }
         });
     }
 }

--- a/src/Quartz.Serialization.Newtonsoft/Calendars/AnnualCalendarSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Calendars/AnnualCalendarSerializer.cs
@@ -16,7 +16,7 @@ internal sealed class AnnualCalendarSerializer : CalendarSerializer<AnnualCalend
     {
         writer.WritePropertyName("ExcludedDays");
         writer.WriteStartArray();
-        foreach (var day in ((AnnualCalendar) calendar).DaysExcluded)
+        foreach (var day in calendar.DaysExcluded)
         {
             writer.WriteValue(day);
         }
@@ -25,7 +25,7 @@ internal sealed class AnnualCalendarSerializer : CalendarSerializer<AnnualCalend
 
     protected override void DeserializeFields(AnnualCalendar calendar, JObject source)
     {
-        var annualCalendar = (AnnualCalendar) calendar;
+        var annualCalendar = calendar;
         var excludedDates = source["ExcludedDays"]!.Values<DateTimeOffset>();
         foreach (var date in excludedDates)
         {

--- a/src/Quartz.Server/Quartz.Server.csproj
+++ b/src/Quartz.Server/Quartz.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Quartz.Tests.AspNetCore/HttpApi/CalendarEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/CalendarEndpointsTest.cs
@@ -32,7 +32,7 @@ public class CalendarEndpointsTest : WebApiTest
         A.CallTo(() => FakeScheduler.GetCalendar("HolidayCalendar", A<CancellationToken>._)).Returns(TestData.HolidayCalendar);
         A.CallTo(() => FakeScheduler.GetCalendar("MonthlyCalendar", A<CancellationToken>._)).Returns(TestData.MonthlyCalendar);
         A.CallTo(() => FakeScheduler.GetCalendar("WeeklyCalendar", A<CancellationToken>._)).Returns(TestData.WeeklyCalendar);
-        A.CallTo(() => FakeScheduler.GetCalendar("NonExistingCalendar", A<CancellationToken>._)).Returns((ICalendar?) null);
+        A.CallTo(() => FakeScheduler.GetCalendar("NonExistingCalendar", A<CancellationToken>._)).Returns(null);
 
         var calendar = await HttpScheduler.GetCalendar("AnnualCalendar");
         calendar.Should().BeEquivalentTo(TestData.AnnualCalendar);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
@@ -51,7 +51,7 @@ public class JobEndpointsTest : WebApiTest
 
         A.CallTo(() => FakeScheduler.GetJobDetail(jobKeyOne, A<CancellationToken>._)).Returns(TestData.JobDetail);
         A.CallTo(() => FakeScheduler.GetJobDetail(jobKeyTwo, A<CancellationToken>._)).Returns(TestData.JobDetail2);
-        A.CallTo(() => FakeScheduler.GetJobDetail(nonExistingJobKey, A<CancellationToken>._)).Returns((IJobDetail?) null);
+        A.CallTo(() => FakeScheduler.GetJobDetail(nonExistingJobKey, A<CancellationToken>._)).Returns(null);
 
         var jobDetails = await HttpScheduler.GetJobDetail(jobKeyOne);
         jobDetails.Should().BeEquivalentTo(TestData.JobDetail);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
@@ -50,7 +50,7 @@ public class TriggerEndpointsTest : WebApiTest
         A.CallTo(() => FakeScheduler.GetTrigger(TestData.CronTrigger.Key, A<CancellationToken>._)).Returns(TestData.CronTrigger);
         A.CallTo(() => FakeScheduler.GetTrigger(TestData.DailyTimeIntervalTrigger.Key, A<CancellationToken>._)).Returns(TestData.DailyTimeIntervalTrigger);
         A.CallTo(() => FakeScheduler.GetTrigger(TestData.SimpleTrigger.Key, A<CancellationToken>._)).Returns(TestData.SimpleTrigger);
-        A.CallTo(() => FakeScheduler.GetTrigger(triggerKeyOne, A<CancellationToken>._)).Returns((ITrigger?) null);
+        A.CallTo(() => FakeScheduler.GetTrigger(triggerKeyOne, A<CancellationToken>._)).Returns(null);
 
         var trigger = await HttpScheduler.GetTrigger(TestData.CalendarIntervalTrigger.Key);
         trigger.Should().BeEquivalentTo(TestData.CalendarIntervalTrigger);
@@ -326,7 +326,7 @@ public class TriggerEndpointsTest : WebApiTest
             .MustHaveHappened(1, Times.Exactly);
 
         Fake.ClearRecordedCalls(FakeScheduler);
-        A.CallTo(() => FakeScheduler.RescheduleJob(triggerKeyTwo, A<ITrigger>._, A<CancellationToken>._)).Returns((DateTimeOffset?) null);
+        A.CallTo(() => FakeScheduler.RescheduleJob(triggerKeyTwo, A<ITrigger>._, A<CancellationToken>._)).Returns(null);
 
         response = await HttpScheduler.RescheduleJob(triggerKeyTwo, TestData.SimpleTrigger);
         response.Should().BeNull();

--- a/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
+++ b/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbMetadataTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbMetadataTest.cs
@@ -50,23 +50,23 @@ public class DbMetadataTest
         TestDbMetadata("MySqlConnector");
     }
 
-#if !NETCORE
-        
-        [Test]
-        [Category("db-oracle")]
-        public void TestDbMetadataOracleODP()
-        {
-            TestDbMetadata("OracleODP");
-        }
+#if NETFRAMEWORK
 
-        [Test]
-        [Category("db-oracle")]
-        public void TestDbMetadataOracleODPManaged()
-        {
-            var provider = TestDbMetadata("OracleODPManaged");
-            var command = (Oracle.ManagedDataAccess.Client.OracleCommand) provider.CreateCommand();
-            Assert.That(command.BindByName, Is.True, "bind by name should default to true");
-        }
+    [Test]
+    [Category("db-oracle")]
+    public void TestDbMetadataOracleODP()
+    {
+        TestDbMetadata("OracleODP");
+    }
+
+    [Test]
+    [Category("db-oracle")]
+    public void TestDbMetadataOracleODPManaged()
+    {
+        var provider = TestDbMetadata("OracleODPManaged");
+        var command = (Oracle.ManagedDataAccess.Client.OracleCommand) provider.CreateCommand();
+        Assert.That(command.BindByName, Is.True, "bind by name should default to true");
+    }
 #endif
 
     private static DbProvider TestDbMetadata(string dbname, bool hashCustomBinaryType = true)

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -22,7 +22,7 @@ public class JobStoreSupportTest
 
     private class SqlExceptionSimulator : Exception
     {
-        public IEnumerable<SqlErrorSimulator> Errors => new List<SqlErrorSimulator>()
+        public IEnumerable<SqlErrorSimulator> Errors => new List<SqlErrorSimulator>
         {
             new SqlErrorSimulator()
         };

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <NoWarn>SYSLIB0011;CAC001</NoWarn>
+    <NoWarn>SYSLIB0011</NoWarn>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,17 +29,13 @@
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
     <ProjectReference Include="..\Quartz.Jobs\Quartz.Jobs.csproj" />
     <ProjectReference Include="..\Quartz.Serialization.Newtonsoft\Quartz.Serialization.Newtonsoft.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Oracle.ManagedDataAccess.Core" />
   </ItemGroup>
 

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/QuartzHttpClientServiceCollectionExtensionsTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/QuartzHttpClientServiceCollectionExtensionsTest.cs
@@ -1,3 +1,7 @@
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+
 using FakeItEasy;
 
 using FluentAssertions;

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreCMTTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreCMTTest.cs
@@ -27,7 +27,7 @@ public class JobStoreCMTTest
     {
         public void ExecuteGetNonManagedConnection()
         {
-            GetNonManagedTXConnection();
+            GetNonManagedTXConnection().GetAwaiter().GetResult();
         }
     }
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -477,7 +477,7 @@ public class StubParameterCollection : DbParameterCollection
 
     public override object SyncRoot => throw new NotImplementedException();
 
-#if !NETCORE
+#if NETFRAMEWORK
     public override bool IsFixedSize => throw new NotImplementedException();
 
     public override bool IsReadOnly => throw new NotImplementedException();

--- a/src/Quartz.Tests.Unit/Impl/Matchers/StringOperatorTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Matchers/StringOperatorTest.cs
@@ -1,3 +1,5 @@
+// ReSharper disable SuspiciousTypeConversion.Global
+
 using System.Runtime.Serialization.Formatters;
 using System.Runtime.Serialization.Formatters.Binary;
 using NUnit.Framework;
@@ -71,7 +73,7 @@ public class StringOperatorTest
         Assert.IsTrue(op.Equals(op));
         Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
         Assert.IsFalse(op.Equals(StringOperator.Equality));
-        Assert.IsFalse(op.Equals((StringOperator) null));
+        Assert.IsFalse(op.Equals(null));
     }
 
     [Test]
@@ -153,7 +155,7 @@ public class StringOperatorTest
         Assert.IsTrue(op.Equals(op));
         Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
         Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals((StringOperator) null));
+        Assert.IsFalse(op.Equals(null));
     }
 
     [Test]
@@ -176,7 +178,7 @@ public class StringOperatorTest
         Assert.IsTrue(op.Equals(op));
         Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
         Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals((StringOperator) null));
+        Assert.IsFalse(op.Equals(null));
     }
 
     [Test]
@@ -270,7 +272,7 @@ public class StringOperatorTest
         Assert.IsTrue(op.Equals(op));
         Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
         Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals((StringOperator) null));
+        Assert.IsFalse(op.Equals(null));
     }
 
     [Test]
@@ -337,7 +339,7 @@ public class StringOperatorTest
         Assert.IsTrue(op.Equals(op));
         Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
         Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals((StringOperator) null));
+        Assert.IsFalse(op.Equals(null));
     }
 
     [Test]
@@ -431,7 +433,7 @@ public class StringOperatorTest
         Assert.IsTrue(op.Equals(op));
         Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
         Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals((StringOperator) null));
+        Assert.IsFalse(op.Equals(null));
     }
 
     [Serializable]
@@ -446,24 +448,19 @@ public class StringOperatorTest
     private static T SerializeAndDeserialize<T>(T stringOperator)
     {
         var formatter = new BinaryFormatter();
-
-        using (var ms = new MemoryStream())
-        {
-            formatter.Serialize(ms, stringOperator);
-
-            ms.Position = 0;
-
-            return (T) formatter.Deserialize(ms);
-        }
+        using var ms = new MemoryStream();
+        formatter.Serialize(ms, stringOperator);
+        ms.Position = 0;
+        return (T) formatter.Deserialize(ms);
     }
 
     private static T Deserialize<T>(string name)
     {
-        using (var fs = File.OpenRead(Path.Combine("Serialized", name + ".ser")))
-        {
-            BinaryFormatter binaryFormatter = new BinaryFormatter();
-            binaryFormatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
-            return (T) binaryFormatter.Deserialize(fs);
-        }
+#pragma warning disable SYSLIB0050
+        using var fs = File.OpenRead(Path.Combine("Serialized", name + ".ser"));
+        BinaryFormatter binaryFormatter = new BinaryFormatter();
+        binaryFormatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
+        return (T) binaryFormatter.Deserialize(fs);
+#pragma warning restore SYSLIB0050
     }
 }

--- a/src/Quartz.Tests.Unit/Plugin/Xml/XMLSchedulingDataProcessorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/Xml/XMLSchedulingDataProcessorPluginTest.cs
@@ -27,7 +27,7 @@ public class XMLSchedulingDataProcessorPluginTest
 
         await dataProcessor.Initialize("something", mockScheduler);
 
-        Assert.That(dataProcessor.JobFiles.Count(), Is.EqualTo(2));
+        Assert.That(dataProcessor.JobFiles.Count, Is.EqualTo(2));
         Assert.That(dataProcessor.JobFiles.Select(x => x.Key), Is.EqualTo(new[] { fp1, fp2 }));
     }
 
@@ -55,7 +55,7 @@ public class XMLSchedulingDataProcessorPluginTest
 
         await dataProcessor.Initialize("something", mockScheduler);
 
-        Assert.That(dataProcessor.JobFiles.Count(), Is.EqualTo(2));
+        Assert.That(dataProcessor.JobFiles.Count, Is.EqualTo(2));
         Assert.That(dataProcessor.JobFiles.Select(x => x.Key).ToArray(), Is.EqualTo(new[] { expectedPathFile1, expectedPathFile2 }));
     }
 

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -1,27 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <NoWarn>SYSLIB0011;CS0618</NoWarn>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Xml\TestData\*" />
-    <Content Include="Xml\TestData\JobTypeNotFound.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Serialized\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="Xml\TestData\JobTypeNotFound.xml" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Serialized\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
@@ -36,10 +33,6 @@
     <ProjectReference Include="..\Quartz.Plugins.TimeZoneConverter\Quartz.Plugins.TimeZoneConverter.csproj" />
     <ProjectReference Include="..\Quartz.Serialization.Newtonsoft\Quartz.Serialization.Newtonsoft.csproj" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup>
     <GlobalPackageReference Remove="Meziantou.Analyzer" />

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -350,7 +350,7 @@ public class QuartzHostedServiceTests
         var quartzHostedService = new QuartzHostedService(
             appliationLifetime,
             schedulerFactory,
-            Options.Create(new QuartzHostedServiceOptions()
+            Options.Create(new QuartzHostedServiceOptions
             {
                 AwaitApplicationStarted = awaitApplicationStarted,
                 StartDelay = withStartDelay ? TimeSpan.FromMinutes(1) : null,
@@ -380,7 +380,7 @@ public class QuartzHostedServiceTests
         var quartzHostedService = new QuartzHostedService(
             appliationLifetime,
             schedulerFactory,
-            Options.Create(new QuartzHostedServiceOptions()
+            Options.Create(new QuartzHostedServiceOptions
             {
                 AwaitApplicationStarted = awaitApplicationStarted,
                 StartDelay = withStartDelay ? TimeSpan.FromMinutes(1) : null,
@@ -421,7 +421,7 @@ public class QuartzHostedServiceTests
         var quartzHostedService = new QuartzHostedService(
             appliationLifetime,
             schedulerFactory,
-            Options.Create(new QuartzHostedServiceOptions()
+            Options.Create(new QuartzHostedServiceOptions
             {
                 AwaitApplicationStarted = awaitApplicationStarted,
                 StartDelay = withStartDelay ? TimeSpan.FromMinutes(1) : null,
@@ -451,7 +451,7 @@ public class QuartzHostedServiceTests
         var quartzHostedService = new QuartzHostedService(
             appliationLifetime,
             schedulerFactory,
-            Options.Create(new QuartzHostedServiceOptions()
+            Options.Create(new QuartzHostedServiceOptions
             {
                 AwaitApplicationStarted = awaitApplicationStarted,
                 StartDelay = withStartDelay ? TimeSpan.FromMinutes(1) : null,

--- a/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
@@ -1501,7 +1501,7 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Add("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsFalse(((IDictionary) dirtyFlagMap).Contains((object) 5));
+        Assert.IsFalse(((IDictionary) dirtyFlagMap).Contains(5));
         Assert.IsFalse(dirtyFlagMap.Dirty);
     }
 
@@ -1512,7 +1512,7 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Contains((object) "a"));
+        Assert.IsTrue(dirtyFlagMap.Contains("a"));
         Assert.IsFalse(dirtyFlagMap.Dirty);
     }
 
@@ -2144,11 +2144,11 @@ public class DirtyFlagMapTest
 
     private static T Deserialize<T>(string name)
     {
-        using (var fs = File.OpenRead(Path.Combine("Serialized", name + ".ser")))
-        {
-            BinaryFormatter binaryFormatter = new BinaryFormatter();
-            binaryFormatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
-            return (T) binaryFormatter.Deserialize(fs);
-        }
+#pragma warning disable SYSLIB0050
+        using var fs = File.OpenRead(Path.Combine("Serialized", name + ".ser"));
+        BinaryFormatter binaryFormatter = new BinaryFormatter();
+        binaryFormatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
+        return (T) binaryFormatter.Deserialize(fs);
+#pragma warning restore SYSLIB0050
     }
 }

--- a/src/Quartz.Tests.Unit/Utils/KeyTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/KeyTest.cs
@@ -404,21 +404,21 @@ public class KeyTest
     [Test]
     public void Serialization_CanBeDeserialized()
     {
+#pragma warning disable SYSLIB0050
         var key = new Key<string>("A", "B");
 
-        using (var ms = new MemoryStream())
-        {
-            ms.Write(_serializedKeyStringWithNameAndGroup, 0, _serializedKeyStringWithNameAndGroup.Length);
-            ms.Position = 0;
+        using var ms = new MemoryStream();
+        ms.Write(_serializedKeyStringWithNameAndGroup, 0, _serializedKeyStringWithNameAndGroup.Length);
+        ms.Position = 0;
 
-            BinaryFormatter formatter = new BinaryFormatter();
-            formatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
+        BinaryFormatter formatter = new BinaryFormatter();
+        formatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
 
-            var deserialized = formatter.Deserialize(ms) as Key<string>;
-            Assert.IsNotNull(deserialized);
-            Assert.AreEqual(key.Group, deserialized.Group);
-            Assert.AreEqual(key.Name, deserialized.Name);
-        }
+        var deserialized = formatter.Deserialize(ms) as Key<string>;
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(key.Group, deserialized.Group);
+        Assert.AreEqual(key.Name, deserialized.Name);
+#pragma warning restore SYSLIB0050
     }
 
     [Test]

--- a/src/Quartz/Configuration/IServiceCollectionQuartzConfigurator.cs
+++ b/src/Quartz/Configuration/IServiceCollectionQuartzConfigurator.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-using Quartz.Simpl;
 using Quartz.Spi;
 
 namespace Quartz;

--- a/src/Quartz/Configuration/QuartzConfiguration.cs
+++ b/src/Quartz/Configuration/QuartzConfiguration.cs
@@ -7,7 +7,7 @@ namespace Quartz.Configuration;
 /// </summary>
 internal sealed class QuartzConfiguration : IPostConfigureOptions<QuartzOptions>
 {
-    public void PostConfigure(string name, QuartzOptions options)
+    public void PostConfigure(string? name, QuartzOptions options)
     {
     }
 }

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -20,7 +20,6 @@
 #endregion
 
 using System.Collections.Specialized;
-using System.Configuration;
 using System.Globalization;
 using System.Reflection;
 
@@ -1040,7 +1039,7 @@ Please add configuration to your application config file to correctly initialize
     protected virtual string? GetNamedConnectionString(string dsConnectionStringName)
     {
 #if NETFRAMEWORK
-        var connectionStringSettings = ConfigurationManager.ConnectionStrings[dsConnectionStringName];
+        var connectionStringSettings = System.Configuration.ConfigurationManager.ConnectionStrings[dsConnectionStringName];
         return connectionStringSettings.ConnectionString;
 #else
             return null;

--- a/src/Quartz/JobDataMap.cs
+++ b/src/Quartz/JobDataMap.cs
@@ -465,7 +465,7 @@ public sealed class JobDataMap : StringKeyDirtyFlagMap
 
         if (obj is string s)
         {
-            return s.Length == 0 ? (Guid?) null : GetGuidValueFromString(key);
+            return s.Length == 0 ? null : GetGuidValueFromString(key);
         }
 
         return GetNullableGuid(key);

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Quartz.NET</AssemblyTitle>
-    <TargetFrameworks>net472;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Quartz/SchedulerException.cs
+++ b/src/Quartz/SchedulerException.cs
@@ -1,3 +1,5 @@
+#pragma warning disable SYSLIB0051 // 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete
+
 #region License
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.

--- a/src/Quartz/Simpl/BinaryObjectSerializer.cs
+++ b/src/Quartz/Simpl/BinaryObjectSerializer.cs
@@ -22,12 +22,12 @@ internal sealed class BinaryObjectSerializer : IObjectSerializer
     /// <param name="obj">Object to serialize.</param>
     public byte[] Serialize<T>(T obj) where T : class
     {
+#pragma warning disable SYSLIB0011
         using MemoryStream ms = new MemoryStream();
         BinaryFormatter bf = new BinaryFormatter();
-#pragma warning disable SYSLIB0011
         bf.Serialize(ms, obj);
-#pragma warning restore SYSLIB0011
         return ms.ToArray();
+#pragma warning restore SYSLIB0011
     }
 
     /// <summary>
@@ -36,9 +36,9 @@ internal sealed class BinaryObjectSerializer : IObjectSerializer
     /// <param name="data">Data to deserialize object from.</param>
     public T? DeSerialize<T>(byte[] data) where T : class
     {
+#pragma warning disable SYSLIB0011
         using MemoryStream ms = new MemoryStream(data);
         BinaryFormatter bf = new BinaryFormatter();
-#pragma warning disable SYSLIB0011
         return (T) bf.Deserialize(ms);
 #pragma warning restore SYSLIB0011
     }

--- a/src/Quartz/Util/Configuration.cs
+++ b/src/Quartz/Util/Configuration.cs
@@ -1,24 +1,21 @@
-using System.Collections.Specialized;
-using System.Configuration;
-
+#if NETFRAMEWORK
 using Microsoft.Extensions.Logging;
-
-using Quartz.Logging;
+#endif
 
 namespace Quartz.Util;
 
 internal static class Configuration
 {
-    internal static NameValueCollection? GetSection(string sectionName)
+    internal static System.Collections.Specialized.NameValueCollection? GetSection(string sectionName)
     {
 #if NETFRAMEWORK
         try
         {
-            return (NameValueCollection) ConfigurationManager.GetSection(sectionName);
+            return (System.Collections.Specialized.NameValueCollection) System.Configuration.ConfigurationManager.GetSection(sectionName);
         }
         catch (Exception e)
         {
-            var logger = LogProvider.CreateLogger(nameof(Configuration));
+            var logger = Logging.LogProvider.CreateLogger(nameof(Configuration));
             logger.LogWarning(e, "could not read configuration using ConfigurationManager.GetSection: {ExceptionMessage}", e.Message);
             return null;
         }

--- a/src/Quartz/Xml/ValidationException.cs
+++ b/src/Quartz/Xml/ValidationException.cs
@@ -1,3 +1,5 @@
+#pragma warning disable SYSLIB0051 // 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete
+
 #region License
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.


### PR DESCRIPTION
* replace net6.0 with net8.0 as supported target
* examples and tests run on NET 8.0
* remove Quartz.OpenTelemetry.Instrumentation from active configuration
* library upgrades
* code warning cleanup