### PR TITLE
Update Build actions to use checkout/@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Run: Compile, UnitTest, IntegrationTest, Pack, Publish'
         run: ./build.cmd Compile UnitTest IntegrationTest Pack Publish
         env:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Run: Compile, UnitTest, IntegrationTest, Pack, Publish'
         run: ./build.cmd Compile UnitTest IntegrationTest Pack Publish
         env:
@@ -70,7 +70,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Run: Compile, UnitTest, IntegrationTest, Pack, Publish'
         run: ./build.cmd Compile UnitTest IntegrationTest Pack Publish
         env:

--- a/.github/workflows/pr-tests-integration-postgres.yml
+++ b/.github/workflows/pr-tests-integration-postgres.yml
@@ -34,6 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Run: Compile, IntegrationTest'
         run: ./build.cmd Compile IntegrationTest

--- a/.github/workflows/pr-tests-unit.yml
+++ b/.github/workflows/pr-tests-unit.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Run: Compile, UnitTest, PublishAot'
         run: ./build.cmd Compile UnitTest PublishAot
   ubuntu-latest:
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Run: Compile, UnitTest, PublishAot'
         run: ./build.cmd Compile UnitTest PublishAot
   macos-latest:
@@ -50,6 +50,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Run: Compile, UnitTest, PublishAot'
         run: ./build.cmd Compile UnitTest PublishAot


### PR DESCRIPTION
(v3 is deprecated)

Warning displayed on build

```text
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3. 
For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

Changelog: https://github.com/actions/checkout/releases/tag/v4.0.0