### PR TITLE
Fix type-load exceptions in AcquireNextTrigger blocking all other triggers

### DIFF
--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -3215,11 +3215,11 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
                     {
                         jobType = typeLoadHelper.LoadType(result.JobType)!;
                     }
-                    catch (JobPersistenceException jpe)
+                    catch (Exception e)
                     {
                         try
                         {
-                            Logger.LogError(jpe, "Error retrieving job, setting trigger state to ERROR.");
+                            Logger.LogError(e, "Error retrieving job, setting trigger state to ERROR.");
                             await Delegate.UpdateTriggerState(conn, triggerKey, StateError, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception ex)


### PR DESCRIPTION
Port of #3108 to `main` (4.x).

## Problem

`JobStoreSupport.AcquireNextTrigger` loads each ready trigger's job type via `typeLoadHelper.LoadType(result.JobType)`. `SimpleTypeLoadHelper.LoadType` throws a **raw `TypeLoadException`** when the type cannot be resolved (and `Type.GetType` / custom `ITypeLoadHelper` implementations can also surface `FileLoadException`, `BadImageFormatException`, `FileNotFoundException`, etc.) — never a `JobPersistenceException`.

The catch clause around that call was `catch (JobPersistenceException)`, so it never matched. The exception escaped the per-trigger handling, propagated to the outer `do-while` handler, which re-threw it as a `JobPersistenceException` and **aborted the entire trigger-acquisition batch** — starving every other ready trigger because of a single trigger whose job type could not be loaded.

## Fix

Widen the catch to `catch (Exception)` so any type-loading failure is handled per-trigger: log the error, set the trigger state to `ERROR`, and continue to the next trigger. This matches the surrounding code, which already catches generic `Exception` for the inner `UpdateTriggerState` call and in the outer batch handler.

The sibling `catch (JobPersistenceException)` around `RetrieveJob` in `TriggerFired` is intentionally left unchanged — `RetrieveJob` already wraps `TypeLoadException` into `JobPersistenceException`, so its narrow catch is correct.

Fixes #3107
