### PR TITLE
Bump vulnerable packages to unblock 3.x CI

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -19,4 +19,13 @@
     <PackageDownload Include="GitVersion.Tool" Version="[5.7.0]" />
   </ItemGroup>
 
+  <!--
+    Override vulnerable transitive dependencies pulled in by Nuke.Common.
+    Remove these when Nuke.Common ships a release that bumps them itself.
+  -->
+  <ItemGroup>
+    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
+++ b/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
@@ -30,10 +30,10 @@
     <ItemGroup>
       <PackageReference Include="KubernetesClient" Version="18.0.5" />
       <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-      <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.14.0" />
-      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-      <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.14.0" />
-      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+      <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+      <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
       <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.1" />
       <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />


### PR DESCRIPTION
## Summary

Three known-vulnerable package versions were breaking restore/build on `3.x`:

| Package | Old | New | Severity | Advisories |
|---|---|---|---|---|
| `OpenTelemetry.Exporter.Console` | 1.14.0 | 1.15.3 | — | (bumped for family consistency) |
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.14.0 | 1.15.3 | moderate | GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933 |
| `OpenTelemetry.Exporter.Zipkin` | 1.14.0 | 1.15.3 | — | (bumped for family consistency) |
| `OpenTelemetry.Extensions.Hosting` | 1.14.0 | 1.15.3 | — | (bumped for family consistency) |
| `OpenTelemetry.Api` (transitive) | 1.14.0 | 1.15.3 | moderate | GHSA-g94r-2vxg-569j |
| `NuGet.Packaging` (transitive via Nuke.Common) | 6.12.1 | 7.3.1 | low | GHSA-g4vj-cjjj-v7hg |
| `System.Security.Cryptography.Xml` (transitive via Nuke.Common) | 9.0.0 | 10.0.7 | **high** | GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf |

The `OpenTelemetry.*` bumps go in `src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj` (direct references). The other two are transitive deps of `Nuke.Common 10.1.0` in `build/_build.csproj`, so they get explicit `<PackageReference>` overrides — annotated as removable once Nuke.Common ships a release that bumps them itself.

`OpenTelemetry.Api` isn't directly referenced; pulling the four exporter/extension packages forward to 1.15.3 brings .Api 1.15.3 along transitively.

## Why now

`OpenTelemetry.Exporter.OpenTelemetryProtocol 1.14.0` triggers `NU1902` errors during restore (it's a direct reference, so `WarningsAsErrors` promotes the moderate-severity warning to a build break). That blocks every PR's CI restore on `3.x`, including the in-flight #3053 (Quartz.Redis rename).

The two transitive overrides in `build/_build.csproj` clean up the `NU1901` / `NU1903` warnings that show up on every job that restores the build project — annoying noise rather than a hard break, but worth fixing while we're here, especially since one of them (`System.Security.Cryptography.Xml`) is high severity.

## Test plan

- [x] `dotnet restore build/_build.csproj` — clean, no NU1901/NU1903
- [x] `dotnet restore src/Quartz.Examples.AspNetCore/...` — clean, no NU1902
- [x] `dotnet build Quartz.slnx -c Release` — succeeds with **0 warnings, 0 errors** (was: 3 NU1902 errors blocking restore)
- [ ] CI: every workflow that previously failed on the vulnerability errors now passes through restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)