### PR TITLE
Refactor code to use TimeProvider.System

### DIFF
--- a/Analyzers/BannedSymbols.txt
+++ b/Analyzers/BannedSymbols.txt
@@ -1,0 +1,5 @@
+P:System.DateTime.Now; Use TimeProvider.GetLocalNow().DateTime instead.
+P:System.DateTime.Today; Use TimeProvider.GetLocalNow().DateTime.Date instead.
+P:System.DateTimeOffset.Now; Use TimeProvider.GetLocalNow() instead.
+P:System.DateTimeOffset.Today; Use TimeProvider.GetLocalNow().Date instead.
+M:System.DateTimeOffset.op_Implicit(System.DateTime); Do not implicitly cast DateTime to DateTimeOffset.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.7" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="8.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />

--- a/Quartz.sln
+++ b/Quartz.sln
@@ -70,6 +70,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quartz.Serialization.System
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{32367329-6157-4580-BB06-F7DD68FC1658}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Analyzers", "Analyzers", "{CBE8BDDE-B71F-4A95-B184-E6CBEBE40231}"
+	ProjectSection(SolutionItems) = preProject
+		Analyzers\bannedsymbols.txt = Analyzers\bannedsymbols.txt
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -160,6 +165,7 @@ Global
 		{12EA4497-DCEC-4C1A-83BD-FFAFA2C01A25} = {32367329-6157-4580-BB06-F7DD68FC1658}
 		{54FCAFBB-0040-4FBB-96BB-0AE9C70742B0} = {32367329-6157-4580-BB06-F7DD68FC1658}
 		{98DAF894-D837-47EC-9472-50C832AFC8B2} = {32367329-6157-4580-BB06-F7DD68FC1658}
+		{CBE8BDDE-B71F-4A95-B184-E6CBEBE40231} = {7E6034DE-2AF7-42CE-B9E3-A1B3B582E6DA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8666F1F-9B78-4A1D-A3DB-0E91324AB539}

--- a/src/Quartz/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/ServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ public static class ServiceCollectionExtensions
             services.TryAddSingleton(typeof(ITypeLoadHelper), typeof(SimpleTypeLoadHelper));
         }
 
+        services.TryAddSingleton(TimeProvider.System);
         if (string.IsNullOrWhiteSpace(properties[StdSchedulerFactory.PropertySchedulerJobFactoryType]))
         {
             // there's no explicit job factory defined, use MS version

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -261,8 +261,6 @@ public sealed class CronExpression : ISerializable
     /// </summary>
     [NonSerialized] private bool calendarDayOfMonth;
 
-    public static readonly int MaxYear =  TimeProvider.System.GetLocalNow().Year + 100;
-
     private static readonly Regex regex = new("^L(-\\d{1,2})?(W(-\\d{1,2})?)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(5)); //e.g. LW L-0W L-4 L-12W LW-4 LW-12
     private static readonly Regex offsetRegex = new("LW-(?<offset>[0-9]+)", RegexOptions.Compiled | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(5));
 
@@ -1219,7 +1217,7 @@ public sealed class CronExpression : ISerializable
         {
             if (stopAt == -1)
             {
-                stopAt = MaxYear;
+                stopAt = CronExpressionConstants.MaxYear;
             }
             if (startAt is -1 or CronExpressionConstants.AllSpec)
             {
@@ -1959,7 +1957,7 @@ public sealed class CronExpression : ISerializable
             }
 
             // test for expressions that never generate a valid fire date,
-            if (nextFireTimeCursor.Date == null || nextFireTimeCursor.Date.Value.Year > MaxYear)
+            if (nextFireTimeCursor.Date == null || nextFireTimeCursor.Date.Value.Year > CronExpressionConstants.MaxYear)
             {
                 return null; // ran out of years
             }

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -26,6 +26,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 
+using Quartz.Configuration;
 using Quartz.Util;
 
 namespace Quartz;
@@ -260,7 +261,7 @@ public sealed class CronExpression : ISerializable
     /// </summary>
     [NonSerialized] private bool calendarDayOfMonth;
 
-    public static readonly int MaxYear = DateTime.Now.Year + 100;
+    public static readonly int MaxYear =  TimeProvider.System.GetLocalNow().Year + 100;
 
     private static readonly Regex regex = new("^L(-\\d{1,2})?(W(-\\d{1,2})?)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(5)); //e.g. LW L-0W L-4 L-12W LW-4 LW-12
     private static readonly Regex offsetRegex = new("LW-(?<offset>[0-9]+)", RegexOptions.Compiled | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(5));

--- a/src/Quartz/CronExpressionConstants.cs
+++ b/src/Quartz/CronExpressionConstants.cs
@@ -46,4 +46,10 @@ internal static class CronExpressionConstants
     /// Field specification for no specification at all '?'.
     /// </summary>
     public const int NoSpec = 98;
+
+
+    /// <summary>
+    /// Max Year to stop processing at.
+    /// </summary>
+    public const int MaxYear = 2200;
 }

--- a/src/Quartz/DateBuilder.cs
+++ b/src/Quartz/DateBuilder.cs
@@ -63,8 +63,18 @@ public sealed class DateBuilder
     private int second;
     private TimeZoneInfo? tz;
 
-    private DateBuilder(TimeProvider timeProvider)
+    /// <summary>
+    /// Create a DateBuilder, with initial settings for the current date and time in the given timezone.
+    /// </summary>
+    /// <param name="timeProvider"></param>
+    /// <param name="tz"></param>
+    private DateBuilder(TimeProvider timeProvider, TimeZoneInfo? tz = null)
     {
+        if (tz != null)
+        {
+            this.tz = tz;
+        }
+
         DateTime now = timeProvider.GetLocalNow().DateTime;
 
         month = now.Month;
@@ -76,33 +86,24 @@ public sealed class DateBuilder
     }
 
     /// <summary>
-    /// Create a DateBuilder, with initial settings for the current date and time in the given timezone.
-    /// </summary>
-    /// <param name="tz"></param>
-    /// <param name="timeProvider"></param>
-    private DateBuilder(TimeZoneInfo tz, TimeProvider timeProvider)
-        : this(timeProvider)
-    {
-        this.tz = tz;
-    }
-
-    /// <summary>
     /// Create a DateBuilder, with initial settings for the current date and time in the system default timezone.
     /// </summary>
+    /// <param name="timeProvider"></param>
     /// <returns></returns>
-    public static DateBuilder NewDate()
+    public static DateBuilder NewDate(TimeProvider? timeProvider = null)
     {
-        return new DateBuilder(TimeProvider.System);
+        return timeProvider == null ? new DateBuilder(TimeProvider.System) : new DateBuilder(timeProvider);
     }
 
     /// <summary>
     /// Create a DateBuilder, with initial settings for the current date and time in the given timezone.
     /// </summary>
     /// <param name="tz">Time zone to use.</param>
+    /// <param name="timeProvider"></param>
     /// <returns></returns>
-    public static DateBuilder NewDateInTimeZone(TimeZoneInfo tz)
+    public static DateBuilder NewDateInTimeZone(TimeZoneInfo tz, TimeProvider? timeProvider = null)
     {
-        return new DateBuilder(tz, TimeProvider.System);
+        return timeProvider == null ? new DateBuilder(TimeProvider.System, tz) : new DateBuilder(timeProvider, tz);
     }
 
     /// <summary>

--- a/src/Quartz/DateBuilder.cs
+++ b/src/Quartz/DateBuilder.cs
@@ -63,13 +63,9 @@ public sealed class DateBuilder
     private int second;
     private TimeZoneInfo? tz;
 
-    /// <summary>
-    /// Create a DateBuilder, with initial settings for the current date
-    /// and time in the system default timezone.
-    /// </summary>
-    private DateBuilder()
+    private DateBuilder(TimeProvider timeProvider)
     {
-        DateTime now = DateTime.Now;
+        DateTime now = timeProvider.GetLocalNow().DateTime;
 
         month = now.Month;
         day = now.Day;
@@ -79,22 +75,14 @@ public sealed class DateBuilder
         second = now.Second;
     }
 
-
     /// <summary>
     /// Create a DateBuilder, with initial settings for the current date and time in the given timezone.
     /// </summary>
     /// <param name="tz"></param>
-    private DateBuilder(TimeZoneInfo tz)
+    /// <param name="timeProvider"></param>
+    private DateBuilder(TimeZoneInfo tz, TimeProvider timeProvider)
+        : this(timeProvider)
     {
-        DateTime now = DateTime.Now;
-
-        month = now.Month;
-        day = now.Day;
-        year = now.Year;
-        hour = now.Hour;
-        minute = now.Minute;
-        second = now.Second;
-
         this.tz = tz;
     }
 
@@ -104,7 +92,7 @@ public sealed class DateBuilder
     /// <returns></returns>
     public static DateBuilder NewDate()
     {
-        return new DateBuilder();
+        return new DateBuilder(TimeProvider.System);
     }
 
     /// <summary>
@@ -114,7 +102,7 @@ public sealed class DateBuilder
     /// <returns></returns>
     public static DateBuilder NewDateInTimeZone(TimeZoneInfo tz)
     {
-        return new DateBuilder(tz);
+        return new DateBuilder(tz, TimeProvider.System);
     }
 
     /// <summary>
@@ -259,7 +247,7 @@ public sealed class DateBuilder
         ValidateMinute(minute);
         ValidateHour(hour);
 
-        DateTimeOffset now = DateTimeOffset.Now;
+        DateTimeOffset now = TimeProvider.System.GetLocalNow();
         DateTimeOffset c = new DateTimeOffset(
             now.Year,
             now.Month,

--- a/src/Quartz/Impl/Calendar/AnnualCalendar.cs
+++ b/src/Quartz/Impl/Calendar/AnnualCalendar.cs
@@ -180,9 +180,9 @@ public sealed class AnnualCalendar : BaseCalendar
     /// <summary>
     /// Redefine a certain day to be excluded (true) or included (false).
     /// </summary>
-    public void SetDayExcluded(DateTime day, bool exclude)
+    public void SetDayExcluded(DateTimeOffset day, bool exclude)
     {
-        DateTime d = new DateTime(FixedYear, day.Month, day.Day, 0, 0, 0);
+        DateTime d = new (FixedYear, day.Month, day.Day, 0, 0, 0);
 
         if (exclude)
         {

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -54,7 +54,7 @@ namespace Quartz.Impl.Triggers;
 [Serializable]
 public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarIntervalTrigger
 {
-    private static readonly int YearToGiveupSchedulingAt = DateTime.Now.AddYears(100).Year;
+    private static readonly int YearToGiveupSchedulingAt = TimeProvider.System.GetLocalNow().AddYears(100).Year;
 
     private DateTimeOffset startTime;
     private DateTimeOffset? endTime;

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -54,8 +54,6 @@ namespace Quartz.Impl.Triggers;
 [Serializable]
 public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarIntervalTrigger
 {
-    private static readonly int YearToGiveupSchedulingAt = TimeProvider.System.GetLocalNow().AddYears(100).Year;
-
     private DateTimeOffset startTime;
     private DateTimeOffset? endTime;
     private DateTimeOffset? nextFireTimeUtc; // Making a public property which called GetNextFireTime/SetNextFireTime would make the json attribute unnecessary
@@ -66,7 +64,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
     // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
     // but there's not yet a good method of serializing/deserializing timezones cross-platform since Windows timezone IDs don't
     // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
-    // on timelines, it may be worth doign the mapping here.
+    // on timelines, it may be worth doing the mapping here.
     // More info: https://github.com/dotnet/corefx/issues/7757
     private string? timeZoneInfoId
     {
@@ -408,7 +406,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
             }
 
             //avoid infinite loop
-            if (nextFireTimeUtc.Value.Year > YearToGiveupSchedulingAt)
+            if (nextFireTimeUtc.Value.Year > TriggerConstants.YearToGiveupSchedulingAt)
             {
                 nextFireTimeUtc = null;
             }
@@ -446,7 +444,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
             }
 
             //avoid infinite loop
-            if (nextFireTimeUtc.Value.Year > YearToGiveupSchedulingAt)
+            if (nextFireTimeUtc.Value.Year > TriggerConstants.YearToGiveupSchedulingAt)
             {
                 nextFireTimeUtc = null;
             }
@@ -497,7 +495,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
             }
 
             //avoid infinite loop
-            if (nextFireTimeUtc.Value.Year > YearToGiveupSchedulingAt)
+            if (nextFireTimeUtc.Value.Year > TriggerConstants.YearToGiveupSchedulingAt)
             {
                 return null;
             }
@@ -656,12 +654,12 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
                 }
 
                 // now baby-step the rest of the way there...
-                while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < YearToGiveupSchedulingAt)
+                while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < TriggerConstants.YearToGiveupSchedulingAt)
                 {
                     sTime = sTime.AddDays(RepeatInterval);
                     MakeHourAdjustmentIfNeeded(ref sTime, initialHourOfDay); //hours can shift due to DST
                 }
-                while (DaylightSavingHourShiftOccurredAndAdvanceNeeded(ref sTime, initialHourOfDay) && sTime.Year < YearToGiveupSchedulingAt)
+                while (DaylightSavingHourShiftOccurredAndAdvanceNeeded(ref sTime, initialHourOfDay) && sTime.Year < TriggerConstants.YearToGiveupSchedulingAt)
                 {
                     sTime = sTime.AddDays(RepeatInterval);
                 }
@@ -699,12 +697,12 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
                     sTime = sTime.AddDays((int) (RepeatInterval * jumpCount * 7));
                 }
 
-                while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < YearToGiveupSchedulingAt)
+                while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < TriggerConstants.YearToGiveupSchedulingAt)
                 {
                     sTime = sTime.AddDays(RepeatInterval * 7);
                     MakeHourAdjustmentIfNeeded(ref sTime, initialHourOfDay); //hours can shift due to DST
                 }
-                while (DaylightSavingHourShiftOccurredAndAdvanceNeeded(ref sTime, initialHourOfDay) && sTime.Year < YearToGiveupSchedulingAt)
+                while (DaylightSavingHourShiftOccurredAndAdvanceNeeded(ref sTime, initialHourOfDay) && sTime.Year < TriggerConstants.YearToGiveupSchedulingAt)
                 {
                     sTime = sTime.AddDays(RepeatInterval * 7);
                 }
@@ -716,13 +714,13 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
                 // because months are already large blocks of time, we will
                 // just advance via brute-force iteration.
 
-                while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < YearToGiveupSchedulingAt)
+                while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < TriggerConstants.YearToGiveupSchedulingAt)
                 {
                     sTime = sTime.AddMonths(RepeatInterval);
                     MakeHourAdjustmentIfNeeded(ref sTime, initialHourOfDay); //hours can shift due to DST
                 }
                 while (DaylightSavingHourShiftOccurredAndAdvanceNeeded(ref sTime, initialHourOfDay)
-                       && sTime.Year < YearToGiveupSchedulingAt)
+                       && sTime.Year < TriggerConstants.YearToGiveupSchedulingAt)
                 {
                     sTime = sTime.AddMonths(RepeatInterval);
                 }
@@ -730,12 +728,12 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
             }
             else if (RepeatIntervalUnit == IntervalUnit.Year)
             {
-                while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < YearToGiveupSchedulingAt)
+                while (sTime.UtcDateTime < afterTime.Value.UtcDateTime && sTime.Year < TriggerConstants.YearToGiveupSchedulingAt)
                 {
                     sTime = sTime.AddYears(RepeatInterval);
                     MakeHourAdjustmentIfNeeded(ref sTime, initialHourOfDay); //hours can shift due to DST
                 }
-                while (DaylightSavingHourShiftOccurredAndAdvanceNeeded(ref sTime, initialHourOfDay) && sTime.Year < YearToGiveupSchedulingAt)
+                while (DaylightSavingHourShiftOccurredAndAdvanceNeeded(ref sTime, initialHourOfDay) && sTime.Year < TriggerConstants.YearToGiveupSchedulingAt)
                 {
                     sTime = sTime.AddYears(RepeatInterval);
                 }

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -184,6 +184,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     private DateTimeOffset? endTimeUtc;
     private DateTimeOffset? nextFireTimeUtc; // Making a public property which called GetNextFireTime/SetNextFireTime would make the json attribute unnecessary
     private DateTimeOffset? previousFireTimeUtc; // Making a public property which called GetPreviousFireTime/SetPreviousFireTime would make the json attribute unnecessary
+    private TimeProvider timeProvider;
 
     [NonSerialized] private TimeZoneInfo? timeZone;
 
@@ -211,6 +212,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     /// </remarks>
     public CronTriggerImpl()
     {
+        timeProvider = TimeProvider.System;
         StartTimeUtc = SystemTime.UtcNow();
         TimeZone = TimeZoneInfo.Local;
     }
@@ -242,6 +244,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     {
         StartTimeUtc = SystemTime.UtcNow();
         TimeZone = TimeZoneInfo.Local;
+        timeProvider = TimeProvider.System;
     }
 
     /// <summary>
@@ -261,6 +264,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         CronExpressionString = cronExpression;
         StartTimeUtc = SystemTime.UtcNow();
         TimeZone = TimeZoneInfo.Local;
+        timeProvider = TimeProvider.System;
     }
 
     /// <summary>
@@ -281,6 +285,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     {
         StartTimeUtc = SystemTime.UtcNow();
         TimeZone = TimeZoneInfo.Local;
+        timeProvider = TimeProvider.System;
     }
 
     /// <summary>
@@ -348,6 +353,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         string cronExpression)
         : base(name, group, jobName, jobGroup)
     {
+        timeProvider = TimeProvider.System;
         CronExpressionString = cronExpression;
 
         if (startTimeUtc == DateTimeOffset.MinValue)
@@ -386,6 +392,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         string cronExpression,
         TimeZoneInfo timeZone) : base(name, group, jobName, jobGroup)
     {
+        timeProvider = TimeProvider.System;
         CronExpressionString = cronExpression;
 
         if (startTimeUtc == DateTimeOffset.MinValue)
@@ -785,7 +792,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     {
         if (dayOnly)
         {
-            test = new DateTime(test.Year, test.Month, test.Day, 0, 0, 0);
+            test = new DateTimeOffset(test.Year, test.Month, test.Day, 0, 0, 0, timeProvider.LocalTimeZone.BaseUtcOffset);
         }
 
         DateTimeOffset? fta = GetFireTimeAfter(test.AddMilliseconds(-1 * 1000));

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -178,7 +178,7 @@ namespace Quartz.Impl.Triggers;
 [Serializable]
 public class CronTriggerImpl : AbstractTrigger, ICronTrigger
 {
-    private const int YearToGiveupSchedulingAt = 2299;
+    private const int YearToGiveupSchedulingAt = CronExpressionConstants.MaxYear;
     private CronExpression? cronEx;
     private DateTimeOffset startTimeUtc = DateTimeOffset.MinValue;
     private DateTimeOffset? endTimeUtc;
@@ -195,7 +195,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
     // but there's not yet a good method of serializing/deserializing timezones cross-platform since Windows timezone IDs don't
     // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
-    // on timelines, it may be worth doign the mapping here.
+    // on timelines, it may be worth doing the mapping here.
     // More info: https://github.com/dotnet/corefx/issues/7757
     private string? timeZoneInfoId
     {

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -78,9 +78,6 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// ending timestamp.
     /// </summary>
     public const int RepeatIndefinitely = -1;
-
-    private static readonly int YearToGiveupSchedulingAt = TimeProvider.System.GetLocalNow().AddYears(100).Year;
-
     private DateTimeOffset startTimeUtc;
     private DateTimeOffset? endTimeUtc;
     private DateTimeOffset? nextFireTimeUtc; // Making a public property which called GetNextFireTime/SetNextFireTime would make the json attribute unnecessary
@@ -440,7 +437,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
             }
 
             //avoid infinite loop
-            if (nextFireTimeUtc.Value.Year > YearToGiveupSchedulingAt)
+            if (nextFireTimeUtc.Value.Year > TriggerConstants.YearToGiveupSchedulingAt)
             {
                 nextFireTimeUtc = null;
             }
@@ -478,7 +475,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
             }
 
             //avoid infinite loop
-            if (nextFireTimeUtc.Value.Year > YearToGiveupSchedulingAt)
+            if (nextFireTimeUtc.Value.Year > TriggerConstants.YearToGiveupSchedulingAt)
             {
                 nextFireTimeUtc = null;
             }
@@ -530,7 +527,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
             }
 
             //avoid infinite loop
-            if (nextFireTimeUtc.Value.Year > YearToGiveupSchedulingAt)
+            if (nextFireTimeUtc.Value.Year > TriggerConstants.YearToGiveupSchedulingAt)
             {
                 return null;
             }

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -79,7 +79,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// </summary>
     public const int RepeatIndefinitely = -1;
 
-    private static readonly int YearToGiveupSchedulingAt = DateTime.Now.Year + 100;
+    private static readonly int YearToGiveupSchedulingAt = TimeProvider.System.GetLocalNow().AddYears(100).Year;
 
     private DateTimeOffset startTimeUtc;
     private DateTimeOffset? endTimeUtc;

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -31,9 +31,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\..\Analyzers\BannedSymbols.txt">
+      <Link>BannedSymbols.txt</Link>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/src/Quartz/SystemTime.cs
+++ b/src/Quartz/SystemTime.cs
@@ -10,10 +10,10 @@ public static class SystemTime
     /// <summary>
     /// Return current UTC time via <see cref="Func{TResult}" />. Allows easier unit testing.
     /// </summary>
-    public static Func<DateTimeOffset> UtcNow = () => DateTimeOffset.UtcNow;
+    public static Func<DateTimeOffset> UtcNow = () =>  TimeProvider.System.GetUtcNow();
 
     /// <summary>
     /// Return current time in current time zone via <see cref="Func&lt;T&gt;" />. Allows easier unit testing.
     /// </summary>
-    public static Func<DateTimeOffset> Now = () => DateTimeOffset.Now;
+    public static Func<DateTimeOffset> Now = () =>  TimeProvider.System.GetLocalNow();
 }

--- a/src/Quartz/TriggerConstants.cs
+++ b/src/Quartz/TriggerConstants.cs
@@ -9,4 +9,6 @@ public static class TriggerConstants
     /// The default value for priority.
     /// </summary>
     public const int DefaultPriority = 5;
+
+    public const int YearToGiveupSchedulingAt = 2200;
 }

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -59,11 +59,6 @@ public static class TimeZoneUtil
     /// <returns></returns>
     public static DateTimeOffset ConvertTime(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
     {
-        if (QuartzEnvironment.IsRunningOnMono)
-        {
-            return TimeZoneInfo.ConvertTime(dateTimeOffset.UtcDateTime, TimeZoneInfo.Utc, timeZoneInfo);
-        }
-
         return TimeZoneInfo.ConvertTime(dateTimeOffset, timeZoneInfo);
     }
 

--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -429,7 +429,7 @@ public class XMLSchedulingDataProcessor
                 }
             }
 
-            DateTime? triggerEndTime = triggerNode.Item.endtimeSpecified ? triggerNode.Item.endtime : null;
+            DateTimeOffset? triggerEndTime = triggerNode.Item.endtimeSpecified ? new DateTimeOffset(triggerNode.Item.endtime) : null;
 
             IScheduleBuilder sched;
 


### PR DESCRIPTION
## Summary
Replace DateTime usage with TimeProvider.System
Replace implicit DateTime to DateTimeOffset conversions with explicit. Add in Analyzer to ensure DateTime isn't used.
Remove a check for IsRUnningOnMono. As it is no longer one of the supported deployment frameworks. Registers a TimeProvider in DI (but is not using it)

`Bcl.TimeProvider` supports Net8, net 4.6.2 ; Netstandard 2.0

❌ This does NOT implement DI for TimeProvider.  A few usage of DateTime are in static variables and private constructors.  I believe this would possibly need a servicelocator to pull in as a dependency.  And would rather see the DI work handle this if possible.

Relates to #2079

