### PR TITLE
Make IJobWrapper public

### DIFF
--- a/src/Quartz/IJobWrapper.cs
+++ b/src/Quartz/IJobWrapper.cs
@@ -1,6 +1,6 @@
 namespace Quartz;
 
-internal interface IJobWrapper
+public interface IJobWrapper
 {
     IJob Target { get; }
 }


### PR DESCRIPTION
This allows accessing the inner job without reflection. The fact that IJobWrapper exists suggests this should be public. In my case, I have extended the JobFactory to have a Post Init stage.