### PR TITLE
Fixed error to the QuartzHostedService class to the StoppedAsync method

### DIFF
--- a/src/Quartz/Hosting/QuartzHostedService.cs
+++ b/src/Quartz/Hosting/QuartzHostedService.cs
@@ -123,7 +123,7 @@ public class QuartzHostedService : IHostedLifecycleService
         }
     }
 
-    public Task StoppedAsync(CancellationToken cancellationToken)
+    public virtual Task StoppedAsync(CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
     }

--- a/src/Quartz/Hosting/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz/Hosting/QuartzServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Quartz;
@@ -19,5 +20,24 @@ public static class QuartzServiceCollectionExtensions
         }
 
         return services.AddHostedService<QuartzHostedService>();
+    }
+
+    /// <summary>
+    /// Add an <see cref="QuartzHostedService"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <typeparam name="TExtendedHostedService">Type extending the <see cref="QuartzHostedService"/> class.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <param name="configure">A delegate that is used to configure an <see cref="QuartzHostedServiceOptions"/>.</param>
+    public static IServiceCollection AddQuartzHostedService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TExtendedHostedService>(
+        this IServiceCollection services,
+        Action<QuartzHostedServiceOptions>? configure = null)
+        where TExtendedHostedService : QuartzHostedService
+    {
+        if (configure is not null)
+        {
+            services.Configure(configure);
+        }
+
+        return services.AddHostedService<TExtendedHostedService>();
     }
 }


### PR DESCRIPTION
Changes:
1. Fixed error to the QuartzHostedService class to the StoppedAsync method. The virtual modifier in the this method is lost. Related to last PR (#2386).
2. A new extension method has been added to the QuartzServiceCollectionExtensions class, which allows you to add an extended implementation of a hosted service to a DI container.