### PR TITLE
Speed up cron next-fire-time computation with a bitmask fast path

### DIFF
--- a/src/Quartz.Benchmark/CronComparisonBenchmark.cs
+++ b/src/Quartz.Benchmark/CronComparisonBenchmark.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+
+using BenchmarkDotNet.Attributes;
+
+using CronosCron = Cronos.CronExpression;
+using QuartzCron = Quartz.CronExpression;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// Head-to-head against the Cronos library as an external yardstick for cron
+/// parsing and next-occurrence performance.
+/// </summary>
+/// <remarks>
+/// Restricted to a 6-field, year-free subset of features both libraries support
+/// with identical semantics (simple, step, range, day-of-week, specific days).
+/// Quartz's year field and the L / W / # modifiers are intentionally excluded —
+/// Cronos either lacks them or interprets them differently, so including them
+/// would compare apples to oranges.
+/// </remarks>
+[MemoryDiagnoser]
+public class CronComparisonBenchmark
+{
+    /// <summary>Equivalent Quartz and Cronos expressions for one comparison row.</summary>
+    public sealed class CronCase
+    {
+        public CronCase(string label, string quartz, string cronos)
+        {
+            Label = label;
+            Quartz = quartz;
+            Cronos = cronos;
+        }
+
+        public string Label { get; }
+        public string Quartz { get; }
+        public string Cronos { get; }
+
+        public override string ToString() => Label;
+    }
+
+    public IEnumerable<CronCase> Cases =>
+    [
+        new CronCase("every-minute", "0 * * * * ?", "0 * * * * *"),
+        new CronCase("daily-noon", "0 0 12 * * ?", "0 0 12 * * *"),
+        new CronCase("every-5-min", "0 0/5 * * * ?", "0 0/5 * * * *"),
+        new CronCase("hours-range", "0 0 0-8 * * ?", "0 0 0-8 * * *"),
+        new CronCase("weekdays", "0 0 12 ? * MON-FRI", "0 0 12 * * 1-5"),
+        new CronCase("specific-days", "0 0 12 1,15 * ?", "0 0 12 1,15 * *")
+    ];
+
+    [ParamsSource(nameof(Cases))]
+    public CronCase Case { get; set; } = null!;
+
+    private QuartzCron quartzExpression = null!;
+    private CronosCron cronosExpression = null!;
+
+    private static readonly DateTime StartUtc = new(2024, 6, 1, 22, 15, 0, DateTimeKind.Utc);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        quartzExpression = new QuartzCron(Case.Quartz) { TimeZone = TimeZoneInfo.Utc };
+        cronosExpression = CronosCron.Parse(Case.Cronos, Cronos.CronFormat.IncludeSeconds);
+    }
+
+    [Benchmark]
+    public QuartzCron Quartz_Parse()
+    {
+        return new QuartzCron(Case.Quartz);
+    }
+
+    [Benchmark]
+    public CronosCron Cronos_Parse()
+    {
+        return CronosCron.Parse(Case.Cronos, Cronos.CronFormat.IncludeSeconds);
+    }
+
+    [Benchmark]
+    public DateTimeOffset? Quartz_GetNext()
+    {
+        return quartzExpression.GetNextValidTimeAfter(StartUtc);
+    }
+
+    [Benchmark]
+    public DateTime? Cronos_GetNext()
+    {
+        return cronosExpression.GetNextOccurrence(StartUtc);
+    }
+}

--- a/src/Quartz.Benchmark/CronExpressionBenchmark.cs
+++ b/src/Quartz.Benchmark/CronExpressionBenchmark.cs
@@ -5,6 +5,11 @@ using BenchmarkDotNet.Attributes;
 
 namespace Quartz.Benchmark;
 
+/// <summary>
+/// Measures cron parsing and next-fire-time computation separately so the
+/// effect of the bitmask fast path is visible on each. Run on a baseline commit
+/// and again after the change, then compare the Mean and Allocated columns.
+/// </summary>
 [MemoryDiagnoser]
 public class CronExpressionBenchmark
 {
@@ -13,23 +18,69 @@ public class CronExpressionBenchmark
 
     public IEnumerable<string> CronExpressionValues =>
     [
+        // simple / single value
         "0 15 10 * * ?",
-        "0 0/5 10 6,15 * ? *",
-        "0 15 10 15 * ? *",
-        "0 15 10 15,31 * ? *",
-        "0 15 10 6,15,LW * ? *",
-        "0 15 10 15,31 * ? *",
-        "0 15 10 15,L-2 * ? *",
-        "0 15 10 1,2,3,4,5,6,7,8,9,10,15,L * ? *",
-        "0 15 10 15,LW-2 * ? *",
-        "0 15 10 ? * 6#3 *"
+        "0 0 12 * * ?",
+        // every-N / step
+        "0 0/5 * * * ?",
+        "0/15 * * * * ?",
+        // ranges
+        "0 0-30 9-17 * * ?",
+        "0 0 8-18 ? * MON-FRI",
+        // many values (where the SortedSet GetViewBetween path hurt most)
+        "0 0,10,20,30,40,50 * * * ?",
+        "0 15 10 1,2,3,4,5,10,15,20,25 * ? *",
+        // last day / nearest weekday / nth weekday
+        "0 15 10 L * ?",
+        "0 15 10 L-2 * ?",
+        "0 15 10 LW * ?",
+        "0 15 10 ? * 6#3 *",
+        "0 15 10 ? * 6L",
+        // year-constrained (exercises the year field, intentionally kept on the set path)
+        "0 15 10 * * ? 2005-2025"
     ];
 
-    [Benchmark]
-    public void CreateExpressionsAndCalculateFireTimeAfter()
+    private CronExpression expression = null!;
+
+    // Mid-year start; the next occurrence usually lies a short distance away.
+    private static readonly DateTimeOffset Start = new DateTime(2005, 6, 1, 22, 15, 0);
+
+    [GlobalSetup]
+    public void Setup()
     {
-        var expression = new CronExpression(CronExpression);
-        expression.GetNextValidTimeAfter(new DateTime(2005, 6, 1, 22, 15, 0));
-        expression.GetNextValidTimeAfter(new DateTime(2005, 12, 31, 23, 59, 59));
+        expression = new CronExpression(CronExpression);
+    }
+
+    [Benchmark]
+    public CronExpression Parse()
+    {
+        return new CronExpression(CronExpression);
+    }
+
+    [Benchmark]
+    public DateTimeOffset? NextOccurrence()
+    {
+        return expression.GetNextValidTimeAfter(Start);
+    }
+
+    /// <summary>
+    /// Chains 100 next-fire computations, the most representative of real
+    /// scheduler load and the clearest amplifier of the per-call win and the
+    /// per-call allocations.
+    /// </summary>
+    [Benchmark]
+    public DateTimeOffset? NextOccurrences100()
+    {
+        DateTimeOffset? next = Start;
+        for (int i = 0; i < 100; i++)
+        {
+            next = expression.GetNextValidTimeAfter(next.Value);
+            if (next is null)
+            {
+                break;
+            }
+        }
+
+        return next;
     }
 }

--- a/src/Quartz.Benchmark/Program.cs
+++ b/src/Quartz.Benchmark/Program.cs
@@ -8,7 +8,7 @@ internal class Program
 {
     private static void Main(string[] args)
     {
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run();
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
         //DispatchBenchmark();
     }

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <!-- External reference point for the cron head-to-head benchmark. -->
+    <PackageReference Include="Cronos" Version="0.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Tests.Unit/CronExpressionDifferentialTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDifferentialTest.cs
@@ -1,0 +1,260 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Differential / property tests for the bitmask fast path added to
+/// <see cref="CronExpression" />. These guard against the bitmask diverging
+/// from the original SortedSet-based behaviour, including the De Bruijn
+/// trailing-zero fallback used on frameworks without
+/// <c>System.Numerics.BitOperations</c> (net462/net472/netstandard2.0).
+/// </summary>
+/// <author>Marko Lahma (.NET)</author>
+public class CronExpressionDifferentialTest
+{
+    /// <summary>
+    /// <see cref="BitUtil.TrailingZeroCount" /> must match a naive reference for
+    /// every single-bit value and for a large number of random values. On the
+    /// full framework this exercises the De Bruijn table; on .NET it exercises
+    /// the BitOperations intrinsic.
+    /// </summary>
+    [Test]
+    public void TrailingZeroCount_MatchesReference()
+    {
+        BitUtil.TrailingZeroCount(0).Should().Be(64, "zero has no set bit");
+
+        for (int bit = 0; bit < 64; bit++)
+        {
+            ulong value = 1UL << bit;
+            BitUtil.TrailingZeroCount(value).Should().Be(bit);
+        }
+
+        var random = new Random(20250623);
+        for (int i = 0; i < 50_000; i++)
+        {
+            ulong value = NextUlong(random);
+            if (value == 0)
+            {
+                continue;
+            }
+
+            BitUtil.TrailingZeroCount(value).Should().Be(ReferenceTrailingZeroCount(value));
+        }
+    }
+
+    /// <summary>
+    /// The bitmask "next allowed value" scan must return, for every start in
+    /// range, the smallest set member greater than or equal to start — verified
+    /// against an independent linear-scan reference.
+    /// </summary>
+    [Test]
+    public void BitmaskNextValue_MatchesReference()
+    {
+        var random = new Random(1337);
+
+        for (int iteration = 0; iteration < 20_000; iteration++)
+        {
+            // Build a random set of values in [0, 63] and the equivalent mask.
+            var set = new SortedSet<int>();
+            ulong mask = 0;
+            int count = random.Next(0, 12);
+            for (int i = 0; i < count; i++)
+            {
+                int value = random.Next(0, 64);
+                set.Add(value);
+                mask |= 1UL << value;
+            }
+
+            for (int start = 0; start < 64; start++)
+            {
+                // Reference: smallest set member >= start, if any.
+                int? expectedMin = null;
+                foreach (int v in set)
+                {
+                    if (v >= start)
+                    {
+                        expectedMin = v;
+                        break;
+                    }
+                }
+
+                bool actual = BitUtil.TryGetMinValueStartingFrom(mask, start, out int actualMin);
+
+                actual.Should().Be(expectedMin.HasValue, "start={0}, set=[{1}]", start, string.Join(",", set));
+                if (expectedMin.HasValue)
+                {
+                    actualMin.Should().Be(expectedMin.Value, "start={0}, set=[{1}]", start, string.Join(",", set));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// End-to-end property test: for randomly generated time-of-day expressions
+    /// (random seconds/minutes/hours, every day) the next fire time computed by
+    /// <see cref="CronExpression.GetNextValidTimeAfter" /> must equal the result
+    /// of an independent brute-force second-by-second scan.
+    /// </summary>
+    [Test]
+    public void GetNextValidTimeAfter_MatchesBruteForce_TimeOfDay()
+    {
+        var random = new Random(987654321);
+
+        for (int iteration = 0; iteration < 500; iteration++)
+        {
+            HashSet<int> secs = RandomSubset(random, 0, 59, maxCount: 4);
+            HashSet<int> mins = RandomSubset(random, 0, 59, maxCount: 4);
+            HashSet<int> hours = RandomSubset(random, 0, 23, maxCount: 4);
+
+            string expr = $"{Join(secs)} {Join(mins)} {Join(hours)} * * ?";
+            var cron = new CronExpression(expr) { TimeZone = TimeZoneInfo.Utc };
+
+            // Random start somewhere across a few years, truncated to seconds.
+            DateTimeOffset start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                .AddSeconds(random.Next(0, 3 * 365 * 24 * 60 * 60));
+
+            DateTimeOffset? actual = cron.GetNextValidTimeAfter(start);
+
+            // Independent oracle: every day fires, so the next match is within
+            // ~26 hours regardless of the start second.
+            DateTimeOffset? expected = null;
+            for (int i = 1; i <= 26 * 60 * 60; i++)
+            {
+                DateTimeOffset candidate = start.AddSeconds(i);
+                if (secs.Contains(candidate.Second) && mins.Contains(candidate.Minute) && hours.Contains(candidate.Hour))
+                {
+                    expected = candidate;
+                    break;
+                }
+            }
+
+            expected.Should().NotBeNull("expression {0} fires daily", expr);
+            actual.Should().Be(expected, "expression {0}, start {1:O}", expr, start);
+        }
+    }
+
+    /// <summary>
+    /// End-to-end property test for the day-of-month mask: random day sets with
+    /// a fixed time of day, verified by an independent day-by-day scan.
+    /// </summary>
+    [Test]
+    public void GetNextValidTimeAfter_MatchesBruteForce_DayOfMonth()
+    {
+        var random = new Random(424242);
+
+        for (int iteration = 0; iteration < 500; iteration++)
+        {
+            HashSet<int> days = RandomSubset(random, 1, 28, maxCount: 5); // <=28 to fire every month
+            HashSet<int> months = RandomSubset(random, 1, 12, maxCount: 4);
+
+            string expr = $"0 0 12 {Join(days)} {Join(months)} ?";
+            var cron = new CronExpression(expr) { TimeZone = TimeZoneInfo.Utc };
+
+            DateTimeOffset start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                .AddDays(random.Next(0, 2 * 365));
+
+            DateTimeOffset? actual = cron.GetNextValidTimeAfter(start);
+
+            DateTimeOffset? expected = null;
+            var noonOnStartDay = new DateTimeOffset(start.Year, start.Month, start.Day, 12, 0, 0, TimeSpan.Zero);
+            for (int i = 0; i <= 400; i++)
+            {
+                DateTimeOffset candidate = noonOnStartDay.AddDays(i);
+                if (candidate > start && days.Contains(candidate.Day) && months.Contains(candidate.Month))
+                {
+                    expected = candidate;
+                    break;
+                }
+            }
+
+            expected.Should().NotBeNull("expression {0} fires within a year", expr);
+            actual.Should().Be(expected, "expression {0}, start {1:O}", expr, start);
+        }
+    }
+
+    private static HashSet<int> RandomSubset(Random random, int min, int max, int maxCount)
+    {
+        int count = random.Next(1, maxCount + 1);
+        var result = new HashSet<int>();
+        while (result.Count < count)
+        {
+            result.Add(random.Next(min, max + 1));
+        }
+
+        return result;
+    }
+
+    private static string Join(IEnumerable<int> values)
+    {
+        return string.Join(",", values.OrderBy(v => v));
+    }
+
+    private static int ReferenceTrailingZeroCount(ulong value)
+    {
+        int count = 0;
+        while ((value & 1) == 0)
+        {
+            count++;
+            value >>= 1;
+        }
+
+        return count;
+    }
+
+    private static ulong NextUlong(Random random)
+    {
+        // Mix two 32-bit draws and occasionally sparse/dense patterns.
+        var bytes = new byte[8];
+        random.NextBytes(bytes);
+        ulong value = BitConverter.ToUInt64(bytes, 0);
+
+        // Bias some iterations toward few set bits to stress the lowest-bit path.
+        if (random.Next(0, 3) == 0)
+        {
+            value &= NextUlongFewBits(random);
+        }
+
+        return value;
+    }
+
+    private static ulong NextUlongFewBits(Random random)
+    {
+        ulong value = 0;
+        int bits = random.Next(1, 4);
+        for (int i = 0; i < bits; i++)
+        {
+            value |= 1UL << random.Next(0, 64);
+        }
+
+        return value;
+    }
+}

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -347,6 +347,33 @@ public class CronExpression : IDeserializationCallback, ISerializable
     /// </summary>
     [NonSerialized] protected bool expressionParsed;
 
+    // Bitmask fast-path representations of the parsed fields, derived from the
+    // SortedSet fields after parsing (see BuildBitmasks). GetTimeAfter uses
+    // these to locate the next allowed value via a trailing-zero bit scan
+    // instead of a SortedSet lookup, avoiding the GetViewBetween allocation and
+    // the red-black-tree walk on the hot path. Only values 0-63 are encoded;
+    // the years field stays on the set path because its range is open-ended.
+    // The sets remain the source of truth (and the public/protected surface).
+    [NonSerialized] private ulong secondsBits;
+    [NonSerialized] private ulong minutesBits;
+    [NonSerialized] private ulong hoursBits;
+    [NonSerialized] private ulong daysOfMonthBits;
+    [NonSerialized] private ulong monthsBits;
+    [NonSerialized] private ulong daysOfWeekBits;
+
+    // Cached minimums (== the corresponding set's Min), read on the wrap-around
+    // path in GetTimeAfter.
+    [NonSerialized] private int secondsMin;
+    [NonSerialized] private int minutesMin;
+    [NonSerialized] private int hoursMin;
+    [NonSerialized] private int daysOfMonthMin;
+    [NonSerialized] private int monthsMin;
+    [NonSerialized] private int daysOfWeekMin;
+
+    // Cached "is '?' (no specific value)" flags for the day fields.
+    [NonSerialized] private bool daysOfMonthNoSpec;
+    [NonSerialized] private bool daysOfWeekNoSpec;
+
     public static readonly int MaxYear = DateTime.Now.Year + 100;
 
     private static readonly char[] splitSeparators = [' ', '\t', '\r', '\n'];
@@ -966,6 +993,8 @@ public class CronExpression : IDeserializationCallback, ISerializable
             {
                 throw new FormatException("Support for specifying both a day-of-week AND a day-of-month parameter is not implemented.");
             }
+
+            BuildBitmasks();
         }
         catch (FormatException)
         {
@@ -975,6 +1004,52 @@ public class CronExpression : IDeserializationCallback, ISerializable
         {
             throw new FormatException($"Illegal cron expression format ({e.Message})", e);
         }
+    }
+
+    /// <summary>
+    /// Builds the bitmask fast-path representation from the parsed SortedSet
+    /// fields. Called at the end of <see cref="BuildExpression" /> — which runs
+    /// from both the constructor and deserialization — so the masks always stay
+    /// in sync with the sets, including for subclasses that override
+    /// <see cref="AddToSet" /> or <see cref="GetSet" />. Sentinel markers
+    /// (AllSpec, NoSpec) and any value outside 0-63 are skipped; the years field
+    /// is intentionally not masked because its range is open-ended.
+    /// </summary>
+    private void BuildBitmasks()
+    {
+        secondsBits = ToBitmask(seconds);
+        minutesBits = ToBitmask(minutes);
+        hoursBits = ToBitmask(hours);
+        daysOfMonthBits = ToBitmask(daysOfMonth);
+        monthsBits = ToBitmask(months);
+        daysOfWeekBits = ToBitmask(daysOfWeek);
+
+        secondsMin = seconds.Min;
+        minutesMin = minutes.Min;
+        hoursMin = hours.Min;
+        daysOfMonthMin = daysOfMonth.Min;
+        monthsMin = months.Min;
+        daysOfWeekMin = daysOfWeek.Min;
+
+        daysOfMonthNoSpec = daysOfMonth.Contains(NoSpec);
+        daysOfWeekNoSpec = daysOfWeek.Contains(NoSpec);
+    }
+
+    private static ulong ToBitmask(SortedSet<int> set)
+    {
+        ulong bits = 0;
+        foreach (int value in set)
+        {
+            // Skip the AllSpec/NoSpec sentinels (98/99) and any out-of-range
+            // value; for '*' the set also contains the real values, so the mask
+            // still captures the wildcard correctly.
+            if ((uint) value <= 63)
+            {
+                bits |= 1UL << value;
+            }
+        }
+
+        return bits;
     }
 
     /// <summary>
@@ -1931,13 +2006,13 @@ public class CronExpression : IDeserializationCallback, ISerializable
             int sec = d.Second;
 
             // get second.................................................
-            if (seconds.TryGetMinValueStartingFrom(sec, out int nextSec))
+            if (BitUtil.TryGetMinValueStartingFrom(secondsBits, sec, out int nextSec))
             {
                 sec = nextSec;
             }
             else
             {
-                sec = seconds.Min;
+                sec = secondsMin;
                 d = d.AddMinutes(1);
             }
             d = new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, d.Minute, sec, d.Millisecond, d.Offset);
@@ -1947,14 +2022,14 @@ public class CronExpression : IDeserializationCallback, ISerializable
             t = -1;
 
             // get minute.................................................
-            if (minutes.TryGetMinValueStartingFrom(min, out int nextMin))
+            if (BitUtil.TryGetMinValueStartingFrom(minutesBits, min, out int nextMin))
             {
                 t = min;
                 min = nextMin;
             }
             else
             {
-                min = minutes.Min;
+                min = minutesMin;
                 hr++;
             }
             if (min != t)
@@ -1970,14 +2045,14 @@ public class CronExpression : IDeserializationCallback, ISerializable
             t = -1;
 
             // get hour...................................................
-            if (hours.TryGetMinValueStartingFrom(hr, out int nextHr))
+            if (BitUtil.TryGetMinValueStartingFrom(hoursBits, hr, out int nextHr))
             {
                 t = hr;
                 hr = nextHr;
             }
             else
             {
-                hr = hours.Min;
+                hr = hoursMin;
                 day++;
             }
             if (hr != t)
@@ -2002,12 +2077,12 @@ public class CronExpression : IDeserializationCallback, ISerializable
             int tmon = mon;
 
             // get day...................................................
-            bool dayOfMSpec = !daysOfMonth.Contains(NoSpec);
-            bool dayOfWSpec = !daysOfWeek.Contains(NoSpec);
+            bool dayOfMSpec = !daysOfMonthNoSpec;
+            bool dayOfWSpec = !daysOfWeekNoSpec;
             if (dayOfMSpec && !dayOfWSpec)
             {
                 // get day by day of month rule
-                bool found = daysOfMonth.TryGetMinValueStartingFrom(day, out int nextDay);
+                bool found = BitUtil.TryGetMinValueStartingFrom(daysOfMonthBits, day, out int nextDay);
                 if (lastdayOfMonth)
                 {
                     if (!nearestWeekday)
@@ -2067,7 +2142,7 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 else if (nearestWeekday)
                 {
                     t = day;
-                    day = daysOfMonth.Min;
+                    day = daysOfMonthMin;
 
                     int ldom = GetLastDayOfMonth(mon, d.Year);
                     if (day > ldom)
@@ -2099,7 +2174,7 @@ public class CronExpression : IDeserializationCallback, ISerializable
                     tcal = new DateTimeOffset(tcal.Year, mon, day, hr, min, sec, d.Offset);
                     if (tcal.ToUniversalTime() < afterTimeUtc)
                     {
-                        day = daysOfMonth.Min;
+                        day = daysOfMonthMin;
                         mon++;
                     }
                 }
@@ -2112,13 +2187,13 @@ public class CronExpression : IDeserializationCallback, ISerializable
                     int lastDay = GetLastDayOfMonth(mon, d.Year);
                     if (day > lastDay)
                     {
-                        day = daysOfMonth.Min;
+                        day = daysOfMonthMin;
                         mon++;
                     }
                 }
                 else
                 {
-                    day = daysOfMonth.Min;
+                    day = daysOfMonthMin;
                     mon++;
                 }
 
@@ -2153,7 +2228,7 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 {
                     // are we looking for the last XXX day of
                     // the month?
-                    int dow = daysOfWeek.Min; // desired
+                    int dow = daysOfWeekMin; // desired
                     // d-o-w
                     int cDow = (int) d.DayOfWeek + 1; // current d-o-w
                     int daysToAdd = 0;
@@ -2203,7 +2278,7 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 else if (nthdayOfWeek != 0)
                 {
                     // are we looking for the Nth XXX day in the month?
-                    int dow = daysOfWeek.Min; // desired
+                    int dow = daysOfWeekMin; // desired
                     // d-o-w
                     int cDow = (int) d.DayOfWeek + 1; // current d-o-w
                     int daysToAdd = 0;
@@ -2251,9 +2326,9 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 else if (everyNthWeek != 0)
                 {
                     int cDow = (int)d.DayOfWeek + 1; // current d-o-w
-                    int dow = daysOfWeek.Min; // desired
+                    int dow = daysOfWeekMin; // desired
                     // d-o-w
-                    if (daysOfWeek.TryGetMinValueStartingFrom(cDow, out int nextDow))
+                    if (BitUtil.TryGetMinValueStartingFrom(daysOfWeekBits, cDow, out int nextDow))
                     {
                         dow = nextDow;
                     }
@@ -2297,9 +2372,9 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 else
                 {
                     int cDow = (int) d.DayOfWeek + 1; // current d-o-w
-                    int dow = daysOfWeek.Min; // desired
+                    int dow = daysOfWeekMin; // desired
                     // d-o-w
-                    if (daysOfWeek.TryGetMinValueStartingFrom(cDow, out int nextDow))
+                    if (BitUtil.TryGetMinValueStartingFrom(daysOfWeekBits, cDow, out int nextDow))
                     {
                         dow = nextDow;
                     }
@@ -2360,14 +2435,14 @@ public class CronExpression : IDeserializationCallback, ISerializable
             }
 
             // get month...................................................
-            if (months.TryGetMinValueStartingFrom(mon, out int nextMonth))
+            if (BitUtil.TryGetMinValueStartingFrom(monthsBits, mon, out int nextMonth))
             {
                 t = mon;
                 mon = nextMonth;
             }
             else
             {
-                mon = months.Min;
+                mon = monthsMin;
                 year++;
             }
             if (mon != t)

--- a/src/Quartz/Util/BitUtil.cs
+++ b/src/Quartz/Util/BitUtil.cs
@@ -1,0 +1,105 @@
+#if NET8_0_OR_GREATER
+using System.Numerics;
+#endif
+
+namespace Quartz.Util;
+
+/// <summary>
+/// Bit manipulation helpers used by the cron expression engine to scan
+/// bitmask-encoded field values without allocating or walking collections.
+/// </summary>
+/// <remarks>
+/// On modern runtimes the operations delegate to the hardware-accelerated
+/// <c>System.Numerics.BitOperations</c>. On frameworks that do not expose it
+/// (net462, net472, netstandard2.0) a De Bruijn sequence lookup is used as a
+/// portable fallback.
+/// </remarks>
+internal static class BitUtil
+{
+#if !NET8_0_OR_GREATER
+    // De Bruijn sequence B(2, 6) and the matching lookup table for the index of
+    // the lowest set bit. See https://www.chessprogramming.org/BitScan.
+    private const ulong DeBruijn64 = 0x03f79d71b4cb0a89UL;
+
+    private static readonly int[] DeBruijnPositions =
+    [
+        0, 1, 48, 2, 57, 49, 28, 3,
+        61, 58, 50, 42, 38, 29, 17, 4,
+        62, 55, 59, 36, 53, 51, 43, 22,
+        45, 39, 33, 30, 24, 18, 12, 5,
+        63, 47, 56, 27, 60, 41, 37, 16,
+        54, 35, 52, 21, 44, 32, 23, 11,
+        46, 26, 40, 15, 34, 20, 31, 10,
+        25, 14, 19, 9, 13, 8, 7, 6
+    ];
+#endif
+
+    /// <summary>
+    /// Returns the number of trailing zero bits in <paramref name="value" />,
+    /// i.e. the zero-based index of its lowest set bit. Returns 64 when
+    /// <paramref name="value" /> is zero (matching <c>BitOperations</c>).
+    /// </summary>
+    internal static int TrailingZeroCount(ulong value)
+    {
+#if NET8_0_OR_GREATER
+        return BitOperations.TrailingZeroCount(value);
+#else
+        if (value == 0)
+        {
+            return 64;
+        }
+
+        // Isolate the lowest set bit, multiply by the De Bruijn constant and
+        // use the top 6 bits as an index into the position table.
+        ulong isolated = value & (0UL - value);
+        return DeBruijnPositions[(isolated * DeBruijn64) >> 58];
+#endif
+    }
+
+    /// <summary>
+    /// Returns the number of set bits in <paramref name="value" />.
+    /// </summary>
+    internal static int PopCount(ulong value)
+    {
+#if NET8_0_OR_GREATER
+        return BitOperations.PopCount(value);
+#else
+        // SWAR popcount (Hacker's Delight).
+        value -= (value >> 1) & 0x5555555555555555UL;
+        value = (value & 0x3333333333333333UL) + ((value >> 2) & 0x3333333333333333UL);
+        value = (value + (value >> 4)) & 0x0f0f0f0f0f0f0f0fUL;
+        return (int) ((value * 0x0101010101010101UL) >> 56);
+#endif
+    }
+
+    /// <summary>
+    /// Finds the smallest value present in <paramref name="bits" /> that is
+    /// greater than or equal to <paramref name="start" />. This is the bitmask
+    /// equivalent of locating the next allowed value in a sorted set, in O(1)
+    /// and without allocation.
+    /// </summary>
+    /// <param name="bits">Bitmask where bit <c>i</c> set means value <c>i</c> is allowed.</param>
+    /// <param name="start">Inclusive lower bound to search from.</param>
+    /// <param name="min">The matched value, when one exists.</param>
+    /// <returns><see langword="true" /> when a value &gt;= <paramref name="start" /> exists; otherwise <see langword="false" />.</returns>
+    internal static bool TryGetMinValueStartingFrom(ulong bits, int start, out int min)
+    {
+        if (start is < 0 or > 63)
+        {
+            min = 0;
+            return false;
+        }
+
+        // Mask off everything below start, then the lowest remaining set bit is
+        // the next allowed value.
+        ulong atOrAbove = bits & (~0UL << start);
+        if (atOrAbove != 0)
+        {
+            min = TrailingZeroCount(atOrAbove);
+            return true;
+        }
+
+        min = 0;
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Inspired by the [Cronos](https://github.com/HangfireIO/Cronos) library, which represents each cron field as an integer bitmask and finds the next matching value with a trailing-zero bit scan. `CronExpression.GetTimeAfter` (run once per trigger fire on the scheduler hot path) previously located the next allowed value for each field via `SortedSet<int>` lookups whose slow path allocates a `GetViewBetween` view and walks a red-black tree.

This PR adds a **non-breaking** bitmask fast path:

- New `Quartz.Util.BitUtil` — `TrailingZeroCount` via `System.Numerics.BitOperations` on net8+, with a De Bruijn lookup-table fallback for `net462`/`net472`/`netstandard2.0`.
- `CronExpression` keeps its `protected SortedSet<int>` fields and `GetSet`/`AddToSet` exactly as-is (no public/protected API or serialization break), and additionally builds `[NonSerialized]` bitmask fields from those sets after parsing (`BuildBitmasks`, called from `BuildExpression`, so it also runs on deserialize and for subclasses).
- `GetTimeAfter` routes its seconds/minutes/hours/months/days lookups through an O(1) bit scan. The `years` field stays on the set path (open-ended range).

## Results

`BenchmarkDotNet`, AMD Ryzen 9 5950X, .NET 10, ShortRun. Next-occurrence (`GetNextValidTimeAfter`):

| Expression | Before | After |
|---|---|---|
| `0 0/5 * * * ?` (×100) | 48.1 µs / 22,816 B | 32.5 µs / **0 B** |
| `0/15 * * * * ?` (×100) | 40.7 µs / 18,600 B | 26.5 µs / **0 B** |
| `0 0,10,…,50 * * * ?` (×100) | 44.0 µs / 20,832 B | 32.4 µs / **0 B** |
| single call, typical | 400–880 ns | 6–35% faster, **0 B** |

The hot path is now allocation-free; expressions with ranges/steps/lists (which hit the old `GetViewBetween` slow path) see the largest gains. Parsing is intentionally unchanged on this branch (the layered approach keeps the sets); the bitmask-parse win is on the 4.x PR.

External yardstick (`CronComparisonBenchmark` vs Cronos 0.13.0, equivalent 6-field expressions): Quartz `GetNext` is now zero-allocation like Cronos; absolute time is still ~8–20× Cronos because the loop constructs many `DateTimeOffset` values per iteration (a deeper rewrite, out of scope here).

## Validation

- All existing cron tests pass on **net10.0 and net472** (the net472 run exercises the De Bruijn fallback): `CronExpressionTest`, `CronExpressionHashTest`, `CronTriggerTest`, `CronScheduleBuilderTest` — 296 cron cases; full unit suite 1384 green.
- New `CronExpressionDifferentialTest` — seeded-random expressions vs an independent brute-force oracle, plus a `BitUtil` fuzz test, run on both TFMs.
- Benchmarks restructured (separate parse / next-occurrence / 100-call chain) and a Cronos head-to-head added.

The companion 4.x change is #3127 (puts the bitmask inside `CronField`, also speeding parse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEQMdnqSWJkTN7KDemLtre
