### PR TITLE
Make ScopedJob implement IAsyncDisposable (3.x branch)

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/Simpl/MicrosoftDependencyInjectionJobFactory.cs
@@ -33,7 +33,12 @@ namespace Quartz.Simpl
             var scope = serviceProvider.CreateScope();
             ConfigureScope(scope, bundle, scheduler);
             var (job, fromContainer) = CreateJob(bundle, scope.ServiceProvider);
+
+#if NET6_0_OR_GREATER
+            return new AsyncScopedJob(scope, job, canDispose: !fromContainer);
+#else
             return new ScopedJob(scope, job, canDispose: !fromContainer);
+#endif
         }
 
         protected virtual void ConfigureScope(IServiceScope scope, TriggerFiredBundle bundle, IScheduler scheduler)
@@ -60,11 +65,6 @@ namespace Quartz.Simpl
             }
             
             return (activatorCache.CreateInstance(serviceProvider, bundle.JobDetail.JobType), false);
-        }
-
-        public override void ReturnJob(IJob job)
-        {
-            (job as IDisposable)?.Dispose();
         }
 
         private sealed class ScopedJob : IJob, IJobWrapper, IDisposable
@@ -96,5 +96,53 @@ namespace Quartz.Simpl
                 return InnerJob.Execute(context);
             }
         }
+
+
+#if NET6_0_OR_GREATER
+        private sealed class AsyncScopedJob : IJob, IJobWrapper, IAsyncDisposable
+        {
+            private readonly IServiceScope scope;
+            private readonly bool canDispose;
+
+            public AsyncScopedJob(IServiceScope scope, IJob innerJob, bool canDispose)
+            {
+                this.scope = scope;
+                this.canDispose = canDispose;
+                InnerJob = innerJob;
+            }
+            
+            internal IJob InnerJob { get; }
+            public IJob Target => InnerJob;
+
+            public async ValueTask DisposeAsync()
+            {
+                if (canDispose)
+                {
+                    if (InnerJob is IAsyncDisposable asyncDisposableInnerJob)
+                    {
+                        await asyncDisposableInnerJob.DisposeAsync().ConfigureAwait(false);
+                    }
+                    else if (InnerJob is IDisposable disposableInnerJob)
+                    {
+                        disposableInnerJob.Dispose();
+                    }
+                }
+
+                if (scope is IAsyncDisposable scopeAsyncDisposable)
+                {
+                    await scopeAsyncDisposable.DisposeAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    scope.Dispose();
+                }
+            }
+
+            public Task Execute(IJobExecutionContext context)
+            {
+                return InnerJob.Execute(context);
+            }
+        }
+#endif
     }
 }

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -306,7 +306,11 @@ namespace Quartz.Core
                     var jobInstance = jec.jobInstance;
                     if (jobInstance != null)
                     {
+#if NET6_0_OR_GREATER
+                        await qs.JobFactory.ReturnJob(jobInstance).ConfigureAwait(false);
+#else
                         qs.JobFactory.ReturnJob(jobInstance);
+#endif
                     }
 
                     jec.Dispose();

--- a/src/Quartz/SPI/IJobFactory.cs
+++ b/src/Quartz/SPI/IJobFactory.cs
@@ -17,6 +17,9 @@
  */
 #endregion
 
+#if NET6_0_OR_GREATER
+using System.Threading.Tasks;
+#endif
 using Quartz.Simpl;
 
 namespace Quartz.Spi
@@ -60,9 +63,16 @@ namespace Quartz.Spi
 	    /// </returns>
 	    IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler);
 
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Allows the job factory to destroy/cleanup the job if needed.
+        /// </summary>
+	    Task ReturnJob(IJob job);
+#else
         /// <summary>
         /// Allows the job factory to destroy/cleanup the job if needed.
         /// </summary>
 	    void ReturnJob(IJob job);
+#endif
 	}
 }

--- a/src/Quartz/Simpl/SimpleJobFactory.cs
+++ b/src/Quartz/Simpl/SimpleJobFactory.cs
@@ -19,6 +19,10 @@
 
 using System;
 
+#if NET6_0_OR_GREATER
+using System.Threading.Tasks;
+#endif
+
 using Quartz.Logging;
 using Quartz.Spi;
 using Quartz.Util;
@@ -79,6 +83,22 @@ namespace Quartz.Simpl
 				throw se;
 			}
 		}
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Allows the job factory to destroy/cleanup the job if needed.
+        /// </summary>
+        public virtual async Task ReturnJob(IJob job)
+        {
+            if (job is IAsyncDisposable asyncDisposableJob)
+            {
+                await asyncDisposableJob.DisposeAsync().ConfigureAwait(false);
+            }
+            else if (job is IDisposable disposableJob)
+            {
+                disposableJob.Dispose();
+            }
+        }
+#else
 
 	    /// <summary>
 	    /// Allows the job factory to destroy/cleanup the job if needed.
@@ -89,5 +109,6 @@ namespace Quartz.Simpl
 	        var disposable = job as IDisposable;
 	        disposable?.Dispose();
 	    }
+#endif
 	}
 }


### PR DESCRIPTION
* Implement IAsyncDisposeable
* remove the overload of ReturnJob in MicrosoftDependencyInjectionJobFactory as it is the same as the base

Resolves https://github.com/quartznet/quartznet/issues/2332

Similar to https://github.com/quartznet/quartznet/pull/2333 but allows multi targeting for older new frameworks while still fixing the issue