### PR TITLE
Improve performance of DailyCalendar solving GetNextIncludedTimeUtc  #2270

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
@@ -71,6 +71,19 @@ namespace Quartz.Tests.Unit.Impl.Calendar
             Assert.AreEqual(expectedStartTime, dailyCalendar.GetTimeRangeStartingTimeUtc(d).DateTime);
             Assert.AreEqual(expectedEndTime, dailyCalendar.GetTimeRangeEndingTimeUtc(d).DateTime);
         }
+        
+        [Test]
+        public void EnsureCalendarCanWorkWithMillisecondPrecision()
+        {
+            var  calendar = new DailyCalendar("14:25:10:05", "14:50");
+            
+            var time = new DateTime(2024, 2, 5, 10, 6, 0, DateTimeKind.Utc);
+            var expected = new DateTime(2024, 2, 5, 10, 6, 0,1, DateTimeKind.Utc);
+
+            var d = calendar.GetNextIncludedTimeUtc(time); 
+            d.Should().Be(expected);
+        }
+        
 
         [Test]
         public void TestStringInvertTimeRange()

--- a/src/Quartz.Tests.Unit/Impl/Calendar/NestedCalendarTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/NestedCalendarTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Tests.Unit.Impl.Calendar;
+
+public class NestedCalendarTests
+{
+    [Test]
+    public void NestedCalendarGetNextIncludedTimeUtc_AndCompletes_WithinExpectedTime()
+    {
+        // Perf Test - Original but was similar setup would take > 10secs. We need to provide enough space for slow CI.
+        const int ExpectToFinishInSeconds = 5;
+        var timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+        var holidayCalendar = new HolidayCalendar
+        {
+            TimeZone = timeZone,
+        };
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 2, 19));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 5, 27));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 6, 19));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 7, 4));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 9, 2));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 10, 14));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 11, 11));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 11, 28));
+        holidayCalendar.AddExcludedDate(new DateTime(2024, 12, 25));
+
+        var weeklyCalendar = new WeeklyCalendar(holidayCalendar)
+        {
+            TimeZone = timeZone,
+        };
+        
+        weeklyCalendar.SetDayExcluded(DayOfWeek.Tuesday, true);
+        
+        var calendar = new DailyCalendar(weeklyCalendar, "06:00", "22:00")
+        {
+            TimeZone = timeZone,
+            InvertTimeRange = true,
+        };
+        var time = new DateTime(2024, 2, 5, 10, 6, 0, DateTimeKind.Utc);
+        var expected = new DateTime(2024, 2, 5, 14, 0, 0, DateTimeKind.Utc);
+
+        var d = calendar.GetNextIncludedTimeUtc(time); 
+        d.Should().Be(expected);
+        
+        calendar.ExecutionTimeOf(cal => cal.GetNextIncludedTimeUtc(time).Should().BeLessThan(TimeSpan.FromSeconds(ExpectToFinishInSeconds)));
+    }
+}

--- a/src/Quartz/Impl/Calendar/DailyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/DailyCalendar.cs
@@ -47,8 +47,6 @@ namespace Quartz.Impl.Calendar
     /// as, for example, WeeklyCalendar defines a set of days that are
     /// excluded <i>every week</i>. Likewise, <see cref="DailyCalendar" /> defines a
     /// set of times that are excluded <i>every day</i>.
-    ///
-    /// The minimum resolution of time supported by this calendar is one second.
     /// </para>
     /// </remarks>
     /// <author>Mike Funk</author>
@@ -63,7 +61,6 @@ namespace Quartz.Impl.Calendar
         private const string InvalidMillis = "Invalid millis: ";
         private const string InvalidTimeRange = "Invalid time range: ";
         private const string Separator = " - ";
-        private const long OneSecondInMillis = 1000;
         private const char Colon = ':';
 
         private const string TwoDigitFormat = "00";
@@ -80,6 +77,7 @@ namespace Quartz.Impl.Calendar
         private int rangeEndingMinute;
         private int rangeEndingSecond;
         private int rangeEndingMillis;
+        private int precisionStepMillis = 1000;
 
         private DailyCalendar()
         {
@@ -481,7 +479,7 @@ namespace Quartz.Impl.Calendar
         /// <seealso cref="ICalendar.GetNextIncludedTimeUtc"/>
         public override DateTimeOffset GetNextIncludedTimeUtc(DateTimeOffset timeUtc)
         {
-            DateTimeOffset nextIncludedTime = timeUtc.AddMilliseconds(OneSecondInMillis);
+            DateTimeOffset nextIncludedTime = timeUtc.AddMilliseconds(precisionStepMillis);
 
             while (!IsTimeIncluded(nextIncludedTime))
             {
@@ -499,7 +497,7 @@ namespace Quartz.Impl.Calendar
                         GetTimeRangeEndingTimeUtc(nextIncludedTime))
                     {
                         nextIncludedTime =
-                            GetTimeRangeEndingTimeUtc(nextIncludedTime).AddMilliseconds(OneSecondInMillis);
+                            GetTimeRangeEndingTimeUtc(nextIncludedTime).AddMilliseconds(precisionStepMillis);
                     }
                     else if (CalendarBase != null &&
                              !CalendarBase.IsTimeIncluded(nextIncludedTime))
@@ -509,7 +507,7 @@ namespace Quartz.Impl.Calendar
                     }
                     else
                     {
-                        nextIncludedTime = nextIncludedTime.AddMilliseconds(OneSecondInMillis);
+                        nextIncludedTime = nextIncludedTime.AddMilliseconds(precisionStepMillis);
                     }
                 }
                 else
@@ -531,7 +529,7 @@ namespace Quartz.Impl.Calendar
                     {
                         //(move to start of next day)
                         nextIncludedTime = GetEndOfDay(nextIncludedTime);
-                        nextIncludedTime = nextIncludedTime.AddMilliseconds(OneSecondInMillis);
+                        nextIncludedTime = nextIncludedTime.AddMilliseconds(precisionStepMillis);
                     }
                     else if (CalendarBase != null &&
                              !CalendarBase.IsTimeIncluded(nextIncludedTime))
@@ -541,7 +539,7 @@ namespace Quartz.Impl.Calendar
                     }
                     else
                     {
-                        nextIncludedTime = nextIncludedTime.AddMilliseconds(OneSecondInMillis);
+                        nextIncludedTime = nextIncludedTime.AddMilliseconds(precisionStepMillis);
                     }
                 }
             }
@@ -765,6 +763,22 @@ namespace Quartz.Impl.Calendar
             this.rangeEndingMinute = rangeEndingMinute;
             this.rangeEndingSecond = rangeEndingSecond;
             this.rangeEndingMillis = rangeEndingMillis;
+            
+          CalculationPrecisionStep();
+        }
+
+        private void CalculationPrecisionStep()
+        {
+            if (rangeStartingMillis != 0 || rangeEndingMillis != 0)
+            {
+                precisionStepMillis = 1;
+            }
+            else if (rangeStartingSecond != 0 || rangeEndingSecond != 0)
+            {
+                precisionStepMillis = 1000;
+            }
+            else 
+                precisionStepMillis = 60000;
         }
 
         /// <summary>

--- a/src/Quartz/Impl/Calendar/DailyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/DailyCalendar.cs
@@ -47,6 +47,8 @@ namespace Quartz.Impl.Calendar
     /// as, for example, WeeklyCalendar defines a set of days that are
     /// excluded <i>every week</i>. Likewise, <see cref="DailyCalendar" /> defines a
     /// set of times that are excluded <i>every day</i>.
+    ///
+    /// The minimum resolution of time supported by this calendar is one second.
     /// </para>
     /// </remarks>
     /// <author>Mike Funk</author>
@@ -61,7 +63,7 @@ namespace Quartz.Impl.Calendar
         private const string InvalidMillis = "Invalid millis: ";
         private const string InvalidTimeRange = "Invalid time range: ";
         private const string Separator = " - ";
-        private const long OneMillis = 1;
+        private const long OneSecondInMillis = 1000;
         private const char Colon = ':';
 
         private const string TwoDigitFormat = "00";
@@ -479,7 +481,7 @@ namespace Quartz.Impl.Calendar
         /// <seealso cref="ICalendar.GetNextIncludedTimeUtc"/>
         public override DateTimeOffset GetNextIncludedTimeUtc(DateTimeOffset timeUtc)
         {
-            DateTimeOffset nextIncludedTime = timeUtc.AddMilliseconds(OneMillis);
+            DateTimeOffset nextIncludedTime = timeUtc.AddMilliseconds(OneSecondInMillis);
 
             while (!IsTimeIncluded(nextIncludedTime))
             {
@@ -497,7 +499,7 @@ namespace Quartz.Impl.Calendar
                         GetTimeRangeEndingTimeUtc(nextIncludedTime))
                     {
                         nextIncludedTime =
-                            GetTimeRangeEndingTimeUtc(nextIncludedTime).AddMilliseconds(OneMillis);
+                            GetTimeRangeEndingTimeUtc(nextIncludedTime).AddMilliseconds(OneSecondInMillis);
                     }
                     else if (CalendarBase != null &&
                              !CalendarBase.IsTimeIncluded(nextIncludedTime))
@@ -507,7 +509,7 @@ namespace Quartz.Impl.Calendar
                     }
                     else
                     {
-                        nextIncludedTime = nextIncludedTime.AddMilliseconds(1);
+                        nextIncludedTime = nextIncludedTime.AddMilliseconds(OneSecondInMillis);
                     }
                 }
                 else
@@ -529,7 +531,7 @@ namespace Quartz.Impl.Calendar
                     {
                         //(move to start of next day)
                         nextIncludedTime = GetEndOfDay(nextIncludedTime);
-                        nextIncludedTime = nextIncludedTime.AddMilliseconds(1);
+                        nextIncludedTime = nextIncludedTime.AddMilliseconds(OneSecondInMillis);
                     }
                     else if (CalendarBase != null &&
                              !CalendarBase.IsTimeIncluded(nextIncludedTime))
@@ -539,7 +541,7 @@ namespace Quartz.Impl.Calendar
                     }
                     else
                     {
-                        nextIncludedTime = nextIncludedTime.AddMilliseconds(1);
+                        nextIncludedTime = nextIncludedTime.AddMilliseconds(OneSecondInMillis);
                     }
                 }
             }


### PR DESCRIPTION
## Change
Improve performance of `DailyCalendar` solving `GetNextIncludedTimeUtc` by changing the stepping increment based on the Start/End range of the DailyCalendar parameters.

## Observations
In the original issue OP noted this took >13 seconds.
With a similar test, it is now milliseconds.

fixes #2270