### PR TITLE
Fix Holiday Calendar with Nested Calendars sometimes crashing when resolving NextIncludedTime

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 [http://www.quartz-scheduler.net](http://www.quartz-scheduler.net)
 
+## Release 3.NEXT, TBD
+ 
+* Fix Holiday Calendar with Nested Calendars sometimes crashing when resolving NextIncludedTime (#2270)
+
+
 ## Release 3.8.1, Feb 17 2024
 
 * Fix handling of env var quartz.config (#2212)

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -1,5 +1,10 @@
-﻿using NUnit.Framework;
+﻿using System;
 
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using Quartz.Impl.Calendar;
 using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Utils
@@ -14,6 +19,33 @@ namespace Quartz.Tests.Unit.Utils
             var infoWithUniversalCoordinatedTime = TimeZoneUtil.FindTimeZoneById("Coordinated Universal Time");
 
             Assert.AreEqual(infoWithUtc, infoWithUniversalCoordinatedTime);
+        }
+
+        [Test]
+        public void GetNextIncludedTimeUtc_CrashOriginal2270()
+        {
+            TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+            var weeklyCalendar = new WeeklyCalendar() { TimeZone = timeZone, };
+
+            var dailyCalendar = new DailyCalendar(weeklyCalendar, "06:00", "22:00") { TimeZone = timeZone, InvertTimeRange = true, };
+
+            var holidayCalendar = new HolidayCalendar(dailyCalendar) { TimeZone = timeZone, };
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 2, 19));
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 5, 27));
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 6, 19));
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 7, 4));
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 9, 2));
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 10, 14));
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 11, 11));
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 11, 28));
+            holidayCalendar.AddExcludedDate(new DateTime(2024, 12, 25));
+
+            var time = new DateTime(2024, 2, 5, 10, 6, 0, DateTimeKind.Utc);
+            var expected = new DateTime(2024, 2, 5, 14, 0, 0, DateTimeKind.Utc);
+
+            var d = holidayCalendar.GetNextIncludedTimeUtc(time);
+            d.Should().Be(expected);
         }
     }
 }

--- a/src/Quartz/Impl/Calendar/HolidayCalendar.cs
+++ b/src/Quartz/Impl/Calendar/HolidayCalendar.cs
@@ -121,16 +121,20 @@ namespace Quartz.Impl.Calendar
 		/// </para>
 		/// </summary>
         public override bool IsTimeIncluded(DateTimeOffset timeStampUtc)
-		{
-			if (!base.IsTimeIncluded(timeStampUtc))
-			{
-				return false;
-			}
+	    {
+		    if (!base.IsTimeIncluded(timeStampUtc))
+		    {
+			    return false;
+		    }
 
+            return IsTimeIncludedThisCalendar(timeStampUtc);
+        }
+
+        private bool IsTimeIncludedThisCalendar(DateTimeOffset timeStampUtc)
+        {
             //apply the timezone
             timeStampUtc = TimeZoneUtil.ConvertTime(timeStampUtc, TimeZone);
-            DateTime lookFor = timeStampUtc.Date;
-
+            var lookFor = timeStampUtc.Date;
             return !dates.Contains(lookFor);
 		}
 
@@ -155,13 +159,18 @@ namespace Quartz.Impl.Calendar
 
             // Get timestamp for 00:00:00, with the correct timezone offset
             DateTimeOffset day = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);
-
-			while (!IsTimeIncluded(day))
+            while (!IsTimeIncludedThisCalendar(day) || !base.IsTimeIncluded(timeUtc))
 			{
 				day = day.AddDays(1);
+            timeUtc = timeUtc.AddDays(1);
+            //ensure earliest value is assigned to return value
+            if (day < timeUtc)
+            {
+                timeUtc = day;
+            }
 			}
 
-            return day;
+            return timeUtc;
 		}
 
 	    /// <summary>


### PR DESCRIPTION
Fix Holiday Calendar with Nested Calendars sometimes crashing when resolving NextIncludedTime

Picked from main.

Resolves #2270 