### PR TITLE
Fix issue with Holiday Calendar with nested calendars not identifying NextIncludedTime

### DIFF
--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -1,5 +1,8 @@
+﻿using FluentAssertions;
+
 using NUnit.Framework;
 
+using Quartz.Impl.Calendar;
 using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Utils;
@@ -14,5 +17,32 @@ public class TimeZoneUtilTest
         var infoWithUniversalCoordinatedTime = TimeZoneUtil.FindTimeZoneById("Coordinated Universal Time");
 
         Assert.AreEqual(infoWithUtc, infoWithUniversalCoordinatedTime);
+    }
+
+    [Test]
+    public void GetNextIncludedTimeUtc_CrashOriginal2270()
+    {
+        TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+        var weeklyCalendar = new WeeklyCalendar() { TimeZone = timeZone, };
+
+        var dailyCalendar = new DailyCalendar(weeklyCalendar, "06:00", "22:00") { TimeZone = timeZone, InvertTimeRange = true, };
+
+        var holidayCalendar = new HolidayCalendar(dailyCalendar) { TimeZone = timeZone, };
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 2, 19));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 5, 27));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 6, 19));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 7, 4));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 9, 2));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 10, 14));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 11, 11));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 11, 28));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 12, 25));
+
+        var time = new DateTime(2024, 2, 5, 10, 6, 0, DateTimeKind.Utc);
+        var expected = new DateTime(2024, 2, 5, 14, 0, 0, DateTimeKind.Utc);
+
+        var d = holidayCalendar.GetNextIncludedTimeUtc(time);
+        d.Should().Be(expected);
     }
 }

--- a/src/Quartz/Impl/Calendar/HolidayCalendar.cs
+++ b/src/Quartz/Impl/Calendar/HolidayCalendar.cs
@@ -126,10 +126,14 @@ public sealed class HolidayCalendar : BaseCalendar
             return false;
         }
 
-        //apply the timezone
-        timeStampUtc = TimeZoneUtil.ConvertTime(timeStampUtc, TimeZone);
-        DateTime lookFor = timeStampUtc.Date;
+        return IsTimeIncludedThisCalendar(timeStampUtc);
+    }
 
+    private bool IsTimeIncludedThisCalendar(DateTimeOffset timeStampUtc)
+    {
+        // apply the timezone
+        timeStampUtc = TimeZoneUtil.ConvertTime(timeStampUtc, TimeZone);
+        var lookFor = timeStampUtc.Date;
         return !dates.Contains(lookFor);
     }
 
@@ -154,13 +158,18 @@ public sealed class HolidayCalendar : BaseCalendar
 
         // Get timestamp for 00:00:00, with the correct timezone offset
         DateTimeOffset day = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);
-
-        while (!IsTimeIncluded(day))
+        while (!IsTimeIncludedThisCalendar(day) || !base.IsTimeIncluded(timeUtc))
         {
             day = day.AddDays(1);
+            timeUtc = timeUtc.AddDays(1);
+            //ensure earliest value is assigned to return value
+            if (day < timeUtc)
+            {
+                timeUtc = day;
+            }
         }
 
-        return day;
+        return timeUtc;
     }
 
     /// <summary>


### PR DESCRIPTION
Fix issue with Holiday Calendar not identifying a date included due to checking modified DateOnly value with base
Resulting in an exception from hitting year 9999.

- Changed to compare original date value with base Calendars, and date only value with current calendar validator (not base calendars). 
- Add scenario described in #2270 

## Notes
Naming is hard, not sure `IsTimeIncludedThisCalendar` is a good name
I did not check other day calendar types, perhaps the scenario exists in other calendars in similar configuration