### PR TITLE
DirtyFlagMap-fixAdd

### DIFF
--- a/src/Quartz/Util/DirtyFlagMap.cs
+++ b/src/Quartz/Util/DirtyFlagMap.cs
@@ -341,7 +341,7 @@ namespace Quartz.Util
         /// 	<para>-or-</para>
         /// 	<para>The <see cref="T:System.Collections.IDictionary"/> has a fixed size.</para>
         /// </exception>
-        public virtual void Add(TKey key, [MaybeNull] TValue value)
+        public virtual void Add(TKey key, [AllowNull] TValue value)
         {
             map.Add(key, value);
             dirty = true;

--- a/src/Quartz/Util/DirtyFlagMap.cs
+++ b/src/Quartz/Util/DirtyFlagMap.cs
@@ -343,7 +343,7 @@ namespace Quartz.Util
         /// </exception>
         public virtual void Add(TKey key, [AllowNull] TValue value)
         {
-            map.Add(key, value);
+            map.Add(key, value!);
             dirty = true;
         }
 


### PR DESCRIPTION
Turns out MaybeNull is an output attribute, and it results in the compiler assuming an object is no longer guaranteed non-null after being added.
The actual input attribute is AllowNull.
- AllowNullAttribute: Specifies that null is allowed as an input even if the corresponding type disallows it.
- MaybeNullAttribute: Specifies that an output may be null even if the corresponding type disallows it.