### PR TITLE
Fix scheduler signal loss causing triggers stuck in WAITING state

### DIFF
--- a/src/Quartz.Tests.Unit/Core/SchedulerSignalRaceTest.cs
+++ b/src/Quartz.Tests.Unit/Core/SchedulerSignalRaceTest.cs
@@ -1,0 +1,206 @@
+using System.Collections.Specialized;
+
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// Regression tests for GitHub issue #3028: triggers stuck in WAITING state
+/// due to signal loss in QuartzSchedulerThread's SemaphoreSlim-based wake-up
+/// mechanism. The original bug was that SemaphoreSlim(0, 1) silently dropped
+/// signals via SemaphoreFullException when the semaphore already held a permit.
+/// </summary>
+[NonParallelizable]
+public class SchedulerSignalRaceTest
+{
+    /// <summary>
+    /// Hammers SignalSchedulingChange by scheduling many triggers in rapid
+    /// succession while the scheduler is running. With the old maxCount=1
+    /// semaphore, some signals were silently dropped, causing triggers to
+    /// sit in WAITING state until the next idle-wait timeout (~30 s).
+    /// </summary>
+    [Test]
+    public async Task RapidScheduling_TriggersFirePromptly()
+    {
+        int triggerCount = 20;
+        ManualResetEventSlim allFired = new ManualResetEventSlim(false);
+        RapidFireJob.Reset(triggerCount, allFired);
+
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+            ["quartz.scheduler.instanceName"] = "SignalRaceTest_Rapid",
+            ["quartz.threadPool.maxConcurrency"] = "5",
+        };
+
+        ISchedulerFactory sf = new StdSchedulerFactory(properties);
+        IScheduler scheduler = await sf.GetScheduler();
+
+        try
+        {
+            await scheduler.Start();
+
+            // Schedule triggers one at a time in rapid succession.
+            // Each ScheduleJob call signals the scheduler thread.
+            for (int i = 0; i < triggerCount; i++)
+            {
+                IJobDetail job = JobBuilder.Create<RapidFireJob>()
+                    .WithIdentity($"rapidJob_{i}", "signalRace")
+                    .Build();
+
+                ITrigger trigger = TriggerBuilder.Create()
+                    .WithIdentity($"rapidTrigger_{i}", "signalRace")
+                    .StartNow()
+                    .Build();
+
+                await scheduler.ScheduleJob(job, trigger);
+            }
+
+            // All 20 triggers should fire well within 10 seconds.
+            // With the old bug, some would wait up to 30 s for the idle timeout.
+            bool completed = allFired.Wait(TimeSpan.FromSeconds(10));
+            Assert.That(completed, Is.True,
+                $"Only {Volatile.Read(ref RapidFireJob.FiredCount)}/{triggerCount} triggers fired within 10 s — possible signal loss");
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    /// <summary>
+    /// Interleaves pause/resume (standby/start) cycles with trigger
+    /// scheduling to verify that stale pause-signal permits don't cause
+    /// the scheduler to miss wake-ups after resuming.
+    /// </summary>
+    [Test]
+    public async Task PauseResume_DoesNotStallTriggers()
+    {
+        var fired = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        PauseResumeJob.Signal = fired;
+
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+            ["quartz.scheduler.instanceName"] = "SignalRaceTest_PauseResume",
+        };
+
+        ISchedulerFactory sf = new StdSchedulerFactory(properties);
+        IScheduler scheduler = await sf.GetScheduler();
+
+        try
+        {
+            await scheduler.Start();
+
+            // Cycle standby/start several times to accumulate stale
+            // pauseSignal permits, then verify a trigger still fires.
+            for (int i = 0; i < 5; i++)
+            {
+                await scheduler.Standby();
+                await scheduler.Start();
+            }
+
+            IJobDetail job = JobBuilder.Create<PauseResumeJob>()
+                .WithIdentity("pauseResumeJob", "signalRace")
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("pauseResumeTrigger", "signalRace")
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+
+            bool didFire = await Task.WhenAny(fired.Task, Task.Delay(TimeSpan.FromSeconds(10))) == fired.Task;
+            Assert.That(didFire, Is.True,
+                "Trigger did not fire within 10 s after pause/resume cycles — possible stale pause permits");
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    /// <summary>
+    /// Schedules a trigger, then immediately pauses and resumes the
+    /// scheduler. The trigger must still fire promptly after resume.
+    /// </summary>
+    [Test]
+    public async Task ScheduleThenPauseResume_TriggerStillFires()
+    {
+        var fired = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        PauseResumeJob.Signal = fired;
+
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+            ["quartz.scheduler.instanceName"] = "SignalRaceTest_SchedulePause",
+        };
+
+        ISchedulerFactory sf = new StdSchedulerFactory(properties);
+        IScheduler scheduler = await sf.GetScheduler();
+
+        try
+        {
+            await scheduler.Start();
+
+            IJobDetail job = JobBuilder.Create<PauseResumeJob>()
+                .WithIdentity("schedPauseJob", "signalRace")
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("schedPauseTrigger", "signalRace")
+                .StartAt(DateTimeOffset.UtcNow.AddSeconds(1))
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+
+            // Pause while the trigger is still waiting to fire
+            await scheduler.Standby();
+            await scheduler.Start();
+
+            bool didFire = await Task.WhenAny(fired.Task, Task.Delay(TimeSpan.FromSeconds(10))) == fired.Task;
+            Assert.That(didFire, Is.True,
+                "Trigger did not fire within 10 s after schedule + pause/resume cycle");
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    public class RapidFireJob : IJob
+    {
+        private static int expectedCount;
+        internal static int FiredCount;
+        private static ManualResetEventSlim allFiredSignal = null!;
+
+        internal static void Reset(int expected, ManualResetEventSlim signal)
+        {
+            expectedCount = expected;
+            FiredCount = 0;
+            allFiredSignal = signal;
+        }
+
+        public ValueTask Execute(IJobExecutionContext context)
+        {
+            if (Interlocked.Increment(ref FiredCount) >= expectedCount)
+            {
+                allFiredSignal.Set();
+            }
+
+            return default;
+        }
+    }
+
+    public class PauseResumeJob : IJob
+    {
+        internal static TaskCompletionSource<bool> Signal = null!;
+
+        public ValueTask Execute(IJobExecutionContext context)
+        {
+            Signal.TrySetResult(true);
+            return default;
+        }
+    }
+}

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -47,8 +47,8 @@ internal sealed class QuartzSchedulerThread
     private readonly QuartzSchedulerResources qsRsrcs;
     private readonly int idleWaitVariableness;
     private readonly Lock sigLock = new();
-    private readonly SemaphoreSlim schedulingChangeSignal = new(0, 1);
-    private readonly SemaphoreSlim pauseSignal = new(0, 1);
+    private readonly SemaphoreSlim schedulingChangeSignal = new(0);
+    private readonly SemaphoreSlim pauseSignal = new(0);
 
     private bool signaled;
     private DateTimeOffset? signaledNextFireTimeUtc;
@@ -129,17 +129,13 @@ internal sealed class QuartzSchedulerThread
 
         if (pause)
         {
+            // Drain stale resume permits so the paused wait loop blocks properly
+            while (pauseSignal.Wait(0)) { }
             SignalSchedulingChange(SchedulerConstants.SchedulingSignalDateTime);
         }
         else
         {
-            try
-            {
-                pauseSignal.Release();
-            }
-            catch (SemaphoreFullException)
-            {
-            }
+            pauseSignal.Release();
         }
     }
 
@@ -148,19 +144,18 @@ internal sealed class QuartzSchedulerThread
     /// </summary>
     internal async Task Halt(bool wait)
     {
+        bool wasPaused;
         lock (sigLock)
         {
+            wasPaused = paused;
             halted = true;
         }
 
-        // Release the pause signal in case Run() is blocked in the paused wait loop.
-        // CancellationToken cancellation will also interrupt any pending WaitAsync calls.
-        try
+        // Release the pause signal only if the loop is actually paused,
+        // otherwise we'd accumulate a stale permit on repeated Halt() calls.
+        if (wasPaused)
         {
             pauseSignal.Release();
-        }
-        catch (SemaphoreFullException)
-        {
         }
 
         await cancellationTokenSource.CancelAsync().ConfigureAwait(false);
@@ -195,13 +190,7 @@ internal sealed class QuartzSchedulerThread
             signaledNextFireTimeUtc = candidateNewNextFireTimeUtc;
         }
 
-        try
-        {
-            schedulingChangeSignal.Release();
-        }
-        catch (SemaphoreFullException)
-        {
-        }
+        schedulingChangeSignal.Release();
     }
 
     public void ClearSignaledSchedulingChange()
@@ -211,6 +200,10 @@ internal sealed class QuartzSchedulerThread
             signaled = false;
             signaledNextFireTimeUtc = SchedulerConstants.SchedulingSignalDateTime;
         }
+
+        // Drain any buffered permits so WaitAsync blocks cleanly on next call.
+        // Prevents stale permits from causing unbounded spurious wakeups.
+        while (schedulingChangeSignal.Wait(0)) { }
     }
 
     public bool IsScheduleChanged()


### PR DESCRIPTION
## Summary

Port of #3033 (3.x) to main branch.

- Fix `SemaphoreSlim(0, 1)` signal loss in `QuartzSchedulerThread` that caused triggers to stay stuck in WAITING state (#3028)
- Remove `maxCount=1` cap so `Release()` never silently drops signals via `SemaphoreFullException`
- Drain buffered semaphore permits in `ClearSignaledSchedulingChange()` and `TogglePause(true)` to keep semaphores synchronized with boolean state
- Guard `Halt()` to only release `pauseSignal` when actually paused
- Add `SchedulerSignalRaceTest` with 3 regression tests for signal loss and pause/resume interleavings

Fixes #3028

## Test plan

- [x] Solution builds with 0 warnings/errors
- [x] All 1683 unit tests pass
- [x] 3 new signal race regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)