### PR TITLE
Fix DbDataSource connection creation

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/Common/DataSourceDbProvider.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/DataSourceDbProvider.cs
@@ -29,11 +29,6 @@ internal sealed class DataSourceDbProvider : DbProvider
         throw new SchedulerException($"Provider not specified for DataSource: {SchedulerBuilder.AdoProviderOptions.DefaultDataSourceName}");
     }
 
-    public override DbCommand CreateCommand()
-    {
-        return this.source.CreateCommand();
-    }
-
     public override DbConnection CreateConnection()
     {
         return this.source.CreateConnection();


### PR DESCRIPTION
My bad on this. I was testing out the change today and ran into an exception due to the existing ADO implementation assigning a connection & transaction to the command. This'll resolve that issue.