### PR TITLE
Fix CronExpression not always returning correct next schedule for weekdayonly and month flags.  Relates to #2331

### DIFF
--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using System.Collections;
 using System.Diagnostics;
 
 using FluentAssertions;
@@ -995,4 +996,100 @@ years: *
 
         actualTimeAfter.Should().Be(expectedTimeAfter);
     }
+    
+    [TestCaseSource(typeof(CronTestScenarios), nameof(CronTestScenarios.TestCases))]
+    public void CronExpressionReturnsExpectedNextFireTime(CronExpression cronExpression, DateTimeOffset timeAfterDate, DateTimeOffset expectedNextFireTime)    {
+        var nextFireTime = cronExpression.GetTimeAfter(timeAfterDate);
+        nextFireTime.Value.Date.Should().Be(expectedNextFireTime.Date, "NextFireTime was not correct");
+    }
+}
+
+public class CronTestScenarios
+{
+    private class TestCaseProps
+    {
+        public CronExpression CronExpression { get; init; }
+
+        public DateTimeOffset TimeAfterDate { get; init; }
+
+        public DateTimeOffset ExpectedNextFireTime { get; init; }
+
+        public string TestCase { get; init; }
+    }
+
+    private static IEnumerable<TestCaseProps> TestCaseData =>
+    [
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 15W * ?"),
+            TimeAfterDate = new DateTimeOffset(2024, 5, 15, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2024, 6, 14, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on Weekday 15th Every Month - 2024-06-15 is a Sat, schedule should be Fri 14th"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 15W * ?"),
+            TimeAfterDate = new DateTimeOffset(2024, 8, 15, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2024, 9, 16, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on Weekday 15th Every Month - 2024-09-15 is a Sunday, expect schedule to be Mon 16th"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 15W * ?"),
+            TimeAfterDate = new DateTimeOffset(2023, 12, 15, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2024, 1, 15, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on Weekday 15th Every Month - 2024-01-15 is Monday, should run on Monday"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 31W * ?"),
+            TimeAfterDate = new DateTimeOffset(2025, 1, 31, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2025, 2, 28, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Test that next fire time to be in next month with less days in month - Issue #2330"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 LW * ?"),
+            TimeAfterDate = new DateTimeOffset(2023, 2, 28, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 3, 31, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on last weekday of the month - 2023-03-31 is a Friday"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 L-2 * ?"),
+            TimeAfterDate = new DateTimeOffset(2023, 4, 28, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 5, 29, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on the second-to-last day of the month"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 ? * 6L"),
+            TimeAfterDate = new DateTimeOffset(2023, 6, 24, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 6, 30, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on the last Friday of the month - 2023-06-30 is the last Friday"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 ? * 6#3"),
+            TimeAfterDate = new DateTimeOffset(2023, 7, 21, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 8, 18, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on the third Friday of the month"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 ? * 2/2"),
+            TimeAfterDate = new DateTimeOffset(2023, 9, 5, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 9, 6, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run every second day (/2) starting Monday (2)"
+        },
+        new TestCaseProps
+        {
+            CronExpression = new CronExpression("0 0 12 1W * ?"),
+            TimeAfterDate = new DateTimeOffset(2023, 10, 1, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 10, 2, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on the first weekday of the month - 2023-10-01 is a Sunday, expect schedule to be Mon 2nd"
+        }
+    ];
+
+    public static IEnumerable TestCases => TestCaseData.Select(model => new TestCaseData(model.CronExpression, model.TimeAfterDate, model.ExpectedNextFireTime));
 }

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -648,8 +648,9 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     public void TestQRTZNET152_Nearest_Weekday_Expression_W_Does_Not_Work_In_CronTrigger()
     {
         CronExpression expression = new CronExpression("0 5 13 5W 1-12 ?");
-        DateTimeOffset test = new DateTimeOffset(2009, 3, 8, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset test = new DateTimeOffset(2009, 3, 8, 0, 0, 0, TimeSpan.Zero); //Sunday
         DateTimeOffset d = expression.GetNextValidTimeAfter(test).Value;
+        // 2009-04-06 is Monday, Sunday is invalid for W
         Assert.AreEqual(new DateTimeOffset(2009, 4, 6, 13, 5, 0, TimeZoneUtil.GetUtcOffset(d, TimeZoneInfo.Local)).ToUniversalTime(), d);
         d = expression.GetNextValidTimeAfter(d).Value;
         Assert.AreEqual(new DateTimeOffset(2009, 5, 5, 13, 5, 0, TimeZoneUtil.GetUtcOffset(d, TimeZoneInfo.Local)), d);

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -129,6 +129,55 @@ public class CronWeekdayModifierTestData
             ExpectedNextFireTime = new DateTimeOffset(2024, 1, 15, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on Weekday 15th Every Month - 2024-01-15 is Monday, should run on Monday"
         },
+        new Model
+        {
+            CronExpression = new CronExpression("0 0 12 31W * ?"),
+            TimeAfterDate = new DateTimeOffset(2025, 1, 31, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2025, 2, 28, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Issue #2330 where exception moving to next month with less days in month"
+        },
+        new Model
+        {
+            CronExpression = new CronExpression("0 0 12 LW * ?"),
+            TimeAfterDate = new DateTimeOffset(2023, 2, 28, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 3, 31, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on last weekday of the month - 2023-03-31 is a Friday"
+        },
+        new Model
+        {
+            CronExpression = new CronExpression("0 0 12 L-2 * ?"),
+            TimeAfterDate = new DateTimeOffset(2023, 4, 28, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 5, 29, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on the second-to-last day of the month"
+        },
+        new Model
+        {
+            CronExpression = new CronExpression("0 0 12 ? * 6L"),
+            TimeAfterDate = new DateTimeOffset(2023, 6, 24, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 6, 30, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on the last Friday of the month - 2023-06-30 is the last Friday"
+        },
+        new Model
+        {
+            CronExpression = new CronExpression("0 0 12 ? * 6#3"),
+            TimeAfterDate = new DateTimeOffset(2023, 7, 21, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 8, 18, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on the third Friday of the month"
+        },
+        new Model
+        {
+            CronExpression = new CronExpression("0 0 12 ? * 2/2"),
+            TimeAfterDate = new DateTimeOffset(2023, 9, 5, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 9, 6, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run every second day (/2) starting monday (2)"
+        },
+        new Model
+        {
+            CronExpression = new CronExpression("0 0 12 1W * ?"),
+            TimeAfterDate = new DateTimeOffset(2023, 10, 1, 12, 0, 0, TimeSpan.Zero),
+            ExpectedNextFireTime = new DateTimeOffset(2023, 10, 2, 12, 0, 0, TimeSpan.Zero),
+            TestCase = "Run on the first weekday of the month - 2023-10-01 is a Sunday, expect schedule to be Mon 2nd"
+        }
     };
 
     public static IEnumerable TestCases => TestCaseModels.Select(model => new TestCaseData(model.CronExpression, model.TimeAfterDate, model.ExpectedNextFireTime));

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -19,10 +19,6 @@
 
 #endregion
 
-using System.Collections;
-
-using FluentAssertions;
-
 using Quartz.Impl.Calendar;
 using Quartz.Simpl;
 
@@ -35,12 +31,6 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
 {
     public CronCalendarTest(Type serializerType) : base(serializerType)
     {
-    }
-
-    [TestCaseSource(typeof(CronTestScenarios), nameof(CronTestScenarios.TestCases))]
-    public void CronWeekdayModifierReturnsNextExpectedFireTimeSet(CronExpression cronExpression, DateTimeOffset timeAfterDate, DateTimeOffset expectedNextFireTime)    {
-        var nextFireTime = cronExpression.GetTimeAfter(timeAfterDate);
-        nextFireTime.Value.Date.Should().Be(expectedNextFireTime.Date, "NextFireTime was not correct");
     }
 
     [Test]
@@ -91,94 +81,4 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
         Assert.AreEqual(original.CronExpression, deserialized.CronExpression);
         Assert.AreEqual(original.TimeZone, deserialized.TimeZone);
     }
-}
-
-public class CronTestScenarios
-{
-    private class TestCaseProps
-    {
-        public CronExpression CronExpression { get; init; }
-
-        public DateTimeOffset TimeAfterDate { get; init; }
-
-        public DateTimeOffset ExpectedNextFireTime { get; init; }
-
-        public string TestCase { get; init; }
-    }
-
-    private static IEnumerable<TestCaseProps> TestCaseData =>
-    [
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 15W * ?"),
-            TimeAfterDate = new DateTimeOffset(2024, 5, 15, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2024, 6, 14, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run on Weekday 15th Every Month - 2024-06-15 is a Sat, schedule should be Fri 14th"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 15W * ?"),
-            TimeAfterDate = new DateTimeOffset(2024, 8, 15, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2024, 9, 16, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run on Weekday 15th Every Month - 2024-09-15 is a Sunday, expect schedule to be Mon 16th"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 15W * ?"),
-            TimeAfterDate = new DateTimeOffset(2023, 12, 15, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2024, 1, 15, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run on Weekday 15th Every Month - 2024-01-15 is Monday, should run on Monday"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 31W * ?"),
-            TimeAfterDate = new DateTimeOffset(2025, 1, 31, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2025, 2, 28, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Test that next fire time to be in next month with less days in month - Issue #2330"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 LW * ?"),
-            TimeAfterDate = new DateTimeOffset(2023, 2, 28, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2023, 3, 31, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run on last weekday of the month - 2023-03-31 is a Friday"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 L-2 * ?"),
-            TimeAfterDate = new DateTimeOffset(2023, 4, 28, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2023, 5, 29, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run on the second-to-last day of the month"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 ? * 6L"),
-            TimeAfterDate = new DateTimeOffset(2023, 6, 24, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2023, 6, 30, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run on the last Friday of the month - 2023-06-30 is the last Friday"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 ? * 6#3"),
-            TimeAfterDate = new DateTimeOffset(2023, 7, 21, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2023, 8, 18, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run on the third Friday of the month"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 ? * 2/2"),
-            TimeAfterDate = new DateTimeOffset(2023, 9, 5, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2023, 9, 6, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run every second day (/2) starting Monday (2)"
-        },
-        new TestCaseProps
-        {
-            CronExpression = new CronExpression("0 0 12 1W * ?"),
-            TimeAfterDate = new DateTimeOffset(2023, 10, 1, 12, 0, 0, TimeSpan.Zero),
-            ExpectedNextFireTime = new DateTimeOffset(2023, 10, 2, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run on the first weekday of the month - 2023-10-01 is a Sunday, expect schedule to be Mon 2nd"
-        }
-    ];
-
-    public static IEnumerable TestCases => TestCaseData.Select(model => new TestCaseData(model.CronExpression, model.TimeAfterDate, model.ExpectedNextFireTime));
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -37,7 +37,7 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
     {
     }
 
-    [TestCaseSource(typeof(CronWeekdayModifierTestData), nameof(CronWeekdayModifierTestData.TestCases))]
+    [TestCaseSource(typeof(CronTestScenarios), nameof(CronTestScenarios.TestCases))]
     public void CronWeekdayModifierReturnsNextExpectedFireTimeSet(CronExpression cronExpression, DateTimeOffset timeAfterDate, DateTimeOffset expectedNextFireTime)    {
         var nextFireTime = cronExpression.GetTimeAfter(timeAfterDate);
         nextFireTime.Value.Date.Should().Be(expectedNextFireTime.Date, "NextFireTime was not correct");
@@ -93,9 +93,9 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
     }
 }
 
-public class CronWeekdayModifierTestData
+public class CronTestScenarios
 {
-    private class Model
+    private class TestCaseProps
     {
         public CronExpression CronExpression { get; init; }
 
@@ -106,79 +106,79 @@ public class CronWeekdayModifierTestData
         public string TestCase { get; init; }
     }
 
-    private static IEnumerable<Model> TestCaseModels => new[]
-    {
-        new Model
+    private static IEnumerable<TestCaseProps> TestCaseData =>
+    [
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 15W * ?"),
             TimeAfterDate = new DateTimeOffset(2024, 5, 15, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2024, 6, 14, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on Weekday 15th Every Month - 2024-06-15 is a Sat, schedule should be Fri 14th"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 15W * ?"),
             TimeAfterDate = new DateTimeOffset(2024, 8, 15, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2024, 9, 16, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on Weekday 15th Every Month - 2024-09-15 is a Sunday, expect schedule to be Mon 16th"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 15W * ?"),
             TimeAfterDate = new DateTimeOffset(2023, 12, 15, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2024, 1, 15, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on Weekday 15th Every Month - 2024-01-15 is Monday, should run on Monday"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 31W * ?"),
             TimeAfterDate = new DateTimeOffset(2025, 1, 31, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2025, 2, 28, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Issue #2330 where exception moving to next month with less days in month"
+            TestCase = "Test that next fire time to be in next month with less days in month - Issue #2330"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 LW * ?"),
             TimeAfterDate = new DateTimeOffset(2023, 2, 28, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2023, 3, 31, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on last weekday of the month - 2023-03-31 is a Friday"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 L-2 * ?"),
             TimeAfterDate = new DateTimeOffset(2023, 4, 28, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2023, 5, 29, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on the second-to-last day of the month"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 ? * 6L"),
             TimeAfterDate = new DateTimeOffset(2023, 6, 24, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2023, 6, 30, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on the last Friday of the month - 2023-06-30 is the last Friday"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 ? * 6#3"),
             TimeAfterDate = new DateTimeOffset(2023, 7, 21, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2023, 8, 18, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on the third Friday of the month"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 ? * 2/2"),
             TimeAfterDate = new DateTimeOffset(2023, 9, 5, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2023, 9, 6, 12, 0, 0, TimeSpan.Zero),
-            TestCase = "Run every second day (/2) starting monday (2)"
+            TestCase = "Run every second day (/2) starting Monday (2)"
         },
-        new Model
+        new TestCaseProps
         {
             CronExpression = new CronExpression("0 0 12 1W * ?"),
             TimeAfterDate = new DateTimeOffset(2023, 10, 1, 12, 0, 0, TimeSpan.Zero),
             ExpectedNextFireTime = new DateTimeOffset(2023, 10, 2, 12, 0, 0, TimeSpan.Zero),
             TestCase = "Run on the first weekday of the month - 2023-10-01 is a Sunday, expect schedule to be Mon 2nd"
         }
-    };
+    ];
 
-    public static IEnumerable TestCases => TestCaseModels.Select(model => new TestCaseData(model.CronExpression, model.TimeAfterDate, model.ExpectedNextFireTime));
+    public static IEnumerable TestCases => TestCaseData.Select(model => new TestCaseData(model.CronExpression, model.TimeAfterDate, model.ExpectedNextFireTime));
 }

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -1473,7 +1473,7 @@ private int CalculateNearestWeekdayForLastDay(DateTimeOffset currentDate, int la
 /// <param name="currentDate">The current date.</param>
 /// <param name="daysOfMonthSet">The set of days of the month.</param>
 /// <returns>A tuple containing the updated set of days of the month and a flag indicating if any day has a negative offset.</returns>
-private (SortedSet<int> daysOfMonthSet, bool dayHasNegativeOffset) CalculateNearestWeekdayForDaysOfMonth(DateTimeOffset currentDate, SortedSet<int> daysOfMonthSet)
+private static (SortedSet<int> daysOfMonthSet, bool dayHasNegativeOffset) CalculateNearestWeekdayForDaysOfMonth(DateTimeOffset currentDate, SortedSet<int> daysOfMonthSet)
 {
     int minDay = daysOfMonthSet.Min;
     int endDayOfMonth = GetLastDayOfMonth(currentDate.Month, currentDate.Year);
@@ -1500,7 +1500,7 @@ private (SortedSet<int> daysOfMonthSet, bool dayHasNegativeOffset) CalculateNear
 /// <param name="dayOfWeek">The day of the week.</param>
 /// <param name="endDayOfMonth">The end day of the month.</param>
 /// <returns>The adjusted day and a flag to indicate adjust day has a negative offset</returns>
-private (int day, bool dayHasNegativeOffset) AdjustDayToNearestWeekday(int day, DayOfWeek dayOfWeek, int endDayOfMonth)
+private static (int day, bool dayHasNegativeOffset) AdjustDayToNearestWeekday(int day, DayOfWeek dayOfWeek, int endDayOfMonth)
 {
     var dayHasNegativeOffset = false;
 

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -315,11 +315,13 @@ public sealed class CronExpression : ISerializable
                 {
                     timeZone = TimeZoneUtil.FindTimeZoneById(timeZoneId);
                 }
+
                 break;
             default:
                 ThrowHelper.ThrowNotSupportedException($"Unknown serialization version {version}");
                 break;
         }
+
         BuildExpression(CronExpressionString);
     }
 
@@ -477,11 +479,13 @@ public sealed class CronExpression : ISerializable
                         ThrowHelper.ThrowFormatException("Support for specifying 'L' with other days of the month is limited to one instance of L");
                     }
                 }
+
                 // throw an exception if L is used with other days of the week
                 if (exprOn == CronExpressionConstants.DayOfWeek && expr.IndexOf('L') != -1 && expr.Length > 1 && expr.IndexOf(',') >= 0)
                 {
                     ThrowHelper.ThrowFormatException("Support for specifying 'L' with other days of the week is not implemented");
                 }
+
                 if (exprOn == CronExpressionConstants.DayOfWeek && expr.IndexOf('#') != -1 && expr.Slice(expr.IndexOf('#') + 1 + 1).IndexOf('#') != -1)
                 {
                     ThrowHelper.ThrowFormatException("Support for specifying multiple \"nth\" days is not implemented.");
@@ -541,10 +545,12 @@ public sealed class CronExpression : ISerializable
         {
             ThrowHelper.ThrowFormatException("Illegal character after '?': " + s[i]);
         }
+
         if (type != CronExpressionConstants.DayOfWeek && type != CronExpressionConstants.DayOfMonth)
         {
             ThrowHelper.ThrowFormatException("'?' can only be specified for Day-of-Month or Day-of-Week.");
         }
+
         if (type == CronExpressionConstants.DayOfWeek && !lastDayOfMonth)
         {
             var val = daysOfMonth.LastOrDefault();
@@ -567,14 +573,17 @@ public sealed class CronExpression : ISerializable
             AddToSet(CronExpressionConstants.AllSpec, -1, incr, type);
             return;
         }
+
         if (c == '/' && (i + 1 >= s.Length || char.IsWhiteSpace(s[i + 1])))
         {
             ThrowHelper.ThrowFormatException("'/' must be followed by an integer.");
         }
+
         if (startsWithAsterisk)
         {
             i++;
         }
+
         c = s[i];
         if (c == '/')
         {
@@ -594,6 +603,7 @@ public sealed class CronExpression : ISerializable
             {
                 ThrowHelper.ThrowFormatException("Illegal characters after asterisk: " + s.ToString());
             }
+
             incr = 1;
         }
 
@@ -606,40 +616,42 @@ public sealed class CronExpression : ISerializable
         switch (type)
         {
             case CronExpressionConstants.DayOfMonth:
+            {
+                lastDayOfMonth = true;
+                if (s.Length > i)
                 {
-                    lastDayOfMonth = true;
+                    var c = s[i];
+                    if (c == '-')
+                    {
+                        (lastDayOffset, i) = GetValue(0, s, i + 1);
+                        if (lastDayOffset > 30)
+                        {
+                            ThrowHelper.ThrowFormatException("Offset from last day must be <= 30");
+                        }
+                    }
+
                     if (s.Length > i)
                     {
-                        var c = s[i];
-                        if (c == '-')
+                        c = s[i];
+                        if (c == 'W')
                         {
-                            (lastDayOffset, i) = GetValue(0, s, i + 1);
-                            if (lastDayOffset > 30)
-                            {
-                                ThrowHelper.ThrowFormatException("Offset from last day must be <= 30");
-                            }
+                            nearestWeekday = true;
                         }
-                        if (s.Length > i)
-                        {
-                            c = s[i];
-                            if (c == 'W')
-                            {
-                                nearestWeekday = true;
-                            }
 
-                            var match = offsetRegex.Match(s.ToString());
-                            if (match.Success)
+                        var match = offsetRegex.Match(s.ToString());
+                        if (match.Success)
+                        {
+                            var offSetGroup = match.Groups["offset"];
+                            if (offSetGroup.Success)
                             {
-                                var offSetGroup = match.Groups["offset"];
-                                if (offSetGroup.Success)
-                                {
-                                    lastWeekdayOffset = int.Parse(offSetGroup.Value);
-                                }
+                                lastWeekdayOffset = int.Parse(offSetGroup.Value);
                             }
                         }
                     }
-                    break;
                 }
+
+                break;
+            }
 
             case CronExpressionConstants.DayOfWeek:
                 AddToSet(7, 7, 0, type);
@@ -673,6 +685,7 @@ public sealed class CronExpression : ISerializable
             {
                 (val, i) = GetValue(val, s, i);
             }
+
             CheckNext(i, s, val, type);
         }
     }
@@ -690,6 +703,7 @@ public sealed class CronExpression : ISerializable
             {
                 ThrowHelper.ThrowFormatException($"Invalid Month value: '{sub.ToString()}'");
             }
+
             if (s.Length > i + 3)
             {
                 if (s[i + 3] == '-')
@@ -711,6 +725,7 @@ public sealed class CronExpression : ISerializable
             {
                 ThrowHelper.ThrowFormatException($"Invalid Day-of-Week value: '{sub.ToString()}'");
             }
+
             if (s.Length > i + 3)
             {
                 var c = s[i + 3];
@@ -724,6 +739,7 @@ public sealed class CronExpression : ISerializable
                         {
                             ThrowHelper.ThrowFormatException($"Invalid Day-of-Week value: '{sub.ToString()}'");
                         }
+
                         break;
                     case '#':
                         try
@@ -739,6 +755,7 @@ public sealed class CronExpression : ISerializable
                         {
                             ThrowHelper.ThrowFormatException("A numeric value between 1 and 5 must follow the '#' option");
                         }
+
                         break;
                     case '/':
                         try
@@ -754,6 +771,7 @@ public sealed class CronExpression : ISerializable
                         {
                             ThrowHelper.ThrowFormatException("A numeric value between 1 and 5 must follow the '/' option");
                         }
+
                         break;
                     case 'L':
                         lastDayOfWeek = true;
@@ -769,10 +787,12 @@ public sealed class CronExpression : ISerializable
             ThrowHelper.ThrowFormatException($"Illegal characters for this position: '{sub.ToString()}'");
             return;
         }
+
         if (eval != -1)
         {
             incr = 1;
         }
+
         AddToSet(sval, eval, incr, type);
     }
 
@@ -783,6 +803,7 @@ public sealed class CronExpression : ISerializable
         {
             i = SkipWhiteSpace(pos, s);
         }
+
         if (i >= s.Length)
         {
             return;
@@ -872,9 +893,9 @@ public sealed class CronExpression : ISerializable
             case '/':
                 HandleSlashOption(s, val, type, pos, -1);
                 return;
-            
+
             default:
-                AddToSet(val, -1, 0, type); 
+                AddToSet(val, -1, 0, type);
                 return;
         }
     }
@@ -896,6 +917,7 @@ public sealed class CronExpression : ISerializable
             AddToSet(val, end, v2, type);
             return;
         }
+
         c = s[i];
         if (char.IsDigit(c))
         {
@@ -904,6 +926,7 @@ public sealed class CronExpression : ISerializable
             AddToSet(val, end, v3, type);
             return;
         }
+
         ThrowHelper.ThrowFormatException($"Unexpected character '{c}' after '/'");
     }
 
@@ -919,11 +942,13 @@ public sealed class CronExpression : ISerializable
             AddToSet(val, end, 1, type);
             return;
         }
+
         c = s[i];
         if (char.IsDigit(c))
         {
             (end, i) = GetValue(v, s, i);
         }
+
         if (i < s.Length && s[i] == '/')
         {
             i++;
@@ -935,6 +960,7 @@ public sealed class CronExpression : ISerializable
                 AddToSet(val, end, v2, type);
                 return;
             }
+
             c = s[i];
             if (char.IsDigit(c))
             {
@@ -942,9 +968,11 @@ public sealed class CronExpression : ISerializable
                 AddToSet(val, end, v3, type);
                 return;
             }
+
             AddToSet(val, end, v2, type);
             return;
         }
+
         AddToSet(val, end, 1, type);
     }
 
@@ -962,6 +990,7 @@ public sealed class CronExpression : ISerializable
                 ThrowHelper.ThrowFormatException($"'C' option is not valid here. (pos={i})");
                 break;
         }
+
         var data = GetSet(type);
         data.Add(val);
     }
@@ -973,6 +1002,7 @@ public sealed class CronExpression : ISerializable
         {
             ThrowHelper.ThrowFormatException($"'#' option is not valid here. (pos={i})");
         }
+
         i++;
         try
         {
@@ -981,6 +1011,7 @@ public sealed class CronExpression : ISerializable
             {
                 ThrowHelper.ThrowFormatException("nthdayOfWeek is < 1 or > 5");
             }
+
             // check first char is numeric and is a valid Day of week (1-7)
             if (int.TryParse(s.Slice(0, pos), out val))
             {
@@ -1009,6 +1040,7 @@ public sealed class CronExpression : ISerializable
         {
             ThrowHelper.ThrowFormatException($"'W' option is not valid here. (pos={i})");
         }
+
         if (val > 31)
         {
             ThrowHelper.ThrowFormatException("The 'W' option does not make sense with values larger than 31 (max number of days in a month)");
@@ -1026,12 +1058,14 @@ public sealed class CronExpression : ISerializable
             {
                 ThrowHelper.ThrowFormatException("Day-of-Week values must be between 1 and 7");
             }
+
             lastDayOfWeek = true;
         }
         else
         {
             ThrowHelper.ThrowFormatException($"'L' option is not valid here. (pos={pos})");
         }
+
         var data = GetSet(type);
         data.Add(val);
     }
@@ -1070,7 +1104,7 @@ public sealed class CronExpression : ISerializable
         for (; position < str.Length && char.IsWhiteSpace(str[position]); position++)
         {
         }
-        
+
         return position;
     }
 
@@ -1082,47 +1116,45 @@ public sealed class CronExpression : ISerializable
 
         return position;
     }
-    
-  
 
     private static (int min, int max, string errorMessage) GetValidationParameters(int type)
     {
         return type switch
         {
-            CronExpressionConstants.Second or CronExpressionConstants.Minute 
+            CronExpressionConstants.Second or CronExpressionConstants.Minute
                 => (0, 59, "Minute and Second values must be between 0 and 59"),
-            CronExpressionConstants.Hour 
+            CronExpressionConstants.Hour
                 => (0, 23, "Hour values must be between 0 and 23"),
-            CronExpressionConstants.DayOfMonth 
+            CronExpressionConstants.DayOfMonth
                 => (1, 31, "Day of month values must be between 1 and 31"),
-            CronExpressionConstants.Month 
+            CronExpressionConstants.Month
                 => (1, 12, "Month values must be between 1 and 12"),
-            CronExpressionConstants.DayOfWeek 
+            CronExpressionConstants.DayOfWeek
                 => (1, 7, "Day-of-Week values must be between 1 and 7"),
             CronExpressionConstants.Year
                 => (TriggerConstants.EarliestYear, TriggerConstants.YearToGiveUpSchedulingAt, $"Year values must be between {TriggerConstants.EarliestYear} and {TriggerConstants.YearToGiveUpSchedulingAt}"),
             _ => throw new ArgumentOutOfRangeException(nameof(type), "Invalid cron expression type")
         };
     }
-    
+
     private static bool IsSpecialValue(int val, int type)
     {
-        return val == CronExpressionConstants.AllSpec || 
-               (type is CronExpressionConstants.DayOfMonth or CronExpressionConstants.DayOfWeek && 
+        return val == CronExpressionConstants.AllSpec ||
+               (type is CronExpressionConstants.DayOfMonth or CronExpressionConstants.DayOfWeek &&
                 val == CronExpressionConstants.NoSpec);
     }
-    
+
     private static void ValidateSetValues(int val, int end, int type)
     {
         var (min, max, errorMessage) = GetValidationParameters(type);
 
-        if ((val < min || val > max || end > max) && 
+        if ((val < min || val > max || end > max) &&
             !IsSpecialValue(val, type))
         {
             ThrowHelper.ThrowFormatException(errorMessage);
         }
     }
-    
+
     private static (int startAt, int stopAt) GetRangeForType(int type, int val, int end)
     {
         return type switch
@@ -1133,12 +1165,12 @@ public sealed class CronExpression : ISerializable
             CronExpressionConstants.Month => (GetStartAt(val, 1), GetStopAt(end, 12)),
             CronExpressionConstants.DayOfWeek => (GetStartAt(val, 1), GetStopAt(end, 7)),
             CronExpressionConstants.Year => (GetStartAt(val, TriggerConstants.EarliestYear), GetStopAt(end, TriggerConstants.YearToGiveUpSchedulingAt)),
-            _ => ThrowHelper.ThrowArgumentException<(int,int)>("Unexpected type encountered")
+            _ => ThrowHelper.ThrowArgumentException<(int, int)>("Unexpected type encountered")
         };
     }
-    
+
     /// <summary>
-    /// Gets the max value for the cron expression type. 
+    /// Gets the max value for the cron expression type.
     /// </summary>
     /// <param name="type"> The type of the cron expression</param>
     /// <param name="startAt"> The start value</param>
@@ -1166,7 +1198,6 @@ public sealed class CronExpression : ISerializable
     private static int GetStopAt(int end, int defaultValue) =>
         end == -1 ? defaultValue : end;
 
-
     private void AddToSet(int val, int end, int incr, int type)
     {
         ValidateSetValues(val, end, type);
@@ -1178,14 +1209,14 @@ public sealed class CronExpression : ISerializable
             data.Add(val != -1 ? val : CronExpressionConstants.NoSpec);
             return;
         }
-        
+
         if (val == CronExpressionConstants.AllSpec && incr <= 0)
         {
             data.Add(CronExpressionConstants.AllSpec);
             // skip adding other data, we check this wildcard in TryGetMinValueStartingFrom
             return;
         }
-        
+
         var (startAt, stopAt) = GetRangeForType(type, val, end);
 
         // if the end of the range is before the start, then we need to overflow into
@@ -1260,6 +1291,7 @@ public sealed class CronExpression : ISerializable
             {
                 break;
             }
+
             c = s[i];
         }
 
@@ -1406,126 +1438,126 @@ public sealed class CronExpression : ISerializable
 
         return new NextFireTimeCursor(false, new DateTimeOffset(d.Year, d.Month, d.Day, hour, d.Minute, d.Second, d.Millisecond, d.Offset));
     }
-    
+
     private (SortedSet<int> daysOfMonthSet, bool dayHasNegativeOffset) CalculateDaysOfMonth(DateTimeOffset currentDate)
-{
-    var daysOfMonthSet = new SortedSet<int>(daysOfMonth);
-    var dayHasNegativeOffset = false;
-
-    if (lastDayOfMonth)
     {
-        int lastDayOfMonthValue = GetLastDayOfMonth(currentDate.Month, currentDate.Year);
-        int lastDayOfMonthWithOffset = lastDayOfMonthValue - lastDayOffset;
+        var daysOfMonthSet = new SortedSet<int>(daysOfMonth);
+        var dayHasNegativeOffset = false;
 
-        if (nearestWeekday)
+        if (lastDayOfMonth)
         {
-            int calculatedLastDay = CalculateNearestWeekdayForLastDay(currentDate, lastDayOfMonthWithOffset);
-            daysOfMonthSet.Add(calculatedLastDay);
+            int lastDayOfMonthValue = GetLastDayOfMonth(currentDate.Month, currentDate.Year);
+            int lastDayOfMonthWithOffset = lastDayOfMonthValue - lastDayOffset;
+
+            if (nearestWeekday)
+            {
+                int calculatedLastDay = CalculateNearestWeekdayForLastDay(currentDate, lastDayOfMonthWithOffset);
+                daysOfMonthSet.Add(calculatedLastDay);
+            }
+            else
+            {
+                daysOfMonthSet.Add(lastDayOfMonthWithOffset);
+            }
         }
-        else
+        else if (nearestWeekday)
         {
-            daysOfMonthSet.Add(lastDayOfMonthWithOffset);
+            (daysOfMonthSet, dayHasNegativeOffset) = CalculateNearestWeekdayForDaysOfMonth(currentDate, daysOfMonthSet);
         }
+
+        return (daysOfMonthSet, dayHasNegativeOffset);
     }
-    else if (nearestWeekday)
+
+    /// <summary>
+    /// Calculates the nearest weekday for the last day of the month.
+    /// </summary>
+    /// <param name="currentDate">The current date.</param>
+    /// <param name="lastDayOfMonthWithOffset">The last day of the month with the offset applied.</param>
+    /// <returns>The calculated last day of the month, adjusted to the nearest weekday.</returns>
+    private int CalculateNearestWeekdayForLastDay(DateTimeOffset currentDate, int lastDayOfMonthWithOffset)
     {
-        (daysOfMonthSet, dayHasNegativeOffset) = CalculateNearestWeekdayForDaysOfMonth(currentDate, daysOfMonthSet);
+        var checkDay = new DateTimeOffset(currentDate.Year, currentDate.Month, lastDayOfMonthWithOffset, currentDate.Hour, currentDate.Minute, currentDate.Second, currentDate.Millisecond, currentDate.Offset);
+        var calculatedDay = lastDayOfMonthWithOffset;
+
+        switch (checkDay.DayOfWeek)
+        {
+            case DayOfWeek.Saturday:
+                calculatedDay -= 1;
+                break;
+            case DayOfWeek.Sunday:
+                calculatedDay -= 2;
+                break;
+        }
+
+        var calculatedLastDayWithOffset = calculatedDay - lastWeekdayOffset;
+
+        // If the day has crossed to the prior month, reset to 1st.
+        if (calculatedLastDayWithOffset <= 0)
+        {
+            calculatedLastDayWithOffset = 1;
+        }
+
+        return calculatedLastDayWithOffset;
     }
 
-    return (daysOfMonthSet, dayHasNegativeOffset);
-}
-
-/// <summary>
-/// Calculates the nearest weekday for the last day of the month.
-/// </summary>
-/// <param name="currentDate">The current date.</param>
-/// <param name="lastDayOfMonthWithOffset">The last day of the month with the offset applied.</param>
-/// <returns>The calculated last day of the month, adjusted to the nearest weekday.</returns>
-private int CalculateNearestWeekdayForLastDay(DateTimeOffset currentDate, int lastDayOfMonthWithOffset)
-{
-    var checkDay = new DateTimeOffset(currentDate.Year, currentDate.Month, lastDayOfMonthWithOffset, currentDate.Hour, currentDate.Minute, currentDate.Second, currentDate.Millisecond, currentDate.Offset);
-    var calculatedDay = lastDayOfMonthWithOffset;
-
-    switch (checkDay.DayOfWeek)
+    /// <summary>
+    /// Calculates the nearest weekday for the specified days of the month.
+    /// </summary>
+    /// <param name="currentDate">The current date.</param>
+    /// <param name="daysOfMonthSet">The set of days of the month.</param>
+    /// <returns>A tuple containing the updated set of days of the month and a flag indicating if any day has a negative offset.</returns>
+    private static (SortedSet<int> daysOfMonthSet, bool dayHasNegativeOffset) CalculateNearestWeekdayForDaysOfMonth(DateTimeOffset currentDate, SortedSet<int> daysOfMonthSet)
     {
-        case DayOfWeek.Saturday:
-            calculatedDay -= 1;
-            break;
-        case DayOfWeek.Sunday:
-            calculatedDay -= 2;
-            break;
+        int endDayOfMonth = GetLastDayOfMonth(currentDate.Month, currentDate.Year);
+        int minDay = (daysOfMonthSet.Min > endDayOfMonth) ? endDayOfMonth : daysOfMonthSet.Min;
+
+        DateTimeOffset firstDayOfMonth = new DateTimeOffset(currentDate.Year, currentDate.Month, minDay, 0, 0, 0, currentDate.Offset);
+        DayOfWeek dayOfWeek = firstDayOfMonth.DayOfWeek;
+
+        // Evict the original date if it is not a weekday
+        if (dayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+        {
+            daysOfMonthSet.Remove(minDay);
+        }
+
+        var (adjustedDay, dayHasNegativeOffset) = AdjustDayToNearestWeekday(minDay, dayOfWeek, endDayOfMonth);
+        daysOfMonthSet.Add(adjustedDay);
+
+        return (daysOfMonthSet, dayHasNegativeOffset);
     }
 
-    var calculatedLastDayWithOffset = calculatedDay - lastWeekdayOffset;
-
-    // If the day has crossed to the prior month, reset to 1st.
-    if (calculatedLastDayWithOffset <= 0)
+    /// <summary>
+    /// Adjusts the day to the nearest weekday based on the specified day of the week and the last day of the month.
+    /// </summary>
+    /// <param name="day">The day to adjust.</param>
+    /// <param name="dayOfWeek">The day of the week.</param>
+    /// <param name="endDayOfMonth">The end day of the month.</param>
+    /// <returns>The adjusted day and a flag to indicate adjust day has a negative offset</returns>
+    private static (int day, bool dayHasNegativeOffset) AdjustDayToNearestWeekday(int day, DayOfWeek dayOfWeek, int endDayOfMonth)
     {
-        calculatedLastDayWithOffset = 1;
+        var dayHasNegativeOffset = false;
+
+        // evict original date since it has a weekDayModifier
+        switch (dayOfWeek)
+        {
+            case DayOfWeek.Saturday when day == 1:
+                day += 2;
+                break;
+            case DayOfWeek.Saturday:
+                day -= 1;
+                dayHasNegativeOffset = true;
+                break;
+            case DayOfWeek.Sunday when day == endDayOfMonth:
+                day -= 2;
+                dayHasNegativeOffset = true;
+                break;
+            case DayOfWeek.Sunday:
+                day += 1;
+                break;
+        }
+
+        return (day, dayHasNegativeOffset);
     }
 
-    return calculatedLastDayWithOffset;
-}
-
-/// <summary>
-/// Calculates the nearest weekday for the specified days of the month.
-/// </summary>
-/// <param name="currentDate">The current date.</param>
-/// <param name="daysOfMonthSet">The set of days of the month.</param>
-/// <returns>A tuple containing the updated set of days of the month and a flag indicating if any day has a negative offset.</returns>
-private static (SortedSet<int> daysOfMonthSet, bool dayHasNegativeOffset) CalculateNearestWeekdayForDaysOfMonth(DateTimeOffset currentDate, SortedSet<int> daysOfMonthSet)
-{
-    int endDayOfMonth = GetLastDayOfMonth(currentDate.Month, currentDate.Year);
-    int minDay = (daysOfMonthSet.Min > endDayOfMonth) ? endDayOfMonth : daysOfMonthSet.Min;
-    
-    DateTimeOffset firstDayOfMonth = new DateTimeOffset(currentDate.Year, currentDate.Month, minDay, 0, 0, 0, currentDate.Offset);
-    DayOfWeek dayOfWeek = firstDayOfMonth.DayOfWeek;
-
-    // Evict the original date if it is not a weekday
-    if (dayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
-    {
-        daysOfMonthSet.Remove(minDay);
-    }
-
-    var (adjustedDay,dayHasNegativeOffset) = AdjustDayToNearestWeekday(minDay, dayOfWeek, endDayOfMonth);
-    daysOfMonthSet.Add(adjustedDay);
-
-    return (daysOfMonthSet, dayHasNegativeOffset);
-}
-
-/// <summary>
-/// Adjusts the day to the nearest weekday based on the specified day of the week and the last day of the month.
-/// </summary>
-/// <param name="day">The day to adjust.</param>
-/// <param name="dayOfWeek">The day of the week.</param>
-/// <param name="endDayOfMonth">The end day of the month.</param>
-/// <returns>The adjusted day and a flag to indicate adjust day has a negative offset</returns>
-private static (int day, bool dayHasNegativeOffset) AdjustDayToNearestWeekday(int day, DayOfWeek dayOfWeek, int endDayOfMonth)
-{
-    var dayHasNegativeOffset = false;
-
-            // evict original date since it has a weekDayModifier
-    switch (dayOfWeek)
-    {
-        case DayOfWeek.Saturday when day == 1:
-            day += 2;
-            break;
-        case DayOfWeek.Saturday:
-            day -= 1;
-            dayHasNegativeOffset = true;
-            break;
-        case DayOfWeek.Sunday when day == endDayOfMonth:
-            day -= 2;
-            dayHasNegativeOffset = true;
-            break;
-        case DayOfWeek.Sunday:
-            day += 1;
-            break;
-    }
-
-    return (day, dayHasNegativeOffset);
-}
-    
     private NextFireTimeCursor ProgressNextFireTimeDayOfMonth(DateTimeOffset d)
     {
         var day = d.Day;
@@ -1583,8 +1615,10 @@ private static (int day, bool dayHasNegativeOffset) AdjustDayToNearestWeekday(in
                     d = new DateTimeOffset(d.Year, month, daysInMonth, 0, 0, 0, d.Offset).AddDays(day - daysInMonth);
                 }
             }
+
             return new NextFireTimeCursor(true, d);
         }
+
         return new NextFireTimeCursor(false, d);
     }
 
@@ -1784,6 +1818,7 @@ private static (int day, bool dayHasNegativeOffset) AdjustDayToNearestWeekday(in
         {
             return ProgressNextFireTimeDayOfMonth(d);
         }
+
         if (dayOfWSpec && !dayOfMSpec)
         {
             return ProgressNextFireTimeDayOfWeek(d);
@@ -1876,15 +1911,7 @@ private static (int day, bool dayHasNegativeOffset) AdjustDayToNearestWeekday(in
         // change to specified time zone
         d = TimeZoneUtil.ConvertTime(d, TimeZone);
 
-        var nextFireTimeProgressors = new[]
-        {
-            ProgressNextFireTimeSecond,
-            ProgressNextFireTimeMinute,
-            ProgressNextFireTimeHour,
-            ProgressNextFireTimeDay,
-            ProgressNextFireTimeMonth,
-            ProgressNextFireTimeYear
-        };
+        var nextFireTimeProgressors = new[] { ProgressNextFireTimeSecond, ProgressNextFireTimeMinute, ProgressNextFireTimeHour, ProgressNextFireTimeDay, ProgressNextFireTimeMonth, ProgressNextFireTimeYear };
 
         var nextFireTimeCursor = new NextFireTimeCursor(false, d);
         var foundNextFireTime = false;
@@ -2014,10 +2041,7 @@ private static (int day, bool dayHasNegativeOffset) AdjustDayToNearestWeekday(in
     /// </returns>
     public object Clone()
     {
-        return new CronExpression(CronExpressionString)
-        {
-            TimeZone = TimeZone
-        };
+        return new CronExpression(CronExpressionString) { TimeZone = TimeZone };
     }
 
     /// <summary>
@@ -2204,11 +2228,7 @@ internal sealed class CronField : IEnumerable<int>
         }
         else if (singleValue != value)
         {
-            values = new SortedSet<int>
-            {
-                singleValue.Value,
-                value
-            };
+            values = new SortedSet<int> { singleValue.Value, value };
             singleValue = null;
         }
     }

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -1475,9 +1475,9 @@ private int CalculateNearestWeekdayForLastDay(DateTimeOffset currentDate, int la
 /// <returns>A tuple containing the updated set of days of the month and a flag indicating if any day has a negative offset.</returns>
 private static (SortedSet<int> daysOfMonthSet, bool dayHasNegativeOffset) CalculateNearestWeekdayForDaysOfMonth(DateTimeOffset currentDate, SortedSet<int> daysOfMonthSet)
 {
-    int minDay = daysOfMonthSet.Min;
     int endDayOfMonth = GetLastDayOfMonth(currentDate.Month, currentDate.Year);
-
+    int minDay = (daysOfMonthSet.Min > endDayOfMonth) ? endDayOfMonth : daysOfMonthSet.Min;
+    
     DateTimeOffset firstDayOfMonth = new DateTimeOffset(currentDate.Year, currentDate.Month, minDay, 0, 0, 0, currentDate.Offset);
     DayOfWeek dayOfWeek = firstDayOfMonth.DayOfWeek;
 

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -81,20 +81,20 @@ namespace Quartz;
 /// <td align="left">Month</td>
 /// <td align="left"> </td>
 /// <td align="left">1-12 or JAN-DEC</td>
-/// <td align="left"> </td>
+/// <td align="left"></td>
 /// <td align="left">, - /// /</td>
 /// </tr>
 /// <tr>
 /// <td align="left">Day-of-Week</td>
 /// <td align="left"> </td>
 /// <td align="left">1-7 or SUN-SAT</td>
-/// <td align="left"> </td>
+/// <td align="left"></td>
 /// <td align="left">, - /// ? / L #</td>
 /// </tr>
 /// <tr>
 /// <td align="left">Year (Optional)</td>
 /// <td align="left"> </td>
-/// <td align="left">empty, 1970-2199</td>
+/// <td align="left">empty, <see cref="TriggerConstants.EarliestYear"/>- <see cref="TriggerConstants.YearToGiveUpSchedulingAt"/></td>
 /// <td align="left"> </td>
 /// <td align="left">, - /// /</td>
 /// </tr>
@@ -109,7 +109,7 @@ namespace Quartz;
 /// specify something in one of the two fields, but not the other.
 /// </para>
 /// <para>
-/// The '-' character is used to specify ranges For example &quot;10-12&quot; in
+/// The '-' character is used to specify ranges. For example &quot;10-12&quot; in
 /// the hour field means &quot;the hours 10, 11 and 12&quot;.
 /// </para>
 /// <para>
@@ -126,7 +126,7 @@ namespace Quartz;
 /// is a set of numbers that can be turned on or off. For seconds and minutes,
 /// the numbers range from 0 to 59. For hours 0 to 23, for days of the month 1 to
 /// 31, and for months 1 to 12. The &quot;/&quot; character simply helps you turn
-/// on every &quot;nth&quot; value in the given set. Thus &quot;7/6&quot; in the
+/// on every &quot;nth&quot; value in the given set. Thus, &quot;7/6&quot; in the
 /// month field only turns on month &quot;7&quot;, it does NOT mean every 6th
 /// month, please note that subtlety.
 /// </para>
@@ -152,7 +152,7 @@ namespace Quartz;
 /// the month&quot;. So if the 15th is a Saturday, the trigger will fire on
 /// Friday the 14th. If the 15th is a Sunday, the trigger will fire on Monday the
 /// 16th. If the 15th is a Tuesday, then it will fire on Tuesday the 15th.
-/// However if you specify &quot;1W&quot; as the value for day-of-month, and the
+/// However, if you specify &quot;1W&quot; as the value for day-of-month, and the
 /// 1st is a Saturday, the trigger will fire on Monday the 3rd, as it will not
 /// 'jump' over the boundary of a month's days.  The 'W' character can only be
 /// specified when the day-of-month is a single day, not a range or list of days.
@@ -185,7 +185,7 @@ namespace Quartz;
 /// </para>
 /// <para>
 /// The legal characters and the names of months and days of the week are not
-/// case sensitive.
+/// case-sensitive.
 /// </para>
 /// <para>
 /// <b>NOTES:</b>
@@ -193,8 +193,8 @@ namespace Quartz;
 /// <li>Support for specifying both a day-of-week and a day-of-month value is
 /// not complete (you'll need to use the '?' character in one of these fields).
 /// </li>
-/// <li>Overflowing ranges is supported - that is, having a larger number on
-/// the left hand side than the right. You might do 22-2 to catch 10 o'clock
+/// <li>Overflowing ranges are supported - that is, having a larger number on
+/// the left-hand side than the right. You might do 22-2 to catch 10 o'clock
 /// at night until 2 o'clock in the morning, or you might have NOV-FEB. It is
 /// very important to note that overuse of overflowing ranges creates ranges
 /// that don't make sense and no effort has been made to determine which
@@ -376,7 +376,7 @@ public sealed class CronExpression : ISerializable
 
         //TODO: IMPROVE THIS! The following is a BAD solution to this problem. Performance will be very bad here, depending on the cron expression. It is, however A solution.
 
-        //keep getting the next included time until it's farther than one second
+        // Keep getting the next included time until it's farther than one second
         // apart. At that point, lastDate is the last valid fire time. We return
         // the second immediately following it.
         while (difference == 1000)
@@ -1100,7 +1100,7 @@ public sealed class CronExpression : ISerializable
             CronExpressionConstants.DayOfWeek 
                 => (1, 7, "Day-of-Week values must be between 1 and 7"),
             CronExpressionConstants.Year
-                => (1970, TriggerConstants.YearToGiveUpSchedulingAt, "Year values must be between 1970 and " + TriggerConstants.YearToGiveUpSchedulingAt),
+                => (TriggerConstants.EarliestYear, TriggerConstants.YearToGiveUpSchedulingAt, $"Year values must be between {TriggerConstants.EarliestYear} and {TriggerConstants.YearToGiveUpSchedulingAt}"),
             _ => throw new ArgumentOutOfRangeException(nameof(type), "Invalid cron expression type")
         };
     }
@@ -1132,7 +1132,7 @@ public sealed class CronExpression : ISerializable
             CronExpressionConstants.DayOfMonth => (GetStartAt(val, 1), GetStopAt(end, 31)),
             CronExpressionConstants.Month => (GetStartAt(val, 1), GetStopAt(end, 12)),
             CronExpressionConstants.DayOfWeek => (GetStartAt(val, 1), GetStopAt(end, 7)),
-            CronExpressionConstants.Year => (GetStartAt(val, 1970), GetStopAt(end, TriggerConstants.YearToGiveUpSchedulingAt)),
+            CronExpressionConstants.Year => (GetStartAt(val, TriggerConstants.EarliestYear), GetStopAt(end, TriggerConstants.YearToGiveUpSchedulingAt)),
             _ => ThrowHelper.ThrowArgumentException<(int,int)>("Unexpected type encountered")
         };
     }

--- a/src/Quartz/TriggerConstants.cs
+++ b/src/Quartz/TriggerConstants.cs
@@ -11,4 +11,5 @@ public static class TriggerConstants
     public const int DefaultPriority = 5;
 
     internal static readonly int YearToGiveUpSchedulingAt = TimeProvider.System.GetUtcNow().Year + 100;
+    internal const int EarliestYear = 1970;
 }

--- a/src/Quartz/Util/SortedSetExtensions.cs
+++ b/src/Quartz/Util/SortedSetExtensions.cs
@@ -2,7 +2,7 @@ namespace Quartz.Util;
 
 internal static class SortedSetExtensions
 {
-    internal static bool TryGetMinValueStartingFrom(this SortedSet<int> set, DateTimeOffset start, bool dayHasNegativeOffset, out int minimumDay)
+    internal static bool TryGetMinValueStartingFrom(this SortedSet<int> set, DateTimeOffset start, bool allowValueBeforeStartDay, out int minimumDay)
     {
         minimumDay = set.Min;
         var startDay = start.Day;
@@ -13,8 +13,9 @@ internal static class SortedSetExtensions
             return true;
         }
 
-        // If the day has a negative offset and the minimum value is less than the start day, return the minimum value
-        if (set.Min < startDay && dayHasNegativeOffset)
+        // In cases such as W modifier finding a match earlier than the month day.
+        // If the flag allowValueBeforeStartDay is set and the minimum value is less than the start day, return the minimum value 
+        if (allowValueBeforeStartDay && set.Min < startDay)
         {
             return true;
         }

--- a/src/Quartz/Util/SortedSetExtensions.cs
+++ b/src/Quartz/Util/SortedSetExtensions.cs
@@ -2,32 +2,40 @@ namespace Quartz.Util;
 
 internal static class SortedSetExtensions
 {
-    internal static bool TryGetMinValueStartingFrom(this SortedSet<int> set, int start, out int min)
+    internal static bool TryGetMinValueStartingFrom(this SortedSet<int> set, DateTimeOffset start, bool dayHasNegativeOffset, out int minimumDay)
     {
-        min = set.Min;
+        minimumDay = set.Min;
+        var startDay = start.Day;
 
-        if (set.Contains(CronExpressionConstants.AllSpec) || set.Contains(start))
+        if (set.Contains(CronExpressionConstants.AllSpec) || set.Contains(startDay))
         {
-            min = start;
+            minimumDay = startDay;
             return true;
         }
 
-        if (set.Count == 0 || set.Max < start)
+        // If the day has a negative offset and the minimum value is less than the start day, return the minimum value
+        if (set.Min < startDay && dayHasNegativeOffset)
+        {
+            return true;
+        }
+        
+        // If the set is empty or the maximum value is less than the start day, no suitable value is found
+        if (set.Count == 0 || set.Max < startDay)
         {
             return false;
         }
 
-        if (set.Min >= start)
+        // If the minimum value is greater than or equal to the start day, return the minimum value
+        if (set.Min >= startDay)
         {
-            // value is contained and would be returned from view
             return true;
         }
 
         // slow path
-        var view = set.GetViewBetween(start, int.MaxValue);
+        var view = set.GetViewBetween(startDay, int.MaxValue);
         if (view.Count > 0)
         {
-            min = view.Min;
+            minimumDay = view.Min;
             return true;
         }
 


### PR DESCRIPTION
Fix an issue whereby setting a monthly `CronExpression` with flag `weekdayonly`  `W` , 
when the scheduled day falls on a weekend (Sun/Sat), 
Quartz would incorrectly skip ahead to the next month (or non weekend date month when calling `GetTimeAfter`

Full detail in #2331 
- Targets v4

Incorporate test and fix from #2330 by @Skimmenthal13 (credit PR #2490) relating to NextFireTime bug when next month is shorter and using `W` modifier at end of month with greater days than next month


