### PR TITLE
Fix JSON schedule config not loaded for named schedulers using root Quartz section (#3106)

### DIFF
--- a/docs/documentation/quartz-3.x/packages/json-configuration.md
+++ b/docs/documentation/quartz-3.x/packages/json-configuration.md
@@ -1,0 +1,345 @@
+# JSON Configuration
+
+Quartz.NET supports hierarchical JSON configuration in `appsettings.json`, providing a modern alternative to flat property keys. This includes both scheduler properties and declarative job/trigger definitions.
+
+::: tip
+Requires Quartz 3.18 or later with the `Quartz.Extensions.DependencyInjection` package.
+:::
+
+## Hierarchical Properties
+
+Instead of flat property keys like `"quartz.threadPool.maxConcurrency": "10"`, you can use a natural nested JSON structure:
+
+```json
+{
+  "Quartz": {
+    "Scheduler": {
+      "InstanceName": "My Scheduler",
+      "InstanceId": "AUTO"
+    },
+    "ThreadPool": {
+      "MaxConcurrency": 10
+    },
+    "JobStore": {
+      "Type": "Quartz.Impl.AdoJobStore.JobStoreTX, Quartz",
+      "DataSource": "default",
+      "TablePrefix": "QRTZ_"
+    },
+    "DataSource": {
+      "default": {
+        "Provider": "SqlServer",
+        "ConnectionString": "Server=localhost;Database=quartznet"
+      }
+    },
+    "Plugin": {
+      "jobHistory": {
+        "Type": "Quartz.Plugin.History.LoggingJobHistoryPlugin, Quartz.Plugins"
+      }
+    },
+    "Serializer": {
+      "Type": "stj"
+    }
+  }
+}
+```
+
+### Mapping Rules
+
+Each JSON path segment becomes a dot-separated segment in the flat property key, with PascalCase automatically converted to camelCase:
+
+| JSON Path | Flat Property Key |
+|---|---|
+| `Scheduler:InstanceName` | `quartz.scheduler.instanceName` |
+| `ThreadPool:MaxConcurrency` | `quartz.threadPool.maxConcurrency` |
+| `DataSource:default:Provider` | `quartz.dataSource.default.provider` |
+| `Plugin:jobHistory:Type` | `quartz.plugin.jobHistory.type` |
+
+### Usage with DI
+
+```csharp
+services.AddQuartz(Configuration.GetSection("Quartz"), q =>
+{
+    // Additional code-based configuration still works alongside JSON
+    q.AddJob<MyJob>(j => j.WithIdentity("codeJob").StoreDurably());
+});
+```
+
+### Usage without DI
+
+```csharp
+var properties = QuartzConfigurationHelper.ToNameValueCollection(
+    Configuration.GetSection("Quartz"));
+var factory = new StdSchedulerFactory();
+factory.Initialize(properties);
+```
+
+### Backward Compatibility
+
+Flat property keys still work. You can mix both styles in the same section:
+
+```json
+{
+  "Quartz": {
+    "quartz.scheduler.instanceId": "AUTO",
+    "ThreadPool": {
+      "MaxConcurrency": 10
+    }
+  }
+}
+```
+
+## JSON Scheduling Data
+
+Jobs and triggers can be defined declaratively in `appsettings.json` under a `Schedule` sub-section:
+
+```json
+{
+  "Quartz": {
+    "Scheduler": {
+      "InstanceName": "My Scheduler"
+    },
+    "Schedule": {
+      "Jobs": [
+        {
+          "Name": "sampleJob",
+          "Group": "sampleGroup",
+          "JobType": "MyApp.Jobs.SampleJob, MyApp",
+          "Description": "A sample job",
+          "Durable": true,
+          "Recover": false,
+          "JobDataMap": {
+            "connectionString": "Server=localhost",
+            "retryCount": "3"
+          }
+        }
+      ],
+      "Triggers": [
+        {
+          "Name": "cronTrigger",
+          "JobName": "sampleJob",
+          "JobGroup": "sampleGroup",
+          "Description": "Fires every 10 seconds",
+          "Cron": {
+            "Expression": "0/10 * * * * ?",
+            "TimeZone": "UTC"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Trigger Types
+
+Exactly one schedule type must be specified per trigger. The trigger type is determined by which nested object is present.
+
+#### Simple Trigger
+
+```json
+{
+  "Name": "simpleTrigger",
+  "JobName": "myJob",
+  "Simple": {
+    "RepeatCount": -1,
+    "Interval": "00:00:10",
+    "MisfireInstruction": "SmartPolicy"
+  }
+}
+```
+
+- `RepeatCount`: Number of times to repeat. Use `-1` for indefinite, `0` for fire once.
+- `Interval`: TimeSpan string (e.g., `"00:00:10"` for 10 seconds, `"01:00:00"` for 1 hour).
+
+#### Cron Trigger
+
+```json
+{
+  "Name": "cronTrigger",
+  "JobName": "myJob",
+  "Cron": {
+    "Expression": "0/30 * * * * ?",
+    "TimeZone": "America/New_York",
+    "MisfireInstruction": "DoNothing"
+  }
+}
+```
+
+#### Calendar Interval Trigger
+
+```json
+{
+  "Name": "calendarTrigger",
+  "JobName": "myJob",
+  "CalendarInterval": {
+    "RepeatInterval": 1,
+    "RepeatIntervalUnit": "Day",
+    "MisfireInstruction": "SmartPolicy"
+  }
+}
+```
+
+`RepeatIntervalUnit` values: `Second`, `Minute`, `Hour`, `Day`, `Week`, `Month`, `Year`.
+
+#### Daily Time Interval Trigger
+
+```json
+{
+  "Name": "businessHoursTrigger",
+  "JobName": "myJob",
+  "DailyTimeInterval": {
+    "RepeatInterval": 15,
+    "RepeatIntervalUnit": "Minute",
+    "RepeatCount": -1,
+    "StartTimeOfDay": "08:00:00",
+    "EndTimeOfDay": "17:00:00",
+    "DaysOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+    "TimeZone": "America/Chicago"
+  }
+}
+```
+
+### Common Trigger Fields
+
+All trigger types support these optional fields:
+
+| Field | Description |
+|---|---|
+| `Name` | Trigger name (required) |
+| `Group` | Trigger group (defaults to DEFAULT) |
+| `JobName` | Associated job name (required) |
+| `JobGroup` | Associated job group (defaults to DEFAULT) |
+| `Description` | Trigger description |
+| `Priority` | Trigger priority (integer) |
+| `CalendarName` | Calendar to apply |
+| `StartTime` | ISO 8601 start time (e.g., `"2024-01-01T00:00:00Z"`) |
+| `StartTimeSecondsInFuture` | Start time as seconds from now (mutually exclusive with StartTime) |
+| `EndTime` | ISO 8601 end time |
+| `JobDataMap` | Key-value pairs for the trigger's data map |
+
+## Multiple Named Schedulers
+
+When the `Quartz` section contains a `Schedulers` sub-section, each child is automatically registered as a named scheduler:
+
+```json
+{
+  "Quartz": {
+    "Schedulers": {
+      "Primary": {
+        "Scheduler": {
+          "InstanceId": "AUTO"
+        },
+        "ThreadPool": {
+          "MaxConcurrency": 10
+        },
+        "Schedule": {
+          "Jobs": [
+            {
+              "Name": "primaryJob",
+              "JobType": "MyApp.Jobs.PrimaryJob, MyApp",
+              "Durable": true
+            }
+          ],
+          "Triggers": [
+            {
+              "Name": "primaryTrigger",
+              "JobName": "primaryJob",
+              "Cron": { "Expression": "0/10 * * * * ?" }
+            }
+          ]
+        }
+      },
+      "Secondary": {
+        "ThreadPool": {
+          "MaxConcurrency": 5
+        }
+      }
+    }
+  }
+}
+```
+
+```csharp
+// Registers "Primary" and "Secondary" named schedulers automatically
+services.AddQuartz(Configuration.GetSection("Quartz"));
+services.AddQuartzHostedService();
+```
+
+Each named scheduler section supports the same hierarchical properties, `Schedule` sub-section with `Jobs`/`Triggers`, and code-based overrides.
+
+You can also register a single named scheduler explicitly. The named overload accepts either the
+scheduler's own section or the root `Quartz` section — when given the root section it resolves the
+matching `Schedulers:{name}` sub-section automatically:
+
+```csharp
+// Both lines are equivalent
+services.AddQuartz("Primary", Configuration.GetSection("Quartz"));
+services.AddQuartz("Primary", Configuration.GetSection("Quartz:Schedulers:Primary"));
+```
+
+::: warning
+Defining both a `Schedulers` sub-section and direct scheduler configuration (e.g., `Scheduler`, `ThreadPool` at the top level) is an error. Use one or the other. A top-level `Schedule`/`Scheduling` section cannot be combined with `Schedulers` either — move it under the appropriate `Schedulers:{name}` entry.
+:::
+
+## Standalone JSON Files (quartz_jobs.json)
+
+For file-based scheduling with hot-reload support, use `JsonSchedulingDataProcessorPlugin` from the `Quartz.Plugins` package. See [Quartz Plugins](quartz-plugins.md) for plugin configuration.
+
+Standalone JSON files use the same `Jobs` and `Triggers` format as the `Schedule` section above, wrapped in an envelope with optional `PreProcessingCommands` and `ProcessingDirectives`:
+
+```json
+{
+  "PreProcessingCommands": {
+    "DeleteJobsInGroup": ["obsoleteGroup"],
+    "DeleteTriggersInGroup": ["oldTriggerGroup"],
+    "DeleteJobs": [
+      { "Name": "oldJob", "Group": "DEFAULT" }
+    ],
+    "DeleteTriggers": [
+      { "Name": "oldTrigger" }
+    ]
+  },
+  "ProcessingDirectives": {
+    "OverWriteExistingData": true,
+    "IgnoreDuplicates": false,
+    "ScheduleTriggerRelativeToReplacedTrigger": false
+  },
+  "Schedule": {
+    "Jobs": [
+      {
+        "Name": "myJob",
+        "JobType": "MyApp.Jobs.MyJob, MyApp",
+        "Durable": true
+      }
+    ],
+    "Triggers": [
+      {
+        "Name": "myTrigger",
+        "JobName": "myJob",
+        "Cron": {
+          "Expression": "0/30 * * * * ?"
+        }
+      }
+    ]
+  }
+}
+```
+
+### PreProcessingCommands
+
+Commands executed before scheduling. All fields are optional:
+
+| Field | Description |
+|---|---|
+| `DeleteJobsInGroup` | Array of group names. Use `"*"` to delete jobs in all groups. |
+| `DeleteTriggersInGroup` | Array of group names. Use `"*"` to delete triggers in all groups. |
+| `DeleteJobs` | Array of `{ "Name": "...", "Group": "..." }` objects. Group is optional. |
+| `DeleteTriggers` | Array of `{ "Name": "...", "Group": "..." }` objects. Group is optional. |
+
+### ProcessingDirectives
+
+| Field | Default | Description |
+|---|---|---|
+| `OverWriteExistingData` | `true` | Replace existing jobs/triggers with the same identity. |
+| `IgnoreDuplicates` | `false` | When `OverWriteExistingData` is `false`, silently skip duplicates instead of erroring. |
+| `ScheduleTriggerRelativeToReplacedTrigger` | `false` | Adjust new trigger timing based on old trigger's last fire time. |

--- a/docs/documentation/quartz-4.x/packages/json-configuration.md
+++ b/docs/documentation/quartz-4.x/packages/json-configuration.md
@@ -267,8 +267,18 @@ services.AddQuartzHostedService();
 
 Each named scheduler section supports the same hierarchical properties, `Schedule` sub-section with `Jobs`/`Triggers`, and code-based overrides.
 
+You can also register a single named scheduler explicitly. The named overload accepts either the
+scheduler's own section or the root `Quartz` section — when given the root section it resolves the
+matching `Schedulers:{name}` sub-section automatically:
+
+```csharp
+// Both lines are equivalent
+services.AddQuartz("Primary", Configuration.GetSection("Quartz"));
+services.AddQuartz("Primary", Configuration.GetSection("Quartz:Schedulers:Primary"));
+```
+
 ::: warning
-Defining both a `Schedulers` sub-section and direct scheduler configuration (e.g., `Scheduler`, `ThreadPool` at the top level) is an error. Use one or the other.
+Defining both a `Schedulers` sub-section and direct scheduler configuration (e.g., `Scheduler`, `ThreadPool` at the top level) is an error. Use one or the other. A top-level `Schedule`/`Scheduling` section cannot be combined with `Schedulers` either — move it under the appropriate `Schedulers:{name}` entry.
 :::
 
 ## Standalone JSON Files (quartz_jobs.json)

--- a/src/Quartz.Tests.Unit/Configuration/JsonSchedulingTests.cs
+++ b/src/Quartz.Tests.Unit/Configuration/JsonSchedulingTests.cs
@@ -83,6 +83,36 @@ public class JsonSchedulingTests
     }
 
     [Test]
+    public void AddQuartz_NamedScheduler_WithRootSectionContainingSchedulers_ResolvesSubsection()
+    {
+        // Reproduces #3106: passing the root "Quartz" section (which holds the scheduler under
+        // "Schedulers:{name}") to the named overload should resolve down to that scheduler's section.
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "Schedulers:LocalScheduler:ThreadPool:MaxConcurrency", "7" },
+            { "Schedulers:LocalScheduler:Schedule:Jobs:0:Name", "rootJob" },
+            { "Schedulers:LocalScheduler:Schedule:Jobs:0:JobType", "Quartz.Job.NativeJob, Quartz.Jobs" },
+            { "Schedulers:LocalScheduler:Schedule:Jobs:0:Durable", "true" },
+            { "Schedulers:LocalScheduler:Schedule:Triggers:0:Name", "rootTrigger" },
+            { "Schedulers:LocalScheduler:Schedule:Triggers:0:JobName", "rootJob" },
+            { "Schedulers:LocalScheduler:Schedule:Triggers:0:Cron:Expression", "0 0 * * * ?" },
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddQuartz("LocalScheduler", config);
+
+        var provider = services.BuildServiceProvider();
+        var snapshot = provider.GetRequiredService<IOptionsSnapshot<QuartzOptions>>();
+        var options = snapshot.Get("LocalScheduler");
+
+        options["quartz.threadPool.maxConcurrency"].Should().Be("7");
+        options.JobDetails.Should().HaveCount(1);
+        options.JobDetails[0].Key.Name.Should().Be("rootJob");
+        options.Triggers.Should().HaveCount(1);
+    }
+
+    [Test]
     public void AddQuartz_SchedulersAndDirectConfig_Throws()
     {
         var config = BuildConfig(new Dictionary<string, string>
@@ -96,6 +126,23 @@ public class JsonSchedulingTests
 
         var act = () => services.AddQuartz(config);
         act.Should().Throw<SchedulerConfigException>().WithMessage("*both*Schedulers*");
+    }
+
+    [Test]
+    public void AddQuartz_SchedulersWithTopLevelSchedule_Throws()
+    {
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "Schedulers:Primary:ThreadPool:MaxConcurrency", "5" },
+            { "Schedule:Jobs:0:Name", "strayJob" },
+            { "Schedule:Jobs:0:JobType", "Quartz.Job.NativeJob, Quartz.Jobs" },
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.AddQuartz(config);
+        act.Should().Throw<SchedulerConfigException>().WithMessage("*top-level*Schedule*");
     }
 
     [Test]

--- a/src/Quartz/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/ServiceCollectionExtensions.cs
@@ -64,6 +64,17 @@ public static class ServiceCollectionExtensions
 
         if (hasNamedSchedulers)
         {
+            // Top-level Schedule/Scheduling has no scheduler to attach to when named schedulers are used.
+            // These are reserved keys that HasDirectSchedulerConfiguration intentionally ignores, so they
+            // slip past the check above and would otherwise be silently dropped. Fail with a clear message.
+            if (configuration.GetSection("Schedule").Exists() || configuration.GetSection("Scheduling").Exists())
+            {
+                throw new SchedulerConfigException(
+                    "The Quartz configuration section contains a 'Schedulers' sub-section together with a top-level " +
+                    "'Schedule' or 'Scheduling' section. Top-level scheduling data has no scheduler to attach to when " +
+                    "named schedulers are used. Move 'Schedule'/'Scheduling' under the appropriate 'Schedulers:{name}' entry.");
+            }
+
             foreach (var child in schedulersSection.GetChildren())
             {
                 AddQuartz(services, child.Key, child, configure);
@@ -88,9 +99,15 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
-        var properties = QuartzConfigurationHelper.ToNameValueCollection(configuration);
+        // Allow passing either the scheduler's own section or the root "Quartz" section that contains a
+        // "Schedulers:{name}" sub-section (issue #3106). Resolve to the scheduler-specific section so its
+        // flat properties, Schedule and Scheduling sub-sections are found.
+        var schedulerSection = configuration.GetSection("Schedulers").GetSection(name);
+        IConfiguration effectiveConfiguration = schedulerSection.Exists() ? schedulerSection : configuration;
+
+        var properties = QuartzConfigurationHelper.ToNameValueCollection(effectiveConfiguration);
         AddQuartz(services, name, properties, configure);
-        JsonSchedulingHelper.ConfigureOptionsFromConfiguration(services, configuration, name);
+        JsonSchedulingHelper.ConfigureOptionsFromConfiguration(services, effectiveConfiguration, name);
         return services;
     }
 


### PR DESCRIPTION
## Problem

Fixes #3106.

When configuring named schedulers under `Quartz:Schedulers:{name}` and calling the **named** `AddQuartz` overload with the **root** `Quartz` section, nothing is registered (0 jobs, 0 triggers):

```csharp
// FAILS today — registers 0 jobs, 0 triggers
services.AddQuartz("LocalScheduler", Configuration.GetSection("Quartz"), _ => { });

// Worked only with the scheduler-specific section
services.AddQuartz("LocalScheduler", Configuration.GetSection("Quartz:Schedulers:LocalScheduler"), _ => { });
```

The named overload assumed the section it received *was* the scheduler's own section, so it read flat properties and the `Schedule`/`Scheduling` sub-sections directly under it. With the root section those live under `Schedulers:{name}:...`, so they were never found (properties were lost too, since `Schedulers` is a reserved/skipped key).

## Fix

- **Named overload auto-resolves the sub-section**: `AddQuartz(name, configuration)` now resolves a `Schedulers:{name}` child when present and uses it for both property conversion and `JsonSchedulingHelper`; otherwise it uses the section as-is. Fully backward-compatible — the recursive call from the root overload and the existing flat-section usage are unaffected.
- **Clear error for an ambiguous mix**: the root `AddQuartz(IConfiguration)` overload now throws a `SchedulerConfigException` when a top-level `Schedule`/`Scheduling` section is combined with a `Schedulers` sub-section. Previously that top-level scheduling data was silently dropped (it has no scheduler to attach to once named schedulers are in play).

## Tests & docs

- New `AddQuartz_NamedScheduler_WithRootSectionContainingSchedulers_ResolvesSubsection` (reproduction).
- New `AddQuartz_SchedulersWithTopLevelSchedule_Throws` (guard).
- Documented both behaviors in the JSON configuration docs.

All `JsonSchedulingTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
