### PR TITLE
fix typo in aspnet-core-integration.md

### DIFF
--- a/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
+++ b/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
@@ -1,4 +1,5 @@
 ---
+
 title: ASP.NET Core Integration
 ---
 
@@ -64,11 +65,11 @@ public class SendEmailJob : IJob
     public Task Execute(IJobExecutionContext context)
     {
         // Code that sends a periodic email to the user (for example)
-        // Note: This method must always return a value
-        // This is especially important for trigger listeners watching job execution
+        // Note: This method must always return a value 
+        // This is especially important for trigger listers watching job execution 
         return Task.FromResult(true);
     }
-}
+}        
 ```
 
 After that, you just need to build Quartz trigger in `Program.cs`, which guarantees that the job will run according to the preset interval.
@@ -81,7 +82,7 @@ builder.Services.AddQuartz(q =>
     // Just use the name of your job that you created in the Jobs folder.
     var jobKey = new JobKey("SendEmailJob");
     q.AddJob<SendEmailJob>(opts => opts.WithIdentity(jobKey));
-
+    
     q.AddTrigger(opts => opts
         .ForJob(jobKey)
         .WithIdentity("SendEmailJob-trigger")

--- a/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
+++ b/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
@@ -66,7 +66,7 @@ public class SendEmailJob : IJob
     {
         // Code that sends a periodic email to the user (for example)
         // Note: This method must always return a value 
-        // This is especially important for trigger listers watching job execution 
+        // This is especially important for trigger listeners watching job execution 
         return Task.FromResult(true);
     }
 }        

--- a/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
+++ b/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
@@ -1,5 +1,4 @@
 ---
-
 title: ASP.NET Core Integration
 ---
 
@@ -65,11 +64,11 @@ public class SendEmailJob : IJob
     public Task Execute(IJobExecutionContext context)
     {
         // Code that sends a periodic email to the user (for example)
-        // Note: This method must always return a value 
-        // This is especially important for trigger listers watching job execution 
+        // Note: This method must always return a value
+        // This is especially important for trigger listeners watching job execution
         return Task.FromResult(true);
     }
-}        
+}
 ```
 
 After that, you just need to build Quartz trigger in `Program.cs`, which guarantees that the job will run according to the preset interval.
@@ -82,7 +81,7 @@ builder.Services.AddQuartz(q =>
     // Just use the name of your job that you created in the Jobs folder.
     var jobKey = new JobKey("SendEmailJob");
     q.AddJob<SendEmailJob>(opts => opts.WithIdentity(jobKey));
-    
+
     q.AddTrigger(opts => opts
         .ForJob(jobKey)
         .WithIdentity("SendEmailJob-trigger")


### PR DESCRIPTION
Fixed typo in aspnet-core-integration.md by changing "listers" to "listeners" 