### PR TITLE
Docs: clarify exception re-execution behavior

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -171,7 +171,10 @@ A better solution is to release the worker thread (exit the job) and allow other
 
 A Job's execute method should contain a try-catch block that handles all possible exceptions.
 
-If a job throws an exception, Quartz will typically immediately re-execute it, meaning the job can and likely will throw the same exception again. This can lead to wasted resources and, in the worst cases, unstable or crashed applications.
+If a job throws an exception, Quartz will treat the current firing as failed and, by default, will not immediately re-execute the job. (Unhandled exceptions are wrapped into a `JobExecutionException` with `refireImmediately: false`.)
+
+If you do want Quartz to immediately re-execute the job, you can throw a `JobExecutionException` with `refireImmediately: true`, but use this with caution as it can create a tight failure loop.
+
 It's better if the job catches all exceptions it may encounter, handles them, and reschedules itself or other jobs to work around the issue.
 
 ### Recoverability and Idempotence


### PR DESCRIPTION
Fixes #2303.

The best-practices page currently says Quartz will typically immediately re-execute a job when it throws, but by default unhandled exceptions are wrapped into JobExecutionException with refireImmediately: false.

This updates the wording to match the actual behavior and notes the explicit opt-in via JobExecutionException(refireImmediately: true).
