### PR TITLE
Fix dashboard authorization policy leaking to host app endpoints (#3066)

### DIFF
--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -17,7 +17,11 @@
  */
 #endregion
 
+using System.Reflection;
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -100,8 +104,30 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
 
         if (!string.IsNullOrWhiteSpace(options.AuthorizationPolicy))
         {
-            hub.RequireAuthorization(options.AuthorizationPolicy);
-            components.RequireAuthorization(options.AuthorizationPolicy);
+            string policyName = options.AuthorizationPolicy;
+            hub.RequireAuthorization(policyName);
+
+            // Apply the policy ONLY to dashboard page endpoints. Calling RequireAuthorization on
+            // 'components' would otherwise apply to every endpoint owned by the builder, which in
+            // the integrated overload is the host app's own pages too (#3066).
+            Assembly dashboardAssembly = typeof(QuartzDashboardApp).Assembly;
+            components.Add(endpointBuilder =>
+            {
+                ComponentTypeMetadata? typeMetadata = null;
+                foreach (object metadata in endpointBuilder.Metadata)
+                {
+                    if (metadata is ComponentTypeMetadata m)
+                    {
+                        typeMetadata = m;
+                        break;
+                    }
+                }
+
+                if (typeMetadata?.Type.Assembly == dashboardAssembly)
+                {
+                    endpointBuilder.Metadata.Add(new AuthorizeAttribute(policyName));
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

When the dashboard's `AuthorizationPolicy` is set and the integrated overload `MapQuartzDashboard(builder, existingComponents)` is used, the policy was being applied to **every** page endpoint owned by the host's `RazorComponentsEndpointConventionBuilder` — including the host application's own pages — so users not in the dashboard role got 401/404 across the whole site instead of just `/quartz`.

The fix replaces the broad `components.RequireAuthorization(...)` with a filtered convention that only attaches `AuthorizeAttribute` to endpoints whose `ComponentTypeMetadata.Type` comes from the `Quartz.Dashboard` assembly. The SignalR hub keeps its own `RequireAuthorization` since it's a separate endpoint not shared with the host.

`ComponentTypeMetadata` (`Microsoft.AspNetCore.Components.Endpoints`) is a public sealed type since .NET 8, so this works on the project's `net8.0` target without any new public API surface.

Fixes #3066

## Test plan

- [x] Build succeeds with zero warnings (`dotnet build src/Quartz.Dashboard/Quartz.Dashboard.csproj`)
- [ ] Manual repro: a Blazor Server host with one anonymous `/` page and `MapQuartzDashboard(blazor)` configured with `AuthorizationPolicy = "ScheduledJobAdmin"`
  - `GET /` (anonymous) → 200 (was 401/404 before fix)
  - `GET /quartz` (anonymous) → 401/redirect
  - `GET /quartz` (in role) → 200
  - `GET /` (in role) → 200
- [ ] Standalone overload `MapQuartzDashboard()` continues to enforce the policy on all dashboard pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)