### PR TITLE
Fix for DST NextFireTime being stuck when issued on DST boundary

### DIFF
--- a/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
+++ b/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
@@ -19,7 +19,13 @@
 
 using System;
 
+using FluentAssertions;
+using FluentAssertions.Execution;
+
 using NUnit.Framework;
+
+using Quartz.Spi;
+using Quartz.Util;
 
 using TimeZoneConverter;
 
@@ -119,6 +125,34 @@ namespace Quartz.Tests.Unit
             // Conversion here is for clarity of interpreting errors if the test fails.
             DateTimeOffset convertedFireTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
             Assert.AreEqual(expectedTime, convertedFireTime);
+        }
+        
+        [Test]
+        public void Investigate_InfiniteTriggerDST_To_Issue_2475()
+        {
+            //DST 
+            var tz = TZConvert.GetTimeZoneInfo("Central European Standard Time"); //UTC+1  +2 in DST
+            var startTime = new DateTimeOffset(2023, 10, 29, 2, 0, 0, TimeSpan.FromHours(2));
+
+            tz.IsDaylightSavingTime(startTime).Should().BeTrue();
+            
+            var trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger1", "group1")
+                .WithSchedule(CronScheduleBuilder.CronSchedule("0 0/1 * ? * * *")
+                    .InTimeZone(tz)
+                )
+                .StartAt(startTime)
+                .ForJob("job1", "group1")
+                .Build();
+
+            var nextFireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger)trigger, null, 20);
+            using (new AssertionScope())
+            {
+                nextFireTimes[0].Should().Be(new DateTimeOffset(2023, 10, 29, 2, 00, 0, TimeSpan.FromHours(2)));
+                nextFireTimes[1].Should().Be(new DateTimeOffset(2023, 10, 29, 2, 01, 0, TimeSpan.FromHours(2)));
+                nextFireTimes[2].Should().Be(new DateTimeOffset(2023, 10, 29, 2, 02, 0, TimeSpan.FromHours(2)));
+            }
+            Console.WriteLine(nextFireTimes[0]);
         }
     }
 }

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -1617,16 +1617,23 @@ namespace Quartz
             }
         }
 
+        public virtual DateTimeOffset? GetTimeAt(DateTimeOffset afterTimeUtc)
+        {
+            return GetTimeAfter(afterTimeUtc, 0);
+        }
+
         /// <summary>
         /// Gets the next fire time after the given time.
         /// </summary>
         /// <param name="afterTimeUtc">The UTC time to start searching from.</param>
+        /// <param name="afterOffsetInSeconds">Default is 1 second</param>
         /// <returns></returns>
-        public virtual DateTimeOffset? GetTimeAfter(DateTimeOffset afterTimeUtc)
+        public virtual DateTimeOffset? GetTimeAfter(DateTimeOffset afterTimeUtc, int afterOffsetInSeconds = 1)
         {
-            // move ahead one second, since we're computing the time *after* the
+            // move ahead afterOffsetInSeconds, since we're computing the time *after* the
             // given time
-            afterTimeUtc = afterTimeUtc.AddSeconds(1);
+            if (afterOffsetInSeconds != 0)
+                afterTimeUtc = afterTimeUtc.AddSeconds(afterOffsetInSeconds);
 
             // CronTrigger does not deal with milliseconds
             DateTimeOffset d = CreateDateTimeWithoutMillis(afterTimeUtc);
@@ -2142,11 +2149,7 @@ namespace Quartz
         {
             // Java version of Quartz uses lenient calendar
             // so hour 24 creates day increment and zeroes hour
-            int hourToSet = hour;
-            if (hourToSet == 24)
-            {
-                hourToSet = 0;
-            }
+            int hourToSet = hour == 24 ? 0 : hour;
             DateTimeOffset d = new DateTimeOffset(date.Year, date.Month, date.Day, hourToSet, date.Minute, date.Second, date.Millisecond, date.Offset);
             if (hour == 24)
             {


### PR DESCRIPTION
Add `GetTimeAtOrAfter` to CronTriggerImpl, which avoids having move aftertime back 1 seconds, which may put it into different DST zone.
Use this when calculating `ComputeFirstFireTimeUtc` only,

CronExpression
- Add `GetTimeAt` which calls an overloaded `GetTimeAfter` with 0 second offset, again avoiding the back in time challenge.

Relates to #2475 

Needs review.
Need to ensure test case is sufficient.
