### PR TITLE
Issue #2330 I Add a check in nearestWeekday (CronExpression.cs) secti…

### DIFF
--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -994,4 +994,19 @@ years: *
 
         actualTimeAfter.Should().Be(expectedTimeAfter);
     }
+    [Test]
+    public void TestExceptionNearestDayOfTheMonth()
+    {
+        try
+        {
+            CronExpression cronExpression = new CronExpression("0 0 12 31W * ?") { TimeZone = TimeZoneInfo.Utc };
+            DateTime cal = new DateTime(2025, 1, 31, 12, 0, 0, DateTimeKind.Utc);
+            DateTimeOffset dtofcal = (DateTimeOffset) cal;
+            var nextFireTime = cronExpression.GetTimeAfter(dtofcal);
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail("Expected no exception, but got: " + ex.Message);
+        }
+    }
 }

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -1502,9 +1502,10 @@ public sealed class CronExpression : ISerializable
         }
         else if (nearestWeekday) //AND not lastDay
         {
-            var day = daysOfMonth.Min;
-            var tcal = new DateTimeOffset(dt.Year, dt.Month, day, 0, 0, 0, dt.Offset);
             var lastDayOfMonth = GetLastDayOfMonth(dt.Month, dt.Year);
+            var day = (daysOfMonth.Min > lastDayOfMonth) ? lastDayOfMonth : daysOfMonth.Min;
+
+            var tcal = new DateTimeOffset(dt.Year, dt.Month, day, 0, 0, 0, dt.Offset);
             var dayOfWeek = tcal.DayOfWeek;
 
             // evict original date since it has a weekDayModifier


### PR DESCRIPTION
…on in order to prevent exeption. If DaysOfMonth variable is greater than lastDayOfTheMonth I use the second to populate the variable day.  Without this check we tryed to istantiate invalid DateTimeOffset like 02/31/2025 now quartz will return 02/28/2025. I also added the test.