### PR TITLE
Bump vulnerable packages to unblock main CI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,12 +35,12 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="9.0.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTracing" Version="0.12.1" />
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="23.26.100" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.100" />
@@ -51,7 +51,7 @@
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.2" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.7" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Testcontainers.FirebirdSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -21,4 +21,13 @@
     <PackageReference Include="Nuke.Components" Version="10.1.0" />
   </ItemGroup>
 
+  <!--
+    Override vulnerable transitive dependencies pulled in by Nuke.Components.
+    Remove these when Nuke ships a release that bumps them itself.
+  -->
+  <ItemGroup>
+    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Port of #3054 to `main`, adapted for the central-package-management layout this branch uses and the older OpenTelemetry baseline (1.11.x → 1.15.x).

Three vulnerability classes were breaking restore/build on `main`:

- **`OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.11.2** in `Quartz.Examples.AspNetCore` — hard `NU1902` ([GHSA-4625-4j76-fww9](https://github.com/advisories/GHSA-4625-4j76-fww9)). Bumped all six directly-referenced OpenTelemetry packages in `Directory.Packages.props` to their latest stable lines together (1.15.x) so the Api/SDK contract stays aligned across exporters and instrumentation.
- **`NuGet.Packaging` 6.12.1** transitively pulled in by `Nuke.Components` 10.1.0 in `build/_build.csproj` — `NU1901` ([GHSA-g4vj-cjjj-v7hg](https://github.com/advisories/GHSA-g4vj-cjjj-v7hg)). Added an explicit `PackageReference` pinning **7.3.1**.
- **`System.Security.Cryptography.Xml` 9.0.0** transitively pulled in via the same Nuke path — `NU1903` ([GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx), [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf)). Added an explicit `PackageReference` pinning **10.0.7**.

`OpenTelemetry.Instrumentation.Runtime` 1.15.1 pulls in `OpenTelemetry.Api >= 1.15.3` which requires `System.Diagnostics.DiagnosticSource >= 10.0.0`, so the central pin for that package was bumped to **10.0.7** (latest stable) to clear the resulting `NU1109` downgrade error.

The two transitive overrides in `_build.csproj` are commented as removable once Nuke ships a release that bumps them itself.

## Test plan

- [x] `dotnet restore Quartz.slnx` — zero NU* warnings/errors
- [x] `dotnet build Quartz.slnx -c Release` — 0 Warning(s), 0 Error(s)
- [x] `dotnet build build/_build.csproj` — 0 Warning(s), 0 Error(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)