### PR TITLE
Port MySQL FORCE INDEX hints with schema-qualified prefix support

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+public class MySQLDelegateTest
+{
+    [Test]
+    public void GetSelectNextTriggerToAcquireSql_ShouldContainForceIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var sql = del.GetSelectNextTriggerToAcquireSqlPublic(10);
+
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST)");
+        sql.Should().Contain("LIMIT 10");
+    }
+
+    [Test]
+    public void GetSelectNextMisfiredTriggersInStateToAcquireSql_ShouldContainForceIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var sql = del.GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(20);
+
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
+        sql.Should().Contain("LIMIT 20");
+    }
+
+    [Test]
+    public void GetSelectNextMisfiredTriggersInStateToAcquireSql_WithMinusOne_ShouldNotContainLimit()
+    {
+        var del = new TestMySQLDelegate();
+
+        var sql = del.GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(-1);
+
+        sql.Should().NotContain("LIMIT");
+        sql.Should().NotContain("FORCE INDEX");
+    }
+
+    [Test]
+    public void GetCountMisfiredTriggersInStateSql_ShouldContainForceIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var sql = del.GetCountMisfiredTriggersInStateSqlPublic();
+
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
+    }
+
+    [Test]
+    public void GetSelectNextTriggerToAcquireSql_WithSchemaQualifiedPrefix_ProducesValidIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var template = del.GetSelectNextTriggerToAcquireSqlPublic(10);
+        var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
+
+        sql.Should().Contain("common.QRTZ_TRIGGERS t FORCE INDEX (IDX_QRTZ_T_NFT_ST)");
+        sql.Should().Contain("common.QRTZ_JOB_DETAILS jd");
+        sql.Should().NotContain("IDX_common.");
+    }
+
+    [Test]
+    public void GetSelectNextMisfiredTriggersInStateToAcquireSql_WithSchemaQualifiedPrefix_ProducesValidIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var template = del.GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(20);
+        var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
+
+        sql.Should().Contain("FROM common.QRTZ_TRIGGERS FORCE INDEX (IDX_QRTZ_T_NFT_ST_MISFIRE)");
+        sql.Should().NotContain("IDX_common.");
+    }
+
+    [Test]
+    public void GetCountMisfiredTriggersInStateSql_WithSchemaQualifiedPrefix_ProducesValidIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var template = del.GetCountMisfiredTriggersInStateSqlPublic();
+        var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
+
+        sql.Should().Contain("FROM common.QRTZ_TRIGGERS FORCE INDEX (IDX_QRTZ_T_NFT_ST_MISFIRE)");
+        sql.Should().NotContain("IDX_common.");
+    }
+
+    private sealed class TestMySQLDelegate : MySQLDelegate
+    {
+        public string GetSelectNextTriggerToAcquireSqlPublic(int maxCount)
+            => GetSelectNextTriggerToAcquireSql(maxCount);
+
+        public string GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(int count)
+            => GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
+
+        public string GetCountMisfiredTriggersInStateSqlPublic()
+            => GetCountMisfiredTriggersInStateSql();
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
@@ -30,13 +30,21 @@ internal static class AdoJobStoreUtil
 {
     /// <summary>
     /// Replace the table prefix in a query by replacing any occurrences of
-    /// "{0}" with the table prefix.
+    /// "{0}" with the table prefix, and "{1}" with the unqualified portion of
+    /// the table prefix (everything after the last '.', or the whole prefix when
+    /// the prefix has no schema qualifier).
     /// </summary>
+    /// <remarks>
+    /// The "{1}" placeholder is intended for identifiers that must not include
+    /// a schema, such as MySQL index names in <c>FORCE INDEX</c> hints.
+    /// </remarks>
     /// <param name="query">The unsubstituted query</param>
     /// <param name="tablePrefix">The table prefix</param>
     /// <returns>The query, with proper table prefix substituted</returns>
     public static string ReplaceTablePrefix(string query, string tablePrefix)
     {
-        return string.Format(CultureInfo.InvariantCulture, query, tablePrefix);
+        var lastDot = tablePrefix.LastIndexOf('.');
+        var unqualifiedPrefix = lastDot >= 0 ? tablePrefix.Substring(lastDot + 1) : tablePrefix;
+        return string.Format(CultureInfo.InvariantCulture, query, tablePrefix, unqualifiedPrefix);
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -27,20 +27,29 @@ public class MySQLDelegate : StdAdoDelegate
 {
     /// <summary>
     /// Gets the select next trigger to acquire SQL clause.
-    /// MySQL version with LIMIT support.
+    /// MySQL version with LIMIT support and a FORCE INDEX hint pointing at IDX_*_T_NFT_ST.
     /// </summary>
-    /// <returns></returns>
     protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
     {
-        return SqlSelectNextTriggerToAcquire + " LIMIT " + maxCount;
+        return SqlSelectNextTriggerToAcquire
+            .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST)")
+            + " LIMIT " + maxCount;
     }
 
     protected override string GetSelectNextMisfiredTriggersInStateToAcquireSql(int count)
     {
         if (count != -1)
         {
-            return SqlSelectHasMisfiredTriggersInState + " LIMIT " + count;
+            return SqlSelectHasMisfiredTriggersInState
+                .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE) WHERE")
+                + " LIMIT " + count;
         }
         return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
+    }
+
+    protected override string GetCountMisfiredTriggersInStateSql()
+    {
+        return SqlCountMisfiredTriggersInStates
+            .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE) WHERE");
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -137,7 +137,7 @@ public partial class StdAdoDelegate
         DateTimeOffset ts,
         CancellationToken cancellationToken = default)
     {
-        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlCountMisfiredTriggersInStates));
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(GetCountMisfiredTriggersInStateSql()));
         AddCommandParameter(cmd, "schedulerName", schedName);
         AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
         AddCommandParameter(cmd, "state1", state1);
@@ -1203,6 +1203,11 @@ public partial class StdAdoDelegate
     {
         // by default we don't support limits, this is db specific
         return SqlSelectNextTriggerToAcquire;
+    }
+
+    protected virtual string GetCountMisfiredTriggersInStateSql()
+    {
+        return SqlCountMisfiredTriggersInStates;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary

Port the MySQL FORCE INDEX hints from #2894 (3.x) to main, with the schema-qualified table prefix fix for #3084 applied from the start.

## Details

main does not yet have the FORCE INDEX hints that #2894 added to 3.x for slow trigger queries on large `QRTZ_TRIGGERS` tables. This PR ports that feature, but written so it never produces malformed SQL when `tablePrefix` includes a schema such as `common.QRTZ_`.

On 3.x the original implementation used `{0}` as the placeholder for both the table reference and the index name, which substituted the schema dot into the index identifier (`IDX_common.QRTZ_T_NFT_ST` — invalid). That bug is being fixed on 3.x in #3086; this PR avoids it on main by using a new placeholder from the outset.

### Approach

- `AdoJobStoreUtil.ReplaceTablePrefix` now also passes `{1}` = the unqualified portion of the table prefix (everything after the last `.`, or the whole prefix when there is no schema).
- `MySQLDelegate` gains three FORCE INDEX overrides — trigger acquire, misfire acquire, count misfire — each using `{1}` for the index name. main has no `SqlSelectNextTriggerToAcquireWithExecutionGroup` template (execution group is now part of `SqlSelectNextTriggerToAcquire` after #3006), so this is three overrides vs. four on 3.x.
- `StdAdoDelegate.CountMisfiredTriggersInState` is rerouted through a new `protected virtual GetCountMisfiredTriggersInStateSql()` hook so MySQL can override the SQL (mirrors the existing `GetSelectNextTriggerToAcquireSql` / `GetSelectNextMisfiredTriggersInStateToAcquireSql` hooks).

### Why this design

- Centralizes schema-stripping in one place instead of every delegate re-implementing it.
- No new `protected` field on `StdAdoDelegate`.
- Future-proof: any other delegate that later needs a schema-stripped identifier can use the same `{1}`.

## Linked issue

Refs #3084

## Test plan

- [x] Added or updated unit tests — new `MySQLDelegateTest` with 7 cases (3 template assertions, 1 minus-one safety, 3 `WithSchemaQualifiedPrefix_ProducesValidIndexHint`)
- [x] Ran `dotnet test src/Quartz.Tests.Unit` locally — 1693/1693 passed
- [ ] Ran integration tests where relevant (`build.cmd Compile UnitTest IntegrationTest`, Docker required)
- [ ] Manually verified against a MariaDB instance with `tablePrefix = common.QRTZ_`

## Notes

PR #3085 (also targeted at main) only added test assertions and tests nothing meaningful on main today because main does not have the FORCE INDEX hints. Closing or replacing it once this lands would be cleanest.

## Breaking change?

No. `AdoJobStoreUtil` is `internal` on main; the `{1}` placeholder is additive and existing templates only use `{0}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)