### PR TITLE
 Added support for IHostedLifecycleService for the QuartzHostedService class

### DIFF
--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -287,6 +287,47 @@ public class Startup
         {
             // when shutting down we want jobs to complete gracefully
             options.WaitForJobsToComplete = true;
+
+            options.HostedServiceStartingHandler = HostedServiceStartingHandler;
+            options.HostedServiceStartedHandler = HostedServiceStartedHandler;
+            options.HostedServiceStoppingHandler = HostedServiceStoppingHandler;
+            options.HostedServiceStoppedHandler = HostedServiceStoppedHandler;
+
+            static async Task HostedServiceStartingHandler(IServiceProvider provider, CancellationToken cancellationToken)
+            {
+                provider.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(nameof(HostedServiceStartingHandler))
+                    .LogInformation("The {0} executes with a delay!!!", nameof(HostedServiceStartingHandler));
+
+                await Task.Delay(25, cancellationToken);
+            }
+
+            static async Task HostedServiceStartedHandler(IServiceProvider provider, CancellationToken cancellationToken)
+            {
+                provider.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(nameof(HostedServiceStartedHandler))
+                    .LogInformation("The {0} executes with a delay!!!", nameof(HostedServiceStartedHandler));
+
+                await Task.Delay(25, cancellationToken);
+            }
+
+            static async Task HostedServiceStoppingHandler(IServiceProvider provider, CancellationToken cancellationToken)
+            {
+                provider.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(nameof(HostedServiceStoppingHandler))
+                    .LogInformation("The {0} executes with a delay!!!", nameof(HostedServiceStoppingHandler));
+
+                await Task.Delay(25, cancellationToken);
+            }
+
+            static async Task HostedServiceStoppedHandler(IServiceProvider provider, CancellationToken cancellationToken)
+            {
+                provider.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(nameof(HostedServiceStoppedHandler))
+                    .LogInformation("The {0} executes with a delay!!!", nameof(HostedServiceStoppedHandler));
+
+                await Task.Delay(25, cancellationToken);
+            }
         });
 
         services

--- a/src/Quartz.Examples.Worker/Program.cs
+++ b/src/Quartz.Examples.Worker/Program.cs
@@ -92,6 +92,47 @@ public class Program
 
                     // when we need to init another IHostedServices first
                     options.StartDelay = TimeSpan.FromSeconds(10);
+
+                    options.HostedServiceStartingHandler = HostedServiceStartingHandler;
+                    options.HostedServiceStartedHandler = HostedServiceStartedHandler;
+                    options.HostedServiceStoppingHandler = HostedServiceStoppingHandler;
+                    options.HostedServiceStoppedHandler = HostedServiceStoppedHandler;
+
+                    static async Task HostedServiceStartingHandler(IServiceProvider provider, CancellationToken cancellationToken)
+                    {
+                        provider.GetRequiredService<ILoggerFactory>()
+                            .CreateLogger(nameof(HostedServiceStartingHandler))
+                            .LogInformation("The {0} executes with a delay!!!", nameof(HostedServiceStartingHandler));
+
+                        await Task.Delay(25, cancellationToken);
+                    }
+
+                    static async Task HostedServiceStartedHandler(IServiceProvider provider, CancellationToken cancellationToken)
+                    {
+                        provider.GetRequiredService<ILoggerFactory>()
+                            .CreateLogger(nameof(HostedServiceStartedHandler))
+                            .LogInformation("The {0} executes with a delay!!!", nameof(HostedServiceStartedHandler));
+
+                        await Task.Delay(25, cancellationToken);
+                    }
+
+                    static async Task HostedServiceStoppingHandler(IServiceProvider provider, CancellationToken cancellationToken)
+                    {
+                        provider.GetRequiredService<ILoggerFactory>()
+                            .CreateLogger(nameof(HostedServiceStoppingHandler))
+                            .LogInformation("The {0} executes with a delay!!!", nameof(HostedServiceStoppingHandler));
+
+                        await Task.Delay(25, cancellationToken);
+                    }
+
+                    static async Task HostedServiceStoppedHandler(IServiceProvider provider, CancellationToken cancellationToken)
+                    {
+                        provider.GetRequiredService<ILoggerFactory>()
+                            .CreateLogger(nameof(HostedServiceStoppedHandler))
+                            .LogInformation("The {0} executes with a delay!!!", nameof(HostedServiceStoppedHandler));
+
+                        await Task.Delay(25, cancellationToken);
+                    }
                 });
             });
 }

--- a/src/Quartz/Hosting/QuartzHostedServiceOptions.cs
+++ b/src/Quartz/Hosting/QuartzHostedServiceOptions.cs
@@ -2,7 +2,7 @@ namespace Quartz;
 
 #if NET8_0_OR_GREATER
 /// <summary>
-/// 
+/// References a method to be called as a handler for one of the IHostedLifecycleService methods.
 /// </summary>
 public delegate Task QuartzHostedServiceHandler(IServiceProvider provider, CancellationToken cancellationToken);
 #endif
@@ -33,22 +33,22 @@ public class QuartzHostedServiceOptions
 
 #if NET8_0_OR_GREATER
     /// <summary>
-    /// 
+    /// The handler that is called before start Quartz hosted service.
     /// </summary>
     public QuartzHostedServiceHandler? HostedServiceStartingHandler { get; set; }
 
     /// <summary>
-    /// 
+    /// The handler that is called after start Quartz hosted service.
     /// </summary>
     public QuartzHostedServiceHandler? HostedServiceStartedHandler { get; set; }
 
     /// <summary>
-    /// 
+    /// TThe handler that is called before stop Quartz hosted service.
     /// </summary>
     public QuartzHostedServiceHandler? HostedServiceStoppingHandler { get; set; }
 
     /// <summary>
-    /// 
+    /// The handler that is called after stop Quartz hosted service.
     /// </summary>
     public QuartzHostedServiceHandler? HostedServiceStoppedHandler { get; set; }
 #endif

--- a/src/Quartz/Hosting/QuartzHostedServiceOptions.cs
+++ b/src/Quartz/Hosting/QuartzHostedServiceOptions.cs
@@ -1,5 +1,12 @@
 namespace Quartz;
 
+#if NET8_0_OR_GREATER
+/// <summary>
+/// 
+/// </summary>
+public delegate Task QuartzHostedServiceHandler(IServiceProvider provider, CancellationToken cancellationToken);
+#endif
+
 public class QuartzHostedServiceOptions
 {
     /// <summary>
@@ -23,4 +30,26 @@ public class QuartzHostedServiceOptions
     /// This avoids the running of jobs <em>during</em> application startup.
     /// </summary>
     public bool AwaitApplicationStarted { get; set; } = true;
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// 
+    /// </summary>
+    public QuartzHostedServiceHandler? HostedServiceStartingHandler { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public QuartzHostedServiceHandler? HostedServiceStartedHandler { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public QuartzHostedServiceHandler? HostedServiceStoppingHandler { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public QuartzHostedServiceHandler? HostedServiceStoppedHandler { get; set; }
+#endif
 }


### PR DESCRIPTION
Changes:
1. Fixed preprocessor directive. Old version of the directive: NET6_OR_GREATER. New version of the directive: NET6_0_OR_GREATER.
2. Added support for IHostedLifecycleService for the QuartzHostedService class. This complements the existing options for configuring related services from DI container with new configuration scenarios.