### PR TITLE
Fix dashboard plugins using static ServiceProvider (#3026)

### DIFF
--- a/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
@@ -27,13 +27,14 @@ namespace Quartz.Dashboard.Plugins;
 
 public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
 {
-    public static IServiceProvider? ServiceProvider { get; set; }
+    private IScheduler? scheduler;
 
     public string Name { get; private set; } = "QuartzDashboardHistory";
 
     public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         Name = pluginName;
+        this.scheduler = scheduler;
         scheduler.ListenerManager.AddJobListener(this, EverythingMatcher<JobKey>.AllJobs());
         return default;
     }
@@ -48,24 +49,38 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
 
     public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
     {
-        IDashboardHistoryStore? store = ServiceProvider?.GetService<IDashboardHistoryStore>();
-        if (store is null)
+        try
+        {
+            if (scheduler?.Context is not { } ctx
+                || !ctx.TryGetValue(DashboardPluginKeys.ServiceProvider, out var value)
+                || value is not IServiceProvider sp)
+            {
+                return default;
+            }
+
+            IDashboardHistoryStore? store = sp.GetService<IDashboardHistoryStore>();
+            if (store is null)
+            {
+                return default;
+            }
+
+            DashboardHistoryEntry entry = new(
+                SchedulerName: context.Scheduler.SchedulerName,
+                JobGroup: context.JobDetail.Key.Group,
+                JobName: context.JobDetail.Key.Name,
+                TriggerGroup: context.Trigger.Key.Group,
+                TriggerName: context.Trigger.Key.Name,
+                FiredAtUtc: context.FireTimeUtc,
+                DurationMs: (long) context.JobRunTime.TotalMilliseconds,
+                Succeeded: jobException is null,
+                ExceptionMessage: jobException?.Message);
+
+            store.Add(entry);
+            return default;
+        }
+        catch (ObjectDisposedException)
         {
             return default;
         }
-
-        DashboardHistoryEntry entry = new(
-            SchedulerName: context.Scheduler.SchedulerName,
-            JobGroup: context.JobDetail.Key.Group,
-            JobName: context.JobDetail.Key.Name,
-            TriggerGroup: context.Trigger.Key.Group,
-            TriggerName: context.Trigger.Key.Name,
-            FiredAtUtc: context.FireTimeUtc,
-            DurationMs: (long) context.JobRunTime.TotalMilliseconds,
-            Succeeded: jobException is null,
-            ExceptionMessage: jobException?.Message);
-
-        store.Add(entry);
-        return default;
     }
 }

--- a/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
@@ -29,8 +29,7 @@ namespace Quartz.Dashboard.Plugins;
 
 public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, ITriggerListener, ISchedulerListener
 {
-    public static IServiceProvider? ServiceProvider { get; set; }
-
+    private IScheduler? scheduler;
     private IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>? hubContext;
     private string schedulerName = string.Empty;
 
@@ -39,6 +38,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         Name = pluginName;
+        this.scheduler = scheduler;
         schedulerName = scheduler.SchedulerName;
 
         scheduler.ListenerManager.AddJobListener(this, EverythingMatcher<JobKey>.AllJobs());
@@ -210,23 +210,33 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
 
     public ValueTask SchedulingDataCleared(CancellationToken cancellationToken = default) => default;
 
-    private ValueTask BroadcastToScheduler(string scheduler, Func<IQuartzDashboardHubClient, Task> send)
+    private async ValueTask BroadcastToScheduler(string schedulerName, Func<IQuartzDashboardHubClient, Task> send)
     {
-        if (string.IsNullOrWhiteSpace(scheduler))
+        if (string.IsNullOrWhiteSpace(schedulerName))
         {
-            return default;
+            return;
         }
 
-        // Lazily resolve hub context — ServiceProvider is set by MapQuartzDashboard()
-        // which runs after the scheduler (and this plugin) is initialized
-        hubContext ??= ServiceProvider?.GetService<IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>>();
-
-        if (hubContext is null)
+        try
         {
-            return default;
-        }
+            if (hubContext is null
+                && scheduler?.Context is { } ctx
+                && ctx.TryGetValue(DashboardPluginKeys.ServiceProvider, out var value)
+                && value is IServiceProvider sp)
+            {
+                hubContext = sp.GetService<IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>>();
+            }
 
-        Task task = send(hubContext.Clients.Group(scheduler));
-        return new ValueTask(task);
+            if (hubContext is null)
+            {
+                return;
+            }
+
+            await send(hubContext.Clients.Group(schedulerName)).ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Host is disposing — silently ignore, dashboard events are non-critical
+        }
     }
 }

--- a/src/Quartz.Dashboard/Plugins/DashboardPluginKeys.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardPluginKeys.cs
@@ -1,0 +1,6 @@
+namespace Quartz.Dashboard.Plugins;
+
+internal static class DashboardPluginKeys
+{
+    public const string ServiceProvider = "Quartz.ServiceProvider";
+}

--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -27,7 +27,6 @@ using Microsoft.Extensions.Options;
 
 using Quartz.Dashboard.Components;
 using Quartz.Dashboard.Hubs;
-using Quartz.Dashboard.Plugins;
 
 namespace Quartz;
 
@@ -85,8 +84,6 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         RazorComponentsEndpointConventionBuilder components)
     {
         QuartzDashboardOptions options = builder.ServiceProvider.GetRequiredService<IOptions<QuartzDashboardOptions>>().Value;
-        DashboardLiveEventsPlugin.ServiceProvider = builder.ServiceProvider;
-        DashboardHistoryPlugin.ServiceProvider = builder.ServiceProvider;
         string dashboardPath = options.TrimmedDashboardPath;
         if (string.IsNullOrWhiteSpace(dashboardPath))
         {

--- a/src/Quartz/Configuration/ServiceCollectionSchedulerFactory.cs
+++ b/src/Quartz/Configuration/ServiceCollectionSchedulerFactory.cs
@@ -73,6 +73,9 @@ internal sealed class ServiceCollectionSchedulerFactory : StdSchedulerFactory
 
     private async Task InitializeScheduler(IScheduler scheduler, CancellationToken cancellationToken)
     {
+        // Make the DI service provider available to plugins via SchedulerContext
+        scheduler.Context["Quartz.ServiceProvider"] = serviceProvider;
+
         // Default scheduler uses flat ISchedulerListener services (backward compatible)
         foreach (var listener in serviceProvider.GetServices<ISchedulerListener>())
         {


### PR DESCRIPTION
## Summary

Port of #3035 to `main` (4.x).

- Store `IServiceProvider` per-scheduler in `SchedulerContext` from `ServiceCollectionSchedulerFactory.InitializeScheduler` instead of using static fields on plugin classes
- Remove static `ServiceProvider` properties from `DashboardLiveEventsPlugin` and `DashboardHistoryPlugin` entirely (4.x allows breaking changes)
- Make `BroadcastToScheduler` async with `try-catch(ObjectDisposedException)` so dashboard failures never abort Quartz's listener notification chain
- `MapQuartzDashboard` remains passive — no scheduler creation during endpoint mapping

Fixes #3026

## Test plan

- [ ] Build succeeds with zero warnings
- [ ] Verify dashboard live events and history still work in a single-host scenario
- [ ] Verify no `ObjectDisposedException` when multiple `WebApplicationFactory` hosts run concurrently and one disposes

🤖 Generated with [Claude Code](https://claude.com/claude-code)