### PR TITLE
Improve object deserialization in `JobDataMap`

### DIFF
--- a/src/Quartz.Serialization.SystemTextJson/Util/ICustomJobDataConverter.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Util/ICustomJobDataConverter.cs
@@ -1,0 +1,15 @@
+namespace Quartz.Util;
+
+/// <summary>
+/// Can be used to convert more complex objects in <see cref="JobDataMap"/>s.
+/// </summary>
+public interface ICustomJobDataConverter
+{
+    /// <summary>
+    /// Whether this converter handles properties with the given name.
+    /// </summary>
+    /// <param name="propertyName">The job data property name to check</param>
+    /// <returns><see langword="true"/> if this converter handles the given <paramref name="propertyName"/>,
+    /// <see langword="false"/> if not.</returns>
+    bool HandlesProperty(string propertyName);
+}

--- a/src/Quartz.Serialization.SystemTextJson/Util/SerializationExtensions.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Util/SerializationExtensions.cs
@@ -4,8 +4,10 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Quartz.Util;
+
 
 internal static class Utf8JsonWriterExtensions
 {
@@ -220,7 +222,24 @@ internal static class Utf8JsonWriterExtensions
                     }
                     break;
                 case JsonValueKind.Object:
-                    value = property.Value.Deserialize<Dictionary<string, string>>(options);
+                    value = null;
+
+                    // try registered converters before falling back to generic dictionary deserialization
+                    foreach (JsonTypeInfo typeInfo in options.Converters
+                                 .Where(c => c is ICustomJobDataConverter custom && custom.HandlesProperty(property.Name))
+                                 .Select(c => c.Type).OfType<Type>()
+                                 .Select(options.GetTypeInfo)
+                            )
+                    {
+                        value = property.Value.Deserialize(typeInfo);
+                        if (value is not null)
+                        {
+                            break;
+                        }
+                    }
+
+                    value ??= property.Value.Deserialize<Dictionary<string, string>>(options);
+
                     break;
                 default:
                     throw new JsonException($"Unsupported value kind: {property.Value.ValueKind}");

--- a/src/Quartz.Serialization.SystemTextJson/Util/SerializationExtensions.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Util/SerializationExtensions.cs
@@ -8,7 +8,6 @@ using System.Text.Json.Serialization.Metadata;
 
 namespace Quartz.Util;
 
-
 internal static class Utf8JsonWriterExtensions
 {
     public static void WriteString(this Utf8JsonWriter writer, string propertyName, DateTimeOffset? value)

--- a/src/Quartz.Tests.Unit/Extensions/Serialization/SerializationExtensionsTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/Serialization/SerializationExtensionsTests.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+
+namespace Quartz.Tests.Unit.Extensions.Serialization;
+
+public class SerializationExtensionsTests
+{
+    [Test]
+    public void GetJobDataMap_WithCustomJobDataConverter()
+    {
+        var source = """{"Test":{"Content":"Hello, World!"}}"""u8;
+
+        TestJobDataObjectSerializer os = new();
+        os.Initialize();
+
+        var map = os.DeSerialize<JobDataMap>(source.ToArray());
+        Assert.That(map, Is.Not.Null);
+        Assert.That(map.ContainsKey("Test"), Is.True);
+        var test = map["Test"] as TestJobData;
+        Assert.That(test, Is.Not.Null);
+        Assert.That(test.Content, Is.EqualTo("Hello, World!"));
+    }
+}

--- a/src/Quartz.Tests.Unit/Extensions/Serialization/TestJobDataConverter.cs
+++ b/src/Quartz.Tests.Unit/Extensions/Serialization/TestJobDataConverter.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Quartz.Simpl;
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit.Extensions.Serialization;
+
+public class TestJobDataConverter : JsonConverter<TestJobData>, ICustomJobDataConverter
+{
+    public override TestJobData Read(ref Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
+    {
+        return JsonSerializer.Deserialize(ref reader, TestJobDataSerializationOptions.Default.TestJobData);
+    }
+
+    public override void Write(Utf8JsonWriter writer, TestJobData value, System.Text.Json.JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, TestJobDataSerializationOptions.Default.TestJobData);
+    }
+
+    public bool HandlesProperty(string propertyName)
+    {
+        return propertyName == "Test";
+    }
+}
+
+public class TestJobData
+{
+    public string Content { get; set; }
+}
+
+[JsonSerializable(typeof(TestJobData))]
+public partial class TestJobDataSerializationOptions : JsonSerializerContext;
+
+public class TestJobDataObjectSerializer : SystemTextJsonObjectSerializer
+{
+    protected override System.Text.Json.JsonSerializerOptions CreateSerializerOptions()
+    {
+        var options = base.CreateSerializerOptions();
+
+        options.Converters.Insert(0, new TestJobDataConverter());
+
+        return options;
+    }
+}


### PR DESCRIPTION
This PR adds special handling when deserializing an object in `JobDataMap`.

More specifically, it checks if the `JsonSerializerOptions` contain a converter that handles deserializing of the current data key.

If no converter has been found, it falls back to the default behaviour, which is trying to deserialize it as `Dictionary<string, string>`.

This change allows developers to register custom converters for complex objects in the options while staying backward compatible.

Related issue: #2469