### PR TITLE
Fix `StdScheduler.Interrupt` not interrupting all identified jobs

### DIFF
--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -2038,7 +2038,6 @@ public sealed class QuartzScheduler
             {
                 cancellableJobExecutionContext.Cancel();
                 interrupted = true;
-                break;
             }
         }
 


### PR DESCRIPTION
Fixes #757.
