### PR TITLE
Fix lint warning about missing initial value in array.reduce in webpack.config.js Quartz.Web

### DIFF
--- a/src/Quartz.Web/App/webpack.config.js
+++ b/src/Quartz.Web/App/webpack.config.js
@@ -90,5 +90,5 @@ function getAureliaDevAliases() {
       map[name] = path.resolve(packageLocation, `../../esm/index.dev.mjs`);
     } catch {/**/}
     return map;
-  });
+  }, {});
 }


### PR DESCRIPTION
Supply default value for `reduce` to please Sonarlint.