### PR TITLE
Fixed the DayOfWeek handling.

### DIFF
--- a/src/Quartz.Tests.Unit/Core/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/Core/CronExpressionTest.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+
+namespace Quartz.Tests.Unit.Core;
+
+[TestFixture]
+public class CronExpressionTest
+{
+    private static readonly TimeZoneInfo testTimeZone = TimeZoneInfo.Local;
+
+    [TestCaseSource(typeof(ExpressionGenerator), nameof(ExpressionGenerator.Expressions))]
+    public void TestDayOfWeekSet((string expression, ICollection<int> set) test)
+    {
+        var cronExpression = new CronExpression(test.expression);
+        cronExpression.TimeZone = testTimeZone;
+
+        var set = cronExpression.GetSet(CronExpressionConstants.DayOfWeek);
+
+        Assert.That(set, Is.Not.Null);
+        Assert.IsNotEmpty(set);
+        Assert.That(set, Is.EquivalentTo(test.set));
+    }
+
+    [TestCaseSource(typeof(ExpressionGenerator), nameof(ExpressionGenerator.Expressions))]
+    public void NextValidSatisfiesItself((string expression, ICollection<int> set) test)
+    {
+        var cronExpression = new CronExpression(test.expression);
+        cronExpression.TimeZone = testTimeZone;
+
+        var now = DateTimeOffset.UtcNow;
+
+        var next = cronExpression.GetNextValidTimeAfter(now);
+
+        Assert.That(next, Is.Not.Null);
+        Assert.That(() => next != default);
+
+        var set = cronExpression.GetSet(CronExpressionConstants.DayOfWeek);
+        if (set.Contains(CronExpressionConstants.AllSpec)) set = [1, 2, 3, 4, 5, 6, 7];
+        var nextDow = CronExpression.CronWeekDayOf(next.Value);
+                
+        Assert.That(() => cronExpression.IsSatisfiedBy(next.Value));
+        Assert.That(() => set.Contains(nextDow));
+        Assert.That(() => (next.Value - now).TotalDays <= 7);
+        Assert.That(() => next.Value > now);
+    }
+
+    [TestCaseSource(typeof(ExpressionGenerator), nameof(ExpressionGenerator.Expressions))]
+    public void NextValidIsPatternWeekDay((string expression, ICollection<int> set) test)
+    {
+        var cronExpression = new CronExpression(test.expression);
+        cronExpression.TimeZone = testTimeZone;
+
+        var next = cronExpression.GetNextValidTimeAfter(DateTimeOffset.UtcNow);
+        var dayOfWeek = CronExpression.CronWeekDayOf(next.Value);
+
+        Assert.That(() => test.set.Contains(CronExpressionConstants.AllSpec) || test.set.Contains(dayOfWeek));
+    }
+
+    [TestCaseSource(typeof(ExpressionGenerator), nameof(ExpressionGenerator.Expressions))]
+    public void ValidateSatisfaction((string expression, ICollection<int> set) test)
+    {
+        var cronExpression = new CronExpression(test.expression);
+        cronExpression.TimeZone = testTimeZone;
+
+        var set = cronExpression.GetSet(CronExpressionConstants.DayOfWeek);
+
+        var now = DateTimeOffset.Parse("2024.01.01 09:30");
+
+       if (set.Contains(CronExpressionConstants.AllSpec)) set = [1, 2, 3, 4, 5, 6, 7];
+
+        foreach (var day in Enumerable.Range(1, 7))
+        {
+            var testDate = now.AddDays(day);
+            var testDow = CronExpression.CronWeekDayOf(testDate);
+
+            if (set.Contains(testDow))
+            {
+                Assert.IsTrue(cronExpression.IsSatisfiedBy(testDate), $"{testDate} matches {test.expression}");
+            }
+            else
+            {
+                Assert.IsFalse(cronExpression.IsSatisfiedBy(testDate));
+            }                
+        }
+    }
+}
+
+public class ExpressionGenerator
+{
+    private const string StartSequence = "0 30 09 ? * ";
+
+    public static IEnumerable<(string, ICollection<int>)> Expressions
+    {
+        get
+        {
+            yield return (StartSequence + "1", [1]);
+            yield return (StartSequence + "2", [2]);
+            yield return (StartSequence + "1,2", [1,2]);
+            yield return (StartSequence + "1-3", [1,2,3]);
+            yield return (StartSequence + "2-5", [2,3,4,5]);
+            yield return (StartSequence + "1-7", [1,2,3,4,5,6,7]);
+            yield return (StartSequence + "*", [CronExpressionConstants.AllSpec]); 
+        }
+    }
+}

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -1648,7 +1648,7 @@ public sealed class CronExpression : ISerializable
             // the month?
             var dow = daysOfWeek.Min; // desired
             // d-o-w
-            var cDow = (int) d.DayOfWeek + 1; // current d-o-w
+            var cDow = CronWeekDayOf(d); // current d-o-w
             var daysToAdd = 0;
             if (cDow < dow)
             {
@@ -1699,7 +1699,7 @@ public sealed class CronExpression : ISerializable
             // are we looking for the Nth XXX day in the month?
             var dow = daysOfWeek.Min; // desired
             // d-o-w
-            var cDow = (int) d.DayOfWeek + 1; // current d-o-w
+            var cDow = CronWeekDayOf(d); // current d-o-w
             var daysToAdd = 0;
             if (cDow < dow)
             {
@@ -1744,7 +1744,7 @@ public sealed class CronExpression : ISerializable
         }
         else if (everyNthWeek != 0)
         {
-            var cDow = (int) d.DayOfWeek + 1; // current d-o-w
+            var cDow = CronWeekDayOf(d); // current d-o-w
             var dow = daysOfWeek.Min; // desired d-o-w
             if (daysOfWeek.TryGetMinValueStartingFrom(cDow, out var min))
             {
@@ -1772,7 +1772,7 @@ public sealed class CronExpression : ISerializable
         }
         else
         {
-            var cDow = (int) d.DayOfWeek + 1; // current d-o-w
+            var cDow = CronWeekDayOf(d); // current d-o-w
             var dow = daysOfWeek.Min; // desired d-o-w
             if (daysOfWeek.TryGetMinValueStartingFrom(cDow, out var min))
             {
@@ -1926,12 +1926,12 @@ public sealed class CronExpression : ISerializable
 
         var nextFireTimeProgressors = new[]
         {
-            ProgressNextFireTimeSecond,
-            ProgressNextFireTimeMinute,
-            ProgressNextFireTimeHour,
-            ProgressNextFireTimeDay,
+            ProgressNextFireTimeYear,
             ProgressNextFireTimeMonth,
-            ProgressNextFireTimeYear
+            ProgressNextFireTimeDay,
+            ProgressNextFireTimeHour,
+            ProgressNextFireTimeMinute,
+            ProgressNextFireTimeSecond
         };
 
         var nextFireTimeCursor = new NextFireTimeCursor(false, d);
@@ -1970,11 +1970,20 @@ public sealed class CronExpression : ISerializable
 
             // apply the proper offset for this date
             d = new DateTimeOffset(nextFireTimeCursor.Date.Value.DateTime, TimeZoneUtil.GetUtcOffset(nextFireTimeCursor.Date.Value.DateTime, TimeZone));
+
             foundNextFireTime = true;
         }
 
         return d.ToUniversalTime();
     }
+
+    /// <summary>
+    /// Returns the Cron equivalent of the day of week from specified date.
+    /// 1:Monday-7:Sunday for 0:Sunday-6:Saturday
+    /// </summary>
+    /// <param name="date">The date</param>
+    /// <returns></returns>
+    public static int CronWeekDayOf(DateTimeOffset date) => date.DayOfWeek == DayOfWeek.Sunday ? 7 : (int) date.DayOfWeek;
 
     /// <summary>
     /// Creates the date time without milliseconds.


### PR DESCRIPTION
System DOW is 0-6 based, where 0 is always Sunday. Cron DOW is 1-7 based, where Sunday is 7. Hence simply casting to int will yield wrong results.

When calculating next valid timestamp, it is better to start from the larger offset as the current implementation tends to skip over possible values.

Added test cases.