### PR TITLE
Fix undici and http-proxy-middleware advisories in docs dependencies (#251, #252, #253)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5946,39 +5946,29 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
         "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+    "node_modules/http-proxy-middleware/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/hyperdyperid": {
@@ -10704,9 +10694,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "ws": "^8.20.1",
     "webpack-dev-server": "^5.2.4",
     "launch-editor": "^2.14.1",
-    "markdown-it": "^14.2.0"
+    "markdown-it": "^14.2.0",
+    "undici": "^7.28.0",
+    "http-proxy-middleware": "^3.0.6"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3122 and #3123. A new Dependabot scan surfaced **3 new alerts** in the VuePress docs dependency tree (`package-lock.json`). This PR resolves all three via the existing `overrides` block.

| Alert | Package | From → To | Severity | Advisory |
|-------|---------|-----------|----------|----------|
| #253 | undici | 7.24.7 → **7.28.0** | high | GHSA-vmh5-mc38-953g (TLS cert validation bypass) |
| #252 | undici | 7.24.7 → **7.28.0** | medium | GHSA-pr7r-676h-xcf6 (cross-user cache disclosure) |
| #251 | http-proxy-middleware | 2.0.9 → **3.0.7** | medium | GHSA-64mm-vxmg-q3vj (Host-header routing bypass) |

### undici → ^7.28.0 (closes #252, #253)
Pulled in transitively by `cheerio` (`^7.19.0`, via `@vuepress/helper`). 7.28.0 is an in-range minor bump — no conflicts. (undici 8.x exists but cheerio caps at 7.x.)

### http-proxy-middleware → ^3.0.6 (closes #251)
This is a **forced major bump (2 → 3)** and is unavoidable: the advisory has **no patched 2.x release** (v2-latest 2.0.10 is still vulnerable; the fix only lands in 3.0.6+), and even the latest `webpack-dev-server` still pins `http-proxy-middleware@^2`.

It's low-risk here because http-proxy-middleware is only consumed by `webpack-dev-server`, which:
- loads it **lazily**, only when a proxy is configured (`require` sits inside the proxy-setup branch of `Server.js`) — VuePress configures no proxy;
- is part of the **webpack dev-server path, which CI never runs** (CI runs only the vite `docs:build`).

v3 still exports `createProxyMiddleware`, so even that dormant path loads. The default vite build doesn't touch http-proxy-middleware at all.

## Testing
- `npm install` resolves cleanly; undici 7.28.0 and http-proxy-middleware 3.0.7 confirmed in the lockfile.
- `npm run docs:build` (the **vite** bundler — the only path CI runs) compiles and renders all **195 pages**.
- `npm audit` drops to just the single remaining js-yaml advisory (below).

## Still intentionally left: js-yaml #249
Unchanged from the discussion in #3123. The only js-yaml patch (4.2.0) removed `safeLoad`/`safeDump`, which `gray-matter@4.0.3` (frontmatter parser) binds at module-load time, so a forced override crashes the build; clearing it would require `patch-package` source surgery. The advisory is a quadratic DoS requiring malicious YAML input, and docs frontmatter is maintainer-authored/trusted, so it's not exploitable here. Left as-is to avoid adding patch tooling. (Still happy to do the patch-package route if you'd rather see the dashboard fully green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)