### PR TITLE
Introducing Quartz.NET Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![NuGet pre-release](http://img.shields.io/nuget/vpre/Quartz.svg)](https://www.nuget.org/packages/Quartz/)
 [![MyGet pre-release](https://img.shields.io/myget/quartznet/vpre/Quartz)](#)
 [![Join the chat at https://gitter.im/quartznet/quartznet](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/quartznet/quartznet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Quartz.NET%20Guru-006BFF)](https://gurubase.io/g/quartz-net)
 
 # Quartz.NET - Enterprise Job Scheduler
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Quartz.NET Guru](https://gurubase.io/g/quartz-net) to Gurubase. Quartz.NET Guru uses the data from this repo and data from the [docs](https://www.quartz-scheduler.net/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Quartz.NET Guru", which highlights that Quartz.NET now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Quartz.NET Guru in Gurubase, just let me know that's totally fine.
