### PR TITLE
Fix JSON schedule config not loaded for named schedulers using root Quartz section (#3106)

### DIFF
--- a/docs/documentation/quartz-3.x/packages/json-configuration.md
+++ b/docs/documentation/quartz-3.x/packages/json-configuration.md
@@ -267,8 +267,18 @@ services.AddQuartzHostedService();
 
 Each named scheduler section supports the same hierarchical properties, `Schedule` sub-section with `Jobs`/`Triggers`, and code-based overrides.
 
+You can also register a single named scheduler explicitly. The named overload accepts either the
+scheduler's own section or the root `Quartz` section — when given the root section it resolves the
+matching `Schedulers:{name}` sub-section automatically:
+
+```csharp
+// Both lines are equivalent
+services.AddQuartz("Primary", Configuration.GetSection("Quartz"));
+services.AddQuartz("Primary", Configuration.GetSection("Quartz:Schedulers:Primary"));
+```
+
 ::: warning
-Defining both a `Schedulers` sub-section and direct scheduler configuration (e.g., `Scheduler`, `ThreadPool` at the top level) is an error. Use one or the other.
+Defining both a `Schedulers` sub-section and direct scheduler configuration (e.g., `Scheduler`, `ThreadPool` at the top level) is an error. Use one or the other. A top-level `Schedule`/`Scheduling` section cannot be combined with `Schedulers` either — move it under the appropriate `Schedulers:{name}` entry.
 :::
 
 ## Standalone JSON Files (quartz_jobs.json)

--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -69,6 +69,17 @@ public static class ServiceCollectionExtensions
 
         if (hasNamedSchedulers)
         {
+            // Top-level Schedule/Scheduling has no scheduler to attach to when named schedulers are used.
+            // These are reserved keys that HasDirectSchedulerConfiguration intentionally ignores, so they
+            // slip past the check above and would otherwise be silently dropped. Fail with a clear message.
+            if (configuration.GetSection("Schedule").Exists() || configuration.GetSection("Scheduling").Exists())
+            {
+                throw new SchedulerConfigException(
+                    "The Quartz configuration section contains a 'Schedulers' sub-section together with a top-level " +
+                    "'Schedule' or 'Scheduling' section. Top-level scheduling data has no scheduler to attach to when " +
+                    "named schedulers are used. Move 'Schedule'/'Scheduling' under the appropriate 'Schedulers:{name}' entry.");
+            }
+
             foreach (IConfigurationSection child in schedulersSection.GetChildren())
             {
                 AddQuartz(services, child.Key, child, configure);
@@ -118,9 +129,15 @@ public static class ServiceCollectionExtensions
         IConfiguration configuration,
         Action<IServiceCollectionQuartzConfigurator>? configure = null)
     {
-        NameValueCollection properties = QuartzConfigurationHelper.ToNameValueCollection(configuration);
+        // Allow passing either the scheduler's own section or the root "Quartz" section that contains a
+        // "Schedulers:{name}" sub-section (issue #3106). Resolve to the scheduler-specific section so its
+        // flat properties, Schedule and Scheduling sub-sections are found.
+        IConfigurationSection schedulerSection = configuration.GetSection("Schedulers").GetSection(name);
+        IConfiguration effectiveConfiguration = schedulerSection.Exists() ? schedulerSection : configuration;
+
+        NameValueCollection properties = QuartzConfigurationHelper.ToNameValueCollection(effectiveConfiguration);
         AddQuartz(services, name, properties, configure);
-        JsonSchedulingHelper.ConfigureOptionsFromConfiguration(services, configuration, name);
+        JsonSchedulingHelper.ConfigureOptionsFromConfiguration(services, effectiveConfiguration, name);
         return services;
     }
 

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/JsonSchedulingTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/JsonSchedulingTests.cs
@@ -166,6 +166,36 @@ public class JsonSchedulingTests
     }
 
     [Test]
+    public void AddQuartz_NamedScheduler_WithRootSectionContainingSchedulers_ResolvesSubsection()
+    {
+        // Reproduces #3106: passing the root "Quartz" section (which holds the scheduler under
+        // "Schedulers:{name}") to the named overload should resolve down to that scheduler's section.
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "Schedulers:LocalScheduler:ThreadPool:MaxConcurrency", "7" },
+            { "Schedulers:LocalScheduler:Schedule:Jobs:0:Name", "rootJob" },
+            { "Schedulers:LocalScheduler:Schedule:Jobs:0:JobType", "Quartz.Job.NativeJob, Quartz.Jobs" },
+            { "Schedulers:LocalScheduler:Schedule:Jobs:0:Durable", "true" },
+            { "Schedulers:LocalScheduler:Schedule:Triggers:0:Name", "rootTrigger" },
+            { "Schedulers:LocalScheduler:Schedule:Triggers:0:JobName", "rootJob" },
+            { "Schedulers:LocalScheduler:Schedule:Triggers:0:Cron:Expression", "0 0 * * * ?" }
+        });
+
+        ServiceCollection services = new ServiceCollection();
+        services.AddLogging();
+        services.AddQuartz("LocalScheduler", config);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsSnapshot<QuartzOptions> optionsSnapshot = provider.GetRequiredService<IOptionsSnapshot<QuartzOptions>>();
+        QuartzOptions options = optionsSnapshot.Get("LocalScheduler");
+
+        options["quartz.threadPool.maxConcurrency"].Should().Be("7");
+        options.JobDetails.Should().HaveCount(1);
+        options.JobDetails[0].Key.Name.Should().Be("rootJob");
+        options.Triggers.Should().HaveCount(1);
+    }
+
+    [Test]
     public void AddQuartz_SchedulersSection_RegistersNamedSchedulers()
     {
         var config = BuildConfig(new Dictionary<string, string>
@@ -211,6 +241,24 @@ public class JsonSchedulingTests
         Action act = () => services.AddQuartz(config);
         act.Should().Throw<SchedulerConfigException>()
             .WithMessage("*both*Schedulers*");
+    }
+
+    [Test]
+    public void AddQuartz_SchedulersWithTopLevelSchedule_Throws()
+    {
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "Schedulers:Primary:ThreadPool:MaxConcurrency", "5" },
+            { "Schedule:Jobs:0:Name", "strayJob" },
+            { "Schedule:Jobs:0:JobType", "Quartz.Job.NativeJob, Quartz.Jobs" },
+        });
+
+        ServiceCollection services = new ServiceCollection();
+        services.AddLogging();
+
+        Action act = () => services.AddQuartz(config);
+        act.Should().Throw<SchedulerConfigException>()
+            .WithMessage("*top-level*Schedule*");
     }
 
     [Test]


### PR DESCRIPTION
## Problem

Fixes #3106.

When configuring named schedulers under `Quartz:Schedulers:{name}` and calling the **named** `AddQuartz` overload with the **root** `Quartz` section, nothing is registered (0 jobs, 0 triggers):

```csharp
// FAILS today — registers 0 jobs, 0 triggers
services.AddQuartz("LocalScheduler", Configuration.GetSection("Quartz"), _ => { });

// Worked only with the scheduler-specific section
services.AddQuartz("LocalScheduler", Configuration.GetSection("Quartz:Schedulers:LocalScheduler"), _ => { });
```

The named overload assumed the section it received *was* the scheduler's own section, so it read flat properties and the `Schedule`/`Scheduling` sub-sections directly under it. With the root section those live under `Schedulers:{name}:...`, so they were never found (properties were lost too, since `Schedulers` is a reserved/skipped key).

## Fix

- **Named overload auto-resolves the sub-section**: `AddQuartz(name, configuration)` now resolves a `Schedulers:{name}` child when present and uses it for both property conversion and `JsonSchedulingHelper`; otherwise it uses the section as-is. Fully backward-compatible — the recursive call from the root overload and the existing flat-section usage are unaffected.
- **Clear error for an ambiguous mix**: the root `AddQuartz(IConfiguration)` overload now throws a `SchedulerConfigException` when a top-level `Schedule`/`Scheduling` section is combined with a `Schedulers` sub-section. Previously that top-level scheduling data was silently dropped (it has no scheduler to attach to once named schedulers are in play).

## Tests & docs

- New `AddQuartz_NamedScheduler_WithRootSectionContainingSchedulers_ResolvesSubsection` (reproduction).
- New `AddQuartz_SchedulersWithTopLevelSchedule_Throws` (guard).
- Documented both behaviors in the JSON configuration docs.

All `JsonSchedulingTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
