### PR TITLE
Fix documentation link to Db page

### DIFF
--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -32,7 +32,7 @@ export const sidebarEn: SidebarConfig = [
         text: "API Documentation",
         link: "http://quartznet.sourceforge.net/apidoc/3.0/html",
       },
-      "/documentation/quartz-3.x/db",
+      "/documentation/quartz-3.x/db/index",
       "/documentation/quartz-3.x/migration-guide",
       "/documentation/quartz-3.x/miscellaneous-features",
     ],


### PR DESCRIPTION
Fix documentation link to Db Page (currently 404)

![image](https://github.com/quartznet/quartznet/assets/127927/be6e024e-d433-4de6-a07d-7ff99bac5714)
