### PR TITLE
Reduce DateTimeOffset churn in the cron next-fire-time loop (3.x)

### DIFF
--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -2006,16 +2006,25 @@ public class CronExpression : IDeserializationCallback, ISerializable
             int sec = d.Second;
 
             // get second.................................................
+            bool secondChanged;
             if (BitUtil.TryGetMinValueStartingFrom(secondsBits, sec, out int nextSec))
             {
+                secondChanged = nextSec != sec;
                 sec = nextSec;
             }
             else
             {
                 sec = secondsMin;
                 d = d.AddMinutes(1);
+                secondChanged = true;
             }
-            d = new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, d.Minute, sec, d.Millisecond, d.Offset);
+
+            // only rebuild the date when something actually changed; each d.* read
+            // re-decomposes the tick count, so the unchanged case is pure waste
+            if (secondChanged)
+            {
+                d = new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, d.Minute, sec, d.Millisecond, d.Offset);
+            }
 
             int min = d.Minute;
             int hr = d.Hour;
@@ -2038,7 +2047,7 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 d = SetCalendarHour(d, hr);
                 continue;
             }
-            d = new DateTimeOffset(d.Year, d.Month, d.Day, d.Hour, min, d.Second, d.Millisecond, d.Offset);
+            // minute unchanged here (min == t), so d already holds the right value
 
             hr = d.Hour;
             int day = d.Day;
@@ -2069,7 +2078,7 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 d = SetCalendarHour(d, hr);
                 continue;
             }
-            d = new DateTimeOffset(d.Year, d.Month, d.Day, hr, d.Minute, d.Second, d.Millisecond, d.Offset);
+            // hour unchanged here (hr == t), so d already holds the right value
 
             day = d.Day;
             int mon = d.Month;
@@ -2422,7 +2431,12 @@ public class CronExpression : IDeserializationCallback, ISerializable
                     "Support for specifying both a day-of-week AND a day-of-month parameter is not implemented.");
             }
 
-            d = new DateTimeOffset(d.Year, d.Month, day, d.Hour, d.Minute, d.Second, d.Offset);
+            // only rebuild when the day actually changed (it often already matches)
+            if (day != d.Day)
+            {
+                d = new DateTimeOffset(d.Year, d.Month, day, d.Hour, d.Minute, d.Second, d.Offset);
+            }
+
             mon = d.Month;
             int year = d.Year;
             t = -1;
@@ -2450,7 +2464,7 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 d = new DateTimeOffset(year, mon, 1, 0, 0, 0, d.Offset);
                 continue;
             }
-            d = new DateTimeOffset(d.Year, mon, d.Day, d.Hour, d.Minute, d.Second, d.Offset);
+            // month unchanged here (mon == t), so d already holds the right value
             year = d.Year;
             t = -1;
 
@@ -2470,7 +2484,7 @@ public class CronExpression : IDeserializationCallback, ISerializable
                 d = new DateTimeOffset(year, 1, 1, 0, 0, 0, d.Offset);
                 continue;
             }
-            d = new DateTimeOffset(year, d.Month, d.Day, d.Hour, d.Minute, d.Second, d.Offset);
+            // year unchanged here (year == t), so d already holds the right value
 
             //apply the proper offset for this date
             var localDateTime = d.DateTime;

--- a/src/Quartz/Util/BitUtil.cs
+++ b/src/Quartz/Util/BitUtil.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 #if NET8_0_OR_GREATER
 using System.Numerics;
 #endif
@@ -39,6 +41,7 @@ internal static class BitUtil
     /// i.e. the zero-based index of its lowest set bit. Returns 64 when
     /// <paramref name="value" /> is zero (matching <c>BitOperations</c>).
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int TrailingZeroCount(ulong value)
     {
 #if NET8_0_OR_GREATER
@@ -59,6 +62,7 @@ internal static class BitUtil
     /// <summary>
     /// Returns the number of set bits in <paramref name="value" />.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int PopCount(ulong value)
     {
 #if NET8_0_OR_GREATER
@@ -82,13 +86,12 @@ internal static class BitUtil
     /// <param name="start">Inclusive lower bound to search from.</param>
     /// <param name="min">The matched value, when one exists.</param>
     /// <returns><see langword="true" /> when a value &gt;= <paramref name="start" /> exists; otherwise <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool TryGetMinValueStartingFrom(ulong bits, int start, out int min)
     {
-        if (start is < 0 or > 63)
-        {
-            min = 0;
-            return false;
-        }
+        // Callers only ever pass a value within the field's natural domain
+        // (0-59, 0-23, 1-31, 1-12, 1-7), so start is always in [0, 63].
+        Debug.Assert(start is >= 0 and <= 63, "start must be in [0, 63]");
 
         // Mask off everything below start, then the lowest remaining set bit is
         // the next allowed value.


### PR DESCRIPTION
## Summary

Port to 3.x of the main-branch `DateTimeOffset`-churn optimization (#3128), follow-up to #3126.

`GetTimeAfter` rebuilt a `DateTimeOffset` after every field even when the field already matched — and since each `d.Year` / `d.Month` / `d.Day` / … access re-decomposes the tick count, an unchanged rebuild cost several decompositions plus a recomposition. In the common steady state most fields are already satisfied, so this was wasted work.

- The second / minute / hour / day / month / year sections now **skip rebuilding the date when the field didn't change**. The value they used to rebuild is provably identical to the existing one (same components, milliseconds already stripped at loop entry, same offset), so behavior is unchanged.
- `BitUtil.TrailingZeroCount` / `PopCount` / `TryGetMinValueStartingFrom` are marked `[MethodImpl(AggressiveInlining)]`; the dead "`start` outside `[0,63]`" guard on the hottest method becomes a `Debug.Assert`.

## Results

`BenchmarkDotNet`, AMD Ryzen 9 5950X, .NET 10, ShortRun. `GetNextValidTimeAfter`, before (`origin/3.x` = #3126) → after:

| Expression | Before | After | Δ |
|---|---:|---:|---:|
| `0/15 * * * * ?` | 259 ns | 188 ns | −27% |
| `0 0,10,…,50 * * * ?` | 322 ns | 234 ns | −27% |
| `0 0/5 * * * ?` | 323 ns | 234 ns | −28% |
| `0 15 10 * * ?` | 459 ns | 320 ns | −30% |
| `0 0-30 9-17 * * ?` | 352 ns | 239 ns | −32% |
| `0 0 8-18 ? * MON-FRI` | 413 ns | 280 ns | −32% |
| `0 0 12 * * ?` | 414 ns | 271 ns | −35% |
| `0 15 10 L * ?` | 728 ns | 470 ns | −35% |
| `0 15 10 LW * ?` | 784 ns | 516 ns | −34% |
| `0 15 10 ? * 6L` | 726 ns | 467 ns | −36% |
| `0 15 10 ? * 6#3 *` | 736 ns | 472 ns | −36% |

27–36% faster (the win is larger than on main because the monolithic 3.x loop rebuilt the date after every field). Allocation is unchanged (already zero on these paths).

## Validation

- All cron tests pass on **net10.0 and net472** (the net472 run exercises the De Bruijn fallback) — 300 cron cases; full unit suite 1401 green; includes the randomized differential test from #3126.
- Each skipped rebuild is guarded by the exact condition under which the value is identical to the existing date, so behavior is unchanged by construction.

Note: 3.x's `L`/`W` day-of-month handling is already allocation-free (it computes the day inline, with no per-month `SortedSet`), so the companion L/W zero-allocation change in #3128 has no 3.x counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEQMdnqSWJkTN7KDemLtre
