### PR TITLE
Make IJobFactory.NewJob asynchronous (#3045)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -71,6 +71,11 @@
   * `Task` return types and parameters have been changed to `ValueTask`.  Any consumers of Quartz expecting a `Task` will require to update the signatures to `ValueTask`,
      or use the `AsTask()` Method on ValueTask to Return the `ValueTask` as a `Task`  (#988)
 
+  * `IJobFactory.NewJob` now returns `ValueTask<IJob>` and accepts a `CancellationToken`, allowing factories to perform asynchronous work
+    (such as resolving tenant context from an external store) before producing a job instance. Existing synchronous implementations should return
+    `new ValueTask<IJob>(job)`. Built-in factories that derive from `SimpleJobFactory` can call the new protected `InstantiateJobCore` helper
+    when they need a job instance from the synchronous code path. (#3045)
+
   * To configure JSON serialization to be used in job store instead of old `UseJsonSerializer` you should now use either `UseSystemTextJsonSerializer` or `UseNewtonsoftJsonSerializer`
     and remove the old package reference `Quartz.Serialization.Json` (and if Newtonsoft used, reference `Quartz.Serialization.Newtonsoft`). Change was made to distinguish the two common
     serializers that are being used (System.Text.Json and JSON.NET).

--- a/src/Quartz.Tests.Unit/Core/JobRunShellAsyncLocalTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobRunShellAsyncLocalTest.cs
@@ -19,6 +19,7 @@ public class JobRunShellAsyncLocalTest
     {
         AsyncLocalCapturingJob.Executed.Reset();
         AsyncLocalCapturingJob.CapturedTenantId = null;
+        AwaitingJobFactory.AwaitedWorkCompleted = false;
     }
 
     [Test]
@@ -62,6 +63,45 @@ public class JobRunShellAsyncLocalTest
         }
     }
 
+    [Test]
+    public async Task AsyncJobFactory_AwaitedWorkCompletesBeforeJobExecute()
+    {
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+            ["quartz.scheduler.instanceName"] = "AsyncJobFactoryTest",
+        };
+
+        ISchedulerFactory sf = new StdSchedulerFactory(properties);
+        IScheduler scheduler = await sf.GetScheduler();
+        scheduler.JobFactory = new AwaitingJobFactory();
+
+        try
+        {
+            IJobDetail job = JobBuilder.Create<AsyncLocalCapturingJob>()
+                .WithIdentity("job1", "asyncfactory")
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger1", "asyncfactory")
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            bool signaled = AsyncLocalCapturingJob.Executed.Wait(TimeSpan.FromSeconds(10));
+            Assert.That(signaled, Is.True, "Job did not execute within timeout");
+            Assert.That(AwaitingJobFactory.AwaitedWorkCompleted, Is.True,
+                "Awaited work in IJobFactory.NewJob must complete before IJob.Execute runs");
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
     private sealed class AsyncLocalSettingJobFactory : IJobFactory
     {
         private readonly string tenantId;
@@ -71,10 +111,10 @@ public class JobRunShellAsyncLocalTest
             this.tenantId = tenantId;
         }
 
-        public IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler)
+        public ValueTask<IJob> NewJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
         {
             TenantId.Value = tenantId;
-            return new AsyncLocalCapturingJob();
+            return new ValueTask<IJob>(new AsyncLocalCapturingJob());
         }
 
         public ValueTask ReturnJob(IJob job)
@@ -94,5 +134,20 @@ public class JobRunShellAsyncLocalTest
             Executed.Set();
             return default;
         }
+    }
+
+    private sealed class AwaitingJobFactory : IJobFactory
+    {
+        public static volatile bool AwaitedWorkCompleted;
+
+        public async ValueTask<IJob> NewJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+            AwaitedWorkCompleted = true;
+            return new AsyncLocalCapturingJob();
+        }
+
+        public ValueTask ReturnJob(IJob job) => default;
     }
 }

--- a/src/Quartz.Tests.Unit/Simpl/MicrosoftDependencyInjectionJobFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/MicrosoftDependencyInjectionJobFactoryTest.cs
@@ -13,10 +13,10 @@ public class MicrosoftDependencyInjectionJobFactoryTest
 {
     [Test]
     [Ignore("WIP")]
-    public void DisposedServiceProviderShouldThrowSchedulerException()
+    public async Task DisposedServiceProviderShouldThrowSchedulerException()
     {
         var factory = new MicrosoftDependencyInjectionJobFactory(new TestServiceProvider(), Options.Create(new QuartzOptions()));
-        factory.NewJob(TestUtil.NewMinimalTriggerFiredBundle(), null!);
+        await factory.NewJob(TestUtil.NewMinimalTriggerFiredBundle(), null!);
     }
 
     [Test]

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -118,7 +118,7 @@ public class JobRunShell : SchedulerListenerSupport
         IJob job;
         try
         {
-            job = qs!.JobFactory.NewJob(firedTriggerBundle, scheduler);
+            job = await qs!.JobFactory.NewJob(firedTriggerBundle, scheduler, cancellationToken).ConfigureAwait(false);
             jec = new JobExecutionContextImpl(scheduler, firedTriggerBundle, job);
         }
         catch (SchedulerException se)

--- a/src/Quartz/SPI/IJobFactory.cs
+++ b/src/Quartz/SPI/IJobFactory.cs
@@ -49,16 +49,21 @@ public interface IJobFactory
     /// <see cref="TriggerState.Error" /> state, which will require human
     /// intervention (e.g. an application restart after fixing whatever
     /// configuration problem led to the issue with instantiating the Job).
+    /// <para>
+    /// Implementations may perform asynchronous work (for example, resolving
+    /// tenant context from an external store) before returning the job instance.
+    /// </para>
     /// </remarks>
     /// <param name="bundle">
     ///   The TriggerFiredBundle from which the <see cref="IJobDetail" />
     ///   and other info relating to the trigger firing can be obtained.
     /// </param>
     /// <param name="scheduler">a handle to the scheduler that is about to execute the job</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <throws>  SchedulerException if there is a problem instantiating the Job. </throws>
     /// <returns> the newly instantiated Job
     /// </returns>
-    IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler);
+    ValueTask<IJob> NewJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Allows the job factory to destroy/cleanup the job if needed.

--- a/src/Quartz/Simpl/PropertySettingJobFactory.cs
+++ b/src/Quartz/Simpl/PropertySettingJobFactory.cs
@@ -92,9 +92,10 @@ public class PropertySettingJobFactory : SimpleJobFactory
     /// <param name="bundle">The TriggerFiredBundle from which the <see cref="IJobDetail" />
     ///   and other info relating to the trigger firing can be obtained.</param>
     /// <param name="scheduler"></param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns>the newly instantiated Job</returns>
     /// <throws>  SchedulerException if there is a problem instantiating the Job. </throws>
-    public override IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler)
+    public override ValueTask<IJob> NewJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         IJob job = InstantiateJob(bundle, scheduler);
 
@@ -105,7 +106,7 @@ public class PropertySettingJobFactory : SimpleJobFactory
             SetObjectProperties(job, jobDataMap);
         }
 
-        return job;
+        return new ValueTask<IJob>(job);
     }
 
     protected virtual JobDataMap BuildJobDataMap(TriggerFiredBundle bundle, IScheduler scheduler)
@@ -134,7 +135,7 @@ public class PropertySettingJobFactory : SimpleJobFactory
 
     protected virtual IJob InstantiateJob(TriggerFiredBundle bundle, IScheduler scheduler)
     {
-        return base.NewJob(bundle, scheduler);
+        return InstantiateJobCore(bundle);
     }
 
     /// <summary>

--- a/src/Quartz/Simpl/SimpleJobFactory.cs
+++ b/src/Quartz/Simpl/SimpleJobFactory.cs
@@ -60,9 +60,19 @@ public class SimpleJobFactory : IJobFactory
     /// <param name="bundle">The TriggerFiredBundle from which the <see cref="IJobDetail" />
     ///   and other info relating to the trigger firing can be obtained.</param>
     /// <param name="scheduler"></param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns>the newly instantiated Job</returns>
     /// <throws>  SchedulerException if there is a problem instantiating the Job. </throws>
-    public virtual IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler)
+    public virtual ValueTask<IJob> NewJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
+    {
+        return new ValueTask<IJob>(InstantiateJobCore(bundle));
+    }
+
+    /// <summary>
+    /// Synchronous core of <see cref="NewJob" /> that derived classes can call when
+    /// they need a job instance without driving the asynchronous code path.
+    /// </summary>
+    protected IJob InstantiateJobCore(TriggerFiredBundle bundle)
     {
         IJobDetail jobDetail = bundle.JobDetail;
         Type jobType = jobDetail.JobType;


### PR DESCRIPTION
## Summary

- Promotes `IJobFactory.NewJob` to return `ValueTask<IJob>` and accept a `CancellationToken`, so factories can perform async I/O (e.g. resolving tenant context from an external store) before producing a job instance. Previously this work had to leak into `IJob.Execute` via wrapper jobs, mixing infrastructure concerns with execution.
- Built-in factories (`SimpleJobFactory`, `PropertySettingJobFactory`, `MicrosoftDependencyInjectionJobFactory`) keep doing their synchronous work and return a synchronously-completed `ValueTask<IJob>` — zero allocation, zero perf delta for the existing path.
- `SimpleJobFactory` exposes a new protected `InstantiateJobCore` helper so `PropertySettingJobFactory.InstantiateJob` (the sync extension hook used by the DI factory) still has a synchronous entry point without sync-over-async.
- `JobRunShell.Run` awaits the factory call, propagating its existing `CancellationToken`. AsyncLocal context still flows from `NewJob` to `IJob.Execute` (#1528) since AsyncLocal propagates across awaits.
- Changelog entry added next to the existing 4.0 `Task → ValueTask` migration line.

Closes #3045.

## Why 4.x only

3.x cannot accept this cleanly: `IScheduler.JobFactory` setter is typed `IJobFactory` and can't be retyped, so an async-only factory can't be assigned. Working around that requires runtime type-check dispatch + dual interface implementation by users (or a helper base class) — added complexity that 4.x avoids entirely. On 4.x this fits neatly into the existing wholesale `Task → ValueTask` migration.

## Test plan

- [x] `dotnet build Quartz.slnx` — clean (0 warnings, warnings-as-errors enabled).
- [x] `dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj -f net10.0` — 1686 passed, 5 pre-existing skips.
- [x] `JobRunShellAsyncLocalTest.AsyncLocal_SetInJobFactory_IsVisibleInJobExecute` still passes — confirms AsyncLocal flow across the new `await`.
- [x] New `JobRunShellAsyncLocalTest.AsyncJobFactory_AwaitedWorkCompletesBeforeJobExecute` — exercises a factory that does `Task.Yield` + `Task.Delay` inside `NewJob` and verifies `Execute` runs after the awaited work completes.
- [ ] Integration test suite — not run locally (requires Docker for Testcontainers); CI will cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)