### PR TITLE
Allow passing health check tags to AddQuartzServer

### DIFF
--- a/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
+++ b/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
@@ -38,3 +38,25 @@ public void ConfigureServices(IServiceCollection services)
     });
 }
 ```
+
+## Health checks
+
+On target frameworks with health check support `AddQuartzServer` also registers an
+[ASP.NET Core health check](https://learn.microsoft.com/aspnet/core/host-and-deploy/health-checks)
+named `quartz-scheduler` that reports unhealthy when the scheduler is not running or cannot reach its store.
+
+You can attach tags to this health check so it can be filtered, for example into separate
+liveness and readiness probes:
+
+```csharp
+services.AddQuartzServer(
+    options => options.WaitForJobsToComplete = true,
+    healthCheckTags: ["ready", "live"]);
+```
+
+```csharp
+app.MapHealthChecks("/healthz/ready", new HealthCheckOptions
+{
+    Predicate = registration => registration.Tags.Contains("ready")
+});
+```

--- a/src/Quartz.AspNetCore/AspNetCore/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/QuartzServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,14 +11,41 @@ namespace Quartz.AspNetCore;
 
 public static class QuartzServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds the Quartz hosted service that starts and stops the scheduler with the application lifetime.
+    /// On target frameworks with health check support a <c>quartz-scheduler</c> health check is also registered.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional configuration for the hosted service.</param>
     public static IServiceCollection AddQuartzServer(
         this IServiceCollection services,
         Action<QuartzHostedServiceOptions>? configure = null)
     {
+        return services.AddQuartzServer(configure, healthCheckTags: null);
+    }
+
+    /// <summary>
+    /// Adds the Quartz hosted service that starts and stops the scheduler with the application lifetime.
+    /// On target frameworks with health check support a <c>quartz-scheduler</c> health check is also registered.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional configuration for the hosted service.</param>
+    /// <param name="healthCheckTags">
+    /// Tags to associate with the <c>quartz-scheduler</c> health check, allowing it to be filtered (for example
+    /// into liveness/readiness probes). Has no effect on target frameworks without health check support.
+    /// </param>
+    public static IServiceCollection AddQuartzServer(
+        this IServiceCollection services,
+        Action<QuartzHostedServiceOptions>? configure,
+        IEnumerable<string>? healthCheckTags)
+    {
 #if SUPPORTS_HEALTH_CHECKS
         services
             .AddHealthChecks()
-            .AddTypeActivatedCheck<QuartzHealthCheck>("quartz-scheduler");
+            .AddTypeActivatedCheck<QuartzHealthCheck>(
+                "quartz-scheduler",
+                failureStatus: null,
+                tags: healthCheckTags ?? Array.Empty<string>());
 #endif
 
         return services.AddQuartzHostedService(configure);

--- a/src/Quartz.Tests.AspNetCore/HealthChecks/QuartzHealthCheckRegistrationTests.cs
+++ b/src/Quartz.Tests.AspNetCore/HealthChecks/QuartzHealthCheckRegistrationTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+using Quartz.AspNetCore;
+
+namespace Quartz.Tests.AspNetCore.HealthChecks;
+
+public class QuartzHealthCheckRegistrationTests
+{
+    [Test]
+    public void AddQuartzServer_WithTags_RegistersHealthCheckWithTags()
+    {
+        ServiceCollection services = new();
+        services.AddQuartzServer(configure: null, healthCheckTags: new[] { "ready", "live" });
+
+        HealthCheckRegistration registration = GetQuartzRegistration(services);
+        registration.Tags.Should().BeEquivalentTo("ready", "live");
+    }
+
+    [Test]
+    public void AddQuartzServer_WithoutTags_RegistersHealthCheckWithoutTags()
+    {
+        ServiceCollection services = new();
+        services.AddQuartzServer();
+
+        HealthCheckRegistration registration = GetQuartzRegistration(services);
+        registration.Tags.Should().BeEmpty();
+    }
+
+    private static HealthCheckRegistration GetQuartzRegistration(IServiceCollection services)
+    {
+        HealthCheckServiceOptions options = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        return options.Registrations.Single(registration => registration.Name == "quartz-scheduler");
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #3111. `AddQuartzServer` auto-registers the `quartz-scheduler` ASP.NET Core health check backed by the `internal sealed QuartzHealthCheck`. Because the check class is internal and the extension exposed no way to attach tags, users wanting Kubernetes-style `ready`/`live` probe filtering had to resort to a brittle `PostConfigure<HealthCheckServiceOptions>` lookup by hardcoded name.

This adds a binary-safe overload that accepts health-check tags:

```csharp
services.AddQuartzServer(
    options => options.WaitForJobsToComplete = true,
    healthCheckTags: ["ready", "live"]);
```

## Changes

- **`QuartzServiceCollectionExtensions`** — new overload `AddQuartzServer(services, Action<QuartzHostedServiceOptions>?, IEnumerable<string>? healthCheckTags)`. The existing `(services, configure = null)` signature is **preserved unchanged** and now forwards to it, so already-compiled callers keep working (no binary break — important for a servicing release). On target frameworks without health-check support (`netstandard2.0`, where `SUPPORTS_HEALTH_CHECKS` is undefined) the parameter is simply unused, consistent with today's behavior of not registering the check there.
- **Test** — new `QuartzHealthCheckRegistrationTests` fixture asserting tags flow through to the registration and that the default (no-tags) path stays empty.
- **Docs** — added a "Health checks" section to the ASP.NET Core integration page (also the NuGet readme).

## Test plan

- `dotnet build src/Quartz.AspNetCore/Quartz.AspNetCore.csproj` — succeeds for all TFMs incl. `netstandard2.0`, 0 warnings (warnings-as-errors).
- `dotnet test src/Quartz.Tests.AspNetCore` — 41/41 pass (including the 2 new tests).
- `dotnet build src/Quartz.Examples.AspNetCore` — existing `AddQuartzServer(options => …)` call still compiles, confirming source/binary compatibility.

A richer configuration API (name + tags + failure status) will follow on `main` for the next major release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
