### PR TITLE
Refactor UnitTests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="10.3.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.33.0" />
     <PackageVersion Include="log4net" Version="2.0.17" />
     <PackageVersion Include="MELT" Version="0.9.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
@@ -26,6 +27,7 @@
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.1.0" />
     <PackageVersion Include="NUnit" Version="4.1.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />

--- a/src/Quartz.Tests.AspNetCore/HttpApi/CalendarEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/CalendarEndpointsTest.cs
@@ -1,6 +1,7 @@
 using FakeItEasy;
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Quartz.Impl.Calendar;
 using Quartz.Tests.AspNetCore.Support;
@@ -15,10 +16,12 @@ public class CalendarEndpointsTest : WebApiTest
         A.CallTo(() => FakeScheduler.GetCalendarNames(A<CancellationToken>._)).Returns(["Calendar 1", "Calendar 2"]);
 
         var calendarNames = await HttpScheduler.GetCalendarNames();
-
-        calendarNames.Count.Should().Be(2);
-        calendarNames.Should().ContainSingle(x => x == "Calendar 1");
-        calendarNames.Should().ContainSingle(x => x == "Calendar 2");
+        using (new AssertionScope())
+        {
+            calendarNames.Count.Should().Be(2);
+            calendarNames.Should().ContainSingle(x => x == "Calendar 1");
+            calendarNames.Should().ContainSingle(x => x == "Calendar 2");
+        }
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
@@ -1,6 +1,7 @@
 using FakeItEasy;
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Quartz.HttpClient;
 using Quartz.Impl.Matchers;
@@ -21,9 +22,12 @@ public class JobEndpointsTest : WebApiTest
 
         var jobKeys = await HttpScheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
 
-        jobKeys.Count.Should().Be(2);
-        jobKeys.Should().ContainSingle(x => x.Equals(jobKeyOne));
-        jobKeys.Should().ContainSingle(x => x.Equals(jobKeyTwo));
+        using (new AssertionScope())
+        {
+            jobKeys.Count.Should().Be(2);
+            jobKeys.Should().ContainSingle(x => x.Equals(jobKeyOne));
+            jobKeys.Should().ContainSingle(x => x.Equals(jobKeyTwo));
+        }
 
         var matchers = new[]
         {

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using FakeItEasy;
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -25,10 +26,12 @@ public class SchedulerEndpointsTest : WebApiTest
         // This endpoint is not used by HttpScheduler
         using var httpClient = WebApplicationFactory.CreateClient();
         var result = await httpClient.Get<SchedulerHeaderDto[]>("schedulers", new JsonSerializerOptions(JsonSerializerDefaults.Web), CancellationToken.None);
-
-        result.Length.Should().Be(2);
-        result.Should().ContainSingle(x => x.SchedulerInstanceId == TestData.SchedulerInstanceId);
-        result.Should().ContainSingle(x => x.SchedulerInstanceId == "TEST_2_NON_CLUSTERED");
+        using (new AssertionScope())
+        {
+            result.Length.Should().Be(2);
+            result.Should().ContainSingle(x => x.SchedulerInstanceId == TestData.SchedulerInstanceId);
+            result.Should().ContainSingle(x => x.SchedulerInstanceId == "TEST_2_NON_CLUSTERED");
+        }
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
@@ -1,6 +1,7 @@
 using FakeItEasy;
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Quartz.HttpClient;
 using Quartz.Impl.Matchers;
@@ -19,10 +20,12 @@ public class TriggerEndpointsTest : WebApiTest
         A.CallTo(() => FakeScheduler.GetTriggerKeys(A<GroupMatcher<TriggerKey>>._, A<CancellationToken>._)).Returns([triggerKeyOne, triggerKeyTwo]);
 
         var triggerKeys = await HttpScheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.AnyGroup());
-
-        triggerKeys.Count.Should().Be(2);
-        triggerKeys.Should().ContainSingle(x => x.Equals(triggerKeyOne));
-        triggerKeys.Should().ContainSingle(x => x.Equals(triggerKeyTwo));
+        using (new AssertionScope())
+        {
+            triggerKeys.Count.Should().Be(2);
+            triggerKeys.Should().ContainSingle(x => x.Equals(triggerKeyOne));
+            triggerKeys.Should().ContainSingle(x => x.Equals(triggerKeyTwo));
+        }
 
         var matchers = new[]
         {

--- a/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
+++ b/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
@@ -17,6 +17,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 

--- a/src/Quartz.Tests.Integration/Core/MissSchedulingChangeSignalTest.cs
+++ b/src/Quartz.Tests.Integration/Core/MissSchedulingChangeSignalTest.cs
@@ -52,13 +52,13 @@ public class MissSchedulingChangeSignalTest
 
         List<TimeSpan> durationBetweenFireTimesInMillis = CollectDurationBetweenFireTimesJob.Durations;
 
-        Assert.False(durationBetweenFireTimesInMillis.Count == 0, "Job was not executed once!");
+        Assert.That(durationBetweenFireTimesInMillis.Count == 0, Is.False, "Job was not executed once!");
 
         // Let's check that every call for around 1 second and not between 23 and 30 seconds
         // which would be the case if the scheduling change signal were not checked
         foreach (TimeSpan durationInMillis in durationBetweenFireTimesInMillis)
         {
-            Assert.True(durationInMillis.TotalMilliseconds < 20000, "Missed an execution with one duration being between two fires: " + durationInMillis + " (all: "
+            Assert.That(durationInMillis.TotalMilliseconds < 20000, Is.True, "Missed an execution with one duration being between two fires: " + durationInMillis + " (all: "
                                                                     + durationBetweenFireTimesInMillis + ")");
         }
     }

--- a/src/Quartz.Tests.Integration/Core/RecoverJobsTest.cs
+++ b/src/Quartz.Tests.Integration/Core/RecoverJobsTest.cs
@@ -74,13 +74,13 @@ public class RecoverJobsTest
                 var triggerState = command.ExecuteScalar().ToString();
 
                 // check that trigger is blocked after fail over situation
-                Assert.AreEqual("BLOCKED", triggerState);
+                Assert.That(triggerState, Is.EqualTo("BLOCKED"));
 
                 command.CommandText = $"SELECT count(*) from QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = '{scheduler.SchedulerName}' AND TRIGGER_NAME='test'";
                 int count = Convert.ToInt32(command.ExecuteScalar());
 
                 // check that fired trigger remains after fail over situation
-                Assert.AreEqual(1, count);
+                Assert.That(count, Is.EqualTo(1));
             }
         }
 
@@ -102,7 +102,7 @@ public class RecoverJobsTest
         // wait job
         await recovery.Shutdown(true);
 
-        Assert.True(isJobRecovered.Wait(TimeSpan.FromSeconds(10)));
+        Assert.That(isJobRecovered.Wait(TimeSpan.FromSeconds(10)), Is.True);
     }
 
     private class TestListener : JobListenerSupport

--- a/src/Quartz.Tests.Integration/ExceptionPolicy/ExceptionJobTest.cs
+++ b/src/Quartz.Tests.Integration/ExceptionPolicy/ExceptionJobTest.cs
@@ -51,7 +51,7 @@ public class ExceptionHandlingTest
 
         await Task.Delay(7 * 1000);
         await sched.DeleteJob(trigger.JobKey);
-        Assert.AreEqual(1, ExceptionJob.LaunchCount,
+        Assert.That(ExceptionJob.LaunchCount, Is.EqualTo(1),
             "The job shouldn't have been refired (UnscheduleFiringTrigger)");
 
         ExceptionJob.LaunchCount = 0;
@@ -67,7 +67,7 @@ public class ExceptionHandlingTest
         await sched.ScheduleJob(trigger);
         await Task.Delay(7 * 1000);
         await sched.DeleteJob(trigger.JobKey);
-        Assert.AreEqual(2, ExceptionJob.LaunchCount,
+        Assert.That(ExceptionJob.LaunchCount, Is.EqualTo(2),
             "The job shouldn't have been refired(UnscheduleFiringTrigger)");
     }
 
@@ -107,7 +107,7 @@ public class ExceptionHandlingTest
         await Task.Delay(1000);
         await sched.DeleteJob(jobKey);
         await Task.Delay(1000);
-        Assert.Greater(ExceptionJob.LaunchCount, 1, "The job should have been refired after exception");
+        Assert.That(ExceptionJob.LaunchCount, Is.GreaterThan(1), "The job should have been refired after exception");
     }
 
     [Test]
@@ -140,6 +140,6 @@ public class ExceptionHandlingTest
             }
         }
         await sched.DeleteJob(jobKey);
-        Assert.AreEqual(1, ExceptionJob.LaunchCount, "The job should NOT have been refired after exception");
+        Assert.That(ExceptionJob.LaunchCount, Is.EqualTo(1), "The job should NOT have been refired after exception");
     }
 }

--- a/src/Quartz.Tests.Integration/GlobalUsings.cs
+++ b/src/Quartz.Tests.Integration/GlobalUsings.cs
@@ -1,2 +1,0 @@
-global using Assert = NUnit.Framework.Legacy.ClassicAssert;
-global using CollectionAssert = NUnit.Framework.Legacy.CollectionAssert;

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbMetadataTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbMetadataTest.cs
@@ -52,15 +52,14 @@ public class DbMetadataTest
     {
         DbProvider dbp = new DbProvider(dbname, "foo");
         DbMetadata md = dbp.Metadata;
-        Assert.IsNotNull(md.AssemblyName);
-        Assert.IsNotNull(md.BindByName);
-        Assert.IsNotNull(md.CommandType);
-        Assert.IsNotNull(md.ConnectionType);
-        Assert.IsNotNull(md.ParameterType);
+        Assert.That(md.AssemblyName, Is.Not.Null);
+        Assert.That(md.CommandType, Is.Not.Null);
+        Assert.That(md.ConnectionType, Is.Not.Null);
+        Assert.That(md.ParameterType, Is.Not.Null);
         if (hashCustomBinaryType)
         {
-            Assert.IsNotNull(md.DbBinaryType);
-            Assert.IsNotNull(md.ParameterDbTypeProperty);
+            Assert.That(md.DbBinaryType, Is.Not.Null);
+            Assert.That(md.ParameterDbTypeProperty, Is.Not.Null);
         }
         return dbp;
     }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbProviderTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/Common/DbProviderTest.cs
@@ -43,7 +43,7 @@ public class DbProviderTest
     public void TestValidProviderSqlServer()
     {
         DbProvider provider = new DbProvider(TestConstants.DefaultSqlServerProvider, "foo");
-        Assert.IsNotNull(provider.ConnectionString);
-        Assert.IsNotNull(provider.Metadata);
+        Assert.That(provider.ConnectionString, Is.Not.Null);
+        Assert.That(provider.Metadata, Is.Not.Null);
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/Calendar/AnnualCalendarTest.cs
@@ -71,12 +71,12 @@ public class AnnualCalendarTest : IntegrationTest
 
         await sched.RescheduleJob(new TriggerKey("trigName", "trigGroup"), triggerreplace);
         await Task.Delay(TimeSpan.FromSeconds(20));
-        Assert.IsFalse(TestJob.JobHasFired, "task must not be neglected - it is forbidden by the calendar");
+        Assert.That(TestJob.JobHasFired, Is.False, "task must not be neglected - it is forbidden by the calendar");
 
         calendar.SetDayExcluded(DateTime.Now, false);
         await sched.AddCalendar("calendar", calendar, true, true);
         await Task.Delay(TimeSpan.FromSeconds(20));
-        Assert.IsTrue(TestJob.JobHasFired, "task must be neglected - it is permitted by the calendar");
+        Assert.That(TestJob.JobHasFired, Is.True, "task must be neglected - it is permitted by the calendar");
 
         await sched.DeleteJob(new JobKey("name", "group"));
         await sched.DeleteCalendar("calendar");

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -34,7 +34,7 @@ public class SmokeTestPerformer
 
                 // QRTZNET-86
                 ITrigger t = await scheduler.GetTrigger(new TriggerKey("NonExistingTrigger", "NonExistingGroup"));
-                Assert.IsNull(t);
+                Assert.That(t, Is.Null);
 
                 AnnualCalendar cal = new AnnualCalendar();
                 cal.SetDayExcluded(new DateTime(2018, 7, 4), true);
@@ -70,7 +70,7 @@ public class SmokeTestPerformer
                 Assert.That(customCalendar, Is.Not.Null);
                 Assert.That(customCalendar.SomeCustomProperty, Is.True);
 
-                Assert.IsNotNull(await scheduler.GetCalendar("annualCalendar"));
+                Assert.That(await scheduler.GetCalendar("annualCalendar"), Is.Not.Null);
 
                 var lonelyJob = JobBuilder.Create()
                     .OfType<SimpleRecoveryJob>()
@@ -102,8 +102,8 @@ public class SmokeTestPerformer
 
                 // check that trigger was stored
                 ITrigger persisted = await scheduler.GetTrigger(new TriggerKey("trig_" + count, schedId));
-                Assert.IsNotNull(persisted);
-                Assert.IsTrue(persisted is SimpleTriggerImpl);
+                Assert.That(persisted, Is.Not.Null);
+                Assert.That(persisted is SimpleTriggerImpl, Is.True);
 
                 count++;
                 job = JobBuilder.Create()
@@ -287,8 +287,8 @@ public class SmokeTestPerformer
 
                 await scheduler.ScheduleJobs(info, true);
 
-                Assert.IsTrue(await scheduler.CheckExists(detail.Key));
-                Assert.IsTrue(await scheduler.CheckExists(simple.Key));
+                Assert.That(await scheduler.CheckExists(detail.Key), Is.True);
+                Assert.That(await scheduler.CheckExists(simple.Key), Is.True);
 
                 // QRTZNET-243
                 await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupContains("a"));
@@ -325,15 +325,15 @@ public class SmokeTestPerformer
                 await scheduler.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals(schedId));
 
                 var pausedTriggerGroups = await scheduler.GetPausedTriggerGroups();
-                Assert.AreEqual(1, pausedTriggerGroups.Count);
+                Assert.That(pausedTriggerGroups.Count, Is.EqualTo(1));
 
                 await Task.Delay(TimeSpan.FromSeconds(3));
                 await scheduler.ResumeTriggers(GroupMatcher<TriggerKey>.GroupEquals(schedId));
 
-                Assert.IsNotNull(scheduler.GetTrigger(new TriggerKey("trig_2", schedId)));
-                Assert.IsNotNull(scheduler.GetJobDetail(new JobKey("job_1", schedId)));
-                Assert.IsNotNull(scheduler.GetMetaData());
-                Assert.IsNotNull(scheduler.GetCalendar("weeklyCalendar"));
+                Assert.That(await scheduler.GetTrigger(new TriggerKey("trig_2", schedId)), Is.Not.Null);
+                Assert.That(await scheduler.GetJobDetail(new JobKey("job_1", schedId)), Is.Not.Null);
+                Assert.That(await scheduler.GetMetaData(), Is.Not.Null);
+                Assert.That(await scheduler.GetCalendar("weeklyCalendar"), Is.Not.Null);
 
                 var genericjobKey = new JobKey("genericJob", "genericGroup");
                 GenericJobType.Reset();
@@ -353,11 +353,13 @@ public class SmokeTestPerformer
                 Assert.That(GenericJobType.TriggeredCount, Is.EqualTo(1));
                 await scheduler.Standby();
 
-                CollectionAssert.IsNotEmpty(await scheduler.GetCalendarNames());
-                CollectionAssert.IsNotEmpty(await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(schedId)));
+                Assert.That(await scheduler.GetCalendarNames(), Is.Not.Empty);
+                Assert.That(await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(schedId)), Is.Not.Empty);
 
-                CollectionAssert.IsNotEmpty(await scheduler.GetTriggersOfJob(new JobKey("job_2", schedId)));
-                Assert.IsNotNull(scheduler.GetJobDetail(new JobKey("job_2", schedId)));
+                Assert.That(await scheduler.GetTriggersOfJob(new JobKey("job_2", schedId)), Is.Not.Empty);
+#pragma warning disable NUnit2023
+                Assert.That(scheduler.GetJobDetail(new JobKey("job_2", schedId)), Is.Not.Null);
+#pragma warning restore NUnit2023
 
                 await scheduler.DeleteCalendar("cronCalendar");
                 await scheduler.DeleteCalendar("holidayCalendar");

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -31,6 +31,10 @@
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="Npgsql" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Oracle.ManagedDataAccess.Core" />
     <PackageReference Include="System.Data.SQLite.Core" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
@@ -72,7 +72,7 @@ public class XMLSchedulingDataProcessorTest
     {
         Stream s = ReadJobXmlFromEmbeddedResource("MinimalConfiguration_20.xml");
         await processor.ProcessStream(s, null);
-        Assert.IsFalse(processor.OverWriteExistingData);
+        Assert.That(processor.OverWriteExistingData, Is.False);
 
         await processor.ScheduleJobs(mockScheduler);
     }
@@ -82,8 +82,8 @@ public class XMLSchedulingDataProcessorTest
     {
         Stream s = ReadJobXmlFromEmbeddedResource("RichConfiguration_20.xml");
         await processor.ProcessStream(s, null);
-        Assert.IsFalse(processor.OverWriteExistingData);
-        Assert.IsTrue(processor.IgnoreDuplicates);
+        Assert.That(processor.OverWriteExistingData, Is.False);
+        Assert.That(processor.IgnoreDuplicates, Is.True);
 
         await processor.ScheduleJobs(mockScheduler);
 
@@ -188,13 +188,13 @@ public class XMLSchedulingDataProcessorTest
 
             // We should still have what we start with.
             var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals("DEFAULT"));
-            Assert.AreEqual(1, jobKeys.Count);
+            Assert.That(jobKeys.Count, Is.EqualTo(1));
             var triggerKeys = await scheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals("DEFAULT"));
-            Assert.AreEqual(1, triggerKeys.Count);
+            Assert.That(triggerKeys.Count, Is.EqualTo(1));
 
             job = await scheduler.GetJobDetail(JobKey.Create("job1"));
             string fooValue = job.JobDataMap.GetString("foo");
-            Assert.AreEqual("dont_chg_me", fooValue);
+            Assert.That(fooValue, Is.EqualTo("dont_chg_me"));
         }
         finally
         {
@@ -260,9 +260,9 @@ public class XMLSchedulingDataProcessorTest
             XMLSchedulingDataProcessor processor = new XMLSchedulingDataProcessor(logger, loadHelper, TimeProvider.System);
             await processor.ProcessFileAndScheduleJobs(tempFileName, scheduler);
             var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals("DEFAULT"));
-            Assert.AreEqual(2, jobKeys.Count);
+            Assert.That(jobKeys.Count, Is.EqualTo(2));
             var triggerKeys = await scheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals("DEFAULT"));
-            Assert.AreEqual(2, triggerKeys.Count);
+            Assert.That(triggerKeys.Count, Is.EqualTo(2));
         }
         finally
         {

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
@@ -34,7 +34,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 4);
         DateTimeOffset thirdTime = fireTimes[2]; // get the third fire time
 
-        Assert.AreEqual(targetCalendar, thirdTime, "Year increment result not as expected.");
+        Assert.That(thirdTime, Is.EqualTo(targetCalendar), "Year increment result not as expected.");
     }
 
     [Test]
@@ -54,7 +54,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 6);
         DateTimeOffset sixthTime = fireTimes[5]; // get the sixth fire time
 
-        Assert.AreEqual(targetCalendar, sixthTime, "Month increment result not as expected.");
+        Assert.That(sixthTime, Is.EqualTo(targetCalendar), "Month increment result not as expected.");
     }
 
     [Test]
@@ -74,7 +74,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 7);
         DateTimeOffset fifthTime = fireTimes[4]; // get the fifth fire time
 
-        Assert.AreEqual(targetCalendar, fifthTime, "Week increment result not as expected.");
+        Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Week increment result not as expected.");
     }
 
     [Test]
@@ -94,7 +94,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
         DateTimeOffset fifthTime = fireTimes[4]; // get the fifth fire time
 
-        Assert.AreEqual(targetCalendar, fifthTime, "Day increment result not as expected.");
+        Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Day increment result not as expected.");
     }
 
     [Test]
@@ -114,7 +114,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 6);
         DateTimeOffset fifthTime = fireTimes[4]; // get the fifth fire time
 
-        Assert.AreEqual(targetCalendar, fifthTime, "Hour increment result not as expected.");
+        Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Hour increment result not as expected.");
     }
 
     [Test]
@@ -134,7 +134,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 6);
         DateTimeOffset fifthTime = fireTimes[4]; // get the fifth fire time
 
-        Assert.AreEqual(targetCalendar, fifthTime, "Minutes increment result not as expected.");
+        Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Minutes increment result not as expected.");
     }
 
     [Test]
@@ -154,7 +154,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 6);
         DateTimeOffset fifthTime = fireTimes[4]; // get the third fire time
 
-        Assert.AreEqual(targetCalendar, fifthTime, "Seconds increment result not as expected.");
+        Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Seconds increment result not as expected.");
     }
 
     [Test]
@@ -176,7 +176,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
         DateTimeOffset testTime = fireTimes[2]; // get the third fire time
 
-        Assert.AreEqual(targetCalendar, testTime, "Day increment result not as expected over spring 2010 daylight savings transition.");
+        Assert.That(testTime, Is.EqualTo(targetCalendar), "Day increment result not as expected over spring 2010 daylight savings transition.");
 
         // And again, Pick a day before a spring daylight savings transition... (QTZ-240)
 
@@ -192,7 +192,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
         testTime = fireTimes[2]; // get the third fire time
 
-        Assert.AreEqual(targetCalendar, testTime, "Day increment result not as expected over spring 2011 daylight savings transition.");
+        Assert.That(testTime, Is.EqualTo(targetCalendar), "Day increment result not as expected over spring 2011 daylight savings transition.");
 
         // And again, Pick a day before a spring daylight savings transition... (QTZ-240) - and prove time of day is not preserved without setPreserveHourOfDayAcrossDaylightSavings(true)
 
@@ -213,7 +213,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset testCal = TimeZoneUtil.ConvertTime(testTime, cetTimeZone);
 
-        Assert.AreNotEqual(targetCalendar.Hour, testCal.Hour, "Day increment time-of-day result not as expected over spring 2011 daylight savings transition.");
+        Assert.That(testCal.Hour, Is.Not.EqualTo(targetCalendar.Hour), "Day increment time-of-day result not as expected over spring 2011 daylight savings transition.");
 
         // And again, Pick a day before a spring daylight savings transition... (QTZ-240) - and prove time of day is preserved with setPreserveHourOfDayAcrossDaylightSavings(true)
 
@@ -234,7 +234,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         testCal = TimeZoneUtil.ConvertTime(testTime, cetTimeZone);
 
-        Assert.AreEqual(targetCalendar.Hour, testCal.Hour, "Day increment time-of-day result not as expected over spring 2011 daylight savings transition.");
+        Assert.That(testCal.Hour, Is.EqualTo(targetCalendar.Hour), "Day increment time-of-day result not as expected over spring 2011 daylight savings transition.");
 
         // Pick a day before a fall daylight savings transition...
 
@@ -252,7 +252,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
         testTime = fireTimes[3]; // get the fourth fire time
 
-        Assert.AreEqual(targetCalendar, testTime, "Day increment result not as expected over fall daylight savings transition.");
+        Assert.That(testTime, Is.EqualTo(targetCalendar), "Day increment result not as expected over fall daylight savings transition.");
     }
 
     [Test]
@@ -271,7 +271,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset? testTime = dailyTrigger.FinalFireTimeUtc;
 
-        Assert.AreEqual(endCalendar, testTime, "Final fire time not computed correctly for day interval.");
+        Assert.That(testTime, Is.EqualTo(endCalendar), "Final fire time not computed correctly for day interval.");
 
         endCalendar = startCalendar.AddDays(15).AddMinutes(-2); // jump 15 days and back up 2 minutes
         dailyTrigger = new CalendarIntervalTriggerImpl
@@ -284,11 +284,11 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         testTime = dailyTrigger.FinalFireTimeUtc;
 
-        Assert.IsTrue(endCalendar > testTime, "Final fire time not computed correctly for minutely interval.");
+        Assert.That(endCalendar > testTime, Is.True, "Final fire time not computed correctly for minutely interval.");
 
         endCalendar = endCalendar.AddMinutes(-3); // back up three more minutes
 
-        Assert.AreEqual(endCalendar, testTime, "Final fire time not computed correctly for minutely interval.");
+        Assert.That(testTime, Is.EqualTo(endCalendar), "Final fire time not computed correctly for minutely interval.");
     }
 
     [Test]
@@ -328,24 +328,26 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     {
         TimeZoneInfo timeZone = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
 
-        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl("trigger", IntervalUnit.Day, 1);
-        trigger.TimeZone = timeZone;
-        trigger.StartTimeUtc = new DateTimeOffset(2012, 11, 2, 12, 0, 0, TimeSpan.FromHours(-4));
+        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl("trigger", IntervalUnit.Day, 1)
+        {
+            TimeZone = timeZone,
+            StartTimeUtc = new DateTimeOffset(2012, 11, 2, 12, 0, 0, TimeSpan.FromHours(-4))
+        };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 6);
 
         var expected = new DateTimeOffset(2012, 11, 2, 12, 0, 0, TimeSpan.FromHours(-4));
-        Assert.AreEqual(expected, fireTimes[0]);
+        Assert.That(fireTimes[0], Is.EqualTo(expected));
 
         expected = new DateTimeOffset(2012, 11, 3, 12, 0, 0, TimeSpan.FromHours(-4));
-        Assert.AreEqual(expected, fireTimes[1]);
+        Assert.That(fireTimes[1], Is.EqualTo(expected));
 
         //this next day should be a new daylight savings change, notice the change in offset
         expected = new DateTimeOffset(2012, 11, 4, 11, 0, 0, TimeSpan.FromHours(-5));
-        Assert.AreEqual(expected, fireTimes[2]);
+        Assert.That(fireTimes[2], Is.EqualTo(expected));
 
         expected = new DateTimeOffset(2012, 11, 5, 11, 0, 0, TimeSpan.FromHours(-5));
-        Assert.AreEqual(expected, fireTimes[3]);
+        Assert.That(fireTimes[3], Is.EqualTo(expected));
     }
 
     [Test]
@@ -359,12 +361,14 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         //-------------------------------------------------
         // DAILY
         //-------------------------------------------------
-        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
-        trigger.TimeZone = timeZone;
-        trigger.RepeatInterval = 1;
-        trigger.RepeatIntervalUnit = IntervalUnit.Day;
-        trigger.PreserveHourOfDayAcrossDaylightSavings = true;
-        trigger.SkipDayIfHourDoesNotExist = true;
+        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl
+        {
+            TimeZone = timeZone,
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Day,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = true
+        };
 
         DateTimeOffset startDate = new DateTimeOffset(2012, 3, 10, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
@@ -373,10 +377,10 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         var targetTime = fires[1]; //get second fire
 
-        Assert.IsFalse(timeZone.IsInvalidTime(targetTime.DateTime), "did not seem to skip the day with an hour that doesn't exist.");
+        Assert.That(timeZone.IsInvalidTime(targetTime.DateTime), Is.False, "did not seem to skip the day with an hour that doesn't exist.");
 
         DateTimeOffset expectedTarget = new DateTimeOffset(2012, 3, 12, 2, 0, 0, TimeSpan.FromHours(-4)); // 3/12/2012 2am
-        Assert.AreEqual(expectedTarget, targetTime);
+        Assert.That(targetTime, Is.EqualTo(expectedTarget));
 
         //-------------------------------------------------
         // WEEKLY
@@ -395,10 +399,10 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetTime = fires[1]; //get second fire
 
-        Assert.IsFalse(timeZone.IsInvalidTime(targetTime.DateTime), "did not seem to skip the day with an hour that doesn't exist.");
+        Assert.That(timeZone.IsInvalidTime(targetTime.DateTime), Is.False, "did not seem to skip the day with an hour that doesn't exist.");
 
         expectedTarget = new DateTimeOffset(2012, 3, 18, 2, 0, 0, TimeSpan.FromHours(-4)); // 3/18/2012 2am
-        Assert.AreEqual(expectedTarget, targetTime);
+        Assert.That(targetTime, Is.EqualTo(expectedTarget));
 
         //-------------------------------------------------
         // MONTHLY
@@ -418,21 +422,23 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetTime = fires[1]; //get second fire
 
-        Assert.IsFalse(timeZone.IsInvalidTime(targetTime.DateTime), "did not seem to skip the day with an hour that doesn't exist.");
+        Assert.That(timeZone.IsInvalidTime(targetTime.DateTime), Is.False, "did not seem to skip the day with an hour that doesn't exist.");
 
         expectedTarget = new DateTimeOffset(2012, 4, 11, 2, 0, 0, TimeSpan.FromHours(-4)); // 4/11/2012 2am
-        Assert.AreEqual(expectedTarget, targetTime);
+        Assert.That(targetTime, Is.EqualTo(expectedTarget));
 
         //-------------------------------------------------
         // YEARLY
         //-------------------------------------------------
 
-        trigger = new CalendarIntervalTriggerImpl();
-        trigger.TimeZone = timeZone;
-        trigger.RepeatInterval = 1;
-        trigger.RepeatIntervalUnit = IntervalUnit.Year;
-        trigger.PreserveHourOfDayAcrossDaylightSavings = true;
-        trigger.SkipDayIfHourDoesNotExist = true;
+        trigger = new CalendarIntervalTriggerImpl
+        {
+            TimeZone = timeZone,
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Year,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = true
+        };
 
         startDate = new DateTimeOffset(2011, 3, 11, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
@@ -441,10 +447,10 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetTime = fires[1]; //get second fire
 
-        Assert.IsFalse(timeZone.IsInvalidTime(targetTime.DateTime), "did not seem to skip the day with an hour that doesn't exist.");
+        Assert.That(timeZone.IsInvalidTime(targetTime.DateTime), Is.False, "did not seem to skip the day with an hour that doesn't exist.");
 
         expectedTarget = new DateTimeOffset(2013, 3, 11, 2, 0, 0, TimeSpan.FromHours(-4)); // 3/11/2013 2am
-        Assert.AreEqual(expectedTarget, targetTime);
+        Assert.That(targetTime, Is.EqualTo(expectedTarget));
     }
 
     [Test]
@@ -462,12 +468,14 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         // DAILY
         //-------------------------------------------------
 
-        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
-        trigger.TimeZone = timeZone;
-        trigger.RepeatInterval = 1;
-        trigger.RepeatIntervalUnit = IntervalUnit.Day;
-        trigger.PreserveHourOfDayAcrossDaylightSavings = true;
-        trigger.SkipDayIfHourDoesNotExist = false;
+        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl
+        {
+            TimeZone = timeZone,
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Day,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = false
+        };
 
         DateTimeOffset startDate = new DateTimeOffset(2012, 3, 10, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
@@ -476,18 +484,23 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         var targetTime = fires[1]; //get second fire
 
-        Assert.IsFalse(timeZone.IsInvalidTime(targetTime.DateTime), "did not seem to skip the day with an hour that doesn't exist.");
-        Assert.AreEqual(expectedTarget, targetTime);
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeZone.IsInvalidTime(targetTime.DateTime), Is.False, "did not seem to skip the day with an hour that doesn't exist.");
+            Assert.That(targetTime, Is.EqualTo(expectedTarget));
+        });
 
         //-------------------------------------------------
         // WEEKLY
         //-------------------------------------------------
-        trigger = new CalendarIntervalTriggerImpl();
-        trigger.TimeZone = timeZone;
-        trigger.RepeatInterval = 1;
-        trigger.RepeatIntervalUnit = IntervalUnit.Week;
-        trigger.PreserveHourOfDayAcrossDaylightSavings = true;
-        trigger.SkipDayIfHourDoesNotExist = false;
+        trigger = new CalendarIntervalTriggerImpl
+        {
+            TimeZone = timeZone,
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Week,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = false
+        };
 
         startDate = new DateTimeOffset(2012, 3, 4, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
@@ -496,18 +509,23 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetTime = fires[1]; //get second fire
 
-        Assert.IsFalse(timeZone.IsInvalidTime(targetTime.DateTime), "did not seem to skip the day with an hour that doesn't exist.");
-        Assert.AreEqual(expectedTarget, targetTime);
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeZone.IsInvalidTime(targetTime.DateTime), Is.False, "did not seem to skip the day with an hour that doesn't exist.");
+            Assert.That(targetTime, Is.EqualTo(expectedTarget));
+        });
 
         //-------------------------------------------------
         // MONTHLY
         //-------------------------------------------------
-        trigger = new CalendarIntervalTriggerImpl();
-        trigger.TimeZone = timeZone;
-        trigger.RepeatInterval = 1;
-        trigger.RepeatIntervalUnit = IntervalUnit.Month;
-        trigger.PreserveHourOfDayAcrossDaylightSavings = true;
-        trigger.SkipDayIfHourDoesNotExist = false;
+        trigger = new CalendarIntervalTriggerImpl
+        {
+            TimeZone = timeZone,
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Month,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = false
+        };
 
         startDate = new DateTimeOffset(2012, 2, 11, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
@@ -516,19 +534,24 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetTime = fires[1]; //get second fire
 
-        Assert.IsFalse(timeZone.IsInvalidTime(targetTime.DateTime), "did not seem to skip the day with an hour that doesn't exist.");
-        Assert.AreEqual(expectedTarget, targetTime);
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeZone.IsInvalidTime(targetTime.DateTime), Is.False, "did not seem to skip the day with an hour that doesn't exist.");
+            Assert.That(targetTime, Is.EqualTo(expectedTarget));
+        });
 
         //-------------------------------------------------
         // YEARLY
         //-------------------------------------------------
 
-        trigger = new CalendarIntervalTriggerImpl();
-        trigger.TimeZone = timeZone;
-        trigger.RepeatInterval = 1;
-        trigger.RepeatIntervalUnit = IntervalUnit.Year;
-        trigger.PreserveHourOfDayAcrossDaylightSavings = true;
-        trigger.SkipDayIfHourDoesNotExist = false;
+        trigger = new CalendarIntervalTriggerImpl
+        {
+            TimeZone = timeZone,
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Year,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = false
+        };
 
         startDate = new DateTimeOffset(2011, 3, 11, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
@@ -537,8 +560,11 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetTime = fires[1]; //get second fire
 
-        Assert.IsFalse(timeZone.IsInvalidTime(targetTime.DateTime), "did not seem to skip the day with an hour that doesn't exist.");
-        Assert.AreEqual(expectedTarget, targetTime);
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeZone.IsInvalidTime(targetTime.DateTime), Is.False, "did not seem to skip the day with an hour that doesn't exist.");
+            Assert.That(targetTime, Is.EqualTo(expectedTarget));
+        });
     }
 
     [Test]
@@ -547,20 +573,22 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
         DateTimeOffset startDate = new DateTimeOffset(2012, 3, 11, 12, 0, 0, TimeSpan.FromHours(-5));
 
-        CalendarIntervalTriggerImpl t = new CalendarIntervalTriggerImpl();
-        t.RepeatInterval = 1;
-        t.RepeatIntervalUnit = IntervalUnit.Day;
-        t.PreserveHourOfDayAcrossDaylightSavings = true;
-        t.SkipDayIfHourDoesNotExist = false;
-        t.StartTimeUtc = startDate;
-        t.TimeZone = est;
+        CalendarIntervalTriggerImpl t = new CalendarIntervalTriggerImpl
+        {
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Day,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = false,
+            StartTimeUtc = startDate,
+            TimeZone = est
+        };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(t, null, 10);
 
         var firstFire = fireTimes[0];
         var secondFire = fireTimes[1];
 
-        Assert.AreNotEqual(firstFire, secondFire);
+        Assert.That(secondFire, Is.Not.EqualTo(firstFire));
     }
 
     [Test]
@@ -569,34 +597,38 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
         DateTimeOffset startDate = new DateTimeOffset(1990, 10, 27, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        CalendarIntervalTriggerImpl t = new CalendarIntervalTriggerImpl();
-        t.RepeatInterval = 1;
-        t.RepeatIntervalUnit = IntervalUnit.Day;
-        t.PreserveHourOfDayAcrossDaylightSavings = true;
-        t.SkipDayIfHourDoesNotExist = false;
-        t.StartTimeUtc = startDate;
-        t.TimeZone = est;
+        CalendarIntervalTriggerImpl t = new CalendarIntervalTriggerImpl
+        {
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Day,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = false,
+            StartTimeUtc = startDate,
+            TimeZone = est
+        };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(t, null, 10);
 
         var firstFire = fireTimes[0];
         var secondFire = fireTimes[1];
-        Assert.AreNotEqual(firstFire, secondFire);
+        Assert.That(secondFire, Is.Not.EqualTo(firstFire));
 
         //try to trigger a shift in month
         startDate = new DateTimeOffset(2012, 6, 1, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        t = new CalendarIntervalTriggerImpl();
-        t.RepeatInterval = 1;
-        t.RepeatIntervalUnit = IntervalUnit.Month;
-        t.PreserveHourOfDayAcrossDaylightSavings = true;
-        t.SkipDayIfHourDoesNotExist = false;
-        t.StartTimeUtc = startDate;
-        t.TimeZone = est;
+        t = new CalendarIntervalTriggerImpl
+        {
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Month,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            SkipDayIfHourDoesNotExist = false,
+            StartTimeUtc = startDate,
+            TimeZone = est
+        };
 
         fireTimes = TriggerUtils.ComputeFireTimes(t, null, 10);
 
-        Assert.AreNotEqual(firstFire, secondFire);
+        Assert.That(secondFire, Is.Not.EqualTo(firstFire));
     }
 
     [Test]
@@ -620,7 +652,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             var previousFire = fireTimes[i - 1];
             var currentFire = fireTimes[i];
 
-            Assert.AreNotEqual(previousFire, currentFire);
+            Assert.That(currentFire, Is.Not.EqualTo(previousFire));
         }
     }
 
@@ -642,8 +674,11 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset? fireTime = trigger.GetFireTimeAfter(fireTimeAfter);
 
-        Assert.AreNotEqual(fireTime, fireTimeAfter);
-        Assert.IsTrue(fireTime > fireTimeAfter);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimeAfter, Is.Not.EqualTo(fireTime));
+            Assert.That(fireTime > fireTimeAfter, Is.True);
+        });
     }
 
     [Test]
@@ -700,12 +735,15 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var scheduleBuilder = trigger.GetScheduleBuilder();
 
         var cloned = (CalendarIntervalTriggerImpl) scheduleBuilder.Build();
-        Assert.That(cloned.PreserveHourOfDayAcrossDaylightSavings, Is.EqualTo(trigger.PreserveHourOfDayAcrossDaylightSavings));
-        Assert.That(cloned.SkipDayIfHourDoesNotExist, Is.EqualTo(trigger.SkipDayIfHourDoesNotExist));
-        Assert.That(cloned.RepeatInterval, Is.EqualTo(trigger.RepeatInterval));
-        Assert.That(cloned.RepeatIntervalUnit, Is.EqualTo(trigger.RepeatIntervalUnit));
-        Assert.That(cloned.MisfireInstruction, Is.EqualTo(trigger.MisfireInstruction));
-        Assert.That(cloned.TimeZone, Is.EqualTo(trigger.TimeZone));
+        Assert.Multiple(() =>
+        {
+            Assert.That(cloned.PreserveHourOfDayAcrossDaylightSavings, Is.EqualTo(trigger.PreserveHourOfDayAcrossDaylightSavings));
+            Assert.That(cloned.SkipDayIfHourDoesNotExist, Is.EqualTo(trigger.SkipDayIfHourDoesNotExist));
+            Assert.That(cloned.RepeatInterval, Is.EqualTo(trigger.RepeatInterval));
+            Assert.That(cloned.RepeatIntervalUnit, Is.EqualTo(trigger.RepeatIntervalUnit));
+            Assert.That(cloned.MisfireInstruction, Is.EqualTo(trigger.MisfireInstruction));
+            Assert.That(cloned.TimeZone, Is.EqualTo(trigger.TimeZone));
+        });
     }
 
     [Test(Description = "https://github.com/quartznet/quartznet/issues/505")]
@@ -760,15 +798,18 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
     protected override void VerifyMatch(CalendarIntervalTriggerImpl original, CalendarIntervalTriggerImpl deserialized)
     {
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(original.Key, deserialized.Key);
-        Assert.AreEqual(original.JobKey, deserialized.JobKey);
-        Assert.That(deserialized.StartTimeUtc, Is.EqualTo(original.StartTimeUtc).Within(TimeSpan.FromSeconds(1)));
-        Assert.AreEqual(original.EndTimeUtc, deserialized.EndTimeUtc);
-        Assert.AreEqual(original.CalendarName, deserialized.CalendarName);
-        Assert.AreEqual(original.Description, deserialized.Description);
-        Assert.AreEqual(original.JobDataMap, deserialized.JobDataMap);
-        Assert.AreEqual(original.RepeatInterval, deserialized.RepeatInterval);
-        Assert.AreEqual(original.RepeatIntervalUnit, deserialized.RepeatIntervalUnit);
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Key, Is.EqualTo(original.Key));
+            Assert.That(deserialized.JobKey, Is.EqualTo(original.JobKey));
+            Assert.That(deserialized.StartTimeUtc, Is.EqualTo(original.StartTimeUtc).Within(TimeSpan.FromSeconds(1)));
+            Assert.That(deserialized.EndTimeUtc, Is.EqualTo(original.EndTimeUtc));
+            Assert.That(deserialized.CalendarName, Is.EqualTo(original.CalendarName));
+            Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+            Assert.That(deserialized.JobDataMap, Is.EqualTo(original.JobDataMap));
+            Assert.That(deserialized.RepeatInterval, Is.EqualTo(original.RepeatInterval));
+            Assert.That(deserialized.RepeatIntervalUnit, Is.EqualTo(original.RepeatIntervalUnit));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
@@ -285,7 +285,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         testTime = dailyTrigger.FinalFireTimeUtc;
 
-        Assert.That(endCalendar > testTime, Is.True, "Final fire time not computed correctly for minutely interval.");
+        Assert.That(endCalendar, Is.GreaterThan(testTime), "Final fire time not computed correctly for minutely interval.");
 
         endCalendar = endCalendar.AddMinutes(-3); // back up three more minutes
 
@@ -678,7 +678,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         Assert.Multiple(() =>
         {
             Assert.That(fireTimeAfter, Is.Not.EqualTo(fireTime));
-            Assert.That(fireTime > fireTimeAfter, Is.True);
+            Assert.That(fireTime, Is.GreaterThan(fireTimeAfter));
         });
     }
 

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Quartz.Impl.Triggers;
 using Quartz.Simpl;
@@ -773,9 +774,11 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         var trigger2 = trigger1
             .GetTriggerBuilder()
             .Build();
-
-        trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
-        trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+        using (new AssertionScope())
+        {
+            trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+        }
     }
 
     protected override CalendarIntervalTriggerImpl GetTargetObject()

--- a/src/Quartz.Tests.Unit/Collections/OrderedDictionaryTest.cs
+++ b/src/Quartz.Tests.Unit/Collections/OrderedDictionaryTest.cs
@@ -12,7 +12,7 @@ internal class OrderedDictionaryTest
         var valuesCollection = dictionary.Values;
 
         var valuesArray = valuesCollection.ToArray();
-        Assert.AreSame(Array.Empty<int>(), valuesArray);
+        Assert.That(valuesArray, Is.SameAs(Array.Empty<int>()));
     }
 
     [Test]
@@ -25,9 +25,9 @@ internal class OrderedDictionaryTest
         var valuesCollection = dictionary.Values;
 
         var valuesArray = valuesCollection.ToArray();
-        Assert.IsNotNull(valuesArray);
-        Assert.AreEqual(2, valuesArray.Length);
-        Assert.AreEqual(5, valuesArray[0]);
-        Assert.AreEqual(2, valuesArray[1]);
+        Assert.That(valuesArray, Is.Not.Null);
+        Assert.That(valuesArray.Length, Is.EqualTo(2));
+        Assert.That(valuesArray[0], Is.EqualTo(5));
+        Assert.That(valuesArray[1], Is.EqualTo(2));
     }
 }

--- a/src/Quartz.Tests.Unit/Collections/OrderedDictionaryTest.cs
+++ b/src/Quartz.Tests.Unit/Collections/OrderedDictionaryTest.cs
@@ -25,9 +25,12 @@ internal class OrderedDictionaryTest
         var valuesCollection = dictionary.Values;
 
         var valuesArray = valuesCollection.ToArray();
-        Assert.That(valuesArray, Is.Not.Null);
-        Assert.That(valuesArray.Length, Is.EqualTo(2));
-        Assert.That(valuesArray[0], Is.EqualTo(5));
-        Assert.That(valuesArray[1], Is.EqualTo(2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(valuesArray, Is.Not.Null);
+            Assert.That(valuesArray.Length, Is.EqualTo(2));
+            Assert.That(valuesArray[0], Is.EqualTo(5));
+            Assert.That(valuesArray[1], Is.EqualTo(2));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Collections/OrderedDictionaryTest.cs
+++ b/src/Quartz.Tests.Unit/Collections/OrderedDictionaryTest.cs
@@ -28,7 +28,7 @@ internal class OrderedDictionaryTest
         Assert.Multiple(() =>
         {
             Assert.That(valuesArray, Is.Not.Null);
-            Assert.That(valuesArray.Length, Is.EqualTo(2));
+            Assert.That(valuesArray, Has.Length.EqualTo(2));
             Assert.That(valuesArray[0], Is.EqualTo(5));
             Assert.That(valuesArray[1], Is.EqualTo(2));
         });

--- a/src/Quartz.Tests.Unit/Core/ExecutingJobsManagerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ExecutingJobsManagerTest.cs
@@ -16,7 +16,10 @@ public class ExecutingJobsManagerTest
     public void Name()
     {
         var actual = _executingJobsManager.Name;
-        Assert.That(actual, Is.EqualTo("Quartz.Core.ExecutingJobsManager"));
-        Assert.That(_executingJobsManager.Name, Is.SameAs(actual));
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual, Is.EqualTo("Quartz.Core.ExecutingJobsManager"));
+            Assert.That(_executingJobsManager.Name, Is.SameAs(actual));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Core/ExecutingJobsManagerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ExecutingJobsManagerTest.cs
@@ -16,7 +16,7 @@ public class ExecutingJobsManagerTest
     public void Name()
     {
         var actual = _executingJobsManager.Name;
-        Assert.AreEqual("Quartz.Core.ExecutingJobsManager", actual);
-        Assert.AreSame(actual, _executingJobsManager.Name);
+        Assert.That(actual, Is.EqualTo("Quartz.Core.ExecutingJobsManager"));
+        Assert.That(_executingJobsManager.Name, Is.SameAs(actual));
     }
 }

--- a/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
@@ -53,8 +53,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            });
         }
     }
 
@@ -116,7 +119,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -136,7 +139,7 @@ public class ListenerManagerTest
         var jobListeners = _manager.GetJobListeners();
         Assert.Multiple(() =>{
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -159,7 +162,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -179,7 +182,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -205,7 +208,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -213,7 +216,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
         });
     }
@@ -231,7 +234,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -239,7 +242,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
         });
     }
@@ -323,7 +326,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -348,7 +351,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -374,7 +377,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -382,7 +385,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
         });
     }
@@ -447,7 +450,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(2));
+            Assert.That(matchers, Has.Count.EqualTo(2));
             Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { groupMatcher, nameMatcher }), Is.True);
         });
     }
@@ -466,7 +469,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(2));
+            Assert.That(matchers, Has.Count.EqualTo(2));
             Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher, groupMatcher }), Is.True);
         });
     }
@@ -531,7 +534,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -541,7 +544,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
     }
@@ -606,7 +609,7 @@ public class ListenerManagerTest
         Assert.That(_manager.RemoveJobListener(tl2.Name), Is.True);
         var jobListeners = _manager.GetJobListeners();
         Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners, Has.Length.EqualTo(1));
         Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
@@ -634,7 +637,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -656,7 +659,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(2));
+            Assert.That(jobListeners, Has.Length.EqualTo(2));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
             Assert.That(jobListeners[1], Is.SameAs(tl2));
         });
@@ -680,7 +683,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
     }
@@ -742,7 +745,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
 
             Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, nameMatcher), Is.True);
@@ -773,7 +776,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
         });
     }
@@ -911,7 +914,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+            Assert.That(matchers, Has.Count.EqualTo(setMatchers.Length));
             Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
         });
     }
@@ -933,7 +936,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+            Assert.That(matchers, Has.Count.EqualTo(setMatchers.Length));
             Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
         });
     }
@@ -1015,7 +1018,7 @@ public class ListenerManagerTest
 
         var jobListeners = _manager.GetTriggerListeners();
         Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners, Has.Length.EqualTo(1));
         Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
@@ -1033,7 +1036,7 @@ public class ListenerManagerTest
 
         var jobListeners = _manager.GetTriggerListeners();
         Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners, Has.Length.EqualTo(1));
         Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
@@ -1053,7 +1056,7 @@ public class ListenerManagerTest
 
         var jobListeners = _manager.GetTriggerListeners();
         Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners, Has.Length.EqualTo(1));
         Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
@@ -1070,7 +1073,7 @@ public class ListenerManagerTest
 
         var jobListeners = _manager.GetTriggerListeners();
         Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners, Has.Length.EqualTo(1));
         Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
@@ -1095,7 +1098,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -1103,7 +1106,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
         });
     }
@@ -1121,7 +1124,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -1129,7 +1132,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
         });
     }
@@ -1213,7 +1216,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -1238,7 +1241,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -1264,7 +1267,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1b));
         });
 
@@ -1272,7 +1275,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
         });
     }
@@ -1337,7 +1340,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(2));
+            Assert.That(matchers, Has.Count.EqualTo(2));
             Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher }), Is.True);
         });
     }
@@ -1356,7 +1359,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(2));
+            Assert.That(matchers, Has.Count.EqualTo(2));
             Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher, groupMatcher }), Is.True);
         });
     }
@@ -1421,7 +1424,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -1431,7 +1434,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
     }
@@ -1498,7 +1501,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -1530,7 +1533,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
 
@@ -1552,7 +1555,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(2));
+            Assert.That(jobListeners, Has.Length.EqualTo(2));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
             Assert.That(jobListeners[1], Is.SameAs(tl2));
         });
@@ -1576,7 +1579,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(jobListeners, Is.Not.Null);
-            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners, Has.Length.EqualTo(1));
             Assert.That(jobListeners[0], Is.SameAs(tl1));
         });
     }
@@ -1638,7 +1641,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
 
             Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, nameMatcher), Is.True);
@@ -1669,7 +1672,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers, Has.Count.EqualTo(1));
             Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
         });
     }
@@ -1807,7 +1810,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+            Assert.That(matchers, Has.Count.EqualTo(setMatchers.Length));
             Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
         });
     }
@@ -1829,7 +1832,7 @@ public class ListenerManagerTest
         Assert.Multiple(() =>
         {
             Assert.That(matchers, Is.Not.Null);
-            Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+            Assert.That(matchers, Has.Count.EqualTo(setMatchers.Length));
             Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
         });
     }
@@ -1842,14 +1845,14 @@ public class ListenerManagerTest
 
         // test adding listener without matcher
         _manager.AddSchedulerListener(tl1);
-        Assert.That(_manager.GetSchedulerListeners().Count, Is.EqualTo(1), "Unexpected size of listener list");
+        Assert.That(_manager.GetSchedulerListeners(), Has.Count.EqualTo(1), "Unexpected size of listener list");
 
         // test adding listener with matcher
         _manager.AddSchedulerListener(tl2);
-        Assert.That(_manager.GetSchedulerListeners().Count, Is.EqualTo(2), "Unexpected size of listener list");
+        Assert.That(_manager.GetSchedulerListeners(), Has.Count.EqualTo(2), "Unexpected size of listener list");
 
         // test removing a listener
         _manager.RemoveSchedulerListener(tl1);
-        Assert.That(_manager.GetSchedulerListeners().Count, Is.EqualTo(1), "Unexpected size of listener list");
+        Assert.That(_manager.GetSchedulerListeners(), Has.Count.EqualTo(1), "Unexpected size of listener list");
     }
 }

--- a/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
@@ -1,3 +1,5 @@
+using FakeItEasy;
+
 using Quartz.Core;
 using Quartz.Impl.Matchers;
 using Quartz.Listener;
@@ -69,8 +71,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            });
         }
     }
 
@@ -87,8 +92,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            });
         }
     }
 
@@ -105,9 +113,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
         Assert.That(matchers, Is.Null);
@@ -123,9 +134,11 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>{
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
         Assert.That(matchers, Is.Null);
@@ -143,9 +156,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
         Assert.That(matchers, Is.Null);
@@ -160,9 +176,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
         Assert.That(matchers, Is.Null);
@@ -183,14 +202,20 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -203,14 +228,20 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -244,8 +275,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            });
         }
     }
 
@@ -262,8 +296,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            });
         }
     }
 
@@ -280,9 +317,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
         Assert.That(matchers, Is.Null);
@@ -302,9 +342,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
         Assert.That(matchers, Is.Null);
@@ -325,14 +368,20 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -349,8 +398,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            });
         }
     }
 
@@ -366,8 +418,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
+            });
         }
     }
 
@@ -379,13 +434,19 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
 
         _manager.AddJobListener(tl1);
-        Assert.That(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher), Is.True);
-        Assert.That(_manager.AddJobListenerMatcher(tl1.Name, nameMatcher), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher), Is.True);
+            Assert.That(_manager.AddJobListenerMatcher(tl1.Name, nameMatcher), Is.True);
+        });
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(2));
-        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { groupMatcher, nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(2));
+            Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { groupMatcher, nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -399,9 +460,12 @@ public class ListenerManagerTest
         Assert.That(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(2));
-        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher, groupMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(2));
+            Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher, groupMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -428,8 +492,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            });
         }
 
         _manager.AddJobListener(new TestJobListener("B"));
@@ -441,8 +508,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            });
         }
     }
 
@@ -455,16 +525,22 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         jobListeners[0] = tl2;
 
         jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
     }
 
     [Test]
@@ -503,8 +579,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            });
         }
     }
 
@@ -546,26 +625,35 @@ public class ListenerManagerTest
         Assert.That(_manager.RemoveJobListener(tl2.Name), Is.True);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         var matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
         Assert.That(matchersTl2, Is.Null);
 
         var matchersTl1 = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.That(matchersTl1, Is.Not.Null);
-        Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchersTl1, Is.Not.Null);
+            Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
+        });
 
         // Ensure adding back the listener without matchers does not "magically" recover the
         // matchers that were registered before we removed the listener
         _manager.AddJobListener(tl2);
 
         jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(2));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
-        Assert.That(jobListeners[1], Is.SameAs(tl2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(2));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+            Assert.That(jobListeners[1], Is.SameAs(tl2));
+        });
 
         matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
         Assert.That(matchersTl2, Is.Null);
@@ -583,9 +671,12 @@ public class ListenerManagerTest
         Assert.That(_manager.RemoveJobListener(tl2.Name), Is.False);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
     }
 
     [Test]
@@ -602,8 +693,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            });
         }
     }
 
@@ -619,8 +713,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
+            });
         }
     }
 
@@ -636,12 +733,15 @@ public class ListenerManagerTest
         Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
 
-        Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, nameMatcher), Is.True);
-        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+            Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, nameMatcher), Is.True);
+            Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -653,17 +753,23 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1);
 
-        Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher), Is.False);
-        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher), Is.False);
+            Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        });
 
         _manager.AddJobListenerMatcher(tl1.Name, nameMatcher);
 
         Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher), Is.False);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -673,8 +779,11 @@ public class ListenerManagerTest
 
         var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
 
-        Assert.That(_manager.RemoveJobListenerMatcher(listenerName, groupMatcher), Is.False);
-        Assert.That(_manager.GetJobListenerMatchers(listenerName), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.RemoveJobListenerMatcher(listenerName, groupMatcher), Is.False);
+            Assert.That(_manager.GetJobListenerMatchers(listenerName), Is.Null);
+        });
     }
 
     [Test]
@@ -691,8 +800,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            });
         }
     }
 
@@ -708,8 +820,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(matchers)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(matchers)));
+            });
         }
     }
 
@@ -719,8 +834,11 @@ public class ListenerManagerTest
         var tl1 = new TestJobListener("tl1");
         var setMatchers = Array.Empty<IMatcher<JobKey>>();
 
-        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.False);
-        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.False);
+            Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -731,8 +849,11 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1);
 
-        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
-        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
+            Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -745,8 +866,11 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1, groupMatcher);
 
-        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
-        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
+            Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -758,8 +882,11 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
         var setMatchers = new IMatcher<JobKey>[] { groupMatcher, nameMatcher };
 
-        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.False);
-        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.False);
+            Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -775,9 +902,12 @@ public class ListenerManagerTest
         Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
-        Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+            Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
+        });
     }
 
     [Test]
@@ -794,9 +924,12 @@ public class ListenerManagerTest
         Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
-        Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+            Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
+        });
     }
 
     [Test]
@@ -812,8 +945,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            });
         }
     }
 
@@ -830,8 +966,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            });
         }
     }
 
@@ -848,8 +987,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            });
         }
     }
 
@@ -944,14 +1086,20 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -964,14 +1112,20 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -987,8 +1141,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            });
         }
     }
 
@@ -1005,8 +1162,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            });
         }
     }
 
@@ -1023,8 +1183,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
+            });
         }
     }
 
@@ -1041,9 +1204,12 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
         Assert.That(matchers, Is.Null);
@@ -1063,9 +1229,12 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
         Assert.That(matchers, Is.Null);
@@ -1086,14 +1255,20 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1b));
+        });
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -1110,8 +1285,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            });
         }
     }
 
@@ -1127,8 +1305,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
+            });
         }
     }
 
@@ -1140,13 +1321,19 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
 
         _manager.AddTriggerListener(tl1);
-        Assert.That(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher), Is.True);
-        Assert.That(_manager.AddTriggerListenerMatcher(tl1.Name, nameMatcher), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher), Is.True);
+            Assert.That(_manager.AddTriggerListenerMatcher(tl1.Name, nameMatcher), Is.True);
+        });
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(2));
-        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(2));
+            Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -1160,9 +1347,12 @@ public class ListenerManagerTest
         Assert.That(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(2));
-        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher, groupMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(2));
+            Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher, groupMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -1189,8 +1379,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            });
         }
 
         _manager.AddTriggerListener(new TestTriggerListener("B"));
@@ -1202,8 +1395,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            });
         }
     }
 
@@ -1216,16 +1412,22 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         jobListeners[0] = tl2;
 
         jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
     }
 
     [Test]
@@ -1247,8 +1449,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            });
         }
     }
 
@@ -1264,8 +1469,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
+            });
         }
     }
 
@@ -1281,16 +1489,22 @@ public class ListenerManagerTest
 
         Assert.That(_manager.RemoveTriggerListener(tl2.Name), Is.True);
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         var matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
         Assert.That(matchersTl2, Is.Null);
 
         var matchersTl1 = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchersTl1, Is.Not.Null);
-        Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchersTl1, Is.Not.Null);
+            Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -1307,26 +1521,35 @@ public class ListenerManagerTest
         Assert.That(_manager.RemoveTriggerListener(tl2.Name), Is.True);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
 
         var matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
         Assert.That(matchersTl2, Is.Null);
 
         var matchersTl1 = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchersTl1, Is.Not.Null);
-        Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchersTl1, Is.Not.Null);
+            Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
+        });
 
         // Ensure adding back the listener without matchers does not "magically" recover the
         // matchers that were registered before we removed the listener
         _manager.AddTriggerListener(tl2);
 
         jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(2));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
-        Assert.That(jobListeners[1], Is.SameAs(tl2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(2));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+            Assert.That(jobListeners[1], Is.SameAs(tl2));
+        });
 
         matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
         Assert.That(matchersTl2, Is.Null);
@@ -1344,9 +1567,12 @@ public class ListenerManagerTest
         Assert.That(_manager.RemoveTriggerListener(tl2.Name), Is.False);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.That(jobListeners, Is.Not.Null);
-        Assert.That(jobListeners.Length, Is.EqualTo(1));
-        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobListeners, Is.Not.Null);
+            Assert.That(jobListeners.Length, Is.EqualTo(1));
+            Assert.That(jobListeners[0], Is.SameAs(tl1));
+        });
     }
 
     [Test]
@@ -1363,8 +1589,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            });
         }
     }
 
@@ -1380,8 +1609,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
+            });
         }
     }
 
@@ -1397,12 +1629,15 @@ public class ListenerManagerTest
         Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
 
-        Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, nameMatcher), Is.True);
-        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+            Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, nameMatcher), Is.True);
+            Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -1422,9 +1657,12 @@ public class ListenerManagerTest
         Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher), Is.False);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(1));
-        Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(1));
+            Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
+        });
     }
 
     [Test]
@@ -1434,8 +1672,11 @@ public class ListenerManagerTest
 
         var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
 
-        Assert.That(_manager.RemoveTriggerListenerMatcher(listenerName, groupMatcher), Is.False);
-        Assert.That(_manager.GetTriggerListenerMatchers(listenerName), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.RemoveTriggerListenerMatcher(listenerName, groupMatcher), Is.False);
+            Assert.That(_manager.GetTriggerListenerMatchers(listenerName), Is.Null);
+        });
     }
 
     [Test]
@@ -1452,8 +1693,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            });
         }
     }
 
@@ -1469,8 +1713,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(matchers)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(matchers)));
+            });
         }
     }
 
@@ -1480,8 +1727,11 @@ public class ListenerManagerTest
         var tl1 = new TestTriggerListener("tl1");
         var setMatchers = Array.Empty<IMatcher<TriggerKey>>();
 
-        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.False);
-        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.False);
+            Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -1492,8 +1742,11 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1);
 
-        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
-        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
+            Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -1506,8 +1759,11 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1, groupMatcher);
 
-        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
-        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
+            Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -1519,8 +1775,11 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
         var setMatchers = new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher };
 
-        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.False);
-        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.False);
+            Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        });
     }
 
     [Test]
@@ -1536,9 +1795,12 @@ public class ListenerManagerTest
         Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
-        Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+            Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
+        });
     }
 
     [Test]
@@ -1555,9 +1817,12 @@ public class ListenerManagerTest
         Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.That(matchers, Is.Not.Null);
-        Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
-        Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchers, Is.Not.Null);
+            Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+            Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
@@ -30,9 +30,7 @@ public class ListenerManagerTest
 
         public override string Name { get; }
     }
-    private class TestSchedulerListener : SchedulerListenerSupport
-    {
-    }
+    private class TestSchedulerListener : SchedulerListenerSupport;
 
     [SetUp]
     public void SetUp()
@@ -53,8 +51,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
         }
     }
 
@@ -71,8 +69,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
         }
     }
 
@@ -89,8 +87,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
         }
     }
 
@@ -107,12 +105,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -125,12 +123,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -145,12 +143,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -162,12 +160,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -185,14 +183,14 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
     }
 
     [Test]
@@ -205,14 +203,14 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
     }
 
     [Test]
@@ -228,8 +226,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
         }
     }
 
@@ -246,8 +244,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
         }
     }
 
@@ -264,8 +262,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(jobListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
         }
     }
 
@@ -282,12 +280,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -304,12 +302,12 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -327,14 +325,14 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetJobListenerMatchers(tl1b.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher }), Is.True);
     }
 
     [Test]
@@ -351,8 +349,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
         }
     }
 
@@ -368,8 +366,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(matcher), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
         }
     }
 
@@ -381,13 +379,13 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
 
         _manager.AddJobListener(tl1);
-        Assert.IsTrue(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher));
-        Assert.IsTrue(_manager.AddJobListenerMatcher(tl1.Name, nameMatcher));
+        Assert.That(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher), Is.True);
+        Assert.That(_manager.AddJobListenerMatcher(tl1.Name, nameMatcher), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(2, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { groupMatcher, nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(2));
+        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { groupMatcher, nameMatcher }), Is.True);
     }
 
     [Test]
@@ -398,12 +396,12 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
 
         _manager.AddJobListener(tl1, nameMatcher);
-        Assert.IsTrue(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher));
+        Assert.That(_manager.AddJobListenerMatcher(tl1.Name, groupMatcher), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(2, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher, groupMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(2));
+        Assert.That(matchers.SequenceEqual(new IMatcher<JobKey>[] { nameMatcher, groupMatcher }), Is.True);
     }
 
     [Test]
@@ -430,8 +428,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(name), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
         }
 
         _manager.AddJobListener(new TestJobListener("B"));
@@ -443,8 +441,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(name), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
         }
     }
 
@@ -457,23 +455,23 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         jobListeners[0] = tl2;
 
         jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
     }
 
     [Test]
     public void GetJobListeners_ShouldReturnEmptyArrayWhenNoJobListenersHaveBeenAdded()
     {
         var jobListeners = _manager.GetJobListeners();
-        Assert.AreSame(Array.Empty<IJobListener>(), jobListeners);
+        Assert.That(jobListeners, Is.SameAs(Array.Empty<IJobListener>()));
     }
 
     [Test]
@@ -488,8 +486,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
         }
     }
 
@@ -505,8 +503,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(name), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
         }
     }
 
@@ -520,18 +518,18 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1, groupMatcher);
         _manager.AddJobListener(tl2);
 
-        Assert.IsTrue(_manager.RemoveJobListener(tl2.Name));
+        Assert.That(_manager.RemoveJobListener(tl2.Name), Is.True);
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
-        Assert.IsNull(matchersTl2);
+        Assert.That(matchersTl2, Is.Null);
 
         var matchersTl1 = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchersTl1);
-        Assert.IsTrue(matchersTl1.SequenceEqual(new[] { groupMatcher }));
+        Assert.That(matchersTl1, Is.Not.Null);
+        Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
     }
 
     [Test]
@@ -545,32 +543,32 @@ public class ListenerManagerTest
         _manager.AddJobListener(tl1, groupMatcher);
         _manager.AddJobListener(tl2, nameMatcher);
 
-        Assert.IsTrue(_manager.RemoveJobListener(tl2.Name));
+        Assert.That(_manager.RemoveJobListener(tl2.Name), Is.True);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
-        Assert.IsNull(matchersTl2);
+        Assert.That(matchersTl2, Is.Null);
 
         var matchersTl1 = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchersTl1);
-        Assert.IsTrue(matchersTl1.SequenceEqual(new[] { groupMatcher }));
+        Assert.That(matchersTl1, Is.Not.Null);
+        Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
 
         // Ensure adding back the listener without matchers does not "magically" recover the
         // matchers that were registered before we removed the listener
         _manager.AddJobListener(tl2);
 
         jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(2, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
-        Assert.AreSame(tl2, jobListeners[1]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(2));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.That(jobListeners[1], Is.SameAs(tl2));
 
         matchersTl2 = _manager.GetJobListenerMatchers(tl2.Name);
-        Assert.IsNull(matchersTl2);
+        Assert.That(matchersTl2, Is.Null);
     }
 
     [Test]
@@ -582,12 +580,12 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1, groupMatcher);
 
-        Assert.IsFalse(_manager.RemoveJobListener(tl2.Name));
+        Assert.That(_manager.RemoveJobListener(tl2.Name), Is.False);
 
         var jobListeners = _manager.GetJobListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
     }
 
     [Test]
@@ -604,8 +602,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
         }
     }
 
@@ -621,8 +619,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(matcher), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
         }
     }
 
@@ -635,15 +633,15 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1, groupMatcher, nameMatcher);
 
-        Assert.IsTrue(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher));
+        Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
 
-        Assert.IsTrue(_manager.RemoveJobListenerMatcher(tl1.Name, nameMatcher));
-        Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, nameMatcher), Is.True);
+        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -655,17 +653,17 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1);
 
-        Assert.False(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher));
-        Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher), Is.False);
+        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
 
         _manager.AddJobListenerMatcher(tl1.Name, nameMatcher);
 
-        Assert.False(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher));
+        Assert.That(_manager.RemoveJobListenerMatcher(tl1.Name, groupMatcher), Is.False);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
     }
 
     [Test]
@@ -675,8 +673,8 @@ public class ListenerManagerTest
 
         var groupMatcher = GroupMatcher<JobKey>.GroupEquals("foo");
 
-        Assert.False(_manager.RemoveJobListenerMatcher(listenerName, groupMatcher));
-        Assert.IsNull(_manager.GetJobListenerMatchers(listenerName));
+        Assert.That(_manager.RemoveJobListenerMatcher(listenerName, groupMatcher), Is.False);
+        Assert.That(_manager.GetJobListenerMatchers(listenerName), Is.Null);
     }
 
     [Test]
@@ -693,8 +691,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
         }
     }
 
@@ -710,8 +708,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(matchers), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(matchers)));
         }
     }
 
@@ -721,8 +719,8 @@ public class ListenerManagerTest
         var tl1 = new TestJobListener("tl1");
         var setMatchers = Array.Empty<IMatcher<JobKey>>();
 
-        Assert.IsFalse(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
-        Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.False);
+        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -733,8 +731,8 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1);
 
-        Assert.IsTrue(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
-        Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
+        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -747,8 +745,8 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1, groupMatcher);
 
-        Assert.IsTrue(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
-        Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
+        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -760,8 +758,8 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<JobKey>.NameContains("foo");
         var setMatchers = new IMatcher<JobKey>[] { groupMatcher, nameMatcher };
 
-        Assert.IsFalse(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
-        Assert.IsNull(_manager.GetJobListenerMatchers(tl1.Name));
+        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.False);
+        Assert.That(_manager.GetJobListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -774,12 +772,12 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1);
 
-        Assert.IsTrue(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
+        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(setMatchers.Length, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(setMatchers));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+        Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
     }
 
     [Test]
@@ -793,12 +791,12 @@ public class ListenerManagerTest
 
         _manager.AddJobListener(tl1, groupMatcher);
 
-        Assert.IsTrue(_manager.SetJobListenerMatchers(tl1.Name, setMatchers));
+        Assert.That(_manager.SetJobListenerMatchers(tl1.Name, setMatchers), Is.True);
 
         var matchers = _manager.GetJobListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(setMatchers.Length, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(setMatchers));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+        Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
     }
 
     [Test]
@@ -814,8 +812,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
         }
     }
 
@@ -832,8 +830,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
         }
     }
 
@@ -850,8 +848,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
         }
     }
 
@@ -868,12 +866,12 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -886,12 +884,12 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -906,12 +904,12 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -923,12 +921,12 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -946,14 +944,14 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
     }
 
     [Test]
@@ -966,14 +964,14 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
     }
 
     [Test]
@@ -989,8 +987,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
         }
     }
 
@@ -1007,8 +1005,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
         }
     }
 
@@ -1025,8 +1023,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(triggerListener), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(triggerListener)));
         }
     }
 
@@ -1043,12 +1041,12 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -1065,12 +1063,12 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
-        Assert.IsNull(matchers);
+        Assert.That(matchers, Is.Null);
     }
 
     [Test]
@@ -1088,14 +1086,14 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1b, setMatchers);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1b, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1b));
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1b.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher }), Is.True);
     }
 
     [Test]
@@ -1112,8 +1110,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
         }
     }
 
@@ -1129,8 +1127,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(matcher), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
         }
     }
 
@@ -1142,13 +1140,13 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
 
         _manager.AddTriggerListener(tl1);
-        Assert.IsTrue(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher));
-        Assert.IsTrue(_manager.AddTriggerListenerMatcher(tl1.Name, nameMatcher));
+        Assert.That(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher), Is.True);
+        Assert.That(_manager.AddTriggerListenerMatcher(tl1.Name, nameMatcher), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(2, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(2));
+        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher }), Is.True);
     }
 
     [Test]
@@ -1159,12 +1157,12 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
 
         _manager.AddTriggerListener(tl1, nameMatcher);
-        Assert.IsTrue(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher));
+        Assert.That(_manager.AddTriggerListenerMatcher(tl1.Name, groupMatcher), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(2, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher, groupMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(2));
+        Assert.That(matchers.SequenceEqual(new IMatcher<TriggerKey>[] { nameMatcher, groupMatcher }), Is.True);
     }
 
     [Test]
@@ -1191,8 +1189,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(name), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
         }
 
         _manager.AddTriggerListener(new TestTriggerListener("B"));
@@ -1204,8 +1202,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(name), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
         }
     }
 
@@ -1218,23 +1216,23 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         jobListeners[0] = tl2;
 
         jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
     }
 
     [Test]
     public void GetTriggerListeners_ShouldReturnEmptyArrayWhenNoTriggerListenersHaveBeenAdded()
     {
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.AreSame(Array.Empty<ITriggerListener>(), jobListeners);
+        Assert.That(jobListeners, Is.SameAs(Array.Empty<ITriggerListener>()));
     }
 
     [Test]
@@ -1249,8 +1247,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
         }
     }
 
@@ -1266,8 +1264,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(name), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(name)));
         }
     }
 
@@ -1281,18 +1279,18 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1, groupMatcher);
         _manager.AddTriggerListener(tl2);
 
-        Assert.IsTrue(_manager.RemoveTriggerListener(tl2.Name));
+        Assert.That(_manager.RemoveTriggerListener(tl2.Name), Is.True);
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
-        Assert.IsNull(matchersTl2);
+        Assert.That(matchersTl2, Is.Null);
 
         var matchersTl1 = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchersTl1);
-        Assert.IsTrue(matchersTl1.SequenceEqual(new[] { groupMatcher }));
+        Assert.That(matchersTl1, Is.Not.Null);
+        Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
     }
 
     [Test]
@@ -1306,32 +1304,32 @@ public class ListenerManagerTest
         _manager.AddTriggerListener(tl1, groupMatcher);
         _manager.AddTriggerListener(tl2, nameMatcher);
 
-        Assert.IsTrue(_manager.RemoveTriggerListener(tl2.Name));
+        Assert.That(_manager.RemoveTriggerListener(tl2.Name), Is.True);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
 
         var matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
-        Assert.IsNull(matchersTl2);
+        Assert.That(matchersTl2, Is.Null);
 
         var matchersTl1 = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchersTl1);
-        Assert.IsTrue(matchersTl1.SequenceEqual(new[] { groupMatcher }));
+        Assert.That(matchersTl1, Is.Not.Null);
+        Assert.That(matchersTl1.SequenceEqual(new[] { groupMatcher }), Is.True);
 
         // Ensure adding back the listener without matchers does not "magically" recover the
         // matchers that were registered before we removed the listener
         _manager.AddTriggerListener(tl2);
 
         jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(2, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
-        Assert.AreSame(tl2, jobListeners[1]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(2));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
+        Assert.That(jobListeners[1], Is.SameAs(tl2));
 
         matchersTl2 = _manager.GetTriggerListenerMatchers(tl2.Name);
-        Assert.IsNull(matchersTl2);
+        Assert.That(matchersTl2, Is.Null);
     }
 
     [Test]
@@ -1343,12 +1341,12 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1, groupMatcher);
 
-        Assert.IsFalse(_manager.RemoveTriggerListener(tl2.Name));
+        Assert.That(_manager.RemoveTriggerListener(tl2.Name), Is.False);
 
         var jobListeners = _manager.GetTriggerListeners();
-        Assert.IsNotNull(jobListeners);
-        Assert.AreEqual(1, jobListeners.Length);
-        Assert.AreSame(tl1, jobListeners[0]);
+        Assert.That(jobListeners, Is.Not.Null);
+        Assert.That(jobListeners.Length, Is.EqualTo(1));
+        Assert.That(jobListeners[0], Is.SameAs(tl1));
     }
 
     [Test]
@@ -1365,8 +1363,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
         }
     }
 
@@ -1382,8 +1380,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(matcher), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(matcher)));
         }
     }
 
@@ -1396,15 +1394,15 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1, groupMatcher, nameMatcher);
 
-        Assert.IsTrue(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher));
+        Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
 
-        Assert.IsTrue(_manager.RemoveTriggerListenerMatcher(tl1.Name, nameMatcher));
-        Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, nameMatcher), Is.True);
+        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -1416,17 +1414,17 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1);
 
-        Assert.False(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher));
-        Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher), Is.False);
+        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
 
         _manager.AddTriggerListenerMatcher(tl1.Name, nameMatcher);
 
-        Assert.False(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher));
+        Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher), Is.False);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(1, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(new[] { nameMatcher }));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(1));
+        Assert.That(matchers.SequenceEqual(new[] { nameMatcher }), Is.True);
     }
 
     [Test]
@@ -1436,8 +1434,8 @@ public class ListenerManagerTest
 
         var groupMatcher = GroupMatcher<TriggerKey>.GroupEquals("foo");
 
-        Assert.False(_manager.RemoveTriggerListenerMatcher(listenerName, groupMatcher));
-        Assert.IsNull(_manager.GetTriggerListenerMatchers(listenerName));
+        Assert.That(_manager.RemoveTriggerListenerMatcher(listenerName, groupMatcher), Is.False);
+        Assert.That(_manager.GetTriggerListenerMatchers(listenerName), Is.Null);
     }
 
     [Test]
@@ -1454,8 +1452,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(listenerName), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
         }
     }
 
@@ -1471,8 +1469,8 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.IsNull(ex.InnerException);
-            Assert.AreEqual(nameof(matchers), ex.ParamName);
+            Assert.That(ex.InnerException, Is.Null);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(matchers)));
         }
     }
 
@@ -1482,8 +1480,8 @@ public class ListenerManagerTest
         var tl1 = new TestTriggerListener("tl1");
         var setMatchers = Array.Empty<IMatcher<TriggerKey>>();
 
-        Assert.IsFalse(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
-        Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.False);
+        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -1494,8 +1492,8 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1);
 
-        Assert.IsTrue(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
-        Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
+        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -1508,8 +1506,8 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1, groupMatcher);
 
-        Assert.IsTrue(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
-        Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
+        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -1521,8 +1519,8 @@ public class ListenerManagerTest
         var nameMatcher = NameMatcher<TriggerKey>.NameContains("foo");
         var setMatchers = new IMatcher<TriggerKey>[] { groupMatcher, nameMatcher };
 
-        Assert.IsFalse(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
-        Assert.IsNull(_manager.GetTriggerListenerMatchers(tl1.Name));
+        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.False);
+        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
     }
 
     [Test]
@@ -1535,12 +1533,12 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1);
 
-        Assert.IsTrue(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
+        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(setMatchers.Length, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(setMatchers));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+        Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
     }
 
     [Test]
@@ -1554,12 +1552,12 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1, groupMatcher);
 
-        Assert.IsTrue(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers));
+        Assert.That(_manager.SetTriggerListenerMatchers(tl1.Name, setMatchers), Is.True);
 
         var matchers = _manager.GetTriggerListenerMatchers(tl1.Name);
-        Assert.IsNotNull(matchers);
-        Assert.AreEqual(setMatchers.Length, matchers.Count);
-        Assert.IsTrue(matchers.SequenceEqual(setMatchers));
+        Assert.That(matchers, Is.Not.Null);
+        Assert.That(matchers.Count, Is.EqualTo(setMatchers.Length));
+        Assert.That(matchers.SequenceEqual(setMatchers), Is.True);
     }
 
     [Test]
@@ -1570,14 +1568,14 @@ public class ListenerManagerTest
 
         // test adding listener without matcher
         _manager.AddSchedulerListener(tl1);
-        Assert.AreEqual(1, _manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
+        Assert.That(_manager.GetSchedulerListeners().Count, Is.EqualTo(1), "Unexpected size of listener list");
 
         // test adding listener with matcher
         _manager.AddSchedulerListener(tl2);
-        Assert.AreEqual(2, _manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
+        Assert.That(_manager.GetSchedulerListeners().Count, Is.EqualTo(2), "Unexpected size of listener list");
 
         // test removing a listener
         _manager.RemoveSchedulerListener(tl1);
-        Assert.AreEqual(1, _manager.GetSchedulerListeners().Count, "Unexpected size of listener list");
+        Assert.That(_manager.GetSchedulerListeners().Count, Is.EqualTo(1), "Unexpected size of listener list");
     }
 }

--- a/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerManagerTest .cs
@@ -257,8 +257,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(jobListener)));
+            });
         }
     }
 
@@ -562,8 +565,11 @@ public class ListenerManagerTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.That(ex.InnerException, Is.Null);
-            Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.InnerException, Is.Null);
+                Assert.That(ex.ParamName, Is.EqualTo(nameof(listenerName)));
+            });
         }
     }
 
@@ -1649,8 +1655,11 @@ public class ListenerManagerTest
 
         _manager.AddTriggerListener(tl1);
 
-        Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher), Is.False);
-        Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_manager.RemoveTriggerListenerMatcher(tl1.Name, groupMatcher), Is.False);
+            Assert.That(_manager.GetTriggerListenerMatchers(tl1.Name), Is.Null);
+        });
 
         _manager.AddTriggerListenerMatcher(tl1.Name, nameMatcher);
 

--- a/src/Quartz.Tests.Unit/Core/MissSchedulingChangeSignalTest.cs
+++ b/src/Quartz.Tests.Unit/Core/MissSchedulingChangeSignalTest.cs
@@ -50,13 +50,13 @@ public class MissSchedulingChangeSignalTest
 
         List<TimeSpan> durationBetweenFireTimesInMillis = CollectDurationBetweenFireTimesJob.Durations;
 
-        Assert.False(durationBetweenFireTimesInMillis.Count == 0, "Job was not executed once!");
+        Assert.That(durationBetweenFireTimesInMillis.Count, Is.Not.EqualTo(0), "Job was not executed once!");
 
         // Let's check that every call for around 1 second and not between 23 and 30 seconds
         // which would be the case if the scheduling change signal were not checked
         foreach (TimeSpan durationInMillis in durationBetweenFireTimesInMillis)
         {
-            Assert.True(durationInMillis.TotalMilliseconds < 20000, "Missed an execution with one duration being between two fires: " + durationInMillis + " (all: "
+            Assert.That(durationInMillis.TotalMilliseconds, Is.LessThan(20000), "Missed an execution with one duration being between two fires: " + durationInMillis + " (all: "
                                                                     + durationBetweenFireTimesInMillis + ")");
         }
     }

--- a/src/Quartz.Tests.Unit/Core/MissSchedulingChangeSignalTest.cs
+++ b/src/Quartz.Tests.Unit/Core/MissSchedulingChangeSignalTest.cs
@@ -50,7 +50,7 @@ public class MissSchedulingChangeSignalTest
 
         List<TimeSpan> durationBetweenFireTimesInMillis = CollectDurationBetweenFireTimesJob.Durations;
 
-        Assert.That(durationBetweenFireTimesInMillis.Count, Is.Not.EqualTo(0), "Job was not executed once!");
+        Assert.That(durationBetweenFireTimesInMillis, Is.Not.Empty, "Job was not executed once!");
 
         // Let's check that every call for around 1 second and not between 23 and 30 seconds
         // which would be the case if the scheduling change signal were not checked

--- a/src/Quartz.Tests.Unit/Core/QuartzRandomTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzRandomTest.cs
@@ -11,8 +11,8 @@ public class QuartzRandomTest
         var rand = new QuartzRandom();
         var result = rand.Next(2, 6);
 
-        Assert.GreaterOrEqual(result, 2);
-        Assert.LessOrEqual(result, 6);
+        Assert.That(result, Is.GreaterThanOrEqualTo(2));
+        Assert.That(result, Is.LessThanOrEqualTo(6));
     }
 
     [Test]
@@ -21,8 +21,8 @@ public class QuartzRandomTest
         var rand = new QuartzRandom();
         var result = rand.Next(-6, -2);
 
-        Assert.GreaterOrEqual(result, -6);
-        Assert.LessOrEqual(result, -2);
+        Assert.That(result, Is.GreaterThanOrEqualTo(-6));
+        Assert.That(result, Is.LessThanOrEqualTo(-2));
     }
 
     [Test]
@@ -31,8 +31,8 @@ public class QuartzRandomTest
         var rand = new QuartzRandom();
         var result = rand.Next(-6, 6);
 
-        Assert.GreaterOrEqual(result, -6);
-        Assert.LessOrEqual(result, 6);
+        Assert.That(result, Is.GreaterThanOrEqualTo(-6));
+        Assert.That(result, Is.LessThanOrEqualTo(6));
     }
 
     [Test]
@@ -41,8 +41,8 @@ public class QuartzRandomTest
         var rand = new QuartzRandom();
         var result = rand.Next(-1, int.MaxValue);
 
-        Assert.GreaterOrEqual(result, -1);
-        Assert.LessOrEqual(result, int.MaxValue);
+        Assert.That(result, Is.GreaterThanOrEqualTo(-1));
+        Assert.That(result, Is.LessThanOrEqualTo(int.MaxValue));
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerResourcesTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerResourcesTest.cs
@@ -17,26 +17,26 @@ public class QuartzSchedulerResourcesTest
     public void DefaultCtor()
     {
         var resources = new QuartzSchedulerResources();
-        Assert.AreEqual(TimeSpan.Zero, resources.BatchTimeWindow);
-        Assert.IsNull(resources.InstanceId);
-        Assert.IsFalse(resources.InterruptJobsOnShutdown);
-        Assert.IsFalse(resources.InterruptJobsOnShutdownWithWait);
-        Assert.IsNull(resources.JobRunShellFactory);
-        Assert.IsNull(resources.JobStore);
-        Assert.IsFalse(resources.MakeSchedulerThreadDaemon);
-        Assert.AreEqual(1, resources.MaxBatchSize);
-        Assert.IsNull(resources.Name);
-        Assert.IsNotNull(resources.SchedulerPlugins);
-        Assert.IsEmpty(resources.SchedulerPlugins);
-        Assert.IsNull(resources.ThreadName);
-        Assert.IsNull(resources.ThreadPool);
+        Assert.That(resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(resources.InstanceId, Is.Null);
+        Assert.That(resources.InterruptJobsOnShutdown, Is.False);
+        Assert.That(resources.InterruptJobsOnShutdownWithWait, Is.False);
+        Assert.That(resources.JobRunShellFactory, Is.Null);
+        Assert.That(resources.JobStore, Is.Null);
+        Assert.That(resources.MakeSchedulerThreadDaemon, Is.False);
+        Assert.That(resources.MaxBatchSize, Is.EqualTo(1));
+        Assert.That(resources.Name, Is.Null);
+        Assert.That(resources.SchedulerPlugins, Is.Not.Null);
+        Assert.That(resources.SchedulerPlugins, Is.Empty);
+        Assert.That(resources.ThreadName, Is.Null);
+        Assert.That(resources.ThreadPool, Is.Null);
     }
 
     [Test]
     public void IdleWaitTime_ValidValues([ValueSource(nameof(ValidIdleWaitTimes))] TimeSpan idleWaitTime)
     {
         _resources.IdleWaitTime = idleWaitTime;
-        Assert.AreEqual(idleWaitTime, _resources.IdleWaitTime);
+        Assert.That(_resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
     }
 
     [Test]
@@ -49,7 +49,7 @@ public class QuartzSchedulerResourcesTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual("value", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
     }
 
@@ -57,7 +57,7 @@ public class QuartzSchedulerResourcesTest
     public void BatchTimeWindow_ValidValues([ValueSource(nameof(ValidBatchTimeWindows))] TimeSpan batchTimeWindow)
     {
         _resources.BatchTimeWindow = batchTimeWindow;
-        Assert.AreEqual(batchTimeWindow, _resources.BatchTimeWindow);
+        Assert.That(_resources.BatchTimeWindow, Is.EqualTo(batchTimeWindow));
     }
 
     [Test]
@@ -70,7 +70,7 @@ public class QuartzSchedulerResourcesTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual("value", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
     }
 
@@ -78,7 +78,7 @@ public class QuartzSchedulerResourcesTest
     public void MaxBatchSize_ValidValues([ValueSource(nameof(ValidMaxBatchSizes))] int maxBatchSize)
     {
         _resources.MaxBatchSize = maxBatchSize;
-        Assert.AreEqual(maxBatchSize, _resources.MaxBatchSize);
+        Assert.That(_resources.MaxBatchSize, Is.EqualTo(maxBatchSize));
     }
 
     [Test]
@@ -91,7 +91,7 @@ public class QuartzSchedulerResourcesTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual("value", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
     }
 

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerResourcesTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerResourcesTest.cs
@@ -17,19 +17,22 @@ public class QuartzSchedulerResourcesTest
     public void DefaultCtor()
     {
         var resources = new QuartzSchedulerResources();
-        Assert.That(resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
-        Assert.That(resources.InstanceId, Is.Null);
-        Assert.That(resources.InterruptJobsOnShutdown, Is.False);
-        Assert.That(resources.InterruptJobsOnShutdownWithWait, Is.False);
-        Assert.That(resources.JobRunShellFactory, Is.Null);
-        Assert.That(resources.JobStore, Is.Null);
-        Assert.That(resources.MakeSchedulerThreadDaemon, Is.False);
-        Assert.That(resources.MaxBatchSize, Is.EqualTo(1));
-        Assert.That(resources.Name, Is.Null);
-        Assert.That(resources.SchedulerPlugins, Is.Not.Null);
-        Assert.That(resources.SchedulerPlugins, Is.Empty);
-        Assert.That(resources.ThreadName, Is.Null);
-        Assert.That(resources.ThreadPool, Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(resources.InstanceId, Is.Null);
+            Assert.That(resources.InterruptJobsOnShutdown, Is.False);
+            Assert.That(resources.InterruptJobsOnShutdownWithWait, Is.False);
+            Assert.That(resources.JobRunShellFactory, Is.Null);
+            Assert.That(resources.JobStore, Is.Null);
+            Assert.That(resources.MakeSchedulerThreadDaemon, Is.False);
+            Assert.That(resources.MaxBatchSize, Is.EqualTo(1));
+            Assert.That(resources.Name, Is.Null);
+            Assert.That(resources.SchedulerPlugins, Is.Not.Null);
+            Assert.That(resources.SchedulerPlugins, Is.Empty);
+            Assert.That(resources.ThreadName, Is.Null);
+            Assert.That(resources.ThreadPool, Is.Null);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -41,9 +41,9 @@ public class QuartzSchedulerTest
     public void TestVersionInfo()
     {
         var versionInfo = typeof(QuartzScheduler).Assembly.GetName().Version;
-        Assert.AreEqual(versionInfo.Major.ToString(CultureInfo.InvariantCulture), QuartzScheduler.VersionMajor);
-        Assert.AreEqual(versionInfo.Minor.ToString(CultureInfo.InvariantCulture), QuartzScheduler.VersionMinor);
-        Assert.AreEqual(versionInfo.Build.ToString(CultureInfo.InvariantCulture), QuartzScheduler.VersionIteration);
+        Assert.That(QuartzScheduler.VersionMajor, Is.EqualTo(versionInfo.Major.ToString(CultureInfo.InvariantCulture)));
+        Assert.That(QuartzScheduler.VersionMinor, Is.EqualTo(versionInfo.Minor.ToString(CultureInfo.InvariantCulture)));
+        Assert.That(QuartzScheduler.VersionIteration, Is.EqualTo(versionInfo.Build.ToString(CultureInfo.InvariantCulture)));
     }
 
     [Test]
@@ -76,7 +76,7 @@ public class QuartzSchedulerTest
         }
         catch (SchedulerException ex)
         {
-            Assert.AreEqual(ExpectedError, ex.Message);
+            Assert.That(ex.Message, Is.EqualTo(ExpectedError));
         }
 
         try
@@ -86,7 +86,7 @@ public class QuartzSchedulerTest
         }
         catch (SchedulerException ex)
         {
-            Assert.AreEqual(ExpectedError, ex.Message);
+            Assert.That(ex.Message, Is.EqualTo(ExpectedError));
         }
 
         await sched.Shutdown(false);
@@ -101,9 +101,9 @@ public class QuartzSchedulerTest
 
         IScheduler sched = await sf.GetScheduler();
         await sched.StartDelayed(TimeSpan.FromMilliseconds(100));
-        Assert.IsFalse(sched.IsStarted);
+        Assert.That(sched.IsStarted, Is.False);
         await Task.Delay(2000);
-        Assert.IsTrue(sched.IsStarted);
+        Assert.That(sched.IsStarted, Is.True);
     }
 
     [Test]
@@ -148,12 +148,12 @@ public class QuartzSchedulerTest
         var scheduler = CreateQuartzScheduler("A", "B", 5);
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.AreEqual(0, executingJobs.Count);
+        Assert.That(executingJobs.Count, Is.EqualTo(0));
 
         scheduler.Start().GetAwaiter().GetResult();
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.AreEqual(0, executingJobs.Count);
+        Assert.That(executingJobs.Count, Is.EqualTo(0));
 
         ScheduleJobs<DelayedJob>(scheduler, 3, true, false, 1, TimeSpan.FromMilliseconds(1), 1);
         ScheduleJobs<DelayedJob>(scheduler, 1, true, false, 1, TimeSpan.FromMilliseconds(1), 0);
@@ -161,17 +161,17 @@ public class QuartzSchedulerTest
         Thread.Sleep(150);
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.AreEqual(4, executingJobs.Count);
+        Assert.That(executingJobs.Count, Is.EqualTo(4));
 
         Thread.Sleep(150);
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.AreEqual(3, executingJobs.Count);
+        Assert.That(executingJobs.Count, Is.EqualTo(3));
 
         Thread.Sleep(300);
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.AreEqual(0, executingJobs.Count);
+        Assert.That(executingJobs.Count, Is.EqualTo(0));
 
         scheduler.Shutdown(true).GetAwaiter().GetResult();
     }
@@ -182,26 +182,26 @@ public class QuartzSchedulerTest
     {
         var scheduler = CreateQuartzScheduler("A", "B", 5);
 
-        Assert.AreEqual(0, scheduler.NumJobsExecuted);
+        Assert.That(scheduler.NumJobsExecuted, Is.EqualTo(0));
 
         scheduler.Start().GetAwaiter().GetResult();
 
-        Assert.AreEqual(0, scheduler.NumJobsExecuted);
+        Assert.That(scheduler.NumJobsExecuted, Is.EqualTo(0));
 
         ScheduleJobs<DelayedJob>(scheduler, 3, true, false, 1, TimeSpan.FromMilliseconds(1), 1);
         ScheduleJobs<DelayedJob>(scheduler, 1, true, false, 1, TimeSpan.FromMilliseconds(1), 0);
 
         Thread.Sleep(150);
 
-        Assert.AreEqual(4, scheduler.NumJobsExecuted);
+        Assert.That(scheduler.NumJobsExecuted, Is.EqualTo(4));
 
         Thread.Sleep(150);
 
-        Assert.AreEqual(7, scheduler.NumJobsExecuted);
+        Assert.That(scheduler.NumJobsExecuted, Is.EqualTo(7));
 
         Thread.Sleep(200);
 
-        Assert.AreEqual(7, scheduler.NumJobsExecuted);
+        Assert.That(scheduler.NumJobsExecuted, Is.EqualTo(7));
 
         scheduler.Shutdown(true).GetAwaiter().GetResult();
     }

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -41,9 +41,12 @@ public class QuartzSchedulerTest
     public void TestVersionInfo()
     {
         var versionInfo = typeof(QuartzScheduler).Assembly.GetName().Version;
-        Assert.That(QuartzScheduler.VersionMajor, Is.EqualTo(versionInfo.Major.ToString(CultureInfo.InvariantCulture)));
-        Assert.That(QuartzScheduler.VersionMinor, Is.EqualTo(versionInfo.Minor.ToString(CultureInfo.InvariantCulture)));
-        Assert.That(QuartzScheduler.VersionIteration, Is.EqualTo(versionInfo.Build.ToString(CultureInfo.InvariantCulture)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(QuartzScheduler.VersionMajor, Is.EqualTo(versionInfo.Major.ToString(CultureInfo.InvariantCulture)));
+            Assert.That(QuartzScheduler.VersionMinor, Is.EqualTo(versionInfo.Minor.ToString(CultureInfo.InvariantCulture)));
+            Assert.That(QuartzScheduler.VersionIteration, Is.EqualTo(versionInfo.Build.ToString(CultureInfo.InvariantCulture)));
+        });
     }
 
     [Test]
@@ -148,12 +151,12 @@ public class QuartzSchedulerTest
         var scheduler = CreateQuartzScheduler("A", "B", 5);
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs.Count, Is.EqualTo(0));
+        Assert.That(executingJobs, Is.Empty);
 
         scheduler.Start().GetAwaiter().GetResult();
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs.Count, Is.EqualTo(0));
+        Assert.That(executingJobs, Is.Empty);
 
         ScheduleJobs<DelayedJob>(scheduler, 3, true, false, 1, TimeSpan.FromMilliseconds(1), 1);
         ScheduleJobs<DelayedJob>(scheduler, 1, true, false, 1, TimeSpan.FromMilliseconds(1), 0);
@@ -161,17 +164,17 @@ public class QuartzSchedulerTest
         Thread.Sleep(150);
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs.Count, Is.EqualTo(4));
+        Assert.That(executingJobs, Has.Count.EqualTo(4));
 
         Thread.Sleep(150);
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs.Count, Is.EqualTo(3));
+        Assert.That(executingJobs, Has.Count.EqualTo(3));
 
         Thread.Sleep(300);
 
         executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs.Count, Is.EqualTo(0));
+        Assert.That(executingJobs, Is.Empty);
 
         scheduler.Shutdown(true).GetAwaiter().GetResult();
     }

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
@@ -15,9 +15,9 @@ public class QuartzSchedulerThreadTest
         QuartzScheduler scheduler = new QuartzScheduler(resources);
 
         var thread = new QuartzSchedulerThread(scheduler, resources);
-        Assert.IsTrue(thread.Paused);
-        Assert.IsFalse(thread.Halted);
-        Assert.AreEqual((int) (idleWaitTime.TotalMilliseconds * 0.2), thread.IdleWaitVariableness);
+        Assert.That(thread.Paused, Is.True);
+        Assert.That(thread.Halted, Is.False);
+        Assert.That(thread.IdleWaitVariableness, Is.EqualTo((int) (idleWaitTime.TotalMilliseconds * 0.2)));
     }
 
     private static IEnumerable<TimeSpan> ValidIdleWaitTimes()

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
@@ -15,9 +15,12 @@ public class QuartzSchedulerThreadTest
         QuartzScheduler scheduler = new QuartzScheduler(resources);
 
         var thread = new QuartzSchedulerThread(scheduler, resources);
-        Assert.That(thread.Paused, Is.True);
-        Assert.That(thread.Halted, Is.False);
-        Assert.That(thread.IdleWaitVariableness, Is.EqualTo((int) (idleWaitTime.TotalMilliseconds * 0.2)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(thread.Paused, Is.True);
+            Assert.That(thread.Halted, Is.False);
+            Assert.That(thread.IdleWaitVariableness, Is.EqualTo((int)(idleWaitTime.TotalMilliseconds * 0.2)));
+        });
     }
 
     private static IEnumerable<TimeSpan> ValidIdleWaitTimes()

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -57,9 +57,12 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
 
     protected override void VerifyMatch(CronExpression original, CronExpression deserialized)
     {
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(original.CronExpressionString, deserialized.CronExpressionString);
-        Assert.AreEqual(original.TimeZone, deserialized.TimeZone);
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.CronExpressionString, Is.EqualTo(original.CronExpressionString));
+            Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        });
     }
 
     /// <summary>
@@ -71,23 +74,26 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         CronExpression cronExpression = new CronExpression("0 15 10 * * ? 2005");
 
         DateTime cal = new DateTime(2005, 6, 1, 10, 15, 0).ToUniversalTime();
-        Assert.IsTrue(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.True);
 
         cal = cal.AddYears(1);
-        Assert.IsFalse(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.False);
 
         cal = new DateTime(2005, 6, 1, 10, 16, 0).ToUniversalTime();
-        Assert.IsFalse(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.False);
 
         cal = new DateTime(2005, 6, 1, 10, 14, 0).ToUniversalTime();
-        Assert.IsFalse(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.False);
 
         cronExpression = new CronExpression("0 15 10 ? * MON-FRI");
 
         // weekends
         cal = new DateTime(2007, 6, 9, 10, 15, 0).ToUniversalTime();
-        Assert.IsFalse(cronExpression.IsSatisfiedBy(cal));
-        Assert.IsFalse(cronExpression.IsSatisfiedBy(cal.AddDays(1)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(cronExpression.IsSatisfiedBy(cal), Is.False);
+            Assert.That(cronExpression.IsSatisfiedBy(cal.AddDays(1)), Is.False);
+        });
     }
 
     [Test]
@@ -96,25 +102,25 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         CronExpression cronExpression = new CronExpression("0 15 10 L-2 * ? 2010");
 
         DateTime cal = new DateTime(2010, 10, 29, 10, 15, 0).ToUniversalTime(); // last day - 2
-        Assert.IsTrue(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.True);
 
         cal = new DateTime(2010, 10, 28, 10, 15, 0).ToUniversalTime();
-        Assert.IsFalse(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.False);
 
         cronExpression = new CronExpression("0 15 10 L-5W * ? 2010");
 
         cal = new DateTime(2010, 10, 26, 10, 15, 0).ToUniversalTime(); // last day - 5
-        Assert.IsTrue(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.True);
 
         cronExpression = new CronExpression("0 15 10 L-1 * ? 2010");
 
         cal = new DateTime(2010, 10, 30, 10, 15, 0).ToUniversalTime(); // last day - 1
-        Assert.IsTrue(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.True);
 
         cronExpression = new CronExpression("0 15 10 L-1W * ? 2010");
 
         cal = new DateTime(2010, 10, 29, 10, 15, 0).ToUniversalTime(); // nearest weekday to last day - 1 (29th is a friday in 2010)
-        Assert.IsTrue(cronExpression.IsSatisfiedBy(cal));
+        Assert.That(cronExpression.IsSatisfiedBy(cal), Is.True);
     }
 
     [TestCase("0 15 10 6,15 * ? 2010", "0 15 10 6,15 * ? 2010")]
@@ -124,7 +130,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         expr.ToString().Should().Be(expected);
     }
 
-    [TestCase("0 15 10 L-1,L-2 * ? 2010", new int[] { 31 - 1, 31 - 2 })] //Multiple L Not supported
+    [TestCase("0 15 10 L-1,L-2 * ? 2010", new[] { 31 - 1, 31 - 2 })] //Multiple L Not supported
     public void CannotUseMultipleLastDayOfMonthInArray(string cronExpression, int[] expectedDays, string scenario = "")
     {
         // Limitation of implementation, could be supported but for now we throw an error.
@@ -133,14 +139,14 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
             .WithMessage("Support for specifying 'L' with other days of the month is limited to one instance of L");
     }
 
-    [TestCase("0 15 10 6,15,LW * ? 2010", new int[] { 6, 15, 29 })] //31 oct 2010 is a Sunday, week day would be 29
-    [TestCase("0 15 10 6,15,L * ? 2010", new int[] { 6, 15, 31 })]
-    [TestCase("0 15 10 15,L * ? 2010", new int[] { 15, 31 })]
-    [TestCase("0 15 10 15,31 * ? 2010", new int[] { 15, 31 })]
-    [TestCase("0 15 10 15,L-2 * ? 2010", new int[] { 15, 31 - 2 })]
-    [TestCase("0 15 10 31,L-2 * ? 2010", new int[] { 31 }, "duplicate day specified + last are equal")]
-    [TestCase("0 15 10 1,3,6,15,L * ? 2010", new int[] { 1, 3, 6, 15, 31 })]
-    [TestCase("0 15 10 15,LW-2 * ? 2010", new int[] { 15, 29 - 2 })] //29 is last week day
+    [TestCase("0 15 10 6,15,LW * ? 2010", new[] { 6, 15, 29 })] //31 oct 2010 is a Sunday, week day would be 29
+    [TestCase("0 15 10 6,15,L * ? 2010", new[] { 6, 15, 31 })]
+    [TestCase("0 15 10 15,L * ? 2010", new[] { 15, 31 })]
+    [TestCase("0 15 10 15,31 * ? 2010", new[] { 15, 31 })]
+    [TestCase("0 15 10 15,L-2 * ? 2010", new[] { 15, 31 - 2 })]
+    [TestCase("0 15 10 31,L-2 * ? 2010", new[] { 31 }, "duplicate day specified + last are equal")]
+    [TestCase("0 15 10 1,3,6,15,L * ? 2010", new[] { 1, 3, 6, 15, 31 })]
+    [TestCase("0 15 10 15,LW-2 * ? 2010", new[] { 15, 29 - 2 })] //29 is last week day
     public void CanUseLastDayOfMonthInArray(string cronExpression, int[] expectedDays, string scenario = "")
     {
         var expr = new CronExpression(cronExpression); //10:15am <variable days> October 2010
@@ -164,11 +170,11 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         return numbers.ToArray();
     }
 
-    [TestCase("0 15 10 5/5 * MON 2010", new int[] { 4, 11, 18, 25, 5, 10, 15, 20, 25, 30 }, "10:15am every 5th day of the month from 5 to 31, and on Mondays in October 2010")]
-    [TestCase("0 15 10 3 * MON,THU,FRI 2010", new int[] { 1, 3, 4, 11, 18, 25, 7, 14, 21, 28, 8, 15, 22, 29 }, "10:15am 3rd of month and every mon,thu,fri October 2010")]
-    [TestCase("0 15 10 1,2,3,4,5,6 * MON,THU,FRI 2010", new int[] { 1, 2, 3, 4, 5, 6, 11, 18, 25, 7, 14, 21, 28, 8, 15, 22, 29 }, "10:15am 1-6th of mon and every Mon,Thu,Fri October 2010")]
-    [TestCase("0 15 10 * * MON,THU,FRI 2010", new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 }, "10:15am EveryDay of Month October 2010, Wildcard specified")]
-    [TestCase("0 15 10 1 * * 2010", new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 }, "10:15am Every Day of Month October 2010, Wildcard specified")]
+    [TestCase("0 15 10 5/5 * MON 2010", new[] { 4, 11, 18, 25, 5, 10, 15, 20, 25, 30 }, "10:15am every 5th day of the month from 5 to 31, and on Mondays in October 2010")]
+    [TestCase("0 15 10 3 * MON,THU,FRI 2010", new[] { 1, 3, 4, 11, 18, 25, 7, 14, 21, 28, 8, 15, 22, 29 }, "10:15am 3rd of month and every mon,thu,fri October 2010")]
+    [TestCase("0 15 10 1,2,3,4,5,6 * MON,THU,FRI 2010", new[] { 1, 2, 3, 4, 5, 6, 11, 18, 25, 7, 14, 21, 28, 8, 15, 22, 29 }, "10:15am 1-6th of mon and every Mon,Thu,Fri October 2010")]
+    [TestCase("0 15 10 * * MON,THU,FRI 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 }, "10:15am EveryDay of Month October 2010, Wildcard specified")]
+    [TestCase("0 15 10 1 * * 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 }, "10:15am Every Day of Month October 2010, Wildcard specified")]
     public void CanUse_DayOfMonth_And_DayOfWeek_Together(string cronExpression, int[] expectedDays, string scenario = "")
     {
         var expr = new CronExpression(cronExpression);
@@ -337,7 +343,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         CronExpression cronExpression = new CronExpression("0 15 23 * * ?");
         DateTimeOffset cal = new DateTime(2005, 6, 1, 23, 16, 0).ToUniversalTime();
         DateTimeOffset nextExpectedFireTime = new DateTime(2005, 6, 2, 23, 15, 0).ToUniversalTime();
-        Assert.AreEqual(nextExpectedFireTime, cronExpression.GetTimeAfter(cal).Value);
+        Assert.That(cronExpression.GetTimeAfter(cal).Value, Is.EqualTo(nextExpectedFireTime));
     }
 
     [Test]
@@ -348,7 +354,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         CronExpression ce = new CronExpression("0 55 15 1 * ?");
         DateTimeOffset expected = new DateTime(2008, 1, 1, 15, 55, 0).ToUniversalTime();
         DateTimeOffset d = ce.GetNextValidTimeAfter(start).Value;
-        Assert.AreEqual(expected, d, "Got wrong date and time when passed year");
+        Assert.That(d, Is.EqualTo(expected), "Got wrong date and time when passed year");
     }
 
     [Test]
@@ -421,7 +427,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         CronExpression cronExpression = new CronExpression("0/5 * * * * ?");
         DateTimeOffset cal = new DateTimeOffset(2005, 6, 1, 1, 59, 55, TimeSpan.Zero);
         DateTimeOffset nextExpectedFireTime = new DateTimeOffset(2005, 6, 1, 2, 0, 0, TimeSpan.Zero);
-        Assert.AreEqual(nextExpectedFireTime, cronExpression.GetTimeAfter(cal).Value);
+        Assert.That(cronExpression.GetTimeAfter(cal).Value, Is.EqualTo(nextExpectedFireTime));
     }
 
     [Test]
@@ -431,7 +437,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         CronExpression cronExpression = new CronExpression("* * 1 * * ?");
         DateTimeOffset cal = new DateTime(2005, 7, 31, 22, 59, 57).ToUniversalTime();
         DateTimeOffset nextExpectedFireTime = new DateTime(2005, 8, 1, 1, 0, 0).ToUniversalTime();
-        Assert.AreEqual(nextExpectedFireTime, cronExpression.GetTimeAfter(cal).Value);
+        Assert.That(cronExpression.GetTimeAfter(cal).Value, Is.EqualTo(nextExpectedFireTime));
     }
 
     [Test]
@@ -455,7 +461,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         }
         catch (FormatException fe)
         {
-            Assert.AreEqual("Day-of-Week values must be between 1 and 7", fe.Message);
+            Assert.That(fe.Message, Is.EqualTo("Day-of-Week values must be between 1 and 7"));
         }
     }
 
@@ -465,7 +471,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         // test failed before because of improper trimming
         string expr = " 30 *   * * * ?  ";
         CronExpression calendar = new CronExpression(expr);
-        Assert.IsFalse(calendar.IsSatisfiedBy(DateTime.UtcNow.Date.AddMinutes(2)), "Time was included");
+        Assert.That(calendar.IsSatisfiedBy(DateTime.UtcNow.Date.AddMinutes(2)), Is.False, "Time was included");
     }
 
     private static void TestCorrectWeekFireDays(CronExpression cronExpression, IList<int> correctFireDays)
@@ -490,12 +496,12 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         for (int i = 0; i < fireDays.Count; ++i)
         {
             int idx = correctFireDays.IndexOf(fireDays[i]);
-            Assert.Greater(idx, -1, $"CronExpression evaluated true for {fireDays[i]} even when it shouldn't have");
+            Assert.That(idx, Is.GreaterThan(-1), $"CronExpression evaluated true for {fireDays[i]} even when it shouldn't have");
             correctFireDays.RemoveAt(idx);
         }
 
         // check that all fired
-        Assert.IsTrue(correctFireDays.Count == 0, $"CronExpression did not evaluate true for all expected days (count: {correctFireDays.Count}).");
+        Assert.That(correctFireDays.Count == 0, Is.True, $"CronExpression did not evaluate true for all expected days (count: {correctFireDays.Count}).");
     }
 
     [Test]
@@ -510,7 +516,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
             shouldFire = shouldFire && start.Day > 15 && start.Day < 28;
 
             bool satisfied = ce.IsSatisfiedBy(start.ToUniversalTime());
-            Assert.AreEqual(shouldFire, satisfied);
+            Assert.That(satisfied, Is.EqualTo(shouldFire));
 
             // cycle with half hour precision
             start = start.AddHours(0.5);
@@ -605,8 +611,9 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         }
         catch (FormatException pe)
         {
-            Assert.IsTrue(
-                pe.Message.StartsWith("Support for specifying 'L' with other days of the week is not implemented"),
+            Assert.That(
+                pe.Message,
+                Does.StartWith("Support for specifying 'L' with other days of the week is not implemented"),
                 "Incorrect FormatException thrown");
         }
 
@@ -617,8 +624,9 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         }
         catch (FormatException pe)
         {
-            Assert.IsTrue(
-                pe.Message.StartsWith("Support for specifying 'L' with other days of the week is not implemented"),
+            Assert.That(
+                pe.Message,
+                Does.StartWith("Support for specifying 'L' with other days of the week is not implemented"),
                 "Incorrect FormatException thrown");
         }
 
@@ -637,12 +645,18 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     {
         CronExpression expression = new CronExpression("0 0 0 29 * ?");
         DateTimeOffset? after = expression.GetNextValidTimeAfter(new DateTime(2009, 1, 30, 0, 0, 0).ToUniversalTime());
-        Assert.IsTrue(after.HasValue);
-        Assert.AreEqual(new DateTime(2009, 3, 29, 0, 0, 0).ToUniversalTime(), after.Value.DateTime);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after.HasValue, Is.True);
+            Assert.That(after.Value.DateTime, Is.EqualTo(new DateTime(2009, 3, 29, 0, 0, 0).ToUniversalTime()));
+        });
 
         after = expression.GetNextValidTimeAfter(new DateTime(2009, 12, 30).ToUniversalTime());
-        Assert.IsTrue(after.HasValue);
-        Assert.AreEqual(new DateTime(2010, 1, 29, 0, 0, 0).ToUniversalTime(), after.Value.DateTime);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after.HasValue, Is.True);
+            Assert.That(after.Value.DateTime, Is.EqualTo(new DateTime(2010, 1, 29, 0, 0, 0).ToUniversalTime()));
+        });
     }
 
     [Test]
@@ -652,9 +666,9 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         DateTimeOffset test = new DateTimeOffset(2009, 3, 8, 0, 0, 0, TimeSpan.Zero); //Sunday
         DateTimeOffset d = expression.GetNextValidTimeAfter(test).Value;
         // 2009-04-06 is Monday, Sunday is invalid for W
-        Assert.AreEqual(new DateTimeOffset(2009, 4, 6, 13, 5, 0, TimeZoneUtil.GetUtcOffset(d, TimeZoneInfo.Local)).ToUniversalTime(), d);
+        Assert.That(d, Is.EqualTo(new DateTimeOffset(2009, 4, 6, 13, 5, 0, TimeZoneUtil.GetUtcOffset(d, TimeZoneInfo.Local)).ToUniversalTime()));
         d = expression.GetNextValidTimeAfter(d).Value;
-        Assert.AreEqual(new DateTimeOffset(2009, 5, 5, 13, 5, 0, TimeZoneUtil.GetUtcOffset(d, TimeZoneInfo.Local)), d);
+        Assert.That(d, Is.EqualTo(new DateTimeOffset(2009, 5, 5, 13, 5, 0, TimeZoneUtil.GetUtcOffset(d, TimeZoneInfo.Local))));
     }
 
     [Test]
@@ -667,7 +681,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         }
         catch (FormatException pe)
         {
-            Assert.IsTrue(pe.Message.StartsWith("The 'W' option does not make sense with values larger than"), "Incorrect ParseException thrown");
+            Assert.That(pe.Message, Does.StartWith("The 'W' option does not make sense with values larger than"), "Incorrect ParseException thrown");
         }
     }
 
@@ -684,8 +698,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         while (++i < 26)
         {
             DateTimeOffset? date = trigger.GetFireTimeAfter(pdate);
-            // Console.WriteLine("fireTime: " + date + ", previousFireTime: " + pdate);
-            Assert.False(pdate.Equals(date), "Next fire time is the same as previous fire time!");
+            Assert.That(pdate, Is.Not.EqualTo(date), "Next fire time is the same as previous fire time!");
             pdate = date;
         }
     }
@@ -704,7 +717,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         {
             DateTimeOffset? date = trigger.GetFireTimeAfter(pdate);
             // Console.WriteLine("fireTime: " + date + ", previousFireTime: " + pdate);
-            Assert.False(pdate.Equals(date), "Next fire time is the same as previous fire time!");
+            Assert.That(pdate, Is.Not.EqualTo(date), "Next fire time is the same as previous fire time!");
             pdate = date;
         }
     }
@@ -722,9 +735,9 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         var daylightChange = TimeZone.CurrentTimeZone.GetDaylightChanges(2012);
         DateTimeOffset before = daylightChange.Start.ToUniversalTime().AddMinutes(-5); // keep outside the potentially undefined interval
         DateTimeOffset? after = expression.GetNextValidTimeAfter(before);
-        Assert.IsTrue(after.HasValue);
+        Assert.That(after.HasValue, Is.True);
         DateTimeOffset expected = daylightChange.Start.Add(daylightChange.Delta).AddMinutes(15).ToUniversalTime();
-        Assert.AreEqual(expected, after.Value);
+        Assert.That(after.Value, Is.EqualTo(expected));
     }
 
     [Test]
@@ -739,7 +752,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         var actualTime = expression.GetTimeAfter(startTime);
         DateTimeOffset expected = new DateTimeOffset(2012, 11, 5, 15, 15, 0, TimeSpan.FromHours(-5));
 
-        Assert.AreEqual(expected, actualTime.Value);
+        Assert.That(actualTime.Value, Is.EqualTo(expected));
     }
 
     [Test]
@@ -754,7 +767,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
 
         var actualTime = expression.GetTimeAfter(startTime);
         DateTimeOffset expected = new DateTimeOffset(2012, 11, 8, 0, 0, 0, TimeSpan.FromHours(-5));
-        Assert.AreEqual(expected, actualTime);
+        Assert.That(actualTime, Is.EqualTo(expected));
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -894,15 +894,18 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     [Test]
     public void TestInvalidCharactersAfterAsterisk()
     {
-        Assert.That(CronExpression.IsValidExpression("* * * ? * *A&/5:"), Is.False);
-        Assert.That(CronExpression.IsValidExpression("* * * ? *14 "), Is.False);
-        Assert.That(CronExpression.IsValidExpression(" * * ? *A&/5 *"), Is.False);
-        Assert.That(CronExpression.IsValidExpression("* * ? */5 *"), Is.False);
-        Assert.That(CronExpression.IsValidExpression("* * ? */52 *"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(CronExpression.IsValidExpression("* * * ? * *A&/5:"), Is.False);
+            Assert.That(CronExpression.IsValidExpression("* * * ? *14 "), Is.False);
+            Assert.That(CronExpression.IsValidExpression(" * * ? *A&/5 *"), Is.False);
+            Assert.That(CronExpression.IsValidExpression("* * ? */5 *"), Is.False);
+            Assert.That(CronExpression.IsValidExpression("* * ? */52 *"), Is.False);
 
-        Assert.That(CronExpression.IsValidExpression("0 0/30 * * * ?"), Is.True);
-        Assert.That(CronExpression.IsValidExpression("0 0/1 * * * ?"), Is.True);
-        Assert.That(CronExpression.IsValidExpression("0 0/30 * * */2 ?"), Is.True);
+            Assert.That(CronExpression.IsValidExpression("0 0/30 * * * ?"), Is.True);
+            Assert.That(CronExpression.IsValidExpression("0 0/1 * * * ?"), Is.True);
+            Assert.That(CronExpression.IsValidExpression("0 0/30 * * */2 ?"), Is.True);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -362,7 +362,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     {
         CronExpression cronExpression = new CronExpression("0 0 12 ? * MON-FRI");
         int[] arrJuneDaysThatShouldFire =
-            { 1, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 18, 19, 20, 22, 21, 25, 26, 27, 28, 29 };
+            [1, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 18, 19, 20, 22, 21, 25, 26, 27, 28, 29];
         List<int> juneDays = new List<int>(arrJuneDaysThatShouldFire);
 
         TestCorrectWeekFireDays(cronExpression, juneDays);
@@ -501,7 +501,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         }
 
         // check that all fired
-        Assert.That(correctFireDays.Count == 0, Is.True, $"CronExpression did not evaluate true for all expected days (count: {correctFireDays.Count}).");
+        Assert.That(correctFireDays, Is.Empty, $"CronExpression did not evaluate true for all expected days (count: {correctFireDays.Count}).");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/CronFieldTest.cs
+++ b/src/Quartz.Tests.Unit/CronFieldTest.cs
@@ -11,7 +11,7 @@ public class CronFieldTest
         field.Should().BeEmpty();
 
         field.Add(1);
-        field.Should().HaveCount(1);
+        field.Should().ContainSingle();
 
         field.Should().Contain(1);
         field.Should().NotContain(2);

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -10,12 +10,12 @@ public class CronScheduleBuilderTest
             .WithSchedule(CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(10, 0, DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Friday))
             .Build();
 
-        Assert.AreEqual("0 0 10 ? * 2,5,6", trigger.CronExpressionString);
+        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 0 10 ? * 2,5,6"));
 
         trigger = (ICronTrigger) TriggerBuilder.Create().WithIdentity("test")
             .WithSchedule(CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(10, 0, DayOfWeek.Wednesday))
             .Build();
 
-        Assert.AreEqual("0 0 10 ? * 4", trigger.CronExpressionString);
+        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 0 10 ? * 4"));
     }
 }

--- a/src/Quartz.Tests.Unit/CronTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CronTriggerTest.cs
@@ -50,7 +50,7 @@ public class CronTriggerTest
         trigger.Key = new TriggerKey("Quartz-579", SchedulerConstants.DefaultGroup);
         trigger.TimeZone = tz;
         trigger.CronExpressionString = "0 0 12 * * ?";
-        Assert.AreEqual(tz, trigger.TimeZone, "TimeZone was changed");
+        Assert.That(trigger.TimeZone, Is.EqualTo(tz), "TimeZone was changed");
     }
 
     [Test]
@@ -69,12 +69,12 @@ public class CronTriggerTest
         trigger.CronExpressionString = "0 50 5,11,17,23 ? * *";
         trigger.StartTimeUtc = startDate;
 
-        Assert.AreEqual(expectedFire, trigger.GetFireTimeAfter(startDate), $"Expected to fire at {expectedFire}");
-        Assert.IsTrue(trigger.WillFireOn(expectedFire), $"Expected to fire at {expectedFire}");
-        Assert.IsTrue(trigger.WillFireOn(expectedFire.AddHours(6)), $"Expected to fire at {expectedFire}");
-        Assert.IsTrue(trigger.WillFireOn(expectedFire.AddHours(12)), $"Expected to fire at {expectedFire}");
-        Assert.IsTrue(trigger.WillFireOn(expectedFire.AddHours(18)), $"Expected to fire at {expectedFire}");
-        Assert.IsTrue(trigger.WillFireOn(expectedFire.AddHours(24)), $"Expected to fire at {expectedFire}");
+        Assert.That(trigger.GetFireTimeAfter(startDate), Is.EqualTo(expectedFire), $"Expected to fire at {expectedFire}");
+        Assert.That(trigger.WillFireOn(expectedFire), Is.True, $"Expected to fire at {expectedFire}");
+        Assert.That(trigger.WillFireOn(expectedFire.AddHours(6)), Is.True, $"Expected to fire at {expectedFire}");
+        Assert.That(trigger.WillFireOn(expectedFire.AddHours(12)), Is.True, $"Expected to fire at {expectedFire}");
+        Assert.That(trigger.WillFireOn(expectedFire.AddHours(18)), Is.True, $"Expected to fire at {expectedFire}");
+        Assert.That(trigger.WillFireOn(expectedFire.AddHours(24)), Is.True, $"Expected to fire at {expectedFire}");
     }
 
     [Test]
@@ -86,7 +86,7 @@ public class CronTriggerTest
         trigger.StartTimeUtc = new DateTimeOffset(2099, 1, 1, 12, 0, 1, TimeSpan.Zero);
         trigger.EndTimeUtc = new DateTimeOffset(2099, 1, 1, 12, 0, 1, TimeSpan.Zero);
 
-        Assert.IsNull(trigger.ComputeFirstFireTimeUtc(null));
+        Assert.That(trigger.ComputeFirstFireTimeUtc(null), Is.Null);
     }
 
     [Test]
@@ -94,8 +94,8 @@ public class CronTriggerTest
     {
         IOperableTrigger trigger = new CronTriggerImpl();
         trigger.StartTimeUtc = new DateTime(1982, 6, 28, 13, 5, 5, 233);
-        Assert.IsFalse(trigger.HasMillisecondPrecision);
-        Assert.AreEqual(0, trigger.StartTimeUtc.Millisecond);
+        Assert.That(trigger.HasMillisecondPrecision, Is.False);
+        Assert.That(trigger.StartTimeUtc.Millisecond, Is.EqualTo(0));
     }
 
     [Test]
@@ -106,10 +106,10 @@ public class CronTriggerTest
         trigger.CronExpressionString = "0 0 12 * * ?";
         ICronTrigger trigger2 = (ICronTrigger) trigger.Clone();
 
-        Assert.AreEqual(trigger, trigger2, "Cloning failed");
+        Assert.That(trigger2, Is.EqualTo(trigger), "Cloning failed");
 
         // equals() doesn't test the cron expression
-        Assert.AreEqual("0 0 12 * * ?", trigger2.CronExpressionString, "Cloning failed for the cron expression");
+        Assert.That(trigger2.CronExpressionString, Is.EqualTo("0 0 12 * * ?"), "Cloning failed for the cron expression");
     }
 
     // http://jira.opensymphony.com/browse/QUARTZ-558
@@ -120,7 +120,7 @@ public class CronTriggerTest
         trigger.Key = new TriggerKey("test", "testGroup");
         ICronTrigger trigger2 = (ICronTrigger) trigger.Clone();
 
-        Assert.AreEqual(trigger, trigger2, "Cloning failed");
+        Assert.That(trigger2, Is.EqualTo(trigger), "Cloning failed");
     }
 
     [Test]
@@ -169,9 +169,12 @@ public class CronTriggerTest
         var triggerBuilder = trigger.GetTriggerBuilder();
         var trigger2 = triggerBuilder.Build();
 
-        Assert.That(trigger.StartTimeUtc, Is.EqualTo(trigger2.StartTimeUtc));
-        Assert.That(trigger.EndTimeUtc, Is.EqualTo(trigger2.EndTimeUtc));
-        Assert.That(trigger.Priority, Is.EqualTo(trigger2.Priority));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.StartTimeUtc, Is.EqualTo(trigger2.StartTimeUtc));
+            Assert.That(trigger.EndTimeUtc, Is.EqualTo(trigger2.EndTimeUtc));
+            Assert.That(trigger.Priority, Is.EqualTo(trigger2.Priority));
+        });
     }
 
     [Test]
@@ -184,8 +187,11 @@ public class CronTriggerTest
         var scheduleBuilder = trigger.GetScheduleBuilder();
 
         var cloned = (CronTriggerImpl) scheduleBuilder.Build();
-        Assert.That(cloned.MisfireInstruction, Is.EqualTo(trigger.MisfireInstruction));
-        Assert.That(cloned.TimeZone, Is.EqualTo(trigger.TimeZone));
-        Assert.That(cloned.CronExpressionString, Is.EqualTo(trigger.CronExpressionString));
+        Assert.Multiple(() =>
+        {
+            Assert.That(cloned.MisfireInstruction, Is.EqualTo(trigger.MisfireInstruction));
+            Assert.That(cloned.TimeZone, Is.EqualTo(trigger.TimeZone));
+            Assert.That(cloned.CronExpressionString, Is.EqualTo(trigger.CronExpressionString));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/CronTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CronTriggerTest.cs
@@ -69,12 +69,15 @@ public class CronTriggerTest
         trigger.CronExpressionString = "0 50 5,11,17,23 ? * *";
         trigger.StartTimeUtc = startDate;
 
-        Assert.That(trigger.GetFireTimeAfter(startDate), Is.EqualTo(expectedFire), $"Expected to fire at {expectedFire}");
-        Assert.That(trigger.WillFireOn(expectedFire), Is.True, $"Expected to fire at {expectedFire}");
-        Assert.That(trigger.WillFireOn(expectedFire.AddHours(6)), Is.True, $"Expected to fire at {expectedFire}");
-        Assert.That(trigger.WillFireOn(expectedFire.AddHours(12)), Is.True, $"Expected to fire at {expectedFire}");
-        Assert.That(trigger.WillFireOn(expectedFire.AddHours(18)), Is.True, $"Expected to fire at {expectedFire}");
-        Assert.That(trigger.WillFireOn(expectedFire.AddHours(24)), Is.True, $"Expected to fire at {expectedFire}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.GetFireTimeAfter(startDate), Is.EqualTo(expectedFire), $"Expected to fire at {expectedFire}");
+            Assert.That(trigger.WillFireOn(expectedFire), Is.True, $"Expected to fire at {expectedFire}");
+            Assert.That(trigger.WillFireOn(expectedFire.AddHours(6)), Is.True, $"Expected to fire at {expectedFire}");
+            Assert.That(trigger.WillFireOn(expectedFire.AddHours(12)), Is.True, $"Expected to fire at {expectedFire}");
+            Assert.That(trigger.WillFireOn(expectedFire.AddHours(18)), Is.True, $"Expected to fire at {expectedFire}");
+            Assert.That(trigger.WillFireOn(expectedFire.AddHours(24)), Is.True, $"Expected to fire at {expectedFire}");
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/CronTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CronTriggerTest.cs
@@ -94,8 +94,11 @@ public class CronTriggerTest
     {
         IOperableTrigger trigger = new CronTriggerImpl();
         trigger.StartTimeUtc = new DateTime(1982, 6, 28, 13, 5, 5, 233);
-        Assert.That(trigger.HasMillisecondPrecision, Is.False);
-        Assert.That(trigger.StartTimeUtc.Millisecond, Is.EqualTo(0));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.HasMillisecondPrecision, Is.False);
+            Assert.That(trigger.StartTimeUtc.Millisecond, Is.EqualTo(0));
+        });
     }
 
     [Test]
@@ -105,11 +108,13 @@ public class CronTriggerTest
         trigger.Key = new TriggerKey("test", "testGroup");
         trigger.CronExpressionString = "0 0 12 * * ?";
         ICronTrigger trigger2 = (ICronTrigger) trigger.Clone();
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger2, Is.EqualTo(trigger), "Cloning failed");
 
-        Assert.That(trigger2, Is.EqualTo(trigger), "Cloning failed");
-
-        // equals() doesn't test the cron expression
-        Assert.That(trigger2.CronExpressionString, Is.EqualTo("0 0 12 * * ?"), "Cloning failed for the cron expression");
+            // equals() doesn't test the cron expression
+            Assert.That(trigger2.CronExpressionString, Is.EqualTo("0 0 12 * * ?"), "Cloning failed for the cron expression");
+        });
     }
 
     // http://jira.opensymphony.com/browse/QUARTZ-558

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -208,7 +208,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
         });
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(10));
+        Assert.That(fireTimes, Has.Count.EqualTo(10));
     }
 
     [Test]
@@ -360,14 +360,14 @@ public class DailyTimeIntervalScheduleBuilderTest
         {
             //check trigger 2 DOW
             //this fails because the reference collection only contains MONDAY b/c it was cleared.
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Monday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Tuesday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Wednesday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Thursday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Friday), Is.True);
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Monday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Tuesday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Wednesday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Thursday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Friday));
 
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Saturday), Is.False);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Sunday), Is.False);
+            Assert.That(trigger2.DaysOfWeek, Does.Not.Contain(DayOfWeek.Saturday));
+            Assert.That(trigger2.DaysOfWeek, Does.Not.Contain(DayOfWeek.Sunday));
         });
     }
 

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -132,7 +132,7 @@ public class DailyTimeIntervalScheduleBuilderTest
         });
         //Assert.AreEqual(1, trigger.RepeatInterval);
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes, Has.Count.EqualTo(48));
     }
 
     [Test]
@@ -159,7 +159,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(17, 0)));
         });
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes, Has.Count.EqualTo(48));
     }
 
     [Test]
@@ -189,7 +189,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(23, 59, 59)));
         });
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes, Has.Count.EqualTo(48));
     }
 
     [Test]
@@ -232,7 +232,7 @@ public class DailyTimeIntervalScheduleBuilderTest
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 45, 0, 4, 1, 2011)));
             Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(10, 45)));
@@ -261,7 +261,7 @@ public class DailyTimeIntervalScheduleBuilderTest
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 17, 2, 2011)));
             Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0)));
@@ -386,7 +386,7 @@ public class DailyTimeIntervalScheduleBuilderTest
         var times = TriggerUtils.ComputeFireTimesBetween(trigger, null, startDate, new DateTime(2015, 1, 2));
         Assert.Multiple(() =>
         {
-            Assert.That(times.Count, Is.EqualTo(2), "wrong occurrancy count");
+            Assert.That(times, Has.Count.EqualTo(2), "wrong occurrancy count");
             Assert.That(times[1].ToLocalTime().DateTime, Is.EqualTo(new DateTime(2015, 1, 1, 10, 0, 0)), "wrong occurrancy count");
         });
     }

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -42,8 +42,10 @@ public class DailyTimeIntervalScheduleBuilderTest
     [Test]
     public async Task TestScheduleActualTrigger()
     {
-        NameValueCollection properties = new NameValueCollection();
-        properties["quartz.serializer.type"] = TestConstants.DefaultSerializerType;
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
+        };
 
         var factory = new StdSchedulerFactory(properties);
         IScheduler scheduler = await factory.GetScheduler();
@@ -70,8 +72,10 @@ public class DailyTimeIntervalScheduleBuilderTest
             return;
         }
 
-        NameValueCollection properties = new NameValueCollection();
-        properties["quartz.serializer.type"] = TestConstants.DefaultSerializerType;
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
+        };
         ISchedulerFactory sf = new StdSchedulerFactory(properties);
         IScheduler scheduler = await sf.GetScheduler();
 
@@ -119,12 +123,12 @@ public class DailyTimeIntervalScheduleBuilderTest
             .WithIdentity("test")
             .WithDailyTimeIntervalSchedule(x => x.WithIntervalInHours(3))
             .Build();
-        Assert.AreEqual("test", trigger.Key.Name);
-        Assert.AreEqual("DEFAULT", trigger.Key.Group);
-        Assert.AreEqual(IntervalUnit.Hour, trigger.RepeatIntervalUnit);
+        Assert.That(trigger.Key.Name, Is.EqualTo("test"));
+        Assert.That(trigger.Key.Group, Is.EqualTo("DEFAULT"));
+        Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
         //Assert.AreEqual(1, trigger.RepeatInterval);
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
     }
 
     [Test]
@@ -139,16 +143,19 @@ public class DailyTimeIntervalScheduleBuilderTest
                     .OnMondayThroughFriday())
             .Build();
 
-        Assert.AreEqual("test", trigger.Key.Name);
-        Assert.AreEqual("group", trigger.Key.Group);
-        Assert.AreEqual(true, TimeProvider.System.GetUtcNow() >= trigger.StartTimeUtc);
-        Assert.AreEqual(true, null == trigger.EndTimeUtc);
-        Assert.AreEqual(IntervalUnit.Minute, trigger.RepeatIntervalUnit);
-        Assert.AreEqual(72, trigger.RepeatInterval);
-        Assert.AreEqual(new TimeOfDay(8, 0), trigger.StartTimeOfDay);
-        Assert.AreEqual(new TimeOfDay(17, 0), trigger.EndTimeOfDay);
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key.Name, Is.EqualTo("test"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("group"));
+            Assert.That(TimeProvider.System.GetUtcNow() >= trigger.StartTimeUtc, Is.EqualTo(true));
+            Assert.That(null == trigger.EndTimeUtc, Is.EqualTo(true));
+            Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Minute));
+            Assert.That(trigger.RepeatInterval, Is.EqualTo(72));
+            Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0)));
+            Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(17, 0)));
+        });
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
     }
 
     [Test]
@@ -166,16 +173,19 @@ public class DailyTimeIntervalScheduleBuilderTest
             .StartAt(startTime)
             .EndAt(endTime)
             .Build();
-        Assert.AreEqual("test", trigger.Key.Name);
-        Assert.AreEqual("test", trigger.Key.Group);
-        Assert.AreEqual(true, startTime == trigger.StartTimeUtc);
-        Assert.AreEqual(true, endTime == trigger.EndTimeUtc);
-        Assert.AreEqual(IntervalUnit.Second, trigger.RepeatIntervalUnit);
-        Assert.AreEqual(121, trigger.RepeatInterval);
-        Assert.AreEqual(new TimeOfDay(10, 0, 0), trigger.StartTimeOfDay);
-        Assert.AreEqual(new TimeOfDay(23, 59, 59), trigger.EndTimeOfDay);
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key.Name, Is.EqualTo("test"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("test"));
+            Assert.That(startTime == trigger.StartTimeUtc, Is.EqualTo(true));
+            Assert.That(endTime == trigger.EndTimeUtc, Is.EqualTo(true));
+            Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Second));
+            Assert.That(trigger.RepeatInterval, Is.EqualTo(121));
+            Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOfDay(10, 0, 0)));
+            Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(23, 59, 59)));
+        });
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
     }
 
     [Test]
@@ -186,12 +196,15 @@ public class DailyTimeIntervalScheduleBuilderTest
             .WithDailyTimeIntervalSchedule(x => x.WithIntervalInHours(1).WithRepeatCount(9))
             .Build();
 
-        Assert.AreEqual("test", trigger.Key.Name);
-        Assert.AreEqual("DEFAULT", trigger.Key.Group);
-        Assert.AreEqual(IntervalUnit.Hour, trigger.RepeatIntervalUnit);
-        Assert.AreEqual(1, trigger.RepeatInterval);
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key.Name, Is.EqualTo("test"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("DEFAULT"));
+            Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
+            Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
+        });
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.AreEqual(10, fireTimes.Count);
+        Assert.That(fireTimes.Count, Is.EqualTo(10));
     }
 
     [Test]
@@ -206,14 +219,20 @@ public class DailyTimeIntervalScheduleBuilderTest
                     .EndingDailyAfterCount(12))
             .StartAt(startTime)
             .Build();
-        Assert.AreEqual("test", trigger.Key.Name);
-        Assert.AreEqual("DEFAULT", trigger.Key.Group);
-        Assert.AreEqual(IntervalUnit.Minute, trigger.RepeatIntervalUnit);
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key.Name, Is.EqualTo("test"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("DEFAULT"));
+            Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Minute));
+        });
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(10, 45, 0, 4, 1, 2011), fireTimes[47]);
-        Assert.AreEqual(new TimeOfDay(10, 45), trigger.EndTimeOfDay);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 45, 0, 4, 1, 2011)));
+            Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(10, 45)));
+        });
     }
 
     [Test]
@@ -228,15 +247,21 @@ public class DailyTimeIntervalScheduleBuilderTest
             .StartAt(startTime)
             .ForJob("testJob", "testJobGroup")
             .Build();
-        Assert.AreEqual("test", trigger.Key.Name);
-        Assert.AreEqual("DEFAULT", trigger.Key.Group);
-        Assert.AreEqual(IntervalUnit.Minute, trigger.RepeatIntervalUnit);
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key.Name, Is.EqualTo("test"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("DEFAULT"));
+            Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Minute));
+        });
         ((IOperableTrigger) trigger).Validate();
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 17, 2, 2011), fireTimes[47]);
-        Assert.AreEqual(new TimeOfDay(8, 0), trigger.EndTimeOfDay);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 17, 2, 2011)));
+            Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0)));
+        });
     }
 
     [Test]
@@ -301,7 +326,7 @@ public class DailyTimeIntervalScheduleBuilderTest
                 .InTimeZone(est))
             .Build();
 
-        Assert.AreEqual(est, trigger.TimeZone);
+        Assert.That(trigger.TimeZone, Is.EqualTo(est));
     }
 
     [Test]
@@ -327,16 +352,19 @@ public class DailyTimeIntervalScheduleBuilderTest
             .OnMondayThroughFriday()
             .Build();
 
-        //check trigger 2 DOW
-        //this fails because the reference collection only contains MONDAY b/c it was cleared.
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Monday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Tuesday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Wednesday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Thursday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Friday));
+        Assert.Multiple(() =>
+        {
+            //check trigger 2 DOW
+            //this fails because the reference collection only contains MONDAY b/c it was cleared.
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Monday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Tuesday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Wednesday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Thursday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Friday), Is.True);
 
-        Assert.IsFalse(trigger2.DaysOfWeek.Contains(DayOfWeek.Saturday));
-        Assert.IsFalse(trigger2.DaysOfWeek.Contains(DayOfWeek.Sunday));
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Saturday), Is.False);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Sunday), Is.False);
+        });
     }
 
     [Test]
@@ -352,8 +380,11 @@ public class DailyTimeIntervalScheduleBuilderTest
             .Build();
 
         var times = TriggerUtils.ComputeFireTimesBetween(trigger, null, startDate, new DateTime(2015, 1, 2));
-        Assert.That(times.Count, Is.EqualTo(2), "wrong occurrancy count");
-        Assert.That(times[1].ToLocalTime().DateTime, Is.EqualTo(new DateTime(2015, 1, 1, 10, 0, 0)), "wrong occurrancy count");
+        Assert.Multiple(() =>
+        {
+            Assert.That(times.Count, Is.EqualTo(2), "wrong occurrancy count");
+            Assert.That(times[1].ToLocalTime().DateTime, Is.EqualTo(new DateTime(2015, 1, 1, 10, 0, 0)), "wrong occurrancy count");
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -22,6 +22,7 @@
 using System.Collections.Specialized;
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Quartz.Impl;
 using Quartz.Impl.Triggers;
@@ -399,8 +400,10 @@ public class DailyTimeIntervalScheduleBuilderTest
         var trigger2 = trigger1
             .GetTriggerBuilder()
             .Build();
-
-        trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
-        trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+        using (new AssertionScope())
+        {
+            trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -124,9 +124,12 @@ public class DailyTimeIntervalScheduleBuilderTest
             .WithIdentity("test")
             .WithDailyTimeIntervalSchedule(x => x.WithIntervalInHours(3))
             .Build();
-        Assert.That(trigger.Key.Name, Is.EqualTo("test"));
-        Assert.That(trigger.Key.Group, Is.EqualTo("DEFAULT"));
-        Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key.Name, Is.EqualTo("test"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("DEFAULT"));
+            Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
+        });
         //Assert.AreEqual(1, trigger.RepeatInterval);
         var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
         Assert.That(fireTimes.Count, Is.EqualTo(48));

--- a/src/Quartz.Tests.Unit/DateBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DateBuilderTest.cs
@@ -8,9 +8,12 @@ public class DateBuilderTest
     {
         DateTimeOffset dto = new DateTimeOffset(new DateTime(2011, 11, 14, 21, 59, 0));
         var nextGivenSecondDate = DateBuilder.NextGivenSecondDate(dto, 0);
-        Assert.AreEqual(22, nextGivenSecondDate.Hour);
-        Assert.AreEqual(0, nextGivenSecondDate.Minute);
-        Assert.AreEqual(0, nextGivenSecondDate.Second);
+        Assert.Multiple(() =>
+        {
+            Assert.That(nextGivenSecondDate.Hour, Is.EqualTo(22));
+            Assert.That(nextGivenSecondDate.Minute, Is.EqualTo(0));
+            Assert.That(nextGivenSecondDate.Second, Is.EqualTo(0));
+        });
     }
 
     [Test]
@@ -18,9 +21,12 @@ public class DateBuilderTest
     {
         DateTimeOffset dto = new DateTimeOffset(new DateTime(2011, 11, 14, 23, 59, 0));
         var nextGivenMinuteDate = DateBuilder.NextGivenMinuteDate(dto, 0);
-        Assert.AreEqual(15, nextGivenMinuteDate.Day);
-        Assert.AreEqual(0, nextGivenMinuteDate.Hour);
-        Assert.AreEqual(0, nextGivenMinuteDate.Minute);
-        Assert.AreEqual(0, nextGivenMinuteDate.Second);
+        Assert.Multiple(() =>
+        {
+            Assert.That(nextGivenMinuteDate.Day, Is.EqualTo(15));
+            Assert.That(nextGivenMinuteDate.Hour, Is.EqualTo(0));
+            Assert.That(nextGivenMinuteDate.Minute, Is.EqualTo(0));
+            Assert.That(nextGivenMinuteDate.Second, Is.EqualTo(0));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
+++ b/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
@@ -53,12 +53,12 @@ public class DaylightSavingTimeTest
         DateTimeOffset expectedTime = new DateTimeOffset(2016, 3, 13, 3, 30, 0, TimeSpan.FromHours(-7));
 
         // We should definitely have a value
-        Assert.NotNull(fireTime);
+        Assert.That(fireTime, Is.Not.Null);
 
         // fireTime always is in UTC, but DateTimeOffset comparison normalized to UTC anyway.
         // Conversion here is for clarity of interpreting errors if the test fails.
         DateTimeOffset convertedFireTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
-        Assert.AreEqual(expectedTime, convertedFireTime);
+        Assert.That(convertedFireTime, Is.EqualTo(expectedTime));
     }
 
     [Test]
@@ -79,12 +79,12 @@ public class DaylightSavingTimeTest
         DateTimeOffset expectedTime = new DateTimeOffset(2016, 11, 6, 1, 30, 0, TimeSpan.FromHours(-7));
 
         // We should definitely have a value
-        Assert.NotNull(fireTime);
+        Assert.That(fireTime, Is.Not.Null);
 
         // fireTime always is in UTC, but DateTimeOffset comparison normalized to UTC anyway.
         // Conversion here is for clarity of interpreting errors if the test fails.
         DateTimeOffset convertedFireTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
-        Assert.AreEqual(expectedTime, convertedFireTime);
+        Assert.That(convertedFireTime, Is.EqualTo(expectedTime));
     }
 
     [Test]
@@ -105,11 +105,11 @@ public class DaylightSavingTimeTest
         DateTimeOffset expectedTime = new DateTimeOffset(2016, 11, 7, 1, 30, 0, TimeSpan.FromHours(-8));
 
         // We should definitely have a value
-        Assert.NotNull(fireTime);
+        Assert.That(fireTime, Is.Not.Null);
 
         // fireTime always is in UTC, but DateTimeOffset comparison normalized to UTC anyway.
         // Conversion here is for clarity of interpreting errors if the test fails.
         DateTimeOffset convertedFireTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
-        Assert.AreEqual(expectedTime, convertedFireTime);
+        Assert.That(convertedFireTime, Is.EqualTo(expectedTime));
     }
 }

--- a/src/Quartz.Tests.Unit/DisallowConcurrentJobExecutionTest.cs
+++ b/src/Quartz.Tests.Unit/DisallowConcurrentJobExecutionTest.cs
@@ -100,7 +100,7 @@ public class DisallowConcurrentExecutionJobTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(jobExecDates.Count, Is.EqualTo(2));
+            Assert.That(jobExecDates, Has.Count.EqualTo(2));
             Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5d));
         });
     }
@@ -134,7 +134,10 @@ public class DisallowConcurrentExecutionJobTest
         barrier.WaitOne();
         await scheduler.Shutdown(true);
 
-        Assert.That(jobExecDates.Count, Is.EqualTo(2));
-        Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobExecDates, Has.Count.EqualTo(2));
+            Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/QuartzHttpClientServiceCollectionExtensionsTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/QuartzHttpClientServiceCollectionExtensionsTest.cs
@@ -128,11 +128,7 @@ namespace Quartz.Tests.Unit.Extensions.DependencyInjection
 
 namespace QuartzHttpClientServiceCollectionExtensionsTestTypes
 {
-    public interface IMyScheduler : IScheduler
-    {
-    }
+    public interface IMyScheduler : IScheduler;
 
-    public interface IMySecondScheduler : IScheduler
-    {
-    }
+    public interface IMySecondScheduler : IScheduler;
 }

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -29,16 +29,16 @@ public class ServiceCollectionExtensionsTests
         var job = quartzOptions.JobDetails.Single();
 
         // The trigger key should have its own manual configuration
-        Assert.AreEqual("TriggerName", trigger.Key.Name);
-        Assert.AreEqual("TriggerGroup", trigger.Key.Group);
+        Assert.That(trigger.Key.Name, Is.EqualTo("TriggerName"));
+        Assert.That(trigger.Key.Group, Is.EqualTo("TriggerGroup"));
 
         // The job key should have its own manual configuration
-        Assert.AreEqual("JobName", job.Key.Name);
-        Assert.AreEqual("JobGroup", job.Key.Group);
+        Assert.That(job.Key.Name, Is.EqualTo("JobName"));
+        Assert.That(job.Key.Group, Is.EqualTo("JobGroup"));
 
         // Also validate that the trigger knows the correct job key
-        Assert.AreEqual(job.Key.Name, trigger.JobKey.Name);
-        Assert.AreEqual(job.Key.Group, trigger.JobKey.Group);
+        Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
+        Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
     }
 
     [Test]
@@ -61,12 +61,12 @@ public class ServiceCollectionExtensionsTests
         var job = quartzOptions.JobDetails.Single();
 
         // The job's key should match the trigger's (auto-generated) key
-        Assert.AreEqual(trigger.Key.Name, job.Key.Name);
-        Assert.AreEqual(trigger.Key.Group, job.Key.Group);
+        Assert.That(job.Key.Name, Is.EqualTo(trigger.Key.Name));
+        Assert.That(job.Key.Group, Is.EqualTo(trigger.Key.Group));
 
         // Also validate that the trigger knows the correct job key
-        Assert.AreEqual(job.Key.Name, trigger.JobKey.Name);
-        Assert.AreEqual(job.Key.Group, trigger.JobKey.Group);
+        Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
+        Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
     }
 
     [Test]
@@ -89,16 +89,16 @@ public class ServiceCollectionExtensionsTests
         var job = quartzOptions.JobDetails.Single();
 
         // The trigger key should have its own manual configuration
-        Assert.AreEqual("TriggerName", trigger.Key.Name);
-        Assert.AreEqual("TriggerGroup", trigger.Key.Group);
+        Assert.That(trigger.Key.Name, Is.EqualTo("TriggerName"));
+        Assert.That(trigger.Key.Group, Is.EqualTo("TriggerGroup"));
 
         // The job's key should match the trigger's (auto-generated) key
-        Assert.AreEqual(trigger.Key.Name, job.Key.Name);
-        Assert.AreEqual(trigger.Key.Group, job.Key.Group);
+        Assert.That(job.Key.Name, Is.EqualTo(trigger.Key.Name));
+        Assert.That(job.Key.Group, Is.EqualTo(trigger.Key.Group));
 
         // Also validate that the trigger knows the correct job key
-        Assert.AreEqual(job.Key.Name, trigger.JobKey.Name);
-        Assert.AreEqual(job.Key.Group, trigger.JobKey.Group);
+        Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
+        Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -22,23 +22,29 @@ public class ServiceCollectionExtensionsTests
 
         var quartzOptions = serviceProvider.GetRequiredService<IOptions<QuartzOptions>>().Value;
 
-        Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
-        Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+        Assert.Multiple(() =>
+        {
+            Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
+            Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+        });
 
         var trigger = quartzOptions.Triggers.Single();
         var job = quartzOptions.JobDetails.Single();
 
-        // The trigger key should have its own manual configuration
-        Assert.That(trigger.Key.Name, Is.EqualTo("TriggerName"));
-        Assert.That(trigger.Key.Group, Is.EqualTo("TriggerGroup"));
+        Assert.Multiple(() =>
+        {
+            // The trigger key should have its own manual configuration
+            Assert.That(trigger.Key.Name, Is.EqualTo("TriggerName"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("TriggerGroup"));
 
-        // The job key should have its own manual configuration
-        Assert.That(job.Key.Name, Is.EqualTo("JobName"));
-        Assert.That(job.Key.Group, Is.EqualTo("JobGroup"));
+            // The job key should have its own manual configuration
+            Assert.That(job.Key.Name, Is.EqualTo("JobName"));
+            Assert.That(job.Key.Group, Is.EqualTo("JobGroup"));
 
-        // Also validate that the trigger knows the correct job key
-        Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
-        Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
+            // Also validate that the trigger knows the correct job key
+            Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
+            Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
+        });
     }
 
     [Test]
@@ -54,19 +60,25 @@ public class ServiceCollectionExtensionsTests
 
         var quartzOptions = serviceProvider.GetRequiredService<IOptions<QuartzOptions>>().Value;
 
-        Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
-        Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+        Assert.Multiple(() =>
+        {
+            Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
+            Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+        });
 
         var trigger = quartzOptions.Triggers.Single();
         var job = quartzOptions.JobDetails.Single();
 
-        // The job's key should match the trigger's (auto-generated) key
-        Assert.That(job.Key.Name, Is.EqualTo(trigger.Key.Name));
-        Assert.That(job.Key.Group, Is.EqualTo(trigger.Key.Group));
+        Assert.Multiple(() =>
+        {
+            // The job's key should match the trigger's (auto-generated) key
+            Assert.That(job.Key.Name, Is.EqualTo(trigger.Key.Name));
+            Assert.That(job.Key.Group, Is.EqualTo(trigger.Key.Group));
 
-        // Also validate that the trigger knows the correct job key
-        Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
-        Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
+            // Also validate that the trigger knows the correct job key
+            Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
+            Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
+        });
     }
 
     [Test]
@@ -82,23 +94,29 @@ public class ServiceCollectionExtensionsTests
 
         var quartzOptions = serviceProvider.GetRequiredService<IOptions<QuartzOptions>>().Value;
 
-        Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
-        Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+        Assert.Multiple(() =>
+        {
+            Assert.That(quartzOptions.Triggers, Has.Exactly(1).Items);
+            Assert.That(quartzOptions.JobDetails, Has.Exactly(1).Items);
+        });
 
         var trigger = quartzOptions.Triggers.Single();
         var job = quartzOptions.JobDetails.Single();
 
-        // The trigger key should have its own manual configuration
-        Assert.That(trigger.Key.Name, Is.EqualTo("TriggerName"));
-        Assert.That(trigger.Key.Group, Is.EqualTo("TriggerGroup"));
+        Assert.Multiple(() =>
+        {
+            // The trigger key should have its own manual configuration
+            Assert.That(trigger.Key.Name, Is.EqualTo("TriggerName"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("TriggerGroup"));
 
-        // The job's key should match the trigger's (auto-generated) key
-        Assert.That(job.Key.Name, Is.EqualTo(trigger.Key.Name));
-        Assert.That(job.Key.Group, Is.EqualTo(trigger.Key.Group));
+            // The job's key should match the trigger's (auto-generated) key
+            Assert.That(job.Key.Name, Is.EqualTo(trigger.Key.Name));
+            Assert.That(job.Key.Group, Is.EqualTo(trigger.Key.Group));
 
-        // Also validate that the trigger knows the correct job key
-        Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
-        Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
+            // Also validate that the trigger knows the correct job key
+            Assert.That(trigger.JobKey.Name, Is.EqualTo(job.Key.Name));
+            Assert.That(trigger.JobKey.Group, Is.EqualTo(job.Key.Group));
+        });
     }
 
     [Test]
@@ -123,8 +141,11 @@ public class ServiceCollectionExtensionsTests
 
         var quartzOptions = provider.GetRequiredService<IOptions<QuartzOptions>>().Value;
 
-        Assert.That(quartzOptions.ContainsKey("quartz.dataSource.default.connectionProvider.type"));
-        Assert.That(quartzOptions["quartz.dataSource.default.connectionProvider.type"], Is.EqualTo(typeof(DataSourceDbProvider).AssemblyQualifiedNameWithoutVersion()));
+        Assert.Multiple(() =>
+        {
+            Assert.That(quartzOptions.ContainsKey("quartz.dataSource.default.connectionProvider.type"));
+            Assert.That(quartzOptions["quartz.dataSource.default.connectionProvider.type"], Is.EqualTo(typeof(DataSourceDbProvider).AssemblyQualifiedNameWithoutVersion()));
+        });
     }
 
     private sealed class DummyJob : IJob

--- a/src/Quartz.Tests.Unit/GlobalUsings.cs
+++ b/src/Quartz.Tests.Unit/GlobalUsings.cs
@@ -1,2 +1,0 @@
-global using Assert = NUnit.Framework.Legacy.ClassicAssert;
-global using CollectionAssert = NUnit.Framework.Legacy.CollectionAssert;

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -57,7 +57,7 @@ public class JobStoreSupportTest
             set
             {
                 FieldInfo fieldInfo = typeof(JobStoreSupport).GetField("driverDelegate", BindingFlags.Instance | BindingFlags.NonPublic);
-                Assert.IsNotNull(fieldInfo);
+                Assert.That(fieldInfo, Is.Not.Null);
                 fieldInfo.SetValue(this, value);
             }
         }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -85,9 +85,7 @@ public class StdAdoDelegateTest
         }
     }
 
-    private class NonSerializableTestClass
-    {
-    }
+    private class NonSerializableTestClass;
 
     [Test]
     public async Task TestSelectBlobTriggerWithNoBlobContent()
@@ -280,14 +278,14 @@ public class StdAdoDelegateTest
             new SimpleTypeLoadHelper(), // Irrelevant, not used actually by method implementation
             CancellationToken.None);
 
-        Assert.IsNotNull(jobDetail);
-        Assert.AreEqual(jobName, jobDetail.Key.Name);
-        Assert.AreEqual(jobGroup, jobDetail.Key.Group);
-        Assert.AreEqual(jobDescription, jobDetail.Description);
-        Assert.AreEqual(typeof(TestJob), jobDetail.JobType.Type);
-        Assert.IsTrue(jobDetail.RequestsRecovery);
-        Assert.IsTrue(jobDetail.Durable);
-        Assert.IsTrue(jobDetail.ConcurrentExecutionDisallowed);
+        Assert.That(jobDetail, Is.Not.Null);
+        Assert.That(jobDetail.Key.Name, Is.EqualTo(jobName));
+        Assert.That(jobDetail.Key.Group, Is.EqualTo(jobGroup));
+        Assert.That(jobDetail.Description, Is.EqualTo(jobDescription));
+        Assert.That(jobDetail.JobType.Type, Is.EqualTo(typeof(TestJob)));
+        Assert.That(jobDetail.RequestsRecovery, Is.True);
+        Assert.That(jobDetail.Durable, Is.True);
+        Assert.That(jobDetail.ConcurrentExecutionDisallowed, Is.True);
 
         var expectedCommandText = "SELECT "
                                   + "JOB_NAME,"
@@ -303,7 +301,7 @@ public class StdAdoDelegateTest
                                   + "WHERE SCHED_NAME = @schedulerName "
                                   + "AND JOB_NAME = @jobName "
                                   + "AND JOB_GROUP = @jobGroup";
-        Assert.AreEqual(expectedCommandText, command.CommandText);
+        Assert.That(command.CommandText, Is.EqualTo(expectedCommandText));
     }
 
     private class TestJob : IJob
@@ -496,6 +494,4 @@ public class StubParameterCollection : DbParameterCollection
     }
 }
 
-internal class TestTriggerPersistenceDelegate : SimpleTriggerPersistenceDelegate
-{
-}
+internal class TestTriggerPersistenceDelegate : SimpleTriggerPersistenceDelegate;

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -278,14 +278,17 @@ public class StdAdoDelegateTest
             new SimpleTypeLoadHelper(), // Irrelevant, not used actually by method implementation
             CancellationToken.None);
 
-        Assert.That(jobDetail, Is.Not.Null);
-        Assert.That(jobDetail.Key.Name, Is.EqualTo(jobName));
-        Assert.That(jobDetail.Key.Group, Is.EqualTo(jobGroup));
-        Assert.That(jobDetail.Description, Is.EqualTo(jobDescription));
-        Assert.That(jobDetail.JobType.Type, Is.EqualTo(typeof(TestJob)));
-        Assert.That(jobDetail.RequestsRecovery, Is.True);
-        Assert.That(jobDetail.Durable, Is.True);
-        Assert.That(jobDetail.ConcurrentExecutionDisallowed, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobDetail, Is.Not.Null);
+            Assert.That(jobDetail.Key.Name, Is.EqualTo(jobName));
+            Assert.That(jobDetail.Key.Group, Is.EqualTo(jobGroup));
+            Assert.That(jobDetail.Description, Is.EqualTo(jobDescription));
+            Assert.That(jobDetail.JobType.Type, Is.EqualTo(typeof(TestJob)));
+            Assert.That(jobDetail.RequestsRecovery, Is.True);
+            Assert.That(jobDetail.Durable, Is.True);
+            Assert.That(jobDetail.ConcurrentExecutionDisallowed, Is.True);
+        });
 
         var expectedCommandText = "SELECT "
                                   + "JOB_NAME,"

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateTriggerTest.cs
@@ -136,6 +136,6 @@ public class UpdateTriggerTest
 
         //Assert
         var resultDataParameters = dataParameterCollectionOutputs.Select(x => x as IDataParameter).Where(x => x.ParameterName == "triggerType").FirstOrDefault();
-        Assert.AreEqual("CRON", resultDataParameters.Value);
+        Assert.That(resultDataParameters.Value, Is.EqualTo("CRON"));
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
@@ -52,7 +52,7 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         {
             Assert.That(cal.IsTimeIncluded(d.ToUniversalTime()), Is.False, "Time was included when it was supposed not to be");
             Assert.That(cal.IsDayExcluded(d), Is.True, "Day was not excluded when it was supposed to be excluded");
-            Assert.That(cal.DaysExcluded.Count, Is.EqualTo(1));
+            Assert.That(cal.DaysExcluded, Has.Count.EqualTo(1));
             Assert.That(cal.DaysExcluded.First().Day, Is.EqualTo(d.Day));
             Assert.That(cal.DaysExcluded.First().Month, Is.EqualTo(d.Month));
         });

--- a/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
@@ -48,11 +48,11 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         // we're local by default
         DateTime d = new DateTime(2005, 1, 1);
         cal.SetDayExcluded(d, true);
-        Assert.IsFalse(cal.IsTimeIncluded(d.ToUniversalTime()), "Time was included when it was supposed not to be");
-        Assert.IsTrue(cal.IsDayExcluded(d), "Day was not excluded when it was supposed to be excluded");
-        Assert.AreEqual(1, cal.DaysExcluded.Count);
-        Assert.AreEqual(d.Day, cal.DaysExcluded.First().Day);
-        Assert.AreEqual(d.Month, cal.DaysExcluded.First().Month);
+        Assert.That(cal.IsTimeIncluded(d.ToUniversalTime()), Is.False, "Time was included when it was supposed not to be");
+        Assert.That(cal.IsDayExcluded(d), Is.True, "Day was not excluded when it was supposed to be excluded");
+        Assert.That(cal.DaysExcluded.Count, Is.EqualTo(1));
+        Assert.That(cal.DaysExcluded.First().Day, Is.EqualTo(d.Day));
+        Assert.That(cal.DaysExcluded.First().Month, Is.EqualTo(d.Month));
     }
 
     [Test]
@@ -62,8 +62,8 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         cal.SetDayExcluded(d, true);
         cal.SetDayExcluded(d, false);
         cal.SetDayExcluded(d, false);
-        Assert.IsTrue(cal.IsTimeIncluded(d), "Time was not included when it was supposed to be");
-        Assert.IsFalse(cal.IsDayExcluded(d), "Day was excluded when it was supposed to be included");
+        Assert.That(cal.IsTimeIncluded(d), Is.True, "Time was not included when it was supposed to be");
+        Assert.That(cal.IsDayExcluded(d), Is.False, "Day was excluded when it was supposed to be included");
     }
 
     [Test]
@@ -72,10 +72,10 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         string errMessage = "Day was not excluded when it was supposed to be excluded";
         DateTime d = new DateTime(2005, 1, 1);
         cal.SetDayExcluded(d, true);
-        Assert.IsTrue(cal.IsDayExcluded(d), errMessage);
-        Assert.IsTrue(cal.IsDayExcluded(d.AddYears(-2)), errMessage);
-        Assert.IsTrue(cal.IsDayExcluded(d.AddYears(2)), errMessage);
-        Assert.IsTrue(cal.IsDayExcluded(d.AddYears(100)), errMessage);
+        Assert.That(cal.IsDayExcluded(d), Is.True, errMessage);
+        Assert.That(cal.IsDayExcluded(d.AddYears(-2)), Is.True, errMessage);
+        Assert.That(cal.IsDayExcluded(d.AddYears(2)), Is.True, errMessage);
+        Assert.That(cal.IsDayExcluded(d.AddYears(100)), Is.True, errMessage);
     }
 
     [Test]
@@ -83,10 +83,10 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     {
         cal.DaysExcluded = null;
         DateTimeOffset test = DateTimeOffset.UtcNow.Date;
-        Assert.AreEqual(test, cal.GetNextIncludedTimeUtc(test), "Did not get today as date when nothing was excluded");
+        Assert.That(cal.GetNextIncludedTimeUtc(test), Is.EqualTo(test), "Did not get today as date when nothing was excluded");
 
         cal.SetDayExcluded(test.Date, true);
-        Assert.AreEqual(test.AddDays(1), cal.GetNextIncludedTimeUtc(test), "Did not get next day when current day excluded");
+        Assert.That(cal.GetNextIncludedTimeUtc(test), Is.EqualTo(test.AddDays(1)), "Did not get next day when current day excluded");
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         day = new DateTime(2008, 2, 1);
         annualCalendar.SetDayExcluded(day, true);
 
-        Assert.IsTrue(annualCalendar.IsDayExcluded(day), "The day 1 February is expected to be excluded but it is not");
+        Assert.That(annualCalendar.IsDayExcluded(day), Is.True, "The day 1 February is expected to be excluded but it is not");
     }
 
     /// <summary>
@@ -121,7 +121,7 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         day = new DateTime(2008, 6, 23);
         annualCalendar.SetDayExcluded(day, false);
 
-        Assert.IsFalse(annualCalendar.IsDayExcluded(day), "The day 23 June is not expected to be excluded but it is");
+        Assert.That(annualCalendar.IsDayExcluded(day), Is.False, "The day 23 June is not expected to be excluded but it is");
     }
 
     [Test]
@@ -137,12 +137,12 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         // 11/5/2012 12:00:00 AM -04:00  translate into 11/4/2012 11:00:00 PM -05:00 (EST)
         DateTimeOffset date = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        Assert.IsFalse(c.IsTimeIncluded(date), "date was expected to not be included.");
-        Assert.IsTrue(c.IsTimeIncluded(date.AddDays(1)));
+        Assert.That(c.IsTimeIncluded(date), Is.False, "date was expected to not be included.");
+        Assert.That(c.IsTimeIncluded(date.AddDays(1)), Is.True);
 
         DateTimeOffset expectedNextAvailable = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-5));
         DateTimeOffset actualNextAvailable = c.GetNextIncludedTimeUtc(date);
-        Assert.AreEqual(expectedNextAvailable, actualNextAvailable);
+        Assert.That(actualNextAvailable, Is.EqualTo(expectedNextAvailable));
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
@@ -48,11 +48,14 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         // we're local by default
         DateTime d = new DateTime(2005, 1, 1);
         cal.SetDayExcluded(d, true);
-        Assert.That(cal.IsTimeIncluded(d.ToUniversalTime()), Is.False, "Time was included when it was supposed not to be");
-        Assert.That(cal.IsDayExcluded(d), Is.True, "Day was not excluded when it was supposed to be excluded");
-        Assert.That(cal.DaysExcluded.Count, Is.EqualTo(1));
-        Assert.That(cal.DaysExcluded.First().Day, Is.EqualTo(d.Day));
-        Assert.That(cal.DaysExcluded.First().Month, Is.EqualTo(d.Month));
+        Assert.Multiple(() =>
+        {
+            Assert.That(cal.IsTimeIncluded(d.ToUniversalTime()), Is.False, "Time was included when it was supposed not to be");
+            Assert.That(cal.IsDayExcluded(d), Is.True, "Day was not excluded when it was supposed to be excluded");
+            Assert.That(cal.DaysExcluded.Count, Is.EqualTo(1));
+            Assert.That(cal.DaysExcluded.First().Day, Is.EqualTo(d.Day));
+            Assert.That(cal.DaysExcluded.First().Month, Is.EqualTo(d.Month));
+        });
     }
 
     [Test]
@@ -62,8 +65,11 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         cal.SetDayExcluded(d, true);
         cal.SetDayExcluded(d, false);
         cal.SetDayExcluded(d, false);
-        Assert.That(cal.IsTimeIncluded(d), Is.True, "Time was not included when it was supposed to be");
-        Assert.That(cal.IsDayExcluded(d), Is.False, "Day was excluded when it was supposed to be included");
+        Assert.Multiple(() =>
+        {
+            Assert.That(cal.IsTimeIncluded(d), Is.True, "Time was not included when it was supposed to be");
+            Assert.That(cal.IsDayExcluded(d), Is.False, "Day was excluded when it was supposed to be included");
+        });
     }
 
     [Test]
@@ -72,10 +78,13 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         string errMessage = "Day was not excluded when it was supposed to be excluded";
         DateTime d = new DateTime(2005, 1, 1);
         cal.SetDayExcluded(d, true);
-        Assert.That(cal.IsDayExcluded(d), Is.True, errMessage);
-        Assert.That(cal.IsDayExcluded(d.AddYears(-2)), Is.True, errMessage);
-        Assert.That(cal.IsDayExcluded(d.AddYears(2)), Is.True, errMessage);
-        Assert.That(cal.IsDayExcluded(d.AddYears(100)), Is.True, errMessage);
+        Assert.Multiple(() =>
+        {
+            Assert.That(cal.IsDayExcluded(d), Is.True, errMessage);
+            Assert.That(cal.IsDayExcluded(d.AddYears(-2)), Is.True, errMessage);
+            Assert.That(cal.IsDayExcluded(d.AddYears(2)), Is.True, errMessage);
+            Assert.That(cal.IsDayExcluded(d.AddYears(100)), Is.True, errMessage);
+        });
     }
 
     [Test]
@@ -137,8 +146,11 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         // 11/5/2012 12:00:00 AM -04:00  translate into 11/4/2012 11:00:00 PM -05:00 (EST)
         DateTimeOffset date = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        Assert.That(c.IsTimeIncluded(date), Is.False, "date was expected to not be included.");
-        Assert.That(c.IsTimeIncluded(date.AddDays(1)), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(c.IsTimeIncluded(date), Is.False, "date was expected to not be included.");
+            Assert.That(c.IsTimeIncluded(date.AddDays(1)), Is.True);
+        });
 
         DateTimeOffset expectedNextAvailable = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-5));
         DateTimeOffset actualNextAvailable = c.GetNextIncludedTimeUtc(date);

--- a/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
@@ -178,9 +178,12 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     /// <inheritdoc />
     protected override void VerifyMatch(AnnualCalendar original, AnnualCalendar deserialized)
     {
-        Assert.That(deserialized, Is.Not.Null);
-        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
-        Assert.That(deserialized.DaysExcluded, Is.EquivalentTo(original.DaysExcluded));
-        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+            Assert.That(deserialized.DaysExcluded, Is.EquivalentTo(original.DaysExcluded));
+            Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/BaseCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/BaseCalendarTest.cs
@@ -33,9 +33,12 @@ public class BaseCalendarTest
         baseCalendar.TimeZone = TimeZoneInfo.GetSystemTimeZones()[3];
         BaseCalendar clone = (BaseCalendar) baseCalendar.Clone();
 
-        Assert.That(clone.Description, Is.EqualTo(baseCalendar.Description));
-        Assert.That(clone.CalendarBase, Is.EqualTo(baseCalendar.CalendarBase));
-        Assert.That(clone.TimeZone, Is.EqualTo(baseCalendar.TimeZone));
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone.Description, Is.EqualTo(baseCalendar.Description));
+            Assert.That(clone.CalendarBase, Is.EqualTo(baseCalendar.CalendarBase));
+            Assert.That(clone.TimeZone, Is.EqualTo(baseCalendar.TimeZone));
+        });
     }
 
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/BaseCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/BaseCalendarTest.cs
@@ -33,9 +33,9 @@ public class BaseCalendarTest
         baseCalendar.TimeZone = TimeZoneInfo.GetSystemTimeZones()[3];
         BaseCalendar clone = (BaseCalendar) baseCalendar.Clone();
 
-        Assert.AreEqual(baseCalendar.Description, clone.Description);
-        Assert.AreEqual(baseCalendar.CalendarBase, clone.CalendarBase);
-        Assert.AreEqual(baseCalendar.TimeZone, clone.TimeZone);
+        Assert.That(clone.Description, Is.EqualTo(baseCalendar.Description));
+        Assert.That(clone.CalendarBase, Is.EqualTo(baseCalendar.CalendarBase));
+        Assert.That(clone.TimeZone, Is.EqualTo(baseCalendar.TimeZone));
     }
 
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -76,9 +76,12 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
 
     protected override void VerifyMatch(CronCalendar original, CronCalendar deserialized)
     {
-        Assert.That(deserialized, Is.Not.Null);
-        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
-        Assert.That(deserialized.CronExpression, Is.EqualTo(original.CronExpression));
-        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+            Assert.That(deserialized.CronExpression, Is.EqualTo(original.CronExpression));
+            Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -40,11 +40,11 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
         string fault = "Time was included when it was not supposed to be";
         DateTime tst = DateTime.UtcNow.AddMinutes(2);
         tst = new DateTime(tst.Year, tst.Month, tst.Day, tst.Hour, tst.Minute, 30);
-        Assert.IsFalse(calendar.IsTimeIncluded(tst), fault);
+        Assert.That(calendar.IsTimeIncluded(tst), Is.False, fault);
 
         calendar.SetCronExpressionString("0/25 * * * * ?");
         fault = "Time was not included as expected";
-        Assert.IsTrue(calendar.IsTimeIncluded(tst), fault);
+        Assert.That(calendar.IsTimeIncluded(tst), Is.True, fault);
     }
 
     [Test]
@@ -52,7 +52,7 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
     {
         CronCalendar calendar = new CronCalendar("0/15 * * * * ?");
         CronCalendar clone = (CronCalendar)calendar.Clone();
-        Assert.AreEqual(calendar.CronExpression, clone.CronExpression);
+        Assert.That(clone.CronExpression, Is.EqualTo(calendar.CronExpression));
     }
 
     [Test]
@@ -63,7 +63,7 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
             TimeZone = TimeZoneInfo.Utc
         };
         var dateTime = new DateTimeOffset(2017, 7, 27, 2, 0, 1, 123, TimeSpan.Zero);
-        Assert.IsFalse(calendar.IsTimeIncluded(dateTime));
+        Assert.That(calendar.IsTimeIncluded(dateTime), Is.False);
     }
 
     protected override CronCalendar GetTargetObject()
@@ -76,9 +76,9 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
 
     protected override void VerifyMatch(CronCalendar original, CronCalendar deserialized)
     {
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(original.Description, deserialized.Description);
-        Assert.AreEqual(original.CronExpression, deserialized.CronExpression);
-        Assert.AreEqual(original.TimeZone, deserialized.TimeZone);
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+        Assert.That(deserialized.CronExpression, Is.EqualTo(original.CronExpression));
+        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
@@ -63,8 +63,11 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
         DateTime expectedStartTime = new DateTime(d.Year, d.Month, d.Day, 1, 20, 0);
         DateTime expectedEndTime = new DateTime(d.Year, d.Month, d.Day, 14, 50, 0);
 
-        Assert.That(dailyCalendar.GetTimeRangeStartingTimeUtc(d).DateTime, Is.EqualTo(expectedStartTime));
-        Assert.That(dailyCalendar.GetTimeRangeEndingTimeUtc(d).DateTime, Is.EqualTo(expectedEndTime));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dailyCalendar.GetTimeRangeStartingTimeUtc(d).DateTime, Is.EqualTo(expectedStartTime));
+            Assert.That(dailyCalendar.GetTimeRangeEndingTimeUtc(d).DateTime, Is.EqualTo(expectedEndTime));
+        });
     }
 
     [Test]
@@ -118,17 +121,17 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
         if (timeZoneOffset > TimeSpan.Zero)
         {
             // Trigger must fire between midnight and utc offset if positive offset.
-            fireTimes.Where(t => t.Hour >= 0 && t.Hour <= timeZoneOffset.Hours).Should().NotBeEmpty();
+            fireTimes.Should().Contain(t => t.Hour >= 0 && t.Hour <= timeZoneOffset.Hours);
         }
         else if (timeZoneOffset < TimeSpan.Zero)
         {
             // Trigger must fire between midnight minus utc offset and midnight if negative offset.
-            fireTimes.Where(t => t.Hour >= 24 + timeZoneOffset.Hours && t.Hour <= 23).Should().NotBeEmpty();
+            fireTimes.Should().Contain(t => t.Hour >= 24 + timeZoneOffset.Hours && t.Hour <= 23);
         }
         else
         {
             // Trigger must not fire between midnight and utc offset if offset is UTC (zero)
-            fireTimes.Where(t => t.Hour >= 0 && t.Hour <= timeZoneOffset.Hours).Should().BeEmpty();
+            fireTimes.Should().NotContain(t => t.Hour >= 0 && t.Hour <= timeZoneOffset.Hours);
         }
     }
 
@@ -158,10 +161,13 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
 
     protected override void VerifyMatch(DailyCalendar original, DailyCalendar deserialized)
     {
-        Assert.That(deserialized, Is.Not.Null);
-        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
-        Assert.That(deserialized.InvertTimeRange, Is.EqualTo(original.InvertTimeRange));
-        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
-        Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+            Assert.That(deserialized.InvertTimeRange, Is.EqualTo(original.InvertTimeRange));
+            Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+            Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
@@ -63,8 +63,8 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
         DateTime expectedStartTime = new DateTime(d.Year, d.Month, d.Day, 1, 20, 0);
         DateTime expectedEndTime = new DateTime(d.Year, d.Month, d.Day, 14, 50, 0);
 
-        Assert.AreEqual(expectedStartTime, dailyCalendar.GetTimeRangeStartingTimeUtc(d).DateTime);
-        Assert.AreEqual(expectedEndTime, dailyCalendar.GetTimeRangeEndingTimeUtc(d).DateTime);
+        Assert.That(dailyCalendar.GetTimeRangeStartingTimeUtc(d).DateTime, Is.EqualTo(expectedStartTime));
+        Assert.That(dailyCalendar.GetTimeRangeEndingTimeUtc(d).DateTime, Is.EqualTo(expectedEndTime));
     }
 
     [Test]
@@ -72,10 +72,10 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
     {
         DailyCalendar dailyCalendar = new DailyCalendar("1:20", "14:50");
         dailyCalendar.InvertTimeRange = true;
-        Assert.IsTrue(dailyCalendar.ToString().IndexOf("inverted: True") > 0);
+        Assert.That(dailyCalendar.ToString().IndexOf("inverted: True") > 0, Is.True);
 
         dailyCalendar.InvertTimeRange = false;
-        Assert.IsTrue(dailyCalendar.ToString().IndexOf("inverted: False") > 0);
+        Assert.That(dailyCalendar.ToString().IndexOf("inverted: False") > 0, Is.True);
     }
 
     [Test]
@@ -89,7 +89,7 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
 
         // 11/2/2012 17:00 (utc) is 11/2/2012 13:00 (est)
         DateTimeOffset timeToCheck = new DateTimeOffset(2012, 11, 2, 17, 0, 0, TimeSpan.FromHours(0));
-        Assert.IsTrue(dailyCalendar.IsTimeIncluded(timeToCheck));
+        Assert.That(dailyCalendar.IsTimeIncluded(timeToCheck), Is.True);
     }
 
     /// <summary>
@@ -158,10 +158,10 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
 
     protected override void VerifyMatch(DailyCalendar original, DailyCalendar deserialized)
     {
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(original.Description, deserialized.Description);
-        Assert.AreEqual(original.InvertTimeRange, deserialized.InvertTimeRange);
-        Assert.AreEqual(original.TimeZone, deserialized.TimeZone);
-        Assert.AreEqual(original.ToString(), deserialized.ToString());
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+        Assert.That(deserialized.InvertTimeRange, Is.EqualTo(original.InvertTimeRange));
+        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
@@ -73,12 +73,14 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
     [Test]
     public void TestStringInvertTimeRange()
     {
-        DailyCalendar dailyCalendar = new DailyCalendar("1:20", "14:50");
-        dailyCalendar.InvertTimeRange = true;
-        Assert.That(dailyCalendar.ToString().IndexOf("inverted: True") > 0, Is.True);
+        DailyCalendar dailyCalendar = new DailyCalendar("1:20", "14:50")
+        {
+            InvertTimeRange = true
+        };
+        Assert.That(dailyCalendar.ToString().IndexOf("inverted: True"), Is.GreaterThan(0));
 
         dailyCalendar.InvertTimeRange = false;
-        Assert.That(dailyCalendar.ToString().IndexOf("inverted: False") > 0, Is.True);
+        Assert.That(dailyCalendar.ToString().IndexOf("inverted: False"), Is.GreaterThan(0));
     }
 
     [Test]
@@ -86,9 +88,11 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
     {
         TimeZoneInfo tz = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
 
-        DailyCalendar dailyCalendar = new DailyCalendar("12:00:00", "14:00:00");
-        dailyCalendar.InvertTimeRange = true; //inclusive calendar
-        dailyCalendar.TimeZone = tz;
+        DailyCalendar dailyCalendar = new DailyCalendar("12:00:00", "14:00:00")
+        {
+            InvertTimeRange = true, //inclusive calendar
+            TimeZone = tz
+        };
 
         // 11/2/2012 17:00 (utc) is 11/2/2012 13:00 (est)
         DateTimeOffset timeToCheck = new DateTimeOffset(2012, 11, 2, 17, 0, 0, TimeSpan.FromHours(0));

--- a/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
@@ -45,7 +45,7 @@ public class HolidayCalendarTest : SerializationTestSupport<HolidayCalendar, ICa
     {
         cal.AddExcludedDate(new DateTime(2007, 10, 20, 12, 40, 22));
         cal.RemoveExcludedDate(new DateTime(2007, 10, 20, 2, 0, 0));
-        Assert.That(cal.ExcludedDates.Count, Is.EqualTo(0));
+        Assert.That(cal.ExcludedDates, Is.Empty);
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
@@ -85,8 +85,11 @@ public class HolidayCalendarTest : SerializationTestSupport<HolidayCalendar, ICa
         // 11/5/2012 12:00:00 AM -04:00  translate into 11/4/2012 11:00:00 PM -05:00 (EST)
         DateTimeOffset date = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        Assert.That(c.IsTimeIncluded(date), Is.False, "date was expected to not be included.");
-        Assert.That(c.IsTimeIncluded(date.AddDays(1)), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(c.IsTimeIncluded(date), Is.False, "date was expected to not be included.");
+            Assert.That(c.IsTimeIncluded(date.AddDays(1)), Is.True);
+        });
 
         DateTimeOffset expectedNextAvailable = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-5));
         DateTimeOffset actualNextAvailable = c.GetNextIncludedTimeUtc(date);
@@ -95,9 +98,12 @@ public class HolidayCalendarTest : SerializationTestSupport<HolidayCalendar, ICa
 
     protected override void VerifyMatch(HolidayCalendar original, HolidayCalendar deserialized)
     {
-        Assert.That(deserialized, Is.Not.Null);
-        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
-        Assert.That(deserialized.ExcludedDates, Is.EqualTo(original.ExcludedDates));
-        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+            Assert.That(deserialized.ExcludedDates, Is.EqualTo(original.ExcludedDates));
+            Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
@@ -45,7 +45,7 @@ public class HolidayCalendarTest : SerializationTestSupport<HolidayCalendar, ICa
     {
         cal.AddExcludedDate(new DateTime(2007, 10, 20, 12, 40, 22));
         cal.RemoveExcludedDate(new DateTime(2007, 10, 20, 2, 0, 0));
-        Assert.IsTrue(cal.ExcludedDates.Count == 0);
+        Assert.That(cal.ExcludedDates.Count, Is.EqualTo(0));
     }
 
     [Test]
@@ -55,7 +55,7 @@ public class HolidayCalendarTest : SerializationTestSupport<HolidayCalendar, ICa
         DateTime excluded = new DateTime(2007, 12, 31);
         cal.AddExcludedDate(excluded);
 
-        Assert.AreEqual(new DateTimeOffset(2008, 1, 1, 0, 0, 0, cal.TimeZone.BaseUtcOffset), cal.GetNextIncludedTimeUtc(excluded));
+        Assert.That(cal.GetNextIncludedTimeUtc(excluded), Is.EqualTo(new DateTimeOffset(2008, 1, 1, 0, 0, 0, cal.TimeZone.BaseUtcOffset)));
     }
 
     /// <summary>
@@ -85,19 +85,19 @@ public class HolidayCalendarTest : SerializationTestSupport<HolidayCalendar, ICa
         // 11/5/2012 12:00:00 AM -04:00  translate into 11/4/2012 11:00:00 PM -05:00 (EST)
         DateTimeOffset date = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        Assert.IsFalse(c.IsTimeIncluded(date), "date was expected to not be included.");
-        Assert.IsTrue(c.IsTimeIncluded(date.AddDays(1)));
+        Assert.That(c.IsTimeIncluded(date), Is.False, "date was expected to not be included.");
+        Assert.That(c.IsTimeIncluded(date.AddDays(1)), Is.True);
 
         DateTimeOffset expectedNextAvailable = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-5));
         DateTimeOffset actualNextAvailable = c.GetNextIncludedTimeUtc(date);
-        Assert.AreEqual(expectedNextAvailable, actualNextAvailable);
+        Assert.That(actualNextAvailable, Is.EqualTo(expectedNextAvailable));
     }
 
     protected override void VerifyMatch(HolidayCalendar original, HolidayCalendar deserialized)
     {
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(original.Description, deserialized.Description);
-        Assert.AreEqual(original.ExcludedDates, deserialized.ExcludedDates);
-        Assert.AreEqual(original.TimeZone, deserialized.TimeZone);
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+        Assert.That(deserialized.ExcludedDates, Is.EqualTo(original.ExcludedDates));
+        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/MonthlyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/MonthlyCalendarTest.cs
@@ -104,9 +104,12 @@ public class MonthlyCalendarTest : SerializationTestSupport<MonthlyCalendar, ICa
 
     protected override void VerifyMatch(MonthlyCalendar original, MonthlyCalendar deserialized)
     {
-        Assert.That(deserialized, Is.Not.Null);
-        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
-        Assert.That(deserialized.DaysExcluded, Is.EqualTo(original.DaysExcluded));
-        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+            Assert.That(deserialized.DaysExcluded, Is.EqualTo(original.DaysExcluded));
+            Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/MonthlyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/MonthlyCalendarTest.cs
@@ -46,9 +46,9 @@ public class MonthlyCalendarTest : SerializationTestSupport<MonthlyCalendar, ICa
     public void TestAddAndRemoveExclusion()
     {
         cal.SetDayExcluded(15, true);
-        Assert.IsTrue(cal.IsDayExcluded(15));
+        Assert.That(cal.IsDayExcluded(15), Is.True);
         cal.SetDayExcluded(15, false);
-        Assert.IsFalse(cal.IsDayExcluded(15));
+        Assert.That(cal.IsDayExcluded(15), Is.False);
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class MonthlyCalendarTest : SerializationTestSupport<MonthlyCalendar, ICa
     {
         DateTime excluded = new DateTime(2007, 8, 3);
         cal.SetDayExcluded(3, true);
-        Assert.AreEqual(excluded.AddDays(1), cal.GetNextIncludedTimeUtc(excluded).DateTime);
+        Assert.That(cal.GetNextIncludedTimeUtc(excluded).DateTime, Is.EqualTo(excluded.AddDays(1)));
     }
 
     [Test]
@@ -86,7 +86,7 @@ public class MonthlyCalendarTest : SerializationTestSupport<MonthlyCalendar, ICa
         // 11/5/2012 12:00:00 AM -04:00  translate into 11/4/2012 11:00:00 PM -05:00 (EST)
         DateTimeOffset date = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        Assert.IsFalse(monthlyCalendar.IsTimeIncluded(date));
+        Assert.That(monthlyCalendar.IsTimeIncluded(date), Is.False);
     }
 
     /// <summary>
@@ -104,9 +104,9 @@ public class MonthlyCalendarTest : SerializationTestSupport<MonthlyCalendar, ICa
 
     protected override void VerifyMatch(MonthlyCalendar original, MonthlyCalendar deserialized)
     {
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(original.Description, deserialized.Description);
-        Assert.AreEqual(original.DaysExcluded, deserialized.DaysExcluded);
-        Assert.AreEqual(original.TimeZone, deserialized.TimeZone);
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+        Assert.That(deserialized.DaysExcluded, Is.EqualTo(original.DaysExcluded));
+        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/WeeklyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/WeeklyCalendarTest.cs
@@ -100,9 +100,12 @@ public class WeeklyCalendarTest : SerializationTestSupport<WeeklyCalendar, ICale
 
     protected override void VerifyMatch(WeeklyCalendar original, WeeklyCalendar deserialized)
     {
-        Assert.That(deserialized, Is.Not.Null);
-        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
-        Assert.That(deserialized.DaysExcluded, Is.EqualTo(original.DaysExcluded));
-        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+            Assert.That(deserialized.DaysExcluded, Is.EqualTo(original.DaysExcluded));
+            Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Calendar/WeeklyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/WeeklyCalendarTest.cs
@@ -45,9 +45,9 @@ public class WeeklyCalendarTest : SerializationTestSupport<WeeklyCalendar, ICale
     public void TestAddAndRemoveExclusion()
     {
         cal.SetDayExcluded(DayOfWeek.Monday, true);
-        Assert.IsTrue(cal.IsDayExcluded(DayOfWeek.Monday));
+        Assert.That(cal.IsDayExcluded(DayOfWeek.Monday), Is.True);
         cal.SetDayExcluded(DayOfWeek.Monday, false);
-        Assert.IsFalse(cal.IsDayExcluded(DayOfWeek.Monday));
+        Assert.That(cal.IsDayExcluded(DayOfWeek.Monday), Is.False);
     }
 
     [Test]
@@ -57,7 +57,7 @@ public class WeeklyCalendarTest : SerializationTestSupport<WeeklyCalendar, ICale
         DateTimeOffset excluded = new DateTimeOffset(2007, 8, 3, 0, 0, 0, TimeSpan.Zero);
         cal.SetDayExcluded(DayOfWeek.Friday, true);
         // next monday should be next possible
-        Assert.AreEqual(excluded.AddDays(3), cal.GetNextIncludedTimeUtc(excluded));
+        Assert.That(cal.GetNextIncludedTimeUtc(excluded), Is.EqualTo(excluded.AddDays(3)));
     }
 
 
@@ -75,12 +75,12 @@ public class WeeklyCalendarTest : SerializationTestSupport<WeeklyCalendar, ICale
 
         //11/5/2012 12:00:00 AM -04:00 will translate into 11/4/2012 11:00:00 PM -05:00, which is a Sunday, not monday
         DateTimeOffset date = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-4));
-        Assert.IsFalse(cal.IsTimeIncluded(date));
+        Assert.That(cal.IsTimeIncluded(date), Is.False);
 
         date = cal.GetNextIncludedTimeUtc(date);
         DateTimeOffset expected = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-5));
 
-        Assert.AreEqual(expected, date);
+        Assert.That(date, Is.EqualTo(expected));
     }
 
 
@@ -100,9 +100,9 @@ public class WeeklyCalendarTest : SerializationTestSupport<WeeklyCalendar, ICale
 
     protected override void VerifyMatch(WeeklyCalendar original, WeeklyCalendar deserialized)
     {
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(original.Description, deserialized.Description);
-        Assert.AreEqual(original.DaysExcluded, deserialized.DaysExcluded);
-        Assert.AreEqual(original.TimeZone, deserialized.TimeZone);
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+        Assert.That(deserialized.DaysExcluded, Is.EqualTo(original.DaysExcluded));
+        Assert.That(deserialized.TimeZone, Is.EqualTo(original.TimeZone));
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
@@ -62,18 +62,23 @@ public class DirectSchedulerFactoryTest
         await _directSchedulerFactory.CreateScheduler(_threadPool, _jobStore);
 
         var scheduler = _schedulerRepository.Lookup(DirectSchedulerFactory.DefaultSchedulerName);
-        Assert.That(scheduler, Is.Not.Null);
-        Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
+        Assert.Multiple(() => { 
+            Assert.That(scheduler, Is.Not.Null);
+            Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
+        });
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.That(stdScheduler.SchedulerName, Is.SameAs(DirectSchedulerFactory.DefaultSchedulerName));
-        Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(DirectSchedulerFactory.DefaultInstanceId));
-        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
-        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
-        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(TimeSpan.FromSeconds(30)));
-        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
-        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stdScheduler.SchedulerName, Is.SameAs(DirectSchedulerFactory.DefaultSchedulerName));
+            Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(DirectSchedulerFactory.DefaultInstanceId));
+            Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+            Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+            Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(TimeSpan.FromSeconds(30)));
+            Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
+            Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
+        });
     }
 
     [Test]
@@ -127,18 +132,24 @@ public class DirectSchedulerFactoryTest
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore, schedulerPluginMap, idleWaitTime);
 
         var scheduler = _schedulerRepository.Lookup(schedulerName);
-        Assert.That(scheduler, Is.Not.Null);
-        Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(scheduler, Is.Not.Null);
+            Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
+        });
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
-        Assert.That(stdScheduler.SchedulerInstanceId, Is.EqualTo(schedulerInstanceId));
-        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
-        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
-        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
-        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
-        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
+            Assert.That(stdScheduler.SchedulerInstanceId, Is.EqualTo(schedulerInstanceId));
+            Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+            Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+            Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
+            Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
+            Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
+        });
 
         if (schedulerPluginMap is null)
         {
@@ -184,18 +195,23 @@ public class DirectSchedulerFactoryTest
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore, schedulerPluginMap, idleWaitTime, maxBatchSize, batchTimeWindow);
 
         var scheduler = _schedulerRepository.Lookup(schedulerName);
-        Assert.That(scheduler, Is.Not.Null);
-        Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(scheduler, Is.Not.Null);
+            Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
+        });
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
-        Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
-        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
-        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
-        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
-        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(maxBatchSize));
-        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(batchTimeWindow));
+        Assert.Multiple(() =>{
+            Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
+            Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
+            Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+            Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+            Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
+            Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(maxBatchSize));
+            Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(batchTimeWindow));
+        });
 
         if (schedulerPluginMap is null)
         {
@@ -248,13 +264,16 @@ public class DirectSchedulerFactoryTest
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
-        Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
-        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
-        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
-        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
-        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(maxBatchSize));
-        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(batchTimeWindow));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
+            Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
+            Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+            Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+            Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
+            Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(maxBatchSize));
+            Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(batchTimeWindow));
+        });
 
         if (schedulerPluginMap is null)
         {

--- a/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
@@ -156,11 +156,11 @@ public class DirectSchedulerFactoryTest
 
         if (schedulerPluginMap is null)
         {
-            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(0));
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins, Is.Empty);
         }
         else
         {
-            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(schedulerPluginMap.Count));
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins, Has.Count.EqualTo(schedulerPluginMap.Count));
             foreach (var plugin in schedulerPluginMap.Values)
             {
                 Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin), Is.True);
@@ -218,11 +218,11 @@ public class DirectSchedulerFactoryTest
 
         if (schedulerPluginMap is null)
         {
-            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(0));
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins, Is.Empty);
         }
         else
         {
-            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(schedulerPluginMap.Count));
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins, Has.Count.EqualTo(schedulerPluginMap.Count));
             foreach (var plugin in schedulerPluginMap.Values)
             {
                 Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin), Is.True);
@@ -280,11 +280,11 @@ public class DirectSchedulerFactoryTest
 
         if (schedulerPluginMap is null)
         {
-            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(0));
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins, Is.Empty);
         }
         else
         {
-            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(schedulerPluginMap.Count));
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins, Has.Count.EqualTo(schedulerPluginMap.Count));
             foreach (var plugin in schedulerPluginMap.Values)
             {
                 Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin), Is.True);

--- a/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
@@ -62,18 +62,18 @@ public class DirectSchedulerFactoryTest
         await _directSchedulerFactory.CreateScheduler(_threadPool, _jobStore);
 
         var scheduler = _schedulerRepository.Lookup(DirectSchedulerFactory.DefaultSchedulerName);
-        Assert.IsNotNull(scheduler);
-        Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
+        Assert.That(scheduler, Is.Not.Null);
+        Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.AreSame(DirectSchedulerFactory.DefaultSchedulerName, stdScheduler.SchedulerName);
-        Assert.AreSame(DirectSchedulerFactory.DefaultInstanceId, stdScheduler.SchedulerInstanceId);
-        Assert.AreSame(_threadPool, stdScheduler.sched.resources.ThreadPool);
-        Assert.AreSame(_jobStore, stdScheduler.sched.resources.JobStore);
-        Assert.AreEqual(TimeSpan.FromSeconds(30), stdScheduler.sched.resources.IdleWaitTime);
-        Assert.AreEqual(1, stdScheduler.sched.resources.MaxBatchSize);
-        Assert.AreEqual(TimeSpan.Zero, stdScheduler.sched.resources.BatchTimeWindow);
+        Assert.That(stdScheduler.SchedulerName, Is.SameAs(DirectSchedulerFactory.DefaultSchedulerName));
+        Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(DirectSchedulerFactory.DefaultInstanceId));
+        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(TimeSpan.FromSeconds(30)));
+        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
+        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
     }
 
     [Test]
@@ -85,19 +85,19 @@ public class DirectSchedulerFactoryTest
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore);
 
         var scheduler = _schedulerRepository.Lookup(schedulerName);
-        Assert.IsNotNull(scheduler);
-        Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
+        Assert.That(scheduler, Is.Not.Null);
+        Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.AreSame(schedulerName, stdScheduler.SchedulerName);
-        Assert.AreSame(schedulerInstanceId, stdScheduler.SchedulerInstanceId);
-        Assert.AreEqual(0, stdScheduler.sched.resources.SchedulerPlugins.Count);
-        Assert.AreSame(_threadPool, stdScheduler.sched.resources.ThreadPool);
-        Assert.AreSame(_jobStore, stdScheduler.sched.resources.JobStore);
-        Assert.AreEqual(TimeSpan.FromSeconds(30), stdScheduler.sched.resources.IdleWaitTime);
-        Assert.AreEqual(1, stdScheduler.sched.resources.MaxBatchSize);
-        Assert.AreEqual(TimeSpan.Zero, stdScheduler.sched.resources.BatchTimeWindow);
+        Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
+        Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
+        Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(0));
+        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(TimeSpan.FromSeconds(30)));
+        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
+        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
     }
 
     [Test]
@@ -113,7 +113,7 @@ public class DirectSchedulerFactoryTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual(nameof(idleWaitTime), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(idleWaitTime)));
         }
     }
 
@@ -127,29 +127,29 @@ public class DirectSchedulerFactoryTest
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore, schedulerPluginMap, idleWaitTime);
 
         var scheduler = _schedulerRepository.Lookup(schedulerName);
-        Assert.IsNotNull(scheduler);
-        Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
+        Assert.That(scheduler, Is.Not.Null);
+        Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.AreSame(schedulerName, stdScheduler.SchedulerName);
-        Assert.AreEqual(schedulerInstanceId, stdScheduler.SchedulerInstanceId);
-        Assert.AreSame(_threadPool, stdScheduler.sched.resources.ThreadPool);
-        Assert.AreSame(_jobStore, stdScheduler.sched.resources.JobStore);
-        Assert.AreEqual(idleWaitTime, stdScheduler.sched.resources.IdleWaitTime);
-        Assert.AreEqual(1, stdScheduler.sched.resources.MaxBatchSize);
-        Assert.AreEqual(TimeSpan.Zero, stdScheduler.sched.resources.BatchTimeWindow);
+        Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
+        Assert.That(stdScheduler.SchedulerInstanceId, Is.EqualTo(schedulerInstanceId));
+        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
+        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
+        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
 
         if (schedulerPluginMap is null)
         {
-            Assert.AreEqual(0, stdScheduler.sched.resources.SchedulerPlugins.Count);
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(0));
         }
         else
         {
-            Assert.AreEqual(schedulerPluginMap.Count, stdScheduler.sched.resources.SchedulerPlugins.Count);
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(schedulerPluginMap.Count));
             foreach (var plugin in schedulerPluginMap.Values)
             {
-                Assert.IsTrue(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin));
+                Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin), Is.True);
             }
         }
     }
@@ -168,7 +168,7 @@ public class DirectSchedulerFactoryTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual(nameof(idleWaitTime), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(idleWaitTime)));
         }
     }
 
@@ -184,29 +184,29 @@ public class DirectSchedulerFactoryTest
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore, schedulerPluginMap, idleWaitTime, maxBatchSize, batchTimeWindow);
 
         var scheduler = _schedulerRepository.Lookup(schedulerName);
-        Assert.IsNotNull(scheduler);
-        Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
+        Assert.That(scheduler, Is.Not.Null);
+        Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.AreSame(schedulerName, stdScheduler.SchedulerName);
-        Assert.AreSame(schedulerInstanceId, stdScheduler.SchedulerInstanceId);
-        Assert.AreSame(_threadPool, stdScheduler.sched.resources.ThreadPool);
-        Assert.AreSame(_jobStore, stdScheduler.sched.resources.JobStore);
-        Assert.AreEqual(idleWaitTime, stdScheduler.sched.resources.IdleWaitTime);
-        Assert.AreEqual(maxBatchSize, stdScheduler.sched.resources.MaxBatchSize);
-        Assert.AreEqual(batchTimeWindow, stdScheduler.sched.resources.BatchTimeWindow);
+        Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
+        Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
+        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
+        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(maxBatchSize));
+        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(batchTimeWindow));
 
         if (schedulerPluginMap is null)
         {
-            Assert.AreEqual(0, stdScheduler.sched.resources.SchedulerPlugins.Count);
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(0));
         }
         else
         {
-            Assert.AreEqual(schedulerPluginMap.Count, stdScheduler.sched.resources.SchedulerPlugins.Count);
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(schedulerPluginMap.Count));
             foreach (var plugin in schedulerPluginMap.Values)
             {
-                Assert.IsTrue(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin));
+                Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin), Is.True);
             }
         }
     }
@@ -227,7 +227,7 @@ public class DirectSchedulerFactoryTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual(nameof(idleWaitTime), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(idleWaitTime)));
         }
     }
 
@@ -243,29 +243,29 @@ public class DirectSchedulerFactoryTest
         await _directSchedulerFactory.CreateScheduler(schedulerName, schedulerInstanceId, _threadPool, _jobStore, schedulerPluginMap, idleWaitTime, maxBatchSize, batchTimeWindow);
 
         var scheduler = _schedulerRepository.Lookup(schedulerName);
-        Assert.IsNotNull(scheduler);
-        Assert.AreEqual(typeof(StdScheduler), scheduler.GetType());
+        Assert.That(scheduler, Is.Not.Null);
+        Assert.That(scheduler.GetType(), Is.EqualTo(typeof(StdScheduler)));
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.AreSame(schedulerName, stdScheduler.SchedulerName);
-        Assert.AreSame(schedulerInstanceId, stdScheduler.SchedulerInstanceId);
-        Assert.AreSame(_threadPool, stdScheduler.sched.resources.ThreadPool);
-        Assert.AreSame(_jobStore, stdScheduler.sched.resources.JobStore);
-        Assert.AreEqual(idleWaitTime, stdScheduler.sched.resources.IdleWaitTime);
-        Assert.AreEqual(maxBatchSize, stdScheduler.sched.resources.MaxBatchSize);
-        Assert.AreEqual(batchTimeWindow, stdScheduler.sched.resources.BatchTimeWindow);
+        Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
+        Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
+        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(idleWaitTime));
+        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(maxBatchSize));
+        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(batchTimeWindow));
 
         if (schedulerPluginMap is null)
         {
-            Assert.AreEqual(0, stdScheduler.sched.resources.SchedulerPlugins.Count);
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(0));
         }
         else
         {
-            Assert.AreEqual(schedulerPluginMap.Count, stdScheduler.sched.resources.SchedulerPlugins.Count);
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(schedulerPluginMap.Count));
             foreach (var plugin in schedulerPluginMap.Values)
             {
-                Assert.IsTrue(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin));
+                Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Contains(plugin), Is.True);
             }
         }
     }
@@ -286,7 +286,7 @@ public class DirectSchedulerFactoryTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual(nameof(idleWaitTime), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(idleWaitTime)));
         }
     }
 
@@ -306,7 +306,7 @@ public class DirectSchedulerFactoryTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual(nameof(maxBatchSize), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(maxBatchSize)));
         }
     }
 
@@ -326,7 +326,7 @@ public class DirectSchedulerFactoryTest
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            Assert.AreEqual(nameof(batchTimeWindow), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(batchTimeWindow)));
         }
     }
 
@@ -353,7 +353,7 @@ public class DirectSchedulerFactoryTest
         await scheduler.Start();
         await scheduler.Shutdown();
 
-        Assert.AreEqual("TestPlugin|MyScheduler|Start|Shutdown", result.ToString());
+        Assert.That(result.ToString(), Is.EqualTo("TestPlugin|MyScheduler|Start|Shutdown"));
     }
 
     private static IEnumerable<TimeSpan> ValidIdleWaitTimes()

--- a/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DirectSchedulerFactoryTest.cs
@@ -95,14 +95,17 @@ public class DirectSchedulerFactoryTest
 
         var stdScheduler = (StdScheduler) scheduler;
 
-        Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
-        Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
-        Assert.That(stdScheduler.sched.resources.SchedulerPlugins.Count, Is.EqualTo(0));
-        Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
-        Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
-        Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(TimeSpan.FromSeconds(30)));
-        Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
-        Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stdScheduler.SchedulerName, Is.SameAs(schedulerName));
+            Assert.That(stdScheduler.SchedulerInstanceId, Is.SameAs(schedulerInstanceId));
+            Assert.That(stdScheduler.sched.resources.SchedulerPlugins, Is.Empty);
+            Assert.That(stdScheduler.sched.resources.ThreadPool, Is.SameAs(_threadPool));
+            Assert.That(stdScheduler.sched.resources.JobStore, Is.SameAs(_jobStore));
+            Assert.That(stdScheduler.sched.resources.IdleWaitTime, Is.EqualTo(TimeSpan.FromSeconds(30)));
+            Assert.That(stdScheduler.sched.resources.MaxBatchSize, Is.EqualTo(1));
+            Assert.That(stdScheduler.sched.resources.BatchTimeWindow, Is.EqualTo(TimeSpan.Zero));
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/JobType/JobTypeTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/JobType/JobTypeTests.cs
@@ -48,7 +48,5 @@ public class JobTypeTests
         }
     }
 
-    public sealed class ClassDoesNotImplementIJob
-    {
-    }
+    public sealed class ClassDoesNotImplementIJob;
 }

--- a/src/Quartz.Tests.Unit/Impl/Matchers/StringOperatorTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Matchers/StringOperatorTest.cs
@@ -42,17 +42,20 @@ public class StringOperatorTest
 
     private static void Anything_Evaluate(StringOperator op)
     {
-        Assert.That(op.Evaluate(null, null), Is.True);
-        Assert.That(op.Evaluate(null, "Quartz"), Is.True);
-        Assert.That(op.Evaluate("Quartz", null), Is.True);
-        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
-        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
-        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "tZ"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "ua"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "QU"), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Evaluate(null, null), Is.True);
+            Assert.That(op.Evaluate(null, "Quartz"), Is.True);
+            Assert.That(op.Evaluate("Quartz", null), Is.True);
+            Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+            Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+            Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "tZ"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "ua"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "QU"), Is.True);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/Matchers/StringOperatorTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Matchers/StringOperatorTest.cs
@@ -60,11 +60,14 @@ public class StringOperatorTest
     {
         var op = StringOperator.Anything;
 
-        Assert.That(op.Equals((object) op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Equality));
-        Assert.That(op, Is.Not.EqualTo(null));
-        Assert.That(op.Equals("xxx"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals((object)op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Equality));
+            Assert.That(op, Is.Not.EqualTo(null));
+            Assert.That(op.Equals("xxx"), Is.False);
+        });
     }
 
     [Test]
@@ -72,10 +75,13 @@ public class StringOperatorTest
     {
         var op = StringOperator.Anything;
 
-        Assert.That(op.Equals(op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Equality));
-        Assert.That(op, Is.Not.EqualTo(null));
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals(op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Equality));
+            Assert.That(op, Is.Not.EqualTo(null));
+        });
     }
 
     [Test]
@@ -110,17 +116,20 @@ public class StringOperatorTest
 
     private static void Contains_Evaluate(StringOperator op)
     {
-        Assert.That(op.Evaluate(null, null), Is.False);
-        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
-        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
-        Assert.That(op.Evaluate(null, string.Empty), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "ua"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Evaluate(null, null), Is.False);
+            Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+            Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+            Assert.That(op.Evaluate(null, string.Empty), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "ua"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        });
     }
 
     [Test]
@@ -144,11 +153,14 @@ public class StringOperatorTest
     {
         var op = StringOperator.Contains;
 
-        Assert.That(op.Equals((object) op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
-        Assert.That(op, Is.Not.EqualTo(null));
-        Assert.That(op.Equals("xxx"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals((object)op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+            Assert.That(op, Is.Not.EqualTo(null));
+            Assert.That(op.Equals("xxx"), Is.False);
+        });
     }
 
     [Test]
@@ -156,10 +168,13 @@ public class StringOperatorTest
     {
         var op = StringOperator.Contains;
 
-        Assert.That(op.Equals(op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
-        Assert.That(op.Equals(null), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals(op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+            Assert.That(op.Equals(null), Is.False);
+        });
     }
 
     [Test]
@@ -167,11 +182,14 @@ public class StringOperatorTest
     {
         var op = new NothingOperator();
 
-        Assert.That(op.Equals((object) op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
-        Assert.That(op, Is.Not.EqualTo(null));
-        Assert.That(op.Equals("xxx"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals((object)op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+            Assert.That(op, Is.Not.EqualTo(null));
+            Assert.That(op.Equals("xxx"), Is.False);
+        });
     }
 
     [Test]
@@ -179,10 +197,13 @@ public class StringOperatorTest
     {
         var op = new NothingOperator();
 
-        Assert.That(op.Equals(op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
-        Assert.That(op.Equals(null), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals(op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+            Assert.That(op.Equals(null), Is.False);
+        });
     }
 
     [Test]
@@ -214,32 +235,38 @@ public class StringOperatorTest
     {
         var op = StringOperator.EndsWith;
 
-        Assert.That(op.Evaluate(null, null), Is.False);
-        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
-        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
-        Assert.That(op.Evaluate(null, string.Empty), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Evaluate(null, null), Is.False);
+            Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+            Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+            Assert.That(op.Evaluate(null, string.Empty), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        });
     }
 
     private static void EndsWith_Evaluate(StringOperator op)
     {
-        Assert.That(op.Evaluate(null, null), Is.False);
-        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
-        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
-        Assert.That(op.Evaluate(null, string.Empty), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Evaluate(null, null), Is.False);
+            Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+            Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+            Assert.That(op.Evaluate(null, string.Empty), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        });
     }
 
     [Test]
@@ -263,11 +290,14 @@ public class StringOperatorTest
     {
         var op = StringOperator.EndsWith;
 
-        Assert.That(op.Equals((object) op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
-        Assert.That(op, Is.Not.EqualTo(null));
-        Assert.That(op.Equals("xxx"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals((object)op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+            Assert.That(op, Is.Not.EqualTo(null));
+            Assert.That(op.Equals("xxx"), Is.False);
+        });
     }
 
     [Test]
@@ -275,10 +305,13 @@ public class StringOperatorTest
     {
         var op = StringOperator.EndsWith;
 
-        Assert.That(op.Equals(op), Is.True);
-        Assert.That(op.Equals(SerializeAndDeserialize(op)), Is.True);
-        Assert.That(op.Equals(StringOperator.Anything), Is.False);
-        Assert.That(op.Equals(null), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals(op), Is.True);
+            Assert.That(op.Equals(SerializeAndDeserialize(op)), Is.True);
+            Assert.That(op.Equals(StringOperator.Anything), Is.False);
+            Assert.That(op.Equals(null), Is.False);
+        });
     }
 
     [Test]
@@ -313,18 +346,21 @@ public class StringOperatorTest
 
     private static void Equality_Evaluate(StringOperator op)
     {
-        Assert.That(op.Evaluate(null, null), Is.True);
-        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", null), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
-        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
-        Assert.That(op.Evaluate(null, string.Empty), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Evaluate(null, null), Is.True);
+            Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", null), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+            Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+            Assert.That(op.Evaluate(null, string.Empty), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        });
     }
 
     [Test]
@@ -332,11 +368,14 @@ public class StringOperatorTest
     {
         var op = StringOperator.Equality;
 
-        Assert.That(op.Equals((object) op), Is.True);
-        Assert.That(op.Equals((object) SerializeAndDeserialize(op)), Is.True);
-        Assert.That(op.Equals((object) StringOperator.Anything), Is.False);
-        Assert.That(op.Equals((object) null), Is.False);
-        Assert.That(op.Equals("xxx"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals((object)op), Is.True);
+            Assert.That(op.Equals((object)SerializeAndDeserialize(op)), Is.True);
+            Assert.That(op.Equals((object)StringOperator.Anything), Is.False);
+            Assert.That(op.Equals((object)null), Is.False);
+            Assert.That(op.Equals("xxx"), Is.False);
+        });
     }
 
     [Test]
@@ -344,10 +383,13 @@ public class StringOperatorTest
     {
         var op = StringOperator.Equality;
 
-        Assert.That(op.Equals(op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
-        Assert.That(op.Equals(null), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals(op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+            Assert.That(op.Equals(null), Is.False);
+        });
     }
 
     [Test]
@@ -379,32 +421,38 @@ public class StringOperatorTest
     {
         var op = StringOperator.StartsWith;
 
-        Assert.That(op.Evaluate(null, null), Is.False);
-        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Quartz"));
-        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
-        Assert.That(op.Evaluate(null, string.Empty), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Evaluate(null, null), Is.False);
+            Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Quartz"));
+            Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+            Assert.That(op.Evaluate(null, string.Empty), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        });
     }
 
     private static void StartsWith_Evaluate(StringOperator op)
     {
-        Assert.That(op.Evaluate(null, null), Is.False);
-        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
-        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
-        Assert.That(op.Evaluate(null, string.Empty), Is.False);
-        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
-        Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
-        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Evaluate(null, null), Is.False);
+            Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+            Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+            Assert.That(op.Evaluate(null, string.Empty), Is.False);
+            Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+            Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
+            Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
+        });
     }
 
     [Test]
@@ -428,22 +476,28 @@ public class StringOperatorTest
     {
         var op = StringOperator.StartsWith;
 
-        Assert.That(op.Equals((object) op), Is.True);
-        Assert.That(op.Equals((object) SerializeAndDeserialize(op)), Is.True);
-        Assert.That(op.Equals((object) StringOperator.Anything), Is.False);
-        Assert.That(op.Equals((object) null), Is.False);
-        Assert.That(op.Equals("xxx"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(op.Equals((object)op), Is.True);
+            Assert.That(op.Equals((object)SerializeAndDeserialize(op)), Is.True);
+            Assert.That(op.Equals((object)StringOperator.Anything), Is.False);
+            Assert.That(op.Equals((object)null), Is.False);
+            Assert.That(op.Equals("xxx"), Is.False);
+        });
     }
 
     [Test]
     public void StartsWith_Equals_StringOperator()
     {
         var op = StringOperator.StartsWith;
+        Assert.Multiple(() =>
+        {
 
-        Assert.That(op.Equals(op), Is.True);
-        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
-        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
-        Assert.That(op.Equals(null), Is.False);
+            Assert.That(op.Equals(op), Is.True);
+            Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+            Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+            Assert.That(op.Equals(null), Is.False);
+        });
     }
 
     [Serializable]

--- a/src/Quartz.Tests.Unit/Impl/Matchers/StringOperatorTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Matchers/StringOperatorTest.cs
@@ -15,7 +15,7 @@ public class StringOperatorTest
     {
         var op = Deserialize<StringOperator>("StringOperator_Anything");
 
-        Assert.IsNotNull(op);
+        Assert.That(op, Is.Not.Null);
         Anything_Evaluate(op);
     }
 
@@ -29,7 +29,9 @@ public class StringOperatorTest
     [Test]
     public void Anything_ShouldBeSingleton()
     {
-        Assert.AreSame(StringOperator.Anything, StringOperator.Anything);
+#pragma warning disable NUnit2009
+        Assert.That(StringOperator.Anything, Is.SameAs(StringOperator.Anything));
+#pragma warning restore NUnit2009
     }
 
     [Test]
@@ -40,17 +42,17 @@ public class StringOperatorTest
 
     private static void Anything_Evaluate(StringOperator op)
     {
-        Assert.IsTrue(op.Evaluate(null, null));
-        Assert.IsTrue(op.Evaluate(null, "Quartz"));
-        Assert.IsTrue(op.Evaluate("Quartz", null));
-        Assert.IsTrue(op.Evaluate("Quartz", "Quartz"));
-        Assert.IsTrue(op.Evaluate("aa", new string('a', 2)));
-        Assert.IsTrue(op.Evaluate("Quartz", "QuartZ"));
-        Assert.IsTrue(op.Evaluate("Quartz", "tz"));
-        Assert.IsTrue(op.Evaluate("Quartz", "tZ"));
-        Assert.IsTrue(op.Evaluate("Quartz", "ua"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Qu"));
-        Assert.IsTrue(op.Evaluate("Quartz", "QU"));
+        Assert.That(op.Evaluate(null, null), Is.True);
+        Assert.That(op.Evaluate(null, "Quartz"), Is.True);
+        Assert.That(op.Evaluate("Quartz", null), Is.True);
+        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "tZ"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "ua"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "QU"), Is.True);
     }
 
     [Test]
@@ -58,11 +60,11 @@ public class StringOperatorTest
     {
         var op = StringOperator.Anything;
 
-        Assert.IsTrue(op.Equals((object) op));
-        Assert.IsTrue(op.Equals((object) SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals((object) StringOperator.Equality));
-        Assert.IsFalse(op.Equals((object) null));
-        Assert.IsFalse(op.Equals("xxx"));
+        Assert.That(op.Equals((object) op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Equality));
+        Assert.That(op, Is.Not.EqualTo(null));
+        Assert.That(op.Equals("xxx"), Is.False);
     }
 
     [Test]
@@ -70,10 +72,10 @@ public class StringOperatorTest
     {
         var op = StringOperator.Anything;
 
-        Assert.IsTrue(op.Equals(op));
-        Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals(StringOperator.Equality));
-        Assert.IsFalse(op.Equals(null));
+        Assert.That(op.Equals(op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Equality));
+        Assert.That(op, Is.Not.EqualTo(null));
     }
 
     [Test]
@@ -81,7 +83,7 @@ public class StringOperatorTest
     {
         var op = Deserialize<StringOperator>("StringOperator_Contains");
 
-        Assert.IsNotNull(op);
+        Assert.That(op, Is.Not.Null);
         Contains_Evaluate(op);
     }
 
@@ -95,7 +97,9 @@ public class StringOperatorTest
     [Test]
     public void Contains_ShouldBeSingleton()
     {
-        Assert.AreSame(StringOperator.Contains, StringOperator.Contains);
+#pragma warning disable NUnit2009
+        Assert.That(StringOperator.Contains, Is.SameAs(StringOperator.Contains));
+#pragma warning restore NUnit2009
     }
 
     [Test]
@@ -106,17 +110,17 @@ public class StringOperatorTest
 
     private static void Contains_Evaluate(StringOperator op)
     {
-        Assert.IsFalse(op.Evaluate(null, null));
-        Assert.IsFalse(op.Evaluate(null, "Quartz"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Quartz"));
-        Assert.IsTrue(op.Evaluate("aa", new string('a', 2)));
-        Assert.IsFalse(op.Evaluate(null, string.Empty));
-        Assert.IsFalse(op.Evaluate("Quartz", "QuartZ"));
-        Assert.IsTrue(op.Evaluate("Quartz", "tz"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tZ"));
-        Assert.IsTrue(op.Evaluate("Quartz", "ua"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Qu"));
-        Assert.IsFalse(op.Evaluate("Quartz", "QU"));
+        Assert.That(op.Evaluate(null, null), Is.False);
+        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+        Assert.That(op.Evaluate(null, string.Empty), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "ua"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
     }
 
     [Test]
@@ -131,7 +135,7 @@ public class StringOperatorTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual("value", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
     }
 
@@ -140,11 +144,11 @@ public class StringOperatorTest
     {
         var op = StringOperator.Contains;
 
-        Assert.IsTrue(op.Equals((object) op));
-        Assert.IsTrue(op.Equals((object) SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals((object) StringOperator.Anything));
-        Assert.IsFalse(op.Equals((object) null));
-        Assert.IsFalse(op.Equals("xxx"));
+        Assert.That(op.Equals((object) op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+        Assert.That(op, Is.Not.EqualTo(null));
+        Assert.That(op.Equals("xxx"), Is.False);
     }
 
     [Test]
@@ -152,10 +156,10 @@ public class StringOperatorTest
     {
         var op = StringOperator.Contains;
 
-        Assert.IsTrue(op.Equals(op));
-        Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals(null));
+        Assert.That(op.Equals(op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+        Assert.That(op.Equals(null), Is.False);
     }
 
     [Test]
@@ -163,11 +167,11 @@ public class StringOperatorTest
     {
         var op = new NothingOperator();
 
-        Assert.IsTrue(op.Equals((object) op));
-        Assert.IsTrue(op.Equals((object) SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals((object) StringOperator.Anything));
-        Assert.IsFalse(op.Equals((object) null));
-        Assert.IsFalse(op.Equals("xxx"));
+        Assert.That(op.Equals((object) op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+        Assert.That(op, Is.Not.EqualTo(null));
+        Assert.That(op.Equals("xxx"), Is.False);
     }
 
     [Test]
@@ -175,10 +179,10 @@ public class StringOperatorTest
     {
         var op = new NothingOperator();
 
-        Assert.IsTrue(op.Equals(op));
-        Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals(null));
+        Assert.That(op.Equals(op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+        Assert.That(op.Equals(null), Is.False);
     }
 
     [Test]
@@ -186,7 +190,7 @@ public class StringOperatorTest
     {
         var op = Deserialize<StringOperator>("StringOperator_EndsWith");
 
-        Assert.IsNotNull(op);
+        Assert.That(op, Is.Not.Null);
         EndsWith_Evaluate(op);
     }
 
@@ -200,7 +204,9 @@ public class StringOperatorTest
     [Test]
     public void EndsWith_ShouldBeSingleton()
     {
-        Assert.AreSame(StringOperator.EndsWith, StringOperator.EndsWith);
+#pragma warning disable NUnit2009
+        Assert.That(StringOperator.EndsWith, Is.SameAs(StringOperator.EndsWith));
+#pragma warning restore NUnit2009
     }
 
     [Test]
@@ -208,32 +214,32 @@ public class StringOperatorTest
     {
         var op = StringOperator.EndsWith;
 
-        Assert.IsFalse(op.Evaluate(null, null));
-        Assert.IsFalse(op.Evaluate(null, "Quartz"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Quartz"));
-        Assert.IsTrue(op.Evaluate("aa", new string('a', 2)));
-        Assert.IsFalse(op.Evaluate(null, string.Empty));
-        Assert.IsFalse(op.Evaluate("Quartz", "QuartZ"));
-        Assert.IsTrue(op.Evaluate("Quartz", "tz"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tZ"));
-        Assert.IsFalse(op.Evaluate("Quartz", "ua"));
-        Assert.IsFalse(op.Evaluate("Quartz", "Qu"));
-        Assert.IsFalse(op.Evaluate("Quartz", "QU"));
+        Assert.That(op.Evaluate(null, null), Is.False);
+        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+        Assert.That(op.Evaluate(null, string.Empty), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
     }
 
     private static void EndsWith_Evaluate(StringOperator op)
     {
-        Assert.IsFalse(op.Evaluate(null, null));
-        Assert.IsFalse(op.Evaluate(null, "Quartz"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Quartz"));
-        Assert.IsTrue(op.Evaluate("aa", new string('a', 2)));
-        Assert.IsFalse(op.Evaluate(null, string.Empty));
-        Assert.IsFalse(op.Evaluate("Quartz", "QuartZ"));
-        Assert.IsTrue(op.Evaluate("Quartz", "tz"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tZ"));
-        Assert.IsFalse(op.Evaluate("Quartz", "ua"));
-        Assert.IsFalse(op.Evaluate("Quartz", "Qu"));
-        Assert.IsFalse(op.Evaluate("Quartz", "QU"));
+        Assert.That(op.Evaluate(null, null), Is.False);
+        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+        Assert.That(op.Evaluate(null, string.Empty), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tz"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
     }
 
     [Test]
@@ -248,7 +254,7 @@ public class StringOperatorTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual("value", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
     }
 
@@ -257,11 +263,11 @@ public class StringOperatorTest
     {
         var op = StringOperator.EndsWith;
 
-        Assert.IsTrue(op.Equals((object) op));
-        Assert.IsTrue(op.Equals((object) SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals((object) StringOperator.Anything));
-        Assert.IsFalse(op.Equals((object) null));
-        Assert.IsFalse(op.Equals("xxx"));
+        Assert.That(op.Equals((object) op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+        Assert.That(op, Is.Not.EqualTo(null));
+        Assert.That(op.Equals("xxx"), Is.False);
     }
 
     [Test]
@@ -269,10 +275,10 @@ public class StringOperatorTest
     {
         var op = StringOperator.EndsWith;
 
-        Assert.IsTrue(op.Equals(op));
-        Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals(null));
+        Assert.That(op.Equals(op), Is.True);
+        Assert.That(op.Equals(SerializeAndDeserialize(op)), Is.True);
+        Assert.That(op.Equals(StringOperator.Anything), Is.False);
+        Assert.That(op.Equals(null), Is.False);
     }
 
     [Test]
@@ -280,7 +286,7 @@ public class StringOperatorTest
     {
         var op = Deserialize<StringOperator>("StringOperator_Equality");
 
-        Assert.IsNotNull(op);
+        Assert.That(op, Is.Not.Null);
         Equality_Evaluate(op);
     }
 
@@ -294,7 +300,9 @@ public class StringOperatorTest
     [Test]
     public void Equality_ShouldBeSingleton()
     {
-        Assert.AreSame(StringOperator.Equality, StringOperator.Equality);
+#pragma warning disable NUnit2009
+        Assert.That(StringOperator.Equality, Is.SameAs(StringOperator.Equality));
+#pragma warning restore NUnit2009
     }
 
     [Test]
@@ -305,18 +313,18 @@ public class StringOperatorTest
 
     private static void Equality_Evaluate(StringOperator op)
     {
-        Assert.IsTrue(op.Evaluate(null, null));
-        Assert.IsFalse(op.Evaluate(null, "Quartz"));
-        Assert.IsFalse(op.Evaluate("Quartz", null));
-        Assert.IsTrue(op.Evaluate("Quartz", "Quartz"));
-        Assert.IsTrue(op.Evaluate("aa", new string('a', 2)));
-        Assert.IsFalse(op.Evaluate(null, string.Empty));
-        Assert.IsFalse(op.Evaluate("Quartz", "QuartZ"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tz"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tZ"));
-        Assert.IsFalse(op.Evaluate("Quartz", "ua"));
-        Assert.IsFalse(op.Evaluate("Quartz", "Qu"));
-        Assert.IsFalse(op.Evaluate("Quartz", "QU"));
+        Assert.That(op.Evaluate(null, null), Is.True);
+        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", null), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+        Assert.That(op.Evaluate(null, string.Empty), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Qu"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
     }
 
     [Test]
@@ -324,11 +332,11 @@ public class StringOperatorTest
     {
         var op = StringOperator.Equality;
 
-        Assert.IsTrue(op.Equals((object) op));
-        Assert.IsTrue(op.Equals((object) SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals((object) StringOperator.Anything));
-        Assert.IsFalse(op.Equals((object) null));
-        Assert.IsFalse(op.Equals("xxx"));
+        Assert.That(op.Equals((object) op), Is.True);
+        Assert.That(op.Equals((object) SerializeAndDeserialize(op)), Is.True);
+        Assert.That(op.Equals((object) StringOperator.Anything), Is.False);
+        Assert.That(op.Equals((object) null), Is.False);
+        Assert.That(op.Equals("xxx"), Is.False);
     }
 
     [Test]
@@ -336,10 +344,10 @@ public class StringOperatorTest
     {
         var op = StringOperator.Equality;
 
-        Assert.IsTrue(op.Equals(op));
-        Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals(null));
+        Assert.That(op.Equals(op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+        Assert.That(op.Equals(null), Is.False);
     }
 
     [Test]
@@ -347,7 +355,7 @@ public class StringOperatorTest
     {
         var op = Deserialize<StringOperator>("StringOperator_StartsWith");
 
-        Assert.IsNotNull(op);
+        Assert.That(op, Is.Not.Null);
         StartsWith_Evaluate(op);
     }
 
@@ -361,7 +369,9 @@ public class StringOperatorTest
     [Test]
     public void StartsWith_ShouldBeSingleton()
     {
-        Assert.AreSame(StringOperator.StartsWith, StringOperator.StartsWith);
+#pragma warning disable NUnit2009
+        Assert.That(StringOperator.StartsWith, Is.SameAs(StringOperator.StartsWith));
+#pragma warning restore NUnit2009
     }
 
     [Test]
@@ -369,32 +379,32 @@ public class StringOperatorTest
     {
         var op = StringOperator.StartsWith;
 
-        Assert.IsFalse(op.Evaluate(null, null));
-        Assert.IsFalse(op.Evaluate(null, "Quartz"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Quartz"));
-        Assert.IsTrue(op.Evaluate("aa", new string('a', 2)));
-        Assert.IsFalse(op.Evaluate(null, string.Empty));
-        Assert.IsFalse(op.Evaluate("Quartz", "QuartZ"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tz"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tZ"));
-        Assert.IsFalse(op.Evaluate("Quartz", "ua"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Qu"));
-        Assert.IsFalse(op.Evaluate("Quartz", "QU"));
+        Assert.That(op.Evaluate(null, null), Is.False);
+        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Quartz"));
+        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+        Assert.That(op.Evaluate(null, string.Empty), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
     }
 
     private static void StartsWith_Evaluate(StringOperator op)
     {
-        Assert.IsFalse(op.Evaluate(null, null));
-        Assert.IsFalse(op.Evaluate(null, "Quartz"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Quartz"));
-        Assert.IsTrue(op.Evaluate("aa", new string('a', 2)));
-        Assert.IsFalse(op.Evaluate(null, string.Empty));
-        Assert.IsFalse(op.Evaluate("Quartz", "QuartZ"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tz"));
-        Assert.IsFalse(op.Evaluate("Quartz", "tZ"));
-        Assert.IsFalse(op.Evaluate("Quartz", "ua"));
-        Assert.IsTrue(op.Evaluate("Quartz", "Qu"));
-        Assert.IsFalse(op.Evaluate("Quartz", "QU"));
+        Assert.That(op.Evaluate(null, null), Is.False);
+        Assert.That(op.Evaluate(null, "Quartz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Quartz"), Is.True);
+        Assert.That(op.Evaluate("aa", new string('a', 2)), Is.True);
+        Assert.That(op.Evaluate(null, string.Empty), Is.False);
+        Assert.That(op.Evaluate("Quartz", "QuartZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tz"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "tZ"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "ua"), Is.False);
+        Assert.That(op.Evaluate("Quartz", "Qu"), Is.True);
+        Assert.That(op.Evaluate("Quartz", "QU"), Is.False);
     }
 
     [Test]
@@ -409,7 +419,7 @@ public class StringOperatorTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual("value", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
     }
 
@@ -418,11 +428,11 @@ public class StringOperatorTest
     {
         var op = StringOperator.StartsWith;
 
-        Assert.IsTrue(op.Equals((object) op));
-        Assert.IsTrue(op.Equals((object) SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals((object) StringOperator.Anything));
-        Assert.IsFalse(op.Equals((object) null));
-        Assert.IsFalse(op.Equals("xxx"));
+        Assert.That(op.Equals((object) op), Is.True);
+        Assert.That(op.Equals((object) SerializeAndDeserialize(op)), Is.True);
+        Assert.That(op.Equals((object) StringOperator.Anything), Is.False);
+        Assert.That(op.Equals((object) null), Is.False);
+        Assert.That(op.Equals("xxx"), Is.False);
     }
 
     [Test]
@@ -430,10 +440,10 @@ public class StringOperatorTest
     {
         var op = StringOperator.StartsWith;
 
-        Assert.IsTrue(op.Equals(op));
-        Assert.IsTrue(op.Equals(SerializeAndDeserialize(op)));
-        Assert.IsFalse(op.Equals(StringOperator.Anything));
-        Assert.IsFalse(op.Equals(null));
+        Assert.That(op.Equals(op), Is.True);
+        Assert.That(op, Is.EqualTo(SerializeAndDeserialize(op)));
+        Assert.That(op, Is.Not.EqualTo(StringOperator.Anything));
+        Assert.That(op.Equals(null), Is.False);
     }
 
     [Serializable]

--- a/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
@@ -86,7 +86,7 @@ public class StdSchedulerFactoryTest
 
         factory.Initialize();
         var scheduler = await factory.GetScheduler();
-        Assert.AreEqual("QuartzScheduler", scheduler.SchedulerName);
+        Assert.That(scheduler.SchedulerName, Is.EqualTo("QuartzScheduler"));
 
         Environment.SetEnvironmentVariable("quartz.scheduler.instanceName", "fromSystemProperties");
         // Make sure to pass the serializer type as an env var instead of in a NameValueCollection (as in the previous test)
@@ -94,7 +94,7 @@ public class StdSchedulerFactoryTest
         Environment.SetEnvironmentVariable("quartz.serializer.type", TestConstants.DefaultSerializerType);
         factory = new StdSchedulerFactory();
         scheduler = await factory.GetScheduler();
-        Assert.AreEqual("fromSystemProperties", scheduler.SchedulerName);
+        Assert.That(scheduler.SchedulerName, Is.EqualTo("fromSystemProperties"));
     }
 
     [Test]
@@ -123,7 +123,7 @@ public class StdSchedulerFactoryTest
             factory.Initialize(); // <- optional, because `GetScheduler` does it anyway
             var scheduler = await factory.GetScheduler();
 
-            Assert.AreEqual(InstanceName, scheduler.SchedulerName);
+            Assert.That(scheduler.SchedulerName, Is.EqualTo(InstanceName));
         }
         finally
         {

--- a/src/Quartz.Tests.Unit/Impl/Triggers/AbstractTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/AbstractTriggerTest.cs
@@ -24,8 +24,11 @@ public class AbstractTriggerTest
 
         AbstractTrigger cloned = trigger.DeepClone();
 
-        Assert.That(cloned.Key, Is.EqualTo(trigger.Key));
-        Assert.That(cloned.JobKey, Is.EqualTo(trigger.JobKey));
+        Assert.Multiple(() =>
+        {
+            Assert.That(cloned.Key, Is.EqualTo(trigger.Key));
+            Assert.That(cloned.JobKey, Is.EqualTo(trigger.JobKey));
+        });
     }
 
     [Serializable]

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -149,9 +149,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(47));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[46], Is.EqualTo(DateBuilder.DateOf(22, 0, 0, 2, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(47));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[46], Is.EqualTo(DateBuilder.DateOf(22, 0, 0, 2, 1, 2011)));
+        });
     }
 
     [Test]
@@ -168,9 +171,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 3, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 3, 1, 2011)));
+        });
     }
 
     [Test]
@@ -196,9 +202,12 @@ public class DailyTimeIntervalTriggerImplTest
         Assert.That(trigger.GetFireTimeAfter(dateOf(6, 0, 0, 22, 5, 2010)), Is.EqualTo(dateOf(8, 0, 0, 3, 1, 2011)));
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(dateOf(8, 0, 0, 3, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(dateOf(23, 0, 0, 5, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(dateOf(8, 0, 0, 3, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(dateOf(23, 0, 0, 5, 1, 2011)));
+        });
     }
 
     [Test]
@@ -236,10 +245,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(35));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[34], Is.EqualTo(DateBuilder.DateOf(16, 0, 0, 2, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(35));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[34], Is.EqualTo(DateBuilder.DateOf(16, 0, 0, 2, 1, 2011)));
+        });
     }
 
     [Test]
@@ -258,10 +270,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(36));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[35], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 2, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(36));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[35], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 2, 1, 2011)));
+        });
     }
 
     [Test]
@@ -280,10 +295,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011)));
+        });
     }
 
     [Test]
@@ -304,10 +322,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(30));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
-        Assert.That(fireTimes[29], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 3, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(30));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
+            Assert.That(fireTimes[29], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 3, 1, 2011)));
+        });
     }
 
     [Test]
@@ -326,9 +347,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 23, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 23, 0, 3, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 23, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 23, 0, 3, 1, 2011)));
+        });
     }
 
     [Test]
@@ -349,10 +373,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011)));
+        });
     }
 
     [Test]
@@ -373,13 +400,17 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011)));
-        Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
-        Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 4, 1, 2011)));
-        Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Tuesday));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 7, 1, 2011)));
-        Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Friday));
+        
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011)));
+            Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
+            Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 4, 1, 2011)));
+            Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Tuesday));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 7, 1, 2011)));
+            Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Friday));
+        });
     }
 
     [Test]
@@ -400,13 +431,16 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Saturday));
-        Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 2, 1, 2011)));
-        Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Sunday));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 15, 1, 2011)));
-        Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Saturday));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Saturday));
+            Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 2, 1, 2011)));
+            Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Sunday));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 15, 1, 2011)));
+            Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Saturday));
+        });
     }
 
     [TestCase(-14)]
@@ -432,13 +466,15 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011)));
-        Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
-        Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 10, 1, 2011)));
-        Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 31, 1, 2011)));
-        Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
+        Assert.Multiple(() =>{
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011)));
+            Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
+            Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 10, 1, 2011)));
+            Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 31, 1, 2011)));
+            Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
+        });
     }
 
     [Test]
@@ -459,10 +495,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(18));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[5], Is.EqualTo(DateBuilder.DateOf(9, 55, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(9, 55, 0, 3, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(18));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[5], Is.EqualTo(DateBuilder.DateOf(9, 55, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(9, 55, 0, 3, 1, 2011)));
+        });
     }
 
     [Test]
@@ -483,9 +522,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 1, 15, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(12, 1, 15, 10, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 1, 15, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(12, 1, 15, 10, 1, 2011)));
+        });
     }
 
     [Test]
@@ -504,9 +546,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 2, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(8, 56, 26, 1, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 2, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(8, 56, 26, 1, 1, 2011)));
+        });
     }
 
     [Test]
@@ -528,9 +573,12 @@ public class DailyTimeIntervalTriggerImplTest
         // Setting this (which is default) should make the trigger just as normal one.
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011)));
+        });
     }
 
     [Test]
@@ -550,9 +598,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(8));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[7], Is.EqualTo(DateBuilder.DateOf(9, 12, 0, 3, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(8));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[7], Is.EqualTo(DateBuilder.DateOf(9, 12, 0, 3, 1, 2011)));
+        });
     }
 
     [Test]
@@ -572,8 +623,11 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(1));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(1));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        });
     }
 
     [Test]
@@ -607,14 +661,17 @@ public class DailyTimeIntervalTriggerImplTest
         DateTimeOffset expected6 = new DateTimeOffset(2012, 3, 11, 10, 0, 0, 0, TimeSpan.FromHours(-4));
         DateTimeOffset expected7 = new DateTimeOffset(2012, 3, 11, 11, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        Assert.That(fireTimes[0], Is.EqualTo(expected0));
-        Assert.That(fireTimes[1], Is.EqualTo(expected1));
-        Assert.That(fireTimes[2], Is.EqualTo(expected2));
-        Assert.That(fireTimes[3], Is.EqualTo(expected3));
-        Assert.That(fireTimes[4], Is.EqualTo(expected4));
-        Assert.That(fireTimes[5], Is.EqualTo(expected5));
-        Assert.That(fireTimes[6], Is.EqualTo(expected6));
-        Assert.That(fireTimes[7], Is.EqualTo(expected7));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes[0], Is.EqualTo(expected0));
+            Assert.That(fireTimes[1], Is.EqualTo(expected1));
+            Assert.That(fireTimes[2], Is.EqualTo(expected2));
+            Assert.That(fireTimes[3], Is.EqualTo(expected3));
+            Assert.That(fireTimes[4], Is.EqualTo(expected4));
+            Assert.That(fireTimes[5], Is.EqualTo(expected5));
+            Assert.That(fireTimes[6], Is.EqualTo(expected6));
+            Assert.That(fireTimes[7], Is.EqualTo(expected7));
+        });
     }
 
     [Test]
@@ -648,14 +705,17 @@ public class DailyTimeIntervalTriggerImplTest
         DateTimeOffset expected6 = new DateTimeOffset(2012, 11, 4, 10, 0, 0, 0, TimeSpan.FromHours(-5));
         DateTimeOffset expected7 = new DateTimeOffset(2012, 11, 4, 11, 0, 0, 0, TimeSpan.FromHours(-5));
 
-        Assert.That(fireTimes[0], Is.EqualTo(expected0));
-        Assert.That(fireTimes[1], Is.EqualTo(expected1));
-        Assert.That(fireTimes[2], Is.EqualTo(expected2));
-        Assert.That(fireTimes[3], Is.EqualTo(expected3));
-        Assert.That(fireTimes[4], Is.EqualTo(expected4));
-        Assert.That(fireTimes[5], Is.EqualTo(expected5));
-        Assert.That(fireTimes[6], Is.EqualTo(expected6));
-        Assert.That(fireTimes[7], Is.EqualTo(expected7));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes[0], Is.EqualTo(expected0));
+            Assert.That(fireTimes[1], Is.EqualTo(expected1));
+            Assert.That(fireTimes[2], Is.EqualTo(expected2));
+            Assert.That(fireTimes[3], Is.EqualTo(expected3));
+            Assert.That(fireTimes[4], Is.EqualTo(expected4));
+            Assert.That(fireTimes[5], Is.EqualTo(expected5));
+            Assert.That(fireTimes[6], Is.EqualTo(expected6));
+            Assert.That(fireTimes[7], Is.EqualTo(expected7));
+        });
     }
 
     [Test]
@@ -683,13 +743,16 @@ public class DailyTimeIntervalTriggerImplTest
 
         //check trigger 2 DOW
         //this fails because the reference collection only contains MONDAY b/c it was cleared.
-        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Monday), Is.True);
-        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Tuesday), Is.True);
-        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Wednesday), Is.True);
-        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Thursday), Is.True);
-        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Friday), Is.True);
-        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Saturday), Is.True);
-        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Sunday), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Monday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Tuesday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Wednesday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Thursday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Friday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Saturday), Is.True);
+            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Sunday), Is.True);
+        });
     }
 
     [Test]
@@ -717,13 +780,16 @@ public class DailyTimeIntervalTriggerImplTest
         trigger.RepeatIntervalUnit = IntervalUnit.Hour;
         trigger.RepeatInterval = 1;
 
-        Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(7, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(7, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(8, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(9, 0, 0, 1, 1, 2011)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(9, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(10, 0, 0, 1, 1, 2011)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(12, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(13, 0, 0, 1, 1, 2011)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 2, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(7, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(7, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(8, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(9, 0, 0, 1, 1, 2011)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(9, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(10, 0, 0, 1, 1, 2011)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(12, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(13, 0, 0, 1, 1, 2011)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 2, 1, 2011)));
+        });
     }
 
     public DateTimeOffset dateOf(int hour, int minute, int second, int dayOfMonth, int month, int year)
@@ -745,17 +811,20 @@ public class DailyTimeIntervalTriggerImplTest
         trigger.RepeatInterval = 1;
 
         // NOTE that if you pass a date past the startTime, you will get the startTime back!
-        Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(7, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(7, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(8, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(9, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(12, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(7, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(7, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(8, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(9, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(12, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
 
-        // Now try some test times at or after startTime
-        Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2012)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2012)), Is.EqualTo(dateOf(8, 0, 0, 2, 1, 2012)));
+            // Now try some test times at or after startTime
+            Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2012)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2012)), Is.EqualTo(dateOf(8, 0, 0, 2, 1, 2012)));
+        });
     }
 
     [Test]
@@ -785,18 +854,21 @@ public class DailyTimeIntervalTriggerImplTest
             new TimeOfDay(8, 0, 0), new TimeOfDay(17, 0, 0),
             IntervalUnit.Hour, 1);
 
-        Assert.That(trigger.Key, Is.Not.Null);
-        Assert.That(trigger.Key.Name, Is.EqualTo("triggerName"));
-        Assert.That(trigger.Key.Group, Is.EqualTo("triggerGroup"));
-        Assert.That(trigger.JobKey, Is.Not.Null);
-        Assert.That(trigger.JobKey.Name, Is.EqualTo("jobName"));
-        Assert.That(trigger.JobKey.Group, Is.EqualTo("jobGroup"));
-        Assert.That(trigger.StartTimeUtc, Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.EndTimeUtc, Is.EqualTo(null));
-        Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0, 0)));
-        Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(17, 0, 0)));
-        Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
-        Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key, Is.Not.Null);
+            Assert.That(trigger.Key.Name, Is.EqualTo("triggerName"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("triggerGroup"));
+            Assert.That(trigger.JobKey, Is.Not.Null);
+            Assert.That(trigger.JobKey.Name, Is.EqualTo("jobName"));
+            Assert.That(trigger.JobKey.Group, Is.EqualTo("jobGroup"));
+            Assert.That(trigger.StartTimeUtc, Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.EndTimeUtc, Is.EqualTo(null));
+            Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0, 0)));
+            Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(17, 0, 0)));
+            Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
+            Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
+        });
 
         trigger = new DailyTimeIntervalTriggerImpl(
             "triggerName", "triggerGroup",
@@ -804,16 +876,19 @@ public class DailyTimeIntervalTriggerImplTest
             new TimeOfDay(8, 0, 0), new TimeOfDay(17, 0, 0),
             IntervalUnit.Hour, 1);
 
-        Assert.That(trigger.Key, Is.Not.Null);
-        Assert.That(trigger.Key.Name, Is.EqualTo("triggerName"));
-        Assert.That(trigger.Key.Group, Is.EqualTo("triggerGroup"));
-        Assert.That(trigger.JobKey, Is.Null);
-        Assert.That(trigger.StartTimeUtc, Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
-        Assert.That(trigger.EndTimeUtc, Is.EqualTo(null));
-        Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0, 0)));
-        Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(17, 0, 0)));
-        Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
-        Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key, Is.Not.Null);
+            Assert.That(trigger.Key.Name, Is.EqualTo("triggerName"));
+            Assert.That(trigger.Key.Group, Is.EqualTo("triggerGroup"));
+            Assert.That(trigger.JobKey, Is.Null);
+            Assert.That(trigger.StartTimeUtc, Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+            Assert.That(trigger.EndTimeUtc, Is.EqualTo(null));
+            Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0, 0)));
+            Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(17, 0, 0)));
+            Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
+            Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
+        });
     }
 
     [Test]
@@ -933,13 +1008,16 @@ public class DailyTimeIntervalTriggerImplTest
         var scheduleBuilder = trigger.GetScheduleBuilder();
 
         var cloned = (DailyTimeIntervalTriggerImpl) scheduleBuilder.Build();
-        Assert.That(trigger.DaysOfWeek, Is.EqualTo(cloned.DaysOfWeek).AsCollection);
-        Assert.That(cloned.RepeatCount, Is.EqualTo(trigger.RepeatCount));
-        Assert.That(cloned.RepeatInterval, Is.EqualTo(trigger.RepeatInterval));
-        Assert.That(cloned.RepeatIntervalUnit, Is.EqualTo(trigger.RepeatIntervalUnit));
-        Assert.That(cloned.StartTimeOfDay, Is.EqualTo(trigger.StartTimeOfDay));
-        Assert.That(cloned.EndTimeOfDay, Is.EqualTo(trigger.EndTimeOfDay));
-        Assert.That(cloned.TimeZone, Is.EqualTo(trigger.TimeZone));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.DaysOfWeek, Is.EqualTo(cloned.DaysOfWeek).AsCollection);
+            Assert.That(cloned.RepeatCount, Is.EqualTo(trigger.RepeatCount));
+            Assert.That(cloned.RepeatInterval, Is.EqualTo(trigger.RepeatInterval));
+            Assert.That(cloned.RepeatIntervalUnit, Is.EqualTo(trigger.RepeatIntervalUnit));
+            Assert.That(cloned.StartTimeOfDay, Is.EqualTo(trigger.StartTimeOfDay));
+            Assert.That(cloned.EndTimeOfDay, Is.EqualTo(trigger.EndTimeOfDay));
+            Assert.That(cloned.TimeZone, Is.EqualTo(trigger.TimeZone));
+        });
     }
 
     [Test(Description = "https://github.com/quartznet/quartznet/issues/382")]

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -53,9 +53,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011)));
+        });
     }
 
     [Test]
@@ -72,10 +75,13 @@ public class DailyTimeIntervalTriggerImplTest
 
         CronCalendar cronCal = new CronCalendar("* * 9-12 * * ?"); // exclude 9-12
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, cronCal, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[1], Is.EqualTo(DateBuilder.DateOf(13, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 4, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[1], Is.EqualTo(DateBuilder.DateOf(13, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 4, 1, 2011)));
+        });
     }
 
     [Test]
@@ -130,9 +136,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 2, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 2, 1, 2011)));
+        });
     }
 
     [Test]
@@ -224,9 +233,12 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.That(fireTimes.Count, Is.EqualTo(48));
-        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(10, 0, 0, 1, 1, 2011)));
-        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(9, 0, 0, 4, 1, 2011)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(10, 0, 0, 1, 1, 2011)));
+            Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(9, 0, 0, 4, 1, 2011)));
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -53,9 +53,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011)));
     }
 
     [Test]
@@ -72,10 +72,10 @@ public class DailyTimeIntervalTriggerImplTest
 
         CronCalendar cronCal = new CronCalendar("* * 9-12 * * ?"); // exclude 9-12
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, cronCal, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(13, 0, 0, 1, 1, 2011), fireTimes[1]);
-        Assert.AreEqual(DateBuilder.DateOf(23, 0, 0, 4, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[1], Is.EqualTo(DateBuilder.DateOf(13, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 4, 1, 2011)));
     }
 
     [Test]
@@ -130,9 +130,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(23, 0, 0, 2, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 2, 1, 2011)));
     }
 
     [Test]
@@ -149,9 +149,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(47, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(22, 0, 0, 2, 1, 2011), fireTimes[46]);
+        Assert.That(fireTimes.Count, Is.EqualTo(47));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[46], Is.EqualTo(DateBuilder.DateOf(22, 0, 0, 2, 1, 2011)));
     }
 
     [Test]
@@ -168,9 +168,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(23, 0, 0, 3, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 3, 1, 2011)));
     }
 
     [Test]
@@ -215,9 +215,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(10, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(9, 0, 0, 4, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(10, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(9, 0, 0, 4, 1, 2011)));
     }
 
     [Test]
@@ -236,10 +236,10 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(35, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011), fireTimes[17]);
-        Assert.AreEqual(DateBuilder.DateOf(16, 0, 0, 2, 1, 2011), fireTimes[34]);
+        Assert.That(fireTimes.Count, Is.EqualTo(35));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[34], Is.EqualTo(DateBuilder.DateOf(16, 0, 0, 2, 1, 2011)));
     }
 
     [Test]
@@ -258,10 +258,10 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(36, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011), fireTimes[17]);
-        Assert.AreEqual(DateBuilder.DateOf(17, 0, 0, 2, 1, 2011), fireTimes[35]);
+        Assert.That(fireTimes.Count, Is.EqualTo(36));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[35], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 2, 1, 2011)));
     }
 
     [Test]
@@ -280,10 +280,10 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011), fireTimes[9]); // The 10th hours is the end of day.
-        Assert.AreEqual(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011)));
     }
 
     [Test]
@@ -304,10 +304,10 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(30, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011), fireTimes[9]); // The 10th hours is the end of day.
-        Assert.AreEqual(DateBuilder.DateOf(17, 0, 0, 3, 1, 2011), fireTimes[29]);
+        Assert.That(fireTimes.Count, Is.EqualTo(30));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
+        Assert.That(fireTimes[29], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 3, 1, 2011)));
     }
 
     [Test]
@@ -326,9 +326,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 23, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(23, 23, 0, 3, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 23, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 23, 0, 3, 1, 2011)));
     }
 
     [Test]
@@ -349,10 +349,10 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011), fireTimes[9]); // The 10th hours is the end of day.
-        Assert.AreEqual(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011)));
     }
 
     [Test]
@@ -373,13 +373,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DayOfWeek.Monday, fireTimes[0].LocalDateTime.DayOfWeek);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 4, 1, 2011), fireTimes[10]);
-        Assert.AreEqual(DayOfWeek.Tuesday, fireTimes[10].LocalDateTime.DayOfWeek);
-        Assert.AreEqual(DateBuilder.DateOf(15, 0, 0, 7, 1, 2011), fireTimes[47]);
-        Assert.AreEqual(DayOfWeek.Friday, fireTimes[47].LocalDateTime.DayOfWeek);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011)));
+        Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
+        Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 4, 1, 2011)));
+        Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Tuesday));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 7, 1, 2011)));
+        Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Friday));
     }
 
     [Test]
@@ -400,13 +400,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DayOfWeek.Saturday, fireTimes[0].LocalDateTime.DayOfWeek);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 2, 1, 2011), fireTimes[10]);
-        Assert.AreEqual(DayOfWeek.Sunday, fireTimes[10].LocalDateTime.DayOfWeek);
-        Assert.AreEqual(DateBuilder.DateOf(15, 0, 0, 15, 1, 2011), fireTimes[47]);
-        Assert.AreEqual(DayOfWeek.Saturday, fireTimes[47].LocalDateTime.DayOfWeek);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Saturday));
+        Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 2, 1, 2011)));
+        Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Sunday));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 15, 1, 2011)));
+        Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Saturday));
     }
 
     [TestCase(-14)]
@@ -432,13 +432,13 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DayOfWeek.Monday, fireTimes[0].LocalDateTime.DayOfWeek);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 10, 1, 2011), fireTimes[10]);
-        Assert.AreEqual(DayOfWeek.Monday, fireTimes[10].LocalDateTime.DayOfWeek);
-        Assert.AreEqual(DateBuilder.DateOf(15, 0, 0, 31, 1, 2011), fireTimes[47]);
-        Assert.AreEqual(DayOfWeek.Monday, fireTimes[47].LocalDateTime.DayOfWeek);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011)));
+        Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
+        Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 10, 1, 2011)));
+        Assert.That(fireTimes[10].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 31, 1, 2011)));
+        Assert.That(fireTimes[47].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
     }
 
     [Test]
@@ -459,10 +459,10 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(18, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(9, 55, 0, 1, 1, 2011), fireTimes[5]);
-        Assert.AreEqual(DateBuilder.DateOf(9, 55, 0, 3, 1, 2011), fireTimes[17]);
+        Assert.That(fireTimes.Count, Is.EqualTo(18));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[5], Is.EqualTo(DateBuilder.DateOf(9, 55, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(9, 55, 0, 3, 1, 2011)));
     }
 
     [Test]
@@ -483,9 +483,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 1, 15, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(12, 1, 15, 10, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 1, 15, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(12, 1, 15, 10, 1, 2011)));
     }
 
     [Test]
@@ -504,9 +504,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 2, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(8, 56, 26, 1, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 2, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(8, 56, 26, 1, 1, 2011)));
     }
 
     [Test]
@@ -528,9 +528,9 @@ public class DailyTimeIntervalTriggerImplTest
         // Setting this (which is default) should make the trigger just as normal one.
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(48, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011), fireTimes[47]);
+        Assert.That(fireTimes.Count, Is.EqualTo(48));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011)));
     }
 
     [Test]
@@ -550,9 +550,9 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(8, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
-        Assert.AreEqual(DateBuilder.DateOf(9, 12, 0, 3, 1, 2011), fireTimes[7]);
+        Assert.That(fireTimes.Count, Is.EqualTo(8));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(fireTimes[7], Is.EqualTo(DateBuilder.DateOf(9, 12, 0, 3, 1, 2011)));
     }
 
     [Test]
@@ -572,8 +572,8 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
-        Assert.AreEqual(1, fireTimes.Count);
-        Assert.AreEqual(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011), fireTimes[0]);
+        Assert.That(fireTimes.Count, Is.EqualTo(1));
+        Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
     }
 
     [Test]
@@ -607,14 +607,14 @@ public class DailyTimeIntervalTriggerImplTest
         DateTimeOffset expected6 = new DateTimeOffset(2012, 3, 11, 10, 0, 0, 0, TimeSpan.FromHours(-4));
         DateTimeOffset expected7 = new DateTimeOffset(2012, 3, 11, 11, 0, 0, 0, TimeSpan.FromHours(-4));
 
-        Assert.AreEqual(expected0, fireTimes[0]);
-        Assert.AreEqual(expected1, fireTimes[1]);
-        Assert.AreEqual(expected2, fireTimes[2]);
-        Assert.AreEqual(expected3, fireTimes[3]);
-        Assert.AreEqual(expected4, fireTimes[4]);
-        Assert.AreEqual(expected5, fireTimes[5]);
-        Assert.AreEqual(expected6, fireTimes[6]);
-        Assert.AreEqual(expected7, fireTimes[7]);
+        Assert.That(fireTimes[0], Is.EqualTo(expected0));
+        Assert.That(fireTimes[1], Is.EqualTo(expected1));
+        Assert.That(fireTimes[2], Is.EqualTo(expected2));
+        Assert.That(fireTimes[3], Is.EqualTo(expected3));
+        Assert.That(fireTimes[4], Is.EqualTo(expected4));
+        Assert.That(fireTimes[5], Is.EqualTo(expected5));
+        Assert.That(fireTimes[6], Is.EqualTo(expected6));
+        Assert.That(fireTimes[7], Is.EqualTo(expected7));
     }
 
     [Test]
@@ -648,14 +648,14 @@ public class DailyTimeIntervalTriggerImplTest
         DateTimeOffset expected6 = new DateTimeOffset(2012, 11, 4, 10, 0, 0, 0, TimeSpan.FromHours(-5));
         DateTimeOffset expected7 = new DateTimeOffset(2012, 11, 4, 11, 0, 0, 0, TimeSpan.FromHours(-5));
 
-        Assert.AreEqual(expected0, fireTimes[0]);
-        Assert.AreEqual(expected1, fireTimes[1]);
-        Assert.AreEqual(expected2, fireTimes[2]);
-        Assert.AreEqual(expected3, fireTimes[3]);
-        Assert.AreEqual(expected4, fireTimes[4]);
-        Assert.AreEqual(expected5, fireTimes[5]);
-        Assert.AreEqual(expected6, fireTimes[6]);
-        Assert.AreEqual(expected7, fireTimes[7]);
+        Assert.That(fireTimes[0], Is.EqualTo(expected0));
+        Assert.That(fireTimes[1], Is.EqualTo(expected1));
+        Assert.That(fireTimes[2], Is.EqualTo(expected2));
+        Assert.That(fireTimes[3], Is.EqualTo(expected3));
+        Assert.That(fireTimes[4], Is.EqualTo(expected4));
+        Assert.That(fireTimes[5], Is.EqualTo(expected5));
+        Assert.That(fireTimes[6], Is.EqualTo(expected6));
+        Assert.That(fireTimes[7], Is.EqualTo(expected7));
     }
 
     [Test]
@@ -683,13 +683,13 @@ public class DailyTimeIntervalTriggerImplTest
 
         //check trigger 2 DOW
         //this fails because the reference collection only contains MONDAY b/c it was cleared.
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Monday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Tuesday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Wednesday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Thursday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Friday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Saturday));
-        Assert.IsTrue(trigger2.DaysOfWeek.Contains(DayOfWeek.Sunday));
+        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Monday), Is.True);
+        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Tuesday), Is.True);
+        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Wednesday), Is.True);
+        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Thursday), Is.True);
+        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Friday), Is.True);
+        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Saturday), Is.True);
+        Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Sunday), Is.True);
     }
 
     [Test]
@@ -717,13 +717,13 @@ public class DailyTimeIntervalTriggerImplTest
         trigger.RepeatIntervalUnit = IntervalUnit.Hour;
         trigger.RepeatInterval = 1;
 
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2011), trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2011), trigger.GetFireTimeAfter(dateOf(7, 0, 0, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2011), trigger.GetFireTimeAfter(dateOf(7, 59, 59, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(9, 0, 0, 1, 1, 2011), trigger.GetFireTimeAfter(dateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(10, 0, 0, 1, 1, 2011), trigger.GetFireTimeAfter(dateOf(9, 0, 0, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(13, 0, 0, 1, 1, 2011), trigger.GetFireTimeAfter(dateOf(12, 59, 59, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 2, 1, 2011), trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2011)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(7, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(7, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2011)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(8, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(9, 0, 0, 1, 1, 2011)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(9, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(10, 0, 0, 1, 1, 2011)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(12, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(13, 0, 0, 1, 1, 2011)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 2, 1, 2011)));
     }
 
     public DateTimeOffset dateOf(int hour, int minute, int second, int dayOfMonth, int month, int year)
@@ -745,17 +745,17 @@ public class DailyTimeIntervalTriggerImplTest
         trigger.RepeatInterval = 1;
 
         // NOTE that if you pass a date past the startTime, you will get the startTime back!
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(dateOf(7, 0, 0, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(dateOf(7, 59, 59, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(dateOf(8, 0, 0, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(dateOf(9, 0, 0, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(dateOf(12, 59, 59, 1, 1, 2011)));
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2011)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(7, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(7, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(8, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(9, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(12, 59, 59, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2011)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
 
         // Now try some test times at or after startTime
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2012)));
-        Assert.AreEqual(dateOf(8, 0, 0, 2, 1, 2012), trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(0, 0, 0, 1, 1, 2012)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.GetFireTimeAfter(dateOf(13, 0, 0, 1, 1, 2012)), Is.EqualTo(dateOf(8, 0, 0, 2, 1, 2012)));
     }
 
     [Test]
@@ -772,7 +772,7 @@ public class DailyTimeIntervalTriggerImplTest
         trigger.RepeatIntervalUnit = IntervalUnit.Hour;
         trigger.RepeatInterval = 1;
 
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.GetFireTimeAfter(new DateTime(2012, 1, 1)));
+        Assert.That(trigger.GetFireTimeAfter(new DateTime(2012, 1, 1)), Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
     }
 
     [Test]
@@ -785,20 +785,18 @@ public class DailyTimeIntervalTriggerImplTest
             new TimeOfDay(8, 0, 0), new TimeOfDay(17, 0, 0),
             IntervalUnit.Hour, 1);
 
-        Assert.IsNotNull(trigger.Key);
-        Assert.AreEqual("triggerName", trigger.Key.Name);
-        Assert.AreEqual("triggerGroup", trigger.Key.Group);
-        Assert.AreSame(trigger.Key, trigger.Key);
-        Assert.IsNotNull(trigger.JobKey);
-        Assert.AreEqual("jobName", trigger.JobKey.Name);
-        Assert.AreEqual("jobGroup", trigger.JobKey.Group);
-        Assert.AreSame(trigger.JobKey, trigger.JobKey);
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.StartTimeUtc);
-        Assert.AreEqual(null, trigger.EndTimeUtc);
-        Assert.AreEqual(new TimeOfDay(8, 0, 0), trigger.StartTimeOfDay);
-        Assert.AreEqual(new TimeOfDay(17, 0, 0), trigger.EndTimeOfDay);
-        Assert.AreEqual(IntervalUnit.Hour, trigger.RepeatIntervalUnit);
-        Assert.AreEqual(1, trigger.RepeatInterval);
+        Assert.That(trigger.Key, Is.Not.Null);
+        Assert.That(trigger.Key.Name, Is.EqualTo("triggerName"));
+        Assert.That(trigger.Key.Group, Is.EqualTo("triggerGroup"));
+        Assert.That(trigger.JobKey, Is.Not.Null);
+        Assert.That(trigger.JobKey.Name, Is.EqualTo("jobName"));
+        Assert.That(trigger.JobKey.Group, Is.EqualTo("jobGroup"));
+        Assert.That(trigger.StartTimeUtc, Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.EndTimeUtc, Is.EqualTo(null));
+        Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0, 0)));
+        Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(17, 0, 0)));
+        Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
+        Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
 
         trigger = new DailyTimeIntervalTriggerImpl(
             "triggerName", "triggerGroup",
@@ -806,16 +804,16 @@ public class DailyTimeIntervalTriggerImplTest
             new TimeOfDay(8, 0, 0), new TimeOfDay(17, 0, 0),
             IntervalUnit.Hour, 1);
 
-        Assert.IsNotNull(trigger.Key);
-        Assert.AreEqual("triggerName", trigger.Key.Name);
-        Assert.AreEqual("triggerGroup", trigger.Key.Group);
-        Assert.IsNull(trigger.JobKey);
-        Assert.AreEqual(dateOf(8, 0, 0, 1, 1, 2012), trigger.StartTimeUtc);
-        Assert.AreEqual(null, trigger.EndTimeUtc);
-        Assert.AreEqual(new TimeOfDay(8, 0, 0), trigger.StartTimeOfDay);
-        Assert.AreEqual(new TimeOfDay(17, 0, 0), trigger.EndTimeOfDay);
-        Assert.AreEqual(IntervalUnit.Hour, trigger.RepeatIntervalUnit);
-        Assert.AreEqual(1, trigger.RepeatInterval);
+        Assert.That(trigger.Key, Is.Not.Null);
+        Assert.That(trigger.Key.Name, Is.EqualTo("triggerName"));
+        Assert.That(trigger.Key.Group, Is.EqualTo("triggerGroup"));
+        Assert.That(trigger.JobKey, Is.Null);
+        Assert.That(trigger.StartTimeUtc, Is.EqualTo(dateOf(8, 0, 0, 1, 1, 2012)));
+        Assert.That(trigger.EndTimeUtc, Is.EqualTo(null));
+        Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOfDay(8, 0, 0)));
+        Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOfDay(17, 0, 0)));
+        Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
+        Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
     }
 
     [Test]
@@ -935,7 +933,7 @@ public class DailyTimeIntervalTriggerImplTest
         var scheduleBuilder = trigger.GetScheduleBuilder();
 
         var cloned = (DailyTimeIntervalTriggerImpl) scheduleBuilder.Build();
-        CollectionAssert.AreEqual(cloned.DaysOfWeek, trigger.DaysOfWeek);
+        Assert.That(trigger.DaysOfWeek, Is.EqualTo(cloned.DaysOfWeek).AsCollection);
         Assert.That(cloned.RepeatCount, Is.EqualTo(trigger.RepeatCount));
         Assert.That(cloned.RepeatInterval, Is.EqualTo(trigger.RepeatInterval));
         Assert.That(cloned.RepeatIntervalUnit, Is.EqualTo(trigger.RepeatIntervalUnit));

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -55,7 +55,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011)));
         });
@@ -138,7 +138,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 2, 1, 2011)));
         });
@@ -160,7 +160,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(47));
+            Assert.That(fireTimes, Has.Count.EqualTo(47));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[46], Is.EqualTo(DateBuilder.DateOf(22, 0, 0, 2, 1, 2011)));
         });
@@ -182,7 +182,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 0, 0, 3, 1, 2011)));
         });
@@ -213,7 +213,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(dateOf(8, 0, 0, 3, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(dateOf(23, 0, 0, 5, 1, 2011)));
         });
@@ -235,7 +235,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(10, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(9, 0, 0, 4, 1, 2011)));
         });
@@ -259,7 +259,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(35));
+            Assert.That(fireTimes, Has.Count.EqualTo(35));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[34], Is.EqualTo(DateBuilder.DateOf(16, 0, 0, 2, 1, 2011)));
@@ -284,7 +284,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(36));
+            Assert.That(fireTimes, Has.Count.EqualTo(36));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(0, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[35], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 2, 1, 2011)));
@@ -309,7 +309,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011)));
@@ -336,7 +336,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(30));
+            Assert.That(fireTimes, Has.Count.EqualTo(30));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
             Assert.That(fireTimes[29], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 3, 1, 2011)));
@@ -361,7 +361,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 23, 0, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(23, 23, 0, 3, 1, 2011)));
         });
@@ -387,7 +387,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[9], Is.EqualTo(DateBuilder.DateOf(17, 0, 0, 1, 1, 2011))); // The 10th hours is the end of day.
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(15, 0, 0, 5, 1, 2011)));
@@ -415,7 +415,7 @@ public class DailyTimeIntervalTriggerImplTest
         
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011)));
             Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
             Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 4, 1, 2011)));
@@ -445,7 +445,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Saturday));
             Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 2, 1, 2011)));
@@ -479,7 +479,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>{
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 3, 1, 2011)));
             Assert.That(fireTimes[0].LocalDateTime.DayOfWeek, Is.EqualTo(DayOfWeek.Monday));
             Assert.That(fireTimes[10], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 10, 1, 2011)));
@@ -509,7 +509,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(18));
+            Assert.That(fireTimes, Has.Count.EqualTo(18));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[5], Is.EqualTo(DateBuilder.DateOf(9, 55, 0, 1, 1, 2011)));
             Assert.That(fireTimes[17], Is.EqualTo(DateBuilder.DateOf(9, 55, 0, 3, 1, 2011)));
@@ -536,7 +536,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 1, 15, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(12, 1, 15, 10, 1, 2011)));
         });
@@ -560,7 +560,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 2, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(8, 56, 26, 1, 1, 2011)));
         });
@@ -587,7 +587,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(48));
+            Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[47], Is.EqualTo(DateBuilder.DateOf(10, 24, 0, 16, 1, 2011)));
         });
@@ -612,7 +612,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(8));
+            Assert.That(fireTimes, Has.Count.EqualTo(8));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
             Assert.That(fireTimes[7], Is.EqualTo(DateBuilder.DateOf(9, 12, 0, 3, 1, 2011)));
         });
@@ -637,7 +637,7 @@ public class DailyTimeIntervalTriggerImplTest
         var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
         Assert.Multiple(() =>
         {
-            Assert.That(fireTimes.Count, Is.EqualTo(1));
+            Assert.That(fireTimes, Has.Count.EqualTo(1));
             Assert.That(fireTimes[0], Is.EqualTo(DateBuilder.DateOf(8, 0, 0, 1, 1, 2011)));
         });
     }
@@ -757,13 +757,13 @@ public class DailyTimeIntervalTriggerImplTest
         //this fails because the reference collection only contains MONDAY b/c it was cleared.
         Assert.Multiple(() =>
         {
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Monday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Tuesday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Wednesday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Thursday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Friday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Saturday), Is.True);
-            Assert.That(trigger2.DaysOfWeek.Contains(DayOfWeek.Sunday), Is.True);
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Monday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Tuesday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Wednesday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Thursday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Friday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Saturday));
+            Assert.That(trigger2.DaysOfWeek, Does.Contain(DayOfWeek.Sunday));
         });
     }
 
@@ -804,7 +804,7 @@ public class DailyTimeIntervalTriggerImplTest
         });
     }
 
-    public DateTimeOffset dateOf(int hour, int minute, int second, int dayOfMonth, int month, int year)
+    private DateTimeOffset dateOf(int hour, int minute, int second, int dayOfMonth, int month, int year)
     {
         return new DateTime(year, month, dayOfMonth, hour, minute, second);
     }
@@ -1068,6 +1068,6 @@ public class DailyTimeIntervalTriggerImplTest
         var from = new DateTimeOffset(2018, 3, 25, 0, 0, 0, TimeSpan.Zero);
         var to = new DateTimeOffset(2018, 3, 27, 0, 0, 0, TimeSpan.Zero);
         var times = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
-        Assert.That(times.Count, Is.LessThan(200));
+        Assert.That(times, Has.Count.LessThan(200));
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/Triggers/SimpleTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/SimpleTriggerImplTest.cs
@@ -27,8 +27,7 @@ public class SimpleTriggerImplTest
         DateTimeOffset? afterTimeUtc = null;
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
-
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -49,7 +48,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -70,8 +69,8 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(startTimeUtc.AddDays(2), actual);
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual, Is.EqualTo(startTimeUtc.AddDays(2)));
     }
 
     [Test]
@@ -93,7 +92,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -114,7 +113,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -135,7 +134,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -156,7 +155,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -177,7 +176,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -198,8 +197,8 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(startTimeUtc, actual);
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual, Is.EqualTo(startTimeUtc));
     }
 
     [Test]
@@ -220,8 +219,8 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(startTimeUtc, actual);
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual, Is.EqualTo(startTimeUtc));
     }
 
     [Test]
@@ -242,7 +241,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -263,7 +262,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -284,8 +283,8 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(startTimeUtc.Add(TimeSpan.FromDays(1)), actual);
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual, Is.EqualTo(startTimeUtc.Add(TimeSpan.FromDays(1))));
     }
 
     [Test]
@@ -306,8 +305,8 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(startTimeUtc.Add(TimeSpan.FromDays(2)), actual);
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual, Is.EqualTo(startTimeUtc.Add(TimeSpan.FromDays(2))));
     }
 
     [Test]
@@ -328,7 +327,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -349,8 +348,8 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(startTimeUtc.AddDays(2), actual);
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual, Is.EqualTo(startTimeUtc.AddDays(2)));
     }
 
     [Test]
@@ -371,6 +370,6 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.IsNull(actual);
+        Assert.That(actual, Is.Null);
     }
 }

--- a/src/Quartz.Tests.Unit/Job/SendMailJobTest.cs
+++ b/src/Quartz.Tests.Unit/Job/SendMailJobTest.cs
@@ -110,10 +110,13 @@ public class SendMailJobTest
         job.Execute(context);
 
         //Then
-        Assert.That(job.actualSmtpHost, Is.EqualTo("someserver"));
-        Assert.That(job.actualSmtpUserName, Is.EqualTo("user 123"));
-        Assert.That(job.actualSmtpPassword, Is.EqualTo("pass 321"));
-        Assert.That(job.actualSmtpPort, Is.EqualTo(123));
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.actualSmtpHost, Is.EqualTo("someserver"));
+            Assert.That(job.actualSmtpUserName, Is.EqualTo("user 123"));
+            Assert.That(job.actualSmtpPassword, Is.EqualTo("pass 321"));
+            Assert.That(job.actualSmtpPort, Is.EqualTo(123));
+        });
     }
 }
 
@@ -136,18 +139,24 @@ internal sealed class ExpectedMail
 
     public void IsEqualTo(MailMessage actualMail)
     {
-        Assert.That(actualMail.To, Does.Contain(new MailAddress(recipient)), "Recipient equals");
-        Assert.That(actualMail.From, Is.EqualTo(new MailAddress(sender)), "Sender equals");
-        Assert.That(actualMail.Subject, Is.EqualTo(subject), "Subject equals");
-        Assert.That(actualMail.Body, Is.EqualTo(message), "Message equals");
+        Assert.Multiple(() =>
+        {
+            Assert.That(actualMail.To, Does.Contain(new MailAddress(recipient)), "Recipient equals");
+            Assert.That(actualMail.From, Is.EqualTo(new MailAddress(sender)), "Sender equals");
+            Assert.That(actualMail.Subject, Is.EqualTo(subject), "Subject equals");
+            Assert.That(actualMail.Body, Is.EqualTo(message), "Message equals");
+        });
         if (!string.IsNullOrEmpty(ccRecipient))
         {
             Assert.That(actualMail.CC, Does.Contain(new MailAddress(ccRecipient)), "CC equals");
         }
         if (!string.IsNullOrEmpty(replyTo))
         {
-            Assert.That(actualMail.ReplyToList.Count, Is.EqualTo(1));
-            Assert.That(actualMail.ReplyToList[0], Is.EqualTo(new MailAddress(replyTo)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(actualMail.ReplyToList.Count, Is.EqualTo(1));
+                Assert.That(actualMail.ReplyToList[0], Is.EqualTo(new MailAddress(replyTo)));
+            });
         }
     }
 }

--- a/src/Quartz.Tests.Unit/Job/SendMailJobTest.cs
+++ b/src/Quartz.Tests.Unit/Job/SendMailJobTest.cs
@@ -154,7 +154,7 @@ internal sealed class ExpectedMail
         {
             Assert.Multiple(() =>
             {
-                Assert.That(actualMail.ReplyToList.Count, Is.EqualTo(1));
+                Assert.That(actualMail.ReplyToList, Has.Count.EqualTo(1));
                 Assert.That(actualMail.ReplyToList[0], Is.EqualTo(new MailAddress(replyTo)));
             });
         }

--- a/src/Quartz.Tests.Unit/Job/SendMailJobTest.cs
+++ b/src/Quartz.Tests.Unit/Job/SendMailJobTest.cs
@@ -52,7 +52,7 @@ public class SendMailJobTest
 
         //Then
         expectedMail.IsEqualTo(job.actualMailSent);
-        Assert.AreEqual("someserver", job.actualSmtpHost);
+        Assert.That(job.actualSmtpHost, Is.EqualTo("someserver"));
     }
 
     [Test]
@@ -81,7 +81,7 @@ public class SendMailJobTest
 
         //Then
         expectedMail.IsEqualTo(job.actualMailSent);
-        Assert.AreEqual("someserver", job.actualSmtpHost);
+        Assert.That(job.actualSmtpHost, Is.EqualTo("someserver"));
     }
 
     [Test]
@@ -110,10 +110,10 @@ public class SendMailJobTest
         job.Execute(context);
 
         //Then
-        Assert.AreEqual("someserver", job.actualSmtpHost);
-        Assert.AreEqual("user 123", job.actualSmtpUserName);
-        Assert.AreEqual("pass 321", job.actualSmtpPassword);
-        Assert.AreEqual(123, job.actualSmtpPort);
+        Assert.That(job.actualSmtpHost, Is.EqualTo("someserver"));
+        Assert.That(job.actualSmtpUserName, Is.EqualTo("user 123"));
+        Assert.That(job.actualSmtpPassword, Is.EqualTo("pass 321"));
+        Assert.That(job.actualSmtpPort, Is.EqualTo(123));
     }
 }
 
@@ -136,18 +136,18 @@ internal sealed class ExpectedMail
 
     public void IsEqualTo(MailMessage actualMail)
     {
-        Assert.Contains(new MailAddress(recipient), actualMail.To, "Recipient equals");
-        Assert.AreEqual(new MailAddress(sender), actualMail.From, "Sender equals");
-        Assert.AreEqual(subject, actualMail.Subject, "Subject equals");
-        Assert.AreEqual(message, actualMail.Body, "Message equals");
+        Assert.That(actualMail.To, Does.Contain(new MailAddress(recipient)), "Recipient equals");
+        Assert.That(actualMail.From, Is.EqualTo(new MailAddress(sender)), "Sender equals");
+        Assert.That(actualMail.Subject, Is.EqualTo(subject), "Subject equals");
+        Assert.That(actualMail.Body, Is.EqualTo(message), "Message equals");
         if (!string.IsNullOrEmpty(ccRecipient))
         {
-            Assert.Contains(new MailAddress(ccRecipient), actualMail.CC, "CC equals");
+            Assert.That(actualMail.CC, Does.Contain(new MailAddress(ccRecipient)), "CC equals");
         }
         if (!string.IsNullOrEmpty(replyTo))
         {
-            Assert.AreEqual(1, actualMail.ReplyToList.Count);
-            Assert.AreEqual(new MailAddress(replyTo), actualMail.ReplyToList[0]);
+            Assert.That(actualMail.ReplyToList.Count, Is.EqualTo(1));
+            Assert.That(actualMail.ReplyToList[0], Is.EqualTo(new MailAddress(replyTo)));
         }
     }
 }

--- a/src/Quartz.Tests.Unit/JobBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/JobBuilderTest.cs
@@ -47,29 +47,35 @@ public class JobBuilderTest
             .StoreDurably()
             .Build();
 
-        Assert.AreEqual("j1", job.Key.Name, "Unexpected job name: " + job.Key.Name);
-        Assert.IsTrue(job.Key.Group.Equals(JobKey.DefaultGroup), "Unexpected job group: " + job.Key.Group);
-        Assert.IsTrue(job.Key.Equals(new JobKey("j1")), "Unexpected job key: " + job.Key);
-        Assert.IsTrue(job.Description is null, "Unexpected job description: " + job.Description);
-        Assert.IsTrue(job.Durable, "Expected isDurable == true ");
-        Assert.IsFalse(job.RequestsRecovery, "Expected requestsRecovery == false ");
-        Assert.IsFalse(job.ConcurrentExecutionDisallowed, "Expected isConcurrentExecutionDisallowed == false ");
-        Assert.IsFalse(job.PersistJobDataAfterExecution, "Expected isPersistJobDataAfterExecution == false ");
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Key.Name, Is.EqualTo("j1"), "Unexpected job name: " + job.Key.Name);
+            Assert.That(job.Key.Group, Is.EqualTo(JobKey.DefaultGroup), "Unexpected job group: " + job.Key.Group);
+            Assert.That(job.Key, Is.EqualTo(new JobKey("j1")), "Unexpected job key: " + job.Key);
+            Assert.That(job.Description, Is.EqualTo(null), "Unexpected job description: " + job.Description);
+            Assert.That(job.Durable, Is.True, "Expected isDurable == true ");
+            Assert.That(job.RequestsRecovery, Is.False, "Expected requestsRecovery == false ");
+            Assert.That(job.ConcurrentExecutionDisallowed, Is.False, "Expected isConcurrentExecutionDisallowed == false ");
+            Assert.That(job.PersistJobDataAfterExecution, Is.False, "Expected isPersistJobDataAfterExecution == false ");
+        });
         job.JobType.Type.Should().Be(typeof(TestJob));
 
         job = JobBuilder.Create()
             .OfType<TestAnnotatedJob>()
             .WithIdentity("j1")
             .WithDescription("my description")
-            .StoreDurably(true)
+            .StoreDurably()
             .RequestRecovery()
             .Build();
 
-        Assert.IsTrue(job.Description.Equals("my description"), "Unexpected job description: " + job.Description);
-        Assert.IsTrue(job.Durable, "Expected isDurable == true ");
-        Assert.IsTrue(job.RequestsRecovery, "Expected requestsRecovery == true ");
-        Assert.IsTrue(job.ConcurrentExecutionDisallowed, "Expected isConcurrentExecutionDisallowed == true ");
-        Assert.IsTrue(job.PersistJobDataAfterExecution, "Expected isPersistJobDataAfterExecution == true ");
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Description, Is.EqualTo("my description"), "Unexpected job description: " + job.Description);
+            Assert.That(job.Durable, Is.True, "Expected isDurable == true ");
+            Assert.That(job.RequestsRecovery, Is.True, "Expected requestsRecovery == true ");
+            Assert.That(job.ConcurrentExecutionDisallowed, Is.True, "Expected isConcurrentExecutionDisallowed == true ");
+            Assert.That(job.PersistJobDataAfterExecution, Is.True, "Expected isPersistJobDataAfterExecution == true ");
+        });
 
         job = JobBuilder.Create()
             .OfType<TestStatefulJob>()
@@ -78,10 +84,13 @@ public class JobBuilderTest
             .RequestRecovery(false)
             .Build();
 
-        Assert.IsTrue(job.Key.Group.Equals("g1"), "Unexpected job group: " + job.Key.Name);
-        Assert.IsFalse(job.Durable, "Expected isDurable == false ");
-        Assert.IsFalse(job.RequestsRecovery, "Expected requestsRecovery == false ");
-        Assert.IsTrue(job.ConcurrentExecutionDisallowed, "Expected isConcurrentExecutionDisallowed == true ");
-        Assert.IsTrue(job.PersistJobDataAfterExecution, "Expected isPersistJobDataAfterExecution == true ");
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Key.Group, Is.EqualTo("g1"), "Unexpected job group: " + job.Key.Name);
+            Assert.That(job.Durable, Is.False, "Expected isDurable == false ");
+            Assert.That(job.RequestsRecovery, Is.False, "Expected requestsRecovery == false ");
+            Assert.That(job.ConcurrentExecutionDisallowed, Is.True, "Expected isConcurrentExecutionDisallowed == true ");
+            Assert.That(job.PersistJobDataAfterExecution, Is.True, "Expected isPersistJobDataAfterExecution == true ");
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/JobDataMapTest.cs
+++ b/src/Quartz.Tests.Unit/JobDataMapTest.cs
@@ -266,6 +266,6 @@ public class JobDataMapTest : SerializationTestSupport<JobDataMap>
         dictionary.Add(SchedulerConstants.ForceJobDataMapDirty, "true");
         var map = new JobDataMap(dictionary);
         map.Dirty.Should().BeTrue();
-        map.ContainsKey(SchedulerConstants.ForceJobDataMapDirty).Should().BeFalse();
+        map.Should().NotContainKey(SchedulerConstants.ForceJobDataMapDirty);
     }
 }

--- a/src/Quartz.Tests.Unit/JobDataMapTest.cs
+++ b/src/Quartz.Tests.Unit/JobDataMapTest.cs
@@ -22,6 +22,7 @@
 using System.Collections;
 using System.Globalization;
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Quartz.Simpl;
 
@@ -53,9 +54,12 @@ public class JobDataMapTest : SerializationTestSupport<JobDataMap>
 
     protected override void VerifyMatch(JobDataMap original, JobDataMap deserialized)
     {
-        deserialized.Should().NotBeNull();
-        deserialized.WrappedMap.Should().BeEquivalentTo(original.WrappedMap);
-        deserialized.Dirty.Should().BeFalse("should not be dirty when returning from serialization");
+        using (new AssertionScope())
+        {
+            deserialized.Should().NotBeNull();
+            deserialized.WrappedMap.Should().BeEquivalentTo(original.WrappedMap);
+            deserialized.Dirty.Should().BeFalse("should not be dirty when returning from serialization");
+        }
     }
 
     [Test]
@@ -63,12 +67,16 @@ public class JobDataMapTest : SerializationTestSupport<JobDataMap>
     {
         var map = new JobDataMap();
         map["key"] = Guid.NewGuid();
-        map.TryGetGuid("key", out var g).Should().BeTrue();
-        g.Should().NotBe(Guid.Empty);
+        using (new AssertionScope())
+        {
+            map.TryGetGuid("key", out var g).Should().BeTrue();
+            g.Should().NotBe(Guid.Empty);
 
-        map["key"] = Guid.NewGuid().ToString();
-        map.TryGetGuid("key", out g).Should().BeTrue();
-        g.Should().NotBe(Guid.Empty);
+            map["key"] = Guid.NewGuid().ToString();
+            map.TryGetGuid("key", out g).Should().BeTrue();
+            g.Should().NotBe(Guid.Empty);
+        }
+
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/JobDetailTest.cs
+++ b/src/Quartz.Tests.Unit/JobDetailTest.cs
@@ -38,10 +38,14 @@ public class JobDetailTest
         JobDetailImpl jd1 = new JobDetailImpl("name", "group", typeof(NoOpJob));
         JobDetailImpl jd2 = new JobDetailImpl("name", "group", typeof(NoOpJob));
         JobDetailImpl jd3 = new JobDetailImpl("namediff", "groupdiff", typeof(NoOpJob));
-        Assert.AreEqual(jd1, jd2);
-        Assert.AreNotEqual(jd1, jd3);
-        Assert.AreNotEqual(jd2, jd3);
-        Assert.AreNotEqual(jd1, null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(jd2, Is.EqualTo(jd1));
+            Assert.That(jd3, Is.Not.EqualTo(jd1));
+            Assert.That(jd3, Is.Not.EqualTo(jd2));
+            Assert.That(jd1, Is.Not.Null);
+        });
+        
     }
 
     [Test]
@@ -50,7 +54,7 @@ public class JobDetailTest
         JobDetailImpl jobDetail = new JobDetailImpl("test", typeof(NoOpJob));
         JobDetailImpl clonedJobDetail = (JobDetailImpl) jobDetail.Clone();
 
-        Assert.AreEqual(jobDetail, clonedJobDetail);
+        Assert.That(clonedJobDetail, Is.EqualTo(jobDetail));
     }
 
     [Test]
@@ -59,8 +63,11 @@ public class JobDetailTest
         JobDetailImpl detail = new JobDetailImpl(nameof(SettingKeyShouldAlsoSetNameAndGroup), typeof(NoOpJob));
         detail.Key = new JobKey("name", "group");
 
-        Assert.That(detail.Name, Is.EqualTo("name"));
-        Assert.That(detail.Group, Is.EqualTo("group"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(detail.Name, Is.EqualTo("name"));
+            Assert.That(detail.Group, Is.EqualTo("group"));
+        });
     }
 
     [Test]
@@ -70,10 +77,13 @@ public class JobDetailTest
         var typeString = type.AssemblyQualifiedNameWithoutVersion();
         var loadedType = new SimpleTypeLoadHelper().LoadType(typeString);
 
-        Assert.That(typeString, Is.Not.Contains(", Version="));
-
-        Assert.That(loadedType, Is.Not.Null);
-        Assert.That(loadedType, Is.EqualTo(type));
+        Assert.Multiple(() =>
+        {
+            Assert.That(typeString, Is.Not.Contains(", Version="));
+            Assert.That(loadedType, Is.Not.Null);
+            Assert.That(loadedType, Is.EqualTo(type));
+        });
+        
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/JobDetailTest.cs
+++ b/src/Quartz.Tests.Unit/JobDetailTest.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Quartz.Impl;
 using Quartz.Job;
@@ -91,9 +92,11 @@ public class JobDetailTest
     {
         var type = typeof(GenericJob<string>);
         var job = new JobDetailImpl("name", "group", type, true, true);
-
-        job.JobType.Type.Should().Be(type);
-        job.JobType.FullName.Should().Be(type.AssemblyQualifiedNameWithoutVersion());
+        using (new AssertionScope())
+        {
+            job.JobType.Type.Should().Be(type);
+            job.JobType.FullName.Should().Be(type.AssemblyQualifiedNameWithoutVersion());
+        }
     }
 
     public class GenericJob<T> : IJob

--- a/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
+++ b/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
@@ -17,7 +17,7 @@ namespace Quartz.Tests.Unit;
 public class JobExecutionAttributesInterfaceInheritanceTest
 {
     private static readonly TimeSpan jobBlockTime = TimeSpan.FromMilliseconds(300);
-    private static readonly List<DateTime> jobExecDates = new();
+    private static readonly List<DateTime> jobExecDates = [];
     private static readonly AutoResetEvent barrier = new(false);
 
     [OneTimeTearDown]

--- a/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
+++ b/src/Quartz.Tests.Unit/JobExecutionAttributesInterfaceInheritanceTest.cs
@@ -82,8 +82,11 @@ public class JobExecutionAttributesInterfaceInheritanceTest
     public void TestWhetherAttributesAreInheritedFromInterfaces()
     {
         IJobDetail job = JobBuilder.Create<TestJob>().Build();
-        Assert.That(job.PersistJobDataAfterExecution, Is.True);
-        Assert.That(job.ConcurrentExecutionDisallowed, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.PersistJobDataAfterExecution, Is.True);
+            Assert.That(job.ConcurrentExecutionDisallowed, Is.True);
+        });
     }
 
     [Test]
@@ -113,7 +116,7 @@ public class JobExecutionAttributesInterfaceInheritanceTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(jobExecDates.Count, Is.EqualTo(2));
+            Assert.That(jobExecDates, Has.Count.EqualTo(2));
             Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5d));
         });
     }
@@ -149,7 +152,7 @@ public class JobExecutionAttributesInterfaceInheritanceTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(jobExecDates.Count, Is.EqualTo(2));
+            Assert.That(jobExecDates, Has.Count.EqualTo(2));
             Assert.That((jobExecDates[1] - jobExecDates[0]).TotalMilliseconds, Is.GreaterThanOrEqualTo(jobBlockTime.TotalMilliseconds).Within(5));
         });
     }

--- a/src/Quartz.Tests.Unit/JobExecutionContextTest.cs
+++ b/src/Quartz.Tests.Unit/JobExecutionContextTest.cs
@@ -42,8 +42,11 @@ public class JobExecutionContextTest
         ctx.MergedJobDataMap[SchedulerConstants.FailedJobOriginalTriggerName] = "originalTriggerName";
         ctx.MergedJobDataMap[SchedulerConstants.FailedJobOriginalTriggerGroup] = "originalTriggerGroup";
         var recoveringTriggerKey = ctx.RecoveringTriggerKey;
-        Assert.NotNull(recoveringTriggerKey);
-        Assert.That(recoveringTriggerKey.Name, Is.EqualTo("originalTriggerName"));
-        Assert.That(recoveringTriggerKey.Group, Is.EqualTo("originalTriggerGroup"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(recoveringTriggerKey, Is.Not.Null);
+            Assert.That(recoveringTriggerKey.Name, Is.EqualTo("originalTriggerName"));
+            Assert.That(recoveringTriggerKey.Group, Is.EqualTo("originalTriggerGroup"));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/Plugin/History/LoggingJobHistoryPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/History/LoggingJobHistoryPluginTest.cs
@@ -45,7 +45,7 @@ public class LoggingJobHistoryPluginTest
         JobExecutionException ex = new JobExecutionException("test error");
         await plugin.JobWasExecuted(CreateJobExecutionContext(), ex);
 
-        Assert.That(plugin.WarnMessages.Count, Is.EqualTo(1));
+        Assert.That(plugin.WarnMessages, Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -53,7 +53,7 @@ public class LoggingJobHistoryPluginTest
     {
         await plugin.JobWasExecuted(CreateJobExecutionContext(), null);
 
-        Assert.That(plugin.InfoMessages.Count, Is.EqualTo(1));
+        Assert.That(plugin.InfoMessages, Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -61,7 +61,7 @@ public class LoggingJobHistoryPluginTest
     {
         await plugin.JobToBeExecuted(CreateJobExecutionContext());
 
-        Assert.That(plugin.InfoMessages.Count, Is.EqualTo(1));
+        Assert.That(plugin.InfoMessages, Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -69,7 +69,7 @@ public class LoggingJobHistoryPluginTest
     {
         await plugin.JobExecutionVetoed(CreateJobExecutionContext());
 
-        Assert.That(plugin.InfoMessages.Count, Is.EqualTo(1));
+        Assert.That(plugin.InfoMessages, Has.Count.EqualTo(1));
     }
 
     protected virtual ICancellableJobExecutionContext CreateJobExecutionContext()

--- a/src/Quartz.Tests.Unit/Plugin/History/LoggingTriggerHistoryPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/History/LoggingTriggerHistoryPluginTest.cs
@@ -52,7 +52,7 @@ public class LoggingTriggerHistoryPluginTest
 
         await plugin.TriggerFired(t, ctx);
 
-        Assert.That(plugin.InfoMessages.Count, Is.EqualTo(1));
+        Assert.That(plugin.InfoMessages, Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -66,7 +66,7 @@ public class LoggingTriggerHistoryPluginTest
 
         await plugin.TriggerMisfired(t);
 
-        Assert.That(plugin.InfoMessages.Count, Is.EqualTo(1));
+        Assert.That(plugin.InfoMessages, Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -83,7 +83,7 @@ public class LoggingTriggerHistoryPluginTest
 
         await plugin.TriggerComplete(t, ctx, SchedulerInstruction.ReExecuteJob);
 
-        Assert.That(plugin.InfoMessages.Count, Is.EqualTo(1));
+        Assert.That(plugin.InfoMessages, Has.Count.EqualTo(1));
     }
 
     private class RecordingLoggingTriggerHistoryPlugin : LoggingTriggerHistoryPlugin

--- a/src/Quartz.Tests.Unit/Plugin/Interrupt/AutoInterruptableJobTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/Interrupt/AutoInterruptableJobTest.cs
@@ -46,7 +46,7 @@ public class AutoInterruptableJobTest
 
         var executingJobs = await scheduler.GetCurrentlyExecutingJobs();
 
-        Assert.That(executingJobs.Count, Is.EqualTo(1), "Number of executing jobs should be 1");
+        Assert.That(executingJobs, Has.Count.EqualTo(1), "Number of executing jobs should be 1");
 
         await sync.WaitAsync(); // wait for the job to terminate
 

--- a/src/Quartz.Tests.Unit/Plugin/TimeZoneConverter/TimeZoneConverterTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/TimeZoneConverter/TimeZoneConverterTest.cs
@@ -17,7 +17,7 @@ public class TimeZoneConverterTest
         }
         finally
         {
-            TimeZoneUtil.CustomResolver = id => null;
+            TimeZoneUtil.CustomResolver = _ => null;
         }
     }
 }

--- a/src/Quartz.Tests.Unit/Plugin/Xml/XMLSchedulingDataProcessorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/Xml/XMLSchedulingDataProcessorPluginTest.cs
@@ -19,13 +19,15 @@ public class XMLSchedulingDataProcessorPluginTest
         {
         }
 
-        var dataProcessor = new XMLSchedulingDataProcessorPlugin();
-        dataProcessor.FileNames = fp1 + ", " + fp2;
+        var dataProcessor = new XMLSchedulingDataProcessorPlugin
+        {
+            FileNames = fp1 + ", " + fp2
+        };
         var mockScheduler = A.Fake<IScheduler>();
 
         await dataProcessor.Initialize("something", mockScheduler);
 
-        Assert.That(dataProcessor.JobFiles.Count, Is.EqualTo(2));
+        Assert.That(dataProcessor.JobFiles, Has.Count.EqualTo(2));
         Assert.That(dataProcessor.JobFiles.Select(x => x.Key), Is.EqualTo(new[] { fp1, fp2 }));
     }
 
@@ -53,7 +55,7 @@ public class XMLSchedulingDataProcessorPluginTest
 
         await dataProcessor.Initialize("something", mockScheduler);
 
-        Assert.That(dataProcessor.JobFiles.Count, Is.EqualTo(2));
+        Assert.That(dataProcessor.JobFiles, Has.Count.EqualTo(2));
         Assert.That(dataProcessor.JobFiles.Select(x => x.Key).ToArray(), Is.EqualTo(new[] { expectedPathFile1, expectedPathFile2 }));
     }
 

--- a/src/Quartz.Tests.Unit/PriorityTest.cs
+++ b/src/Quartz.Tests.Unit/PriorityTest.cs
@@ -45,6 +45,12 @@ public class PriorityTest
         countdownEvent = new CountdownEvent(2);
     }
 
+    [TearDown]
+    public void TearDown()
+    {
+        countdownEvent.Dispose();
+    }
+
     [Test]
     public async Task TestSameDefaultPriority()
     {
@@ -72,7 +78,7 @@ public class PriorityTest
 
         countdownEvent.Wait();
 
-        Assert.AreEqual("T1T2", result.ToString());
+        Assert.That(result.ToString(), Is.EqualTo("T1T2"));
 
         await sched.Shutdown();
     }
@@ -107,7 +113,7 @@ public class PriorityTest
 
         countdownEvent.Wait();
 
-        Assert.AreEqual("T2T1", result.ToString());
+        Assert.That(result.ToString(), Is.EqualTo("T2T1"));
 
         await sched.Shutdown();
     }

--- a/src/Quartz.Tests.Unit/QualityTest.cs
+++ b/src/Quartz.Tests.Unit/QualityTest.cs
@@ -24,7 +24,8 @@ public class QualityTest
             .Select(method =>
                 $"'{method.DeclaringType.Name}.{method.Name}' is an async void method.")
             .ToList();
-        Assert.False(messages.Any(),
+        Assert.That(messages.Any(),
+            Is.False,
             "Async void methods found!" + Environment.NewLine + string.Join(Environment.NewLine, messages));
     }
 }

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -23,6 +23,10 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="FluentAssertions.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
@@ -30,6 +34,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Npgsql.DependencyInjection" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Verify.NUnit" />
   </ItemGroup>

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -404,8 +404,11 @@ public class QuartzHostedServiceTests
 
         await quartzHostedService.StopAsync(CancellationToken.None);
 
-        Assert.That(schedulerFactory.LastCreatedScheduler.IsStarted, Is.False);
-        Assert.That(schedulerFactory.LastCreatedScheduler.IsShutdown, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(schedulerFactory.LastCreatedScheduler.IsStarted, Is.False);
+            Assert.That(schedulerFactory.LastCreatedScheduler.IsShutdown, Is.True);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -11,20 +11,20 @@ public class QuartzHostedServiceTests
 {
     private sealed class MockApplicationLifetime : Lifetime
     {
-        public CancellationTokenSource StartedSource { get; } = new CancellationTokenSource();
-        public CancellationTokenSource StoppingSource { get; } = new CancellationTokenSource();
-        public CancellationToken ApplicationStarted => this.StartedSource.Token;
-        public CancellationToken ApplicationStopping => this.StoppingSource.Token;
+        public CancellationTokenSource StartedSource { get; } = new();
+        public CancellationTokenSource StoppingSource { get; } = new();
+        public CancellationToken ApplicationStarted => StartedSource.Token;
+        public CancellationToken ApplicationStopping => StoppingSource.Token;
         public CancellationToken ApplicationStopped => throw new NotImplementedException();
 
         public void SetStarted()
         {
-            this.StartedSource.Cancel();
+            StartedSource.Cancel();
         }
 
         public void StopApplication()
         {
-            this.StoppingSource.Cancel();
+            StoppingSource.Cancel();
         }
     }
 
@@ -353,13 +353,13 @@ public class QuartzHostedServiceTests
                 StartDelay = withStartDelay ? TimeSpan.FromMinutes(1) : null,
             }));
 
-        Assert.Null(schedulerFactory.LastCreatedScheduler);
+        Assert.That(schedulerFactory.LastCreatedScheduler, Is.Null);
 
         using var startupCts = new CancellationTokenSource();
 
         await quartzHostedService.StartAsync(startupCts.Token);
 
-        Assert.NotNull(schedulerFactory.LastCreatedScheduler);
+        Assert.That(schedulerFactory.LastCreatedScheduler, Is.Not.Null);
 
         await startupCts.CancelAsync().ConfigureAwait(false);
     }
@@ -387,8 +387,8 @@ public class QuartzHostedServiceTests
 
         await quartzHostedService.StartAsync(startupCts.Token);
 
-        Assert.NotNull(schedulerFactory.LastCreatedScheduler);
-        Assert.AreEqual(shouldSchedulerBeStartedImmediately, schedulerFactory.LastCreatedScheduler.IsStarted);
+        Assert.That(schedulerFactory.LastCreatedScheduler, Is.Not.Null);
+        Assert.That(schedulerFactory.LastCreatedScheduler.IsStarted, Is.EqualTo(shouldSchedulerBeStartedImmediately));
 
         appliationLifetime.SetStarted();
 
@@ -398,14 +398,14 @@ public class QuartzHostedServiceTests
                 .ContinueWith(_ => { }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default); // Wait for the hosted service to respond to the ApplicationStarted token
         }
 
-        Assert.AreEqual(!withStartDelay, schedulerFactory.LastCreatedScheduler.IsStarted);
+        Assert.That(schedulerFactory.LastCreatedScheduler.IsStarted, Is.EqualTo(!withStartDelay));
 
         await startupCts.CancelAsync().ConfigureAwait(false);
 
         await quartzHostedService.StopAsync(CancellationToken.None);
 
-        Assert.False(schedulerFactory.LastCreatedScheduler.IsStarted);
-        Assert.True(schedulerFactory.LastCreatedScheduler.IsShutdown);
+        Assert.That(schedulerFactory.LastCreatedScheduler.IsStarted, Is.False);
+        Assert.That(schedulerFactory.LastCreatedScheduler.IsShutdown, Is.True);
     }
 
     [Test]
@@ -435,7 +435,7 @@ public class QuartzHostedServiceTests
 
         await startupTask;
 
-        Assert.AreEqual(shouldSchedulerBeStarted, schedulerFactory.LastCreatedScheduler.IsStarted);
+        Assert.That(schedulerFactory.LastCreatedScheduler.IsStarted, Is.EqualTo(shouldSchedulerBeStarted));
     }
 
     [Test]
@@ -474,10 +474,10 @@ public class QuartzHostedServiceTests
         // Confirm that not only have we stopped, but that we have not started AFTER being stopped
         if (shouldSchedulerBeStarted)
         {
-            Assert.True(schedulerFactory.LastCreatedScheduler.IsShutdown);
+            Assert.That(schedulerFactory.LastCreatedScheduler.IsShutdown, Is.True);
         }
 
-        Assert.False(schedulerFactory.LastCreatedScheduler.IsStarted);
+        Assert.That(schedulerFactory.LastCreatedScheduler.IsStarted, Is.False);
 
         await startupCts.CancelAsync().ConfigureAwait(false);
     }

--- a/src/Quartz.Tests.Unit/SchedulerBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerBuilderTest.cs
@@ -19,8 +19,11 @@ public class SchedulerBuilderTest
         config.UseInMemoryStore();
         config.UseDefaultThreadPool(x => x.MaxConcurrency = 100);
 
-        Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(RAMJobStore).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.threadPool.maxConcurrency"], Is.EqualTo("100"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(RAMJobStore).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.threadPool.maxConcurrency"], Is.EqualTo("100"));
+        });
     }
 
 
@@ -46,18 +49,21 @@ public class SchedulerBuilderTest
                 db.UseConnectionProvider<CustomConnectionProvider>();
             });
         });
-        Assert.That(config.Properties["quartz.dataSource.sql-server-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.Properties["quartz.dataSource.sql-server-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
 
-        Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(SqlServerDelegate).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("sql-server-01"));
-        Assert.That(config.Properties["quartz.jobStore.tablePrefix"], Is.EqualTo("QRTZ2019_"));
-        Assert.That(config.Properties["quartz.jobStore.performSchemaValidation"], Is.EqualTo("true"));
-        Assert.That(config.Properties["quartz.jobStore.clusterCheckinInterval"], Is.EqualTo("10000"));
-        Assert.That(config.Properties["quartz.jobStore.clusterCheckinMisfireThreshold"], Is.EqualTo("15000"));
-        Assert.That(config.Properties[StdSchedulerFactory.PropertyJobStoreDbRetryInterval], Is.EqualTo("20000"));
+            Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(SqlServerDelegate).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("sql-server-01"));
+            Assert.That(config.Properties["quartz.jobStore.tablePrefix"], Is.EqualTo("QRTZ2019_"));
+            Assert.That(config.Properties["quartz.jobStore.performSchemaValidation"], Is.EqualTo("true"));
+            Assert.That(config.Properties["quartz.jobStore.clusterCheckinInterval"], Is.EqualTo("10000"));
+            Assert.That(config.Properties["quartz.jobStore.clusterCheckinMisfireThreshold"], Is.EqualTo("15000"));
+            Assert.That(config.Properties[StdSchedulerFactory.PropertyJobStoreDbRetryInterval], Is.EqualTo("20000"));
 
-        Assert.That(config.Properties["quartz.dataSource.sql-server-01.connectionProvider.type"], Is.EqualTo("Quartz.Tests.Unit.SchedulerBuilderTest+CustomConnectionProvider, Quartz.Tests.Unit"));
+            Assert.That(config.Properties["quartz.dataSource.sql-server-01.connectionProvider.type"], Is.EqualTo("Quartz.Tests.Unit.SchedulerBuilderTest+CustomConnectionProvider, Quartz.Tests.Unit"));
+        });
     }
 
     public class CustomConnectionProvider : IDbProvider
@@ -93,11 +99,13 @@ public class SchedulerBuilderTest
             .UsePersistentStore(s =>
                 s.UsePostgres("postgres-01", "Server=localhost;Database=quartznet;")
             );
-        Assert.That(config.Properties["quartz.dataSource.postgres-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
-
-        Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(PostgreSQLDelegate).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("postgres-01"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.Properties["quartz.dataSource.postgres-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
+            Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(PostgreSQLDelegate).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("postgres-01"));
+        });
     }
 
     [Test]
@@ -108,11 +116,13 @@ public class SchedulerBuilderTest
             .UsePersistentStore(s =>
                 s.UseMySql("mysql-01", "Server=localhost;Database=quartznet;")
             );
-        Assert.That(config.Properties["quartz.dataSource.mysql-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
-
-        Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(MySQLDelegate).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("mysql-01"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.Properties["quartz.dataSource.mysql-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
+            Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(MySQLDelegate).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("mysql-01"));
+        });
     }
 
     [Test]
@@ -123,11 +133,13 @@ public class SchedulerBuilderTest
             .UsePersistentStore(p =>
                 p.UseFirebird("firebird-01", "Server=localhost;Database=quartznet;")
             );
-        Assert.That(config.Properties["quartz.dataSource.firebird-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
-
-        Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(FirebirdDelegate).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("firebird-01"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.Properties["quartz.dataSource.firebird-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
+            Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(FirebirdDelegate).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("firebird-01"));
+        });
     }
 
     [Test]
@@ -137,11 +149,13 @@ public class SchedulerBuilderTest
         config.UsePersistentStore(s =>
             s.UseOracle("oracle-01", "Server=localhost;Database=quartznet;")
         );
-        Assert.That(config.Properties["quartz.dataSource.oracle-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
-
-        Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(OracleDelegate).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("oracle-01"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.Properties["quartz.dataSource.oracle-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
+            Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(OracleDelegate).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("oracle-01"));
+        });
 
     }
 
@@ -152,11 +166,13 @@ public class SchedulerBuilderTest
         config.UsePersistentStore(options =>
             options.UseSQLite("sqlite-01", "Server=localhost;Database=quartznet;")
         );
-        Assert.That(config.Properties["quartz.dataSource.sqlite-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
-
-        Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(SQLiteDelegate).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("sqlite-01"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.Properties["quartz.dataSource.sqlite-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
+            Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(SQLiteDelegate).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("sqlite-01"));
+        });
     }
 
     [Test]
@@ -166,11 +182,13 @@ public class SchedulerBuilderTest
         config.UsePersistentStore(options =>
             options.UseMicrosoftSQLite("sqlite-01", "Server=localhost;Database=quartznet;")
         );
-        Assert.That(config.Properties["quartz.dataSource.sqlite-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
-
-        Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(SQLiteDelegate).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("sqlite-01"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.Properties["quartz.dataSource.sqlite-01.connectionString"], Is.EqualTo("Server=localhost;Database=quartznet;"));
+            Assert.That(config.Properties["quartz.jobStore.type"], Is.EqualTo(typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.driverDelegateType"], Is.EqualTo(typeof(SQLiteDelegate).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(config.Properties["quartz.jobStore.dataSource"], Is.EqualTo("sqlite-01"));
+        });
     }
 
     [Test]
@@ -188,17 +206,20 @@ public class SchedulerBuilderTest
         var builder = SchedulerBuilder.Create()
             .UseXmlSchedulingConfiguration(x =>
             {
-                x.Files = new[] { "jobs.xml", "jobs2.xml" };
+                x.Files = ["jobs.xml", "jobs2.xml"];
                 x.ScanInterval = TimeSpan.FromSeconds(2);
                 x.FailOnFileNotFound = true;
                 x.FailOnSchedulingError = true;
             });
 
-        Assert.That(builder.Properties["quartz.plugin.xml.type"], Is.EqualTo(typeof(XMLSchedulingDataProcessorPlugin).AssemblyQualifiedNameWithoutVersion()));
-        Assert.That(builder.Properties["quartz.plugin.xml.fileNames"], Is.EqualTo("jobs.xml,jobs2.xml"));
-        Assert.That(builder.Properties["quartz.plugin.xml.failOnFileNotFound"], Is.EqualTo("true"));
-        Assert.That(builder.Properties["quartz.plugin.xml.failOnSchedulingError"], Is.EqualTo("true"));
-        Assert.That(builder.Properties["quartz.plugin.xml.scanInterval"], Is.EqualTo("2"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(builder.Properties["quartz.plugin.xml.type"], Is.EqualTo(typeof(XMLSchedulingDataProcessorPlugin).AssemblyQualifiedNameWithoutVersion()));
+            Assert.That(builder.Properties["quartz.plugin.xml.fileNames"], Is.EqualTo("jobs.xml,jobs2.xml"));
+            Assert.That(builder.Properties["quartz.plugin.xml.failOnFileNotFound"], Is.EqualTo("true"));
+            Assert.That(builder.Properties["quartz.plugin.xml.failOnSchedulingError"], Is.EqualTo("true"));
+            Assert.That(builder.Properties["quartz.plugin.xml.scanInterval"], Is.EqualTo("2"));
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/SchedulerListenerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerListenerTest.cs
@@ -120,7 +120,7 @@ public class SchedulerListenerTest
             return default;
         }
 
-        public ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = new CancellationToken())
+        public ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = new())
         {
             return default;
         }
@@ -201,8 +201,11 @@ public class SchedulerListenerTest
 
         await scheduler.Shutdown(true);
 
-        Assert.AreEqual(2, jobExecutionCount);
-        Assert.AreEqual(3, triggerListener.FireCount);
-        Assert.AreEqual(1, schedulerListener.TriggerFinalizedCount);
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobExecutionCount, Is.EqualTo(2));
+            Assert.That(triggerListener.FireCount, Is.EqualTo(3));
+            Assert.That(schedulerListener.TriggerFinalizedCount, Is.EqualTo(1));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -85,8 +85,10 @@ public class SchedulerTest
     {
         string input = "0 0 03-07 ? * MON-FRI | 0 35/15 07 ? * MON-FRI | 0 05/15 08-14 ? * MON-FRI | 0 0/10 15-16 ? * MON-FRI | 0 05/15 17-23 ? * MON-FRI";
 
-        NameValueCollection properties = new NameValueCollection();
-        properties["quartz.serializer.type"] = TestConstants.DefaultSerializerType;
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
+        };
         ISchedulerFactory factory = new StdSchedulerFactory(properties);
 
         IScheduler scheduler = await factory.GetScheduler();
@@ -98,12 +100,14 @@ public class SchedulerTest
     [Test]
     public async Task TestBasicStorageFunctions()
     {
-        NameValueCollection config = new NameValueCollection();
-        config["quartz.scheduler.instanceName"] = "SchedulerTest_Scheduler";
-        config["quartz.scheduler.instanceId"] = "AUTO";
-        config["quartz.threadPool.threadCount"] = "2";
-        config["quartz.threadPool.type"] = "Quartz.Simpl.DefaultThreadPool, Quartz";
-        config["quartz.serializer.type"] = TestConstants.DefaultSerializerType;
+        NameValueCollection config = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = "SchedulerTest_Scheduler",
+            ["quartz.scheduler.instanceId"] = "AUTO",
+            ["quartz.threadPool.threadCount"] = "2",
+            ["quartz.threadPool.type"] = "Quartz.Simpl.DefaultThreadPool, Quartz",
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
+        };
         IScheduler sched = await new StdSchedulerFactory(config).GetScheduler();
 
         // test basic storage functions of scheduler...
@@ -115,16 +119,16 @@ public class SchedulerTest
             .Build();
 
         var exists = await sched.CheckExists(new JobKey("j1"));
-        Assert.IsFalse(exists, "Unexpected existence of job named 'j1'.");
+        Assert.That(exists, Is.False, "Unexpected existence of job named 'j1'.");
 
         await sched.AddJob(job, false);
 
         exists = await sched.CheckExists(new JobKey("j1"));
-        Assert.IsTrue(exists, "Expected existence of job named 'j1' but checkExists return false.");
+        Assert.That(exists, Is.True, "Expected existence of job named 'j1' but checkExists return false.");
 
         job = await sched.GetJobDetail(new JobKey("j1"));
 
-        Assert.IsNotNull(job, "Stored job not found!");
+        Assert.That(job, Is.Not.Null, "Stored job not found!");
 
         await sched.DeleteJob(new JobKey("j1"));
 
@@ -136,20 +140,20 @@ public class SchedulerTest
             .Build();
 
         exists = await sched.CheckExists(new TriggerKey("t1"));
-        Assert.IsFalse(exists, "Unexpected existence of trigger named '11'.");
+        Assert.That(exists, Is.False, "Unexpected existence of trigger named '11'.");
 
         await sched.ScheduleJob(job, trigger);
 
         exists = await sched.CheckExists(new TriggerKey("t1"));
-        Assert.IsTrue(exists, "Expected existence of trigger named 't1' but checkExists return false.");
+        Assert.That(exists, Is.True, "Expected existence of trigger named 't1' but checkExists return false.");
 
         job = await sched.GetJobDetail(new JobKey("j1"));
 
-        Assert.IsNotNull(job, "Stored job not found!");
+        Assert.That(job, Is.Not.Null, "Stored job not found!");
 
         trigger = await sched.GetTrigger(new TriggerKey("t1"));
 
-        Assert.IsNotNull(trigger, "Stored trigger not found!");
+        Assert.That(trigger, Is.Not.Null, "Stored trigger not found!");
 
         job = JobBuilder.Create()
             .OfType<TestJob>()
@@ -182,34 +186,43 @@ public class SchedulerTest
         var jobGroups = await sched.GetJobGroupNames();
         var triggerGroups = await sched.GetTriggerGroupNames();
 
-        Assert.AreEqual(2, jobGroups.Count, "Job group list size expected to be = 2 ");
-        Assert.AreEqual(2, triggerGroups.Count, "Trigger group list size expected to be = 2 ");
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobGroups.Count, Is.EqualTo(2), "Job group list size expected to be = 2 ");
+            Assert.That(triggerGroups.Count, Is.EqualTo(2), "Trigger group list size expected to be = 2 ");
+        });
 
         var jobKeys = await sched.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(JobKey.DefaultGroup));
         var triggerKeys = await sched.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals(TriggerKey.DefaultGroup));
 
-        Assert.AreEqual(1, jobKeys.Count, "Number of jobs expected in default group was 1 ");
-        Assert.AreEqual(1, triggerKeys.Count, "Number of triggers expected in default group was 1 ");
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobKeys.Count, Is.EqualTo(1), "Number of jobs expected in default group was 1 ");
+            Assert.That(triggerKeys.Count, Is.EqualTo(1), "Number of triggers expected in default group was 1 ");
+        });
 
         jobKeys = await sched.GetJobKeys(GroupMatcher<JobKey>.GroupEquals("g1"));
         triggerKeys = await sched.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals("g1"));
 
-        Assert.AreEqual(2, jobKeys.Count, "Number of jobs expected in 'g1' group was 2 ");
-        Assert.AreEqual(2, triggerKeys.Count, "Number of triggers expected in 'g1' group was 2 ");
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobKeys.Count, Is.EqualTo(2), "Number of jobs expected in 'g1' group was 2 ");
+            Assert.That(triggerKeys.Count, Is.EqualTo(2), "Number of triggers expected in 'g1' group was 2 ");
+        });
 
         TriggerState s = await sched.GetTriggerState(new TriggerKey("t2", "g1"));
-        Assert.AreEqual(TriggerState.Normal, s, "State of trigger t2 expected to be NORMAL ");
+        Assert.That(s, Is.EqualTo(TriggerState.Normal), "State of trigger t2 expected to be NORMAL ");
 
         await sched.PauseTrigger(new TriggerKey("t2", "g1"));
         s = await sched.GetTriggerState(new TriggerKey("t2", "g1"));
-        Assert.AreEqual(TriggerState.Paused, s, "State of trigger t2 expected to be PAUSED ");
+        Assert.That(s, Is.EqualTo(TriggerState.Paused), "State of trigger t2 expected to be PAUSED ");
 
         await sched.ResumeTrigger(new TriggerKey("t2", "g1"));
         s = await sched.GetTriggerState(new TriggerKey("t2", "g1"));
-        Assert.AreEqual(TriggerState.Normal, s, "State of trigger t2 expected to be NORMAL ");
+        Assert.That(s, Is.EqualTo(TriggerState.Normal), "State of trigger t2 expected to be NORMAL ");
 
         var pausedGroups = await sched.GetPausedTriggerGroups();
-        Assert.AreEqual(0, pausedGroups.Count, "Size of paused trigger groups list expected to be 0 ");
+        Assert.That(pausedGroups.Count, Is.EqualTo(0), "Size of paused trigger groups list expected to be 0 ");
 
         await sched.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals("g1"));
 
@@ -229,42 +242,48 @@ public class SchedulerTest
         await sched.ScheduleJob(job, trigger);
 
         pausedGroups = await sched.GetPausedTriggerGroups();
-        Assert.AreEqual(1, pausedGroups.Count, "Size of paused trigger groups list expected to be 1 ");
+        Assert.That(pausedGroups.Count, Is.EqualTo(1), "Size of paused trigger groups list expected to be 1 ");
 
         s = await sched.GetTriggerState(new TriggerKey("t2", "g1"));
-        Assert.AreEqual(TriggerState.Paused, s, "State of trigger t2 expected to be PAUSED ");
+        Assert.That(s, Is.EqualTo(TriggerState.Paused), "State of trigger t2 expected to be PAUSED ");
 
         s = await sched.GetTriggerState(new TriggerKey("t4", "g1"));
-        Assert.AreEqual(TriggerState.Paused, s, "State of trigger t4 expected to be PAUSED");
+        Assert.That(s, Is.EqualTo(TriggerState.Paused), "State of trigger t4 expected to be PAUSED");
 
         await sched.ResumeTriggers(GroupMatcher<TriggerKey>.GroupEquals("g1"));
 
         s = await sched.GetTriggerState(new TriggerKey("t2", "g1"));
-        Assert.AreEqual(TriggerState.Normal, s, "State of trigger t2 expected to be NORMAL ");
+        Assert.That(s, Is.EqualTo(TriggerState.Normal), "State of trigger t2 expected to be NORMAL ");
 
         s = await sched.GetTriggerState(new TriggerKey("t4", "g1"));
-        Assert.AreEqual(TriggerState.Normal, s, "State of trigger t2 expected to be NORMAL ");
+        Assert.That(s, Is.EqualTo(TriggerState.Normal), "State of trigger t2 expected to be NORMAL ");
 
         pausedGroups = await sched.GetPausedTriggerGroups();
-        Assert.AreEqual(0, pausedGroups.Count, "Size of paused trigger groups list expected to be 0 ");
-
-        Assert.IsFalse(await sched.UnscheduleJob(new TriggerKey("foasldfksajdflk")), "Scheduler should have returned 'false' from attempt to unschedule non-existing trigger. ");
-
-        Assert.IsTrue(await sched.UnscheduleJob(new TriggerKey("t3", "g1")), "Scheduler should have returned 'true' from attempt to unschedule existing trigger. ");
+        await Assert.MultipleAsync(async () =>
+        {
+            Assert.That(pausedGroups.Count, Is.EqualTo(0), "Size of paused trigger groups list expected to be 0 ");
+            Assert.That(await sched.UnscheduleJob(new TriggerKey("foasldfksajdflk")), Is.False, "Scheduler should have returned 'false' from attempt to unschedule non-existing trigger. ");
+            Assert.That(await sched.UnscheduleJob(new TriggerKey("t3", "g1")), Is.True, "Scheduler should have returned 'true' from attempt to unschedule existing trigger. ");
+        });
 
         jobKeys = await sched.GetJobKeys(GroupMatcher<JobKey>.GroupEquals("g1"));
         triggerKeys = await sched.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals("g1"));
 
-        Assert.AreEqual(2, jobKeys.Count, "Number of jobs expected in 'g1' group was 1 "); // job should have been deleted also, because it is non-durable
-        Assert.AreEqual(2, triggerKeys.Count, "Number of triggers expected in 'g1' group was 1 ");
-
-        Assert.IsTrue(await sched.UnscheduleJob(new TriggerKey("t1")), "Scheduler should have returned 'true' from attempt to unschedule existing trigger. ");
+        await Assert.MultipleAsync(async () =>
+        {
+            Assert.That(jobKeys.Count, Is.EqualTo(2), "Number of jobs expected in 'g1' group was 1 "); // job should have been deleted also, because it is non-durable
+            Assert.That(triggerKeys.Count, Is.EqualTo(2), "Number of triggers expected in 'g1' group was 1 ");
+            Assert.That(await sched.UnscheduleJob(new TriggerKey("t1")), Is.True, "Scheduler should have returned 'true' from attempt to unschedule existing trigger. ");
+        });
 
         jobKeys = await sched.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(JobKey.DefaultGroup));
         triggerKeys = await sched.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals(TriggerKey.DefaultGroup));
 
-        Assert.AreEqual(1, jobKeys.Count, "Number of jobs expected in default group was 1 "); // job should have been left in place, because it is non-durable
-        Assert.AreEqual(0, triggerKeys.Count, "Number of triggers expected in default group was 0 ");
+        Assert.Multiple(() =>
+        {
+            Assert.That(jobKeys.Count, Is.EqualTo(1), "Number of jobs expected in default group was 1 "); // job should have been left in place, because it is non-durable
+            Assert.That(triggerKeys.Count, Is.EqualTo(0), "Number of triggers expected in default group was 0 ");
+        });
 
         await sched.Shutdown();
     }
@@ -381,16 +400,18 @@ public class SchedulerTest
             after = (SchedulerException) formatter.Deserialize(stream);
         }
 
-        Assert.NotNull(before.InnerException);
-        Assert.NotNull(after.InnerException);
-        Assert.AreEqual(before.ToString(), after.ToString());
+        Assert.That(before.InnerException, Is.Not.Null);
+        Assert.That(after.InnerException, Is.Not.Null);
+        Assert.That(after.ToString(), Is.EqualTo(before.ToString()));
     }
 
     [Test]
     public async Task ReschedulingTriggerShouldKeepOriginalNextFireTime()
     {
-        NameValueCollection properties = new NameValueCollection();
-        properties["quartz.serializer.type"] = TestConstants.DefaultSerializerType;
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
+        };
         ISchedulerFactory factory = new StdSchedulerFactory(properties);
         IScheduler scheduler = await factory.GetScheduler();
         await scheduler.Start();

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -325,8 +325,11 @@ public class SchedulerTest
 
         stopwatch.Stop();
 
-        Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5));
-        Assert.That(completed.WaitOne(0), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TestJobWithDelay.Delay.TotalMilliseconds).Within(5));
+            Assert.That(completed.WaitOne(0), Is.True);
+        });
     }
 
     [Test]
@@ -364,10 +367,13 @@ public class SchedulerTest
 
         stopwatch.Stop();
 
-        // Shutdown should be fast since we're not waiting for tasks to complete
-        Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50));
-        // The task should still be executing
-        Assert.That(completed.WaitOne(0), Is.False);
+        Assert.Multiple(() =>
+        {
+            // Shutdown should be fast since we're not waiting for tasks to complete
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50));
+            // The task should still be executing
+            Assert.That(completed.WaitOne(0), Is.False);
+        });
     }
 
     [Test]
@@ -400,9 +406,12 @@ public class SchedulerTest
             after = (SchedulerException) formatter.Deserialize(stream);
         }
 
-        Assert.That(before.InnerException, Is.Not.Null);
-        Assert.That(after.InnerException, Is.Not.Null);
-        Assert.That(after.ToString(), Is.EqualTo(before.ToString()));
+        Assert.Multiple(() =>
+        {
+            Assert.That(before.InnerException, Is.Not.Null);
+            Assert.That(after.InnerException, Is.Not.Null);
+            Assert.That(after.ToString(), Is.EqualTo(before.ToString()));
+        });
     }
 
     [Test]
@@ -429,9 +438,12 @@ public class SchedulerTest
         await scheduler.ScheduleJob(job, trigger);
 
         trigger = (IOperableTrigger) await scheduler.GetTrigger(trigger.Key);
-        Assert.That(trigger.StartTimeUtc, Is.EqualTo(triggerStartTime));
-        Assert.That(trigger.GetNextFireTimeUtc(), Is.EqualTo(triggerStartTime));
-        Assert.That(trigger.GetPreviousFireTimeUtc(), Is.EqualTo(null));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.StartTimeUtc, Is.EqualTo(triggerStartTime));
+            Assert.That(trigger.GetNextFireTimeUtc(), Is.EqualTo(triggerStartTime));
+            Assert.That(trigger.GetPreviousFireTimeUtc(), Is.EqualTo(null));
+        });
 
         var previousFireTimeUtc = triggerStartTime.AddDays(1);
         trigger.SetPreviousFireTimeUtc(previousFireTimeUtc);
@@ -440,8 +452,11 @@ public class SchedulerTest
         await scheduler.RescheduleJob(trigger.Key, trigger);
 
         trigger = (IOperableTrigger) await scheduler.GetTrigger(trigger.Key);
-        Assert.That(trigger.GetNextFireTimeUtc(), Is.Not.Null);
-        Assert.That(trigger.GetNextFireTimeUtc(), Is.EqualTo(previousFireTimeUtc.AddHours(1)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.GetNextFireTimeUtc(), Is.Not.Null);
+            Assert.That(trigger.GetNextFireTimeUtc(), Is.EqualTo(previousFireTimeUtc.AddHours(1)));
+        });
 
         await scheduler.Shutdown(true);
     }

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -188,8 +188,8 @@ public class SchedulerTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(jobGroups.Count, Is.EqualTo(2), "Job group list size expected to be = 2 ");
-            Assert.That(triggerGroups.Count, Is.EqualTo(2), "Trigger group list size expected to be = 2 ");
+            Assert.That(jobGroups, Has.Count.EqualTo(2), "Job group list size expected to be = 2 ");
+            Assert.That(triggerGroups, Has.Count.EqualTo(2), "Trigger group list size expected to be = 2 ");
         });
 
         var jobKeys = await sched.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(JobKey.DefaultGroup));
@@ -197,8 +197,8 @@ public class SchedulerTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(jobKeys.Count, Is.EqualTo(1), "Number of jobs expected in default group was 1 ");
-            Assert.That(triggerKeys.Count, Is.EqualTo(1), "Number of triggers expected in default group was 1 ");
+            Assert.That(jobKeys, Has.Count.EqualTo(1), "Number of jobs expected in default group was 1 ");
+            Assert.That(triggerKeys, Has.Count.EqualTo(1), "Number of triggers expected in default group was 1 ");
         });
 
         jobKeys = await sched.GetJobKeys(GroupMatcher<JobKey>.GroupEquals("g1"));
@@ -206,8 +206,8 @@ public class SchedulerTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(jobKeys.Count, Is.EqualTo(2), "Number of jobs expected in 'g1' group was 2 ");
-            Assert.That(triggerKeys.Count, Is.EqualTo(2), "Number of triggers expected in 'g1' group was 2 ");
+            Assert.That(jobKeys, Has.Count.EqualTo(2), "Number of jobs expected in 'g1' group was 2 ");
+            Assert.That(triggerKeys, Has.Count.EqualTo(2), "Number of triggers expected in 'g1' group was 2 ");
         });
 
         TriggerState s = await sched.GetTriggerState(new TriggerKey("t2", "g1"));
@@ -222,7 +222,7 @@ public class SchedulerTest
         Assert.That(s, Is.EqualTo(TriggerState.Normal), "State of trigger t2 expected to be NORMAL ");
 
         var pausedGroups = await sched.GetPausedTriggerGroups();
-        Assert.That(pausedGroups.Count, Is.EqualTo(0), "Size of paused trigger groups list expected to be 0 ");
+        Assert.That(pausedGroups, Is.Empty, "Size of paused trigger groups list expected to be 0 ");
 
         await sched.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals("g1"));
 
@@ -242,7 +242,7 @@ public class SchedulerTest
         await sched.ScheduleJob(job, trigger);
 
         pausedGroups = await sched.GetPausedTriggerGroups();
-        Assert.That(pausedGroups.Count, Is.EqualTo(1), "Size of paused trigger groups list expected to be 1 ");
+        Assert.That(pausedGroups, Has.Count.EqualTo(1), "Size of paused trigger groups list expected to be 1 ");
 
         s = await sched.GetTriggerState(new TriggerKey("t2", "g1"));
         Assert.That(s, Is.EqualTo(TriggerState.Paused), "State of trigger t2 expected to be PAUSED ");
@@ -261,7 +261,7 @@ public class SchedulerTest
         pausedGroups = await sched.GetPausedTriggerGroups();
         await Assert.MultipleAsync(async () =>
         {
-            Assert.That(pausedGroups.Count, Is.EqualTo(0), "Size of paused trigger groups list expected to be 0 ");
+            Assert.That(pausedGroups, Is.Empty, "Size of paused trigger groups list expected to be 0 ");
             Assert.That(await sched.UnscheduleJob(new TriggerKey("foasldfksajdflk")), Is.False, "Scheduler should have returned 'false' from attempt to unschedule non-existing trigger. ");
             Assert.That(await sched.UnscheduleJob(new TriggerKey("t3", "g1")), Is.True, "Scheduler should have returned 'true' from attempt to unschedule existing trigger. ");
         });
@@ -271,8 +271,8 @@ public class SchedulerTest
 
         await Assert.MultipleAsync(async () =>
         {
-            Assert.That(jobKeys.Count, Is.EqualTo(2), "Number of jobs expected in 'g1' group was 1 "); // job should have been deleted also, because it is non-durable
-            Assert.That(triggerKeys.Count, Is.EqualTo(2), "Number of triggers expected in 'g1' group was 1 ");
+            Assert.That(jobKeys, Has.Count.EqualTo(2), "Number of jobs expected in 'g1' group was 1 "); // job should have been deleted also, because it is non-durable
+            Assert.That(triggerKeys, Has.Count.EqualTo(2), "Number of triggers expected in 'g1' group was 1 ");
             Assert.That(await sched.UnscheduleJob(new TriggerKey("t1")), Is.True, "Scheduler should have returned 'true' from attempt to unschedule existing trigger. ");
         });
 
@@ -281,8 +281,8 @@ public class SchedulerTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(jobKeys.Count, Is.EqualTo(1), "Number of jobs expected in default group was 1 "); // job should have been left in place, because it is non-durable
-            Assert.That(triggerKeys.Count, Is.EqualTo(0), "Number of triggers expected in default group was 0 ");
+            Assert.That(jobKeys, Has.Count.EqualTo(1), "Number of jobs expected in default group was 1 "); // job should have been left in place, because it is non-durable
+            Assert.That(triggerKeys, Is.Empty, "Number of triggers expected in default group was 0 ");
         });
 
         await sched.Shutdown();

--- a/src/Quartz.Tests.Unit/SerializationTest.cs
+++ b/src/Quartz.Tests.Unit/SerializationTest.cs
@@ -93,10 +93,10 @@ public class SerializationTest
     public void TestHolidayCalendarDeserialization()
     {
         var calendar = Deserialize<HolidayCalendar>();
-        Assert.That(calendar.ExcludedDates.Count, Is.EqualTo(1));
+        Assert.That(calendar.ExcludedDates, Has.Count.EqualTo(1));
 
         calendar = Deserialize<HolidayCalendar>(23);
-        Assert.That(calendar.ExcludedDates.Count, Is.EqualTo(1));
+        Assert.That(calendar.ExcludedDates, Has.Count.EqualTo(1));
 
         BinaryFormatter formatter = new BinaryFormatter();
         using (var stream = new MemoryStream())
@@ -109,7 +109,7 @@ public class SerializationTest
             stream.Position = 0;
 
             calendar = (HolidayCalendar) formatter.Deserialize(stream);
-            Assert.That(calendar.ExcludedDates.Count, Is.EqualTo(1));
+            Assert.That(calendar.ExcludedDates, Has.Count.EqualTo(1));
         }
     }
 
@@ -119,7 +119,7 @@ public class SerializationTest
         HolidayCalendar holidayCalendar = new HolidayCalendar();
         holidayCalendar.AddExcludedDate(new DateTime(2010, 1, 20));
         HolidayCalendar clone = holidayCalendar.DeepClone();
-        Assert.That(clone.ExcludedDates.Count, Is.EqualTo(1));
+        Assert.That(clone.ExcludedDates, Has.Count.EqualTo(1));
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/SerializationTest.cs
+++ b/src/Quartz.Tests.Unit/SerializationTest.cs
@@ -23,7 +23,7 @@ public class SerializationTest
         DateTime day = new DateTime(2011, 12, 20, 0, 0, 0);
         annualCalendar.SetDayExcluded(day, true);
         AnnualCalendar clone = annualCalendar.DeepClone();
-        Assert.IsTrue(clone.IsDayExcluded(day));
+        Assert.That(clone.IsDayExcluded(day), Is.True);
     }
 
     [Test]
@@ -39,7 +39,7 @@ public class SerializationTest
         TimeZoneInfo timeZone = TimeZoneInfo.GetSystemTimeZones()[3];
         baseCalendar.TimeZone = timeZone;
         BaseCalendar clone = baseCalendar.DeepClone();
-        Assert.AreEqual(timeZone.Id, clone.TimeZone.Id);
+        Assert.That(clone.TimeZone.Id, Is.EqualTo(timeZone.Id));
     }
 
     [Test]
@@ -53,7 +53,7 @@ public class SerializationTest
     {
         CronCalendar cronCalendar = new CronCalendar("* * 8-17 ? * *");
         CronCalendar clone = cronCalendar.DeepClone();
-        Assert.AreEqual("* * 8-17 ? * *", clone.CronExpression.CronExpressionString);
+        Assert.That(clone.CronExpression.CronExpressionString, Is.EqualTo("* * 8-17 ? * *"));
     }
 
     [Test]
@@ -69,17 +69,23 @@ public class SerializationTest
         DailyCalendar clone = dailyCalendar.DeepClone();
 
         DateTimeOffset timeRangeStartTimeUtc = clone.GetTimeRangeStartingTimeUtc(DateTimeOffset.UtcNow);
-        Assert.AreEqual(12, timeRangeStartTimeUtc.Hour);
-        Assert.AreEqual(13, timeRangeStartTimeUtc.Minute);
-        Assert.AreEqual(14, timeRangeStartTimeUtc.Second);
-        Assert.AreEqual(150, timeRangeStartTimeUtc.Millisecond);
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeRangeStartTimeUtc.Hour, Is.EqualTo(12));
+            Assert.That(timeRangeStartTimeUtc.Minute, Is.EqualTo(13));
+            Assert.That(timeRangeStartTimeUtc.Second, Is.EqualTo(14));
+            Assert.That(timeRangeStartTimeUtc.Millisecond, Is.EqualTo(150));
+        });
 
         DateTimeOffset timeRangeEndingTimeUtc = clone.GetTimeRangeEndingTimeUtc(DateTimeOffset.UtcNow);
 
-        Assert.AreEqual(13, timeRangeEndingTimeUtc.Hour);
-        Assert.AreEqual(14, timeRangeEndingTimeUtc.Minute);
-        Assert.AreEqual(0, timeRangeEndingTimeUtc.Second);
-        Assert.AreEqual(0, timeRangeEndingTimeUtc.Millisecond);
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeRangeEndingTimeUtc.Hour, Is.EqualTo(13));
+            Assert.That(timeRangeEndingTimeUtc.Minute, Is.EqualTo(14));
+            Assert.That(timeRangeEndingTimeUtc.Second, Is.EqualTo(0));
+            Assert.That(timeRangeEndingTimeUtc.Millisecond, Is.EqualTo(0));
+        });
     }
 
     [Test]
@@ -113,7 +119,7 @@ public class SerializationTest
         HolidayCalendar holidayCalendar = new HolidayCalendar();
         holidayCalendar.AddExcludedDate(new DateTime(2010, 1, 20));
         HolidayCalendar clone = holidayCalendar.DeepClone();
-        Assert.AreEqual(1, clone.ExcludedDates.Count);
+        Assert.That(clone.ExcludedDates.Count, Is.EqualTo(1));
     }
 
     [Test]
@@ -128,7 +134,7 @@ public class SerializationTest
         MonthlyCalendar monthlyCalendar = new MonthlyCalendar();
         monthlyCalendar.SetDayExcluded(20, true);
         MonthlyCalendar clone = monthlyCalendar.DeepClone();
-        Assert.IsTrue(clone.IsDayExcluded(20));
+        Assert.That(clone.IsDayExcluded(20), Is.True);
     }
 
     [Test]
@@ -143,7 +149,7 @@ public class SerializationTest
         WeeklyCalendar weeklyCalendar = new WeeklyCalendar();
         weeklyCalendar.SetDayExcluded(DayOfWeek.Monday, true);
         WeeklyCalendar clone = weeklyCalendar.DeepClone();
-        Assert.IsTrue(clone.IsDayExcluded(DayOfWeek.Monday));
+        Assert.That(clone.IsDayExcluded(DayOfWeek.Monday), Is.True);
     }
 
     /* TODO
@@ -170,43 +176,61 @@ public class SerializationTest
     public void TestJobDataMapDeserialization()
     {
         JobDataMap map = Deserialize<JobDataMap>();
-        Assert.AreEqual("bar", map["foo"]);
-        Assert.AreEqual(123, map["num"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(map["foo"], Is.EqualTo("bar"));
+            Assert.That(map["num"], Is.EqualTo(123));
+        });
     }
 
     [Test]
     public void TestJobDataMapSerialization()
     {
-        JobDataMap map = new JobDataMap();
-        map["foo"] = "bar";
-        map["num"] = 123;
+        JobDataMap map = new JobDataMap
+        {
+            ["foo"] = "bar",
+            ["num"] = 123
+        };
         JobDataMap clone = map.DeepClone();
-        Assert.AreEqual("bar", clone["foo"]);
-        Assert.AreEqual(123, clone["num"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone["foo"], Is.EqualTo("bar"));
+            Assert.That(clone["num"], Is.EqualTo(123));
+        });
     }
 
     [Test]
     public void TestStringKeyDirtyFlagMapSerialization()
     {
-        StringKeyDirtyFlagMap map = new StringKeyDirtyFlagMap();
-        map["foo"] = "bar";
-        map["num"] = 123;
+        StringKeyDirtyFlagMap map = new StringKeyDirtyFlagMap
+        {
+            ["foo"] = "bar",
+            ["num"] = 123
+        };
 
         StringKeyDirtyFlagMap clone = map.DeepClone();
-        Assert.AreEqual("bar", clone["foo"]);
-        Assert.AreEqual(123, clone["num"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone["foo"], Is.EqualTo("bar"));
+            Assert.That(clone["num"], Is.EqualTo(123));
+        });
     }
 
     [Test]
     public void TestSchedulerContextSerialization()
     {
-        SchedulerContext map = new SchedulerContext();
-        map["foo"] = "bar";
-        map["num"] = 123;
+        SchedulerContext map = new SchedulerContext
+        {
+            ["foo"] = "bar",
+            ["num"] = 123
+        };
 
         SchedulerContext clone = map.DeepClone();
-        Assert.AreEqual("bar", clone["foo"]);
-        Assert.AreEqual(123, clone["num"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone["foo"], Is.EqualTo("bar"));
+            Assert.That(clone["num"], Is.EqualTo(123));
+        });
     }
 
     [Test]
@@ -216,8 +240,11 @@ public class SerializationTest
 
         GroupMatcher<TriggerKey> got = SerializeAndDeserialize(expected);
 
-        Assert.AreEqual(expected.CompareToValue, got.CompareToValue);
-        Assert.AreEqual(expected.CompareWithOperator, got.CompareWithOperator);
+        Assert.Multiple(() =>
+        {
+            Assert.That(got.CompareToValue, Is.EqualTo(expected.CompareToValue));
+            Assert.That(got.CompareWithOperator, Is.EqualTo(expected.CompareWithOperator));
+        });
     }
 
     [Test]
@@ -227,8 +254,11 @@ public class SerializationTest
 
         NameMatcher<JobKey> got = SerializeAndDeserialize(expected);
 
-        Assert.AreEqual(expected.CompareToValue, got.CompareToValue);
-        Assert.AreEqual(expected.CompareWithOperator, got.CompareWithOperator);
+        Assert.Multiple(() =>
+        {
+            Assert.That(got.CompareToValue, Is.EqualTo(expected.CompareToValue));
+            Assert.That(got.CompareWithOperator, Is.EqualTo(expected.CompareWithOperator));
+        });
     }
 
     private static T SerializeAndDeserialize<T>(T instance) where T : class
@@ -250,9 +280,7 @@ public class SerializationTest
     private static T Deserialize<T>(int version) where T : class
     {
         BinaryFormatter formatter = new BinaryFormatter();
-        using (var stream = File.OpenRead(Path.Combine("Serialized", typeof(T).Name + "_" + version + ".ser")))
-        {
-            return (T) formatter.Deserialize(stream);
-        }
+        using var stream = File.OpenRead(Path.Combine("Serialized", typeof(T).Name + "_" + version + ".ser"));
+        return (T) formatter.Deserialize(stream);
     }
 }

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -634,7 +634,7 @@ public class JsonSerializationTestTrigger : SimpleTriggerImpl
         }
     }
 
-    public sealed class NewtonsoftSerializer : Quartz.Triggers.TriggerSerializer<JsonSerializationTestTrigger>
+    public sealed class NewtonsoftSerializer : Triggers.TriggerSerializer<JsonSerializationTestTrigger>
     {
         public override string TriggerTypeForJson => "TestTrigger";
 

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Microsoft.Extensions.Time.Testing;
 
@@ -179,10 +180,13 @@ public class JsonObjectSerializerTest
 
         CompareSerialization(collection, (deserialized, original) =>
         {
-            original.Count.Should().Be(2);
-            deserialized.Count.Should().Be(2);
-            deserialized["key"].Should().Be(original["key"]);
-            deserialized["key2"].Should().Be(original["key2"]);
+            using (new AssertionScope())
+            {
+                original.Count.Should().Be(2);
+                deserialized.Count.Should().Be(2);
+                deserialized["key"].Should().Be(original["key"]);
+                deserialized["key2"].Should().Be(original["key2"]);
+            }
         });
 
         await VerifyCreatedJson(collection);
@@ -206,15 +210,18 @@ public class JsonObjectSerializerTest
             collection,
             (deserialized, original) =>
             {
-                original.Should().HaveCount(7);
-                deserialized.Should().HaveCount(7);
-                deserialized["key"].Should().Be(original["key"]);
-                deserialized.GetDateTime("key2").Should().Be(original.GetDateTime("key2"));
-                deserialized["key3"].Should().Be(original["key3"]);
-                deserialized["key4"].Should().Be(original["key4"]);
-                deserialized["key5"].Should().Be(original["key5"]);
-                deserialized.GetDateTimeOffset("key6").Should().Be(original.GetDateTimeOffset("key6"));
-                deserialized.GetDateTimeOffset("key7").Should().Be(original.GetDateTimeOffset("key7"));
+                using (new AssertionScope())
+                {
+                    original.Should().HaveCount(7);
+                    deserialized.Should().HaveCount(7);
+                    deserialized["key"].Should().Be(original["key"]);
+                    deserialized.GetDateTime("key2").Should().Be(original.GetDateTime("key2"));
+                    deserialized["key3"].Should().Be(original["key3"]);
+                    deserialized["key4"].Should().Be(original["key4"]);
+                    deserialized["key5"].Should().Be(original["key5"]);
+                    deserialized.GetDateTimeOffset("key6").Should().Be(original.GetDateTimeOffset("key6"));
+                    deserialized.GetDateTimeOffset("key7").Should().Be(original.GetDateTimeOffset("key7"));
+                }
             },
             skipDefaultEqualityCheck: true
         );
@@ -305,8 +312,11 @@ public class JsonObjectSerializerTest
             trigger,
             (deserialized, original) =>
             {
-                original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
-                original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                using (new AssertionScope())
+                {
+                    original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
+                    original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                }
             }
         );
 
@@ -342,8 +352,11 @@ public class JsonObjectSerializerTest
             trigger,
             (deserialized, original) =>
             {
-                original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
-                original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                using (new AssertionScope())
+                {
+                    original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
+                    original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                }
             }
         );
 
@@ -382,8 +395,11 @@ public class JsonObjectSerializerTest
             trigger,
             (deserialized, original) =>
             {
-                original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
-                original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                using (new AssertionScope())
+                {
+                    original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
+                    original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                }
             }
         );
 
@@ -421,8 +437,11 @@ public class JsonObjectSerializerTest
             trigger,
             (deserialized, original) =>
             {
-                original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
-                original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                using (new AssertionScope())
+                {
+                    original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
+                    original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                }
             }
         );
 
@@ -461,8 +480,11 @@ public class JsonObjectSerializerTest
             trigger,
             (deserialized, original) =>
             {
-                original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
-                original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                using (new AssertionScope())
+                {
+                    original.GetNextFireTimeUtc().Should().Be(deserialized.GetNextFireTimeUtc());
+                    original.GetPreviousFireTimeUtc().Should().Be(deserialized.GetPreviousFireTimeUtc());
+                }
             }
         );
 

--- a/src/Quartz.Tests.Unit/Simpl/MicrosoftDependencyInjectionJobFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/MicrosoftDependencyInjectionJobFactoryTest.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -43,12 +44,14 @@ public class MicrosoftDependencyInjectionJobFactoryTest
         await scheduler.TriggerJob(jobDetail.Key);
 
         await Task.Delay(100);
+        using (new AssertionScope())
+        {
+            TestJob.Executed.Should().BeTrue();
+            TestJob.Disposed.Should().BeTrue();
+            TestJob.TestValue.Should().Be(testValue);
 
-        TestJob.Executed.Should().BeTrue();
-        TestJob.Disposed.Should().BeTrue();
-        TestJob.TestValue.Should().Be(testValue);
-
-        Dependency.Disposed.Should().BeTrue();
+            Dependency.Disposed.Should().BeTrue();
+        }
     }
 
     private class TestJob : IJob, IDisposable

--- a/src/Quartz.Tests.Unit/Simpl/PropertySettingJobFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/PropertySettingJobFactoryTest.cs
@@ -209,14 +209,17 @@ public class PropertySettingJobFactoryTest
         TestObject myObject = new TestObject();
         factory.SetObjectProperties(myObject, jobDataMap);
 
-        Assert.That(myObject.IntValue, Is.EqualTo(1));
-        Assert.That(myObject.LongValue, Is.EqualTo(2L));
-        Assert.That(myObject.FloatValue, Is.EqualTo(3.0f));
-        Assert.That(myObject.DoubleValue, Is.EqualTo(4.0));
-        Assert.That(myObject.BooleanValue, Is.EqualTo(true));
-        Assert.That(myObject.ShortValue, Is.EqualTo(5));
-        Assert.That(myObject.CharValue, Is.EqualTo('a'));
-        Assert.That(myObject.ByteValue, Is.EqualTo((byte) 6));
+        Assert.Multiple(() =>
+        {
+            Assert.That(myObject.IntValue, Is.EqualTo(1));
+            Assert.That(myObject.LongValue, Is.EqualTo(2L));
+            Assert.That(myObject.FloatValue, Is.EqualTo(3.0f));
+            Assert.That(myObject.DoubleValue, Is.EqualTo(4.0));
+            Assert.That(myObject.BooleanValue, Is.EqualTo(true));
+            Assert.That(myObject.ShortValue, Is.EqualTo(5));
+            Assert.That(myObject.CharValue, Is.EqualTo('a'));
+            Assert.That(myObject.ByteValue, Is.EqualTo((byte) 6));
+        });
     }
 
     internal sealed class TestObject

--- a/src/Quartz.Tests.Unit/Simpl/PropertySettingJobFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/PropertySettingJobFactoryTest.cs
@@ -75,19 +75,22 @@ public class PropertySettingJobFactoryTest
         TestObject myObject = new TestObject();
         factory.SetObjectProperties(myObject, jobDataMap);
 
-        Assert.That(myObject.IntValue, Is.EqualTo(1));
-        Assert.That(myObject.LongValue, Is.EqualTo(2));
-        Assert.That(myObject.FloatValue, Is.EqualTo(3.0f));
-        Assert.That(myObject.DoubleValue, Is.EqualTo(4.0));
-        Assert.That(myObject.BooleanValue, Is.True);
-        Assert.That(myObject.ShortValue, Is.EqualTo(5));
-        Assert.That(myObject.CharValue, Is.EqualTo('a'));
-        Assert.That(myObject.ByteValue, Is.EqualTo((byte) 6));
-        Assert.That(myObject.StringValue, Is.EqualTo("S1"));
-        Assert.That(myObject.EnumValue1, Is.EqualTo(DayOfWeek.Monday));
-        Assert.That(myObject.EnumValue2, Is.EqualTo(DayOfWeek.Monday));
-        Assert.That(myObject.EnumValue3, Is.EqualTo(DayOfWeek.Monday));
-        Assert.That(myObject.MapValue.ContainsKey("A"), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(myObject.IntValue, Is.EqualTo(1));
+            Assert.That(myObject.LongValue, Is.EqualTo(2));
+            Assert.That(myObject.FloatValue, Is.EqualTo(3.0f));
+            Assert.That(myObject.DoubleValue, Is.EqualTo(4.0));
+            Assert.That(myObject.BooleanValue, Is.True);
+            Assert.That(myObject.ShortValue, Is.EqualTo(5));
+            Assert.That(myObject.CharValue, Is.EqualTo('a'));
+            Assert.That(myObject.ByteValue, Is.EqualTo((byte) 6));
+            Assert.That(myObject.StringValue, Is.EqualTo("S1"));
+            Assert.That(myObject.EnumValue1, Is.EqualTo(DayOfWeek.Monday));
+            Assert.That(myObject.EnumValue2, Is.EqualTo(DayOfWeek.Monday));
+            Assert.That(myObject.EnumValue3, Is.EqualTo(DayOfWeek.Monday));
+            Assert.That(myObject.MapValue.ContainsKey("A"), Is.True);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Simpl/PropertySettingJobFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/PropertySettingJobFactoryTest.cs
@@ -75,19 +75,19 @@ public class PropertySettingJobFactoryTest
         TestObject myObject = new TestObject();
         factory.SetObjectProperties(myObject, jobDataMap);
 
-        Assert.AreEqual(1, myObject.IntValue);
-        Assert.AreEqual(2, myObject.LongValue);
-        Assert.AreEqual(3.0f, myObject.FloatValue);
-        Assert.AreEqual(4.0, myObject.DoubleValue);
-        Assert.IsTrue(myObject.BooleanValue);
-        Assert.AreEqual(5, myObject.ShortValue);
-        Assert.AreEqual('a', myObject.CharValue);
-        Assert.AreEqual((byte) 6, myObject.ByteValue);
-        Assert.AreEqual("S1", myObject.StringValue);
-        Assert.AreEqual(DayOfWeek.Monday, myObject.EnumValue1);
-        Assert.AreEqual(DayOfWeek.Monday, myObject.EnumValue2);
-        Assert.AreEqual(DayOfWeek.Monday, myObject.EnumValue3);
-        Assert.IsTrue(myObject.MapValue.ContainsKey("A"));
+        Assert.That(myObject.IntValue, Is.EqualTo(1));
+        Assert.That(myObject.LongValue, Is.EqualTo(2));
+        Assert.That(myObject.FloatValue, Is.EqualTo(3.0f));
+        Assert.That(myObject.DoubleValue, Is.EqualTo(4.0));
+        Assert.That(myObject.BooleanValue, Is.True);
+        Assert.That(myObject.ShortValue, Is.EqualTo(5));
+        Assert.That(myObject.CharValue, Is.EqualTo('a'));
+        Assert.That(myObject.ByteValue, Is.EqualTo((byte) 6));
+        Assert.That(myObject.StringValue, Is.EqualTo("S1"));
+        Assert.That(myObject.EnumValue1, Is.EqualTo(DayOfWeek.Monday));
+        Assert.That(myObject.EnumValue2, Is.EqualTo(DayOfWeek.Monday));
+        Assert.That(myObject.EnumValue3, Is.EqualTo(DayOfWeek.Monday));
+        Assert.That(myObject.MapValue.ContainsKey("A"), Is.True);
     }
 
     [Test]
@@ -130,7 +130,7 @@ public class PropertySettingJobFactoryTest
         map.Add("A", "B");
         testObject.MapValue = map;
         factory.SetObjectProperties(testObject, jobDataMap);
-        Assert.IsNull(testObject.MapValue);
+        Assert.That(testObject.MapValue, Is.Null);
     }
 
     [Test]
@@ -209,14 +209,14 @@ public class PropertySettingJobFactoryTest
         TestObject myObject = new TestObject();
         factory.SetObjectProperties(myObject, jobDataMap);
 
-        Assert.AreEqual(1, myObject.IntValue);
-        Assert.AreEqual(2L, myObject.LongValue);
-        Assert.AreEqual(3.0f, myObject.FloatValue);
-        Assert.AreEqual(4.0, myObject.DoubleValue);
-        Assert.AreEqual(true, myObject.BooleanValue);
-        Assert.AreEqual(5, myObject.ShortValue);
-        Assert.AreEqual('a', myObject.CharValue);
-        Assert.AreEqual((byte) 6, myObject.ByteValue);
+        Assert.That(myObject.IntValue, Is.EqualTo(1));
+        Assert.That(myObject.LongValue, Is.EqualTo(2L));
+        Assert.That(myObject.FloatValue, Is.EqualTo(3.0f));
+        Assert.That(myObject.DoubleValue, Is.EqualTo(4.0));
+        Assert.That(myObject.BooleanValue, Is.EqualTo(true));
+        Assert.That(myObject.ShortValue, Is.EqualTo(5));
+        Assert.That(myObject.CharValue, Is.EqualTo('a'));
+        Assert.That(myObject.ByteValue, Is.EqualTo((byte) 6));
     }
 
     internal sealed class TestObject

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -118,7 +118,7 @@ public class RAMJobStoreTest
         List<IOperableTrigger> acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromSeconds(1))).ToList();
         Assert.Multiple(() =>
         {
-            Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
+            Assert.That(acquiredTriggers, Has.Count.EqualTo(1));
             Assert.That(acquiredTriggers[0].Key, Is.EqualTo(early.Key));
         });
         await fJobStore.ReleaseAcquiredTrigger(early);
@@ -152,7 +152,7 @@ public class RAMJobStoreTest
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 6, TimeSpan.FromMilliseconds(100000))).ToList();
         Assert.Multiple(() =>
         {
-            Assert.That(acquiredTriggers.Count, Is.EqualTo(4));
+            Assert.That(acquiredTriggers, Has.Count.EqualTo(4));
             Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
             Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
             Assert.That(acquiredTriggers[2].Key, Is.EqualTo(trigger3.Key));
@@ -214,7 +214,7 @@ public class RAMJobStoreTest
         Assert.Multiple(async () =>
         {
             Assert.That(trigger, Is.Not.Null);
-            Assert.That((await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).Count, Is.EqualTo(0));
+            Assert.That((await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))), Is.Empty);
         });
     }
 
@@ -394,7 +394,7 @@ public class RAMJobStoreTest
             int maxCount = 1;
             TimeSpan timeWindow = TimeSpan.Zero;
             var triggers = await store.AcquireNextTriggers(noLaterThan, maxCount, timeWindow);
-            Assert.That(triggers.Count, Is.EqualTo(1));
+            Assert.That(triggers, Has.Count.EqualTo(1));
             var trigger = triggers.First();
             Assert.That(trigger.Key.Name, Is.EqualTo("job" + i));
 
@@ -435,7 +435,7 @@ public class RAMJobStoreTest
         int maxCount = 7;
         TimeSpan timeWindow = TimeSpan.FromMinutes(8);
         var triggers = (await store.AcquireNextTriggers(noLaterThan, maxCount, timeWindow)).ToList();
-        Assert.That(triggers.Count, Is.EqualTo(7));
+        Assert.That(triggers, Has.Count.EqualTo(7));
         for (int i = 0; i < 7; i++)
         {
             Assert.That(triggers[i].Key.Name, Is.EqualTo("job" + i));

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -72,15 +72,15 @@ public class RAMJobStoreTest
 
         DateTimeOffset firstFireTime = trigger1.GetNextFireTimeUtc().Value;
 
-        Assert.AreEqual(0, (await fJobStore.AcquireNextTriggers(d.AddMilliseconds(10), 1, TimeSpan.Zero)).Count);
-        Assert.AreEqual(trigger2, (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First());
-        Assert.AreEqual(trigger3, (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First());
-        Assert.AreEqual(trigger1, (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First());
-        Assert.AreEqual(0, (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).Count);
+        Assert.That((await fJobStore.AcquireNextTriggers(d.AddMilliseconds(10), 1, TimeSpan.Zero)).Count, Is.EqualTo(0));
+        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger2));
+        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger3));
+        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger1));
+        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).Count, Is.EqualTo(0));
 
         // release trigger3
         await fJobStore.ReleaseAcquiredTrigger(trigger3);
-        Assert.AreEqual(trigger3, (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).First());
+        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).First(), Is.EqualTo(trigger3));
     }
 
     [Test]
@@ -113,25 +113,25 @@ public class RAMJobStoreTest
         DateTimeOffset firstFireTime = trigger1.GetNextFireTimeUtc().Value;
 
         List<IOperableTrigger> acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromSeconds(1))).ToList();
-        Assert.AreEqual(1, acquiredTriggers.Count);
-        Assert.AreEqual(early.Key, acquiredTriggers[0].Key);
+        Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
+        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(early.Key));
         await fJobStore.ReleaseAcquiredTrigger(early);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromMilliseconds(205000))).ToList();
-        Assert.AreEqual(2, acquiredTriggers.Count);
-        Assert.AreEqual(early.Key, acquiredTriggers[0].Key);
-        Assert.AreEqual(trigger1.Key, acquiredTriggers[1].Key);
+        Assert.That(acquiredTriggers.Count, Is.EqualTo(2));
+        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(early.Key));
+        Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger1.Key));
         await fJobStore.ReleaseAcquiredTrigger(early);
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
 
         await fJobStore.RemoveTrigger(early.Key);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 5, TimeSpan.FromMilliseconds(100000))).ToList();
-        Assert.AreEqual(4, acquiredTriggers.Count);
-        Assert.AreEqual(trigger1.Key, acquiredTriggers[0].Key);
-        Assert.AreEqual(trigger2.Key, acquiredTriggers[1].Key);
-        Assert.AreEqual(trigger3.Key, acquiredTriggers[2].Key);
-        Assert.AreEqual(trigger4.Key, acquiredTriggers[3].Key);
+        Assert.That(acquiredTriggers.Count, Is.EqualTo(4));
+        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
+        Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
+        Assert.That(acquiredTriggers[2].Key, Is.EqualTo(trigger3.Key));
+        Assert.That(acquiredTriggers[3].Key, Is.EqualTo(trigger4.Key));
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
         await fJobStore.ReleaseAcquiredTrigger(trigger2);
         await fJobStore.ReleaseAcquiredTrigger(trigger3);
@@ -139,11 +139,11 @@ public class RAMJobStoreTest
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 6, TimeSpan.FromMilliseconds(100000))).ToList();
 
-        Assert.AreEqual(4, acquiredTriggers.Count);
-        Assert.AreEqual(trigger1.Key, acquiredTriggers[0].Key);
-        Assert.AreEqual(trigger2.Key, acquiredTriggers[1].Key);
-        Assert.AreEqual(trigger3.Key, acquiredTriggers[2].Key);
-        Assert.AreEqual(trigger4.Key, acquiredTriggers[3].Key);
+        Assert.That(acquiredTriggers.Count, Is.EqualTo(4));
+        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
+        Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
+        Assert.That(acquiredTriggers[2].Key, Is.EqualTo(trigger3.Key));
+        Assert.That(acquiredTriggers[3].Key, Is.EqualTo(trigger4.Key));
 
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
         await fJobStore.ReleaseAcquiredTrigger(trigger2);
@@ -151,15 +151,15 @@ public class RAMJobStoreTest
         await fJobStore.ReleaseAcquiredTrigger(trigger4);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(1), 5, TimeSpan.Zero)).ToList();
-        Assert.AreEqual(1, acquiredTriggers.Count);
-        Assert.AreEqual(trigger1.Key, acquiredTriggers[0].Key);
+        Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
+        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
 
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(250), 5, TimeSpan.FromMilliseconds(19999L))).ToList();
-        Assert.AreEqual(2, acquiredTriggers.Count);
-        Assert.AreEqual(trigger1.Key, acquiredTriggers[0].Key);
-        Assert.AreEqual(trigger2.Key, acquiredTriggers[1].Key);
+        Assert.That(acquiredTriggers.Count, Is.EqualTo(2));
+        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
+        Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
 
         await fJobStore.ReleaseAcquiredTrigger(early);
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
@@ -167,8 +167,8 @@ public class RAMJobStoreTest
         await fJobStore.ReleaseAcquiredTrigger(trigger3);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(150), 5, TimeSpan.FromMilliseconds(5000L))).ToList();
-        Assert.AreEqual(1, acquiredTriggers.Count);
-        Assert.AreEqual(trigger1.Key, acquiredTriggers[0].Key);
+        Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
+        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
     }
 
@@ -177,22 +177,22 @@ public class RAMJobStoreTest
     {
         IOperableTrigger trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, DateTimeOffset.Now.AddSeconds(100), DateTimeOffset.Now.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
         trigger.ComputeFirstFireTimeUtc(null);
-        Assert.AreEqual(TriggerState.None, await fJobStore.GetTriggerState(trigger.Key));
+        Assert.That(await fJobStore.GetTriggerState(trigger.Key), Is.EqualTo(TriggerState.None));
         await fJobStore.StoreTrigger(trigger, false);
-        Assert.AreEqual(TriggerState.Normal, await fJobStore.GetTriggerState(trigger.Key));
+        Assert.That(await fJobStore.GetTriggerState(trigger.Key), Is.EqualTo(TriggerState.Normal));
 
         await fJobStore.PauseTrigger(trigger.Key);
-        Assert.AreEqual(TriggerState.Paused, await fJobStore.GetTriggerState(trigger.Key));
+        Assert.That(await fJobStore.GetTriggerState(trigger.Key), Is.EqualTo(TriggerState.Paused));
 
         await fJobStore.ResumeTrigger(trigger.Key);
-        Assert.AreEqual(TriggerState.Normal, await fJobStore.GetTriggerState(trigger.Key));
+        Assert.That(await fJobStore.GetTriggerState(trigger.Key), Is.EqualTo(TriggerState.Normal));
 
         trigger = (await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).First();
-        Assert.IsNotNull(trigger);
+        Assert.That(trigger, Is.Not.Null);
         await fJobStore.ReleaseAcquiredTrigger(trigger);
         trigger = (await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).First();
-        Assert.IsNotNull(trigger);
-        Assert.AreEqual(0, (await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).Count);
+        Assert.That(trigger, Is.Not.Null);
+        Assert.That((await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).Count, Is.EqualTo(0));
     }
 
     [Test]
@@ -226,13 +226,13 @@ public class RAMJobStoreTest
         tr.CalendarName = null;
 
         await fJobStore.StoreTrigger(tr, false);
-        Assert.AreEqual(tr, await fJobStore.RetrieveTrigger(new TriggerKey(trName, trGroup)));
+        Assert.That(await fJobStore.RetrieveTrigger(new TriggerKey(trName, trGroup)), Is.EqualTo(tr));
 
         tr.CalendarName = "NonExistingCalendar";
         await fJobStore.StoreTrigger(tr, true);
-        Assert.AreEqual(tr, await fJobStore.RetrieveTrigger(new TriggerKey(trName, trGroup)));
+        Assert.That(await fJobStore.RetrieveTrigger(new TriggerKey(trName, trGroup)), Is.EqualTo(tr));
         var trigger = await fJobStore.RetrieveTrigger(new TriggerKey(trName, trGroup));
-        Assert.AreEqual(tr.CalendarName, trigger.CalendarName, "StoreJob doesn't replace triggers");
+        Assert.That(trigger.CalendarName, Is.EqualTo(tr.CalendarName), "StoreJob doesn't replace triggers");
 
         bool exceptionRaised = false;
         try
@@ -243,7 +243,7 @@ public class RAMJobStoreTest
         {
             exceptionRaised = true;
         }
-        Assert.IsTrue(exceptionRaised, "an attempt to store duplicate trigger succeeded");
+        Assert.That(exceptionRaised, Is.True, "an attempt to store duplicate trigger succeeded");
     }
 
     [Test]
@@ -271,7 +271,7 @@ public class RAMJobStoreTest
         IOperableTrigger tr = new SimpleTriggerImpl(trName, trGroup, DateTimeOffset.UtcNow);
         tr.JobKey = new JobKey(jobName2, jobGroup);
         await fJobStore.StoreTrigger(tr, false);
-        Assert.AreEqual(TriggerState.Paused, await fJobStore.GetTriggerState(tr.Key));
+        Assert.That(await fJobStore.GetTriggerState(tr.Key), Is.EqualTo(TriggerState.Paused));
     }
 
     [Test]
@@ -279,7 +279,7 @@ public class RAMJobStoreTest
     {
         RAMJobStore store = new RAMJobStore();
         IJobDetail job = await store.RetrieveJob(new JobKey("not", "existing"));
-        Assert.IsNull(job);
+        Assert.That(job, Is.Null);
     }
 
     [Test]
@@ -287,7 +287,7 @@ public class RAMJobStoreTest
     {
         RAMJobStore store = new RAMJobStore();
         IOperableTrigger trigger = await store.RetrieveTrigger(new TriggerKey("not", "existing"));
-        Assert.IsNull(trigger);
+        Assert.That(trigger, Is.Null);
     }
 
     [Test]
@@ -306,7 +306,7 @@ public class RAMJobStoreTest
         {
             JobKey jobKey = JobKey.Create("job" + i);
             IJobDetail storedJob = await store.RetrieveJob(jobKey);
-            Assert.AreEqual(jobKey, storedJob.Key);
+            Assert.That(storedJob.Key, Is.EqualTo(jobKey));
         }
     }
 
@@ -329,11 +329,11 @@ public class RAMJobStoreTest
         {
             JobKey jobKey = JobKey.Create("job" + i);
             IJobDetail storedJob = await store.RetrieveJob(jobKey);
-            Assert.AreEqual(jobKey, storedJob.Key);
+            Assert.That(storedJob.Key, Is.EqualTo(jobKey));
 
             TriggerKey triggerKey = new TriggerKey("job" + i);
             ITrigger storedTrigger = await store.RetrieveTrigger(triggerKey);
-            Assert.AreEqual(triggerKey, storedTrigger.Key);
+            Assert.That(storedTrigger.Key, Is.EqualTo(triggerKey));
         }
     }
 
@@ -359,7 +359,7 @@ public class RAMJobStoreTest
             // Manually trigger the first fire time computation that scheduler would do. Otherwise
             // the store.acquireNextTriggers() will not work properly.
             DateTimeOffset? fireTime = trigger.ComputeFirstFireTimeUtc(null);
-            Assert.AreEqual(true, fireTime is not null);
+            Assert.That(fireTime is not null, Is.EqualTo(true));
 
             await store.StoreJobAndTrigger(job, trigger);
         }
@@ -371,9 +371,9 @@ public class RAMJobStoreTest
             int maxCount = 1;
             TimeSpan timeWindow = TimeSpan.Zero;
             var triggers = await store.AcquireNextTriggers(noLaterThan, maxCount, timeWindow);
-            Assert.AreEqual(1, triggers.Count);
+            Assert.That(triggers.Count, Is.EqualTo(1));
             var trigger = triggers.First();
-            Assert.AreEqual("job" + i, trigger.Key.Name);
+            Assert.That(trigger.Key.Name, Is.EqualTo("job" + i));
 
             // Let's remove the trigger now.
             await store.RemoveJob(trigger.JobKey);
@@ -402,7 +402,7 @@ public class RAMJobStoreTest
             // Manually trigger the first fire time computation that scheduler would do. Otherwise
             // the store.acquireNextTriggers() will not work properly.
             DateTimeOffset? fireTime = trigger.ComputeFirstFireTimeUtc(null);
-            Assert.AreEqual(true, fireTime is not null);
+            Assert.That(fireTime is not null, Is.EqualTo(true));
 
             await store.StoreJobAndTrigger(job, trigger);
         }
@@ -412,10 +412,10 @@ public class RAMJobStoreTest
         int maxCount = 7;
         TimeSpan timeWindow = TimeSpan.FromMinutes(8);
         var triggers = (await store.AcquireNextTriggers(noLaterThan, maxCount, timeWindow)).ToList();
-        Assert.AreEqual(7, triggers.Count);
+        Assert.That(triggers.Count, Is.EqualTo(7));
         for (int i = 0; i < 7; i++)
         {
-            Assert.AreEqual("job" + i, triggers[i].Key.Name);
+            Assert.That(triggers[i].Key.Name, Is.EqualTo("job" + i));
         }
     }
 
@@ -442,7 +442,7 @@ public class RAMJobStoreTest
 
         // pretend to fire it
         var aqTs = await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(10000), 1, TimeSpan.Zero);
-        Assert.AreEqual(trigger1.Key, aqTs.First().Key);
+        Assert.That(aqTs.First().Key, Is.EqualTo(trigger1.Key));
 
         var fTs = await fJobStore.TriggersFired(aqTs);
         var ft = fTs.First();
@@ -451,12 +451,12 @@ public class RAMJobStoreTest
         await fJobStore.TriggeredJobComplete(ft.TriggerFiredBundle.Trigger, ft.TriggerFiredBundle.JobDetail, SchedulerInstruction.SetTriggerError);
 
         var state = await fJobStore.GetTriggerState(trigger1.Key);
-        Assert.AreEqual(TriggerState.Error, state);
+        Assert.That(state, Is.EqualTo(TriggerState.Error));
 
         // test reset
         await fJobStore.ResetTriggerFromErrorState(trigger1.Key);
         state = await fJobStore.GetTriggerState(trigger1.Key);
-        Assert.AreEqual(TriggerState.Normal, state);
+        Assert.That(state, Is.EqualTo(TriggerState.Normal));
     }
 
     [Test]
@@ -471,10 +471,10 @@ public class RAMJobStoreTest
         await store.StoreJob(job, false);
 
         var deleteSuccess = await store.RemoveJob(new JobKey("job0"));
-        Assert.IsTrue(deleteSuccess, "Expected RemoveJob to return True when deleting an existing job");
+        Assert.That(deleteSuccess, Is.True, "Expected RemoveJob to return True when deleting an existing job");
 
         deleteSuccess = await store.RemoveJob(new JobKey("job0"));
-        Assert.IsFalse(deleteSuccess, "Expected RemoveJob to return False when deleting an non-existing job");
+        Assert.That(deleteSuccess, Is.False, "Expected RemoveJob to return False when deleting an non-existing job");
     }
 
     public class SampleSignaler : ISchedulerSignaler

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -72,13 +72,13 @@ public class RAMJobStoreTest
 
         DateTimeOffset firstFireTime = trigger1.GetNextFireTimeUtc().Value;
 
-        Assert.Multiple(async () =>
+        await Assert.MultipleAsync(async () =>
         {
-            Assert.That((await fJobStore.AcquireNextTriggers(d.AddMilliseconds(10), 1, TimeSpan.Zero)).Count, Is.EqualTo(0));
+            Assert.That((await fJobStore.AcquireNextTriggers(d.AddMilliseconds(10), 1, TimeSpan.Zero)), Is.Empty);
             Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger2));
             Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger3));
             Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger1));
-            Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).Count, Is.EqualTo(0));
+            Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)), Is.Empty);
         });
 
         // release trigger3
@@ -126,7 +126,7 @@ public class RAMJobStoreTest
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromMilliseconds(205000))).ToList();
         Assert.Multiple(() =>
         {
-            Assert.That(acquiredTriggers.Count, Is.EqualTo(2));
+            Assert.That(acquiredTriggers, Has.Count.EqualTo(2));
             Assert.That(acquiredTriggers[0].Key, Is.EqualTo(early.Key));
             Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger1.Key));
         });
@@ -138,7 +138,7 @@ public class RAMJobStoreTest
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 5, TimeSpan.FromMilliseconds(100000))).ToList();
         Assert.Multiple(() =>
         {
-            Assert.That(acquiredTriggers.Count, Is.EqualTo(4));
+            Assert.That(acquiredTriggers, Has.Count.EqualTo(4));
             Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
             Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
             Assert.That(acquiredTriggers[2].Key, Is.EqualTo(trigger3.Key));
@@ -166,7 +166,7 @@ public class RAMJobStoreTest
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(1), 5, TimeSpan.Zero)).ToList();
         Assert.Multiple(() =>{
-        Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
+        Assert.That(acquiredTriggers, Has.Count.EqualTo(1));
         Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
         });
 
@@ -174,7 +174,7 @@ public class RAMJobStoreTest
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(250), 5, TimeSpan.FromMilliseconds(19999L))).ToList();
         Assert.Multiple(() =>{
-        Assert.That(acquiredTriggers.Count, Is.EqualTo(2));
+        Assert.That(acquiredTriggers, Has.Count.EqualTo(2));
         Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
         Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
         });
@@ -186,7 +186,7 @@ public class RAMJobStoreTest
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(150), 5, TimeSpan.FromMilliseconds(5000L))).ToList();
         Assert.Multiple(() =>{
-        Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
+        Assert.That(acquiredTriggers, Has.Count.EqualTo(1));
         Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
         });
         await fJobStore.ReleaseAcquiredTrigger(trigger1);

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -72,11 +72,14 @@ public class RAMJobStoreTest
 
         DateTimeOffset firstFireTime = trigger1.GetNextFireTimeUtc().Value;
 
-        Assert.That((await fJobStore.AcquireNextTriggers(d.AddMilliseconds(10), 1, TimeSpan.Zero)).Count, Is.EqualTo(0));
-        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger2));
-        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger3));
-        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger1));
-        Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).Count, Is.EqualTo(0));
+        Assert.Multiple(async () =>
+        {
+            Assert.That((await fJobStore.AcquireNextTriggers(d.AddMilliseconds(10), 1, TimeSpan.Zero)).Count, Is.EqualTo(0));
+            Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger2));
+            Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger3));
+            Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).First(), Is.EqualTo(trigger1));
+            Assert.That((await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero)).Count, Is.EqualTo(0));
+        });
 
         // release trigger3
         await fJobStore.ReleaseAcquiredTrigger(trigger3);
@@ -113,37 +116,48 @@ public class RAMJobStoreTest
         DateTimeOffset firstFireTime = trigger1.GetNextFireTimeUtc().Value;
 
         List<IOperableTrigger> acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromSeconds(1))).ToList();
-        Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
-        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(early.Key));
+        Assert.Multiple(() =>
+        {
+            Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
+            Assert.That(acquiredTriggers[0].Key, Is.EqualTo(early.Key));
+        });
         await fJobStore.ReleaseAcquiredTrigger(early);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 4, TimeSpan.FromMilliseconds(205000))).ToList();
-        Assert.That(acquiredTriggers.Count, Is.EqualTo(2));
-        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(early.Key));
-        Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger1.Key));
+        Assert.Multiple(() =>
+        {
+            Assert.That(acquiredTriggers.Count, Is.EqualTo(2));
+            Assert.That(acquiredTriggers[0].Key, Is.EqualTo(early.Key));
+            Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger1.Key));
+        });
         await fJobStore.ReleaseAcquiredTrigger(early);
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
 
         await fJobStore.RemoveTrigger(early.Key);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 5, TimeSpan.FromMilliseconds(100000))).ToList();
-        Assert.That(acquiredTriggers.Count, Is.EqualTo(4));
-        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
-        Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
-        Assert.That(acquiredTriggers[2].Key, Is.EqualTo(trigger3.Key));
-        Assert.That(acquiredTriggers[3].Key, Is.EqualTo(trigger4.Key));
+        Assert.Multiple(() =>
+        {
+            Assert.That(acquiredTriggers.Count, Is.EqualTo(4));
+            Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
+            Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
+            Assert.That(acquiredTriggers[2].Key, Is.EqualTo(trigger3.Key));
+            Assert.That(acquiredTriggers[3].Key, Is.EqualTo(trigger4.Key));
+        });
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
         await fJobStore.ReleaseAcquiredTrigger(trigger2);
         await fJobStore.ReleaseAcquiredTrigger(trigger3);
         await fJobStore.ReleaseAcquiredTrigger(trigger4);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 6, TimeSpan.FromMilliseconds(100000))).ToList();
-
-        Assert.That(acquiredTriggers.Count, Is.EqualTo(4));
-        Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
-        Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
-        Assert.That(acquiredTriggers[2].Key, Is.EqualTo(trigger3.Key));
-        Assert.That(acquiredTriggers[3].Key, Is.EqualTo(trigger4.Key));
+        Assert.Multiple(() =>
+        {
+            Assert.That(acquiredTriggers.Count, Is.EqualTo(4));
+            Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
+            Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
+            Assert.That(acquiredTriggers[2].Key, Is.EqualTo(trigger3.Key));
+            Assert.That(acquiredTriggers[3].Key, Is.EqualTo(trigger4.Key));
+        });
 
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
         await fJobStore.ReleaseAcquiredTrigger(trigger2);
@@ -151,15 +165,19 @@ public class RAMJobStoreTest
         await fJobStore.ReleaseAcquiredTrigger(trigger4);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(1), 5, TimeSpan.Zero)).ToList();
+        Assert.Multiple(() =>{
         Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
         Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
+        });
 
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(250), 5, TimeSpan.FromMilliseconds(19999L))).ToList();
+        Assert.Multiple(() =>{
         Assert.That(acquiredTriggers.Count, Is.EqualTo(2));
         Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
         Assert.That(acquiredTriggers[1].Key, Is.EqualTo(trigger2.Key));
+        });
 
         await fJobStore.ReleaseAcquiredTrigger(early);
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
@@ -167,8 +185,10 @@ public class RAMJobStoreTest
         await fJobStore.ReleaseAcquiredTrigger(trigger3);
 
         acquiredTriggers = (await fJobStore.AcquireNextTriggers(firstFireTime.AddMilliseconds(150), 5, TimeSpan.FromMilliseconds(5000L))).ToList();
+        Assert.Multiple(() =>{
         Assert.That(acquiredTriggers.Count, Is.EqualTo(1));
         Assert.That(acquiredTriggers[0].Key, Is.EqualTo(trigger1.Key));
+        });
         await fJobStore.ReleaseAcquiredTrigger(trigger1);
     }
 
@@ -191,8 +211,11 @@ public class RAMJobStoreTest
         Assert.That(trigger, Is.Not.Null);
         await fJobStore.ReleaseAcquiredTrigger(trigger);
         trigger = (await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).First();
-        Assert.That(trigger, Is.Not.Null);
-        Assert.That((await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).Count, Is.EqualTo(0));
+        Assert.Multiple(async () =>
+        {
+            Assert.That(trigger, Is.Not.Null);
+            Assert.That((await fJobStore.AcquireNextTriggers(trigger.GetNextFireTimeUtc().Value.AddSeconds(10), 1, TimeSpan.FromMilliseconds(1))).Count, Is.EqualTo(0));
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Simpl/SchedulerTypeBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/SchedulerTypeBuilderTest.cs
@@ -73,46 +73,28 @@ namespace Quartz.Tests.Unit.Simpl
         }
 
         // ReSharper disable once MemberCanBePrivate.Global
-        public interface INestedInterface : IScheduler
-        {
-        }
+        public interface INestedInterface : IScheduler;
     }
 }
 
 namespace SchedulerTypeBuilderTestTypes
 {
-    public interface IMyScheduler : IScheduler
-    {
-    }
+    public interface IMyScheduler : IScheduler;
 
-    public class DummyClass
-    {
-    }
+    public class DummyClass;
 
-    public interface IDummyInterface
-    {
-    }
+    public interface IDummyInterface;
 
-    public interface IGenericInterface<T> : IScheduler
-    {
-    }
+    public interface IGenericInterface<T> : IScheduler;
 
-    public interface IInterfaceWhichImplementMultipleInterfaces : IScheduler, ICalendar
-    {
-    }
+    public interface IInterfaceWhichImplementMultipleInterfaces : IScheduler, ICalendar;
 
-    internal interface INonPublicInterface : IScheduler
-    {
-    }
+    internal interface INonPublicInterface : IScheduler;
 }
 
 namespace SchedulerTypeBuilderTestTypesB
 {
-    public interface IMyScheduler : IScheduler
-    {
-    }
+    public interface IMyScheduler : IScheduler;
 }
 
-public interface IMySchedulerWithoutNameSpace : IScheduler
-{
-}
+public interface IMySchedulerWithoutNameSpace : IScheduler;

--- a/src/Quartz.Tests.Unit/Simpl/SimpleInstanceIdGeneratorTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/SimpleInstanceIdGeneratorTest.cs
@@ -41,7 +41,7 @@ public class SimpleInstanceIdGeneratorTest
     public async Task IdShouldNotExceed50Chars()
     {
         string instanceId = await generator.GenerateInstanceId();
-        Assert.That(instanceId.Length, Is.LessThanOrEqualTo(50));
+        Assert.That(instanceId, Has.Length.LessThanOrEqualTo(50));
     }
 
     private class TestInstanceIdGenerator : HostNameBasedIdGenerator

--- a/src/Quartz.Tests.Unit/Simpl/SystemPropertyInstanceIdGeneratorTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/SystemPropertyInstanceIdGeneratorTest.cs
@@ -47,7 +47,7 @@ public class SystemPropertyInstanceIdGeneratorTest
 
         string instId = await gen.GenerateInstanceId();
 
-        Assert.AreEqual("foo", instId);
+        Assert.That(instId, Is.EqualTo("foo"));
     }
 
     [Test]
@@ -58,7 +58,7 @@ public class SystemPropertyInstanceIdGeneratorTest
 
         string instId = await gen.GenerateInstanceId();
 
-        Assert.AreEqual("1foo", instId);
+        Assert.That(instId, Is.EqualTo("1foo"));
     }
 
     [Test]
@@ -69,7 +69,7 @@ public class SystemPropertyInstanceIdGeneratorTest
 
         string instId = await gen.GenerateInstanceId();
 
-        Assert.AreEqual("foo2", instId);
+        Assert.That(instId, Is.EqualTo("foo2"));
     }
 
     [Test]
@@ -81,7 +81,7 @@ public class SystemPropertyInstanceIdGeneratorTest
 
         string instId = await gen.GenerateInstanceId();
 
-        Assert.AreEqual("1foo2", instId);
+        Assert.That(instId, Is.EqualTo("1foo2"));
     }
 
     [Test]
@@ -92,7 +92,7 @@ public class SystemPropertyInstanceIdGeneratorTest
 
         string instId = await gen.GenerateInstanceId();
 
-        Assert.AreEqual("goo", instId);
+        Assert.That(instId, Is.EqualTo("goo"));
     }
 
     [Test]
@@ -117,6 +117,6 @@ public class SystemPropertyInstanceIdGeneratorTest
 
         IScheduler sched = await new StdSchedulerFactory(config).GetScheduler();
 
-        Assert.AreEqual("1goo2", sched.SchedulerInstanceId);
+        Assert.That(sched.SchedulerInstanceId, Is.EqualTo("1goo2"));
     }
 }

--- a/src/Quartz.Tests.Unit/Simpl/TaskSchedulingThreadPoolTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/TaskSchedulingThreadPoolTest.cs
@@ -48,13 +48,13 @@ public class TaskSchedulingThreadPoolTest
             task2Done.Set();
         });
 
-        Assert.IsTrue(WaitHandle.WaitAll(new[] { task1Done, task2Done }, TimeSpan.FromSeconds(1)));
+        Assert.That(WaitHandle.WaitAll(new[] { task1Done, task2Done }, TimeSpan.FromSeconds(1)), Is.True);
 
-        Assert.AreEqual(4, logBook.Count);
-        Assert.AreEqual("START #1", logBook[0]);
-        Assert.AreEqual("END #1", logBook[1]);
-        Assert.AreEqual("START #2", logBook[2]);
-        Assert.AreEqual("END #2", logBook[3]);
+        Assert.That(logBook.Count, Is.EqualTo(4));
+        Assert.That(logBook[0], Is.EqualTo("START #1"));
+        Assert.That(logBook[1], Is.EqualTo("END #1"));
+        Assert.That(logBook[2], Is.EqualTo("START #2"));
+        Assert.That(logBook[3], Is.EqualTo("END #2"));
     }
 
     private class CustomTaskSchedulingThreadPool : TaskSchedulingThreadPool

--- a/src/Quartz.Tests.Unit/Simpl/TaskSchedulingThreadPoolTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/TaskSchedulingThreadPoolTest.cs
@@ -51,7 +51,7 @@ public class TaskSchedulingThreadPoolTest
         Assert.Multiple(() =>
         {
             Assert.That(WaitHandle.WaitAll([task1Done, task2Done], TimeSpan.FromSeconds(1)), Is.True);
-            Assert.That(logBook.Count, Is.EqualTo(4));
+            Assert.That(logBook, Has.Count.EqualTo(4));
             Assert.That(logBook[0], Is.EqualTo("START #1"));
             Assert.That(logBook[1], Is.EqualTo("END #1"));
             Assert.That(logBook[2], Is.EqualTo("START #2"));

--- a/src/Quartz.Tests.Unit/Simpl/TaskSchedulingThreadPoolTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/TaskSchedulingThreadPoolTest.cs
@@ -48,13 +48,16 @@ public class TaskSchedulingThreadPoolTest
             task2Done.Set();
         });
 
-        Assert.That(WaitHandle.WaitAll(new[] { task1Done, task2Done }, TimeSpan.FromSeconds(1)), Is.True);
-
-        Assert.That(logBook.Count, Is.EqualTo(4));
-        Assert.That(logBook[0], Is.EqualTo("START #1"));
-        Assert.That(logBook[1], Is.EqualTo("END #1"));
-        Assert.That(logBook[2], Is.EqualTo("START #2"));
-        Assert.That(logBook[3], Is.EqualTo("END #2"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(WaitHandle.WaitAll([task1Done, task2Done], TimeSpan.FromSeconds(1)), Is.True);
+            Assert.That(logBook.Count, Is.EqualTo(4));
+            Assert.That(logBook[0], Is.EqualTo("START #1"));
+            Assert.That(logBook[1], Is.EqualTo("END #1"));
+            Assert.That(logBook[2], Is.EqualTo("START #2"));
+            Assert.That(logBook[3], Is.EqualTo("END #2"));
+        });
+       
     }
 
     private class CustomTaskSchedulingThreadPool : TaskSchedulingThreadPool

--- a/src/Quartz.Tests.Unit/SimpleScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/SimpleScheduleBuilderTest.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 namespace Quartz.Tests.Unit;
 
@@ -16,8 +17,10 @@ public class SimpleScheduleBuilderTest
         var trigger2 = trigger1
             .GetTriggerBuilder()
             .Build();
-
-        trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
-        trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+        using (new AssertionScope())
+        {
+            trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
@@ -137,7 +137,7 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
 
         // Make sure empty sub-objects are cloned okay
         ITrigger clone = simpleTrigger.Clone();
-        Assert.That(clone.JobDataMap.Count, Is.EqualTo(0));
+        Assert.That(clone.JobDataMap, Is.Empty);
 
         // Make sure non-empty sub-objects are cloned okay
         simpleTrigger.JobDataMap.Put("K1", "V1");
@@ -145,7 +145,7 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
         clone = simpleTrigger.Clone();
         Assert.Multiple(() =>
         {
-            Assert.That(clone.JobDataMap.Count, Is.EqualTo(2));
+            Assert.That(clone.JobDataMap, Has.Count.EqualTo(2));
             Assert.That(clone.JobDataMap["K1"], Is.EqualTo("V1"));
             Assert.That(clone.JobDataMap["K2"], Is.EqualTo("V2"));
         });
@@ -155,8 +155,8 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
         clone.JobDataMap.Remove("K1");
         Assert.Multiple(() =>
         {
-            Assert.That(clone.JobDataMap.Count, Is.EqualTo(1));
-            Assert.That(simpleTrigger.JobDataMap.Count, Is.EqualTo(2));
+            Assert.That(clone.JobDataMap, Has.Count.EqualTo(1));
+            Assert.That(simpleTrigger.JobDataMap, Has.Count.EqualTo(2));
             Assert.That(simpleTrigger.JobDataMap["K1"], Is.EqualTo("V1"));
             Assert.That(simpleTrigger.JobDataMap["K2"], Is.EqualTo("V2"));
         });

--- a/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
@@ -187,8 +187,11 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
     {
         IOperableTrigger trigger = new SimpleTriggerImpl();
         trigger.StartTimeUtc = new DateTimeOffset(1982, 6, 28, 13, 5, 5, 233, TimeSpan.Zero);
-        Assert.That(trigger.HasMillisecondPrecision, Is.True);
-        Assert.That(trigger.StartTimeUtc.Millisecond, Is.EqualTo(233));
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.HasMillisecondPrecision, Is.True);
+            Assert.That(trigger.StartTimeUtc.Millisecond, Is.EqualTo(233));
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
@@ -62,28 +62,33 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
 
         SimpleTriggerImpl t = new SimpleTriggerImpl("SimpleTrigger", "SimpleGroup",
             "JobName", "JobGroup", StartTime,
-            EndTime, 5, TimeSpan.FromSeconds(1));
-        t.CalendarName = "MyCalendar";
-        t.Description = "SimpleTriggerDesc";
-        t.JobDataMap = jobDataMap;
-        t.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount;
+            EndTime, 5, TimeSpan.FromSeconds(1))
+        {
+            CalendarName = "MyCalendar",
+            Description = "SimpleTriggerDesc",
+            JobDataMap = jobDataMap,
+            MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount
+        };
 
         return t;
     }
 
     protected override void VerifyMatch(SimpleTriggerImpl original, SimpleTriggerImpl deserialized)
     {
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(original.Key, deserialized.Key);
-        Assert.AreEqual(original.JobKey, deserialized.JobKey);
-        Assert.AreEqual(original.StartTimeUtc, deserialized.StartTimeUtc);
-        Assert.AreEqual(original.EndTimeUtc, deserialized.EndTimeUtc);
-        Assert.AreEqual(original.RepeatCount, deserialized.RepeatCount);
-        Assert.AreEqual(original.RepeatInterval, deserialized.RepeatInterval);
-        Assert.AreEqual(original.CalendarName, deserialized.CalendarName);
-        Assert.AreEqual(original.Description, deserialized.Description);
-        Assert.AreEqual(original.JobDataMap, deserialized.JobDataMap);
-        Assert.AreEqual(original.MisfireInstruction, deserialized.MisfireInstruction);
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Key, Is.EqualTo(original.Key));
+            Assert.That(deserialized.JobKey, Is.EqualTo(original.JobKey));
+            Assert.That(deserialized.StartTimeUtc, Is.EqualTo(original.StartTimeUtc));
+            Assert.That(deserialized.EndTimeUtc, Is.EqualTo(original.EndTimeUtc));
+            Assert.That(deserialized.RepeatCount, Is.EqualTo(original.RepeatCount));
+            Assert.That(deserialized.RepeatInterval, Is.EqualTo(original.RepeatInterval));
+            Assert.That(deserialized.CalendarName, Is.EqualTo(original.CalendarName));
+            Assert.That(deserialized.Description, Is.EqualTo(original.Description));
+            Assert.That(deserialized.JobDataMap, Is.EqualTo(original.JobDataMap));
+            Assert.That(deserialized.MisfireInstruction, Is.EqualTo(original.MisfireInstruction));
+        });
     }
 
     [Test]
@@ -93,16 +98,21 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
 
         DateTimeOffset endTime = new DateTimeOffset(2005, 7, 5, 10, 0, 0, TimeSpan.Zero);
 
-        SimpleTriggerImpl simpleTrigger = new SimpleTriggerImpl();
-        simpleTrigger.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount;
-        simpleTrigger.RepeatCount = 5;
-        simpleTrigger.StartTimeUtc = startTime;
-        simpleTrigger.EndTimeUtc = endTime;
+        SimpleTriggerImpl simpleTrigger = new SimpleTriggerImpl
+        {
+            MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount,
+            RepeatCount = 5,
+            StartTimeUtc = startTime,
+            EndTimeUtc = endTime
+        };
 
         simpleTrigger.UpdateAfterMisfire(null);
-        Assert.AreEqual(startTime, simpleTrigger.StartTimeUtc);
-        Assert.AreEqual(endTime, simpleTrigger.EndTimeUtc.Value);
-        Assert.IsTrue(!simpleTrigger.GetNextFireTimeUtc().HasValue);
+        Assert.Multiple(() =>
+        {
+            Assert.That(simpleTrigger.StartTimeUtc, Is.EqualTo(startTime));
+            Assert.That(simpleTrigger.EndTimeUtc.Value, Is.EqualTo(endTime));
+            Assert.That(!simpleTrigger.GetNextFireTimeUtc().HasValue, Is.True);
+        });
     }
 
     [Test]
@@ -116,9 +126,8 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
         simpleTrigger.RepeatInterval = TimeSpan.FromMilliseconds(10);
         simpleTrigger.RepeatCount = 4;
 
-        DateTimeOffset? fireTimeAfter;
-        fireTimeAfter = simpleTrigger.GetFireTimeAfter(startTime.AddMilliseconds(34));
-        Assert.AreEqual(startTime.AddMilliseconds(40), fireTimeAfter.Value);
+        var fireTimeAfter = simpleTrigger.GetFireTimeAfter(startTime.AddMilliseconds(34));
+        Assert.That(fireTimeAfter.Value, Is.EqualTo(startTime.AddMilliseconds(40)));
     }
 
     [Test]
@@ -128,24 +137,30 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
 
         // Make sure empty sub-objects are cloned okay
         ITrigger clone = simpleTrigger.Clone();
-        Assert.AreEqual(0, clone.JobDataMap.Count);
+        Assert.That(clone.JobDataMap.Count, Is.EqualTo(0));
 
         // Make sure non-empty sub-objects are cloned okay
         simpleTrigger.JobDataMap.Put("K1", "V1");
         simpleTrigger.JobDataMap.Put("K2", "V2");
         clone = simpleTrigger.Clone();
-        Assert.AreEqual(2, clone.JobDataMap.Count);
-        Assert.AreEqual("V1", clone.JobDataMap["K1"]);
-        Assert.AreEqual("V2", clone.JobDataMap["K2"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone.JobDataMap.Count, Is.EqualTo(2));
+            Assert.That(clone.JobDataMap["K1"], Is.EqualTo("V1"));
+            Assert.That(clone.JobDataMap["K2"], Is.EqualTo("V2"));
+        });
 
         // Make sure sub-object collections have really been cloned by ensuring
         // their modification does not change the source Trigger
         clone.JobDataMap.Remove("K1");
-        Assert.AreEqual(1, clone.JobDataMap.Count);
-
-        Assert.AreEqual(2, simpleTrigger.JobDataMap.Count);
-        Assert.AreEqual("V1", simpleTrigger.JobDataMap["K1"]);
-        Assert.AreEqual("V2", simpleTrigger.JobDataMap["K2"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone.JobDataMap.Count, Is.EqualTo(1));
+            Assert.That(simpleTrigger.JobDataMap.Count, Is.EqualTo(2));
+            Assert.That(simpleTrigger.JobDataMap["K1"], Is.EqualTo("V1"));
+            Assert.That(simpleTrigger.JobDataMap["K2"], Is.EqualTo("V2"));
+        });
+        
     }
 
     // QRTZNET-73
@@ -153,16 +168,18 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
     public void TestGetFireTimeAfter_WithCalendar()
     {
         DailyCalendar dailyCalendar = new DailyCalendar("1:20", "14:50");
-        SimpleTriggerImpl simpleTrigger = new SimpleTriggerImpl();
-        simpleTrigger.RepeatInterval = TimeSpan.FromMilliseconds(10);
-        simpleTrigger.RepeatCount = 1;
+        SimpleTriggerImpl simpleTrigger = new SimpleTriggerImpl
+        {
+            RepeatInterval = TimeSpan.FromMilliseconds(10),
+            RepeatCount = 1
+        };
         DateTimeOffset neverFireTime = DateBuilder.EvenMinuteDateBefore(dailyCalendar.GetTimeRangeStartingTimeUtc(DateTime.Now));
         simpleTrigger.StartTimeUtc = neverFireTime;
 
         simpleTrigger.ComputeFirstFireTimeUtc(dailyCalendar);
         DateTimeOffset? fireTimeAfter = simpleTrigger.GetNextFireTimeUtc();
 
-        Assert.IsNull(fireTimeAfter);
+        Assert.That(fireTimeAfter, Is.Null);
     }
 
     [Test]
@@ -170,8 +187,8 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
     {
         IOperableTrigger trigger = new SimpleTriggerImpl();
         trigger.StartTimeUtc = new DateTimeOffset(1982, 6, 28, 13, 5, 5, 233, TimeSpan.Zero);
-        Assert.IsTrue(trigger.HasMillisecondPrecision);
-        Assert.AreEqual(233, trigger.StartTimeUtc.Millisecond);
+        Assert.That(trigger.HasMillisecondPrecision, Is.True);
+        Assert.That(trigger.StartTimeUtc.Millisecond, Is.EqualTo(233));
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/TestUtil.cs
+++ b/src/Quartz.Tests.Unit/TestUtil.cs
@@ -30,18 +30,9 @@ namespace Quartz.Tests.Unit;
 /// <author>Marko Lahma (.NET)</author>
 public static class TestUtil
 {
-    public static void AssertCollectionEquality<T>(IList<T> col1, IList<T> col2)
-    {
-        Assert.AreEqual(col1.Count, col2.Count, "Collection sizes differ");
-        for (int i = 0; i < col1.Count; ++i)
-        {
-            Assert.AreEqual(col1[i], col2[i], $"Collection items differ at index {i}: {col1[i]} vs {col2[i]}");
-        }
-    }
-
     /// <summary>
     /// Creates the minimal fired bundle with job detail that has
-    /// given job type.
+    /// given the job type.
     /// </summary>
     /// <param name="jobType">Type of the job.</param>
     /// <param name="trigger">The trigger.</param>

--- a/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
@@ -42,13 +42,16 @@ public class TriggerBuilderTest
         ITrigger trigger = TriggerBuilder.Create()
             .Build();
 
-        Assert.IsTrue(trigger.Key.Name is not null, "Expected non-null trigger name ");
-        Assert.IsTrue(trigger.Key.Group.Equals(JobKey.DefaultGroup), "Unexpected trigger group: " + trigger.Key.Group);
-        Assert.IsTrue(trigger.JobKey is null, "Unexpected job key: " + trigger.JobKey);
-        Assert.IsTrue(trigger.Description is null, "Unexpected job description: " + trigger.Description);
-        Assert.IsTrue(trigger.Priority == TriggerConstants.DefaultPriority, "Unexpected trigger priority: " + trigger.Priority);
-        Assert.That(trigger.StartTimeUtc.DateTime, Is.EqualTo(DateTimeOffset.UtcNow.DateTime).Within(TimeSpan.FromSeconds(1)), "Unexpected start-time: " + trigger.StartTimeUtc);
-        Assert.IsTrue(trigger.EndTimeUtc is null, "Unexpected end-time: " + trigger.EndTimeUtc);
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key.Name, Is.Not.EqualTo(null), "Expected non-null trigger name ");
+            Assert.That(trigger.Key.Group, Is.EqualTo(JobKey.DefaultGroup), "Unexpected trigger group: " + trigger.Key.Group);
+            Assert.That(trigger.JobKey, Is.EqualTo(null), "Unexpected job key: " + trigger.JobKey);
+            Assert.That(trigger.Description, Is.EqualTo(null), "Unexpected job description: " + trigger.Description);
+            Assert.That(trigger.Priority, Is.EqualTo(TriggerConstants.DefaultPriority), "Unexpected trigger priority: " + trigger.Priority);
+            Assert.That(trigger.StartTimeUtc.DateTime, Is.EqualTo(DateTimeOffset.UtcNow.DateTime).Within(TimeSpan.FromSeconds(1)), "Unexpected start-time: " + trigger.StartTimeUtc);
+            Assert.That(trigger.EndTimeUtc, Is.EqualTo(null), "Unexpected end-time: " + trigger.EndTimeUtc);
+        });
 
         DateTimeOffset stime = DateBuilder.EvenSecondDateAfterNow();
 
@@ -60,13 +63,16 @@ public class TriggerBuilderTest
             .StartAt(stime)
             .Build();
 
-        Assert.IsTrue(trigger.Key.Name.Equals("t1"), "Unexpected trigger name " + trigger.Key.Name);
-        Assert.IsTrue(trigger.Key.Group.Equals(JobKey.DefaultGroup), "Unexpected trigger group: " + trigger.Key.Group);
-        Assert.IsTrue(trigger.JobKey is null, "Unexpected job key: " + trigger.JobKey);
-        Assert.IsTrue(trigger.Description.Equals("my description"), "Unexpected job description: " + trigger.Description);
-        Assert.IsTrue(trigger.Priority == 2, "Unexpected trigger priority: " + trigger);
-        Assert.IsTrue(trigger.StartTimeUtc.Equals(stime), "Unexpected start-time: " + trigger.StartTimeUtc);
-        Assert.IsTrue(trigger.EndTimeUtc is not null, "Unexpected end-time: " + trigger.EndTimeUtc);
+        Assert.Multiple(() =>
+        {
+            Assert.That(trigger.Key.Name, Is.EqualTo("t1"), "Unexpected trigger name " + trigger.Key.Name);
+            Assert.That(trigger.Key.Group, Is.EqualTo(JobKey.DefaultGroup), "Unexpected trigger group: " + trigger.Key.Group);
+            Assert.That(trigger.JobKey, Is.EqualTo(null), "Unexpected job key: " + trigger.JobKey);
+            Assert.That(trigger.Description, Is.EqualTo("my description"), "Unexpected job description: " + trigger.Description);
+            Assert.That(trigger.Priority, Is.EqualTo(2), "Unexpected trigger priority: " + trigger);
+            Assert.That(trigger.StartTimeUtc, Is.EqualTo(stime), "Unexpected start-time: " + trigger.StartTimeUtc);
+            Assert.That(trigger.EndTimeUtc, Is.Not.EqualTo(null), "Unexpected end-time: " + trigger.EndTimeUtc);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/TriggerComparatorTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerComparatorTest.cs
@@ -17,25 +17,30 @@ public class TriggerComparatorTest
         ITrigger t5 = TriggerBuilder.Create().WithIdentity("a", "b").Build();
         ITrigger t6 = TriggerBuilder.Create().WithIdentity("a", "c").Build();
 
-        List<ITrigger> ts = new List<ITrigger>();
         // add triggers to list in somewhat randomized order
-        ts.Add(t5);
-        ts.Add(t6);
-        ts.Add(t4);
-        ts.Add(t3);
-        ts.Add(t1);
-        ts.Add(t2);
+        List<ITrigger> ts =
+        [
+            t5,
+            t6,
+            t4,
+            t3,
+            t1,
+            t2
+        ];
 
         // sort the list
         ts.Sort(TriggerComparer.Instance);
 
-        // check the order of the list
-        Assert.AreEqual(t1, ts[0]);
-        Assert.AreEqual(t2, ts[1]);
-        Assert.AreEqual(t3, ts[2]);
-        Assert.AreEqual(t4, ts[3]);
-        Assert.AreEqual(t5, ts[4]);
-        Assert.AreEqual(t6, ts[5]);
+        Assert.Multiple(() =>
+        {
+            // check the order of the list
+            Assert.That(ts[0], Is.EqualTo(t1));
+            Assert.That(ts[1], Is.EqualTo(t2));
+            Assert.That(ts[2], Is.EqualTo(t3));
+            Assert.That(ts[3], Is.EqualTo(t4));
+            Assert.That(ts[4], Is.EqualTo(t5));
+            Assert.That(ts[5], Is.EqualTo(t6));
+        });
     }
 
     [Test]
@@ -61,30 +66,36 @@ public class TriggerComparatorTest
         ITrigger t9 = TriggerBuilder.Create().WithIdentity("j").StartAt(DateBuilder.FutureDate(7, IntervalUnit.Minute)).Build();
         ((IOperableTrigger) t9).ComputeFirstFireTimeUtc(null);
 
-        List<ITrigger> ts = new List<ITrigger>();
         // add triggers to list in somewhat randomized order
-        ts.Add(t5);
-        ts.Add(t9);
-        ts.Add(t6);
-        ts.Add(t8);
-        ts.Add(t4);
-        ts.Add(t3);
-        ts.Add(t1);
-        ts.Add(t7);
-        ts.Add(t2);
+        List<ITrigger> ts =
+        [
+            t5,
+            t9,
+            t6,
+            t8,
+            t4,
+            t3,
+            t1,
+            t7,
+            t2
+            // sort the list
+        ];
 
         // sort the list
         ts.Sort(TriggerComparer.Instance);
 
-        // check the order of the list
-        Assert.AreEqual(t1, ts[0]);
-        Assert.AreEqual(t2, ts[1]);
-        Assert.AreEqual(t3, ts[2]);
-        Assert.AreEqual(t4, ts[3]);
-        Assert.AreEqual(t5, ts[4]);
-        Assert.AreEqual(t6, ts[5]);
-        Assert.AreEqual(t7, ts[6]);
-        Assert.AreEqual(t8, ts[7]);
-        Assert.AreEqual(t9, ts[8]);
+        Assert.Multiple(() =>
+        {
+            // check the order of the list
+            Assert.That(ts[0], Is.EqualTo(t1));
+            Assert.That(ts[1], Is.EqualTo(t2));
+            Assert.That(ts[2], Is.EqualTo(t3));
+            Assert.That(ts[3], Is.EqualTo(t4));
+            Assert.That(ts[4], Is.EqualTo(t5));
+            Assert.That(ts[5], Is.EqualTo(t6));
+            Assert.That(ts[6], Is.EqualTo(t7));
+            Assert.That(ts[7], Is.EqualTo(t8));
+            Assert.That(ts[8], Is.EqualTo(t9));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/TriggerKeyTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerKeyTest.cs
@@ -7,11 +7,14 @@ public class TriggerKeyTest
     [Test]
     public void TriggerKeyShouldBeSerializable()
     {
-        TriggerKey original = new TriggerKey("name", "group");
+        TriggerKey original = new("name", "group");
 
         TriggerKey cloned = original.DeepClone();
 
-        Assert.That(cloned.Name, Is.EqualTo(original.Name));
-        Assert.That(cloned.Group, Is.EqualTo(original.Group));
+        Assert.Multiple(() =>
+        {
+            Assert.That(cloned.Name, Is.EqualTo(original.Name));
+            Assert.That(cloned.Group, Is.EqualTo(original.Group));
+        });
     }
 }

--- a/src/Quartz.Tests.Unit/TriggerTimeComparatorTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerTimeComparatorTest.cs
@@ -40,63 +40,63 @@ public class TriggerTimeComparatorTest
     public void Compare_ReferenceEquality()
     {
         var actual = _comparer.Compare(_triggerAPrio1NextFireTimeMaxValue, _triggerAPrio1NextFireTimeMaxValue);
-        Assert.AreEqual(0, actual);
+        Assert.That(actual, Is.EqualTo(0));
     }
 
     [Test]
     public void Compare_NextFireTimeOfTrigger2IsNull()
     {
         var actual = _comparer.Compare(_triggerAPrio1NextFireTimeMinValueInstance1, _triggerAPrio1NextFireTimeNullInstance1);
-        Assert.AreEqual(-1, actual);
+        Assert.That(actual, Is.EqualTo(-1));
     }
 
     [Test]
     public void Compare_NextFireTimeOfTrigger2IsLess()
     {
         var actual = _comparer.Compare(_triggerAPrio1NextFireTimeMaxValue, _triggerAPrio1NextFireTimeMinValueInstance1);
-        Assert.AreEqual(1, actual);
+        Assert.That(actual, Is.EqualTo(1));
     }
 
     [Test]
     public void Compare_NextFireTimeOfTrigger2IsGreater()
     {
         var actual = _comparer.Compare(_triggerAPrio1NextFireTimeMinValueInstance1, _triggerAPrio1NextFireTimeMaxValue);
-        Assert.AreEqual(-1, actual);
+        Assert.That(actual, Is.EqualTo(-1));
     }
 
     [Test]
     public void Compare_NextFireTimeIsEqual_PriorityOfTrigger2IsLess()
     {
         var actual = _comparer.Compare(_triggerBPrio2NextFireTimeMinValue, _triggerBPrio1NextFireTimeMinValue);
-        Assert.AreEqual(-1, actual);
+        Assert.That(actual, Is.EqualTo(-1));
     }
 
     [Test]
     public void Compare_NextFireTimeIsEqual_PriorityOfTrigger2IsGreater()
     {
         var actual = _comparer.Compare(_triggerBPrio1NextFireTimeMinValue, _triggerBPrio2NextFireTimeMinValue);
-        Assert.AreEqual(1, actual);
+        Assert.That(actual, Is.EqualTo(1));
     }
 
     [Test]
     public void Compare_NextFireTimeIsEqual_PriorityIsEqual_KeyIsEqual()
     {
         var actual = _comparer.Compare(_triggerAPrio1NextFireTimeMinValueInstance1, _triggerAPrio1NextFireTimeMinValueInstance2);
-        Assert.AreEqual(0, actual);
+        Assert.That(actual, Is.EqualTo(0));
     }
 
     [Test]
     public void Compare_NextFireTimeIsEqual_PriorityIsEqual_KeyOfTrigger2IsGreater()
     {
         var actual = _comparer.Compare(_triggerAPrio1NextFireTimeMinValueInstance1, _triggerBPrio1NextFireTimeMinValue);
-        Assert.AreEqual(-1, actual);
+        Assert.That(actual, Is.EqualTo(-1));
     }
 
     [Test]
     public void Compare_NextFireTimeIsEqual_PriorityIsEqual_KeyOfTrigger2IsLess()
     {
         var actual = _comparer.Compare(_triggerBPrio1NextFireTimeMinValue, _triggerAPrio1NextFireTimeMinValueInstance1);
-        Assert.AreEqual(1, actual);
+        Assert.That(actual, Is.EqualTo(1));
     }
 
 
@@ -104,33 +104,33 @@ public class TriggerTimeComparatorTest
     public void Compare_NextFireTimeIsNull_PriorityOfTrigger2IsLess()
     {
         var actual = _comparer.Compare(_triggerBPrio2NextFireTimeNull, _triggerBPrio1NextFireTimeNull);
-        Assert.AreEqual(-1, actual);
+        Assert.That(actual, Is.EqualTo(-1));
     }
 
     [Test]
     public void Compare_NextFireTimeIsNull_PriorityOfTrigger2IsGreater()
     {
         var actual = _comparer.Compare(_triggerBPrio1NextFireTimeNull, _triggerBPrio2NextFireTimeNull);
-        Assert.AreEqual(1, actual);
+        Assert.That(actual, Is.EqualTo(1));
     }
 
     [Test]
     public void Compare_NextFireTimeIsNull_PriorityIsEqual_KeyIsEqual()
     {
         var actual = _comparer.Compare(_triggerAPrio1NextFireTimeNullInstance1, _triggerAPrio1NextFireTimeNullInstance2);
-        Assert.AreEqual(0, actual);
+        Assert.That(actual, Is.EqualTo(0));
     }
 
     public void Compare_NextFireTimeIsNull_PriorityIsEqual_KeyOfTrigger2IsLess()
     {
         var actual = _comparer.Compare(_triggerBPrio1NextFireTimeNull, _triggerAPrio1NextFireTimeNullInstance1);
-        Assert.AreEqual(0, actual);
+        Assert.That(actual, Is.EqualTo(0));
     }
 
     public void Compare_NextFireTimeIsNull_PriorityIsEqual_KeyOfTrigger2IsGreater()
     {
         var actual = _comparer.Compare(_triggerAPrio1NextFireTimeNullInstance1, _triggerBPrio1NextFireTimeNull);
-        Assert.AreEqual(0, actual);
+        Assert.That(actual, Is.EqualTo(0));
     }
 
     private class MutableTrigger : IMutableTrigger

--- a/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
@@ -41,7 +41,7 @@ public class DirtyFlagMapTest
         var map = Deserialize<DirtyFlagMap<string, int>>("DirtyFlagMap_EmptyAndDirty_V1");
 
         Assert.That(map, Is.Not.Null);
-        Assert.That(map.Count, Is.EqualTo(0));
+        Assert.That(map, Is.Empty);
         Assert.That(map.Dirty, Is.True);
     }
 
@@ -51,7 +51,7 @@ public class DirtyFlagMapTest
         var map = Deserialize<DirtyFlagMap<string, int>>("DirtyFlagMap_EmptyAndNotDirty_V1");
 
         Assert.That(map, Is.Not.Null);
-        Assert.That(map.Count, Is.EqualTo(0));
+        Assert.That(map, Is.Empty);
         Assert.That(map.Dirty, Is.False);
     }
 
@@ -62,7 +62,7 @@ public class DirtyFlagMapTest
         Assert.Multiple(() =>
         {
             Assert.That(map, Is.Not.Null);
-            Assert.That(map.Count, Is.EqualTo(2));
+            Assert.That(map, Has.Count.EqualTo(2));
             Assert.That(map.ContainsKey("A"), Is.True);
             Assert.That(map["A"], Is.EqualTo(2));
             Assert.That(map.ContainsKey("B"), Is.True);
@@ -78,7 +78,7 @@ public class DirtyFlagMapTest
         Assert.Multiple(() =>
         {
             Assert.That(map, Is.Not.Null);
-            Assert.That(map.Count, Is.EqualTo(2));
+            Assert.That(map, Has.Count.EqualTo(2));
             Assert.That(map.ContainsKey("C"), Is.True);
             Assert.That(map["C"], Is.EqualTo(3));
             Assert.That(map.ContainsKey("F"), Is.True);
@@ -98,7 +98,7 @@ public class DirtyFlagMapTest
         Assert.Multiple(() =>
         {
             Assert.That(deserialized, Is.Not.Null);
-            Assert.That(deserialized.Count, Is.EqualTo(0));
+            Assert.That(deserialized, Is.Empty);
             Assert.That(deserialized.Dirty, Is.True);
         });
     }
@@ -112,7 +112,7 @@ public class DirtyFlagMapTest
         Assert.Multiple(() =>
         {
             Assert.That(deserialized, Is.Not.Null);
-            Assert.That(deserialized.Count, Is.EqualTo(0));
+            Assert.That(deserialized, Is.Empty);
             Assert.That(deserialized.Dirty, Is.False);
         });
     }
@@ -128,7 +128,7 @@ public class DirtyFlagMapTest
         Assert.Multiple(() =>
         {
             Assert.That(deserialized, Is.Not.Null);
-            Assert.That(deserialized.Count, Is.EqualTo(2));
+            Assert.That(deserialized, Has.Count.EqualTo(2));
             Assert.That(map.ContainsKey("A"), Is.True);
             Assert.That(map["A"], Is.EqualTo(2));
             Assert.That(map.ContainsKey("B"), Is.True);
@@ -149,7 +149,7 @@ public class DirtyFlagMapTest
         Assert.Multiple(() =>
         {
             Assert.That(map, Is.Not.Null);
-            Assert.That(map.Count, Is.EqualTo(2));
+            Assert.That(map, Has.Count.EqualTo(2));
             Assert.That(map.ContainsKey("C"), Is.True);
             Assert.That(map["C"], Is.EqualTo(3));
             Assert.That(map.ContainsKey("F"), Is.True);

--- a/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
@@ -289,8 +289,11 @@ public class DirtyFlagMapTest
 
         var actual = dirtyFlagMap["a"];
 
-        Assert.That(dirtyFlagMap.Dirty, Is.False);
-        Assert.That(actual, Is.EqualTo(default(int)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(actual, Is.EqualTo(default(int)));
+        });
 
         /*
         try
@@ -708,9 +711,12 @@ public class DirtyFlagMapTest
             // An item with the same key has already been added. Key: c
         }
 
-        Assert.That(dirtyFlagMap.Dirty, Is.False);
-        Assert.That(dirtyFlagMap.ContainsKey("c"), Is.True);
-        Assert.That(dirtyFlagMap["c"], Is.EqualTo("z"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(dirtyFlagMap.ContainsKey("c"), Is.True);
+            Assert.That(dirtyFlagMap["c"], Is.EqualTo("z"));
+        });
     }
 
     [Test]
@@ -1302,8 +1308,11 @@ public class DirtyFlagMapTest
 
         var actual = ((IDictionary)dirtyFlagMap)["a"];
 
-        Assert.That(dirtyFlagMap.Dirty, Is.False);
-        Assert.That(actual, Is.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(actual, Is.Null);
+        });
     }
 
     [Test]
@@ -1649,8 +1658,11 @@ public class DirtyFlagMapTest
 
         ((IDictionary)dirtyFlagMap).Remove("a");
 
-        Assert.That(dirtyFlagMap.Dirty, Is.True);
-        Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/DirtyFlagMapTest.cs
@@ -1,4 +1,5 @@
 #region License
+
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
  *
@@ -15,6 +16,7 @@
  * under the License.
  *
  */
+
 #endregion
 
 using System.Collections;
@@ -38,9 +40,9 @@ public class DirtyFlagMapTest
     {
         var map = Deserialize<DirtyFlagMap<string, int>>("DirtyFlagMap_EmptyAndDirty_V1");
 
-        Assert.IsNotNull(map);
-        Assert.AreEqual(0, map.Count);
-        Assert.IsTrue(map.Dirty);
+        Assert.That(map, Is.Not.Null);
+        Assert.That(map.Count, Is.EqualTo(0));
+        Assert.That(map.Dirty, Is.True);
     }
 
     [Test]
@@ -48,37 +50,41 @@ public class DirtyFlagMapTest
     {
         var map = Deserialize<DirtyFlagMap<string, int>>("DirtyFlagMap_EmptyAndNotDirty_V1");
 
-        Assert.IsNotNull(map);
-        Assert.AreEqual(0, map.Count);
-        Assert.IsFalse(map.Dirty);
+        Assert.That(map, Is.Not.Null);
+        Assert.That(map.Count, Is.EqualTo(0));
+        Assert.That(map.Dirty, Is.False);
     }
 
     [Test]
     public void NotEmptyAndDirty_V1_CanBeDeserialized()
     {
         var map = Deserialize<DirtyFlagMap<string, int>>("DirtyFlagMap_NotEmptyAndDirty_V1");
-
-        Assert.IsNotNull(map);
-        Assert.AreEqual(2, map.Count);
-        Assert.IsTrue(map.ContainsKey("A"));
-        Assert.AreEqual(2, map["A"]);
-        Assert.IsTrue(map.ContainsKey("B"));
-        Assert.AreEqual(7, map["B"]);
-        Assert.IsTrue(map.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(map, Is.Not.Null);
+            Assert.That(map.Count, Is.EqualTo(2));
+            Assert.That(map.ContainsKey("A"), Is.True);
+            Assert.That(map["A"], Is.EqualTo(2));
+            Assert.That(map.ContainsKey("B"), Is.True);
+            Assert.That(map["B"], Is.EqualTo(7));
+            Assert.That(map.Dirty, Is.True);
+        });
     }
 
     [Test]
     public void NotEmptyAndNotDirty_V1_CanBeDeserialized()
     {
         var map = Deserialize<DirtyFlagMap<string, int>>("DirtyFlagMap_NotEmptyAndNotDirty_V1");
-
-        Assert.IsNotNull(map);
-        Assert.AreEqual(2, map.Count);
-        Assert.IsTrue(map.ContainsKey("C"));
-        Assert.AreEqual(3, map["C"]);
-        Assert.IsTrue(map.ContainsKey("F"));
-        Assert.AreEqual(1, map["F"]);
-        Assert.IsFalse(map.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(map, Is.Not.Null);
+            Assert.That(map.Count, Is.EqualTo(2));
+            Assert.That(map.ContainsKey("C"), Is.True);
+            Assert.That(map["C"], Is.EqualTo(3));
+            Assert.That(map.ContainsKey("F"), Is.True);
+            Assert.That(map["F"], Is.EqualTo(1));
+            Assert.That(map.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -89,10 +95,12 @@ public class DirtyFlagMapTest
         map.Clear();
 
         var deserialized = SerializeAndDeserialize(map);
-
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(0, deserialized.Count);
-        Assert.IsTrue(deserialized.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Count, Is.EqualTo(0));
+            Assert.That(deserialized.Dirty, Is.True);
+        });
     }
 
     [Test]
@@ -101,10 +109,12 @@ public class DirtyFlagMapTest
         var map = new DirtyFlagMap<string, int>();
 
         var deserialized = SerializeAndDeserialize(map);
-
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(0, deserialized.Count);
-        Assert.IsFalse(deserialized.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Count, Is.EqualTo(0));
+            Assert.That(deserialized.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -115,14 +125,16 @@ public class DirtyFlagMapTest
         map.Add("B", 7);
 
         var deserialized = SerializeAndDeserialize(map);
-
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(2, deserialized.Count);
-        Assert.IsTrue(map.ContainsKey("A"));
-        Assert.AreEqual(2, map["A"]);
-        Assert.IsTrue(map.ContainsKey("B"));
-        Assert.AreEqual(7, map["B"]);
-        Assert.IsTrue(map.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Count, Is.EqualTo(2));
+            Assert.That(map.ContainsKey("A"), Is.True);
+            Assert.That(map["A"], Is.EqualTo(2));
+            Assert.That(map.ContainsKey("B"), Is.True);
+            Assert.That(map["B"], Is.EqualTo(7));
+            Assert.That(map.Dirty, Is.True);
+        });
     }
 
     [Test]
@@ -134,14 +146,16 @@ public class DirtyFlagMapTest
         map.ClearDirtyFlag();
 
         var deserialized = SerializeAndDeserialize(map);
-
-        Assert.IsNotNull(map);
-        Assert.AreEqual(2, map.Count);
-        Assert.IsTrue(map.ContainsKey("C"));
-        Assert.AreEqual(3, map["C"]);
-        Assert.IsTrue(map.ContainsKey("F"));
-        Assert.AreEqual(1, map["F"]);
-        Assert.IsFalse(map.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(map, Is.Not.Null);
+            Assert.That(map.Count, Is.EqualTo(2));
+            Assert.That(map.ContainsKey("C"), Is.True);
+            Assert.That(map["C"], Is.EqualTo(3));
+            Assert.That(map.ContainsKey("F"), Is.True);
+            Assert.That(map["F"], Is.EqualTo(1));
+            Assert.That(map.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -157,10 +171,10 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -170,9 +184,12 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", null);
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.TryGetValue("a", out var value));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.TryGetValue("a", out var value), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(value, Is.Null);
+        });
     }
 
     [Test]
@@ -182,10 +199,13 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.TryGetValue("a", out var value));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(value);
-        Assert.AreEqual("x", value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.TryGetValue("a", out var value), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(value, Is.Not.Null);
+            Assert.That(value, Is.EqualTo("x"));
+        });
     }
 
     [Test]
@@ -193,9 +213,12 @@ public class DirtyFlagMapTest
     {
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
 
-        Assert.IsFalse(dirtyFlagMap.TryGetValue("a", out var value));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.TryGetValue("a", out var value), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(value, Is.Null);
+        });
     }
 
     [Test]
@@ -203,10 +226,12 @@ public class DirtyFlagMapTest
     {
         var dirtyFlagMap = new DirtyFlagMap<string, int>();
 
-        Assert.IsFalse(dirtyFlagMap.TryGetValue("a", out var value));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(value);
-        Assert.AreEqual(default(int), value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.TryGetValue("a", out var value), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(value, Is.EqualTo(default(int)));
+        });
     }
 
     [Test]
@@ -214,9 +239,12 @@ public class DirtyFlagMapTest
     {
         var dirtyFlagMap = new DirtyFlagMap<string, int?>();
 
-        Assert.IsFalse(dirtyFlagMap.TryGetValue("a", out var value));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.TryGetValue("a", out var value), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(value, Is.Null);
+        });
     }
 
     [Test]
@@ -228,9 +256,12 @@ public class DirtyFlagMapTest
 
         var actual = dirtyFlagMap["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(actual);
-        Assert.AreEqual("x", actual);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual, Is.EqualTo("x"));
+        });
     }
 
     [Test]
@@ -242,8 +273,11 @@ public class DirtyFlagMapTest
 
         var actual = dirtyFlagMap["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(actual);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(actual, Is.Null);
+        });
     }
 
     [Test]
@@ -255,9 +289,8 @@ public class DirtyFlagMapTest
 
         var actual = dirtyFlagMap["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(default(int), actual);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
+        Assert.That(actual, Is.EqualTo(default(int)));
 
         /*
         try
@@ -282,8 +315,11 @@ public class DirtyFlagMapTest
 
         var actual = dirtyFlagMap["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(actual);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(actual, Is.Null);
+        });
 
         /*
         try
@@ -308,8 +344,11 @@ public class DirtyFlagMapTest
 
         var value = dirtyFlagMap["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(value, Is.Null);
+        });
 
         /*
         try
@@ -338,10 +377,10 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -353,25 +392,34 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap["a"] = "y";
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("y", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("y"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap["a"] = null;
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap["a"] = "b";
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("b", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("b"));
+        });
     }
 
     [Test]
@@ -384,17 +432,23 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap["a"] = "y";
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("y", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("y"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap["b"] = null;
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("b"));
-        Assert.IsNull(dirtyFlagMap["b"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("b"), Is.True);
+            Assert.That(dirtyFlagMap["b"], Is.Null);
+        });
     }
 
     [Test]
@@ -404,17 +458,23 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap["a"] = "x";
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap["b"] = null;
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("b"));
-        Assert.IsNull(dirtyFlagMap["b"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("b"), Is.True);
+            Assert.That(dirtyFlagMap["b"], Is.Null);
+        });
     }
 
     [Test]
@@ -430,10 +490,10 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -443,8 +503,11 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Add("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Remove("a"));
-        Assert.IsTrue(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Remove("a"), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+        });
     }
 
     [Test]
@@ -454,9 +517,12 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Add("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsFalse(dirtyFlagMap.Remove("x"));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Remove("x"), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+        });
     }
 
     [Test]
@@ -472,10 +538,10 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -485,19 +551,25 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        // #1417: We should not remove entry if values are not equal, see commented code below
+        Assert.Multiple(() =>
+        {
+            // #1417: We should not remove entry if values are not equal, see commented code below
 
-        Assert.IsTrue(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", null)));
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsFalse(dirtyFlagMap.ContainsKey("a"));
+            Assert.That(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", null)), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
+        });
 
         dirtyFlagMap.Clear();
         dirtyFlagMap.Put("a", null);
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", "y")));
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsFalse(dirtyFlagMap.ContainsKey("a"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", "y")), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
+        });
 
         /*
         Assert.IsFalse(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", null)));
@@ -529,16 +601,22 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", "x")));
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsFalse(dirtyFlagMap.ContainsKey("a"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", "x")), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
+        });
 
         dirtyFlagMap.Put("a", null);
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", null)));
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsFalse(dirtyFlagMap.ContainsKey("a"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", null)), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
+        });
     }
 
     [Test]
@@ -547,8 +625,11 @@ public class DirtyFlagMapTest
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
         var kvp = new KeyValuePair<string, string>("a", "x");
 
-        Assert.IsFalse(dirtyFlagMap.Remove(kvp));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Remove(kvp), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -564,10 +645,10 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual("key", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -587,9 +668,12 @@ public class DirtyFlagMapTest
             // An item with the same key has already been added. Key: a
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
 
         dirtyFlagMap.Put("b", null);
         dirtyFlagMap.ClearDirtyFlag();
@@ -604,9 +688,12 @@ public class DirtyFlagMapTest
             // An item with the same key has already been added. Key: b
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("b"));
-        Assert.IsNull(dirtyFlagMap["b"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(dirtyFlagMap.ContainsKey("b"), Is.True);
+            Assert.That(dirtyFlagMap["b"], Is.Null);
+        });
 
         dirtyFlagMap.Put("c", "z");
         dirtyFlagMap.ClearDirtyFlag();
@@ -621,9 +708,9 @@ public class DirtyFlagMapTest
             // An item with the same key has already been added. Key: c
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("c"));
-        Assert.AreEqual("z", dirtyFlagMap["c"]);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
+        Assert.That(dirtyFlagMap.ContainsKey("c"), Is.True);
+        Assert.That(dirtyFlagMap["c"], Is.EqualTo("z"));
     }
 
     [Test]
@@ -643,9 +730,12 @@ public class DirtyFlagMapTest
             // An item with the same key has already been added. Key: a
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
 
         dirtyFlagMap.Clear();
         dirtyFlagMap.Put("a", null);
@@ -661,9 +751,12 @@ public class DirtyFlagMapTest
             // An item with the same key has already been added. Key: a
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
     }
 
     [Test]
@@ -673,17 +766,23 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap.Add("a", "x");
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap.Add("b", null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("b"));
-        Assert.IsNull(dirtyFlagMap["b"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("b"), Is.True);
+            Assert.That(dirtyFlagMap["b"], Is.Null);
+        });
     }
 
     [Test]
@@ -699,10 +798,10 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -718,10 +817,10 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual("key", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -732,9 +831,12 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap.Add(kvp);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
     }
 
     [Test]
@@ -748,25 +850,34 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap.Add(new KeyValuePair<string, string>("a", "y"));
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("y", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("y"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap.Add(new KeyValuePair<string, string>("a", null));
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap.Add(new KeyValuePair<string, string>("a", "z"));
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("z", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("z"));
+        });
 
         /*
         try
@@ -828,9 +939,12 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap.Add(new KeyValuePair<string, string>("a", "x"));
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
 
         dirtyFlagMap.Clear();
         dirtyFlagMap.Put("a", null);
@@ -838,9 +952,12 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap.Add(new KeyValuePair<string, string>("a", null));
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
     }
 
     [Test]
@@ -851,15 +968,15 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap).Add(key, "x");
+            ((IDictionary)dirtyFlagMap).Add(key, "x");
             Assert.Fail();
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual("key", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -872,14 +989,14 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap).Add(key, 5);
+            ((IDictionary)dirtyFlagMap).Add(key, 5);
             Assert.Fail();
         }
         catch (InvalidCastException)
         {
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
 
         /*
         try
@@ -897,7 +1014,6 @@ public class DirtyFlagMapTest
         */
     }
 
-
     [Test]
     public void IDictionary_Add_KeyAndValue_KeyIsNotFound_ValueIsNotNull_ValueCannotBeAssignedToTValue()
     {
@@ -908,14 +1024,14 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap).Add(key, 5);
+            ((IDictionary)dirtyFlagMap).Add(key, 5);
             Assert.Fail();
         }
         catch (InvalidCastException)
         {
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
 
         /*
 
@@ -940,11 +1056,14 @@ public class DirtyFlagMapTest
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
         object key = "a";
 
-        ((IDictionary) dirtyFlagMap).Add(key, "x");
+        ((IDictionary)dirtyFlagMap).Add(key, "x");
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
     }
 
     [Test]
@@ -957,14 +1076,14 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap).Add(key, null);
+            ((IDictionary)dirtyFlagMap).Add(key, null);
             Assert.Fail();
         }
         catch (NullReferenceException)
         {
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
 
         /*
         try
@@ -988,11 +1107,14 @@ public class DirtyFlagMapTest
         var dirtyFlagMap = new DirtyFlagMap<string, int?>();
         object key = "a";
 
-        ((IDictionary) dirtyFlagMap).Add(key, null);
+        ((IDictionary)dirtyFlagMap).Add(key, null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
     }
 
     [Test]
@@ -1001,11 +1123,14 @@ public class DirtyFlagMapTest
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
         object key = "a";
 
-        ((IDictionary) dirtyFlagMap).Add(key, null);
+        ((IDictionary)dirtyFlagMap).Add(key, null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
     }
 
     [Test]
@@ -1017,27 +1142,36 @@ public class DirtyFlagMapTest
 
         // #1417: We should throw ArgumentException, see commented code below
 
-        ((IDictionary) dirtyFlagMap).Add("a", "y");
+        ((IDictionary)dirtyFlagMap).Add("a", "y");
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("y", dirtyFlagMap["a"]);
-
-        dirtyFlagMap.ClearDirtyFlag();
-
-        ((IDictionary) dirtyFlagMap).Add("a", null);
-
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("y"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
-        ((IDictionary) dirtyFlagMap).Add("a", "z");
+        ((IDictionary)dirtyFlagMap).Add("a", null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("z", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
+
+        dirtyFlagMap.ClearDirtyFlag();
+
+        ((IDictionary)dirtyFlagMap).Add("a", "z");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("z"));
+        });
 
         /*
         try
@@ -1097,17 +1231,23 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", "x")));
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsFalse(dirtyFlagMap.ContainsKey("a"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", "x")), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
+        });
 
         dirtyFlagMap.Clear();
         dirtyFlagMap.Put("a", null);
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", null)));
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsFalse(dirtyFlagMap.ContainsKey("a"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Remove(new KeyValuePair<string, string>("a", null)), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
+        });
     }
 
     [Test]
@@ -1121,7 +1261,7 @@ public class DirtyFlagMapTest
 
         try
         {
-            var actual = ((IDictionary) dirtyFlagMap)[5];
+            var actual = ((IDictionary)dirtyFlagMap)[5];
             Assert.Fail("Should have thrown, but returned " + actual);
         }
         catch (InvalidCastException)
@@ -1143,11 +1283,14 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        var actual = ((IDictionary) dirtyFlagMap)["a"];
+        var actual = ((IDictionary)dirtyFlagMap)["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(actual);
-        Assert.AreEqual("x", actual);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(actual, Is.Not.Null);
+        });
+        Assert.That(actual, Is.EqualTo("x"));
     }
 
     [Test]
@@ -1157,10 +1300,10 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", null);
         dirtyFlagMap.ClearDirtyFlag();
 
-        var actual = ((IDictionary) dirtyFlagMap)["a"];
+        var actual = ((IDictionary)dirtyFlagMap)["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(actual);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
+        Assert.That(actual, Is.Null);
     }
 
     [Test]
@@ -1170,11 +1313,14 @@ public class DirtyFlagMapTest
 
         // #1417: This should throw a KeyNotFoundException, see commented code below
 
-        var actual = ((IDictionary) dirtyFlagMap)["a"];
+        var actual = ((IDictionary)dirtyFlagMap)["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(default(int), actual);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual, Is.EqualTo(default(int)));
+        });
 
         /*
         try
@@ -1197,10 +1343,13 @@ public class DirtyFlagMapTest
 
         // #1417: This should throw a KeyNotFoundException, see commented code below
 
-        var actual = ((IDictionary) dirtyFlagMap)["a"];
+        var actual = ((IDictionary)dirtyFlagMap)["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(actual);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(actual, Is.Null);
+        });
 
         /*
         try
@@ -1223,10 +1372,13 @@ public class DirtyFlagMapTest
 
         // #1417: This should throw a KeyNotFoundException, see commented code below
 
-        var value = ((IDictionary) dirtyFlagMap)["a"];
+        var value = ((IDictionary)dirtyFlagMap)["a"];
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
-        Assert.IsNull(value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+            Assert.That(value, Is.Null);
+        });
 
         /*
         try
@@ -1250,15 +1402,15 @@ public class DirtyFlagMapTest
 
         try
         {
-            var actual = ((IDictionary) dirtyFlagMap)[key];
+            var actual = ((IDictionary)dirtyFlagMap)[key];
             Assert.Fail("Should have thrown, but returned " + actual);
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -1271,14 +1423,14 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap)[key] = "y";
+            ((IDictionary)dirtyFlagMap)[key] = "y";
             Assert.Fail();
         }
         catch (InvalidCastException)
         {
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
 
         /*
         try
@@ -1303,27 +1455,36 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        ((IDictionary) dirtyFlagMap)["a"] = "y";
+        ((IDictionary)dirtyFlagMap)["a"] = "y";
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("y", dirtyFlagMap["a"]);
-
-        dirtyFlagMap.ClearDirtyFlag();
-
-        ((IDictionary) dirtyFlagMap)["a"] = null;
-
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("y"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
-        ((IDictionary) dirtyFlagMap)["a"] = "b";
+        ((IDictionary)dirtyFlagMap)["a"] = null;
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("b", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
+
+        dirtyFlagMap.ClearDirtyFlag();
+
+        ((IDictionary)dirtyFlagMap)["a"] = "b";
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("b"));
+        });
     }
 
     [Test]
@@ -1334,19 +1495,25 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("b", null);
         dirtyFlagMap.ClearDirtyFlag();
 
-        ((IDictionary) dirtyFlagMap)["a"] = "y";
+        ((IDictionary)dirtyFlagMap)["a"] = "y";
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("y", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("y"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
-        ((IDictionary) dirtyFlagMap)["b"] = null;
+        ((IDictionary)dirtyFlagMap)["b"] = null;
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("b"));
-        Assert.IsNull(dirtyFlagMap["b"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("b"), Is.True);
+            Assert.That(dirtyFlagMap["b"], Is.Null);
+        });
     }
 
     [Test]
@@ -1354,19 +1521,25 @@ public class DirtyFlagMapTest
     {
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
 
-        ((IDictionary) dirtyFlagMap)["a"] = "x";
+        ((IDictionary)dirtyFlagMap)["a"] = "x";
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
-        ((IDictionary) dirtyFlagMap)["b"] = null;
+        ((IDictionary)dirtyFlagMap)["b"] = null;
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("b"));
-        Assert.IsNull(dirtyFlagMap["b"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("b"), Is.True);
+            Assert.That(dirtyFlagMap["b"], Is.Null);
+        });
     }
 
     [Test]
@@ -1377,17 +1550,16 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap)[key] = "x";
+            ((IDictionary)dirtyFlagMap)[key] = "x";
             Assert.Fail();
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
-
 
     [Test]
     public void IDictionary_Indexer_Set_ValueCannotBeAssignedToTValue()
@@ -1398,14 +1570,14 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap)["a"] = 5;
+            ((IDictionary)dirtyFlagMap)["a"] = 5;
             Assert.Fail();
         }
         catch (InvalidCastException)
         {
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
 
         /*
         try
@@ -1423,7 +1595,6 @@ public class DirtyFlagMapTest
         */
     }
 
-
     [Test]
     public void IDictionary_Remove_KeyIsNull()
     {
@@ -1432,15 +1603,15 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap).Remove(key);
+            ((IDictionary)dirtyFlagMap).Remove(key);
             Assert.Fail();
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual("key", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -1453,14 +1624,14 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary) dirtyFlagMap).Remove(key);
+            ((IDictionary)dirtyFlagMap).Remove(key);
             Assert.Fail();
         }
         catch (InvalidCastException)
         {
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
 
         /*
         ((IDictionary) dirtyFlagMap).Remove(key);
@@ -1476,10 +1647,10 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Add("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        ((IDictionary) dirtyFlagMap).Remove("a");
+        ((IDictionary)dirtyFlagMap).Remove("a");
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsFalse(dirtyFlagMap.ContainsKey("a"));
+        Assert.That(dirtyFlagMap.Dirty, Is.True);
+        Assert.That(dirtyFlagMap.ContainsKey("a"), Is.False);
     }
 
     [Test]
@@ -1488,9 +1659,9 @@ public class DirtyFlagMapTest
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
         object key = "a";
 
-        ((IDictionary) dirtyFlagMap).Remove(key);
+        ((IDictionary)dirtyFlagMap).Remove(key);
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -1500,8 +1671,11 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Add("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsFalse(((IDictionary) dirtyFlagMap).Contains(5));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(((IDictionary)dirtyFlagMap).Contains(5), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1511,8 +1685,11 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Contains("a"));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Contains("a"), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1521,8 +1698,11 @@ public class DirtyFlagMapTest
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
         object key = "a";
 
-        Assert.IsFalse(dirtyFlagMap.Contains(key));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Contains(key), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1538,7 +1718,7 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
     }
 
@@ -1550,12 +1730,12 @@ public class DirtyFlagMapTest
 
         try
         {
-            ((IDictionary<string, string>) dirtyFlagMap).Contains(kvp);
+            ((IDictionary<string, string>)dirtyFlagMap).Contains(kvp);
             Assert.Fail();
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual("key", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
     }
 
@@ -1564,8 +1744,11 @@ public class DirtyFlagMapTest
     {
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
 
-        Assert.IsFalse(dirtyFlagMap.Contains(new KeyValuePair<string, string>("a", "x")));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Contains(new KeyValuePair<string, string>("a", "x")), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1575,13 +1758,16 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Add("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        // #1417: this should return false
-        Assert.IsTrue(dirtyFlagMap.Contains(new KeyValuePair<string, string>("a", "y")));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            // #1417: this should return false
+            Assert.That(dirtyFlagMap.Contains(new KeyValuePair<string, string>("a", "y")), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
 
-        // #1417: this should return false
-        Assert.IsTrue(dirtyFlagMap.Contains(new KeyValuePair<string, string>("a", null)));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+            // #1417: this should return false
+            Assert.That(dirtyFlagMap.Contains(new KeyValuePair<string, string>("a", null)), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1591,14 +1777,20 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Add("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Contains(new KeyValuePair<string, string>("a", "x")));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Contains(new KeyValuePair<string, string>("a", "x")), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
 
         dirtyFlagMap.Add("b", null);
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.Contains(new KeyValuePair<string, string>("b", null)));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Contains(new KeyValuePair<string, string>("b", null)), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1608,8 +1800,11 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1619,8 +1814,11 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsFalse(dirtyFlagMap.ContainsKey("x"));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.ContainsKey("x"), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1636,7 +1834,7 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
     }
 
@@ -1648,11 +1846,14 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("b", null);
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsTrue(dirtyFlagMap.ContainsValue("x"));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.ContainsValue("x"), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
 
-        Assert.IsTrue(dirtyFlagMap.ContainsValue(null));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+            Assert.That(dirtyFlagMap.ContainsValue(null), Is.True);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
@@ -1662,28 +1863,31 @@ public class DirtyFlagMapTest
         dirtyFlagMap.Put("a", "x");
         dirtyFlagMap.ClearDirtyFlag();
 
-        Assert.IsFalse(dirtyFlagMap.ContainsValue("y"));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.ContainsValue("y"), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
 
-        Assert.IsFalse(dirtyFlagMap.ContainsValue("a"));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+            Assert.That(dirtyFlagMap.ContainsValue("a"), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
 
-        Assert.IsFalse(dirtyFlagMap.ContainsValue(null));
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+            Assert.That(dirtyFlagMap.ContainsValue(null), Is.False);
+            Assert.That(dirtyFlagMap.Dirty, Is.False);
+        });
     }
 
     [Test]
     public void TestClear()
     {
         DirtyFlagMap<string, string> dirtyFlagMap = new DirtyFlagMap<string, string>();
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
 
         dirtyFlagMap.Clear();
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
         dirtyFlagMap.Put("X", "Y");
         dirtyFlagMap.ClearDirtyFlag();
         dirtyFlagMap.Clear();
-        Assert.IsTrue(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.True);
     }
 
     [Test]
@@ -1695,31 +1899,40 @@ public class DirtyFlagMapTest
 
         var original = dirtyFlagMap.Put("a", 4);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual(5, original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual(4, dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo(5));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo(4));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         original = dirtyFlagMap.Put("a", 0);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual(4, original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual(0, dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo(4));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo(0));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         original = dirtyFlagMap.Put("a", 7);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual(0, original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual(7, dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo(0));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo(7));
+        });
     }
 
     [Test]
@@ -1731,30 +1944,39 @@ public class DirtyFlagMapTest
 
         var original = dirtyFlagMap.Put("a", 4);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual(5, original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual(4, dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo(5));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo(4));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         original = dirtyFlagMap.Put("a", null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual(4, original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo(4));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         original = dirtyFlagMap.Put("a", 7);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNull(original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual(7, dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Null);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo(7));
+        });
     }
 
     [Test]
@@ -1766,30 +1988,39 @@ public class DirtyFlagMapTest
 
         var original = dirtyFlagMap.Put("a", "y");
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual("x", original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("y", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo("x"));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("y"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         original = dirtyFlagMap.Put("a", null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual("y", original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo("y"));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         original = dirtyFlagMap.Put("a", "z");
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNull(original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("z", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Null);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("z"));
+        });
     }
 
     [Test]
@@ -1801,11 +2032,14 @@ public class DirtyFlagMapTest
 
         var original = dirtyFlagMap.Put("a", 5);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual(5, original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual(5, dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo(5));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo(5));
+        });
 
         dirtyFlagMap.Clear();
         dirtyFlagMap.Put("a", 0);
@@ -1813,11 +2047,14 @@ public class DirtyFlagMapTest
 
         original = dirtyFlagMap.Put("a", 0);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual(0, original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual(0, dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo(0));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo(0));
+        });
     }
 
     [Test]
@@ -1829,11 +2066,14 @@ public class DirtyFlagMapTest
 
         var original = dirtyFlagMap.Put("a", 5);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual(5, original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual(5, dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo(5));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo(5));
+        });
 
         dirtyFlagMap.Clear();
         dirtyFlagMap.Put("a", null);
@@ -1841,10 +2081,13 @@ public class DirtyFlagMapTest
 
         original = dirtyFlagMap.Put("a", null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNull(original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Null);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
     }
 
     [Test]
@@ -1856,11 +2099,14 @@ public class DirtyFlagMapTest
 
         var original = dirtyFlagMap.Put("a", "x");
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNotNull(original);
-        Assert.AreEqual("x", original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Not.Null);
+            Assert.That(original, Is.EqualTo("x"));
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
 
         dirtyFlagMap.Clear();
         dirtyFlagMap.Put("a", null);
@@ -1868,10 +2114,13 @@ public class DirtyFlagMapTest
 
         original = dirtyFlagMap.Put("a", null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsNull(original);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.IsNull(dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(original, Is.Null);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.Null);
+        });
     }
 
     [Test]
@@ -1881,17 +2130,23 @@ public class DirtyFlagMapTest
 
         dirtyFlagMap.Put("a", "x");
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("a"));
-        Assert.AreEqual("x", dirtyFlagMap["a"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("a"), Is.True);
+            Assert.That(dirtyFlagMap["a"], Is.EqualTo("x"));
+        });
 
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap.Put("b", null);
 
-        Assert.IsTrue(dirtyFlagMap.Dirty);
-        Assert.IsTrue(dirtyFlagMap.ContainsKey("b"));
-        Assert.IsNull(dirtyFlagMap["b"]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dirtyFlagMap.Dirty, Is.True);
+            Assert.That(dirtyFlagMap.ContainsKey("b"), Is.True);
+            Assert.That(dirtyFlagMap["b"], Is.Null);
+        });
     }
 
     [Test]
@@ -1907,10 +2162,10 @@ public class DirtyFlagMapTest
         }
         catch (ArgumentNullException ex)
         {
-            Assert.AreEqual(nameof(key), ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo(nameof(key)));
         }
 
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
     }
 
     [Test]
@@ -1921,63 +2176,69 @@ public class DirtyFlagMapTest
         dirtyFlagMap.ClearDirtyFlag();
 
         dirtyFlagMap.Remove("b");
-        Assert.IsFalse(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.False);
 
         dirtyFlagMap.Remove("a");
-        Assert.IsTrue(dirtyFlagMap.Dirty);
+        Assert.That(dirtyFlagMap.Dirty, Is.True);
     }
 
     [Test]
     public void ICollection_SyncRoot()
     {
         var dirtyFlagMap1 = new DirtyFlagMap<string, string>();
-        var collection1 = (ICollection) dirtyFlagMap1;
+        var collection1 = (ICollection)dirtyFlagMap1;
 
         var syncRoot1 = collection1.SyncRoot;
-        Assert.IsNotNull(syncRoot1);
-        Assert.AreSame(syncRoot1, collection1.SyncRoot);
-        Assert.AreEqual(typeof(object), syncRoot1.GetType());
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncRoot1, Is.Not.Null);
+            Assert.That(collection1.SyncRoot, Is.SameAs(syncRoot1));
+            Assert.That(syncRoot1.GetType(), Is.EqualTo(typeof(object)));
+        });
 
         var dirtyFlagMap2 = new DirtyFlagMap<string, string>();
-        var collection2 = (ICollection) dirtyFlagMap2;
+        var collection2 = (ICollection)dirtyFlagMap2;
 
         var syncRoot2 = collection2.SyncRoot;
-        Assert.IsNotNull(syncRoot2);
-        Assert.AreSame(syncRoot2, collection2.SyncRoot);
-        Assert.AreEqual(typeof(object), syncRoot2.GetType());
-        Assert.AreNotSame(syncRoot1, syncRoot2);
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncRoot2, Is.Not.Null);
+            Assert.That(collection2.SyncRoot, Is.SameAs(syncRoot2));
+            Assert.That(syncRoot2.GetType(), Is.EqualTo(typeof(object)));
+            Assert.That(syncRoot2, Is.Not.SameAs(syncRoot1));
+        });
     }
 
     [Test]
     public void ICollectionKeyValuePairOfTKeyAndTValue_IsReadOnly()
     {
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
-        var collection = (ICollection<KeyValuePair<string, string>>) dirtyFlagMap;
-        Assert.IsFalse(collection.IsReadOnly);
+        var collection = (ICollection<KeyValuePair<string, string>>)dirtyFlagMap;
+        Assert.That(collection.IsReadOnly, Is.False);
     }
 
     [Test]
     public void IDictionary_IsReadOnly()
     {
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
-        var dictionary = (IDictionary) dirtyFlagMap;
-        Assert.IsFalse(dictionary.IsReadOnly);
+        var dictionary = (IDictionary)dirtyFlagMap;
+        Assert.That(dictionary.IsReadOnly, Is.False);
     }
 
     [Test]
     public void IDictionary_IsSynchronized()
     {
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
-        var dictionary = (IDictionary) dirtyFlagMap;
-        Assert.IsFalse(dictionary.IsSynchronized);
+        var dictionary = (IDictionary)dirtyFlagMap;
+        Assert.That(dictionary.IsSynchronized, Is.False);
     }
 
     [Test]
     public void IDictionary_IsFixedSize()
     {
         var dirtyFlagMap = new DirtyFlagMap<string, string>();
-        var dictionary = (IDictionary) dirtyFlagMap;
-        Assert.IsFalse(dictionary.IsFixedSize);
+        var dictionary = (IDictionary)dirtyFlagMap;
+        Assert.That(dictionary.IsFixedSize, Is.False);
     }
 
     //[Test]
@@ -2137,7 +2398,7 @@ public class DirtyFlagMapTest
 
             ms.Position = 0;
 
-            return (T) formatter.Deserialize(ms);
+            return (T)formatter.Deserialize(ms);
         }
     }
 
@@ -2147,7 +2408,7 @@ public class DirtyFlagMapTest
         using var fs = File.OpenRead(Path.Combine("Serialized", name + ".ser"));
         BinaryFormatter binaryFormatter = new BinaryFormatter();
         binaryFormatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
-        return (T) binaryFormatter.Deserialize(fs);
+        return (T)binaryFormatter.Deserialize(fs);
 #pragma warning restore SYSLIB0050
     }
 }

--- a/src/Quartz.Tests.Unit/Utils/KeyTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/KeyTest.cs
@@ -40,8 +40,11 @@ public class KeyTest
 
         var key = new Key<string>(name);
 
-        Assert.That(key.Name, Is.SameAs(name));
-        Assert.That(key.Group, Is.SameAs(Key<string>.DefaultGroup));
+        Assert.Multiple(() =>
+        {
+            Assert.That(key.Name, Is.SameAs(name));
+            Assert.That(key.Group, Is.SameAs(Key<string>.DefaultGroup));
+        });
     }
 
     [Test]
@@ -418,9 +421,12 @@ public class KeyTest
         formatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
 
         var deserialized = formatter.Deserialize(ms) as Key<string>;
-        Assert.That(deserialized, Is.Not.Null);
-        Assert.That(deserialized.Group, Is.EqualTo(key.Group));
-        Assert.That(deserialized.Name, Is.EqualTo(key.Name));
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Group, Is.EqualTo(key.Group));
+            Assert.That(deserialized.Name, Is.EqualTo(key.Name));
+        });
 #pragma warning restore SYSLIB0050
     }
 

--- a/src/Quartz.Tests.Unit/Utils/KeyTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/KeyTest.cs
@@ -40,8 +40,8 @@ public class KeyTest
 
         var key = new Key<string>(name);
 
-        Assert.AreSame(name, key.Name);
-        Assert.AreSame(Key<string>.DefaultGroup, key.Group);
+        Assert.That(key.Name, Is.SameAs(name));
+        Assert.That(key.Group, Is.SameAs(Key<string>.DefaultGroup));
     }
 
     [Test]
@@ -50,7 +50,7 @@ public class KeyTest
         const string name = null;
 
         var actualException = Assert.Throws<ArgumentNullException>(() => new Key<string>(name));
-        Assert.AreEqual("name", actualException.ParamName);
+        Assert.That(actualException.ParamName, Is.EqualTo("name"));
     }
 
     [Test]
@@ -61,8 +61,11 @@ public class KeyTest
 
         var key = new Key<string>(name, group);
 
-        Assert.AreSame(name, key.Name);
-        Assert.AreSame(group, key.Group);
+        Assert.Multiple(() =>
+        {
+            Assert.That(key.Name, Is.SameAs(name));
+            Assert.That(key.Group, Is.SameAs(group));
+        });
     }
 
     [Test]
@@ -72,7 +75,7 @@ public class KeyTest
         const string group = "Group";
 
         var actualException = Assert.Throws<ArgumentNullException>(() => new Key<string>(name, group));
-        Assert.AreEqual("name", actualException.ParamName);
+        Assert.That(actualException.ParamName, Is.EqualTo("name"));
     }
 
     [Test]
@@ -82,13 +85,13 @@ public class KeyTest
         const string group = null;
 
         var actualException = Assert.Throws<ArgumentNullException>(() => new Key<string>(name, group));
-        Assert.AreEqual("group", actualException.ParamName);
+        Assert.That(actualException.ParamName, Is.EqualTo("group"));
     }
 
     [Test]
     public void DefaultGroupIsDefault()
     {
-        Assert.AreEqual("DEFAULT", Key<string>.DefaultGroup);
+        Assert.That(Key<string>.DefaultGroup, Is.EqualTo("DEFAULT"));
     }
 
     [Test]
@@ -96,7 +99,7 @@ public class KeyTest
     {
         var key = new Key<string>("A");
 
-        Assert.AreEqual(0, key.CompareTo(key));
+        Assert.That(key.CompareTo(key), Is.EqualTo(0));
     }
 
     [Test]
@@ -104,7 +107,7 @@ public class KeyTest
     {
         var key = new Key<string>("A", CreateUniqueReference(Key<string>.DefaultGroup));
 
-        Assert.AreEqual(0, key.CompareTo(key));
+        Assert.That(key.CompareTo(key), Is.EqualTo(0));
     }
 
     [Test]
@@ -112,7 +115,7 @@ public class KeyTest
     {
         var key = new Key<string>("A", Key<string>.DefaultGroup);
 
-        Assert.AreEqual(0, key.CompareTo(key));
+        Assert.That(key.CompareTo(key), Is.EqualTo(0));
     }
 
     [Test]
@@ -120,7 +123,7 @@ public class KeyTest
     {
         var key = new Key<string>("A", "G");
 
-        Assert.AreEqual(0, key.CompareTo(key));
+        Assert.That(key.CompareTo(key), Is.EqualTo(0));
     }
 
     [Test]
@@ -131,7 +134,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName);
         var key2 = new Key<string>(keyName);
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -142,7 +145,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, Key<string>.DefaultGroup);
         var key2 = new Key<string>(keyName, Key<string>.DefaultGroup);
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -153,7 +156,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, Key<string>.DefaultGroup);
         var key2 = new Key<string>(keyName, CreateUniqueReference(Key<string>.DefaultGroup));
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -164,7 +167,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, CreateUniqueReference(Key<string>.DefaultGroup));
         var key2 = new Key<string>(keyName, Key<string>.DefaultGroup);
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -175,7 +178,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, CreateUniqueReference(Key<string>.DefaultGroup));
         var key2 = new Key<string>(keyName, CreateUniqueReference(Key<string>.DefaultGroup));
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -187,7 +190,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, groupName);
         var key2 = new Key<string>(keyName, groupName);
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -199,7 +202,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, groupName);
         var key2 = new Key<string>(keyName, CreateUniqueReference(groupName));
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -210,7 +213,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName);
         var key2 = new Key<string>(CreateUniqueReference(keyName));
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -221,7 +224,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, Key<string>.DefaultGroup);
         var key2 = new Key<string>(CreateUniqueReference(keyName), Key<string>.DefaultGroup);
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -232,7 +235,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, Key<string>.DefaultGroup);
         var key2 = new Key<string>(CreateUniqueReference(keyName), CreateUniqueReference(Key<string>.DefaultGroup));
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -243,7 +246,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, CreateUniqueReference(Key<string>.DefaultGroup));
         var key2 = new Key<string>(CreateUniqueReference(keyName), Key<string>.DefaultGroup);
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -254,7 +257,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, CreateUniqueReference(Key<string>.DefaultGroup));
         var key2 = new Key<string>(CreateUniqueReference(keyName), CreateUniqueReference(Key<string>.DefaultGroup));
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -266,7 +269,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, groupName);
         var key2 = new Key<string>(CreateUniqueReference(keyName), groupName);
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -278,7 +281,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, groupName);
         var key2 = new Key<string>(CreateUniqueReference(keyName), CreateUniqueReference(groupName));
 
-        Assert.AreEqual(0, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(0));
     }
 
     [Test]
@@ -287,7 +290,7 @@ public class KeyTest
         var key1 = new Key<string>("A");
         var key2 = new Key<string>("B");
 
-        Assert.AreEqual(-1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(-1));
     }
 
     [Test]
@@ -296,7 +299,7 @@ public class KeyTest
         var key1 = new Key<string>("B");
         var key2 = new Key<string>("A");
 
-        Assert.AreEqual(1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(1));
     }
 
     [Test]
@@ -307,7 +310,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName);
         var key2 = new Key<string>(CreateUniqueReference(keyName), "G");
 
-        Assert.AreEqual(-1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(-1));
     }
 
     [Test]
@@ -318,7 +321,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, Key<string>.DefaultGroup);
         var key2 = new Key<string>(CreateUniqueReference(keyName), "G");
 
-        Assert.AreEqual(-1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(-1));
     }
 
     [Test]
@@ -329,7 +332,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, "DEFAULT");
         var key2 = new Key<string>(CreateUniqueReference(keyName), "G");
 
-        Assert.AreEqual(-1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(-1));
     }
 
     [Test]
@@ -340,7 +343,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, "G");
         var key2 = new Key<string>(CreateUniqueReference(keyName));
 
-        Assert.AreEqual(1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(1));
     }
 
     [Test]
@@ -351,7 +354,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, "G");
         var key2 = new Key<string>(CreateUniqueReference(keyName), Key<string>.DefaultGroup);
 
-        Assert.AreEqual(1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(1));
     }
 
     [Test]
@@ -362,7 +365,7 @@ public class KeyTest
         var key1 = new Key<string>(keyName, "G");
         var key2 = new Key<string>(CreateUniqueReference(keyName), "DEFAULT");
 
-        Assert.AreEqual(1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(1));
     }
 
     [Test]
@@ -371,7 +374,7 @@ public class KeyTest
         var key1 = new Key<string>("A", "G");
         var key2 = new Key<string>("B", "H");
 
-        Assert.AreEqual(-1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(-1));
     }
 
     [Test]
@@ -380,7 +383,7 @@ public class KeyTest
         var key1 = new Key<string>("B", "G");
         var key2 = new Key<string>("A", "H");
 
-        Assert.AreEqual(-1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(-1));
     }
 
     [Test]
@@ -389,7 +392,7 @@ public class KeyTest
         var key1 = new Key<string>("A", "H");
         var key2 = new Key<string>("B", "G");
 
-        Assert.AreEqual(1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(1));
     }
 
     [Test]
@@ -398,7 +401,7 @@ public class KeyTest
         var key1 = new Key<string>("B", "H");
         var key2 = new Key<string>("A", "G");
 
-        Assert.AreEqual(1, key1.CompareTo(key2));
+        Assert.That(key1.CompareTo(key2), Is.EqualTo(1));
     }
 
     [Test]
@@ -415,9 +418,9 @@ public class KeyTest
         formatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
 
         var deserialized = formatter.Deserialize(ms) as Key<string>;
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(key.Group, deserialized.Group);
-        Assert.AreEqual(key.Name, deserialized.Name);
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized.Group, Is.EqualTo(key.Group));
+        Assert.That(deserialized.Name, Is.EqualTo(key.Name));
 #pragma warning restore SYSLIB0050
     }
 
@@ -434,9 +437,12 @@ public class KeyTest
             ms.Position = 0;
 
             var deserialized = formatter.Deserialize(ms) as Key<string>;
-            Assert.IsNotNull(deserialized);
-            Assert.AreEqual(key.Group, deserialized.Group);
-            Assert.AreEqual(key.Name, deserialized.Name);
+            Assert.Multiple(() =>
+            {
+                Assert.That(deserialized, Is.Not.Null);
+                Assert.That(deserialized.Group, Is.EqualTo(key.Group));
+                Assert.That(deserialized.Name, Is.EqualTo(key.Name));
+            });
         }
     }
 

--- a/src/Quartz.Tests.Unit/Utils/KeyTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/KeyTest.cs
@@ -6,7 +6,7 @@ using Quartz.Util;
 namespace Quartz.Tests.Unit.Utils;
 
 /// <summary>
-/// Unit tests for Key<T>.
+/// Unit tests for Key&lt;T&gt;
 /// </summary>
 /// <author>Gert Driesen</author>
 [TestFixture]

--- a/src/Quartz.Tests.Unit/Utils/ObjectUtilsTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/ObjectUtilsTest.cs
@@ -34,7 +34,7 @@ public class ObjectUtilsTest
     public void NullObjectForValueTypeShouldReturnDefaultforValueType()
     {
         object value = ObjectUtils.ConvertValueIfNecessary(typeof(int), null);
-        Assert.AreEqual(0, value);
+        Assert.That(value, Is.EqualTo(0));
     }
 
     [Test]
@@ -47,56 +47,56 @@ public class ObjectUtilsTest
     public void TimeSpanConversionShouldWork()
     {
         TimeSpan ts = (TimeSpan) ObjectUtils.ConvertValueIfNecessary(typeof(TimeSpan), "1");
-        Assert.AreEqual(1, ts.TotalDays);
+        Assert.That(ts.TotalDays, Is.EqualTo(1));
     }
 
     [Test]
     public void TestConvertAssignable()
     {
         IComparable val = (IComparable) ObjectUtils.ConvertValueIfNecessary(typeof(IComparable), "test");
-        Assert.AreEqual("test", val);
+        Assert.That(val, Is.EqualTo("test"));
     }
 
     [Test]
     public void TestConvertStringToEnum()
     {
         DayOfWeek val = (DayOfWeek) ObjectUtils.ConvertValueIfNecessary(typeof(DayOfWeek), "Wednesday");
-        Assert.AreEqual(DayOfWeek.Wednesday, val);
+        Assert.That(val, Is.EqualTo(DayOfWeek.Wednesday));
     }
 
     [Test]
     public void TestConvertEnumToString()
     {
         string val = (string) ObjectUtils.ConvertValueIfNecessary(typeof(string), DayOfWeek.Wednesday);
-        Assert.AreEqual("Wednesday", val);
+        Assert.That(val, Is.EqualTo("Wednesday"));
     }
 
     [Test]
     public void TestConvertIntToDouble()
     {
         double val = (double) ObjectUtils.ConvertValueIfNecessary(typeof(double), 1234);
-        Assert.AreEqual(1234.0, val);
+        Assert.That(val, Is.EqualTo(1234.0));
     }
 
     [Test]
     public void TestConvertDoubleToInt()
     {
         int val = (int) ObjectUtils.ConvertValueIfNecessary(typeof(int), 1234.5);
-        Assert.AreEqual(1234, val);
+        Assert.That(val, Is.EqualTo(1234));
     }
 
     [Test]
     public void TestConvertStringToType()
     {
         Type val = (Type) ObjectUtils.ConvertValueIfNecessary(typeof(Type), "System.String");
-        Assert.AreEqual(typeof(string), val);
+        Assert.That(val, Is.EqualTo(typeof(string)));
     }
 
     [Test]
     public void TestConvertTypeToString()
     {
         string val = (string) ObjectUtils.ConvertValueIfNecessary(typeof(string), typeof(string));
-        Assert.AreEqual("System.String", val);
+        Assert.That(val, Is.EqualTo("System.String"));
     }
 
     [Test]
@@ -111,22 +111,28 @@ public class ObjectUtilsTest
         props["TimeDefault"] = "1";
         ObjectUtils.SetObjectProperties(o, props);
 
-        Assert.AreEqual(1, o.TimeHours.TotalHours);
-        Assert.AreEqual(1, o.TimeMilliseconds.TotalMilliseconds);
-        Assert.AreEqual(1, o.TimeMinutes.TotalMinutes);
-        Assert.AreEqual(1, o.TimeSeconds.TotalSeconds);
-        Assert.AreEqual(1, o.TimeDefault.TotalDays);
+        Assert.Multiple(() =>
+        {
+            Assert.That(o.TimeHours.TotalHours, Is.EqualTo(1));
+            Assert.That(o.TimeMilliseconds.TotalMilliseconds, Is.EqualTo(1));
+            Assert.That(o.TimeMinutes.TotalMinutes, Is.EqualTo(1));
+            Assert.That(o.TimeSeconds.TotalSeconds, Is.EqualTo(1));
+            Assert.That(o.TimeDefault.TotalDays, Is.EqualTo(1));
+        });
     }
 
     [Test]
     public void TestIsAnnotationPresentOnSuperClass()
     {
-        Assert.IsTrue(ObjectUtils.IsAttributePresent(typeof(BaseJob), typeof(DisallowConcurrentExecutionAttribute)));
-        Assert.IsFalse(ObjectUtils.IsAttributePresent(typeof(BaseJob), typeof(PersistJobDataAfterExecutionAttribute)));
-        Assert.IsTrue(ObjectUtils.IsAttributePresent(typeof(ExtendedJob), typeof(DisallowConcurrentExecutionAttribute)));
-        Assert.IsFalse(ObjectUtils.IsAttributePresent(typeof(ExtendedJob), typeof(PersistJobDataAfterExecutionAttribute)));
-        Assert.IsTrue(ObjectUtils.IsAttributePresent(typeof(ReallyExtendedJob), typeof(DisallowConcurrentExecutionAttribute)));
-        Assert.IsTrue(ObjectUtils.IsAttributePresent(typeof(ReallyExtendedJob), typeof(PersistJobDataAfterExecutionAttribute)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ObjectUtils.IsAttributePresent(typeof(BaseJob), typeof(DisallowConcurrentExecutionAttribute)), Is.True);
+            Assert.That(ObjectUtils.IsAttributePresent(typeof(BaseJob), typeof(PersistJobDataAfterExecutionAttribute)), Is.False);
+            Assert.That(ObjectUtils.IsAttributePresent(typeof(ExtendedJob), typeof(DisallowConcurrentExecutionAttribute)), Is.True);
+            Assert.That(ObjectUtils.IsAttributePresent(typeof(ExtendedJob), typeof(PersistJobDataAfterExecutionAttribute)), Is.False);
+            Assert.That(ObjectUtils.IsAttributePresent(typeof(ReallyExtendedJob), typeof(DisallowConcurrentExecutionAttribute)), Is.True);
+            Assert.That(ObjectUtils.IsAttributePresent(typeof(ReallyExtendedJob), typeof(PersistJobDataAfterExecutionAttribute)), Is.True);
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Utils/PropertiesParserTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/PropertiesParserTest.cs
@@ -42,6 +42,6 @@ public class PropertiesParserTest
 
         PropertiesParser propertiesParser = new PropertiesParser(props);
         NameValueCollection propGroup = propertiesParser.GetPropertyGroup("x.y", true);
-        Assert.AreEqual("", propGroup.Get("z"));
+        Assert.That(propGroup.Get("z"), Is.EqualTo(""));
     }
 }

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -14,7 +14,7 @@ public class TimeZoneUtilTest
         var infoWithUtc = TimeZoneUtil.FindTimeZoneById("UTC");
         var infoWithUniversalCoordinatedTime = TimeZoneUtil.FindTimeZoneById("Coordinated Universal Time");
 
-        Assert.AreEqual(infoWithUtc, infoWithUniversalCoordinatedTime);
+        Assert.That(infoWithUniversalCoordinatedTime, Is.EqualTo(infoWithUtc));
     }
 
     [Test]

--- a/src/Quartz/Util/DirtyFlagMap.cs
+++ b/src/Quartz/Util/DirtyFlagMap.cs
@@ -273,6 +273,14 @@ public class DirtyFlagMap<TKey, TValue> : IDictionary<TKey, TValue?>, IDictionar
         set => this[(TKey) key] = (TValue) value!;
     }
 
+    /// <summary>
+    /// Determines whether the <see cref="DirtyFlagMap{TKey, TValue}"/> contains the specified key.
+    /// Essentially this is a wrapper around <see cref="ContainsKey(TKey)"/>.
+    /// </summary>
+    /// <param name="item">The key to locate in the <see cref="DirtyFlagMap{TKey, TValue}"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if the <see cref="DirtyFlagMap{TKey, TValue}"/> contains the specified key; otherwise, <see langword="false"/>.
+    /// </returns>
     public bool Contains(KeyValuePair<TKey, TValue?> item)
     {
         return Contains(item.Key);


### PR DESCRIPTION
- Update Assertions to use constraint model ([Nunit 4 suggested approach](https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html))
  - i.e. `Assert.True` becomes `Assert.That( value, Is.True)`
  - `Assert.Equal` => `Assert.That(val, Is.EqualTo(expected)`
  - `Assert.IsNotNull` => `Assert.That(val, Is.Not.Null)`
  - etc
- Wrap multiple asserts inside [Assert.Multiple](https://docs.nunit.org/articles/nunit/writing-tests/assertions/multiple-asserts.html)
- Minor refactor on language optimizations (object initializer, empty braces) in test lib.
- Add FluentAssertions.Analyzer package
- Add NUnit.Analyzers to package
- Remove the global using Assert for ClassicAssert, no longer required.
- Add `[OneTimeTearDown]` to dispose of objects Nunit.Analyzer requested. (DisallowConcurrentJobExecutioNTests)
