### PR TITLE
Implement IsJobGroupPaused/IsTriggerGroupPaused in ADO.NET job store

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -750,6 +750,53 @@ public class JobStoreSupportTest
         recovered.Should().Be(0);
     }
 
+    [Test]
+    public async Task IsJobGroupPaused_ShouldReturnFalse()
+    {
+        bool result = await jobStoreSupport.IsJobGroupPaused("anyGroup");
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task IsTriggerGroupPaused_ShouldDelegateToDriverDelegate()
+    {
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+
+        A.CallTo(() => driverDelegate.IsTriggerGroupPaused(conn, "pausedGroup", A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<bool>(true));
+
+        bool result = await jobStoreSupport.CallIsTriggerGroupPaused(conn, "pausedGroup");
+
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task IsTriggerGroupPaused_ShouldReturnFalse_WhenGroupNotPaused()
+    {
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+
+        A.CallTo(() => driverDelegate.IsTriggerGroupPaused(conn, "activeGroup", A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<bool>(false));
+
+        bool result = await jobStoreSupport.CallIsTriggerGroupPaused(conn, "activeGroup");
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void IsTriggerGroupPaused_ShouldWrapException_InJobPersistenceException()
+    {
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+
+        A.CallTo(() => driverDelegate.IsTriggerGroupPaused(conn, "group", A<CancellationToken>.Ignored))
+            .Throws(new Exception("db error"));
+
+        Func<Task> act = async () => await jobStoreSupport.CallIsTriggerGroupPaused(conn, "group");
+
+        act.Should().ThrowAsync<JobPersistenceException>()
+            .WithMessage("*group*");
+    }
+
     private static RetryTestJobStoreSupport CreateRetryTestStore(int maxTransientRetries = 3)
     {
         return new RetryTestJobStoreSupport
@@ -829,6 +876,11 @@ public class JobStoreSupportTest
             bool updateTriggers)
         {
             return StoreCalendar(conn, calName, calendar, replaceExisting, updateTriggers, CancellationToken.None);
+        }
+
+        internal ValueTask<bool> CallIsTriggerGroupPaused(ConnectionAndTransactionHolder conn, string group)
+        {
+            return IsTriggerGroupPaused(conn, group, CancellationToken.None);
         }
     }
 

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -1128,7 +1128,9 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         string group,
         CancellationToken cancellationToken = default)
     {
-        Throw.NotImplementedException();
+        // The ADO.NET store does not persist paused job group state.
+        // PauseJobs() only pauses individual triggers of jobs in the group
+        // without recording the job group itself as paused.
         return new ValueTask<bool>(false);
     }
 
@@ -1142,8 +1144,27 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         string group,
         CancellationToken cancellationToken = default)
     {
-        Throw.NotImplementedException();
-        return new ValueTask<bool>(false);
+        // no locks necessary for read...
+        return ExecuteWithoutLock(conn => IsTriggerGroupPaused(conn, group, cancellationToken), cancellationToken);
+    }
+
+    /// <summary>
+    /// Returns true if the given TriggerGroup is paused.
+    /// </summary>
+    public virtual async ValueTask<bool> IsTriggerGroupPaused(
+        ConnectionAndTransactionHolder conn,
+        string group,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await Delegate.IsTriggerGroupPaused(conn, group, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            Throw.JobPersistenceException("Couldn't determine if trigger group '" + group + "' is paused: " + e.Message, e);
+            return default;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Implement `IsTriggerGroupPaused` in `JobStoreSupport` by delegating to the existing `IDriverDelegate.IsTriggerGroupPaused` query against `QRTZ_PAUSED_TRIGGER_GRPS`
- Implement `IsJobGroupPaused` to return `false` since the ADO.NET store does not persist job group pause state (`PauseJobs()` only pauses individual triggers)
- Both methods previously threw `NotImplementedException`, crashing the Dashboard Jobs page with persistent stores

Fixes #3025
3.x counterpart: #3030

## Test plan
- [x] New unit tests for `IsTriggerGroupPaused` delegation (paused/not-paused/exception wrapping)
- [x] New unit test for `IsJobGroupPaused` returning false
- [x] All existing `JobStoreSupportTest` tests still pass
- [x] Full solution builds with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)