### PR TITLE
Reconcile published 3.x docs with the 3.x branch (#3116)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@ Integration tests provision their database dependencies through Testcontainers f
 
 This builds and runs tests like the CI server does.
 
+## Documentation
+
+The documentation website is built and published from this **`main`** branch. All versioned docs live under `docs/documentation/` (for example `docs/documentation/quartz-3.x/` for the current stable line and `docs/documentation/quartz-4.x/` for the next release). Edit the docs here; the `3.x` maintenance branch no longer carries the docs site.
+
+The published Quartz 3.x package pages under `docs/documentation/quartz-3.x/packages/` are mirrored, in compact NuGet-rendered form, by the per-package `src/<Project>/README.md` files on the `3.x` branch (which are packed into the NuGet packages). When you change one, update the other in a companion PR so the published page and the shipped package README stay consistent.
+
 ## Bugs and feature requests?
 
 Please log a new issue in the GitHub repo.

--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -27,6 +27,7 @@ export const sidebarEn: SidebarConfig = [
         ],
       },
       "/documentation/quartz-3.x/configuration/reference",
+      "/documentation/quartz-3.x/packages/json-configuration",
       "/documentation/faq",
       "/documentation/best-practices",
       "/documentation/troubleshooting",
@@ -108,6 +109,7 @@ export const sidebarEn: SidebarConfig = [
             ],
           },
           "/documentation/quartz-4.x/configuration/reference",
+          "/documentation/quartz-4.x/packages/json-configuration",
           "/documentation/quartz-4.x/migration-guide",
           "/documentation/troubleshooting",
           {

--- a/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
+++ b/docs/documentation/quartz-3.x/packages/aspnet-core-integration.md
@@ -46,6 +46,28 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+## Health checks
+
+On target frameworks with health check support `AddQuartzServer` also registers an
+[ASP.NET Core health check](https://learn.microsoft.com/aspnet/core/host-and-deploy/health-checks)
+named `quartz-scheduler` that reports unhealthy when the scheduler is not running or cannot reach its store.
+
+You can attach tags to this health check so it can be filtered, for example into separate
+liveness and readiness probes:
+
+```csharp
+services.AddQuartzServer(
+    options => options.WaitForJobsToComplete = true,
+    healthCheckTags: ["ready", "live"]);
+```
+
+```csharp
+app.MapHealthChecks("/healthz/ready", new HealthCheckOptions
+{
+    Predicate = registration => registration.Tags.Contains("ready")
+});
+```
+
 ## A practical example of the setup
 
 In the code below you can see a real application of the Quartz package within ASP.NET Core MVC.


### PR DESCRIPTION
## Summary

Part of #3116, and the companion to the `3.x` cleanup PR (`fix/3116-docs-3x-cleanup`).

The documentation website is published **only from `main`**, so documentation improvements made on the `3.x` branch never reached users. This brings the published Quartz 3.x docs up to date with the 3.x branch and documents how the two stay in sync going forward.

## Changes

- **Health checks**: document the health-check registration added in 3.x (#3112), including `healthCheckTags`, on the published `quartz-3.x/packages/aspnet-core-integration` page (the 3.x `AddQuartzServer(..., healthCheckTags:)` overload).
- **Sidebar**: wire the existing-but-orphaned `json-configuration` page into the **Getting Started** section (next to the configuration reference) for both 3.x and 4.x.
- **CONTRIBUTING.md**: note that docs are published from `main`, and that the 3.x package READMEs (`src/<Project>/README.md` on the `3.x` branch) mirror `docs/documentation/quartz-3.x/packages/` here — change one, change the other in a companion PR.

## Verification

`npm run docs:build` succeeds — 195 pages rendered, both `json-configuration` pages emitted into the sidebar, the health-checks content renders on the aspnet page, no dead links.
