### PR TITLE
Adding a new functionality to determine the duration of the delay of a quartz cron job

### DIFF
--- a/database/schema_30_to_31_upgrade.sql
+++ b/database/schema_30_to_31_upgrade.sql
@@ -1,0 +1,5 @@
+--USE [database_name];
+--GO
+
+ALTER TABLE qrtz_triggers
+ADD initial_next_fire_time bigint NULL;

--- a/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
+++ b/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
@@ -326,6 +326,7 @@ public class SimpleTriggerImplBenchmark
         public const int RepeatIndefinitely = -1;
 
         private DateTimeOffset? nextFireTimeUtc; // Making a public property which called GetNextFireTime/SetNextFireTime would make the json attribute unnecessary
+        private DateTimeOffset? initialNextFireTimeUtc; // Making a public property which called GetNextFireTime/SetNextFireTime would make the json attribute unnecessary
         private DateTimeOffset? previousFireTimeUtc; // Making a public property which called GetPreviousFireTime/SetPreviousFireTime would make the json attribute unnecessary
 
         private int repeatCount;
@@ -887,6 +888,11 @@ public class SimpleTriggerImplBenchmark
         public override void SetNextFireTimeUtc(DateTimeOffset? nextFireTime)
         {
             nextFireTimeUtc = nextFireTime;
+        }
+
+        public override void SetInitialNextFireTimeUtc(DateTimeOffset? value)
+        {
+            initialNextFireTimeUtc = value;
         }
 
         public override void SetPreviousFireTimeUtc(DateTimeOffset? previousFireTime)

--- a/src/Quartz.Tests.Unit/Impl/Triggers/AbstractTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/AbstractTriggerTest.cs
@@ -94,6 +94,11 @@ public class AbstractTriggerTest
             throw new NotImplementedException();
         }
 
+        public override void SetInitialNextFireTimeUtc(DateTimeOffset? value)
+        {
+            throw new NotImplementedException();
+        }
+
         public override void SetPreviousFireTimeUtc(DateTimeOffset? previousFireTime)
         {
             throw new NotImplementedException();

--- a/src/Quartz/Impl/AdoJobStore/AdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoConstants.cs
@@ -78,6 +78,7 @@ public class AdoConstants
     public const string ColumnMifireInstruction = "MISFIRE_INSTR";
     public const string ColumnPriority = "PRIORITY";
     public const string AliasColumnNextFireTime = "ALIAS_NXT_FR_TM";
+    public const string ColumnInitialNextFireTime = "INITIAL_NEXT_FIRE_TIME";
 
     // TableSimpleTriggers columns names
     public const string ColumnRepeatCount = "REPEAT_COUNT";

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -297,6 +297,7 @@ public interface IDriverDelegate
     /// <param name="trigger">The trigger.</param>
     /// <param name="state">The state.</param>
     /// <param name="jobDetail">The job detail.</param>
+    /// <param name="updateInitialNextFireTime">Determine if initial next fire time should be updated or no.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns>the number of rows updated</returns>
     ValueTask<int> UpdateTrigger(
@@ -304,6 +305,7 @@ public interface IDriverDelegate
         IOperableTrigger trigger,
         string state,
         IJobDetail jobDetail,
+        bool updateInitialNextFireTime = true,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -105,8 +105,8 @@ public class StdAdoConstants : AdoConstants
         $"INSERT INTO {TablePrefixSubst}{TableSimpleTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnRepeatCount}, {ColumnRepeatInterval}, {ColumnTimesTriggered})  VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerRepeatCount, @triggerRepeatInterval, @triggerTimesTriggered)";
 
     public static readonly string SqlInsertTrigger =
-        $@"INSERT INTO {TablePrefixSubst}{TableTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnJobName}, {ColumnJobGroup}, {ColumnDescription}, {ColumnNextFireTime}, {ColumnPreviousFireTime}, {ColumnTriggerState}, {ColumnTriggerType}, {ColumnStartTime}, {ColumnEndTime}, {ColumnCalendarName}, {ColumnMifireInstruction}, {ColumnJobDataMap}, {ColumnPriority})
-                        VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerJobName, @triggerJobGroup, @triggerDescription, @triggerNextFireTime, @triggerPreviousFireTime, @triggerState, @triggerType, @triggerStartTime, @triggerEndTime, @triggerCalendarName, @triggerMisfireInstruction, @triggerJobJobDataMap, @triggerPriority)";
+        $@"INSERT INTO {TablePrefixSubst}{TableTriggers} ({ColumnSchedulerName}, {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnJobName}, {ColumnJobGroup}, {ColumnDescription}, {ColumnNextFireTime}, {ColumnInitialNextFireTime}, {ColumnPreviousFireTime}, {ColumnTriggerState}, {ColumnTriggerType}, {ColumnStartTime}, {ColumnEndTime}, {ColumnCalendarName}, {ColumnMifireInstruction}, {ColumnJobDataMap}, {ColumnPriority})
+                        VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerJobName, @triggerJobGroup, @triggerDescription, @triggerNextFireTime, @triggerInitialNextFireTime, @triggerPreviousFireTime, @triggerState, @triggerType, @triggerStartTime, @triggerEndTime, @triggerCalendarName, @triggerMisfireInstruction, @triggerJobJobDataMap, @triggerPriority)";
 
     // SELECT
 
@@ -245,7 +245,8 @@ public class StdAdoConstants : AdoConstants
                 {ColumnTimeZoneId},
                 {ColumnRepeatCount},
                 {ColumnRepeatInterval},
-                {ColumnTimesTriggered}
+                {ColumnTimesTriggered},
+                {ColumnInitialNextFireTime}
             FROM
                 {TablePrefixSubst}{TableTriggers} t
             LEFT JOIN
@@ -324,9 +325,10 @@ public class StdAdoConstants : AdoConstants
         $"UPDATE {TablePrefixSubst}{TableSimpleTriggers} SET {ColumnRepeatCount} = @triggerRepeatCount, {ColumnRepeatInterval} = @triggerRepeatInterval, {ColumnTimesTriggered} = @triggerTimesTriggered WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
     public static readonly string SqlUpdateTrigger =
-        $@"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnJobName} = @triggerJobName, {ColumnJobGroup} = @triggerJobGroup, {ColumnDescription} = @triggerDescription, {ColumnNextFireTime} = @triggerNextFireTime, {ColumnPreviousFireTime} = @triggerPreviousFireTime,
-                        {ColumnTriggerState} = @triggerState, {ColumnTriggerType} = @triggerType, {ColumnStartTime} = @triggerStartTime, {ColumnEndTime} = @triggerEndTime, {ColumnCalendarName} = @triggerCalendarName, {ColumnMifireInstruction} = @triggerMisfireInstruction, {ColumnPriority} = @triggerPriority, {ColumnJobDataMap} = @triggerJobJobDataMap
-                        WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
+    $@"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnJobName} = @triggerJobName, {ColumnJobGroup} = @triggerJobGroup, {ColumnDescription} = @triggerDescription, {ColumnNextFireTime} = @triggerNextFireTime, {ColumnPreviousFireTime} = @triggerPreviousFireTime,
+                     {ColumnTriggerState} = @triggerState, {ColumnTriggerType} = @triggerType, {ColumnStartTime} = @triggerStartTime, {ColumnEndTime} = @triggerEndTime, {ColumnCalendarName} = @triggerCalendarName, {ColumnMifireInstruction} = @triggerMisfireInstruction, {ColumnPriority} = @triggerPriority, {ColumnJobDataMap} = @triggerJobJobDataMap,
+                     {ColumnInitialNextFireTime} = COALESCE(NULLIF(@trigerInitialNextFireTime, 0), {ColumnInitialNextFireTime})
+                     WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
     public static readonly string SqlUpdateFiredTrigger = $"UPDATE {TablePrefixSubst}{TableFiredTriggers} SET {ColumnInstanceName} = @instanceName, {ColumnFiredTime} = @firedTime, {ColumnScheduledTime} = @scheduledTime, {ColumnEntryState} = @entryState, {ColumnJobName} = @jobName, {ColumnJobGroup} = @jobGroup, {ColumnIsNonConcurrent} = @isNonConcurrent, {ColumnRequestsRecovery} = @requestsRecover WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnEntryId} = @entryId";
 
@@ -337,8 +339,9 @@ public class StdAdoConstants : AdoConstants
         $"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @groupName AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)";
 
     public static readonly string SqlUpdateTriggerSkipData =
-        $@"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnJobName} = @triggerJobName, {ColumnJobGroup} = @triggerJobGroup, {ColumnDescription} = @triggerDescription, {ColumnNextFireTime} = @triggerNextFireTime, {ColumnPreviousFireTime} = @triggerPreviousFireTime,
-                        {ColumnTriggerState} = @triggerState, {ColumnTriggerType} = @triggerType, {ColumnStartTime} = @triggerStartTime, {ColumnEndTime} = @triggerEndTime, {ColumnCalendarName} = @triggerCalendarName, {ColumnMifireInstruction} = @triggerMisfireInstruction, {ColumnPriority} = @triggerPriority
+            $@"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnJobName} = @triggerJobName, {ColumnJobGroup} = @triggerJobGroup, {ColumnDescription} = @triggerDescription, {ColumnNextFireTime} = @triggerNextFireTime, {ColumnPreviousFireTime} = @triggerPreviousFireTime,
+                        {ColumnTriggerState} = @triggerState, {ColumnTriggerType} = @triggerType, {ColumnStartTime} = @triggerStartTime, {ColumnEndTime} = @triggerEndTime, {ColumnCalendarName} = @triggerCalendarName, {ColumnMifireInstruction} = @triggerMisfireInstruction, {ColumnPriority} = @triggerPriority,
+                        {ColumnInitialNextFireTime} = COALESCE(NULLIF(@trigerInitialNextFireTime, 0), {ColumnInitialNextFireTime})
                     WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup";
 
     public static readonly string SqlUpdateTriggerState =

--- a/src/Quartz/Impl/Triggers/AbstractTrigger.cs
+++ b/src/Quartz/Impl/Triggers/AbstractTrigger.cs
@@ -227,6 +227,8 @@ public abstract class AbstractTrigger : IOperableTrigger, IEquatable<AbstractTri
 
     public abstract void SetNextFireTimeUtc(DateTimeOffset? nextFireTime);
 
+    public abstract void SetInitialNextFireTimeUtc(DateTimeOffset? previousFireTime);
+
     public abstract void SetPreviousFireTimeUtc(DateTimeOffset? previousFireTime);
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -59,6 +59,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
     private DateTimeOffset startTime;
     private DateTimeOffset? endTime;
     private DateTimeOffset? nextFireTimeUtc;
+    private DateTimeOffset? initialNextFireTimeUtc;
     private DateTimeOffset? previousFireTimeUtc;
     private int repeatInterval;
     internal TimeZoneInfo? timeZone;
@@ -567,6 +568,11 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
     public override void SetNextFireTimeUtc(DateTimeOffset? value)
     {
         nextFireTimeUtc = value;
+    }
+
+    public override void SetInitialNextFireTimeUtc(DateTimeOffset? fireTime)
+    {
+        initialNextFireTimeUtc = fireTime;
     }
 
     public override void SetPreviousFireTimeUtc(DateTimeOffset? previousFireTimeUtc)

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -182,6 +182,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     private DateTimeOffset startTimeUtc = DateTimeOffset.MinValue;
     private DateTimeOffset? endTimeUtc;
     private DateTimeOffset? nextFireTimeUtc;
+    private DateTimeOffset? initialNextFireTimeUtc;
     private DateTimeOffset? previousFireTimeUtc;
 
     [NonSerialized] private TimeZoneInfo? timeZone;
@@ -553,6 +554,11 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         nextFireTimeUtc = fireTime;
     }
 
+    public override void SetInitialNextFireTimeUtc(DateTimeOffset? fireTime)
+    {
+        initialNextFireTimeUtc = fireTime;
+    }
+
     /// <summary>
     /// Sets the previous fire time.
     /// <para>
@@ -922,6 +928,8 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         {
             nextFireTimeUtc = GetFireTimeAfter(nextFireTimeUtc);
         }
+
+        initialNextFireTimeUtc = nextFireTimeUtc;
 
         return nextFireTimeUtc;
     }

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -83,6 +83,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     private DateTimeOffset startTimeUtc;
     private DateTimeOffset? endTimeUtc;
     private DateTimeOffset? nextFireTimeUtc;
+    private DateTimeOffset? initialNextFireTimeUtc;
     private DateTimeOffset? previousFireTimeUtc;
     private int repeatInterval = 1;
     private IntervalUnit repeatIntervalUnit = IntervalUnit.Minute;
@@ -612,6 +613,11 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     public override void SetNextFireTimeUtc(DateTimeOffset? value)
     {
         nextFireTimeUtc = value;
+    }
+
+    public override void SetInitialNextFireTimeUtc(DateTimeOffset? fireTime)
+    {
+        initialNextFireTimeUtc = fireTime;
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -39,6 +39,7 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
     public const int RepeatIndefinitely = -1;
 
     private DateTimeOffset? nextFireTimeUtc;
+    private DateTimeOffset? initialNextFireTimeUtc;
     private DateTimeOffset? previousFireTimeUtc;
 
     private int repeatCount;
@@ -640,6 +641,11 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
     public override void SetNextFireTimeUtc(DateTimeOffset? nextFireTime)
     {
         nextFireTimeUtc = nextFireTime;
+    }
+
+    public override void SetInitialNextFireTimeUtc(DateTimeOffset? fireTime)
+    {
+        initialNextFireTimeUtc = fireTime;
     }
 
     public override void SetPreviousFireTimeUtc(DateTimeOffset? previousFireTime)

--- a/src/Quartz/SPI/IOperableTrigger.cs
+++ b/src/Quartz/SPI/IOperableTrigger.cs
@@ -107,5 +107,7 @@ public interface IOperableTrigger : IMutableTrigger
 
     void SetNextFireTimeUtc(DateTimeOffset? value);
 
+    void SetInitialNextFireTimeUtc(DateTimeOffset? value);
+
     void SetPreviousFireTimeUtc(DateTimeOffset? value);
 }


### PR DESCRIPTION
### New Feature
---
The new feature that I am adding with this PR is to know the duration of the delay of a quartz cron job.

### Scenario
---

I am currently deploying a Quartz application on AKS, where a single node is handling 4 concurrent Quartz jobs by default.
Occasionally when there is too much load on the system, there are a number of misfired jobs that remain in the queue, waiting for an available thread to execute.

To optimize the application's performance and scale it effectively, I need to track the number of misfired jobs and their corresponding wait times.
For instance, if there are five misfired jobs with wait times exceeding 15 minutes, I would like to trigger the creation of an additional node to handle the load.

### Current Behavior:
---
Currently if a certain job gets misfired 5 times before being fired, the next_fire_time is updated 5 times, there is no possibility to know the initial fire time and how long the job is late.

### New Behavior:
---
By adding a new column initial_next_fire_time to the qrtz_triggers that will not be updated on misfire. It will be possible to track the delay of a certain cron job.



> [!NOTE]
> This feature is not available for jobs scheduled With Simple Schedule
