### PR TITLE
Allow the dashboard Blazor circuit anonymous access under a fail-closed FallbackPolicy (#3117)

### DIFF
--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -181,10 +181,32 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         }
         else
         {
-            // Without a dashboard policy, static assets opt out of authorization so applications
-            // enforcing a fail-closed FallbackPolicy can still load dashboard CSS/JS; the files are
-            // public package content (#3097).
+            // Without a dashboard policy the dashboard adds no authorization of its own. The static
+            // asset endpoint opts out of authorization so applications enforcing a fail-closed
+            // FallbackPolicy can still load dashboard CSS/JS; the files are public package content (#3097).
             staticAssets.AllowAnonymous();
+
+            if (dashboardOwnsComponents)
+            {
+                // Standalone mode: the components builder contains only dashboard pages plus the
+                // Blazor framework/circuit endpoints (e.g. /_blazor). Mark the non-page endpoints
+                // AllowAnonymous so the circuit stays reachable under a fail-closed FallbackPolicy;
+                // the dashboard pages and the live-events hub are intentionally left without
+                // metadata so they remain governed by the host's policies and scheduler data is
+                // never silently exposed to anonymous users (#3117).
+                components.Add(endpointBuilder =>
+                {
+                    if (GetComponentType(endpointBuilder) is null)
+                    {
+                        endpointBuilder.Metadata.Add(new AllowAnonymousAttribute());
+                    }
+                });
+            }
+
+            // Integrated mode: the host owns its pages and Blazor plumbing, so the dashboard does
+            // not touch the shared components builder here (#3066). Set
+            // QuartzDashboardOptions.AuthorizationPolicy to make the dashboard reachable under a
+            // fail-closed FallbackPolicy in that case.
         }
     }
 

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
@@ -84,6 +84,36 @@ public class DashboardEndpointsTest
     }
 
     [Test]
+    public async Task StandaloneWithoutPolicyShouldAllowAnonymousCircuitButProtectPages()
+    {
+        // #3117: without a dashboard policy the Blazor circuit (/_blazor) opts out of authorization
+        // so it stays reachable under a fail-closed FallbackPolicy, while the dashboard pages and the
+        // live-events hub carry no metadata of their own and remain governed by the host's policies
+        // (so scheduler data is never silently exposed to anonymous users).
+        await using WebApplication app = CreateApp();
+        app.MapQuartzDashboard();
+
+        List<RouteEndpoint> endpoints = GetRouteEndpoints(app);
+
+        // the /_blazor circuit endpoints are marked anonymous
+        List<RouteEndpoint> frameworkEndpoints = endpoints
+            .Where(e => e.RoutePattern.RawText?.StartsWith("/_blazor", StringComparison.Ordinal) == true)
+            .ToList();
+        frameworkEndpoints.Should().NotBeEmpty();
+        frameworkEndpoints.Should().OnlyContain(e => e.Metadata.GetMetadata<IAllowAnonymous>() != null);
+
+        // dashboard pages stay subject to the host fallback (neither anonymous nor explicitly authorized)
+        RouteEndpoint dashboardPage = endpoints.First(e => e.RoutePattern.RawText == "/quartz");
+        dashboardPage.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull();
+        dashboardPage.Metadata.GetMetadata<IAuthorizeData>().Should().BeNull();
+
+        // the live-events hub also stays behind the host fallback (it carries scheduler data)
+        RouteEndpoint hub = endpoints.First(e => e.RoutePattern.RawText == "/quartz/hub");
+        hub.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull();
+        hub.Metadata.GetMetadata<IAuthorizeData>().Should().BeNull();
+    }
+
+    [Test]
     public async Task IntegratedPolicyShouldNotLeakToHostEndpoints()
     {
         // regression test for #3066


### PR DESCRIPTION
## Problem

When the dashboard runs standalone with no `QuartzDashboardOptions.AuthorizationPolicy` and the host enforces a fail-closed `FallbackPolicy`, the Blazor circuit (`/_blazor`) is blocked because it carries no authorization metadata (#3117). Today only the Quartz-owned static-asset catch-all opts out via `AllowAnonymous` (#3097).

## Change

In the no-policy branch of `MapQuartzDashboardCore`, in **standalone mode only**, mark the non-page component endpoints (the `/_blazor` circuit; `GetComponentType() == null`) `AllowAnonymous` so the circuit stays reachable under a fail-closed `FallbackPolicy`.

Deliberately left **without** authorization metadata so they remain governed by the host's policies (scheduler data is never silently exposed to anonymous users):

- the dashboard **pages**, and
- the live-events **SignalR hub**.

Integrated mode is untouched — the host owns its own pages and Blazor plumbing (#3066); set `AuthorizationPolicy` there to gate the dashboard.

Host-owned assets — `/_framework/blazor.web.js` and any CSS served by `app.MapStaticAssets()` — are outside Quartz's control and cannot be annotated; that caveat is documented on `main` (companion docs-site PR).

## Tests

Added `StandaloneWithoutPolicyShouldAllowAnonymousCircuitButProtectPages` (asserts `/_blazor` is anonymous while `/quartz` and the hub carry neither `IAllowAnonymous` nor `IAuthorizeData`). Full `Quartz.Tests.AspNetCore` suite green (93/93); the pre-existing fail-closed E2E test (`/quartz` → 401, CSS → 200) still passes unchanged.

Relates to #3117 (3.x branch fix; docs land on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
