### PR TITLE
Fix malformed MySQL FORCE INDEX hint with schema-qualified table prefix

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
@@ -15,7 +15,18 @@ public class MySQLDelegateTest
 
         var sql = del.GetSelectNextTriggerToAcquireSqlPublic(10);
 
-        sql.Should().Contain("FORCE INDEX (IDX_{0}T_NFT_ST)");
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST)");
+        sql.Should().Contain("LIMIT 10");
+    }
+
+    [Test]
+    public void GetSelectNextTriggerToAcquireWithExecutionGroupSql_ShouldContainForceIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var sql = del.GetSelectNextTriggerToAcquireWithExecutionGroupSqlPublic(10);
+
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST)");
         sql.Should().Contain("LIMIT 10");
     }
 
@@ -26,7 +37,7 @@ public class MySQLDelegateTest
 
         var sql = del.GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(20);
 
-        sql.Should().Contain("FORCE INDEX (IDX_{0}T_NFT_ST_MISFIRE)");
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
         sql.Should().Contain("LIMIT 20");
     }
 
@@ -48,13 +59,66 @@ public class MySQLDelegateTest
 
         var sql = del.GetCountMisfiredTriggersInStateSqlPublic();
 
-        sql.Should().Contain("FORCE INDEX (IDX_{0}T_NFT_ST_MISFIRE)");
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
+    }
+
+    [Test]
+    public void GetSelectNextTriggerToAcquireSql_WithSchemaQualifiedPrefix_ProducesValidIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var template = del.GetSelectNextTriggerToAcquireSqlPublic(10);
+        var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
+
+        sql.Should().Contain("common.QRTZ_TRIGGERS t FORCE INDEX (IDX_QRTZ_T_NFT_ST)");
+        sql.Should().Contain("common.QRTZ_JOB_DETAILS jd");
+        sql.Should().NotContain("IDX_common.");
+    }
+
+    [Test]
+    public void GetSelectNextTriggerToAcquireWithExecutionGroupSql_WithSchemaQualifiedPrefix_ProducesValidIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var template = del.GetSelectNextTriggerToAcquireWithExecutionGroupSqlPublic(10);
+        var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
+
+        sql.Should().Contain("common.QRTZ_TRIGGERS t FORCE INDEX (IDX_QRTZ_T_NFT_ST)");
+        sql.Should().Contain("common.QRTZ_JOB_DETAILS jd");
+        sql.Should().NotContain("IDX_common.");
+    }
+
+    [Test]
+    public void GetSelectNextMisfiredTriggersInStateToAcquireSql_WithSchemaQualifiedPrefix_ProducesValidIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var template = del.GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(20);
+        var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
+
+        sql.Should().Contain("FROM common.QRTZ_TRIGGERS FORCE INDEX (IDX_QRTZ_T_NFT_ST_MISFIRE)");
+        sql.Should().NotContain("IDX_common.");
+    }
+
+    [Test]
+    public void GetCountMisfiredTriggersInStateSql_WithSchemaQualifiedPrefix_ProducesValidIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var template = del.GetCountMisfiredTriggersInStateSqlPublic();
+        var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
+
+        sql.Should().Contain("FROM common.QRTZ_TRIGGERS FORCE INDEX (IDX_QRTZ_T_NFT_ST_MISFIRE)");
+        sql.Should().NotContain("IDX_common.");
     }
 
     private class TestMySQLDelegate : MySQLDelegate
     {
         public string GetSelectNextTriggerToAcquireSqlPublic(int maxCount)
             => GetSelectNextTriggerToAcquireSql(maxCount);
+
+        public string GetSelectNextTriggerToAcquireWithExecutionGroupSqlPublic(int maxCount)
+            => GetSelectNextTriggerToAcquireWithExecutionGroupSql(maxCount);
 
         public string GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(int count)
             => GetSelectNextMisfiredTriggersInStateToAcquireSql(count);

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
@@ -45,13 +45,21 @@ public static class AdoJobStoreUtil
 
     /// <summary>
     /// Replace the table prefix in a query by replacing any occurrences of
-    /// "{0}" with the table prefix.
+    /// "{0}" with the table prefix, and "{1}" with the unqualified portion of
+    /// the table prefix (everything after the last '.', or the whole prefix when
+    /// the prefix has no schema qualifier).
     /// </summary>
+    /// <remarks>
+    /// The "{1}" placeholder is intended for identifiers that must not include
+    /// a schema, such as MySQL index names in <c>FORCE INDEX</c> hints.
+    /// </remarks>
     /// <param name="query">The unsubstituted query</param>
     /// <param name="tablePrefix">The table prefix</param>
     /// <returns>The query, with proper table prefix substituted</returns>
     public static string ReplaceTablePrefix(string query, string tablePrefix)
     {
-        return string.Format(CultureInfo.InvariantCulture, query, tablePrefix);
+        var lastDot = tablePrefix.LastIndexOf('.');
+        var unqualifiedPrefix = lastDot >= 0 ? tablePrefix.Substring(lastDot + 1) : tablePrefix;
+        return string.Format(CultureInfo.InvariantCulture, query, tablePrefix, unqualifiedPrefix);
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -33,14 +33,14 @@ public class MySQLDelegate : StdAdoDelegate
     protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
     {
         return SqlSelectNextTriggerToAcquire
-            .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{0}T_NFT_ST)")
+            .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST)")
             + " LIMIT " + maxCount;
     }
 
     protected override string GetSelectNextTriggerToAcquireWithExecutionGroupSql(int maxCount)
     {
         return SqlSelectNextTriggerToAcquireWithExecutionGroup
-            .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{0}T_NFT_ST)")
+            .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST)")
             + " LIMIT " + maxCount;
     }
 
@@ -49,7 +49,7 @@ public class MySQLDelegate : StdAdoDelegate
         if (count != -1)
         {
             return SqlSelectHasMisfiredTriggersInState
-                .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{0}T_NFT_ST_MISFIRE) WHERE")
+                .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE) WHERE")
                 + " LIMIT " + count;
         }
         return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
@@ -58,6 +58,6 @@ public class MySQLDelegate : StdAdoDelegate
     protected override string GetCountMisfiredTriggersInStateSql()
     {
         return SqlCountMisfiredTriggersInStates
-            .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{0}T_NFT_ST_MISFIRE) WHERE");
+            .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE) WHERE");
     }
 }


### PR DESCRIPTION
## Summary

Fix the FORCE INDEX hint added in #2894 so it produces valid SQL when the configured table prefix includes a schema (e.g. `common.QRTZ_`).

## Details

#2894 added FORCE INDEX hints to four `MySQLDelegate` methods using the SQL template placeholder `{0}` for both the table reference **and** the index name:

```csharp
.Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{0}T_NFT_ST)")
```

When the configured `tablePrefix` contains a schema (e.g. `common.QRTZ_`), `string.Format` substitutes `{0}` everywhere and the index identifier inherits the schema dot:

```sql
... FROM common.QRTZ_TRIGGERS t FORCE INDEX (IDX_common.QRTZ_T_NFT_ST) ...
```

MySQL/MariaDB index names cannot contain `.` — schema qualification belongs only on the table reference. This is the cause of the `JobPersistenceException: An error occurred while scanning for the next trigger to fire` reported in #3084 (regression from 3.15.1).

### Approach

Introduce a second `string.Format` placeholder `{1}` in `AdoJobStoreUtil.ReplaceTablePrefix` that resolves to the **unqualified** portion of the prefix (everything after the last `.`, or the whole prefix when there is no schema). All four `MySQLDelegate` FORCE INDEX templates now use `{1}` for the index name. Templates that only use `{0}` are unaffected; the change is non-breaking.

### Why this design

- Centralizes schema-stripping in one place instead of every delegate re-implementing it.
- No new `protected` surface on `StdAdoDelegate`.
- Future-proof: any other delegate (Oracle, PostgreSQL, …) that later needs a schema-stripped identifier can use the same `{1}`.

## Linked issue

Fixes #3084

## Test plan

- [x] Added or updated unit tests
- [x] Ran `dotnet test src/Quartz.Tests.Unit` locally — 1378/1378 passed (9 MySQLDelegateTest including 4 new `WithSchemaQualifiedPrefix_ProducesValidIndexHint` cases)
- [ ] Ran integration tests where relevant (`build.cmd Compile UnitTest IntegrationTest`, Docker required)
- [ ] Manually verified against a MariaDB instance with `tablePrefix = common.QRTZ_`

## Breaking change?

No. Existing SQL templates only use `{0}`; widening `string.Format` to two args is invisible to them. Grep across `src/Quartz/Impl/AdoJobStore` confirms no template currently contains a literal `{1}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)