### PR TITLE
Allow the dashboard Blazor circuit anonymous access under a fail-closed FallbackPolicy + docs (#3117)

### DIFF
--- a/docs/documentation/quartz-3.x/packages/dashboard.md
+++ b/docs/documentation/quartz-3.x/packages/dashboard.md
@@ -113,7 +113,16 @@ app.UseEndpoints(endpoints =>
 });
 ```
 
-When `AuthorizationPolicy` is set, the policy is applied to the dashboard pages, the SignalR hub and the dashboard static asset endpoint. Without a policy, the static asset endpoint (`_content/Quartz.Dashboard/*`) explicitly allows anonymous access so that applications enforcing a fail-closed `FallbackPolicy` can still load the dashboard CSS and JavaScript — the files are public package content.
+When `AuthorizationPolicy` is set, the policy is applied to the dashboard pages, the SignalR hub, the Blazor circuit (`/_blazor`) and the dashboard static asset endpoint, so the whole dashboard is gated consistently — including under a fail-closed `FallbackPolicy`.
+
+Without a policy the dashboard adds no authorization of its own:
+
+- The static asset endpoint (`_content/Quartz.Dashboard/*`) and the Blazor circuit (`/_blazor`) explicitly allow anonymous access so the dashboard's plumbing keeps working under a fail-closed `FallbackPolicy` — these are public package content.
+- The dashboard **pages** and the **SignalR hub** carry no authorization metadata of their own, so they remain governed by your host's policies. Under a fail-closed `FallbackPolicy`, an unauthenticated request to `/quartz` is redirected to login (by design) while authenticated users get the full dashboard. To expose the dashboard to unauthenticated users, either don't enforce a fail-closed `FallbackPolicy` over the dashboard paths, or set an `AuthorizationPolicy` your users satisfy.
+
+::: warning Fail-closed `FallbackPolicy` with `MapStaticAssets()`
+Assets served by the host's `app.MapStaticAssets()` (the .NET 9/10 default) and the framework script `_framework/blazor.web.js` are served by **host/framework-owned endpoints** that Quartz cannot annotate, so a fail-closed `FallbackPolicy` blocks them for unauthenticated users regardless of the dashboard configuration. If you need them reachable before authentication (for example so the login page is styled), mark your static assets anonymous with `app.MapStaticAssets().AllowAnonymous();` — static web assets are public content. The classic `app.UseStaticFiles()` middleware runs before authorization and is not subject to the `FallbackPolicy`. See [API-only projects](#api-only-projects-no-razor-files) for the related `RequiresAspNetWebAssets` setting.
+:::
 
 ### API key or custom authorization checks
 

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -95,6 +95,17 @@ app.UseEndpoints(endpoints =>
 });
 ```
 
+When `AuthorizationPolicy` is set, the policy is applied to the dashboard pages, the SignalR hub, the Blazor circuit (`/_blazor`) and the dashboard static asset endpoint, so the whole dashboard is gated consistently — including under a fail-closed `FallbackPolicy`.
+
+Without a policy the dashboard adds no authorization of its own:
+
+- The static asset endpoint (`_content/Quartz.Dashboard/*`) and the Blazor circuit (`/_blazor`) explicitly allow anonymous access so the dashboard's plumbing keeps working under a fail-closed `FallbackPolicy` — these are public package content.
+- The dashboard **pages** and the **SignalR hub** carry no authorization metadata of their own, so they remain governed by your host's policies. Under a fail-closed `FallbackPolicy`, an unauthenticated request to `/quartz` is redirected to login (by design) while authenticated users get the full dashboard. To expose the dashboard to unauthenticated users, either don't enforce a fail-closed `FallbackPolicy` over the dashboard paths, or set an `AuthorizationPolicy` your users satisfy.
+
+::: warning Fail-closed `FallbackPolicy` with `MapStaticAssets()`
+Assets served by the host's `app.MapStaticAssets()` (the .NET 9/10 default) and the framework script `_framework/blazor.web.js` are served by **host/framework-owned endpoints** that Quartz cannot annotate, so a fail-closed `FallbackPolicy` blocks them for unauthenticated users regardless of the dashboard configuration. If you need them reachable before authentication (for example so the login page is styled), mark your static assets anonymous with `app.MapStaticAssets().AllowAnonymous();` — static web assets are public content. The classic `app.UseStaticFiles()` middleware runs before authorization and is not subject to the `FallbackPolicy`. See [API-only projects](#api-only-projects-no-razor-files) for the related `RequiresAspNetWebAssets` setting.
+:::
+
 ### API key or custom authorization checks
 
 If you need machine-to-machine access, use your API auth scheme (for example, an API key handler) and bind that to a policy used by `MapQuartzApi()`.

--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -181,10 +181,32 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         }
         else
         {
-            // Without a dashboard policy, static assets opt out of authorization so applications
-            // enforcing a fail-closed FallbackPolicy can still load dashboard CSS/JS; the files are
-            // public package content (#3097).
+            // Without a dashboard policy the dashboard adds no authorization of its own. The static
+            // asset endpoint opts out of authorization so applications enforcing a fail-closed
+            // FallbackPolicy can still load dashboard CSS/JS; the files are public package content (#3097).
             staticAssets.AllowAnonymous();
+
+            if (dashboardOwnsComponents)
+            {
+                // Standalone mode: the components builder contains only dashboard pages plus the
+                // Blazor framework/circuit endpoints (e.g. /_blazor). Mark the non-page endpoints
+                // AllowAnonymous so the circuit stays reachable under a fail-closed FallbackPolicy;
+                // the dashboard pages and the live-events hub are intentionally left without
+                // metadata so they remain governed by the host's policies and scheduler data is
+                // never silently exposed to anonymous users (#3117).
+                components.Add(endpointBuilder =>
+                {
+                    if (GetComponentType(endpointBuilder) is null)
+                    {
+                        endpointBuilder.Metadata.Add(new AllowAnonymousAttribute());
+                    }
+                });
+            }
+
+            // Integrated mode: the host owns its pages and Blazor plumbing, so the dashboard does
+            // not touch the shared components builder here (#3066). Set
+            // QuartzDashboardOptions.AuthorizationPolicy to make the dashboard reachable under a
+            // fail-closed FallbackPolicy in that case.
         }
     }
 

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
@@ -84,6 +84,36 @@ public class DashboardEndpointsTest
     }
 
     [Test]
+    public async Task StandaloneWithoutPolicyShouldAllowAnonymousCircuitButProtectPages()
+    {
+        // #3117: without a dashboard policy the Blazor circuit (/_blazor) opts out of authorization
+        // so it stays reachable under a fail-closed FallbackPolicy, while the dashboard pages and the
+        // live-events hub carry no metadata of their own and remain governed by the host's policies
+        // (so scheduler data is never silently exposed to anonymous users).
+        await using WebApplication app = CreateApp();
+        app.MapQuartzDashboard();
+
+        List<RouteEndpoint> endpoints = GetRouteEndpoints(app);
+
+        // the /_blazor circuit endpoints are marked anonymous
+        List<RouteEndpoint> frameworkEndpoints = endpoints
+            .Where(e => e.RoutePattern.RawText?.StartsWith("/_blazor", StringComparison.Ordinal) == true)
+            .ToList();
+        frameworkEndpoints.Should().NotBeEmpty();
+        frameworkEndpoints.Should().OnlyContain(e => e.Metadata.GetMetadata<IAllowAnonymous>() != null);
+
+        // dashboard pages stay subject to the host fallback (neither anonymous nor explicitly authorized)
+        RouteEndpoint dashboardPage = endpoints.First(e => e.RoutePattern.RawText == "/quartz");
+        dashboardPage.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull();
+        dashboardPage.Metadata.GetMetadata<IAuthorizeData>().Should().BeNull();
+
+        // the live-events hub also stays behind the host fallback (it carries scheduler data)
+        RouteEndpoint hub = endpoints.First(e => e.RoutePattern.RawText == "/quartz/hub");
+        hub.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull();
+        hub.Metadata.GetMetadata<IAuthorizeData>().Should().BeNull();
+    }
+
+    [Test]
     public async Task IntegratedPolicyShouldNotLeakToHostEndpoints()
     {
         // regression test for #3066


### PR DESCRIPTION
## Problem

When the dashboard runs standalone with no `QuartzDashboardOptions.AuthorizationPolicy` and the host enforces a fail-closed `FallbackPolicy`, the Blazor circuit (`/_blazor`) is blocked because it carries no authorization metadata (#3117). Today only the Quartz-owned static-asset catch-all opts out via `AllowAnonymous` (#3097).

## Change

In the no-policy branch of `MapQuartzDashboardCore`, in **standalone mode only**, mark the non-page component endpoints (the `/_blazor` circuit; `GetComponentType() == null`) `AllowAnonymous` so the circuit stays reachable under a fail-closed `FallbackPolicy`.

Deliberately left **without** authorization metadata so they remain governed by the host's policies (scheduler data is never silently exposed to anonymous users):

- the dashboard **pages**, and
- the live-events **SignalR hub**.

Integrated mode is untouched — the host owns its own pages and Blazor plumbing (#3066); set `AuthorizationPolicy` there to gate the dashboard.

## Docs

Host-owned assets — `/_framework/blazor.web.js` and any CSS served by `app.MapStaticAssets()` — are outside Quartz's control and cannot be annotated. The dashboard guide (`docs/documentation/quartz-3.x` and `quartz-4.x/packages/dashboard.md`) now documents the no-policy behavior and adds a caveat to exempt those host-owned assets (e.g. `app.MapStaticAssets().AllowAnonymous();`) under a fail-closed `FallbackPolicy`. (The published 3.x guide lives on `main`; the code/test change is in a companion PR to `3.x`, #3120.)

## Tests

Added `StandaloneWithoutPolicyShouldAllowAnonymousCircuitButProtectPages`. Full `Quartz.Tests.AspNetCore` suite green (93/93); the pre-existing fail-closed E2E test (`/quartz` → 401, CSS → 200) still passes unchanged.

Fixes #3117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
