### PR TITLE
Fix GetTimeBefore throwing for positive-offset timezones (#3046)

### DIFF
--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -1019,6 +1019,24 @@ years: *
         actualTimeAfter.Should().Be(expectedTimeAfter);
     }
 
+    [Test]
+    public void GetTimeBeforeDoesNotThrowForPositiveOffsetTimeZone()
+    {
+        // Issue #3046: GetTimeBefore threw ArgumentOutOfRangeException when the
+        // timezone had a positive UTC offset, because the inverse binary search
+        // stepped into year 1 where internal DateTimeOffset constructions inside
+        // GetTimeAfter produced a UTC instant before year 1.
+        TimeZoneInfo plus11 = TimeZoneInfo.CreateCustomTimeZone(
+            "Test+11", TimeSpan.FromHours(11), "Test+11", "Test+11");
+        CronExpression cron = new CronExpression("0 0 0 ? * FRI *") { TimeZone = plus11 };
+        DateTimeOffset time = new DateTimeOffset(2026, 4, 16, 0, 0, 0, TimeSpan.Zero);
+
+        DateTimeOffset? before = null;
+        Assert.DoesNotThrow(() => before = cron.GetTimeBefore(time));
+        Assert.That(before, Is.Not.Null);
+        Assert.That(before!.Value, Is.LessThan(time));
+    }
+
     [TestCaseSource(typeof(CronTestScenarios), nameof(CronTestScenarios.TestCases))]
     public void CronExpressionReturnsExpectedNextFireTime(CronExpression cronExpression, DateTimeOffset timeAfterDate, DateTimeOffset expectedNextFireTime)    {
         var nextFireTime = cronExpression.GetTimeAfter(timeAfterDate);

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -2356,10 +2356,18 @@ public sealed class CronExpression : ISerializable
     public DateTimeOffset? GetTimeBefore(DateTimeOffset endTime)
     {
         long end = endTime.Ticks;
-        long min = new DateTimeOffset(1, 1, 1, 0, 0, 0, TimeSpan.Zero).Ticks;
+        // Start at year 2 so that DateTimeOffset constructions inside GetTimeAfter —
+        // which combine year/month/day with a timezone offset of up to +14 hours —
+        // cannot produce a UTC instant below year 1.
+        long min = new DateTimeOffset(2, 1, 1, 0, 0, 0, TimeSpan.Zero).Ticks;
         long max = end;
 
-        DateTimeOffset date = new DateTimeOffset(1, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        if (end <= min)
+        {
+            return null;
+        }
+
+        DateTimeOffset date = new DateTimeOffset(min, TimeSpan.Zero);
         DateTimeOffset? after = GetTimeAfter(date);
         if (after == null || after.Value.Ticks >= end)
         {
@@ -2368,7 +2376,7 @@ public sealed class CronExpression : ISerializable
 
         // Inverse binary search for tighter lower bound
         long interval = TimeSpan.FromHours(1).Ticks;
-        while (interval < max)
+        while (interval < max - min)
         {
             date = new DateTimeOffset(max - interval, TimeSpan.Zero);
             after = GetTimeAfter(date);


### PR DESCRIPTION
## Summary
- `CronExpression.GetTimeBefore` threw `ArgumentOutOfRangeException` for any timezone with a positive UTC offset (issue #3046).
- The inverse binary search seeded its lower bound at year 1 UTC; once it stepped into year 1, `GetTimeAfter` constructed `DateTimeOffset`s whose UTC instant fell before year 1 and hit the `DateTime` range guard.
- Bumped the search lower bound to year 2 (safe for any valid TZ offset up to ±14h) and clamped the inverse search so it never drops below that minimum.

Companion PR #3047 applies the same fix on `3.x`.

Fixes #3046

## Test plan
- [x] New `GetTimeBeforeDoesNotThrowForPositiveOffsetTimeZone` regression test reproduces the reported scenario with a portable `CreateCustomTimeZone(+11)` and passes
- [x] Existing `TestGetTimeBefore` still passes
- [x] All `CronExpression` unit tests pass (296/296)

🤖 Generated with [Claude Code](https://claude.com/claude-code)