### PR TITLE
Add public plugin configuration extensibility helpers (main)

### DIFF
--- a/docs/documentation/quartz-3.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-3.x/packages/quartz-plugins.md
@@ -113,3 +113,65 @@ var job = JobBuilder.Create<SlowJob>()
     .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, TimeSpan.FromSeconds(5).TotalMilliseconds.ToString(CultureInfo.InvariantCulture))
     .Build();
 ```
+
+## Authoring plugin configuration extensions
+
+::: tip
+Quartz 3.19 or later required.
+:::
+
+When you write your own `ISchedulerPlugin`, you can offer the same strongly typed configuration experience as the built-in plugins by creating an extension method that targets `IPropertyConfigurationRoot`. The `UsePlugin` helper takes care of the whole registration: it sets the `quartz.plugin.{name}.type` property and, when the configuration is backed by Microsoft DI (`AddQuartz`), registers the plugin type into the container so it gets constructed with constructor injection.
+
+```csharp
+public static class MyPluginConfigurationExtensions
+{
+    public static T UseMyPlugin<T>(this T configurer, Action<MyPluginOptions>? configure = null)
+        where T : IPropertyConfigurationRoot
+    {
+        configurer.UsePlugin<MyPlugin>("myPlugin");
+
+        // optional: register companion services your plugin needs injected;
+        // returns false when there is no container (plain SchedulerBuilder usage)
+        configurer.TryRegisterSingleton<IMyPluginDependency, MyPluginDependency>();
+
+        configure?.Invoke(new MyPluginOptions(configurer));
+        return configurer;
+    }
+}
+```
+
+Strongly typed options use the `PropertiesSetter` base class with the plugin's property prefix; each property setter maps to a `quartz.plugin.{name}.{property}` configuration key that gets applied to the plugin's public setters:
+
+```csharp
+public sealed class MyPluginOptions : PropertiesSetter
+{
+    internal MyPluginOptions(IPropertySetter parent) : base(parent, "quartz.plugin.myPlugin")
+    {
+    }
+
+    // maps to quartz.plugin.myPlugin.someSetting and MyPlugin.SomeSetting setter
+    public string SomeSetting
+    {
+        set => SetProperty("someSetting", value);
+    }
+}
+```
+
+The same extension method then works with all configuration styles:
+
+```csharp
+// Microsoft DI - plugin is constructed by the container, constructor injection available
+services.AddQuartz(q =>
+{
+    q.UseMyPlugin(options =>
+    {
+        options.SomeSetting = "value";
+    });
+});
+
+// plain SchedulerBuilder - plugin is created via reflection and needs
+// a public parameterless constructor
+var scheduler = await SchedulerBuilder.Create()
+    .UseMyPlugin()
+    .BuildScheduler();
+```

--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -135,6 +135,64 @@ var job = JobBuilder.Create<SlowJob>()
     .WithIdentity("slowJob")
     .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true)
     // allow only five seconds for this job, overriding default configuration
-    .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, TimeSpan.FromSeconds(5).TotalMilliseconds.ToString()));
+    .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, TimeSpan.FromSeconds(5).TotalMilliseconds.ToString())
     .Build();
+```
+
+## Authoring plugin configuration extensions
+
+When you write your own `ISchedulerPlugin`, you can offer the same strongly typed configuration experience as the built-in plugins by creating an extension method that targets `IPropertyConfigurationRoot`. The `UsePlugin` helper takes care of the whole registration: it sets the `quartz.plugin.{name}.type` property and, when the configuration is backed by Microsoft DI (`AddQuartz`), registers the plugin type into the container so it gets constructed with constructor injection.
+
+```csharp
+public static class MyPluginConfigurationExtensions
+{
+    public static T UseMyPlugin<T>(this T configurer, Action<MyPluginOptions>? configure = null)
+        where T : IPropertyConfigurationRoot
+    {
+        configurer.UsePlugin<MyPlugin>("myPlugin");
+
+        // optional: register companion services your plugin needs injected;
+        // returns false when there is no container (plain SchedulerBuilder usage)
+        configurer.TryRegisterSingleton<IMyPluginDependency, MyPluginDependency>();
+
+        configure?.Invoke(new MyPluginOptions(configurer));
+        return configurer;
+    }
+}
+```
+
+Strongly typed options use the `PropertiesSetter` base class with the plugin's property prefix; each property setter maps to a `quartz.plugin.{name}.{property}` configuration key that gets applied to the plugin's public setters:
+
+```csharp
+public sealed class MyPluginOptions : PropertiesSetter
+{
+    internal MyPluginOptions(IPropertySetter parent) : base(parent, "quartz.plugin.myPlugin")
+    {
+    }
+
+    // maps to quartz.plugin.myPlugin.someSetting and MyPlugin.SomeSetting setter
+    public string SomeSetting
+    {
+        set => SetProperty("someSetting", value);
+    }
+}
+```
+
+The same extension method then works with all configuration styles:
+
+```csharp
+// Microsoft DI - plugin is constructed by the container, constructor injection available
+services.AddQuartz(q =>
+{
+    q.UseMyPlugin(options =>
+    {
+        options.SomeSetting = "value";
+    });
+});
+
+// plain SchedulerBuilder - plugin is created via reflection and needs
+// a public parameterless constructor
+var scheduler = await SchedulerBuilder.Create()
+    .UseMyPlugin()
+    .BuildScheduler();
 ```

--- a/src/Quartz.Plugins/PluginConfigurationExtensions.cs
+++ b/src/Quartz.Plugins/PluginConfigurationExtensions.cs
@@ -5,7 +5,6 @@ using Quartz.Plugin.History;
 using Quartz.Plugin.Interrupt;
 using Quartz.Plugin.Json;
 using Quartz.Plugin.Xml;
-using Quartz.Util;
 
 namespace Quartz;
 
@@ -15,11 +14,7 @@ public static class PluginConfigurationExtensions
         this T configurer,
         Action<XmlSchedulingOptions> configure) where T : IPropertyConfigurationRoot
     {
-        if (configurer is IContainerConfigurationSupport containerConfigurationSupport)
-        {
-            containerConfigurationSupport.RegisterSingleton<XMLSchedulingDataProcessorPlugin, XMLSchedulingDataProcessorPlugin>();
-        }
-        configurer.SetProperty("quartz.plugin.xml.type", typeof(XMLSchedulingDataProcessorPlugin).AssemblyQualifiedNameWithoutVersion());
+        configurer.UsePlugin<XMLSchedulingDataProcessorPlugin>("xml");
         configure.Invoke(new XmlSchedulingOptions(configurer));
         return configurer;
     }
@@ -34,11 +29,7 @@ public static class PluginConfigurationExtensions
     public static T UseStructuredJobLogging<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         this T configurer) where T : IPropertyConfigurationRoot
     {
-        if (configurer is IContainerConfigurationSupport containerConfigurationSupport)
-        {
-            containerConfigurationSupport.RegisterSingleton<StructuredLoggingJobHistoryPlugin, StructuredLoggingJobHistoryPlugin>();
-        }
-        configurer.SetProperty("quartz.plugin.structuredJobLogging.type", typeof(StructuredLoggingJobHistoryPlugin).AssemblyQualifiedNameWithoutVersion());
+        configurer.UsePlugin<StructuredLoggingJobHistoryPlugin>("structuredJobLogging");
         return configurer;
     }
 
@@ -52,11 +43,7 @@ public static class PluginConfigurationExtensions
     public static T UseStructuredTriggerLogging<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         this T configurer) where T : IPropertyConfigurationRoot
     {
-        if (configurer is IContainerConfigurationSupport containerConfigurationSupport)
-        {
-            containerConfigurationSupport.RegisterSingleton<StructuredLoggingTriggerHistoryPlugin, StructuredLoggingTriggerHistoryPlugin>();
-        }
-        configurer.SetProperty("quartz.plugin.structuredTriggerLogging.type", typeof(StructuredLoggingTriggerHistoryPlugin).AssemblyQualifiedNameWithoutVersion());
+        configurer.UsePlugin<StructuredLoggingTriggerHistoryPlugin>("structuredTriggerLogging");
         return configurer;
     }
 
@@ -67,11 +54,7 @@ public static class PluginConfigurationExtensions
         this T configurer,
         Action<JsonSchedulingOptions> configure) where T : IPropertyConfigurationRoot
     {
-        if (configurer is IContainerConfigurationSupport containerConfigurationSupport)
-        {
-            containerConfigurationSupport.RegisterSingleton<JsonSchedulingDataProcessorPlugin, JsonSchedulingDataProcessorPlugin>();
-        }
-        configurer.SetProperty("quartz.plugin.json.type", typeof(JsonSchedulingDataProcessorPlugin).AssemblyQualifiedNameWithoutVersion());
+        configurer.UsePlugin<JsonSchedulingDataProcessorPlugin>("json");
         configure.Invoke(new JsonSchedulingOptions(configurer));
         return configurer;
     }
@@ -83,11 +66,7 @@ public static class PluginConfigurationExtensions
         this T configurer,
         Action<JobAutoInterruptOptions>? configure = null) where T : IPropertyConfigurationRoot
     {
-        if (configurer is IContainerConfigurationSupport containerConfigurationSupport)
-        {
-            containerConfigurationSupport.RegisterSingleton<JobInterruptMonitorPlugin, JobInterruptMonitorPlugin>();
-        }
-        configurer.SetProperty("quartz.plugin.jobAutoInterrupt.type", typeof(JobInterruptMonitorPlugin).AssemblyQualifiedNameWithoutVersion());
+        configurer.UsePlugin<JobInterruptMonitorPlugin>("jobAutoInterrupt");
         configure?.Invoke(new JobAutoInterruptOptions(configurer));
         return configurer;
     }

--- a/src/Quartz.Tests.Unit/SchedulerPluginConfigurationExtensionsTests.cs
+++ b/src/Quartz.Tests.Unit/SchedulerPluginConfigurationExtensionsTests.cs
@@ -1,0 +1,274 @@
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Configuration;
+using Quartz.Listener;
+using Quartz.Plugin.Interrupt;
+using Quartz.Spi;
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit;
+
+[NonParallelizable]
+public sealed class SchedulerPluginConfigurationExtensionsTests
+{
+    [Test]
+    public void UsePluginOnSchedulerBuilderShouldSetPluginTypeProperty()
+    {
+        var builder = SchedulerBuilder.Create();
+
+        builder.UsePlugin<TestPluginWithDependency>("testPlugin");
+
+        builder.Properties["quartz.plugin.testPlugin.type"].Should().Be(typeof(TestPluginWithDependency).AssemblyQualifiedNameWithoutVersion());
+    }
+
+    [Test]
+    public void UsePluginUnderAddQuartzShouldRegisterPluginAndSetProperty()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITestPluginDependency, TestPluginDependency>();
+        services.AddQuartz(q => q.UsePlugin<TestPluginWithDependency>("testPlugin"));
+
+        using var provider = services.BuildServiceProvider();
+
+        var plugin = provider.GetService<TestPluginWithDependency>();
+        plugin.Should().NotBeNull();
+        plugin.Dependency.Should().NotBeNull("plugin should be constructed by the container with constructor injection");
+
+        var options = provider.GetRequiredService<IOptions<QuartzOptions>>().Value;
+        options["quartz.plugin.testPlugin.type"].Should().Be(typeof(TestPluginWithDependency).AssemblyQualifiedNameWithoutVersion());
+    }
+
+    [Test]
+    public void TryRegisterSingletonOnSchedulerBuilderShouldReturnFalse()
+    {
+        var builder = SchedulerBuilder.Create();
+
+        var registered = builder.TryRegisterSingleton<ITestPluginDependency, TestPluginDependency>();
+
+        registered.Should().BeFalse();
+    }
+
+    [Test]
+    public void TryRegisterSingletonUnderAddQuartzShouldRegisterService()
+    {
+        var services = new ServiceCollection();
+        var registered = false;
+        services.AddQuartz(q =>
+        {
+            registered = q.TryRegisterSingleton<ITestPluginDependency, TestPluginDependency>();
+        });
+
+        registered.Should().BeTrue();
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetService<ITestPluginDependency>().Should().BeOfType<TestPluginDependency>();
+    }
+
+    [Test]
+    public void UsePluginShouldRequireConfigurer()
+    {
+        IPropertyConfigurationRoot configurer = null;
+
+        Action act = () => configurer.UsePlugin<TestPluginWithDependency>("testPlugin");
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("my.plugin")]
+    public void UsePluginShouldValidatePluginName(string name)
+    {
+        var builder = SchedulerBuilder.Create();
+
+        Action act = () => builder.UsePlugin<TestPluginWithDependency>(name);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void BuiltInPluginExtensionUnderAddQuartzShouldStillRegisterPluginAndSetProperty()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UseJobAutoInterrupt());
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetService<JobInterruptMonitorPlugin>().Should().NotBeNull();
+
+        var options = provider.GetRequiredService<IOptions<QuartzOptions>>().Value;
+        options["quartz.plugin.jobAutoInterrupt.type"].Should().Be(typeof(JobInterruptMonitorPlugin).AssemblyQualifiedNameWithoutVersion());
+    }
+
+    [Test]
+    public async Task UsePluginInDeferredConfigurationShouldConstructPluginWithInjectedDependencies()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ITestPluginDependency, TestPluginDependency>();
+
+        services.AddQuartz((q, sp) =>
+        {
+            q.SchedulerName = "DeferredUsePluginTest";
+            q.UseInMemoryStore();
+            q.UsePlugin<TestPluginWithDependency>("testPlugin");
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ISchedulerFactory>();
+        var scheduler = await factory.GetScheduler();
+
+        scheduler.Context.TryGetValue(TestPluginWithDependency.ContextKey, out var pluginInstance).Should().BeTrue();
+        var plugin = (TestPluginWithDependency) pluginInstance;
+        plugin.Dependency.Should().NotBeNull("plugin should be constructed with constructor injection even in deferred configuration");
+
+        await scheduler.Shutdown();
+    }
+
+    [Test]
+    public async Task TryRegisterSingletonInDeferredConfigurationShouldMakeCompanionServiceAvailable()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddQuartz((q, sp) =>
+        {
+            q.SchedulerName = "DeferredCompanionServiceTest";
+            q.UseInMemoryStore();
+            q.TryRegisterSingleton<ITestPluginDependency, TestPluginDependency>();
+            q.UsePlugin<TestPluginWithDependency>("testPlugin");
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ISchedulerFactory>();
+        var scheduler = await factory.GetScheduler();
+
+        scheduler.Context.TryGetValue(TestPluginWithDependency.ContextKey, out var pluginInstance).Should().BeTrue();
+        var plugin = (TestPluginWithDependency) pluginInstance;
+        plugin.Dependency.Should().NotBeNull("companion service registered during deferred configuration should be available for constructor injection");
+
+        await scheduler.Shutdown();
+    }
+
+    [Test]
+    public void DeferredRegistryShouldResolveSameSingletonInstanceForRepeatedLookups()
+    {
+        var registry = new DeferredSingletonRegistry();
+        registry.Register(typeof(ITestPluginDependency), typeof(TestPluginDependency));
+        using var provider = new ServiceCollection().BuildServiceProvider();
+
+        var first = registry.Resolve(typeof(ITestPluginDependency), provider);
+        var second = registry.Resolve(typeof(ITestPluginDependency), provider);
+
+        first.Should().BeOfType<TestPluginDependency>();
+        second.Should().BeSameAs(first, "repeated lookups of a registered service type should observe the same singleton");
+    }
+
+    [Test]
+    public void DeferredRegistryShouldNotResolveUnregisteredServiceType()
+    {
+        var registry = new DeferredSingletonRegistry();
+        registry.Register(typeof(ITestPluginDependency), typeof(TestPluginDependency));
+        using var provider = new ServiceCollection().BuildServiceProvider();
+
+        registry.Resolve(typeof(TestListenerWithDependency), provider).Should().BeNull("only registered service types resolve from the registry");
+        registry.IsRegistered(typeof(ITestPluginDependency)).Should().BeTrue();
+        registry.IsRegistered(typeof(TestListenerWithDependency)).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task DeferredListenerShouldReceiveCompanionServiceFromDeferredRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddQuartz((q, sp) =>
+        {
+            q.SchedulerName = "DeferredListenerCompanionTest";
+            q.UseInMemoryStore();
+            q.TryRegisterSingleton<ITestPluginDependency, TestPluginDependency>();
+            q.AddSchedulerListener<TestListenerWithDependency>();
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ISchedulerFactory>();
+        var scheduler = await factory.GetScheduler();
+
+        var listener = scheduler.ListenerManager.GetSchedulerListeners().OfType<TestListenerWithDependency>().Single();
+        listener.Dependency.Should().NotBeNull("companion service registered during deferred configuration should be available for listener constructor injection");
+
+        await scheduler.Shutdown();
+    }
+
+    [Test]
+    public async Task BuiltInPluginExtensionInDeferredConfigurationShouldInitializePlugin()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddQuartz((q, sp) =>
+        {
+            q.SchedulerName = "DeferredBuiltInPluginTest";
+            q.UseInMemoryStore();
+            q.UseJobAutoInterrupt();
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ISchedulerFactory>();
+        var scheduler = await factory.GetScheduler();
+
+        scheduler.ListenerManager.GetTriggerListeners().Should().Contain(l => l is JobInterruptMonitorPlugin);
+
+        await scheduler.Shutdown();
+    }
+}
+
+public interface ITestPluginDependency
+{
+}
+
+public sealed class TestPluginDependency : ITestPluginDependency
+{
+}
+
+public sealed class TestListenerWithDependency : SchedulerListenerSupport
+{
+    public TestListenerWithDependency(ITestPluginDependency dependency)
+    {
+        Dependency = dependency;
+    }
+
+    public ITestPluginDependency Dependency { get; }
+}
+
+public sealed class TestPluginWithDependency : ISchedulerPlugin
+{
+    public const string ContextKey = "TestPluginWithDependency";
+
+    public TestPluginWithDependency(ITestPluginDependency dependency)
+    {
+        Dependency = dependency;
+    }
+
+    public ITestPluginDependency Dependency { get; }
+
+    public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
+    {
+        scheduler.Context[ContextKey] = this;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Start(CancellationToken cancellationToken = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Shutdown(CancellationToken cancellationToken = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Quartz/Configuration/DeferredServiceCollection.cs
+++ b/src/Quartz/Configuration/DeferredServiceCollection.cs
@@ -40,12 +40,19 @@ internal sealed class DeferredServiceCollection : IServiceCollection
         // Silently discard — the service provider is already built, so adding
         // to the original IServiceCollection would have no effect and could
         // cause confusion if the collection is inspected later.
-        // Registrations that matter (jobs, triggers, listeners, calendars)
-        // are all intercepted above.
+        // Registrations that matter (jobs, triggers, listeners, calendars,
+        // singleton type registrations) are all intercepted above.
     }
 
     private bool TryHandleDeferred(ServiceDescriptor descriptor)
     {
+        // Keyed descriptors throw from ImplementationType/ImplementationInstance/ImplementationFactory
+        // and cannot match any of the shapes below; let them fall through to the discard path.
+        if (descriptor.IsKeyedService)
+        {
+            return false;
+        }
+
         // Intercept IConfigureOptions<QuartzOptions> factory registrations.
         // These come from AddJob/AddTrigger/ScheduleJob/AddCalendar extension methods
         // which register IConfigureOptions<QuartzOptions> to add job details and triggers.
@@ -138,6 +145,19 @@ internal sealed class DeferredServiceCollection : IServiceCollection
         // methods which always emit the paired *Configuration.
         if (descriptor.ServiceType == typeof(IJobListener) || descriptor.ServiceType == typeof(ITriggerListener))
         {
+            return true;
+        }
+
+        // Capture bare singleton type registrations, e.g. plugin self-registrations coming from
+        // UsePlugin / IContainerConfigurationSupport.RegisterSingleton. They cannot be added to
+        // the already-built container; the scheduler factories consult the registry when
+        // instantiating components so that constructor injection still works.
+        if (descriptor.Lifetime == ServiceLifetime.Singleton
+            && descriptor.ImplementationInstance is null
+            && descriptor.ImplementationFactory is null
+            && descriptor.ImplementationType is not null)
+        {
+            options._deferredSingletons.Register(descriptor.ServiceType, descriptor.ImplementationType);
             return true;
         }
 

--- a/src/Quartz/Configuration/DeferredSingletonRegistry.cs
+++ b/src/Quartz/Configuration/DeferredSingletonRegistry.cs
@@ -1,0 +1,173 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// Holds singleton registrations captured during deferred Quartz configuration
+/// (<c>AddQuartz(Action&lt;IServiceCollectionQuartzConfigurator, IServiceProvider&gt;)</c>).
+/// The service provider is already built when the deferred configuration callback runs, so
+/// these registrations cannot be added to the container itself; instead the scheduler
+/// factories consult this registry when instantiating components, constructing the
+/// implementation types with constructor injection against the root provider.
+/// </summary>
+internal sealed class DeferredSingletonRegistry
+{
+    private readonly Lock syncRoot = new();
+    private readonly List<Registration> registrations = new();
+    private readonly Dictionary<Type, object> instances = new();
+    private readonly HashSet<Type> resolutionStack = new();
+
+    public void Register(Type serviceType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
+    {
+        lock (syncRoot)
+        {
+            registrations.Add(new Registration(serviceType, implementationType));
+        }
+    }
+
+    /// <summary>
+    /// Resolves an instance for the given service type if it has been registered, returns null otherwise.
+    /// Instances are cached to preserve singleton semantics; the last registration for a service type
+    /// wins, mirroring container behavior. Other deferred registrations are available as constructor
+    /// dependencies during instantiation.
+    /// </summary>
+    public object? Resolve(Type serviceType, IServiceProvider serviceProvider)
+    {
+        lock (syncRoot)
+        {
+            if (instances.TryGetValue(serviceType, out var existing))
+            {
+                return existing;
+            }
+
+            Registration? registration = FindRegistration(serviceType);
+            if (registration is null)
+            {
+                return null;
+            }
+
+            if (!resolutionStack.Add(serviceType))
+            {
+                throw new InvalidOperationException($"A circular dependency was detected resolving deferred singleton registration for service type {serviceType}.");
+            }
+
+            try
+            {
+                var instance = ActivatorUtilities.CreateInstance(WrapServiceProvider(serviceProvider), registration.ImplementationType);
+                instances[serviceType] = instance;
+                return instance;
+            }
+            finally
+            {
+                resolutionStack.Remove(serviceType);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the registry has a registration for the given service type.
+    /// </summary>
+    public bool IsRegistered(Type serviceType)
+    {
+        lock (syncRoot)
+        {
+            return instances.ContainsKey(serviceType) || FindRegistration(serviceType) is not null;
+        }
+    }
+
+    // Caller must hold syncRoot. Returns the most recent matching registration (last-wins).
+    private Registration? FindRegistration(Type serviceType)
+    {
+        for (var i = registrations.Count - 1; i >= 0; i--)
+        {
+            if (registrations[i].ServiceType == serviceType)
+            {
+                return registrations[i];
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Wraps a service provider so that deferred registrations are available as constructor
+    /// dependencies for types constructed via <see cref="ActivatorUtilities"/>. Services from
+    /// the container take precedence; the registry is a fallback for registrations that could
+    /// not be added to the already-built container. When the registry is empty the provider is
+    /// returned unchanged so that the common non-deferred path keeps the container's full
+    /// service provider capabilities (constructor selection, keyed services).
+    /// </summary>
+    public IServiceProvider WrapServiceProvider(IServiceProvider serviceProvider)
+    {
+        lock (syncRoot)
+        {
+            if (registrations.Count == 0)
+            {
+                return serviceProvider;
+            }
+        }
+        return new RegistryAwareServiceProvider(this, serviceProvider);
+    }
+
+    private sealed class RegistryAwareServiceProvider : IServiceProvider, IServiceProviderIsService, IKeyedServiceProvider
+    {
+        private readonly DeferredSingletonRegistry registry;
+        private readonly IServiceProvider inner;
+
+        public RegistryAwareServiceProvider(DeferredSingletonRegistry registry, IServiceProvider inner)
+        {
+            this.registry = registry;
+            this.inner = inner;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            return inner.GetService(serviceType) ?? registry.Resolve(serviceType, inner);
+        }
+
+        // ActivatorUtilities consults IServiceProviderIsService for best-constructor selection;
+        // surface both the container's knowledge and the registry's registrations so that
+        // wrapping does not degrade constructor selection.
+        public bool IsService(Type serviceType)
+        {
+            if (registry.IsRegistered(serviceType))
+            {
+                return true;
+            }
+            return inner is IServiceProviderIsService isService && isService.IsService(serviceType);
+        }
+
+        public object? GetKeyedService(Type serviceType, object? serviceKey)
+        {
+            if (inner is IKeyedServiceProvider keyedServiceProvider)
+            {
+                return keyedServiceProvider.GetKeyedService(serviceType, serviceKey);
+            }
+            return null;
+        }
+
+        public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
+        {
+            if (inner is IKeyedServiceProvider keyedServiceProvider)
+            {
+                return keyedServiceProvider.GetRequiredKeyedService(serviceType, serviceKey);
+            }
+            throw new InvalidOperationException("The underlying service provider does not support keyed services.");
+        }
+    }
+
+    private sealed class Registration
+    {
+        public Registration(Type serviceType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
+        {
+            ServiceType = serviceType;
+            ImplementationType = implementationType;
+        }
+
+        public Type ServiceType { get; }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        public Type ImplementationType { get; }
+    }
+}

--- a/src/Quartz/Configuration/NamedSchedulerFactory.cs
+++ b/src/Quartz/Configuration/NamedSchedulerFactory.cs
@@ -41,6 +41,9 @@ internal sealed class NamedSchedulerFactory : StdSchedulerFactory
 
     private async Task InitializeScheduler(IScheduler scheduler, CancellationToken cancellationToken)
     {
+        // Deferred listeners may depend on singletons registered during deferred configuration
+        IServiceProvider deferredAwareServiceProvider = quartzOptions._deferredSingletons.WrapServiceProvider(serviceProvider);
+
         // Scheduler listeners for this named scheduler
         IEnumerable<SchedulerListenerConfiguration> schedulerListenerConfigurations = serviceProvider.GetServices<SchedulerListenerConfiguration>()
             .Where(x => x.OptionsName == optionsName);
@@ -53,7 +56,7 @@ internal sealed class NamedSchedulerFactory : StdSchedulerFactory
         // Deferred scheduler listeners from factory-based AddQuartz overload
         foreach (SchedulerListenerConfiguration configuration in quartzOptions._deferredSchedulerListeners.Where(x => x.OptionsName == optionsName))
         {
-            ISchedulerListener listener = ListenerCreationHelper.CreateSchedulerListener(configuration, serviceProvider);
+            ISchedulerListener listener = ListenerCreationHelper.CreateSchedulerListener(configuration, deferredAwareServiceProvider);
             scheduler.ListenerManager.AddSchedulerListener(listener);
         }
 
@@ -70,7 +73,7 @@ internal sealed class NamedSchedulerFactory : StdSchedulerFactory
         // Deferred job listeners from factory-based AddQuartz overload
         foreach (JobListenerConfiguration configuration in quartzOptions._deferredJobListeners.Where(x => x.OptionsName == optionsName))
         {
-            IJobListener listener = ListenerCreationHelper.CreateJobListener(configuration, serviceProvider);
+            IJobListener listener = ListenerCreationHelper.CreateJobListener(configuration, deferredAwareServiceProvider);
             scheduler.ListenerManager.AddJobListener(listener, configuration.Matchers ?? []);
         }
 
@@ -87,7 +90,7 @@ internal sealed class NamedSchedulerFactory : StdSchedulerFactory
         // Deferred trigger listeners from factory-based AddQuartz overload
         foreach (TriggerListenerConfiguration configuration in quartzOptions._deferredTriggerListeners.Where(x => x.OptionsName == optionsName))
         {
-            ITriggerListener listener = ListenerCreationHelper.CreateTriggerListener(configuration, serviceProvider);
+            ITriggerListener listener = ListenerCreationHelper.CreateTriggerListener(configuration, deferredAwareServiceProvider);
             scheduler.ListenerManager.AddTriggerListener(listener, configuration.Matchers ?? []);
         }
 
@@ -148,7 +151,23 @@ internal sealed class NamedSchedulerFactory : StdSchedulerFactory
                 return typed;
             }
 
-            return (T) ActivatorUtilities.CreateInstance(serviceProvider, implementationType);
+            // Singleton registrations captured during deferred configuration cannot be part of the
+            // already-built container; consult the registry first so that those instances (and their
+            // companion services) are used, then fall back to plain ActivatorUtilities construction
+            // with the deferred registrations available as constructor dependencies. Consult both the
+            // service type and the configured concrete type so registrations are found regardless of
+            // which one they were keyed with (this matches ServiceCollectionSchedulerFactory).
+            if (quartzOptions._deferredSingletons.Resolve(typeof(T), serviceProvider) is T deferred)
+            {
+                return deferred;
+            }
+            if (implementationType != typeof(T)
+                && quartzOptions._deferredSingletons.Resolve(implementationType, serviceProvider) is T deferredConcrete)
+            {
+                return deferredConcrete;
+            }
+
+            return (T) ActivatorUtilities.CreateInstance(quartzOptions._deferredSingletons.WrapServiceProvider(serviceProvider), implementationType);
         }
 
         T? service = serviceProvider.GetService<T>();

--- a/src/Quartz/Configuration/QuartzOptions.cs
+++ b/src/Quartz/Configuration/QuartzOptions.cs
@@ -17,6 +17,7 @@ public class QuartzOptions : Dictionary<string, string?>
     internal readonly List<JobListenerConfiguration> _deferredJobListeners = new();
     internal readonly List<TriggerListenerConfiguration> _deferredTriggerListeners = new();
     internal readonly List<CalendarConfiguration> _deferredCalendars = new();
+    internal readonly DeferredSingletonRegistry _deferredSingletons = new();
 
     public string? SchedulerId
     {

--- a/src/Quartz/Configuration/ServiceCollectionSchedulerFactory.cs
+++ b/src/Quartz/Configuration/ServiceCollectionSchedulerFactory.cs
@@ -76,6 +76,9 @@ internal sealed class ServiceCollectionSchedulerFactory : StdSchedulerFactory
         // Make the DI service provider available to plugins via SchedulerContext
         scheduler.Context["Quartz.ServiceProvider"] = serviceProvider;
 
+        // Deferred listeners may depend on singletons registered during deferred configuration
+        var deferredAwareServiceProvider = options.Value._deferredSingletons.WrapServiceProvider(serviceProvider);
+
         // Default scheduler uses flat ISchedulerListener services (backward compatible)
         foreach (var listener in serviceProvider.GetServices<ISchedulerListener>())
         {
@@ -85,7 +88,7 @@ internal sealed class ServiceCollectionSchedulerFactory : StdSchedulerFactory
         // Process deferred scheduler listeners from factory-based AddQuartz overload
         foreach (var config in options.Value._deferredSchedulerListeners.Where(x => x.OptionsName.Length == 0))
         {
-            var listener = ListenerCreationHelper.CreateSchedulerListener(config, serviceProvider);
+            var listener = ListenerCreationHelper.CreateSchedulerListener(config, deferredAwareServiceProvider);
             scheduler.ListenerManager.AddSchedulerListener(listener);
         }
 
@@ -103,7 +106,7 @@ internal sealed class ServiceCollectionSchedulerFactory : StdSchedulerFactory
         // Process deferred job listeners from factory-based AddQuartz overload
         foreach (var config in options.Value._deferredJobListeners.Where(x => x.OptionsName.Length == 0))
         {
-            var listener = ListenerCreationHelper.CreateJobListener(config, serviceProvider);
+            var listener = ListenerCreationHelper.CreateJobListener(config, deferredAwareServiceProvider);
             scheduler.ListenerManager.AddJobListener(listener, config.Matchers ?? []);
         }
 
@@ -120,7 +123,7 @@ internal sealed class ServiceCollectionSchedulerFactory : StdSchedulerFactory
         // Process deferred trigger listeners from factory-based AddQuartz overload
         foreach (var config in options.Value._deferredTriggerListeners.Where(x => x.OptionsName.Length == 0))
         {
-            var listener = ListenerCreationHelper.CreateTriggerListener(config, serviceProvider);
+            var listener = ListenerCreationHelper.CreateTriggerListener(config, deferredAwareServiceProvider);
             scheduler.ListenerManager.AddTriggerListener(listener, config.Matchers ?? []);
         }
 
@@ -165,11 +168,25 @@ internal sealed class ServiceCollectionSchedulerFactory : StdSchedulerFactory
     protected override T InstantiateType<T>(Type? implementationType)
     {
         var service = serviceProvider.GetService<T>();
-        if (service is null)
+        if (service is not null)
         {
-            service = ObjectUtils.InstantiateType<T>(implementationType);
+            return service;
         }
 
-        return service;
+        // Singleton registrations captured during deferred configuration cannot be part of the
+        // already-built container; construct them here with constructor injection support.
+        // Consult both the service type and the configured concrete type so registrations are
+        // found regardless of which one they were keyed with.
+        if (options.Value._deferredSingletons.Resolve(typeof(T), serviceProvider) is T deferred)
+        {
+            return deferred;
+        }
+        if (implementationType is not null && implementationType != typeof(T)
+            && options.Value._deferredSingletons.Resolve(implementationType, serviceProvider) is T deferredConcrete)
+        {
+            return deferredConcrete;
+        }
+
+        return ObjectUtils.InstantiateType<T>(implementationType);
     }
 }

--- a/src/Quartz/SchedulerPluginConfigurationExtensions.cs
+++ b/src/Quartz/SchedulerPluginConfigurationExtensions.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Quartz.Impl;
+using Quartz.Spi;
+using Quartz.Util;
+
+namespace Quartz;
+
+/// <summary>
+/// Extension methods for registering <see cref="ISchedulerPlugin"/> implementations against
+/// any configuration root (<see cref="SchedulerBuilder"/> or the Microsoft DI configurator).
+/// These allow third-party plugin authors to create strongly typed configuration extension
+/// methods that behave exactly like the built-in ones.
+/// </summary>
+public static class SchedulerPluginConfigurationExtensions
+{
+    /// <summary>
+    /// Configures the scheduler plugin <typeparamref name="TPlugin"/> into use by setting
+    /// the <c>quartz.plugin.{name}.type</c> property.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When the configurer is backed by a Microsoft DI service collection (the <c>AddQuartz</c>
+    /// configuration path), the plugin type is also registered as a singleton into the container
+    /// and will be constructed via dependency injection, allowing constructor-injected services.
+    /// </para>
+    /// <para>
+    /// When the configurer is a plain <see cref="SchedulerBuilder"/> (property-based configuration),
+    /// the plugin is instantiated via reflection and must have a public parameterless constructor.
+    /// In both cases remaining <c>quartz.plugin.{name}.*</c> properties are applied to public
+    /// setters of the plugin instance.
+    /// </para>
+    /// <para>
+    /// A typical plugin configuration extension method looks like:
+    /// <code>
+    /// public static T UseMyPlugin&lt;T&gt;(this T configurer, Action&lt;MyPluginOptions&gt;? configure = null)
+    ///     where T : IPropertyConfigurationRoot
+    /// {
+    ///     configurer.UsePlugin&lt;MyPlugin&gt;("myPlugin");
+    ///     configure?.Invoke(new MyPluginOptions(configurer));
+    ///     return configurer;
+    /// }
+    /// </code>
+    /// where <c>MyPluginOptions</c> derives from <see cref="PropertiesSetter"/> with prefix
+    /// <c>quartz.plugin.myPlugin</c>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TPlugin">The plugin type to configure.</typeparam>
+    /// <param name="configurer">The configuration root to register the plugin against.</param>
+    /// <param name="name">
+    /// The plugin name, used as the <c>{name}</c> part of the <c>quartz.plugin.{name}.type</c>
+    /// property key. Must not contain '.' characters.
+    /// </param>
+    /// <returns>The configurer for chaining.</returns>
+    public static IPropertyConfigurationRoot UsePlugin<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] TPlugin>(
+        this IPropertyConfigurationRoot configurer,
+        string name)
+        where TPlugin : class, ISchedulerPlugin
+    {
+        ArgumentNullException.ThrowIfNull(configurer);
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Plugin name cannot be null or empty", nameof(name));
+        }
+        if (name.Contains('.'))
+        {
+            // a dot would split the property key into an unintended plugin name and property path
+            throw new ArgumentException("Plugin name cannot contain '.' characters", nameof(name));
+        }
+
+        if (configurer is IContainerConfigurationSupport containerConfigurationSupport)
+        {
+            containerConfigurationSupport.RegisterSingleton<TPlugin, TPlugin>();
+        }
+        configurer.SetProperty(StdSchedulerFactory.PropertyPluginPrefix + "." + name + "." + StdSchedulerFactory.PropertyPluginType, typeof(TPlugin).AssemblyQualifiedNameWithoutVersion());
+        return configurer;
+    }
+
+    /// <summary>
+    /// Registers a singleton service into the container backing the configurer, when one is present.
+    /// Intended for plugin configuration extension methods that need companion services available
+    /// for constructor injection.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Returns <see langword="false"/> when the configurer is a plain property-based configuration
+    /// source such as <see cref="SchedulerBuilder"/> without container support; no registration
+    /// takes place in that case.
+    /// </para>
+    /// <para>
+    /// Registration uses add semantics rather than try-add semantics: registering the same service
+    /// type twice results in two registrations, with the last one winning when a single instance
+    /// is resolved.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TService">The service type to register.</typeparam>
+    /// <typeparam name="TImplementation">The implementation type to register.</typeparam>
+    /// <param name="configurer">The configuration root to register the service against.</param>
+    /// <returns><see langword="true"/> when the service was registered into a container; otherwise <see langword="false"/>.</returns>
+    public static bool TryRegisterSingleton<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] TImplementation>(
+        this IPropertyConfigurationRoot configurer)
+        where TService : class
+        where TImplementation : class, TService
+    {
+        ArgumentNullException.ThrowIfNull(configurer);
+
+        if (configurer is IContainerConfigurationSupport containerConfigurationSupport)
+        {
+            containerConfigurationSupport.RegisterSingleton<TService, TImplementation>();
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Port of #3104 to `main`. Addresses #3092 (the 3.x PR closes it).

## Summary

Adds the curated public extensibility surface for third-party plugin authors instead of making `IContainerConfigurationSupport` public:

- **`UsePlugin<TPlugin>(name)`** (extension on `IPropertyConfigurationRoot` in Quartz core) — registers the plugin type into the backing container when one is present *and* sets `quartz.plugin.{name}.type` atomically.
- **`TryRegisterSingleton<TService, TImplementation>()`** — escape hatch for companion services a plugin needs constructor-injected; returns `false` on a plain `SchedulerBuilder`.

The five built-in plugin extension methods now dogfood `UsePlugin`. `IContainerConfigurationSupport` stays internal and free to evolve in 4.x (default interface members are viable on main's target frameworks if it ever goes public).

Also ports the deferred-`AddQuartz` fix: bare singleton type descriptors (plugin self-registrations) are captured into a `DeferredSingletonRegistry` on `QuartzOptions` instead of being silently discarded, and both `ServiceCollectionSchedulerFactory` and `NamedSchedulerFactory` consult the registry in `InstantiateType` (construction via `ActivatorUtilities`, with other deferred registrations available as constructor dependencies).

## Port adjustments for main

- Inline `[DynamicallyAccessedMembers]` attributes (no `#if NET6_0_OR_GREATER` guards), `ArgumentNullException.ThrowIfNull`, `name.Contains(char)`.
- Deferred machinery lives in `src/Quartz/Configuration/` (`Quartz.Configuration` namespace, `_camelCase` internal fields on `QuartzOptions`, `Lock` for synchronization).
- Keyed-descriptor guard in `DeferredServiceCollection.TryHandleDeferred` is unconditional (MEDI 8+ everywhere).
- Tests use `ValueTask` `ISchedulerPlugin` signatures and the `SchedulerContext` indexer (`Put` no longer exists on main).
- Docs section added to `docs/documentation/quartz-4.x/packages/quartz-plugins.md`.

## Testing

- New `SchedulerPluginConfigurationExtensionsTests` including the deferred scenarios; DI + SchedulerBuilder regression suites pass; full solution builds clean with main's analyzers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
