### PR TITLE
Bump Meziantou.Analyzer from 2.0.177 to 3.0.44

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
-    <GlobalPackageReference Include="Meziantou.Analyzer" Version="2.0.177" />
+    <GlobalPackageReference Include="Meziantou.Analyzer" Version="3.0.44" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
   </ItemGroup>
 </Project>

--- a/src/Quartz/Impl/Matchers/AndMatcher.cs
+++ b/src/Quartz/Impl/Matchers/AndMatcher.cs
@@ -78,7 +78,7 @@ public sealed class AndMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 
     public override bool Equals(object? obj)
     {
-        if (this == obj)
+        if (ReferenceEquals(this, obj))
         {
             return true;
         }

--- a/src/Quartz/Impl/Matchers/KeyMatcher.cs
+++ b/src/Quartz/Impl/Matchers/KeyMatcher.cs
@@ -69,7 +69,7 @@ public sealed class KeyMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 
     public override bool Equals(object? obj)
     {
-        if (this == obj)
+        if (ReferenceEquals(this, obj))
         {
             return true;
         }

--- a/src/Quartz/Impl/Matchers/NotMatcher.cs
+++ b/src/Quartz/Impl/Matchers/NotMatcher.cs
@@ -73,7 +73,7 @@ public sealed class NotMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 
     public override bool Equals(object? obj)
     {
-        if (this == obj)
+        if (ReferenceEquals(this, obj))
         {
             return true;
         }

--- a/src/Quartz/Impl/Matchers/OrMatcher.cs
+++ b/src/Quartz/Impl/Matchers/OrMatcher.cs
@@ -79,7 +79,7 @@ public sealed class OrMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 
     public override bool Equals(object? obj)
     {
-        if (this == obj)
+        if (ReferenceEquals(this, obj))
         {
             return true;
         }

--- a/src/Quartz/Impl/Matchers/StringMatcher.cs
+++ b/src/Quartz/Impl/Matchers/StringMatcher.cs
@@ -59,7 +59,7 @@ public abstract class StringMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey
 
     public override bool Equals(object? obj)
     {
-        if (this == obj)
+        if (ReferenceEquals(this, obj))
         {
             return true;
         }

--- a/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
+++ b/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
@@ -801,7 +801,7 @@ internal sealed class RecurrenceRule
     /// </summary>
     private static DateTimeOffset ToDateTimeOffset(DateTime local, TimeZoneInfo tz)
     {
-        if (tz == TimeZoneInfo.Utc)
+        if (ReferenceEquals(tz, TimeZoneInfo.Utc))
         {
             return new DateTimeOffset(local, TimeSpan.Zero);
         }


### PR DESCRIPTION
## Summary
- Upgrades Meziantou.Analyzer from 2.0.177 to 3.0.44 (major version bump)
- Fixes 6 new MA0169 analyzer errors by replacing `==` operator with `ReferenceEquals()` in `Equals` overrides and `TimeZoneInfo` comparison

## Changes
- `Directory.Packages.props` — version bump
- `StringMatcher.cs`, `AndMatcher.cs`, `OrMatcher.cs`, `NotMatcher.cs`, `KeyMatcher.cs` — use `ReferenceEquals(this, obj)` instead of `this == obj` in `Equals` overrides  
- `RecurrenceRule.cs` — use `ReferenceEquals(tz, TimeZoneInfo.Utc)` instead of `tz == TimeZoneInfo.Utc`

Supersedes #3020

## Test plan
- [x] Solution builds with 0 errors and 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)