### PR TITLE
Updated the expression for CronTrigger Example 4 according to description

### DIFF
--- a/docs/documentation/quartz-3.x/tutorial/crontriggers.md
+++ b/docs/documentation/quartz-3.x/tutorial/crontriggers.md
@@ -95,7 +95,7 @@ Here are a few more examples of expressions and their meanings - you can find ev
 Note that the trigger will NOT fire at 10:00 am, just at 8:00, 8:30, 9:00 and 9:30**
 
 ```text
-    "0 0/30 8-9 5,20 * ?"
+    "0 0/30 8-10 5,20 * ?"
 ```
 
 Note that some scheduling requirements are too complicated to express with a single trigger - such as "every 5 minutes between 9:00 am and 10:00 am,


### PR DESCRIPTION
Changed the expression according to description: 
CronTrigger Example 4 - an expression to create a trigger that fires every half hour between the hours of 8 am and 10 am on the 5th and 20th of every month. Note that the trigger will NOT fire at 10:00 am, just at 8:00, 8:30, 9:00 and 9:30