### PR TITLE
Dashboard docs: add note about UseStaticFiles

### DIFF
--- a/docs/documentation/quartz-3.x/packages/dashboard.md
+++ b/docs/documentation/quartz-3.x/packages/dashboard.md
@@ -163,4 +163,12 @@ If your host project has no `.razor` files of its own (e.g., a pure API project 
 
 This property tells the .NET SDK to include the Blazor framework scripts (`_framework/blazor.web.js`, `blazor.server.js`) in the app's static web assets. Without it, requests to `/_framework/blazor.web.js` return HTTP 404 because in .NET 10+, these files are no longer embedded in the ASP.NET Core assemblies — they are served as static web assets instead.
 
+Additionally, static files must be enabled in the request pipeline:
+
+```csharp
+app.UseRouting();
+app.Antiforgery();
+app.UseStaticFiles();
+```
+
 On .NET 8 and .NET 9, the framework scripts are served via endpoint routing and no extra configuration is needed.


### PR DESCRIPTION
I have found that when running a non-Blazor API project, turning on `<RequiresAspNetWebAssets>` is not enough to make the dashboard work properly. You also have to ensure that UseStaticFiles is called when configuring the request pipeline, otherwise blazor.web.js will not be served.