### PR TITLE
Update NativeJob.cs

### DIFF
--- a/src/Quartz.Jobs/Job/NativeJob.cs
+++ b/src/Quartz.Jobs/Job/NativeJob.cs
@@ -120,7 +120,7 @@ namespace Quartz.Job
 			JobDataMap data = context.MergedJobDataMap;
 
 			string command = data.GetString(PropertyCommand) ?? throw new JobExecutionException("command missing");
-			string parameters = data.GetString(PropertyParameters) ?? "";
+			string parameters = data.TryGetString(PropertyParameters, out string? paramValue) ? paramValue! : string.Empty;
 
 		    bool wait = true;
 			if (data.ContainsKey(PropertyWaitForProcess))
@@ -133,7 +133,7 @@ namespace Quartz.Job
 				consumeStreams = data.GetBooleanValue(PropertyConsumeStreams);
 			}
 
-            var workingDirectory = data.GetString(PropertyWorkingDirectory);
+			data.TryGetString(PropertyWorkingDirectory, out var workingDirectory);
 			int exitCode = RunNativeCommand(command, parameters, workingDirectory, wait, consumeStreams);
 		    context.Result = exitCode;
             return Task.FromResult(true);

--- a/src/Quartz.Tests.Unit/Job/NativeJobTest.cs
+++ b/src/Quartz.Tests.Unit/Job/NativeJobTest.cs
@@ -1,0 +1,24 @@
+using System;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using Quartz.Job;
+
+namespace Quartz.Tests.Unit.Job;
+
+public class NativeJobTest
+{
+    [Test]
+    public void TestNativeJob()
+    {
+        var job = new NativeJob();
+        var context = TestUtil.NewJobExecutionContextFor(job);
+        context.MergedJobDataMap.Put(NativeJob.PropertyCommand, "Test");
+
+        Action act = () => job.Execute(context);
+
+        act.Should().NotThrow<Exception>();
+    }
+}


### PR DESCRIPTION
Behavier of GetString has changed. Now NativeJob raised an exception if parameters or workingDirectory wasn't included in MergedJobDataMap. See issue 2406
https://github.com/quartznet/quartznet/pull/2406