### PR TITLE
fix: handle ObjectDisposedException when canceling jobs in QuartzSche…

### DIFF
--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -441,7 +441,14 @@ public sealed class QuartzScheduler
                 var jobs = GetCurrentlyExecutingJobs().OfType<ICancellableJobExecutionContext>();
                 foreach (var job in jobs)
                 {
-                    job.Cancel();
+                    try
+                    {
+                        job.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+
+                    }
                 }
             }
 


### PR DESCRIPTION
During scheduler shutdown, after enumerating all jobs currently executing, some of them might be finished by the time the loop tries to reach the .Cancel() request. in this case, this exception would hit, which will cause  the shutdown to fail early[