### PR TITLE
Fix dashboard JobDataMap and SimpleSchedule trigger display

### DIFF
--- a/src/Quartz.Dashboard/Components/Pages/JobDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/JobDetail.razor
@@ -77,6 +77,8 @@
                 <thead>
                     <tr>
                         <th>Trigger</th>
+                        <th>Type</th>
+                        <th>Schedule</th>
                         <th>State</th>
                     </tr>
                 </thead>
@@ -85,6 +87,8 @@
                     {
                         string triggerGroup = DisplayValueHelper.GetString(trigger, "Group", "Key.Group");
                         string triggerName = DisplayValueHelper.GetString(trigger, "Name", "Key.Name");
+                        string triggerType = DisplayValueHelper.GetString(trigger, "TriggerType");
+                        string triggerSchedule = DisplayValueHelper.GetString(trigger, "ScheduleSummary");
                         string triggerState = GetTriggerState(triggerGroup, triggerName);
                         <tr>
                             <td>
@@ -92,6 +96,8 @@
                                     <KeyBadge GroupName="@triggerGroup" ItemName="@triggerName" />
                                 </a>
                             </td>
+                            <td>@(triggerType is { Length: > 0 } ? triggerType : "—")</td>
+                            <td>@(triggerSchedule is { Length: > 0 } ? triggerSchedule : "—")</td>
                             <td><StateIndicator State="@triggerState" /></td>
                         </tr>
                     }
@@ -128,7 +134,7 @@
 
     private bool IsReadOnly => Options.Value.ReadOnly;
 
-    private JobDataMap? JobDataMap => DisplayValueHelper.GetObject(_job, "JobDataMap") as JobDataMap;
+    private JobDataMap? JobDataMap => DisplayValueHelper.GetJobDataMap(_job, "JobDataMap");
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
@@ -56,6 +56,9 @@
             </tbody>
         </table>
 
+        <h2>JobDataMap</h2>
+        <JobDataMapEditor DataMap="@TriggerDataMap" ReadOnly="true" />
+
         @if (!IsReadOnly && !string.IsNullOrWhiteSpace(_cronExpression))
         {
             <section class="qz-section">
@@ -105,6 +108,8 @@
     public string Name { get; set; } = string.Empty;
 
     private bool IsReadOnly => Options.Value.ReadOnly;
+
+    private JobDataMap? TriggerDataMap => DisplayValueHelper.GetJobDataMap(_trigger, "JobDataMap", "jobDataMap");
 
     protected override async Task OnInitializedAsync()
     {
@@ -162,10 +167,17 @@
             return cronExpression;
         }
 
-        string repeatInterval = DisplayValueHelper.GetString(_trigger, "RepeatInterval", "RepeatIntervalTimeSpan");
+        string repeatInterval = DisplayValueHelper.GetString(_trigger, "RepeatIntervalTimeSpan", "RepeatInterval");
         if (!string.IsNullOrWhiteSpace(repeatInterval))
         {
-            return "Every " + repeatInterval;
+            string description = "Every " + repeatInterval;
+            string repeatCount = DisplayValueHelper.GetString(_trigger, "RepeatCount");
+            if (int.TryParse(repeatCount, NumberStyles.Integer, CultureInfo.InvariantCulture, out int count))
+            {
+                description += count < 0 ? ", repeat forever" : ", " + count + " time(s)";
+            }
+
+            return description;
         }
 
         return DisplayValueHelper.GetString(_trigger, "TriggerType", "Type");

--- a/src/Quartz.Dashboard/Components/Shared/DisplayValueHelper.cs
+++ b/src/Quartz.Dashboard/Components/Shared/DisplayValueHelper.cs
@@ -21,10 +21,15 @@ using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 
+using Quartz;
+
 namespace Quartz.Dashboard.Components.Shared;
 
 internal static class DisplayValueHelper
 {
+    private static readonly JsonSerializerOptions JobDataMapOptions =
+        new JsonSerializerOptions(JsonSerializerDefaults.Web).AddQuartzConverters(newtonsoftCompatibilityMode: false);
+
     public static object? GetObject(object? source, params string[] paths)
     {
         if (source is null)
@@ -38,6 +43,22 @@ internal static class DisplayValueHelper
             {
                 return value;
             }
+        }
+
+        return null;
+    }
+
+    public static JobDataMap? GetJobDataMap(object? source, params string[] paths)
+    {
+        object? value = GetObject(source, paths);
+        if (value is JobDataMap dataMap)
+        {
+            return dataMap;
+        }
+
+        if (value is JsonElement { ValueKind: JsonValueKind.Object } element)
+        {
+            return element.Deserialize<JobDataMap>(JobDataMapOptions);
         }
 
         return null;

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -107,7 +107,12 @@ public sealed record JobKeyDto(string Group, string Name);
 
 public sealed record TriggerKeyDto(string Group, string Name);
 
-public sealed record TriggerHeaderDto(string Group, string Name, string? ExecutionGroup = null);
+public sealed record TriggerHeaderDto(string Group, string Name, string? ExecutionGroup = null)
+{
+    public string? TriggerType { get; init; }
+
+    public string? ScheduleSummary { get; init; }
+}
 
 public sealed record JobDetailDto(
     string Name,

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -150,7 +150,11 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         List<TriggerHeaderDto> result = [];
         foreach (ITrigger trigger in triggers)
         {
-            result.Add(new TriggerHeaderDto(trigger.Key.Group, trigger.Key.Name, trigger.ExecutionGroup));
+            result.Add(new TriggerHeaderDto(trigger.Key.Group, trigger.Key.Name, trigger.ExecutionGroup)
+            {
+                TriggerType = GetTriggerTypeName(trigger),
+                ScheduleSummary = DescribeSchedule(trigger)
+            });
         }
 
         return result;
@@ -271,8 +275,7 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
             throw new KeyNotFoundException($"Trigger '{group}.{name}' was not found in scheduler '{schedulerName}'.");
         }
 
-        JsonElement triggerJson = JsonSerializer.SerializeToElement<object>(trigger, serializerOptions);
-        return new TriggerDetailDto(triggerJson);
+        return new TriggerDetailDto(SerializeTrigger(trigger));
     }
 
     public async ValueTask<string> GetTriggerState(string schedulerName, string group, string name)
@@ -408,6 +411,49 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         JsonSerializerOptions options = new(JsonSerializerDefaults.Web);
         options.AddQuartzConverters(newtonsoftCompatibilityMode: false);
         return options;
+    }
+
+    private static JsonElement SerializeTrigger(ITrigger trigger)
+    {
+        try
+        {
+            // Use the canonical Quartz converters (same options used for deserialization) so the JSON
+            // exposes TriggerType, schedule fields, JobDataMap and fire times under the property names
+            // the dashboard UI reads. Plain reflection omits most of these.
+            return JsonSerializer.SerializeToElement<object>(trigger, deserializerOptions);
+        }
+        catch (JsonSerializationException)
+        {
+            // Custom trigger types aren't handled by the converter; fall back to a best-effort
+            // reflection serialization so the detail page still renders.
+            return JsonSerializer.SerializeToElement<object>(trigger, serializerOptions);
+        }
+    }
+
+    private static string GetTriggerTypeName(ITrigger trigger)
+    {
+        return trigger switch
+        {
+            ICronTrigger => "Cron",
+            ISimpleTrigger => "Simple",
+            ICalendarIntervalTrigger => "Calendar interval",
+            IDailyTimeIntervalTrigger => "Daily time interval",
+            _ => trigger.GetType().Name
+        };
+    }
+
+    private static string? DescribeSchedule(ITrigger trigger)
+    {
+        switch (trigger)
+        {
+            case ICronTrigger cron:
+                return cron.CronExpressionString;
+            case ISimpleTrigger simple:
+                string summary = "Every " + simple.RepeatInterval;
+                return summary + (simple.RepeatCount < 0 ? ", repeat forever" : ", " + simple.RepeatCount + " time(s)");
+            default:
+                return null;
+        }
     }
 
     private static JobDataMap DeserializeJobDataMap(JsonElement element)

--- a/src/Quartz.Dashboard/Services/QuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/QuartzApiClient.cs
@@ -155,7 +155,11 @@ public sealed class QuartzApiClient : IQuartzApiClient
             string triggerName = GetStringProperty(key, "name");
             string triggerGroup = GetStringProperty(key, "group");
             string? executionGroup = GetNullableStringProperty(trigger, "executionGroup");
-            result.Add(new TriggerHeaderDto(triggerGroup, triggerName, executionGroup));
+            result.Add(new TriggerHeaderDto(triggerGroup, triggerName, executionGroup)
+            {
+                TriggerType = GetNullableStringProperty(trigger, "triggerType"),
+                ScheduleSummary = DescribeSchedule(trigger)
+            });
         }
 
         return result;
@@ -635,6 +639,25 @@ public sealed class QuartzApiClient : IQuartzApiClient
         }
 
         return value.Clone();
+    }
+
+    private static string? DescribeSchedule(JsonElement trigger)
+    {
+        string? cron = GetNullableStringProperty(trigger, "cronExpressionString");
+        if (!string.IsNullOrWhiteSpace(cron))
+        {
+            return cron;
+        }
+
+        string? repeatInterval = GetNullableStringProperty(trigger, "repeatIntervalTimeSpan");
+        if (!string.IsNullOrWhiteSpace(repeatInterval))
+        {
+            string summary = "Every " + repeatInterval;
+            int repeatCount = GetIntProperty(trigger, "repeatCount");
+            return summary + (repeatCount < 0 ? ", repeat forever" : ", " + repeatCount + " time(s)");
+        }
+
+        return null;
     }
 
     public async ValueTask<ExecutionLimitsDto?> GetExecutionLimits(string schedulerName)

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 
 using Microsoft.Extensions.Options;
 
+using Quartz.Dashboard.Components.Shared;
 using Quartz.Dashboard.Services;
 using Quartz.Impl;
 using Quartz.Impl.Calendar;
@@ -106,6 +107,112 @@ public class InProcessQuartzApiClientTest
             CronCalendar cronCalendar = calendar.Should().BeOfType<CronCalendar>().Subject;
             cronCalendar.CronExpression.CronExpressionString.Should().Be("0 0 3 * * ?");
             cronCalendar.Description.Should().Be("maintenance window");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task GetJobExposesJobDataMapThatConvertsBackToJobDataMap()
+    {
+        // regression test for #3130 - JobDetail.razor cast the JsonElement directly to JobDataMap,
+        // which always produced null. DisplayValueHelper.GetJobDataMap now performs the conversion.
+        IScheduler scheduler = await CreateScheduler("GetJobDataMapTest");
+        try
+        {
+            JobKey jobKey = new("job1", "group1");
+            IJobDetail job = JobBuilder.Create<NoOpJob>()
+                .WithIdentity(jobKey)
+                .UsingJobData("Name", "abc")
+                .UsingJobData("Count", 5)
+                .UsingJobData("Enabled", true)
+                .StoreDurably()
+                .Build();
+            await scheduler.AddJob(job, replace: true);
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+            JobDetailDto dto = await client.GetJob(scheduler.SchedulerName, jobKey.Group, jobKey.Name);
+
+            dto.JobDataMap.GetProperty("Name").GetString().Should().Be("abc");
+
+            JobDataMap? map = DisplayValueHelper.GetJobDataMap(dto, "JobDataMap");
+            map.Should().NotBeNull();
+            map!["Name"].Should().Be("abc");
+            map["Count"].Should().Be(5);
+            map["Enabled"].Should().Be(true);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task GetTriggerForSimpleTriggerIncludesTypeScheduleAndJobDataMap()
+    {
+        // regression test for #3130 - simple triggers were serialized via plain reflection, so the
+        // detail page was missing TriggerType / schedule / JobDataMap. GetTrigger now uses the
+        // canonical Quartz converters.
+        IScheduler scheduler = await CreateScheduler("GetSimpleTriggerTest");
+        try
+        {
+            JobKey jobKey = new("job1", "group1");
+            IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity(jobKey).StoreDurably().Build();
+            TriggerKey triggerKey = new("trigger1", "group1");
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .UsingJobData("Color", "red")
+                .WithSimpleSchedule(x => x.WithIntervalInSeconds(30).WithRepeatCount(3))
+                .Build();
+            await scheduler.ScheduleJob(job, trigger);
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+            TriggerDetailDto detail = await client.GetTrigger(scheduler.SchedulerName, triggerKey.Group, triggerKey.Name);
+
+            JsonElement value = detail.Value;
+            value.GetProperty("triggerType").GetString().Should().Be("SimpleTrigger");
+            value.GetProperty("jobDataMap").GetProperty("Color").GetString().Should().Be("red");
+            value.TryGetProperty("repeatIntervalTimeSpan", out _).Should().BeTrue();
+
+            DisplayValueHelper.GetJobDataMap(value, "JobDataMap", "jobDataMap")!["Color"].Should().Be("red");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task GetJobTriggersPopulatesTypeAndScheduleSummary()
+    {
+        // regression test for #3130 - the associated triggers table now shows each trigger's type
+        // and a schedule summary, so SimpleSchedule triggers are no longer indistinguishable.
+        IScheduler scheduler = await CreateScheduler("GetJobTriggersTest");
+        try
+        {
+            JobKey jobKey = new("job1", "group1");
+            IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity(jobKey).StoreDurably().Build();
+            await scheduler.ScheduleJob(
+                job,
+                TriggerBuilder.Create().WithIdentity("simple", "group1").ForJob(jobKey)
+                    .WithSimpleSchedule(x => x.WithIntervalInSeconds(30).WithRepeatCount(2)).Build());
+            await scheduler.ScheduleJob(
+                TriggerBuilder.Create().WithIdentity("cron", "group1").ForJob(jobKey)
+                    .WithCronSchedule("0 0 1 * * ?").Build());
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+            List<TriggerHeaderDto> headers = await client.GetJobTriggers(scheduler.SchedulerName, jobKey.Group, jobKey.Name);
+
+            headers.Should().HaveCount(2);
+            TriggerHeaderDto simple = headers.Single(h => h.Name == "simple");
+            simple.TriggerType.Should().Be("Simple");
+            simple.ScheduleSummary.Should().Contain("Every").And.Contain("time(s)");
+            TriggerHeaderDto cron = headers.Single(h => h.Name == "cron");
+            cron.TriggerType.Should().Be("Cron");
+            cron.ScheduleSummary.Should().Be("0 0 1 * * ?");
         }
         finally
         {


### PR DESCRIPTION
Fixes #3130.

## Problem
On the dashboard:
- Job data registered with `UsingJobData(...)` never appeared on the **Job Detail** page — the JobDataMap section always showed "No JobDataMap entries" (and the "Trigger with overrides" editor was empty, since it is seeded from it).
- A **trigger's** JobDataMap was never shown.
- **SimpleSchedule** triggers' details rendered nearly blank.

## Root causes
- `JobDetailDto.JobDataMap` is a `JsonElement`, but `JobDetail.razor` cast it directly with `as JobDataMap`, which silently yields `null`.
- `TriggerDetail.razor` had no JobDataMap section.
- `InProcessQuartzApiClient.GetTrigger` serialized triggers with plain reflection, so the JSON lacked `TriggerType`, the schedule fields, `JobDataMap` and fire times that the UI reads. Cron triggers only looked OK by coincidence; SimpleSchedule triggers looked empty.

## Changes
- Add `DisplayValueHelper.GetJobDataMap(...)` that converts the stored `JsonElement` to a real `JobDataMap` using the Quartz converters; use it on the job and trigger detail pages.
- Serialize triggers in `GetTrigger` with the canonical Quartz converters (the same shape the HTTP API already produces), with a reflection fallback for non-standard trigger types.
- Add `TriggerType` / `ScheduleSummary` to `TriggerHeaderDto` and surface them in the job's associated-triggers table (populated from the live trigger in-process, and from the server JSON for the HTTP client). Show the trigger's JobDataMap on the trigger detail page and include the repeat count in the schedule summary.
- Add regression tests in `InProcessQuartzApiClientTest`.

## Verification
- `dotnet build src/Quartz.Dashboard` — clean (0 warnings / 0 errors).
- `dotnet test src/Quartz.Tests.AspNetCore --filter ...Dashboard` — 43/43 pass (3 new).
- Validated against `Quartz.Examples.AspNetCore`, which wires `AddQuartzDashboard()` with `UsingJobData` + `WithSimpleSchedule`.

The equivalent fix for the 3.x line is in #3132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
