### PR TITLE
Fix markdown-it DoS advisory in docs dependencies (#250)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6765,9 +6765,20 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -6884,14 +6895,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -10673,7 +10694,8 @@
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "uuid": "^11.1.1",
     "ws": "^8.20.1",
     "webpack-dev-server": "^5.2.4",
-    "launch-editor": "^2.14.1"
+    "launch-editor": "^2.14.1",
+    "markdown-it": "^14.2.0"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3122. After that PR cleared the original 9 alerts, a fresh Dependabot scan surfaced **2 remaining moderate alerts** in the VuePress docs dependency tree:

- **#250 markdown-it** (GHSA-6v5v-wf23-fmfq) — quadratic-complexity DoS in the smartquotes rule
- **#249 js-yaml** (GHSA-h67p-54hq-rp68) — quadratic-complexity DoS in merge-key handling

This PR resolves **#250** and intentionally leaves **#249** (rationale below).

## Fix: markdown-it → 14.2.0 (closes #250)

Pinned via the existing `overrides` block. Every consumer in the tree (`@vuepress/markdown`, the `@mdit-vue/*` and `@mdit/*` plugins, `markdownlint-cli2`) declares `markdown-it@^14`, so 14.2.0 is a drop-in minor upgrade — no range conflicts, no forced pins.

## Intentionally not fixed: js-yaml #249

The only patched js-yaml release is **4.2.0**, but `gray-matter@4.0.3` (the frontmatter parser pulled in transitively via `@mdit-vue/plugin-frontmatter`) calls `yaml.safeLoad`/`yaml.safeDump` — APIs **removed in js-yaml v4**. gray-matter binds them at module-load time (`engines.js`), so a forced `overrides` bump crashes the docs build on import, before any custom gray-matter engine could apply. gray-matter 4.0.3 is the latest release and still pins `js-yaml@^3`.

Fully clearing #249 would therefore require patching gray-matter's source (e.g. `patch-package` rewriting `safeLoad`/`safeDump` → `load`/`dump`), adding patch tooling + a `postinstall` hook to the docs build.

The advisory is a **quadratic-complexity DoS that requires maliciously crafted YAML input**. Docs frontmatter is maintainer-authored and parsed only at static build time — there is no untrusted YAML in this build — so it is **not exploitable here**. Left as-is to avoid adding patch tooling for a non-applicable advisory. (Happy to do the patch-package route in a follow-up if you'd prefer the dashboard fully green.)

## Testing
- `npm install` resolves cleanly; markdown-it confirmed at 14.2.0 across the tree.
- `npm run docs:build` (the **vite** bundler — the only path CI runs) compiles and renders all pages successfully.
- `npm audit` drops to the single remaining js-yaml advisory.

## Note (separate, pre-existing — not in this PR)
The alternate webpack bundler (`docs:build-webpack`) is broken on `main` independent of these changes — it fails on a missing `sass-loader` (a transitive lock entry that is never installed/declared). It is **not exercised by CI** (CI only runs the vite `docs:build`), so it's dormant. Can be fixed separately by adding `sass-loader` as a devDependency if the webpack path is meant to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)