### PR TITLE
Support negative timezone offsets in TestTimeZone2

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
@@ -94,6 +94,9 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
         Assert.IsTrue(dailyCalendar.IsTimeIncluded(timeToCheck));
     }
 
+    /// <summary>
+    /// Ensure that the DailyCalendar use the same TimeZone offset for all the checks
+    /// </summary>
     [Test]
     public void TestTimeZone2()
     {
@@ -122,7 +125,7 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
         else if (timeZoneOffset < TimeSpan.Zero)
         {
             // Trigger must fire between midnight minus utc offset and midnight if negative offset.
-            fireTimes.Where(t => t.Hour >= 24 - timeZoneOffset.Hours && t.Hour <= 23).Should().NotBeEmpty();
+            fireTimes.Where(t => t.Hour >= 24 + timeZoneOffset.Hours && t.Hour <= 23).Should().NotBeEmpty();
         }
         else
         {

--- a/src/Quartz/Impl/Calendar/DailyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/DailyCalendar.cs
@@ -833,7 +833,7 @@ public sealed class DailyCalendar : BaseCalendar
     /// <returns></returns>
     private static DateTimeOffset GetStartOfDay(DateTimeOffset time)
     {
-        return new DateTimeOffset(new DateTime(time.Year, time.Month, time.Day, 0, 0, 0, 0), time.Offset);
+        return new DateTimeOffset(time.Date, time.Offset);
     }
 
     /// <summary>
@@ -843,7 +843,7 @@ public sealed class DailyCalendar : BaseCalendar
     /// <returns></returns>
     private static DateTimeOffset GetEndOfDay(DateTimeOffset time)
     {
-        return new DateTimeOffset(new DateTime(time.Year, time.Month, time.Day, 23, 59, 59, 999), time.Offset);
+        return new DateTimeOffset(time.Date.AddDays(1).AddMilliseconds(-1), time.Offset);
     }
 
     /// <summary>


### PR DESCRIPTION
 - Simplify GetStartOfDay
 - Ensure GetEndOfDay has maximum precision of platform

**Describe the bug**

I am seeing test `TestTimeZone2` introduced in #2113 failing.

**Version used**

Quartz.NET 3.9.0

**To Reproduce**

Have a negative timezone offset on your system clock. 
Run unit tests.

**Expected behavior**

Passing test.

**Additional context**
Looking at the test line where the failure occurs:

https://github.com/quartznet/quartznet/blob/e62b215388d4bba29d0c027c8249bafc6a2b6605/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs#L128

A negative `timeZoneOffset.Hours` is subtracted from 24 resulting in a time range greater than 24 hours which is more than the available hours in the day.

Adding a negative solves this issue for me. I believe this was the intent.