### PR TITLE
Use async pattern where already available.

### DIFF
--- a/src/Quartz.Benchmark/DefaultThreadPoolBenchmark.cs
+++ b/src/Quartz.Benchmark/DefaultThreadPoolBenchmark.cs
@@ -18,14 +18,14 @@ public class DefaultThreadPoolBenchmark
 
         for (var i = 0; i < 500_000; i++)
         {
-            threadPool!.RunInThread(() => Task.CompletedTask);
+            threadPool.RunInThread(() => Task.CompletedTask);
         }
 
         threadPool.Shutdown(true);
     }
 
     [Benchmark(OperationsPerInvoke = 1_000_000)]
-    public void RunInThread_CompletedTask_MaxConcurrencyIsMaxValue_MultiThreaded()
+    public async Task RunInThread_CompletedTask_MaxConcurrencyIsMaxValue_MultiThreaded()
     {
         var threadPool = new DefaultThreadPool
         {
@@ -33,7 +33,7 @@ public class DefaultThreadPoolBenchmark
         };
         threadPool.Initialize();
 
-        Execute(threadPool, 20, 50_000, (tp) => tp.RunInThread(() => Task.CompletedTask));
+        await Execute(threadPool, 20, 50_000, (tp) => tp.RunInThread(() => Task.CompletedTask));
 
         threadPool.Shutdown(true);
     }
@@ -45,26 +45,28 @@ public class DefaultThreadPoolBenchmark
         {
             MaxConcurrency = 16
         };
+        
         threadPool.Initialize();
 
         for (var i = 0; i < 500_000; i++)
         {
-            threadPool!.RunInThread(() => Task.CompletedTask);
+            threadPool.RunInThread(() => Task.CompletedTask);
         }
 
         threadPool.Shutdown(true);
     }
 
     [Benchmark(OperationsPerInvoke = 1_000_000)]
-    public void RunInThread_CompletedTask_MaxConcurrencyIsSixteen_MultiThreaded()
+    public async Task RunInThread_CompletedTask_MaxConcurrencyIsSixteen_MultiThreaded()
     {
         var threadPool = new DefaultThreadPool
         {
             MaxConcurrency = 16
         };
+        
         threadPool.Initialize();
 
-        Execute(threadPool, 20, 50_000, (tp) => tp.RunInThread(() => Task.CompletedTask));
+        await Execute(threadPool, 20, 50_000, (tp) => tp.RunInThread(() => Task.CompletedTask));
 
         threadPool.Shutdown(true);
     }
@@ -85,7 +87,7 @@ public class DefaultThreadPoolBenchmark
         threadPool.Shutdown(true);
     }
 
-    private static void Execute(DefaultThreadPool scheduler, int threadCount, int iterationsPerThread, Action<DefaultThreadPool> action)
+    private static async Task Execute(DefaultThreadPool scheduler, int threadCount, int iterationsPerThread, Action<DefaultThreadPool> action)
     {
         ManualResetEvent start = new ManualResetEvent(false);
 
@@ -106,6 +108,6 @@ public class DefaultThreadPoolBenchmark
 
         start.Set();
 
-        Task.WaitAll(tasks);
+        await Task.WhenAll(tasks);
     }
 }

--- a/src/Quartz.Examples/09_TriggeringAJobUsingJobListeners/SimpleJob1Listener.cs
+++ b/src/Quartz.Examples/09_TriggeringAJobUsingJobListeners/SimpleJob1Listener.cs
@@ -66,8 +66,8 @@ public class SimpleJob1Listener : IJobListener
         }
         catch (SchedulerException e)
         {
-            Console.Error.WriteLine("Unable to schedule job2!");
-            Console.Error.WriteLine(e.StackTrace);
+            await Console.Error.WriteLineAsync("Unable to schedule job2!");
+            await Console.Error.WriteLineAsync(e.StackTrace);
         }
     }
 }

--- a/src/Quartz.HttpClient/HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpClient/HttpScheduler.cs
@@ -41,7 +41,9 @@ public class HttpScheduler : IScheduler
     {
         get
         {
-            var dto = httpClient.Get<SchedulerContextDto>($"{SchedulerEndpointUrl()}/context", jsonSerializerOptions, CancellationToken.None).GetAwaiter().GetResult();
+            var dto = httpClient.Get<SchedulerContextDto>($"{SchedulerEndpointUrl()}/context", jsonSerializerOptions, CancellationToken.None)
+                .AsTask().GetAwaiter().GetResult();
+
             return dto.AsContext();
         }
     }

--- a/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 
 using Microsoft.Extensions.Logging;
 
@@ -47,13 +47,11 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
     private void ScheduleJobInterruptMonitor(string fireInstanceId, JobKey jobkey, TimeSpan delay)
     {
         var monitor = new InterruptMonitor(fireInstanceId, jobkey, scheduler, delay);
-#pragma warning disable MA0134
-        Task.Factory.StartNew(
+        _ = Task.Factory.StartNew(
             monitor.Run,
             monitor.cancellationTokenSource.Token,
             TaskCreationOptions.HideScheduler,
             taskScheduler).Unwrap();
-#pragma warning restore MA0134
 
         interruptMonitors.TryAdd(fireInstanceId, monitor);
     }

--- a/src/Quartz.Plugins/Plugin/Xml/XMLSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Xml/XMLSchedulingDataProcessorPlugin.cs
@@ -341,7 +341,7 @@ public class XMLSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileScanListe
 
         public string FileBasename { get; private set; } = null!;
 
-        public ValueTask Initialize(CancellationToken cancellationToken = default)
+        public async ValueTask Initialize(CancellationToken cancellationToken = default)
         {
             Stream? f = null;
             try
@@ -388,7 +388,15 @@ public class XMLSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileScanListe
             {
                 try
                 {
-                    f?.Dispose();
+                    if (f != null)
+                    {
+#if NET5_0_OR_GREATER
+                        await f.DisposeAsync().ConfigureAwait(false);
+#else
+                        await Task.Yield();
+                        f.Dispose();
+#endif
+                    }
                 }
                 catch (IOException ioe)
                 {

--- a/src/Quartz.Plugins/Plugin/Xml/XMLSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Xml/XMLSchedulingDataProcessorPlugin.cs
@@ -403,8 +403,6 @@ public class XMLSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileScanListe
                     plugin.logger.LogWarning(ioe, "Error closing jobs file {FileName}", FileName);
                 }
             }
-
-            return default;
         }
     }
 }

--- a/src/Quartz.Server/QuartzServer.cs
+++ b/src/Quartz.Server/QuartzServer.cs
@@ -131,7 +131,7 @@ public class QuartzServer : ServiceControl, IQuartzServer
     /// </summary>
     public bool Start(HostControl hostControl)
     {
-        Start().GetAwaiter().GetResult();
+        Start().AsTask().GetAwaiter().GetResult();
         return true;
     }
 
@@ -140,7 +140,7 @@ public class QuartzServer : ServiceControl, IQuartzServer
     /// </summary>
     public bool Stop(HostControl hostControl)
     {
-        Stop().GetAwaiter().GetResult();
+        Stop().AsTask().GetAwaiter().GetResult();
         return true;
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/DeleteNonExistsJobTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/DeleteNonExistsJobTest.cs
@@ -137,10 +137,10 @@ public class DeleteNonExistsJobTest
 
     public class TestJob : IJob
     {
-        public ValueTask Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context)
         {
             logger.LogInformation("Job is executing {Context}", context);
-            return default;
+            await Task.Yield();
         }
     }
 }

--- a/src/Quartz.Tests.Unit/DisallowConcurrentJobExecutionTest.cs
+++ b/src/Quartz.Tests.Unit/DisallowConcurrentJobExecutionTest.cs
@@ -42,7 +42,7 @@ public class DisallowConcurrentExecutionJobTest
 
         public override string Name => "TestJobListener";
 
-        public override ValueTask JobWasExecuted(
+        public override async ValueTask JobWasExecuted(
             IJobExecutionContext context,
             JobExecutionException jobException,
             CancellationToken cancellationToken = default)
@@ -55,11 +55,10 @@ public class DisallowConcurrentExecutionJobTest
                 }
                 catch (Exception e)
                 {
-                    Console.Error.WriteLine(e.ToString());
+                    await Console.Error.WriteLineAsync(e.ToString());
                     throw new AssertionException("Await on barrier was interrupted: " + e);
                 }
             }
-            return default;
         }
     }
 

--- a/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
@@ -63,7 +63,7 @@ public class DirectSchedulerFactoryTest
     {
         await _directSchedulerFactory.CreateScheduler(_threadPool, _jobStore);
 
-        var scheduler = _schedulerRepository.Lookup(DirectSchedulerFactory.DefaultSchedulerName).GetAwaiter().GetResult();
+        var scheduler = await _schedulerRepository.Lookup(DirectSchedulerFactory.DefaultSchedulerName);
         Assert.IsNotNull(scheduler);
         Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
 
@@ -86,7 +86,7 @@ public class DirectSchedulerFactoryTest
 
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore);
 
-        var scheduler = _schedulerRepository.Lookup(schedulerName).GetAwaiter().GetResult();
+        var scheduler = await _schedulerRepository.Lookup(schedulerName);
         Assert.IsNotNull(scheduler);
         Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
 
@@ -128,7 +128,7 @@ public class DirectSchedulerFactoryTest
 
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore, schedulerPluginMap, idleWaitTime);
 
-        var scheduler = _schedulerRepository.Lookup(schedulerName).GetAwaiter().GetResult();
+        var scheduler = await _schedulerRepository.Lookup(schedulerName);
         Assert.IsNotNull(scheduler);
         Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
 
@@ -185,7 +185,7 @@ public class DirectSchedulerFactoryTest
 
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore, schedulerPluginMap, idleWaitTime, maxBatchSize, batchTimeWindow);
 
-        var scheduler = _schedulerRepository.Lookup(schedulerName).GetAwaiter().GetResult();
+        var scheduler = await _schedulerRepository.Lookup(schedulerName);
         Assert.IsNotNull(scheduler);
         Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
 
@@ -245,7 +245,7 @@ public class DirectSchedulerFactoryTest
 
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore, schedulerPluginMap, idleWaitTime, maxBatchSize, batchTimeWindow, schedulerExporter);
 
-        var scheduler = _schedulerRepository.Lookup(schedulerName).GetAwaiter().GetResult();
+        var scheduler = await _schedulerRepository.Lookup(schedulerName);
         Assert.IsNotNull(scheduler);
         Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
 

--- a/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
+++ b/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
@@ -48,7 +48,7 @@ public class JobExecutionAttributesInterfaceInheritanceTest
 
         public override string Name => "TestJobListener";
 
-        public override ValueTask JobWasExecuted(
+        public override async ValueTask JobWasExecuted(
             IJobExecutionContext context,
             JobExecutionException jobException,
             CancellationToken cancellationToken = default)
@@ -61,11 +61,10 @@ public class JobExecutionAttributesInterfaceInheritanceTest
                 }
                 catch (Exception e)
                 {
-                    Console.Error.WriteLine(e.ToString());
+                    await Console.Error.WriteLineAsync(e.ToString());
                     throw new AssertionException("Await on barrier was interrupted: " + e);
                 }
             }
-            return default;
         }
     }
 

--- a/src/Quartz.Tests.Unit/Plugin/History/LoggingJobHistoryPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/History/LoggingJobHistoryPluginTest.cs
@@ -67,9 +67,9 @@ public class LoggingJobHistoryPluginTest
     }
 
     [Test]
-    public void TestJobWasVetoedMessage()
+    public async Task TestJobWasVetoedMessage()
     {
-        plugin.JobExecutionVetoed(CreateJobExecutionContext());
+        await plugin.JobExecutionVetoed(CreateJobExecutionContext());
 
         Assert.That(plugin.InfoMessages.Count, Is.EqualTo(1));
     }

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -272,7 +272,7 @@ public class SchedulerTest
     }
 
     [Test]
-    public void TestShutdownWithWaitShouldBlockUntilAllTasksHaveCompleted()
+    public async Task TestShutdownWithWaitShouldBlockUntilAllTasksHaveCompleted()
     {
         var schedulerName = Guid.NewGuid().ToString();
         var executing = new ManualResetEvent(false);
@@ -284,8 +284,8 @@ public class SchedulerTest
         };
 
         var factory = new StdSchedulerFactory(properties);
-        var scheduler = factory.GetScheduler().GetAwaiter().GetResult();
-        scheduler.Start().GetAwaiter().GetResult();
+        var scheduler = await factory.GetScheduler();
+        await scheduler.Start();
 
         var job = JobBuilder.Create<TestJobWithDelay>()
             .UsingJobData(TestJobWithDelay.CreateJobDataMap(executing, completed))
@@ -295,14 +295,16 @@ public class SchedulerTest
             .ForJob(job)
             .StartNow()
             .Build();
-        scheduler.ScheduleJob(job, trigger).GetAwaiter().GetResult();
+        await scheduler.ScheduleJob(job, trigger);
 
         // Wait for job to start executing
         executing.WaitOne();
 
         var stopwatch = Stopwatch.StartNew();
 
-        scheduler.Shutdown(true).GetAwaiter().GetResult();
+        // There was a deadlock on shutdown, the test should cancel and fail instead of running forever.
+        CancellationTokenSource timeout = new(TimeSpan.FromSeconds(30));
+        await scheduler.Shutdown(true, timeout.Token);
 
         stopwatch.Stop();
 

--- a/src/Quartz/Hosting/QuartzHostedService.cs
+++ b/src/Quartz/Hosting/QuartzHostedService.cs
@@ -58,7 +58,7 @@ public sealed class QuartzHostedService : IHostedService
         using var combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(startupCancellationToken, applicationLifetime.ApplicationStarted);
 
         await Task.Delay(Timeout.InfiniteTimeSpan, combinedCancellationSource.Token) // Wait "indefinitely", until startup completes or is aborted
-            .ContinueWith(_ => { }, TaskContinuationOptions.OnlyOnCanceled) // Without an OperationCanceledException on cancellation
+            .ContinueWith(_ => { },  CancellationToken.None, TaskContinuationOptions.OnlyOnCanceled, TaskScheduler.Default) // Without an OperationCanceledException on cancellation
             .ConfigureAwait(false);
 
         if (!startupCancellationToken.IsCancellationRequested)


### PR DESCRIPTION
These are the lines that were identified as Safe cleanup actions in my other PR.

 - Do not sync wait on ValueTask, always call ToTask first.
 - ContinueWith on TaskScheduler.Default instead of current