### PR TITLE
Allow configuring the Quartz health check (name, tags, failure status)

### DIFF
--- a/docs/documentation/quartz-4.x/packages/aspnet-core-integration.md
+++ b/docs/documentation/quartz-4.x/packages/aspnet-core-integration.md
@@ -95,3 +95,33 @@ builder.Services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
 ```
 
 For more information on cron triggers and their format, you can use the tutorial directly from Quartz - [Cron Triggers](../tutorial/crontriggers.md).
+
+## Health checks
+
+Call `AddQuartzHealthChecks` to register an
+[ASP.NET Core health check](https://learn.microsoft.com/aspnet/core/host-and-deploy/health-checks)
+that reports unhealthy when the scheduler is not running or cannot reach its store.
+
+```csharp
+services.AddQuartzHealthChecks();
+```
+
+The registration can be customized via the optional configuration callback, for example to attach
+tags so the check can be filtered into separate liveness and readiness probes:
+
+```csharp
+services.AddQuartzHealthChecks(options =>
+{
+    options.Name = "quartz-scheduler";   // defaults to "quartz-scheduler"
+    options.Tags.Add("ready");
+    options.Tags.Add("live");
+    options.FailureStatus = HealthStatus.Unhealthy;
+});
+```
+
+```csharp
+app.MapHealthChecks("/healthz/ready", new HealthCheckOptions
+{
+    Predicate = registration => registration.Tags.Contains("ready")
+});
+```

--- a/src/Quartz.AspNetCore/AspNetCore/HealthChecks/QuartzHealthCheckOptions.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HealthChecks/QuartzHealthCheckOptions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Quartz.AspNetCore.HealthChecks;
+
+/// <summary>
+/// Options for the Quartz scheduler health check registered by
+/// <see cref="QuartzServiceCollectionExtensions.AddQuartzHealthChecks" />.
+/// </summary>
+public sealed class QuartzHealthCheckOptions
+{
+    /// <summary>
+    /// The name used to register the health check. Defaults to <c>quartz-scheduler</c>.
+    /// </summary>
+    public string Name { get; set; } = "quartz-scheduler";
+
+    /// <summary>
+    /// Tags associated with the health check, allowing it to be filtered (for example into
+    /// separate liveness and readiness probes).
+    /// </summary>
+    public IList<string> Tags { get; } = new List<string>();
+
+    /// <summary>
+    /// The <see cref="HealthStatus" /> reported when the check fails. When <see langword="null" />
+    /// the default (<see cref="HealthStatus.Unhealthy" />) is used.
+    /// </summary>
+    public HealthStatus? FailureStatus { get; set; }
+}

--- a/src/Quartz.AspNetCore/AspNetCore/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/QuartzServiceCollectionExtensions.cs
@@ -16,11 +16,28 @@ namespace Quartz.AspNetCore;
 
 public static class QuartzServiceCollectionExtensions
 {
-    public static IServiceCollection AddQuartzHealthChecks(this IServiceCollection services)
+    /// <summary>
+    /// Registers a health check for the Quartz scheduler that reports unhealthy when the scheduler
+    /// is not running or cannot reach its store.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">
+    /// Optional configuration for the health check registration, allowing the name, tags and failure
+    /// status to be customized (for example to attach liveness/readiness probe tags).
+    /// </param>
+    public static IServiceCollection AddQuartzHealthChecks(
+        this IServiceCollection services,
+        Action<QuartzHealthCheckOptions>? configure = null)
     {
+        var options = new QuartzHealthCheckOptions();
+        configure?.Invoke(options);
+
         services
             .AddHealthChecks()
-            .AddTypeActivatedCheck<QuartzHealthCheck>("quartz-scheduler");
+            .AddTypeActivatedCheck<QuartzHealthCheck>(
+                options.Name,
+                failureStatus: options.FailureStatus,
+                tags: options.Tags);
 
         return services;
     }

--- a/src/Quartz.Tests.AspNetCore/HealthChecks/QuartzHealthCheckRegistrationTests.cs
+++ b/src/Quartz.Tests.AspNetCore/HealthChecks/QuartzHealthCheckRegistrationTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+using Quartz.AspNetCore;
+
+namespace Quartz.Tests.AspNetCore.HealthChecks;
+
+public class QuartzHealthCheckRegistrationTests
+{
+    [Test]
+    public void WithoutConfigurationRegistersDefaultHealthCheck()
+    {
+        ServiceCollection services = new();
+        services.AddQuartzHealthChecks();
+
+        HealthCheckRegistration registration = GetQuartzRegistration(services, "quartz-scheduler");
+        registration.Tags.Should().BeEmpty();
+        registration.FailureStatus.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    [Test]
+    public void WithConfigurationAppliesNameTagsAndFailureStatus()
+    {
+        ServiceCollection services = new();
+        services.AddQuartzHealthChecks(options =>
+        {
+            options.Name = "quartz";
+            options.Tags.Add("ready");
+            options.Tags.Add("live");
+            options.FailureStatus = HealthStatus.Degraded;
+        });
+
+        HealthCheckRegistration registration = GetQuartzRegistration(services, "quartz");
+        registration.Tags.Should().BeEquivalentTo("ready", "live");
+        registration.FailureStatus.Should().Be(HealthStatus.Degraded);
+    }
+
+    private static HealthCheckRegistration GetQuartzRegistration(IServiceCollection services, string name)
+    {
+        HealthCheckServiceOptions options = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        return options.Registrations.Single(registration => registration.Name == name);
+    }
+}


### PR DESCRIPTION
## Summary

Main/4.x counterpart of #3111. On `main` the `AddQuartzServer` method no longer exists — the scheduler health check is registered through the public `AddQuartzHealthChecks()` extension, which previously took no arguments and so offered no way to attach tags. Because `QuartzHealthCheck` is `internal`, consumers couldn't tag the registration themselves (the original ask in #3111: filtering the check into Kubernetes `ready`/`live` probes).

This adds an optional configuration callback to `AddQuartzHealthChecks`:

```csharp
services.AddQuartzHealthChecks(options =>
{
    options.Name = "quartz-scheduler"; // default
    options.Tags.Add("ready");
    options.Tags.Add("live");
    options.FailureStatus = HealthStatus.Degraded;
});
```

## Changes

- **`QuartzHealthCheckOptions`** (new `public sealed`) — exposes `Name`, `Tags`, and `FailureStatus`. Since `Quartz.AspNetCore` targets only `net8.0` on main, the health-check types are always available, so no conditional compilation is needed.
- **`AddQuartzHealthChecks`** — gains an optional `Action<QuartzHealthCheckOptions>? configure` parameter; the existing parameterless call (used in the example app) is unaffected.
- **Test** — new `QuartzHealthCheckRegistrationTests` verifying the default registration and that name/tags/failure status flow through.
- **Docs** — added a "Health checks" section to the 4.x ASP.NET Core integration page.

## Relationship to the 3.x PR

The 3.x servicing PR (#3112) keeps `AddQuartzServer` and adds a binary-safe `healthCheckTags` overload (tags only). This PR provides the richer, 4.x-shaped API on the `AddQuartzHealthChecks` entry point that replaced `AddQuartzServer` on main.

## Test plan

- `dotnet build src/Quartz.AspNetCore/Quartz.AspNetCore.csproj` — succeeds, 0 warnings (warnings-as-errors).
- `dotnet test src/Quartz.Tests.AspNetCore` — 92/92 pass (including the 2 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
