### PR TITLE
Fix Dashboard Live not working over HTTP

### DIFF
--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -94,7 +94,8 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         }
 
         // Map SignalR hub under the dashboard path
-        HubEndpointConventionBuilder hub = builder.MapHub<QuartzDashboardHub>(dashboardPath + "/hub");
+        HubEndpointConventionBuilder hub = builder.MapHub<QuartzDashboardHub>(dashboardPath + "/hub")
+            .DisableAntiforgery();
 
         // Serve dashboard static web assets via endpoint routing as a fallback
         // for hosts that don't configure UseStaticFiles() (e.g., API-only projects)


### PR DESCRIPTION
## Summary
- Disable antiforgery validation on the SignalR hub endpoint so the server-side negotiate POST isn't rejected over HTTP

Port of #3032 to main. Fixes #3029

## Test plan
- [ ] Run the example app over HTTP only, navigate to `/quartz/live`, confirm connection shows "Connected" and live events appear
- [ ] Run over HTTPS, confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)