### PR TITLE
Serve Blazor plumbing under custom DashboardPath for prefix-forwarding reverse proxies (#3134)

### DIFF
--- a/docs/documentation/quartz-3.x/packages/dashboard.md
+++ b/docs/documentation/quartz-3.x/packages/dashboard.md
@@ -64,9 +64,11 @@ services.AddQuartzDashboard(options =>
 });
 ```
 
-All dashboard pages, navigation links and the SignalR hub are then served under the configured path (for example `/my-api/quartz/jobs`).
+With a custom `DashboardPath` the dashboard is fully self-contained under the configured path. The pages, navigation links and SignalR hub as well as the Blazor plumbing — the interactive circuit (`{DashboardPath}/_blazor`), the framework script (`{DashboardPath}/_framework/blazor.web.js`) and the dashboard static assets (`{DashboardPath}/_content/Quartz.Dashboard/*`) — are all served under it, and the dashboard shell emits a `<base href>` rooted at the dashboard itself.
 
-Dashboard links are generated relative to the application base URI, so the dashboard also works behind a reverse proxy or an application path base (`UsePathBase`) — the configured `DashboardPath` is interpreted relative to the path base.
+This makes the dashboard work behind a reverse proxy that forwards only a path prefix to the application without setting a path base: configure `DashboardPath` with the externally visible path (for example `/my-api/quartz` when the proxy forwards `/my-api/*` verbatim) and make sure the proxy forwards WebSocket connections for `{DashboardPath}/_blazor`.
+
+Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix.
 
 ::: warning
 A custom `DashboardPath` is **not** supported when integrating into an existing Blazor application with `MapQuartzDashboard(blazor)`; the dashboard page routes are fixed at `/quartz` in that mode and startup fails with a descriptive exception if a custom path is configured.
@@ -122,6 +124,8 @@ Without a policy the dashboard adds no authorization of its own:
 
 ::: warning Fail-closed `FallbackPolicy` with `MapStaticAssets()`
 Assets served by the host's `app.MapStaticAssets()` (the .NET 9/10 default) and the framework script `_framework/blazor.web.js` are served by **host/framework-owned endpoints** that Quartz cannot annotate, so a fail-closed `FallbackPolicy` blocks them for unauthenticated users regardless of the dashboard configuration. If you need them reachable before authentication (for example so the login page is styled), mark your static assets anonymous with `app.MapStaticAssets().AllowAnonymous();` — static web assets are public content. The classic `app.UseStaticFiles()` middleware runs before authorization and is not subject to the `FallbackPolicy`. See [API-only projects](#api-only-projects-no-razor-files) for the related `RequiresAspNetWebAssets` setting.
+
+With a custom `DashboardPath` this caveat does not apply to the dashboard itself: the framework script and the dashboard static assets are then served under the dashboard path by dashboard-owned endpoints that carry the dashboard's authorization metadata.
 :::
 
 ### API key or custom authorization checks
@@ -132,7 +136,7 @@ For dashboard access control, prefer ASP.NET Core policy/handler-based authoriza
 
 - **Clustered ADO.NET job stores:** actions in dashboard are scheduler operations and can affect cluster behavior; restrict write access to trusted operator roles.
 - **Many local schedulers in one host:** dashboard scheduler selector supports multiple registered schedulers; use clear scheduler names and environment-specific grouping.
-- **Reverse proxy and Blazor Server:** enable WebSocket/SignalR forwarding and sticky sessions where required by your hosting stack.
+- **Reverse proxy and Blazor Server:** enable WebSocket/SignalR forwarding and sticky sessions where required by your hosting stack. The Blazor circuit connects to `/_blazor` (or `{DashboardPath}/_blazor` when a custom `DashboardPath` is configured).
 - **Split operator experiences:** expose a read-only dashboard instance (`ReadOnly = true`) for observers, and a separate write-enabled dashboard for operators.
 - **Operational retention:** dashboard history is plugin-fed operational history; configure plugin + external retention/reporting if you need long-term analytics.
 

--- a/docs/documentation/quartz-3.x/packages/dashboard.md
+++ b/docs/documentation/quartz-3.x/packages/dashboard.md
@@ -55,6 +55,10 @@ By default, dashboard UI is available at `/quartz`.
 
 ## Hosting under a custom path
 
+::: tip
+The self-contained custom-path behavior described below requires a Quartz.Dashboard release **newer than 3.18.2** (#3134). On 3.18.2 and earlier only the dashboard pages, links and hub honor the custom path; the Blazor framework script, the circuit and the static assets stay at the application root, so a prefix-forwarding reverse proxy needs `UsePathBase` (or equivalent) instead.
+:::
+
 When the dashboard hosts its own Blazor root (the parameterless `MapQuartzDashboard()` overload), the dashboard can be served from a custom base path:
 
 ```csharp
@@ -66,9 +70,13 @@ services.AddQuartzDashboard(options =>
 
 With a custom `DashboardPath` the dashboard is fully self-contained under the configured path. The pages, navigation links and SignalR hub as well as the Blazor plumbing — the interactive circuit (`{DashboardPath}/_blazor`), the framework script (`{DashboardPath}/_framework/blazor.web.js`) and the dashboard static assets (`{DashboardPath}/_content/Quartz.Dashboard/*`) — are all served under it, and the dashboard shell emits a `<base href>` rooted at the dashboard itself.
 
-This makes the dashboard work behind a reverse proxy that forwards only a path prefix to the application without setting a path base: configure `DashboardPath` with the externally visible path (for example `/my-api/quartz` when the proxy forwards `/my-api/*` verbatim) and make sure the proxy forwards WebSocket connections for `{DashboardPath}/_blazor`.
+This makes the dashboard work behind a reverse proxy that forwards only a path prefix to the application without setting a path base: configure `DashboardPath` with the externally visible path (for example `/my-api/quartz` when the proxy forwards `/my-api/*` verbatim) and make sure the proxy forwards WebSocket connections for `{DashboardPath}/_blazor` **and** `{DashboardPath}/hub` (the live-views hub). Note that the dashboard's server-side circuit connects to the live-events hub through the same externally visible URL the browser uses, so the application must be able to reach its own public address for the Live Logs view to work.
 
 Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix.
+
+::: warning Upgrading existing custom-path deployments
+In earlier releases the Blazor circuit stayed at the site root; with a custom `DashboardPath` it now connects at `{DashboardPath}/_blazor`. Reverse-proxy rules scoped to `/_blazor` (for example a WebSocket-upgrade location) must be updated accordingly.
+:::
 
 ::: warning
 A custom `DashboardPath` is **not** supported when integrating into an existing Blazor application with `MapQuartzDashboard(blazor)`; the dashboard page routes are fixed at `/quartz` in that mode and startup fails with a descriptive exception if a custom path is configured.

--- a/docs/documentation/quartz-3.x/packages/dashboard.md
+++ b/docs/documentation/quartz-3.x/packages/dashboard.md
@@ -72,7 +72,12 @@ With a custom `DashboardPath` the dashboard is fully self-contained under the co
 
 This makes the dashboard work behind a reverse proxy that forwards only a path prefix to the application without setting a path base: configure `DashboardPath` with the externally visible path (for example `/my-api/quartz` when the proxy forwards `/my-api/*` verbatim) and make sure the proxy forwards WebSocket connections for `{DashboardPath}/_blazor` **and** `{DashboardPath}/hub` (the live-views hub). Note that the dashboard's server-side circuit connects to the live-events hub through the same externally visible URL the browser uses, so the application must be able to reach its own public address for the Live Logs view to work.
 
-Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix.
+Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix. With minimal hosting (`WebApplication`), call `app.UseRouting()` explicitly **after** `app.UsePathBase(...)` — otherwise the implicit routing step matches against the un-stripped path and every dashboard route returns 404:
+
+```csharp
+app.UsePathBase("/my-api");
+app.UseRouting();
+```
 
 ::: warning Upgrading existing custom-path deployments
 In earlier releases the Blazor circuit stayed at the site root; with a custom `DashboardPath` it now connects at `{DashboardPath}/_blazor`. Reverse-proxy rules scoped to `/_blazor` (for example a WebSocket-upgrade location) must be updated accordingly.

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -53,6 +53,27 @@ app.UseEndpoints(endpoints =>
 
 By default, dashboard UI is available at `/quartz`.
 
+## Hosting under a custom path
+
+When the dashboard hosts its own Blazor root (the parameterless `MapQuartzDashboard()` overload), the dashboard can be served from a custom base path:
+
+```csharp
+services.AddQuartzDashboard(options =>
+{
+    options.DashboardPath = "/my-api/quartz";
+});
+```
+
+With a custom `DashboardPath` the dashboard is fully self-contained under the configured path. The pages, navigation links and SignalR hub as well as the Blazor plumbing — the interactive circuit (`{DashboardPath}/_blazor`), the framework script (`{DashboardPath}/_framework/blazor.web.js`) and the dashboard static assets (`{DashboardPath}/_content/Quartz.Dashboard/*`) — are all served under it, and the dashboard shell emits a `<base href>` rooted at the dashboard itself.
+
+This makes the dashboard work behind a reverse proxy that forwards only a path prefix to the application without setting a path base: configure `DashboardPath` with the externally visible path (for example `/my-api/quartz` when the proxy forwards `/my-api/*` verbatim) and make sure the proxy forwards WebSocket connections for `{DashboardPath}/_blazor`.
+
+Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix.
+
+::: warning
+A custom `DashboardPath` is **not** supported when integrating into an existing Blazor application with `MapQuartzDashboard(blazor)`; the dashboard page routes are fixed at `/quartz` in that mode and startup fails with a descriptive exception if a custom path is configured.
+:::
+
 ## Enabling history plugin
 
 To populate execution history and make related views useful, enable Quartz history plugins in `QuartzOptions`:
@@ -104,6 +125,8 @@ Without a policy the dashboard adds no authorization of its own:
 
 ::: warning Fail-closed `FallbackPolicy` with `MapStaticAssets()`
 Assets served by the host's `app.MapStaticAssets()` (the .NET 9/10 default) and the framework script `_framework/blazor.web.js` are served by **host/framework-owned endpoints** that Quartz cannot annotate, so a fail-closed `FallbackPolicy` blocks them for unauthenticated users regardless of the dashboard configuration. If you need them reachable before authentication (for example so the login page is styled), mark your static assets anonymous with `app.MapStaticAssets().AllowAnonymous();` — static web assets are public content. The classic `app.UseStaticFiles()` middleware runs before authorization and is not subject to the `FallbackPolicy`. See [API-only projects](#api-only-projects-no-razor-files) for the related `RequiresAspNetWebAssets` setting.
+
+With a custom `DashboardPath` this caveat does not apply to the dashboard itself: the framework script and the dashboard static assets are then served under the dashboard path by dashboard-owned endpoints that carry the dashboard's authorization metadata.
 :::
 
 ### API key or custom authorization checks
@@ -115,7 +138,7 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
 
 - **Clustered ADO.NET job stores:** actions in dashboard are scheduler operations and can affect cluster behavior; restrict write access to trusted operator roles.
 - **Many local schedulers in one host:** dashboard scheduler selector supports multiple registered schedulers; use clear scheduler names and environment-specific grouping.
-- **Reverse proxy and Blazor Server:** enable WebSocket/SignalR forwarding and sticky sessions where required by your hosting stack.
+- **Reverse proxy and Blazor Server:** enable WebSocket/SignalR forwarding and sticky sessions where required by your hosting stack. The Blazor circuit connects to `/_blazor` (or `{DashboardPath}/_blazor` when a custom `DashboardPath` is configured).
 - **Split operator experiences:** expose a read-only dashboard instance (`ReadOnly = true`) for observers, and a separate write-enabled dashboard for operators.
 - **Operational retention:** dashboard history is plugin-fed operational history; configure plugin + external retention/reporting if you need long-term analytics.
 

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -66,9 +66,13 @@ services.AddQuartzDashboard(options =>
 
 With a custom `DashboardPath` the dashboard is fully self-contained under the configured path. The pages, navigation links and SignalR hub as well as the Blazor plumbing — the interactive circuit (`{DashboardPath}/_blazor`), the framework script (`{DashboardPath}/_framework/blazor.web.js`) and the dashboard static assets (`{DashboardPath}/_content/Quartz.Dashboard/*`) — are all served under it, and the dashboard shell emits a `<base href>` rooted at the dashboard itself.
 
-This makes the dashboard work behind a reverse proxy that forwards only a path prefix to the application without setting a path base: configure `DashboardPath` with the externally visible path (for example `/my-api/quartz` when the proxy forwards `/my-api/*` verbatim) and make sure the proxy forwards WebSocket connections for `{DashboardPath}/_blazor`.
+This makes the dashboard work behind a reverse proxy that forwards only a path prefix to the application without setting a path base: configure `DashboardPath` with the externally visible path (for example `/my-api/quartz` when the proxy forwards `/my-api/*` verbatim) and make sure the proxy forwards WebSocket connections for `{DashboardPath}/_blazor` **and** `{DashboardPath}/hub` (the live-views hub). Note that the dashboard's server-side circuit connects to the live-events hub through the same externally visible URL the browser uses, so the application must be able to reach its own public address for the Live Logs view to work.
 
 Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix.
+
+::: warning Upgrading existing custom-path deployments
+In earlier releases the Blazor circuit stayed at the site root; with a custom `DashboardPath` it now connects at `{DashboardPath}/_blazor`. Reverse-proxy rules scoped to `/_blazor` (for example a WebSocket-upgrade location) must be updated accordingly.
+:::
 
 ::: warning
 A custom `DashboardPath` is **not** supported when integrating into an existing Blazor application with `MapQuartzDashboard(blazor)`; the dashboard page routes are fixed at `/quartz` in that mode and startup fails with a descriptive exception if a custom path is configured.

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -68,7 +68,12 @@ With a custom `DashboardPath` the dashboard is fully self-contained under the co
 
 This makes the dashboard work behind a reverse proxy that forwards only a path prefix to the application without setting a path base: configure `DashboardPath` with the externally visible path (for example `/my-api/quartz` when the proxy forwards `/my-api/*` verbatim) and make sure the proxy forwards WebSocket connections for `{DashboardPath}/_blazor` **and** `{DashboardPath}/hub` (the live-views hub). Note that the dashboard's server-side circuit connects to the live-events hub through the same externally visible URL the browser uses, so the application must be able to reach its own public address for the Live Logs view to work.
 
-Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix.
+Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix. With minimal hosting (`WebApplication`), call `app.UseRouting()` explicitly **after** `app.UsePathBase(...)` — otherwise the implicit routing step matches against the un-stripped path and every dashboard route returns 404:
+
+```csharp
+app.UsePathBase("/my-api");
+app.UseRouting();
+```
 
 ::: warning Upgrading existing custom-path deployments
 In earlier releases the Blazor circuit stayed at the site root; with a custom `DashboardPath` it now connects at `{DashboardPath}/_blazor`. Reverse-proxy rules scoped to `/_blazor` (for example a WebSocket-upgrade location) must be updated accordingly.

--- a/src/Quartz.Dashboard/Components/DashboardLink.cs
+++ b/src/Quartz.Dashboard/Components/DashboardLink.cs
@@ -62,11 +62,11 @@ internal static class DashboardLink
         // circuit in custom-path mode the base URI is the rendered dashboard-rooted <base href>, so
         // the base-relative path is already dashboard-rooted and must not be prefix-stripped — a
         // dashboard path whose name collides with a page route (e.g. "/jobs") would otherwise be
-        // misresolved. Comparisons use the percent-encoded form because browsers emit encoded URIs.
-        // The leading slash of the dashboard path keeps the EndsWith comparison segment-aligned.
-        string dashboardPath = options.EscapedDashboardPath;
+        // misresolved. The comparison is against the base URI's PATH (not the whole absolute URI,
+        // whose host name could otherwise spuriously match the dashboard path) in its percent-encoded
+        // form (browsers emit encoded URIs); the leading slash keeps the EndsWith segment-aligned.
         if (options.HasCustomDashboardPath
-            && baseUri.TrimEnd('/').EndsWith(dashboardPath, StringComparison.OrdinalIgnoreCase))
+            && GetAbsolutePath(baseUri).TrimEnd('/').EndsWith(options.EscapedDashboardPath, StringComparison.OrdinalIgnoreCase))
         {
             return relative;
         }
@@ -75,25 +75,45 @@ internal static class DashboardLink
         // the only shape used in default-path mode) and the base-relative path carries the dashboard
         // path prefix; strip it. A path-base-rooted URI without the prefix (e.g. the application
         // root itself) is not a dashboard location.
-        string dashboardRoot = dashboardPath.TrimStart('/');
-        if (relative.Equals(dashboardRoot, StringComparison.OrdinalIgnoreCase))
+        return TryStripDashboardPrefix(relative, options, out string stripped) ? stripped : null;
+    }
+
+    /// <summary>
+    /// Strips the dashboard path prefix from an already-normalized base-relative path. Returns
+    /// <see langword="true"/> with <paramref name="stripped"/> set to the remaining leaf ("" for the
+    /// dashboard root) when the path is under the dashboard root, otherwise <see langword="false"/>.
+    /// The comparison uses the percent-encoded dashboard path, matching browser-emitted URIs.
+    /// </summary>
+    internal static bool TryStripDashboardPrefix(string normalizedPath, QuartzDashboardOptions options, out string stripped)
+    {
+        string dashboardRoot = options.EscapedDashboardPath.TrimStart('/');
+        if (normalizedPath.Equals(dashboardRoot, StringComparison.OrdinalIgnoreCase))
         {
-            return string.Empty;
+            stripped = string.Empty;
+            return true;
         }
 
-        if (relative.StartsWith(dashboardRoot + "/", StringComparison.OrdinalIgnoreCase))
+        if (normalizedPath.StartsWith(dashboardRoot + "/", StringComparison.OrdinalIgnoreCase))
         {
-            return relative.Substring(dashboardRoot.Length + 1);
+            stripped = normalizedPath.Substring(dashboardRoot.Length + 1);
+            return true;
         }
 
-        return null;
+        stripped = normalizedPath;
+        return false;
+    }
+
+    private static string GetAbsolutePath(string baseUri)
+    {
+        return Uri.TryCreate(baseUri, UriKind.Absolute, out Uri? parsed) ? parsed.AbsolutePath : baseUri;
     }
 
     /// <summary>
     /// Returns the base-relative part of an absolute URI, or <see langword="null"/> when the URI
-    /// lies outside the base URI space.
+    /// lies outside the base URI space. Matches the application base URI case-insensitively so it
+    /// does not throw on casing differences the way <c>NavigationManager.ToBaseRelativePath</c> does.
     /// </summary>
-    private static string? ToBaseRelative(string uri, string baseUri)
+    internal static string? ToBaseRelative(string uri, string baseUri)
     {
         if (uri.StartsWith(baseUri, StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Quartz.Dashboard/Components/DashboardLink.cs
+++ b/src/Quartz.Dashboard/Components/DashboardLink.cs
@@ -28,8 +28,72 @@ internal static class DashboardLink
 {
     internal static string To(QuartzDashboardOptions options, string subPath)
     {
+        if (options.HasCustomDashboardPath)
+        {
+            // QuartzDashboardApp renders a dashboard-rooted <base href> in custom-path mode (a custom
+            // path implies standalone hosting), so links are relative to the dashboard root itself;
+            // an empty href resolves to the base URI (RFC 3986 §5.4)
+            return subPath;
+        }
+
         string root = options.TrimmedDashboardPath.TrimStart('/');
         return subPath.Length == 0 ? root : root + "/" + subPath;
+    }
+
+    /// <summary>
+    /// Converts an absolute URI into a path relative to the dashboard root ("" for the root itself,
+    /// no leading slash, query string and fragment stripped), or <see langword="null"/> when the URI
+    /// is not a dashboard location. Handles both base URI shapes seen in standalone custom-path mode:
+    /// during static server-side rendering the base URI is the application path base and the relative
+    /// path still carries the dashboard path prefix, while on the interactive circuit the base URI is
+    /// the dashboard root itself (the rendered &lt;base href&gt;).
+    /// </summary>
+    internal static string? ToDashboardRelativePath(string uri, string baseUri, QuartzDashboardOptions options)
+    {
+        string relative;
+        if (uri.StartsWith(baseUri, StringComparison.OrdinalIgnoreCase))
+        {
+            relative = NormalizeRelativePath(uri.Substring(baseUri.Length));
+        }
+        else
+        {
+            // Mirror NavigationManager.ToBaseRelativePath's special case: the document URL may equal
+            // the base URI without its trailing slash (e.g. "/my-api/quartz" with base "/my-api/quartz/")
+            int delimiterIndex = uri.IndexOfAny(['?', '#']);
+            string uriWithoutSuffix = delimiterIndex >= 0 ? uri.Substring(0, delimiterIndex) : uri;
+            if (string.Concat(uriWithoutSuffix, "/").Equals(baseUri, StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+
+            return null;
+        }
+
+        // During static server-side rendering the base URI is the application path base, so the
+        // base-relative path still carries the dashboard path prefix; strip it. This is also the
+        // only shape used in default-path mode. Checked first so a pathological path base ending
+        // in the dashboard path still resolves deterministically.
+        string dashboardRoot = options.TrimmedDashboardPath.TrimStart('/');
+        if (relative.Equals(dashboardRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        if (relative.StartsWith(dashboardRoot + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            return relative.Substring(dashboardRoot.Length + 1);
+        }
+
+        // In custom-path mode the interactive circuit's base URI is the rendered dashboard-rooted
+        // <base href>, so the base-relative path is already dashboard-rooted. The leading slash of
+        // TrimmedDashboardPath keeps the EndsWith comparison segment-aligned.
+        if (options.HasCustomDashboardPath
+            && new Uri(baseUri).AbsolutePath.TrimEnd('/').EndsWith(options.TrimmedDashboardPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return relative;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Quartz.Dashboard/Components/DashboardLink.cs
+++ b/src/Quartz.Dashboard/Components/DashboardLink.cs
@@ -50,30 +50,32 @@ internal static class DashboardLink
     /// </summary>
     internal static string? ToDashboardRelativePath(string uri, string baseUri, QuartzDashboardOptions options)
     {
-        string relative;
-        if (uri.StartsWith(baseUri, StringComparison.OrdinalIgnoreCase))
+        string? relative = ToBaseRelative(uri, baseUri);
+        if (relative is null)
         {
-            relative = NormalizeRelativePath(uri.Substring(baseUri.Length));
-        }
-        else
-        {
-            // Mirror NavigationManager.ToBaseRelativePath's special case: the document URL may equal
-            // the base URI without its trailing slash (e.g. "/my-api/quartz" with base "/my-api/quartz/")
-            int delimiterIndex = uri.IndexOfAny(['?', '#']);
-            string uriWithoutSuffix = delimiterIndex >= 0 ? uri.Substring(0, delimiterIndex) : uri;
-            if (string.Concat(uriWithoutSuffix, "/").Equals(baseUri, StringComparison.OrdinalIgnoreCase))
-            {
-                return string.Empty;
-            }
-
             return null;
         }
 
-        // During static server-side rendering the base URI is the application path base, so the
-        // base-relative path still carries the dashboard path prefix; strip it. This is also the
-        // only shape used in default-path mode. Checked first so a pathological path base ending
-        // in the dashboard path still resolves deterministically.
-        string dashboardRoot = options.TrimmedDashboardPath.TrimStart('/');
+        relative = NormalizeRelativePath(relative);
+
+        // Decide which shape the base URI has before touching the relative path. On the interactive
+        // circuit in custom-path mode the base URI is the rendered dashboard-rooted <base href>, so
+        // the base-relative path is already dashboard-rooted and must not be prefix-stripped — a
+        // dashboard path whose name collides with a page route (e.g. "/jobs") would otherwise be
+        // misresolved. Comparisons use the percent-encoded form because browsers emit encoded URIs.
+        // The leading slash of the dashboard path keeps the EndsWith comparison segment-aligned.
+        string dashboardPath = options.EscapedDashboardPath;
+        if (options.HasCustomDashboardPath
+            && baseUri.TrimEnd('/').EndsWith(dashboardPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return relative;
+        }
+
+        // Otherwise the base URI is the application path base (static server-side rendering; also
+        // the only shape used in default-path mode) and the base-relative path carries the dashboard
+        // path prefix; strip it. A path-base-rooted URI without the prefix (e.g. the application
+        // root itself) is not a dashboard location.
+        string dashboardRoot = dashboardPath.TrimStart('/');
         if (relative.Equals(dashboardRoot, StringComparison.OrdinalIgnoreCase))
         {
             return string.Empty;
@@ -84,13 +86,25 @@ internal static class DashboardLink
             return relative.Substring(dashboardRoot.Length + 1);
         }
 
-        // In custom-path mode the interactive circuit's base URI is the rendered dashboard-rooted
-        // <base href>, so the base-relative path is already dashboard-rooted. The leading slash of
-        // TrimmedDashboardPath keeps the EndsWith comparison segment-aligned.
-        if (options.HasCustomDashboardPath
-            && new Uri(baseUri).AbsolutePath.TrimEnd('/').EndsWith(options.TrimmedDashboardPath, StringComparison.OrdinalIgnoreCase))
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the base-relative part of an absolute URI, or <see langword="null"/> when the URI
+    /// lies outside the base URI space.
+    /// </summary>
+    private static string? ToBaseRelative(string uri, string baseUri)
+    {
+        if (uri.StartsWith(baseUri, StringComparison.OrdinalIgnoreCase))
         {
-            return relative;
+            return uri.Substring(baseUri.Length);
+        }
+
+        // Mirror NavigationManager.ToBaseRelativePath's special case: the document URL may equal
+        // the base URI without its trailing slash (e.g. "/my-api/quartz" with base "/my-api/quartz/")
+        if (string.Concat(StripQueryAndFragment(uri), "/").Equals(baseUri, StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
         }
 
         return null;
@@ -103,12 +117,12 @@ internal static class DashboardLink
     /// </summary>
     internal static string NormalizeRelativePath(string relativePath)
     {
-        int delimiterIndex = relativePath.IndexOfAny(['?', '#']);
-        if (delimiterIndex >= 0)
-        {
-            relativePath = relativePath.Substring(0, delimiterIndex);
-        }
+        return StripQueryAndFragment(relativePath).Trim('/');
+    }
 
-        return relativePath.Trim('/');
+    private static string StripQueryAndFragment(string uriOrPath)
+    {
+        int delimiterIndex = uriOrPath.IndexOfAny(['?', '#']);
+        return delimiterIndex >= 0 ? uriOrPath.Substring(0, delimiterIndex) : uriOrPath;
     }
 }

--- a/src/Quartz.Dashboard/Components/DashboardRouteTable.cs
+++ b/src/Quartz.Dashboard/Components/DashboardRouteTable.cs
@@ -34,27 +34,15 @@ internal static class DashboardRouteTable
     private static readonly Lazy<List<RouteEntry>> Routes = new(BuildRouteTable);
 
     /// <summary>
-    /// Matches a base-relative path (no leading slash, as produced by
-    /// <c>NavigationManager.ToBaseRelativePath</c>) against the dashboard route table.
-    /// Returns <see langword="null"/> when the path does not map to a dashboard page.
+    /// Matches a dashboard-root-relative path ("" for the dashboard root, no leading slash, as
+    /// produced by <see cref="DashboardLink.ToDashboardRelativePath"/>) against the dashboard
+    /// route table. Returns <see langword="null"/> when the path does not map to a dashboard page.
     /// </summary>
-    internal static RouteData? Match(string relativePath, QuartzDashboardOptions options)
+    internal static RouteData? Match(string dashboardRelativePath)
     {
-        relativePath = DashboardLink.NormalizeRelativePath(relativePath);
+        dashboardRelativePath = DashboardLink.NormalizeRelativePath(dashboardRelativePath);
 
-        string dashboardRoot = options.TrimmedDashboardPath.TrimStart('/');
-        if (!relativePath.StartsWith(dashboardRoot, StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        string remainder = relativePath.Substring(dashboardRoot.Length);
-        if (remainder.Length > 0 && remainder[0] != '/')
-        {
-            return null;
-        }
-
-        string[] segments = remainder.Length == 0 ? [] : remainder.TrimStart('/').Split('/');
+        string[] segments = dashboardRelativePath.Length == 0 ? [] : dashboardRelativePath.Split('/');
 
         foreach (RouteEntry route in Routes.Value)
         {

--- a/src/Quartz.Dashboard/Components/DashboardRouteTable.cs
+++ b/src/Quartz.Dashboard/Components/DashboardRouteTable.cs
@@ -34,6 +34,37 @@ internal static class DashboardRouteTable
     private static readonly Lazy<List<RouteEntry>> Routes = new(BuildRouteTable);
 
     /// <summary>
+    /// Matches like <see cref="Match(string)"/> but retries with the dashboard path prefix
+    /// stripped when the direct match fails. The relative path form is ambiguous when the
+    /// application path base happens to end with the custom dashboard path: static server-side
+    /// rendering then produces a dashboard-prefixed relative path that the base URI shape check
+    /// in <see cref="DashboardLink.ToDashboardRelativePath"/> cannot distinguish from an
+    /// interactive leaf, so a failed match gets a second chance without the prefix.
+    /// </summary>
+    internal static RouteData? Match(string dashboardRelativePath, QuartzDashboardOptions options)
+    {
+        RouteData? match = Match(dashboardRelativePath);
+        if (match is not null || !options.HasCustomDashboardPath)
+        {
+            return match;
+        }
+
+        string normalized = DashboardLink.NormalizeRelativePath(dashboardRelativePath);
+        string dashboardRoot = options.EscapedDashboardPath.TrimStart('/');
+        if (normalized.Equals(dashboardRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            return Match(string.Empty);
+        }
+
+        if (normalized.StartsWith(dashboardRoot + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            return Match(normalized.Substring(dashboardRoot.Length + 1));
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Matches a dashboard-root-relative path ("" for the dashboard root, no leading slash, as
     /// produced by <see cref="DashboardLink.ToDashboardRelativePath"/>) against the dashboard
     /// route table. Returns <see langword="null"/> when the path does not map to a dashboard page.

--- a/src/Quartz.Dashboard/Components/DashboardRouteTable.cs
+++ b/src/Quartz.Dashboard/Components/DashboardRouteTable.cs
@@ -43,25 +43,29 @@ internal static class DashboardRouteTable
     /// </summary>
     internal static RouteData? Match(string dashboardRelativePath, QuartzDashboardOptions options)
     {
-        RouteData? match = Match(dashboardRelativePath);
-        if (match is not null || !options.HasCustomDashboardPath)
-        {
-            return match;
-        }
+        return Match(ResolveLeaf(dashboardRelativePath, options));
+    }
 
+    /// <summary>
+    /// Resolves a dashboard-relative path to the leaf that actually maps to a dashboard page,
+    /// applying the same prefix-strip retry as <see cref="Match(string, QuartzDashboardOptions)"/>.
+    /// Used where the leaf itself is needed (navigation highlighting) rather than the route data.
+    /// Returns the direct form when neither the direct nor the stripped path maps to a page.
+    /// </summary>
+    internal static string ResolveLeaf(string dashboardRelativePath, QuartzDashboardOptions options)
+    {
         string normalized = DashboardLink.NormalizeRelativePath(dashboardRelativePath);
-        string dashboardRoot = options.EscapedDashboardPath.TrimStart('/');
-        if (normalized.Equals(dashboardRoot, StringComparison.OrdinalIgnoreCase))
+        if (!options.HasCustomDashboardPath || Match(normalized) is not null)
         {
-            return Match(string.Empty);
+            return normalized;
         }
 
-        if (normalized.StartsWith(dashboardRoot + "/", StringComparison.OrdinalIgnoreCase))
+        if (DashboardLink.TryStripDashboardPrefix(normalized, options, out string stripped) && Match(stripped) is not null)
         {
-            return Match(normalized.Substring(dashboardRoot.Length + 1));
+            return stripped;
         }
 
-        return null;
+        return normalized;
     }
 
     /// <summary>

--- a/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
@@ -133,17 +133,22 @@
 
     private string NavClass(string route)
     {
-        string relativePath = DashboardLink.NormalizeRelativePath(NavigationManager.ToBaseRelativePath(_currentUri));
-        string target = Link(route);
+        // Compare dashboard-root-relative paths so highlighting works in every render context:
+        // ToDashboardRelativePath resolves both the prerender and the interactive base URI shapes
+        string? relativePath = DashboardLink.ToDashboardRelativePath(_currentUri, NavigationManager.BaseUri, Options.Value);
+        if (relativePath is null)
+        {
+            return string.Empty;
+        }
 
         // Exact match for dashboard root, prefix match for sub-pages
         if (route.Length == 0)
         {
-            return relativePath.Equals(target, StringComparison.OrdinalIgnoreCase) ? "qz-nav-active" : string.Empty;
+            return relativePath.Length == 0 ? "qz-nav-active" : string.Empty;
         }
 
-        bool isActive = relativePath.Equals(target, StringComparison.OrdinalIgnoreCase)
-            || relativePath.StartsWith(target + "/", StringComparison.OrdinalIgnoreCase);
+        bool isActive = relativePath.Equals(route, StringComparison.OrdinalIgnoreCase)
+            || relativePath.StartsWith(route + "/", StringComparison.OrdinalIgnoreCase);
 
         return isActive ? "qz-nav-active" : string.Empty;
     }

--- a/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
@@ -118,11 +118,11 @@
 
 @code
 {
-    private string _currentUri = string.Empty;
+    private string? _currentRelativePath;
 
     protected override void OnInitialized()
     {
-        _currentUri = NavigationManager.Uri;
+        UpdateCurrentRelativePath(NavigationManager.Uri);
         NavigationManager.LocationChanged += OnLocationChanged;
     }
 
@@ -131,11 +131,16 @@
         return DashboardLink.To(Options.Value, subPath);
     }
 
+    private void UpdateCurrentRelativePath(string uri)
+    {
+        // Resolved once per location change (NavClass runs for every nav link on every render):
+        // ToDashboardRelativePath handles both the prerender and the interactive base URI shapes
+        _currentRelativePath = DashboardLink.ToDashboardRelativePath(uri, NavigationManager.BaseUri, Options.Value);
+    }
+
     private string NavClass(string route)
     {
-        // Compare dashboard-root-relative paths so highlighting works in every render context:
-        // ToDashboardRelativePath resolves both the prerender and the interactive base URI shapes
-        string? relativePath = DashboardLink.ToDashboardRelativePath(_currentUri, NavigationManager.BaseUri, Options.Value);
+        string? relativePath = _currentRelativePath;
         if (relativePath is null)
         {
             return string.Empty;
@@ -155,7 +160,7 @@
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
-        _currentUri = e.Location;
+        UpdateCurrentRelativePath(e.Location);
         InvokeAsync(StateHasChanged);
     }
 

--- a/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
@@ -134,8 +134,11 @@
     private void UpdateCurrentRelativePath(string uri)
     {
         // Resolved once per location change (NavClass runs for every nav link on every render):
-        // ToDashboardRelativePath handles both the prerender and the interactive base URI shapes
-        _currentRelativePath = DashboardLink.ToDashboardRelativePath(uri, NavigationManager.BaseUri, Options.Value);
+        // ToDashboardRelativePath handles both the prerender and the interactive base URI shapes,
+        // and ResolveLeaf applies the same prefix-strip retry as route matching so highlighting is
+        // correct even when the application path base ends with the custom dashboard path
+        string? relative = DashboardLink.ToDashboardRelativePath(uri, NavigationManager.BaseUri, Options.Value);
+        _currentRelativePath = relative is null ? null : DashboardRouteTable.ResolveLeaf(relative, Options.Value);
     }
 
     private string NavClass(string route)

--- a/src/Quartz.Dashboard/Components/Pages/History.razor
+++ b/src/Quartz.Dashboard/Components/Pages/History.razor
@@ -303,7 +303,15 @@
         string normalizedTriggerFilter = triggerFilter.Trim();
 
         string updatedPath = BuildHistoryRelativeUri(normalizedPage, normalizedJobFilter, normalizedTriggerFilter);
-        string currentPath = Navigation.ToBaseRelativePath(Navigation.Uri).TrimStart('/');
+
+        // Not Navigation.ToBaseRelativePath: it compares ordinally and throws when the browser URL
+        // casing differs from the base URI casing (server-side route matching is case-insensitive,
+        // so such URLs render fine); an unmatched base just falls through to NavigateTo below
+        string uri = Navigation.Uri;
+        string baseUri = Navigation.BaseUri;
+        string currentPath = uri.StartsWith(baseUri, StringComparison.OrdinalIgnoreCase)
+            ? uri.Substring(baseUri.Length).TrimStart('/')
+            : string.Empty;
         if (PathsEqual(updatedPath, currentPath))
         {
             _page = normalizedPage;

--- a/src/Quartz.Dashboard/Components/Pages/History.razor
+++ b/src/Quartz.Dashboard/Components/Pages/History.razor
@@ -307,11 +307,7 @@
         // Not Navigation.ToBaseRelativePath: it compares ordinally and throws when the browser URL
         // casing differs from the base URI casing (server-side route matching is case-insensitive,
         // so such URLs render fine); an unmatched base just falls through to NavigateTo below
-        string uri = Navigation.Uri;
-        string baseUri = Navigation.BaseUri;
-        string currentPath = uri.StartsWith(baseUri, StringComparison.OrdinalIgnoreCase)
-            ? uri.Substring(baseUri.Length).TrimStart('/')
-            : string.Empty;
+        string currentPath = (DashboardLink.ToBaseRelative(Navigation.Uri, Navigation.BaseUri) ?? string.Empty).TrimStart('/');
         if (PathsEqual(updatedPath, currentPath))
         {
             _page = normalizedPage;

--- a/src/Quartz.Dashboard/Components/QuartzDashboardApp.razor
+++ b/src/Quartz.Dashboard/Components/QuartzDashboardApp.razor
@@ -37,7 +37,20 @@
             // the only prefix a path-forwarding reverse proxy is guaranteed to expose (#3134).
             // The percent-encoded form keeps the browser's document.baseURI comparable to the
             // configured path (the path base from Navigation.BaseUri is already encoded).
-            return pathBase.TrimEnd('/') + options.EscapedDashboardPath + "/";
+            string baseHrefPath = pathBase.TrimEnd('/') + options.EscapedDashboardPath;
+
+            // Server-side route matching is case-insensitive, so the request URL may carry different
+            // casing than the configured path; keep the request's casing in the <base href> so the
+            // document base URI stays an ordinal prefix of the browser URL (relative navigations and
+            // NavigationManager.ToBaseRelativePath depend on that)
+            string requestPath = new Uri(Navigation.Uri).AbsolutePath;
+            if (requestPath.StartsWith(baseHrefPath, StringComparison.OrdinalIgnoreCase)
+                && (requestPath.Length == baseHrefPath.Length || requestPath[baseHrefPath.Length] == '/'))
+            {
+                return requestPath.Substring(0, baseHrefPath.Length) + "/";
+            }
+
+            return baseHrefPath + "/";
         }
     }
 }

--- a/src/Quartz.Dashboard/Components/QuartzDashboardApp.razor
+++ b/src/Quartz.Dashboard/Components/QuartzDashboardApp.razor
@@ -34,8 +34,10 @@
 
             // Custom-path standalone mode: root the document at the dashboard itself so the framework
             // script, stylesheet, _blazor circuit and navigation links all resolve under DashboardPath —
-            // the only prefix a path-forwarding reverse proxy is guaranteed to expose (#3134)
-            return pathBase.TrimEnd('/') + options.TrimmedDashboardPath + "/";
+            // the only prefix a path-forwarding reverse proxy is guaranteed to expose (#3134).
+            // The percent-encoded form keeps the browser's document.baseURI comparable to the
+            // configured path (the path base from Navigation.BaseUri is already encoded).
+            return pathBase.TrimEnd('/') + options.EscapedDashboardPath + "/";
         }
     }
 }

--- a/src/Quartz.Dashboard/Components/QuartzDashboardApp.razor
+++ b/src/Quartz.Dashboard/Components/QuartzDashboardApp.razor
@@ -1,11 +1,12 @@
 @inject Microsoft.AspNetCore.Components.NavigationManager Navigation
+@inject Microsoft.Extensions.Options.IOptions<QuartzDashboardOptions> Options
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quartz.NET Dashboard</title>
-    <base href="@(new Uri(Navigation.BaseUri).AbsolutePath)" />
+    <base href="@BaseHref" />
     <HeadOutlet @rendermode="RenderMode.InteractiveServer" />
 </head>
 <body>
@@ -14,3 +15,27 @@
     <script src="_framework/blazor.web.js"></script>
 </body>
 </html>
+
+@code
+{
+    private string BaseHref
+    {
+        get
+        {
+            // Path base of the host application ("/" when none); this shell only renders during
+            // static server-side rendering, where Navigation.BaseUri reflects HttpRequest.PathBase
+            string pathBase = new Uri(Navigation.BaseUri).AbsolutePath;
+
+            QuartzDashboardOptions options = Options.Value;
+            if (!options.HasCustomDashboardPath)
+            {
+                return pathBase;
+            }
+
+            // Custom-path standalone mode: root the document at the dashboard itself so the framework
+            // script, stylesheet, _blazor circuit and navigation links all resolve under DashboardPath —
+            // the only prefix a path-forwarding reverse proxy is guaranteed to expose (#3134)
+            return pathBase.TrimEnd('/') + options.TrimmedDashboardPath + "/";
+        }
+    }
+}

--- a/src/Quartz.Dashboard/Components/Routes.razor
+++ b/src/Quartz.Dashboard/Components/Routes.razor
@@ -39,11 +39,8 @@ else
 
     private void UpdateRouteData(string uri)
     {
-        // ToBaseRelativePath throws for URIs outside the base URI space; treat those as not found
-        string baseUri = Navigation.BaseUri;
-        _routeData = uri.StartsWith(baseUri, StringComparison.OrdinalIgnoreCase)
-            ? DashboardRouteTable.Match(uri.Substring(baseUri.Length), Options.Value)
-            : null;
+        string? relative = DashboardLink.ToDashboardRelativePath(uri, Navigation.BaseUri, Options.Value);
+        _routeData = relative is null ? null : DashboardRouteTable.Match(relative);
     }
 
     public void Dispose()

--- a/src/Quartz.Dashboard/Components/Routes.razor
+++ b/src/Quartz.Dashboard/Components/Routes.razor
@@ -40,7 +40,7 @@ else
     private void UpdateRouteData(string uri)
     {
         string? relative = DashboardLink.ToDashboardRelativePath(uri, Navigation.BaseUri, Options.Value);
-        _routeData = relative is null ? null : DashboardRouteTable.Match(relative);
+        _routeData = relative is null ? null : DashboardRouteTable.Match(relative, Options.Value);
     }
 
     public void Dispose()

--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -17,7 +17,9 @@
  */
 #endregion
 
+using System.Collections.Concurrent;
 using System.Reflection;
+using System.Security.Cryptography;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -177,11 +179,12 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         if (hasCustomPath)
         {
             // With a custom path the shell renders a dashboard-rooted <base href>, so the browser
-            // requests the static assets and the Blazor framework script under the dashboard path.
+            // requests the static assets and the Blazor framework plumbing under the dashboard path.
             // Mirror them there so a reverse proxy that forwards only the dashboard prefix can reach
             // them (#3134); the root asset endpoint stays for backwards compatibility.
             assetEndpoints.Add(MapDashboardStaticAssets(builder, pathPrefix: dashboardPath));
             assetEndpoints.Add(MapDashboardFrameworkScript(builder, dashboardPath));
+            assetEndpoints.Add(MapDashboardOpaqueRedirect(builder, dashboardPath));
         }
 
         if (!string.IsNullOrWhiteSpace(options.AuthorizationPolicy))
@@ -269,16 +272,19 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
 
     private static readonly FileExtensionContentTypeProvider ContentTypeProvider = new();
 
+    private static readonly string[] GetAndHeadMethods = ["GET", "HEAD"];
+
     private static RouteHandlerBuilder MapDashboardStaticAssets(IEndpointRouteBuilder builder, string pathPrefix)
     {
         string pattern = pathPrefix.Length == 0
             ? "_content/Quartz.Dashboard/{**path}"
             : pathPrefix + "/_content/Quartz.Dashboard/{**path}";
 
-        return builder.MapGet(pattern, async (HttpContext context, string path) =>
+        return builder.MapMethods(pattern, GetAndHeadMethods, async (HttpContext context, string path) =>
         {
             var env = context.RequestServices.GetRequiredService<IWebHostEnvironment>();
-            var fileInfo = env.WebRootFileProvider.GetFileInfo($"_content/Quartz.Dashboard/{path}");
+            string assetPath = $"_content/Quartz.Dashboard/{path}";
+            var fileInfo = env.WebRootFileProvider.GetFileInfo(assetPath);
             if (!fileInfo.Exists)
             {
                 context.Response.StatusCode = StatusCodes.Status404NotFound;
@@ -290,7 +296,7 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
                 contentType = "application/octet-stream";
             }
 
-            await WriteFileAsync(context, fileInfo, contentType).ConfigureAwait(false);
+            await WriteFileAsync(context, assetPath, fileInfo, contentType).ConfigureAwait(false);
         }).ExcludeFromDescription();
     }
 
@@ -305,14 +311,15 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         catch (InvalidOperationException)
         {
             // .NET 10+ ships the script as a static web asset instead of an embedded manifest;
-            // the WebRootFileProvider lookup covers those hosts
+            // the WebRootFileProvider lookup and the root-endpoint forwarding cover those hosts
             return null;
         }
     });
 
     private static IEndpointConventionBuilder MapDashboardFrameworkScript(IEndpointRouteBuilder builder, string dashboardPath)
     {
-        return builder.MapGet(dashboardPath + "/_framework/blazor.web.js", async (HttpContext context) =>
+        const string scriptPath = "/_framework/blazor.web.js";
+        return builder.MapMethods(dashboardPath + scriptPath, GetAndHeadMethods, async (HttpContext context) =>
         {
             var env = context.RequestServices.GetRequiredService<IWebHostEnvironment>();
             IFileInfo fileInfo = env.WebRootFileProvider.GetFileInfo("_framework/blazor.web.js");
@@ -321,28 +328,94 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
                 fileInfo = fallbackProvider.GetFileInfo("_framework/blazor.web.js");
             }
 
-            if (!fileInfo.Exists)
+            if (fileInfo.Exists)
             {
-                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                // parity with the framework-owned script endpoint
+                context.Response.Headers.CacheControl = "no-cache";
+                await WriteFileAsync(context, "_framework/blazor.web.js", fileInfo, "text/javascript").ConfigureAwait(false);
                 return;
             }
 
-            // parity with the framework-owned script endpoint
-            context.Response.Headers.CacheControl = "no-cache";
-            await WriteFileAsync(context, fileInfo, "text/javascript").ConfigureAwait(false);
+            // .NET 10+ hosts serve the script through MapStaticAssets endpoints rather than the web
+            // root or an embedded manifest; forward to the framework-owned root endpoint when present
+            if (!await TryForwardToRootEndpointAsync(context, scriptPath).ConfigureAwait(false))
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
         }).ExcludeFromDescription();
     }
 
-    private static async Task WriteFileAsync(HttpContext context, IFileInfo fileInfo, string contentType)
+    private static IEndpointConventionBuilder MapDashboardOpaqueRedirect(IEndpointRouteBuilder builder, string dashboardPath)
+    {
+        // The framework emits enhanced-navigation redirects as URLs relative to the document base,
+        // which the dashboard-rooted <base href> resolves under the dashboard path; forward those
+        // requests to the framework-owned root endpoint so the redirect flow completes (#3134)
+        const string redirectPath = "/_framework/opaque-redirect";
+        return builder.MapGet(dashboardPath + redirectPath, async (HttpContext context) =>
+        {
+            if (!await TryForwardToRootEndpointAsync(context, redirectPath).ConfigureAwait(false))
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
+        }).ExcludeFromDescription();
+    }
+
+    private static async Task<bool> TryForwardToRootEndpointAsync(HttpContext context, string rootPath)
+    {
+        var dataSource = context.RequestServices.GetRequiredService<EndpointDataSource>();
+        RouteEndpoint? rootEndpoint = null;
+        foreach (Endpoint endpoint in dataSource.Endpoints)
+        {
+            if (endpoint is RouteEndpoint { RequestDelegate: not null } routeEndpoint)
+            {
+                string? rawText = routeEndpoint.RoutePattern.RawText;
+                if (rawText is not null
+                    && (rootPath.Equals(rawText, StringComparison.OrdinalIgnoreCase)
+                        || (rawText.Length == rootPath.Length - 1 && rootPath.EndsWith(rawText, StringComparison.OrdinalIgnoreCase))))
+                {
+                    rootEndpoint = routeEndpoint;
+                    break;
+                }
+            }
+        }
+
+        if (rootEndpoint is null)
+        {
+            return false;
+        }
+
+        // Handlers resolve content from the request path and the endpoint metadata, so both must
+        // describe the root endpoint while its delegate runs
+        PathString originalPath = context.Request.Path;
+        Endpoint? originalEndpoint = context.GetEndpoint();
+        context.Request.Path = rootPath;
+        context.SetEndpoint(rootEndpoint);
+        try
+        {
+            await rootEndpoint.RequestDelegate!(context).ConfigureAwait(false);
+        }
+        finally
+        {
+            context.Request.Path = originalPath;
+            context.SetEndpoint(originalEndpoint);
+        }
+
+        return true;
+    }
+
+    private static readonly ConcurrentDictionary<string, (long Length, DateTimeOffset LastModified, EntityTagHeaderValue ETag)> ETagCache = new();
+
+    private static async Task WriteFileAsync(HttpContext context, string assetPath, IFileInfo fileInfo, string contentType)
     {
         // Stable validator so browsers can revalidate with If-None-Match and get a 304
         // instead of re-downloading the body on every full page load
-        var etag = new EntityTagHeaderValue($"\"{fileInfo.Length:x}-{fileInfo.LastModified.UtcTicks:x}\"");
+        EntityTagHeaderValue etag = await GetETagAsync(assetPath, fileInfo, context.RequestAborted).ConfigureAwait(false);
         context.Response.Headers.ETag = etag.ToString();
 
         foreach (EntityTagHeaderValue requestTag in context.Request.GetTypedHeaders().IfNoneMatch)
         {
-            if (requestTag.Compare(etag, useStrongComparison: false))
+            // RFC 9110: "*" matches any current representation
+            if (EntityTagHeaderValue.Any.Equals(requestTag) || requestTag.Compare(etag, useStrongComparison: false))
             {
                 context.Response.StatusCode = StatusCodes.Status304NotModified;
                 return;
@@ -351,6 +424,36 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
 
         context.Response.ContentType = contentType;
         context.Response.ContentLength = fileInfo.Length;
+
+        if (HttpMethods.IsHead(context.Request.Method))
+        {
+            return;
+        }
+
         await context.Response.SendFileAsync(fileInfo, context.RequestAborted).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<EntityTagHeaderValue> GetETagAsync(string assetPath, IFileInfo fileInfo, CancellationToken cancellationToken)
+    {
+        // Content-derived so identical files validate identically across machines and restarts
+        // (the embedded provider stamps LastModified from the assembly file's write time, which
+        // differs per instance); Length + LastModified only guard the per-process cache entry
+        if (ETagCache.TryGetValue(assetPath, out var cached)
+            && cached.Length == fileInfo.Length
+            && cached.LastModified == fileInfo.LastModified)
+        {
+            return cached.ETag;
+        }
+
+        byte[] hash;
+        Stream stream = fileInfo.CreateReadStream();
+        await using (stream.ConfigureAwait(false))
+        {
+            hash = await SHA256.HashDataAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+
+        var etag = new EntityTagHeaderValue($"\"{Convert.ToHexString(hash)}\"");
+        ETagCache[assetPath] = (fileInfo.Length, fileInfo.LastModified, etag);
+        return etag;
     }
 }

--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -28,6 +28,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 
 using Quartz.Dashboard.Components;
@@ -104,7 +105,7 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         QuartzDashboardOptions options = builder.ServiceProvider.GetRequiredService<IOptions<QuartzDashboardOptions>>().Value;
         string dashboardPath = options.TrimmedDashboardPath;
 
-        bool hasCustomPath = !string.Equals(dashboardPath, QuartzDashboardOptions.DefaultDashboardPath, StringComparison.OrdinalIgnoreCase);
+        bool hasCustomPath = options.HasCustomDashboardPath;
         if (hasCustomPath && !dashboardOwnsComponents)
         {
             throw new InvalidOperationException(
@@ -120,14 +121,37 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
             // Interactive navigation is handled by the dashboard's own route matching in Routes.razor.
             components.Add(endpointBuilder =>
             {
-                if (endpointBuilder is not RouteEndpointBuilder routeEndpointBuilder
-                    || GetComponentType(endpointBuilder)?.Assembly != typeof(QuartzDashboardApp).Assembly)
+                if (endpointBuilder is not RouteEndpointBuilder routeEndpointBuilder)
                 {
                     return;
                 }
 
                 string? rawText = routeEndpointBuilder.RoutePattern.RawText;
-                if (rawText is null
+                if (string.IsNullOrEmpty(rawText) || rawText[0] != '/')
+                {
+                    return;
+                }
+
+                Type? componentType = GetComponentType(endpointBuilder);
+                if (componentType is null)
+                {
+                    // The /_blazor circuit endpoints move under the dashboard path so a reverse proxy
+                    // that forwards only the dashboard prefix can reach them (#3134); SignalR dispatch
+                    // does not depend on the route pattern. Other framework-owned endpoints stay put:
+                    // newer runtimes register the blazor.web.js script endpoint through this data
+                    // source and it serves content keyed by its original path, so re-rooting it breaks
+                    // it — the dashboard maps its own copy under the dashboard path instead.
+                    // Standalone mode only: a custom path is rejected in integrated mode, so the
+                    // builder never contains host application endpoints here.
+                    if (rawText == "/_blazor" || rawText.StartsWith("/_blazor/", StringComparison.Ordinal))
+                    {
+                        routeEndpointBuilder.RoutePattern = RoutePatternFactory.Parse(dashboardPath + rawText);
+                    }
+
+                    return;
+                }
+
+                if (componentType.Assembly != typeof(QuartzDashboardApp).Assembly
                     || !rawText.StartsWith(QuartzDashboardOptions.DefaultDashboardPath, StringComparison.OrdinalIgnoreCase)
                     || (rawText.Length > QuartzDashboardOptions.DefaultDashboardPath.Length && rawText[QuartzDashboardOptions.DefaultDashboardPath.Length] != '/'))
                 {
@@ -144,7 +168,19 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
 
         // Serve dashboard static web assets via endpoint routing as a fallback
         // for hosts that don't configure UseStaticFiles() (e.g., API-only projects)
-        RouteHandlerBuilder staticAssets = MapDashboardStaticAssets(builder);
+        RouteHandlerBuilder staticAssets = MapDashboardStaticAssets(builder, pathPrefix: string.Empty);
+
+        RouteHandlerBuilder? prefixedStaticAssets = null;
+        IEndpointConventionBuilder? frameworkScript = null;
+        if (hasCustomPath)
+        {
+            // With a custom path the shell renders a dashboard-rooted <base href>, so the browser
+            // requests the static assets and the Blazor framework script under the dashboard path.
+            // Mirror them there so a reverse proxy that forwards only the dashboard prefix can reach
+            // them (#3134); the root asset endpoint stays for backwards compatibility.
+            prefixedStaticAssets = MapDashboardStaticAssets(builder, pathPrefix: dashboardPath);
+            frameworkScript = MapDashboardFrameworkScript(builder, dashboardPath);
+        }
 
         if (!string.IsNullOrWhiteSpace(options.AuthorizationPolicy))
         {
@@ -155,6 +191,8 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
             // carries explicit authorization metadata and keeps working in applications that use a
             // fail-closed FallbackPolicy (#3097).
             staticAssets.RequireAuthorization(policyName);
+            prefixedStaticAssets?.RequireAuthorization(policyName);
+            frameworkScript?.RequireAuthorization(policyName);
 
             if (dashboardOwnsComponents)
             {
@@ -182,9 +220,11 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         else
         {
             // Without a dashboard policy the dashboard adds no authorization of its own. The static
-            // asset endpoint opts out of authorization so applications enforcing a fail-closed
+            // asset endpoints opt out of authorization so applications enforcing a fail-closed
             // FallbackPolicy can still load dashboard CSS/JS; the files are public package content (#3097).
             staticAssets.AllowAnonymous();
+            prefixedStaticAssets?.AllowAnonymous();
+            frameworkScript?.AllowAnonymous();
 
             if (dashboardOwnsComponents)
             {
@@ -225,9 +265,13 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
 
     private static readonly FileExtensionContentTypeProvider ContentTypeProvider = new();
 
-    private static RouteHandlerBuilder MapDashboardStaticAssets(IEndpointRouteBuilder builder)
+    private static RouteHandlerBuilder MapDashboardStaticAssets(IEndpointRouteBuilder builder, string pathPrefix)
     {
-        return builder.MapGet("_content/Quartz.Dashboard/{**path}", async (HttpContext context, string path) =>
+        string pattern = pathPrefix.Length == 0
+            ? "_content/Quartz.Dashboard/{**path}"
+            : pathPrefix + "/_content/Quartz.Dashboard/{**path}";
+
+        return builder.MapGet(pattern, async (HttpContext context, string path) =>
         {
             var env = context.RequestServices.GetRequiredService<IWebHostEnvironment>();
             var fileInfo = env.WebRootFileProvider.GetFileInfo($"_content/Quartz.Dashboard/{path}");
@@ -242,14 +286,58 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
                 contentType = "application/octet-stream";
             }
 
-            context.Response.ContentType = contentType;
-            context.Response.ContentLength = fileInfo.Length;
-
-            var stream = fileInfo.CreateReadStream();
-            await using (stream.ConfigureAwait(false))
-            {
-                await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
-            }
+            await WriteFileAsync(context, fileInfo, contentType).ConfigureAwait(false);
         }).ExcludeFromDescription();
+    }
+
+    private static readonly Lazy<IFileProvider?> FrameworkScriptFallbackProvider = new(static () =>
+    {
+        try
+        {
+            // .NET 8 and 9 embed blazor.web.js into Microsoft.AspNetCore.Components.Endpoints; this is
+            // the same source the framework-owned /_framework/blazor.web.js endpoint serves it from
+            return new ManifestEmbeddedFileProvider(typeof(RazorComponentsEndpointRouteBuilderExtensions).Assembly);
+        }
+        catch (InvalidOperationException)
+        {
+            // .NET 10+ ships the script as a static web asset instead of an embedded manifest;
+            // the WebRootFileProvider lookup covers those hosts
+            return null;
+        }
+    });
+
+    private static IEndpointConventionBuilder MapDashboardFrameworkScript(IEndpointRouteBuilder builder, string dashboardPath)
+    {
+        return builder.MapGet(dashboardPath + "/_framework/blazor.web.js", async (HttpContext context) =>
+        {
+            var env = context.RequestServices.GetRequiredService<IWebHostEnvironment>();
+            IFileInfo fileInfo = env.WebRootFileProvider.GetFileInfo("_framework/blazor.web.js");
+            if (!fileInfo.Exists && FrameworkScriptFallbackProvider.Value is { } fallbackProvider)
+            {
+                fileInfo = fallbackProvider.GetFileInfo("_framework/blazor.web.js");
+            }
+
+            if (!fileInfo.Exists)
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+
+            // parity with the framework-owned script endpoint
+            context.Response.Headers.CacheControl = "no-cache";
+            await WriteFileAsync(context, fileInfo, "text/javascript").ConfigureAwait(false);
+        }).ExcludeFromDescription();
+    }
+
+    private static async Task WriteFileAsync(HttpContext context, IFileInfo fileInfo, string contentType)
+    {
+        context.Response.ContentType = contentType;
+        context.Response.ContentLength = fileInfo.Length;
+
+        Stream stream = fileInfo.CreateReadStream();
+        await using (stream.ConfigureAwait(false))
+        {
+            await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -30,6 +30,7 @@ using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 
 using Quartz.Dashboard.Components;
 using Quartz.Dashboard.Hubs;
@@ -168,18 +169,19 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
 
         // Serve dashboard static web assets via endpoint routing as a fallback
         // for hosts that don't configure UseStaticFiles() (e.g., API-only projects)
-        RouteHandlerBuilder staticAssets = MapDashboardStaticAssets(builder, pathPrefix: string.Empty);
+        List<IEndpointConventionBuilder> assetEndpoints =
+        [
+            MapDashboardStaticAssets(builder, pathPrefix: string.Empty)
+        ];
 
-        RouteHandlerBuilder? prefixedStaticAssets = null;
-        IEndpointConventionBuilder? frameworkScript = null;
         if (hasCustomPath)
         {
             // With a custom path the shell renders a dashboard-rooted <base href>, so the browser
             // requests the static assets and the Blazor framework script under the dashboard path.
             // Mirror them there so a reverse proxy that forwards only the dashboard prefix can reach
             // them (#3134); the root asset endpoint stays for backwards compatibility.
-            prefixedStaticAssets = MapDashboardStaticAssets(builder, pathPrefix: dashboardPath);
-            frameworkScript = MapDashboardFrameworkScript(builder, dashboardPath);
+            assetEndpoints.Add(MapDashboardStaticAssets(builder, pathPrefix: dashboardPath));
+            assetEndpoints.Add(MapDashboardFrameworkScript(builder, dashboardPath));
         }
 
         if (!string.IsNullOrWhiteSpace(options.AuthorizationPolicy))
@@ -187,12 +189,13 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
             string policyName = options.AuthorizationPolicy;
             hub.RequireAuthorization(policyName);
 
-            // Gate static assets with the same policy as the rest of the dashboard so the endpoint
-            // carries explicit authorization metadata and keeps working in applications that use a
+            // Gate static assets with the same policy as the rest of the dashboard so the endpoints
+            // carry explicit authorization metadata and keep working in applications that use a
             // fail-closed FallbackPolicy (#3097).
-            staticAssets.RequireAuthorization(policyName);
-            prefixedStaticAssets?.RequireAuthorization(policyName);
-            frameworkScript?.RequireAuthorization(policyName);
+            foreach (IEndpointConventionBuilder assetEndpoint in assetEndpoints)
+            {
+                assetEndpoint.RequireAuthorization(policyName);
+            }
 
             if (dashboardOwnsComponents)
             {
@@ -222,9 +225,10 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
             // Without a dashboard policy the dashboard adds no authorization of its own. The static
             // asset endpoints opt out of authorization so applications enforcing a fail-closed
             // FallbackPolicy can still load dashboard CSS/JS; the files are public package content (#3097).
-            staticAssets.AllowAnonymous();
-            prefixedStaticAssets?.AllowAnonymous();
-            frameworkScript?.AllowAnonymous();
+            foreach (IEndpointConventionBuilder assetEndpoint in assetEndpoints)
+            {
+                assetEndpoint.AllowAnonymous();
+            }
 
             if (dashboardOwnsComponents)
             {
@@ -331,13 +335,22 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
 
     private static async Task WriteFileAsync(HttpContext context, IFileInfo fileInfo, string contentType)
     {
+        // Stable validator so browsers can revalidate with If-None-Match and get a 304
+        // instead of re-downloading the body on every full page load
+        var etag = new EntityTagHeaderValue($"\"{fileInfo.Length:x}-{fileInfo.LastModified.UtcTicks:x}\"");
+        context.Response.Headers.ETag = etag.ToString();
+
+        foreach (EntityTagHeaderValue requestTag in context.Request.GetTypedHeaders().IfNoneMatch)
+        {
+            if (requestTag.Compare(etag, useStrongComparison: false))
+            {
+                context.Response.StatusCode = StatusCodes.Status304NotModified;
+                return;
+            }
+        }
+
         context.Response.ContentType = contentType;
         context.Response.ContentLength = fileInfo.Length;
-
-        Stream stream = fileInfo.CreateReadStream();
-        await using (stream.ConfigureAwait(false))
-        {
-            await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
-        }
+        await context.Response.SendFileAsync(fileInfo, context.RequestAborted).ConfigureAwait(false);
     }
 }

--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -296,7 +296,10 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
                 contentType = "application/octet-stream";
             }
 
-            await WriteFileAsync(context, assetPath, fileInfo, contentType).ConfigureAwait(false);
+            // Key the ETag cache by the resolved physical path (canonical, not the request path);
+            // a non-physical provider yields null, which disables caching rather than caching under
+            // attacker-controlled input
+            await WriteFileAsync(context, fileInfo, contentType, etagCacheKey: fileInfo.PhysicalPath).ConfigureAwait(false);
         }).ExcludeFromDescription();
     }
 
@@ -308,10 +311,12 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
             // the same source the framework-owned /_framework/blazor.web.js endpoint serves it from
             return new ManifestEmbeddedFileProvider(typeof(RazorComponentsEndpointRouteBuilderExtensions).Assembly);
         }
-        catch (InvalidOperationException)
+        catch (Exception)
         {
-            // .NET 10+ ships the script as a static web asset instead of an embedded manifest;
-            // the WebRootFileProvider lookup and the root-endpoint forwarding cover those hosts
+            // .NET 10+ ships the script as a static web asset instead of an embedded manifest, so the
+            // provider cannot be constructed; the WebRootFileProvider lookup and the root-endpoint
+            // forwarding cover those hosts. Any failure must yield null rather than escape the Lazy
+            // factory, which would cache the exception and rethrow it on every later access.
             return null;
         }
     });
@@ -332,7 +337,8 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
             {
                 // parity with the framework-owned script endpoint
                 context.Response.Headers.CacheControl = "no-cache";
-                await WriteFileAsync(context, "_framework/blazor.web.js", fileInfo, "text/javascript").ConfigureAwait(false);
+                // the embedded provider exposes no physical path, so fall back to a fixed logical key
+                await WriteFileAsync(context, fileInfo, "text/javascript", etagCacheKey: fileInfo.PhysicalPath ?? "_framework/blazor.web.js").ConfigureAwait(false);
                 return;
             }
 
@@ -405,11 +411,11 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
 
     private static readonly ConcurrentDictionary<string, (long Length, DateTimeOffset LastModified, EntityTagHeaderValue ETag)> ETagCache = new();
 
-    private static async Task WriteFileAsync(HttpContext context, string assetPath, IFileInfo fileInfo, string contentType)
+    private static async Task WriteFileAsync(HttpContext context, IFileInfo fileInfo, string contentType, string? etagCacheKey)
     {
         // Stable validator so browsers can revalidate with If-None-Match and get a 304
         // instead of re-downloading the body on every full page load
-        EntityTagHeaderValue etag = await GetETagAsync(assetPath, fileInfo, context.RequestAborted).ConfigureAwait(false);
+        EntityTagHeaderValue etag = await GetETagAsync(fileInfo, etagCacheKey, context.RequestAborted).ConfigureAwait(false);
         context.Response.Headers.ETag = etag.ToString();
 
         foreach (EntityTagHeaderValue requestTag in context.Request.GetTypedHeaders().IfNoneMatch)
@@ -433,12 +439,17 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         await context.Response.SendFileAsync(fileInfo, context.RequestAborted).ConfigureAwait(false);
     }
 
-    private static async ValueTask<EntityTagHeaderValue> GetETagAsync(string assetPath, IFileInfo fileInfo, CancellationToken cancellationToken)
+    private static async ValueTask<EntityTagHeaderValue> GetETagAsync(IFileInfo fileInfo, string? cacheKey, CancellationToken cancellationToken)
     {
-        // Content-derived so identical files validate identically across machines and restarts
-        // (the embedded provider stamps LastModified from the assembly file's write time, which
-        // differs per instance); Length + LastModified only guard the per-process cache entry
-        if (ETagCache.TryGetValue(assetPath, out var cached)
+        // The cache is keyed by a canonical identity supplied by the caller (the file's physical
+        // path, or a fixed logical key for embedded content) — never the request path, so an
+        // unauthenticated client cannot grow it without bound by requesting the same file under many
+        // non-canonical path variants (casing, duplicate slashes) that all resolve to one file.
+        // The ETag itself is content-derived so identical files validate identically across machines
+        // and restarts (the embedded provider stamps LastModified from the assembly file's write
+        // time); Length + LastModified only guard the per-process cache entry.
+        if (cacheKey is not null
+            && ETagCache.TryGetValue(cacheKey, out var cached)
             && cached.Length == fileInfo.Length
             && cached.LastModified == fileInfo.LastModified)
         {
@@ -453,7 +464,11 @@ public static class QuartzDashboardEndpointRouteBuilderExtensions
         }
 
         var etag = new EntityTagHeaderValue($"\"{Convert.ToHexString(hash)}\"");
-        ETagCache[assetPath] = (fileInfo.Length, fileInfo.LastModified, etag);
+        if (cacheKey is not null)
+        {
+            ETagCache[cacheKey] = (fileInfo.Length, fileInfo.LastModified, etag);
+        }
+
         return etag;
     }
 }

--- a/src/Quartz.Dashboard/QuartzDashboardOptions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardOptions.cs
@@ -73,4 +73,11 @@ public class QuartzDashboardOptions
     /// </summary>
     internal bool HasCustomDashboardPath =>
         !string.Equals(TrimmedDashboardPath, DefaultDashboardPath, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// <see cref="TrimmedDashboardPath"/> in its percent-encoded form, as browsers emit it in
+    /// request URIs and the &lt;base href&gt;. Server-side route patterns keep the raw form
+    /// (route matching compares decoded values); client-side URI comparisons need this one.
+    /// </summary>
+    internal string EscapedDashboardPath => new Uri("http://localhost" + TrimmedDashboardPath).AbsolutePath;
 }

--- a/src/Quartz.Dashboard/QuartzDashboardOptions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardOptions.cs
@@ -50,19 +50,7 @@ public class QuartzDashboardOptions
     /// <see cref="DashboardPath"/> normalized to a rooted path without a trailing slash,
     /// falling back to <see cref="DefaultDashboardPath"/> when unset or empty.
     /// </summary>
-    internal string TrimmedDashboardPath
-    {
-        get
-        {
-            if (string.IsNullOrWhiteSpace(DashboardPath))
-            {
-                return DefaultDashboardPath;
-            }
-
-            string trimmed = DashboardPath.Trim().Trim('/');
-            return trimmed.Length == 0 ? DefaultDashboardPath : "/" + trimmed;
-        }
-    }
+    internal string TrimmedDashboardPath => DashboardPathCache.Trimmed;
 
     internal string TrimmedApiPath => ApiPath.TrimEnd('/');
 
@@ -71,13 +59,47 @@ public class QuartzDashboardOptions
     /// A custom path implies the standalone hosting mode because it is rejected when
     /// integrating with an existing Blazor application.
     /// </summary>
-    internal bool HasCustomDashboardPath =>
-        !string.Equals(TrimmedDashboardPath, DefaultDashboardPath, StringComparison.OrdinalIgnoreCase);
+    internal bool HasCustomDashboardPath => DashboardPathCache.HasCustom;
 
     /// <summary>
     /// <see cref="TrimmedDashboardPath"/> in its percent-encoded form, as browsers emit it in
     /// request URIs and the &lt;base href&gt;. Server-side route patterns keep the raw form
     /// (route matching compares decoded values); client-side URI comparisons need this one.
     /// </summary>
-    internal string EscapedDashboardPath => new Uri("http://localhost" + TrimmedDashboardPath).AbsolutePath;
+    internal string EscapedDashboardPath => DashboardPathCache.Escaped;
+
+    private (string Source, string Trimmed, string Escaped, bool HasCustom)? dashboardPathCache;
+
+    /// <summary>
+    /// Values derived from <see cref="DashboardPath"/>, computed once and reused — they are read
+    /// on Blazor render hot paths (links, route matching) while the option itself only changes
+    /// during startup configuration.
+    /// </summary>
+    private (string Source, string Trimmed, string Escaped, bool HasCustom) DashboardPathCache
+    {
+        get
+        {
+            string source = DashboardPath;
+            var cache = dashboardPathCache;
+            if (cache is null || !string.Equals(cache.Value.Source, source, StringComparison.Ordinal))
+            {
+                string trimmed = DefaultDashboardPath;
+                if (!string.IsNullOrWhiteSpace(source))
+                {
+                    string candidate = source.Trim().Trim('/');
+                    if (candidate.Length > 0)
+                    {
+                        trimmed = "/" + candidate;
+                    }
+                }
+
+                string escaped = new Uri("http://localhost" + trimmed).AbsolutePath;
+                bool hasCustom = !string.Equals(trimmed, DefaultDashboardPath, StringComparison.OrdinalIgnoreCase);
+                cache = (source, trimmed, escaped, hasCustom);
+                dashboardPathCache = cache;
+            }
+
+            return cache.Value;
+        }
+    }
 }

--- a/src/Quartz.Dashboard/QuartzDashboardOptions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardOptions.cs
@@ -68,20 +68,22 @@ public class QuartzDashboardOptions
     /// </summary>
     internal string EscapedDashboardPath => DashboardPathCache.Escaped;
 
-    private (string Source, string Trimmed, string Escaped, bool HasCustom)? dashboardPathCache;
+    private DerivedDashboardPath? dashboardPathCache;
 
     /// <summary>
     /// Values derived from <see cref="DashboardPath"/>, computed once and reused — they are read
     /// on Blazor render hot paths (links, route matching) while the option itself only changes
-    /// during startup configuration.
+    /// during startup configuration. Held behind a single reference so a concurrent reader always
+    /// observes a fully-populated instance (reference reads/writes are atomic) even if the option
+    /// is mutated mid-render.
     /// </summary>
-    private (string Source, string Trimmed, string Escaped, bool HasCustom) DashboardPathCache
+    private DerivedDashboardPath DashboardPathCache
     {
         get
         {
             string source = DashboardPath;
-            var cache = dashboardPathCache;
-            if (cache is null || !string.Equals(cache.Value.Source, source, StringComparison.Ordinal))
+            DerivedDashboardPath? cache = dashboardPathCache;
+            if (cache is null || !string.Equals(cache.Source, source, StringComparison.Ordinal))
             {
                 string trimmed = DefaultDashboardPath;
                 if (!string.IsNullOrWhiteSpace(source))
@@ -95,11 +97,13 @@ public class QuartzDashboardOptions
 
                 string escaped = new Uri("http://localhost" + trimmed).AbsolutePath;
                 bool hasCustom = !string.Equals(trimmed, DefaultDashboardPath, StringComparison.OrdinalIgnoreCase);
-                cache = (source, trimmed, escaped, hasCustom);
+                cache = new DerivedDashboardPath(source, trimmed, escaped, hasCustom);
                 dashboardPathCache = cache;
             }
 
-            return cache.Value;
+            return cache;
         }
     }
+
+    private sealed record DerivedDashboardPath(string Source, string Trimmed, string Escaped, bool HasCustom);
 }

--- a/src/Quartz.Dashboard/QuartzDashboardOptions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardOptions.cs
@@ -65,4 +65,12 @@ public class QuartzDashboardOptions
     }
 
     internal string TrimmedApiPath => ApiPath.TrimEnd('/');
+
+    /// <summary>
+    /// Whether <see cref="DashboardPath"/> differs from the compile-time default "/quartz".
+    /// A custom path implies the standalone hosting mode because it is rejected when
+    /// integrating with an existing Blazor application.
+    /// </summary>
+    internal bool HasCustomDashboardPath =>
+        !string.Equals(TrimmedDashboardPath, DefaultDashboardPath, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -41,6 +41,9 @@ public static class QuartzDashboardServiceCollectionExtensions
                 options => !string.IsNullOrWhiteSpace(options.DashboardPath) && options.DashboardPath.StartsWith('/'),
                 "DashboardPath must start with '/'")
             .Validate(
+                options => IsRoutableDashboardPath(options.DashboardPath),
+                "DashboardPath must be a simple URL path: it cannot contain '{', '}', '?', '#', '.' or '..' segments, or empty segments ('//')")
+            .Validate(
                 options => !string.IsNullOrWhiteSpace(options.ApiPath) && options.ApiPath.StartsWith('/'),
                 "ApiPath must start with '/'");
 
@@ -69,5 +72,42 @@ public static class QuartzDashboardServiceCollectionExtensions
         });
 
         return services;
+    }
+
+    private static readonly char[] InvalidDashboardPathChars = ['{', '}', '?', '#'];
+
+    /// <summary>
+    /// Validates that <see cref="QuartzDashboardOptions.DashboardPath"/> is a plain URL path: the
+    /// value is concatenated into route templates (where <c>{</c>/<c>}</c> would be parsed as route
+    /// parameters) and percent-encoded for client-side comparisons (where <c>?</c>/<c>#</c> and
+    /// <c>.</c>/<c>..</c> segments would be truncated or collapsed, diverging from the server route).
+    /// </summary>
+    private static bool IsRoutableDashboardPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            // the empty/whitespace case is reported by the "must start with '/'" validation
+            return true;
+        }
+
+        string trimmed = path.Trim().Trim('/');
+        if (trimmed.Length == 0)
+        {
+            // normalizes to the default "/quartz"
+            return true;
+        }
+
+        foreach (string segment in trimmed.Split('/'))
+        {
+            if (segment.Length == 0
+                || segment == "."
+                || segment == ".."
+                || segment.IndexOfAny(InvalidDashboardPathChars) >= 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
@@ -440,6 +440,19 @@ public class DashboardEndpointsTest
         }
     }
 
+    [TestCase("/tenant{env}")]
+    [TestCase("/ops/../quartz")]
+    [TestCase("/ops?x=1")]
+    [TestCase("/ops#frag")]
+    [TestCase("/ops//scheduler")]
+    public async Task InvalidDashboardPathShouldFailValidation(string dashboardPath)
+    {
+        await using WebApplication app = CreateApp(options => options.DashboardPath = dashboardPath);
+
+        Action act = () => app.MapQuartzDashboard();
+        act.Should().Throw<Microsoft.Extensions.Options.OptionsValidationException>().WithMessage("*DashboardPath*");
+    }
+
     [Test]
     public async Task CustomDashboardPathShouldForwardOpaqueRedirectToRootEndpoint()
     {
@@ -456,21 +469,11 @@ public class DashboardEndpointsTest
         {
             using System.Net.Http.HttpClient client = app.GetTestClient();
 
-            // without a valid protected payload the framework endpoint rejects the request (it may
-            // even throw), but anything other than the mirror's own 404 proves the request was
-            // forwarded to the framework-owned root endpoint
-            HttpStatusCode? status = null;
-            try
-            {
-                using HttpResponseMessage response = await client.GetAsync("/my-api/quartz/_framework/opaque-redirect");
-                status = response.StatusCode;
-            }
-            catch (Exception)
-            {
-                // the root endpoint threw while rejecting the unprotected payload — forwarding worked
-            }
-
-            status.Should().NotBe(HttpStatusCode.NotFound);
+            // the framework endpoint rejects the missing protected payload (400); a 404 would mean
+            // the mirror found nothing to forward to, and a throw from the mirror itself would
+            // surface as a test error rather than passing vacuously
+            using HttpResponseMessage response = await client.GetAsync("/my-api/quartz/_framework/opaque-redirect");
+            response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);
         }
         finally
         {

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
@@ -154,9 +154,10 @@ public class DashboardEndpointsTest
         patterns.Should().Contain(p => p != null && p.StartsWith("/ops/scheduler/_blazor", StringComparison.Ordinal));
         patterns.Should().Contain(p => p != null && p.StartsWith("/ops/scheduler/_blazor", StringComparison.Ordinal) && p.EndsWith("negotiate", StringComparison.Ordinal));
 
-        // dashboard-owned framework script and static asset endpoints exist under the dashboard
-        // path; the root-level asset endpoint stays for backwards compatibility
+        // dashboard-owned framework script, opaque-redirect and static asset endpoints exist under
+        // the dashboard path; the root-level asset endpoint stays for backwards compatibility
         patterns.Should().Contain("/ops/scheduler/_framework/blazor.web.js");
+        patterns.Should().Contain("/ops/scheduler/_framework/opaque-redirect");
         patterns.Should().Contain("/ops/scheduler/_content/Quartz.Dashboard/{**path}");
         patterns.Should().Contain("_content/Quartz.Dashboard/{**path}");
     }
@@ -186,6 +187,8 @@ public class DashboardEndpointsTest
 
         endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_framework/blazor.web.js")
             .Metadata.GetMetadata<IAuthorizeData>()!.Policy.Should().Be("dashboard-policy");
+        endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_framework/opaque-redirect")
+            .Metadata.GetMetadata<IAuthorizeData>()!.Policy.Should().Be("dashboard-policy");
         endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_content/Quartz.Dashboard/{**path}")
             .Metadata.GetMetadata<IAuthorizeData>()!.Policy.Should().Be("dashboard-policy");
     }
@@ -208,6 +211,8 @@ public class DashboardEndpointsTest
         circuitEndpoints.Should().OnlyContain(e => e.Metadata.GetMetadata<IAllowAnonymous>() != null);
 
         endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_framework/blazor.web.js")
+            .Metadata.GetMetadata<IAllowAnonymous>().Should().NotBeNull();
+        endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_framework/opaque-redirect")
             .Metadata.GetMetadata<IAllowAnonymous>().Should().NotBeNull();
         endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_content/Quartz.Dashboard/{**path}")
             .Metadata.GetMetadata<IAllowAnonymous>().Should().NotBeNull();
@@ -389,6 +394,83 @@ public class DashboardEndpointsTest
             // root-level endpoints stay reachable for backwards compatibility
             using HttpResponseMessage rootCssResponse = await client.GetAsync("/_content/Quartz.Dashboard/css/quartz-dashboard.css");
             rootCssResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Test]
+    public async Task CustomDashboardPathScriptShouldSupportHeadAndConditionalRequests()
+    {
+        await using WebApplication app = CreateApp(options => options.DashboardPath = "/my-api/quartz");
+        app.MapQuartzDashboard();
+        await app.StartAsync();
+        try
+        {
+            using System.Net.Http.HttpClient client = app.GetTestClient();
+            const string scriptUrl = "/my-api/quartz/_framework/blazor.web.js";
+
+            // HEAD returns the headers without a body (probes, link checkers)
+            using var headRequest = new HttpRequestMessage(HttpMethod.Head, scriptUrl);
+            using HttpResponseMessage headResponse = await client.SendAsync(headRequest);
+            headResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            (await headResponse.Content.ReadAsByteArrayAsync()).Should().BeEmpty();
+
+            using HttpResponseMessage getResponse = await client.GetAsync(scriptUrl);
+            getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            string etag = getResponse.Headers.ETag!.ToString();
+
+            // revalidation with the served validator returns 304 without a body
+            using var conditionalRequest = new HttpRequestMessage(HttpMethod.Get, scriptUrl);
+            conditionalRequest.Headers.TryAddWithoutValidation("If-None-Match", etag);
+            using HttpResponseMessage notModified = await client.SendAsync(conditionalRequest);
+            notModified.StatusCode.Should().Be(HttpStatusCode.NotModified);
+
+            // RFC 9110: "*" matches any current representation
+            using var anyRequest = new HttpRequestMessage(HttpMethod.Get, scriptUrl);
+            anyRequest.Headers.TryAddWithoutValidation("If-None-Match", "*");
+            using HttpResponseMessage anyNotModified = await client.SendAsync(anyRequest);
+            anyNotModified.StatusCode.Should().Be(HttpStatusCode.NotModified);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Test]
+    public async Task CustomDashboardPathShouldForwardOpaqueRedirectToRootEndpoint()
+    {
+        // the framework emits enhanced-navigation redirects as URLs relative to the document base,
+        // so with a dashboard-rooted <base href> the browser requests them under the dashboard path
+        await using WebApplication app = CreateApp(options => options.DashboardPath = "/my-api/quartz");
+        app.MapQuartzDashboard();
+
+        GetRouteEndpoints(app).Select(e => e.RoutePattern.RawText)
+            .Should().Contain("/my-api/quartz/_framework/opaque-redirect");
+
+        await app.StartAsync();
+        try
+        {
+            using System.Net.Http.HttpClient client = app.GetTestClient();
+
+            // without a valid protected payload the framework endpoint rejects the request (it may
+            // even throw), but anything other than the mirror's own 404 proves the request was
+            // forwarded to the framework-owned root endpoint
+            HttpStatusCode? status = null;
+            try
+            {
+                using HttpResponseMessage response = await client.GetAsync("/my-api/quartz/_framework/opaque-redirect");
+                status = response.StatusCode;
+            }
+            catch (Exception)
+            {
+                // the root endpoint threw while rejecting the unprotected payload — forwarding worked
+            }
+
+            status.Should().NotBe(HttpStatusCode.NotFound);
         }
         finally
         {

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardEndpointsTest.cs
@@ -148,8 +148,77 @@ public class DashboardEndpointsTest
         patterns.Should().NotContain("/quartz");
         patterns.Where(p => p?.StartsWith("/quartz/", StringComparison.Ordinal) == true).Should().BeEmpty();
 
-        // framework endpoints are not re-rooted
-        patterns.Should().Contain(p => p != null && p.StartsWith("/_blazor", StringComparison.Ordinal));
+        // the Blazor circuit endpoints move under the dashboard path so a reverse proxy that
+        // forwards only the dashboard prefix can reach them (#3134)
+        patterns.Where(p => p?.StartsWith("/_blazor", StringComparison.Ordinal) == true).Should().BeEmpty();
+        patterns.Should().Contain(p => p != null && p.StartsWith("/ops/scheduler/_blazor", StringComparison.Ordinal));
+        patterns.Should().Contain(p => p != null && p.StartsWith("/ops/scheduler/_blazor", StringComparison.Ordinal) && p.EndsWith("negotiate", StringComparison.Ordinal));
+
+        // dashboard-owned framework script and static asset endpoints exist under the dashboard
+        // path; the root-level asset endpoint stays for backwards compatibility
+        patterns.Should().Contain("/ops/scheduler/_framework/blazor.web.js");
+        patterns.Should().Contain("/ops/scheduler/_content/Quartz.Dashboard/{**path}");
+        patterns.Should().Contain("_content/Quartz.Dashboard/{**path}");
+    }
+
+    [Test]
+    public async Task CustomDashboardPathPolicyShouldCoverRerootedEndpoints()
+    {
+        await using WebApplication app = CreateApp(options =>
+        {
+            options.DashboardPath = "/ops/scheduler";
+            options.AuthorizationPolicy = "dashboard-policy";
+        });
+        app.MapQuartzDashboard();
+
+        List<RouteEndpoint> endpoints = GetRouteEndpoints(app);
+
+        endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler")
+            .Metadata.GetMetadata<IAuthorizeData>()!.Policy.Should().Be("dashboard-policy");
+        endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/hub")
+            .Metadata.GetMetadata<IAuthorizeData>()!.Policy.Should().Be("dashboard-policy");
+
+        List<RouteEndpoint> circuitEndpoints = endpoints
+            .Where(e => e.RoutePattern.RawText?.StartsWith("/ops/scheduler/_blazor", StringComparison.Ordinal) == true)
+            .ToList();
+        circuitEndpoints.Should().NotBeEmpty();
+        circuitEndpoints.Should().OnlyContain(e => e.Metadata.GetMetadata<IAuthorizeData>() != null);
+
+        endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_framework/blazor.web.js")
+            .Metadata.GetMetadata<IAuthorizeData>()!.Policy.Should().Be("dashboard-policy");
+        endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_content/Quartz.Dashboard/{**path}")
+            .Metadata.GetMetadata<IAuthorizeData>()!.Policy.Should().Be("dashboard-policy");
+    }
+
+    [Test]
+    public async Task CustomDashboardPathWithoutPolicyShouldAllowAnonymousPlumbingButProtectPages()
+    {
+        // #3117 semantics must hold for the re-rooted endpoints too: the Blazor plumbing opts out of
+        // authorization so it stays reachable under a fail-closed FallbackPolicy, while the pages and
+        // the live-events hub remain governed by the host's policies
+        await using WebApplication app = CreateApp(options => options.DashboardPath = "/ops/scheduler");
+        app.MapQuartzDashboard();
+
+        List<RouteEndpoint> endpoints = GetRouteEndpoints(app);
+
+        List<RouteEndpoint> circuitEndpoints = endpoints
+            .Where(e => e.RoutePattern.RawText?.StartsWith("/ops/scheduler/_blazor", StringComparison.Ordinal) == true)
+            .ToList();
+        circuitEndpoints.Should().NotBeEmpty();
+        circuitEndpoints.Should().OnlyContain(e => e.Metadata.GetMetadata<IAllowAnonymous>() != null);
+
+        endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_framework/blazor.web.js")
+            .Metadata.GetMetadata<IAllowAnonymous>().Should().NotBeNull();
+        endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/_content/Quartz.Dashboard/{**path}")
+            .Metadata.GetMetadata<IAllowAnonymous>().Should().NotBeNull();
+
+        RouteEndpoint dashboardPage = endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler");
+        dashboardPage.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull();
+        dashboardPage.Metadata.GetMetadata<IAuthorizeData>().Should().BeNull();
+
+        RouteEndpoint hub = endpoints.First(e => e.RoutePattern.RawText == "/ops/scheduler/hub");
+        hub.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull();
+        hub.Metadata.GetMetadata<IAuthorizeData>().Should().BeNull();
     }
 
     [Test]
@@ -197,6 +266,195 @@ public class DashboardEndpointsTest
 
             // dashboard pages remain subject to the fail-closed fallback policy
             using HttpResponseMessage pageResponse = await client.GetAsync("/quartz");
+            pageResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Test]
+    public async Task CustomDashboardPathShouldServeShellWithDashboardRootedBaseHref()
+    {
+        // end-to-end repro of #3134: with a custom path the shell must root the document at the
+        // dashboard itself so the framework script, stylesheet and circuit resolve under the prefix
+        await using WebApplication app = CreateApp(
+            options => options.DashboardPath = "/my-api/quartz",
+            builder => builder.Services.AddQuartz());
+
+        app.UseAntiforgery();
+        app.MapQuartzDashboard();
+        await app.StartAsync();
+        try
+        {
+            using System.Net.Http.HttpClient client = app.GetTestClient();
+
+            using HttpResponseMessage response = await client.GetAsync("/my-api/quartz");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            string body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain("<base href=\"/my-api/quartz/\"");
+            body.Should().Contain("_framework/blazor.web.js");
+
+            // route matching tolerates the trailing-slash form of the dashboard root
+            using HttpResponseMessage slashResponse = await client.GetAsync("/my-api/quartz/");
+            slashResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Test]
+    public async Task DefaultDashboardPathShouldKeepPathBaseRootedBaseHref()
+    {
+        // regression guard: default-path behavior must stay unchanged by the #3134 fix
+        await using WebApplication app = CreateApp(
+            configureBuilder: builder => builder.Services.AddQuartz());
+
+        app.UseAntiforgery();
+        app.MapQuartzDashboard();
+        await app.StartAsync();
+        try
+        {
+            using System.Net.Http.HttpClient client = app.GetTestClient();
+
+            using HttpResponseMessage response = await client.GetAsync("/quartz");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            string body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain("<base href=\"/\"");
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Test]
+    public async Task CustomDashboardPathShouldHonorApplicationPathBase()
+    {
+        await using WebApplication app = CreateApp(
+            options => options.DashboardPath = "/my-api/quartz",
+            builder => builder.Services.AddQuartz());
+
+        // UsePathBase only affects routing when UseRouting is (re-)registered after it
+        app.UsePathBase("/app");
+        app.UseRouting();
+        app.UseAntiforgery();
+        app.MapQuartzDashboard();
+        await app.StartAsync();
+        try
+        {
+            using System.Net.Http.HttpClient client = app.GetTestClient();
+
+            using HttpResponseMessage response = await client.GetAsync("/app/my-api/quartz");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            string body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain("<base href=\"/app/my-api/quartz/\"");
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Test]
+    public async Task CustomDashboardPathShouldServeFrameworkScriptAndStaticAssets()
+    {
+        await using WebApplication app = CreateApp(
+            options => options.DashboardPath = "/my-api/quartz",
+            builder => builder.Environment.WebRootFileProvider = new TestFileProvider(new Dictionary<string, byte[]>
+            {
+                ["_content/Quartz.Dashboard/css/quartz-dashboard.css"] = "body { }"u8.ToArray(),
+            }));
+
+        app.MapQuartzDashboard();
+        await app.StartAsync();
+        try
+        {
+            using System.Net.Http.HttpClient client = app.GetTestClient();
+
+            // the framework script is mirrored under the dashboard path; on .NET 8/9 it is served
+            // from the embedded manifest of Microsoft.AspNetCore.Components.Endpoints
+            using HttpResponseMessage scriptResponse = await client.GetAsync("/my-api/quartz/_framework/blazor.web.js");
+            scriptResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            scriptResponse.Content.Headers.ContentType!.MediaType.Should().Be("text/javascript");
+            (await scriptResponse.Content.ReadAsByteArrayAsync()).Should().NotBeEmpty();
+
+            using HttpResponseMessage cssResponse = await client.GetAsync("/my-api/quartz/_content/Quartz.Dashboard/css/quartz-dashboard.css");
+            cssResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            cssResponse.Content.Headers.ContentType!.MediaType.Should().Be("text/css");
+
+            // root-level endpoints stay reachable for backwards compatibility
+            using HttpResponseMessage rootCssResponse = await client.GetAsync("/_content/Quartz.Dashboard/css/quartz-dashboard.css");
+            rootCssResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Test]
+    public async Task CustomDashboardPathShouldServeBlazorNegotiate()
+    {
+        await using WebApplication app = CreateApp(options => options.DashboardPath = "/my-api/quartz");
+        app.MapQuartzDashboard();
+        await app.StartAsync();
+        try
+        {
+            using System.Net.Http.HttpClient client = app.GetTestClient();
+
+            // proves the re-rooted SignalR circuit endpoints still dispatch correctly
+            using HttpResponseMessage response = await client.PostAsync("/my-api/quartz/_blazor/negotiate?negotiateVersion=1", content: null);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            string body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain("availableTransports");
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Test]
+    public async Task CustomDashboardPathAssetsShouldBeServedUnderFailClosedFallbackPolicy()
+    {
+        // the #3097/#3117 guarantees must hold for the endpoints mirrored under a custom path
+        await using WebApplication app = CreateApp(
+            options => options.DashboardPath = "/my-api/quartz",
+            builder =>
+            {
+                builder.Services
+                    .AddAuthentication(TestAuthenticationHandler.SchemeName)
+                    .AddScheme<Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions, TestAuthenticationHandler>(TestAuthenticationHandler.SchemeName, null);
+                builder.Services.AddAuthorization(options =>
+                {
+                    options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                        .RequireAssertion(_ => false)
+                        .Build();
+                });
+                builder.Environment.WebRootFileProvider = new TestFileProvider(new Dictionary<string, byte[]>
+                {
+                    ["_content/Quartz.Dashboard/css/quartz-dashboard.css"] = "body { }"u8.ToArray(),
+                });
+            });
+
+        app.MapQuartzDashboard();
+        await app.StartAsync();
+        try
+        {
+            using System.Net.Http.HttpClient client = app.GetTestClient();
+
+            using HttpResponseMessage cssResponse = await client.GetAsync("/my-api/quartz/_content/Quartz.Dashboard/css/quartz-dashboard.css");
+            cssResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using HttpResponseMessage scriptResponse = await client.GetAsync("/my-api/quartz/_framework/blazor.web.js");
+            scriptResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            // dashboard pages remain subject to the fail-closed fallback policy
+            using HttpResponseMessage pageResponse = await client.GetAsync("/my-api/quartz");
             pageResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
         finally

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardLinkTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardLinkTest.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+
+using Quartz.Dashboard.Components;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+public class DashboardLinkTest
+{
+    private static QuartzDashboardOptions DefaultOptions => new();
+
+    private static QuartzDashboardOptions CustomPathOptions => new() { DashboardPath = "/my-api/quartz" };
+
+    // default path: the base URI is the application root (or path base); the base-relative
+    // path carries the "quartz" prefix
+    [TestCase("https://host/quartz", "https://host/", "")]
+    [TestCase("https://host/quartz/", "https://host/", "")]
+    [TestCase("https://host/quartz/jobs", "https://host/", "jobs")]
+    [TestCase("https://host/QUARTZ/JOBS", "https://host/", "JOBS")]
+    [TestCase("https://host/quartz/jobs?page=2", "https://host/", "jobs")]
+    [TestCase("https://host/quartz/jobs#fragment", "https://host/", "jobs")]
+    [TestCase("https://host/app/quartz/jobs", "https://host/app/", "jobs")]
+    [TestCase("https://host/other", "https://host/", null)]
+    [TestCase("https://host/quartzx", "https://host/", null)]
+    [TestCase("https://elsewhere/quartz", "https://host/", null)]
+    // the application root itself (with or without the trailing slash) is not a dashboard location
+    [TestCase("https://host", "https://host/", null)]
+    [TestCase("https://host/app", "https://host/app/", null)]
+    // default path with UsePathBase("/quartz"): the dashboard lives at /quartz/quartz, a bare
+    // /quartz/jobs is a host application URL and must not resolve as a dashboard location
+    [TestCase("https://host/quartz/quartz/jobs", "https://host/quartz/", "jobs")]
+    [TestCase("https://host/quartz/jobs", "https://host/quartz/", null)]
+    public void ToDashboardRelativePathShouldResolveDefaultPathUris(string uri, string baseUri, string? expected)
+    {
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, DefaultOptions).Should().Be(expected);
+    }
+
+    // custom path, static SSR shape: the base URI is the application root (or path base); the
+    // base-relative path carries the full dashboard path prefix
+    [TestCase("https://host/my-api/quartz", "https://host/", "")]
+    [TestCase("https://host/my-api/quartz/", "https://host/", "")]
+    [TestCase("https://host/my-api/quartz/jobs?page=2", "https://host/", "jobs")]
+    [TestCase("https://host/my-api/quartz/triggers/g/n", "https://host/", "triggers/g/n")]
+    [TestCase("https://host/app/my-api/quartz/jobs", "https://host/app/", "jobs")]
+    [TestCase("https://host/quartz/jobs", "https://host/", null)]
+    [TestCase("https://host/other", "https://host/", null)]
+    // custom path, interactive circuit shape: the base URI is the rendered dashboard-rooted
+    // <base href>, so the base-relative path is already dashboard-rooted
+    [TestCase("https://host/my-api/quartz/jobs", "https://host/my-api/quartz/", "jobs")]
+    [TestCase("https://host/my-api/quartz/jobs/DEFAULT/x", "https://host/my-api/quartz/", "jobs/DEFAULT/x")]
+    [TestCase("https://host/my-api/quartz/", "https://host/my-api/quartz/", "")]
+    [TestCase("https://host/my-api/quartz", "https://host/my-api/quartz/", "")]
+    [TestCase("https://host/my-api/quartz?page=2", "https://host/my-api/quartz/", "")]
+    [TestCase("https://host/app/my-api/quartz/jobs", "https://host/app/my-api/quartz/", "jobs")]
+    [TestCase("https://host/elsewhere", "https://host/my-api/quartz/", null)]
+    public void ToDashboardRelativePathShouldResolveCustomPathUris(string uri, string baseUri, string? expected)
+    {
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, CustomPathOptions).Should().Be(expected);
+    }
+
+    // a custom DashboardPath whose name collides with a dashboard page route must not be
+    // prefix-stripped on the interactive circuit, where the base URI is already dashboard-rooted
+    [TestCase("https://host/jobs/jobs", "https://host/jobs/", "jobs")]
+    [TestCase("https://host/jobs/jobs/DEFAULT/x", "https://host/jobs/", "jobs/DEFAULT/x")]
+    [TestCase("https://host/jobs", "https://host/jobs/", "")]
+    [TestCase("https://host/jobs/jobs", "https://host/", "jobs")]
+    [TestCase("https://host/jobs", "https://host/", "")]
+    public void ToDashboardRelativePathShouldResolveRouteNameCollidingCustomPath(string uri, string baseUri, string? expected)
+    {
+        var options = new QuartzDashboardOptions { DashboardPath = "/jobs" };
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, options).Should().Be(expected);
+    }
+
+    // browsers emit percent-encoded URIs; the configured path must be compared in encoded form
+    [TestCase("https://host/my%20path/jobs", "https://host/", "jobs")]
+    [TestCase("https://host/my%20path/jobs", "https://host/my%20path/", "jobs")]
+    [TestCase("https://host/my%20path", "https://host/my%20path/", "")]
+    public void ToDashboardRelativePathShouldCompareEncodedForms(string uri, string baseUri, string? expected)
+    {
+        var options = new QuartzDashboardOptions { DashboardPath = "/my path" };
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, options).Should().Be(expected);
+    }
+
+    [Test]
+    public void LinksShouldBeDashboardRelativeWithCustomPath()
+    {
+        DashboardLink.To(CustomPathOptions, "").Should().Be("");
+        DashboardLink.To(CustomPathOptions, "jobs").Should().Be("jobs");
+    }
+
+    [Test]
+    public void LinksShouldCarryDashboardRootWithDefaultPath()
+    {
+        DashboardLink.To(DefaultOptions, "").Should().Be("quartz");
+        DashboardLink.To(DefaultOptions, "jobs").Should().Be("quartz/jobs");
+    }
+
+    [TestCase("quartz/jobs?page=2", "quartz/jobs")]
+    [TestCase("/quartz/jobs/#fragment", "quartz/jobs")]
+    [TestCase("quartz/", "quartz")]
+    [TestCase("", "")]
+    public void NormalizeRelativePathShouldStripQueryFragmentAndSlashes(string input, string expected)
+    {
+        DashboardLink.NormalizeRelativePath(input).Should().Be(expected);
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardLinkTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardLinkTest.cs
@@ -80,6 +80,17 @@ public class DashboardLinkTest
         DashboardLink.ToDashboardRelativePath(uri, baseUri, options).Should().Be(expected);
     }
 
+    // the shape check must compare the base URI's PATH, not the whole absolute URI: a host name
+    // whose tail equals the dashboard path (e.g. host "scheduler" with DashboardPath "/scheduler")
+    // must not be mistaken for the interactive dashboard-rooted shape
+    [TestCase("http://scheduler/scheduler/jobs", "http://scheduler/", "jobs")]
+    [TestCase("http://scheduler/scheduler", "http://scheduler/", "")]
+    public void ToDashboardRelativePathShouldNotMatchHostNameSuffix(string uri, string baseUri, string? expected)
+    {
+        var options = new QuartzDashboardOptions { DashboardPath = "/scheduler" };
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, options).Should().Be(expected);
+    }
+
     [Test]
     public void LinksShouldBeDashboardRelativeWithCustomPath()
     {

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
@@ -14,20 +14,21 @@ public class DashboardRouteTableTest
 
     private static QuartzDashboardOptions CustomPathOptions => new() { DashboardPath = "/my-api/quartz" };
 
-    [TestCase("quartz", typeof(Pages.Dashboard))]
-    [TestCase("quartz/", typeof(Pages.Dashboard))]
-    [TestCase("quartz/jobs", typeof(Pages.Jobs))]
-    [TestCase("QUARTZ/JOBS", typeof(Pages.Jobs))]
-    [TestCase("quartz/triggers", typeof(Pages.Triggers))]
-    [TestCase("quartz/calendars", typeof(Pages.Calendars))]
-    [TestCase("quartz/executing", typeof(Pages.CurrentlyExecuting))]
-    [TestCase("quartz/history", typeof(Pages.History))]
-    [TestCase("quartz/history?page=2&job=x", typeof(Pages.History))]
-    [TestCase("quartz/live", typeof(Pages.LiveLogs))]
-    [TestCase("quartz/actions", typeof(Pages.ActionLog))]
-    public void ShouldMatchDefaultPathRoutes(string relativePath, Type expectedPageType)
+    [TestCase("", typeof(Pages.Dashboard))]
+    [TestCase("/", typeof(Pages.Dashboard))]
+    [TestCase("jobs", typeof(Pages.Jobs))]
+    [TestCase("JOBS", typeof(Pages.Jobs))]
+    [TestCase("jobs?page=2", typeof(Pages.Jobs))]
+    [TestCase("triggers", typeof(Pages.Triggers))]
+    [TestCase("calendars", typeof(Pages.Calendars))]
+    [TestCase("executing", typeof(Pages.CurrentlyExecuting))]
+    [TestCase("history", typeof(Pages.History))]
+    [TestCase("history?page=2&job=x", typeof(Pages.History))]
+    [TestCase("live", typeof(Pages.LiveLogs))]
+    [TestCase("actions", typeof(Pages.ActionLog))]
+    public void ShouldMatchDashboardRelativeRoutes(string dashboardRelativePath, Type expectedPageType)
     {
-        RouteData? routeData = DashboardRouteTable.Match(relativePath, DefaultOptions);
+        RouteData? routeData = DashboardRouteTable.Match(dashboardRelativePath);
 
         routeData.Should().NotBeNull();
         routeData!.PageType.Should().Be(expectedPageType);
@@ -36,7 +37,7 @@ public class DashboardRouteTableTest
     [Test]
     public void ShouldExtractRouteParameterValues()
     {
-        RouteData? routeData = DashboardRouteTable.Match("quartz/jobs/DEFAULT/my%20job", DefaultOptions);
+        RouteData? routeData = DashboardRouteTable.Match("jobs/DEFAULT/my%20job");
 
         routeData.Should().NotBeNull();
         routeData!.PageType.Should().Be<Pages.JobDetail>();
@@ -44,30 +45,70 @@ public class DashboardRouteTableTest
         routeData.RouteValues["Name"].Should().Be("my job");
     }
 
-    [TestCase("quartz/unknown")]
-    [TestCase("quartzx")]
-    [TestCase("other/path")]
-    [TestCase("")]
-    public void ShouldNotMatchUnknownRoutes(string relativePath)
+    [TestCase("unknown")]
+    [TestCase("jobs/too/many/segments")]
+    [TestCase("quartz/jobs")]
+    public void ShouldNotMatchUnknownRoutes(string dashboardRelativePath)
     {
-        DashboardRouteTable.Match(relativePath, DefaultOptions).Should().BeNull();
+        DashboardRouteTable.Match(dashboardRelativePath).Should().BeNull();
+    }
+
+    // default path: the base URI is the application root (or path base); the base-relative
+    // path carries the "quartz" prefix
+    [TestCase("https://host/quartz", "https://host/", "")]
+    [TestCase("https://host/quartz/", "https://host/", "")]
+    [TestCase("https://host/quartz/jobs", "https://host/", "jobs")]
+    [TestCase("https://host/QUARTZ/JOBS", "https://host/", "JOBS")]
+    [TestCase("https://host/quartz/jobs?page=2", "https://host/", "jobs")]
+    [TestCase("https://host/quartz/jobs#fragment", "https://host/", "jobs")]
+    [TestCase("https://host/app/quartz/jobs", "https://host/app/", "jobs")]
+    [TestCase("https://host/other", "https://host/", null)]
+    [TestCase("https://host/quartzx", "https://host/", null)]
+    [TestCase("https://elsewhere/quartz", "https://host/", null)]
+    // default path with UsePathBase("/quartz"): the dashboard lives at /quartz/quartz, a bare
+    // /quartz/jobs is a host application URL and must not resolve as a dashboard location
+    [TestCase("https://host/quartz/quartz/jobs", "https://host/quartz/", "jobs")]
+    [TestCase("https://host/quartz/jobs", "https://host/quartz/", null)]
+    public void ToDashboardRelativePathShouldResolveDefaultPathUris(string uri, string baseUri, string? expected)
+    {
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, DefaultOptions).Should().Be(expected);
+    }
+
+    // custom path, static SSR shape: the base URI is the application root (or path base); the
+    // base-relative path carries the full dashboard path prefix
+    [TestCase("https://host/my-api/quartz", "https://host/", "")]
+    [TestCase("https://host/my-api/quartz/", "https://host/", "")]
+    [TestCase("https://host/my-api/quartz/jobs?page=2", "https://host/", "jobs")]
+    [TestCase("https://host/my-api/quartz/triggers/g/n", "https://host/", "triggers/g/n")]
+    [TestCase("https://host/app/my-api/quartz/jobs", "https://host/app/", "jobs")]
+    [TestCase("https://host/quartz/jobs", "https://host/", null)]
+    [TestCase("https://host/other", "https://host/", null)]
+    // custom path, interactive circuit shape: the base URI is the rendered dashboard-rooted
+    // <base href>, so the base-relative path is already dashboard-rooted
+    [TestCase("https://host/my-api/quartz/jobs", "https://host/my-api/quartz/", "jobs")]
+    [TestCase("https://host/my-api/quartz/jobs/DEFAULT/x", "https://host/my-api/quartz/", "jobs/DEFAULT/x")]
+    [TestCase("https://host/my-api/quartz/", "https://host/my-api/quartz/", "")]
+    [TestCase("https://host/my-api/quartz", "https://host/my-api/quartz/", "")]
+    [TestCase("https://host/my-api/quartz?page=2", "https://host/my-api/quartz/", "")]
+    [TestCase("https://host/app/my-api/quartz/jobs", "https://host/app/my-api/quartz/", "jobs")]
+    [TestCase("https://host/elsewhere", "https://host/my-api/quartz/", null)]
+    public void ToDashboardRelativePathShouldResolveCustomPathUris(string uri, string baseUri, string? expected)
+    {
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, CustomPathOptions).Should().Be(expected);
     }
 
     [Test]
-    public void ShouldMatchRoutesUnderCustomDashboardPath()
+    public void LinksShouldBeDashboardRelativeWithCustomPath()
     {
-        RouteData? routeData = DashboardRouteTable.Match("my-api/quartz/triggers/g/n", CustomPathOptions);
-
-        routeData.Should().NotBeNull();
-        routeData!.PageType.Should().Be<Pages.TriggerDetail>();
-        routeData.RouteValues["Group"].Should().Be("g");
-        routeData.RouteValues["Name"].Should().Be("n");
+        DashboardLink.To(CustomPathOptions, "").Should().Be("");
+        DashboardLink.To(CustomPathOptions, "jobs").Should().Be("jobs");
     }
 
     [Test]
-    public void ShouldNotMatchDefaultPathWhenCustomPathConfigured()
+    public void LinksShouldCarryDashboardRootWithDefaultPath()
     {
-        DashboardRouteTable.Match("quartz/jobs", CustomPathOptions).Should().BeNull();
+        DashboardLink.To(DefaultOptions, "").Should().Be("quartz");
+        DashboardLink.To(DefaultOptions, "jobs").Should().Be("quartz/jobs");
     }
 
     [TestCase("quartz/jobs?page=2", "quartz/jobs")]
@@ -90,5 +131,17 @@ public class DashboardRouteTableTest
     public void TrimmedDashboardPathShouldNormalize(string configured, string expected)
     {
         new QuartzDashboardOptions { DashboardPath = configured }.TrimmedDashboardPath.Should().Be(expected);
+    }
+
+    [TestCase("/quartz", false)]
+    [TestCase("/QUARTZ/", false)]
+    [TestCase("quartz", false)]
+    [TestCase("/", false)]
+    [TestCase("", false)]
+    [TestCase("/my-api/quartz", true)]
+    [TestCase("/scheduler", true)]
+    public void HasCustomDashboardPathShouldCompareAgainstDefault(string configured, bool expected)
+    {
+        new QuartzDashboardOptions { DashboardPath = configured }.HasCustomDashboardPath.Should().Be(expected);
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
@@ -10,10 +10,6 @@ namespace Quartz.Tests.AspNetCore.Dashboard;
 
 public class DashboardRouteTableTest
 {
-    private static QuartzDashboardOptions DefaultOptions => new();
-
-    private static QuartzDashboardOptions CustomPathOptions => new() { DashboardPath = "/my-api/quartz" };
-
     [TestCase("", typeof(Pages.Dashboard))]
     [TestCase("/", typeof(Pages.Dashboard))]
     [TestCase("jobs", typeof(Pages.Jobs))]
@@ -53,130 +49,32 @@ public class DashboardRouteTableTest
         DashboardRouteTable.Match(dashboardRelativePath).Should().BeNull();
     }
 
-    // default path: the base URI is the application root (or path base); the base-relative
-    // path carries the "quartz" prefix
-    [TestCase("https://host/quartz", "https://host/", "")]
-    [TestCase("https://host/quartz/", "https://host/", "")]
-    [TestCase("https://host/quartz/jobs", "https://host/", "jobs")]
-    [TestCase("https://host/QUARTZ/JOBS", "https://host/", "JOBS")]
-    [TestCase("https://host/quartz/jobs?page=2", "https://host/", "jobs")]
-    [TestCase("https://host/quartz/jobs#fragment", "https://host/", "jobs")]
-    [TestCase("https://host/app/quartz/jobs", "https://host/app/", "jobs")]
-    [TestCase("https://host/other", "https://host/", null)]
-    [TestCase("https://host/quartzx", "https://host/", null)]
-    [TestCase("https://elsewhere/quartz", "https://host/", null)]
-    // the application root itself (with or without the trailing slash) is not a dashboard location
-    [TestCase("https://host", "https://host/", null)]
-    [TestCase("https://host/app", "https://host/app/", null)]
-    // default path with UsePathBase("/quartz"): the dashboard lives at /quartz/quartz, a bare
-    // /quartz/jobs is a host application URL and must not resolve as a dashboard location
-    [TestCase("https://host/quartz/quartz/jobs", "https://host/quartz/", "jobs")]
-    [TestCase("https://host/quartz/jobs", "https://host/quartz/", null)]
-    public void ToDashboardRelativePathShouldResolveDefaultPathUris(string uri, string baseUri, string? expected)
+    [Test]
+    public void MatchWithOptionsShouldRetryWithPrefixStrippedWhenDirectMatchFails()
     {
-        DashboardLink.ToDashboardRelativePath(uri, baseUri, DefaultOptions).Should().Be(expected);
+        // static SSR under an application path base that ends with the custom dashboard path
+        // produces dashboard-prefixed relative paths that the base URI shape check cannot
+        // distinguish from an interactive leaf; the failed direct match retries stripped
+        var options = new QuartzDashboardOptions { DashboardPath = "/ops" };
+
+        DashboardRouteTable.Match("ops/jobs", options)!.PageType.Should().Be<Pages.Jobs>();
+        DashboardRouteTable.Match("ops", options)!.PageType.Should().Be<Pages.Dashboard>();
+        DashboardRouteTable.Match("ops/nope", options).Should().BeNull();
     }
 
-    // a custom DashboardPath whose name collides with a dashboard page route must not be
-    // prefix-stripped on the interactive circuit, where the base URI is already dashboard-rooted
-    [TestCase("https://host/jobs/jobs", "https://host/jobs/", "jobs")]
-    [TestCase("https://host/jobs/jobs/DEFAULT/x", "https://host/jobs/", "jobs/DEFAULT/x")]
-    [TestCase("https://host/jobs", "https://host/jobs/", "")]
-    [TestCase("https://host/jobs/jobs", "https://host/", "jobs")]
-    [TestCase("https://host/jobs", "https://host/", "")]
-    public void ToDashboardRelativePathShouldResolveRouteNameCollidingCustomPath(string uri, string baseUri, string? expected)
+    [Test]
+    public void MatchWithOptionsShouldPreferTheDirectMatch()
     {
+        // an interactive leaf that begins with a route-colliding dashboard path name must not be stripped
         var options = new QuartzDashboardOptions { DashboardPath = "/jobs" };
-        DashboardLink.ToDashboardRelativePath(uri, baseUri, options).Should().Be(expected);
-    }
 
-    // browsers emit percent-encoded URIs; the configured path must be compared in encoded form
-    [TestCase("https://host/my%20path/jobs", "https://host/", "jobs")]
-    [TestCase("https://host/my%20path/jobs", "https://host/my%20path/", "jobs")]
-    [TestCase("https://host/my%20path", "https://host/my%20path/", "")]
-    public void ToDashboardRelativePathShouldCompareEncodedForms(string uri, string baseUri, string? expected)
-    {
-        var options = new QuartzDashboardOptions { DashboardPath = "/my path" };
-        DashboardLink.ToDashboardRelativePath(uri, baseUri, options).Should().Be(expected);
-    }
-
-    // custom path, static SSR shape: the base URI is the application root (or path base); the
-    // base-relative path carries the full dashboard path prefix
-    [TestCase("https://host/my-api/quartz", "https://host/", "")]
-    [TestCase("https://host/my-api/quartz/", "https://host/", "")]
-    [TestCase("https://host/my-api/quartz/jobs?page=2", "https://host/", "jobs")]
-    [TestCase("https://host/my-api/quartz/triggers/g/n", "https://host/", "triggers/g/n")]
-    [TestCase("https://host/app/my-api/quartz/jobs", "https://host/app/", "jobs")]
-    [TestCase("https://host/quartz/jobs", "https://host/", null)]
-    [TestCase("https://host/other", "https://host/", null)]
-    // custom path, interactive circuit shape: the base URI is the rendered dashboard-rooted
-    // <base href>, so the base-relative path is already dashboard-rooted
-    [TestCase("https://host/my-api/quartz/jobs", "https://host/my-api/quartz/", "jobs")]
-    [TestCase("https://host/my-api/quartz/jobs/DEFAULT/x", "https://host/my-api/quartz/", "jobs/DEFAULT/x")]
-    [TestCase("https://host/my-api/quartz/", "https://host/my-api/quartz/", "")]
-    [TestCase("https://host/my-api/quartz", "https://host/my-api/quartz/", "")]
-    [TestCase("https://host/my-api/quartz?page=2", "https://host/my-api/quartz/", "")]
-    [TestCase("https://host/app/my-api/quartz/jobs", "https://host/app/my-api/quartz/", "jobs")]
-    [TestCase("https://host/elsewhere", "https://host/my-api/quartz/", null)]
-    public void ToDashboardRelativePathShouldResolveCustomPathUris(string uri, string baseUri, string? expected)
-    {
-        DashboardLink.ToDashboardRelativePath(uri, baseUri, CustomPathOptions).Should().Be(expected);
+        DashboardRouteTable.Match("jobs/DEFAULT/x", options)!.PageType.Should().Be<Pages.JobDetail>();
+        DashboardRouteTable.Match("jobs", options)!.PageType.Should().Be<Pages.Jobs>();
     }
 
     [Test]
-    public void LinksShouldBeDashboardRelativeWithCustomPath()
+    public void MatchWithOptionsShouldNotFallBackWithDefaultPath()
     {
-        DashboardLink.To(CustomPathOptions, "").Should().Be("");
-        DashboardLink.To(CustomPathOptions, "jobs").Should().Be("jobs");
-    }
-
-    [Test]
-    public void LinksShouldCarryDashboardRootWithDefaultPath()
-    {
-        DashboardLink.To(DefaultOptions, "").Should().Be("quartz");
-        DashboardLink.To(DefaultOptions, "jobs").Should().Be("quartz/jobs");
-    }
-
-    [TestCase("quartz/jobs?page=2", "quartz/jobs")]
-    [TestCase("/quartz/jobs/#fragment", "quartz/jobs")]
-    [TestCase("quartz/", "quartz")]
-    [TestCase("", "")]
-    public void NormalizeRelativePathShouldStripQueryFragmentAndSlashes(string input, string expected)
-    {
-        DashboardLink.NormalizeRelativePath(input).Should().Be(expected);
-    }
-
-    [TestCase("/quartz", "/quartz")]
-    [TestCase("/quartz/", "/quartz")]
-    [TestCase("/my-api/quartz", "/my-api/quartz")]
-    [TestCase("/my-api/quartz/", "/my-api/quartz")]
-    [TestCase("my-api/quartz", "/my-api/quartz")]
-    [TestCase("/", "/quartz")]
-    [TestCase("", "/quartz")]
-    [TestCase("   ", "/quartz")]
-    public void TrimmedDashboardPathShouldNormalize(string configured, string expected)
-    {
-        new QuartzDashboardOptions { DashboardPath = configured }.TrimmedDashboardPath.Should().Be(expected);
-    }
-
-    [TestCase("/quartz", false)]
-    [TestCase("/QUARTZ/", false)]
-    [TestCase("quartz", false)]
-    [TestCase("/", false)]
-    [TestCase("", false)]
-    [TestCase("/my-api/quartz", true)]
-    [TestCase("/scheduler", true)]
-    public void HasCustomDashboardPathShouldCompareAgainstDefault(string configured, bool expected)
-    {
-        new QuartzDashboardOptions { DashboardPath = configured }.HasCustomDashboardPath.Should().Be(expected);
-    }
-
-    [TestCase("/quartz", "/quartz")]
-    [TestCase("/my-api/quartz", "/my-api/quartz")]
-    [TestCase("/my path", "/my%20path")]
-    [TestCase("/työt", "/ty%C3%B6t")]
-    public void EscapedDashboardPathShouldPercentEncode(string configured, string expected)
-    {
-        new QuartzDashboardOptions { DashboardPath = configured }.EscapedDashboardPath.Should().Be(expected);
+        DashboardRouteTable.Match("quartz/jobs", new QuartzDashboardOptions()).Should().BeNull();
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
@@ -65,6 +65,9 @@ public class DashboardRouteTableTest
     [TestCase("https://host/other", "https://host/", null)]
     [TestCase("https://host/quartzx", "https://host/", null)]
     [TestCase("https://elsewhere/quartz", "https://host/", null)]
+    // the application root itself (with or without the trailing slash) is not a dashboard location
+    [TestCase("https://host", "https://host/", null)]
+    [TestCase("https://host/app", "https://host/app/", null)]
     // default path with UsePathBase("/quartz"): the dashboard lives at /quartz/quartz, a bare
     // /quartz/jobs is a host application URL and must not resolve as a dashboard location
     [TestCase("https://host/quartz/quartz/jobs", "https://host/quartz/", "jobs")]
@@ -72,6 +75,29 @@ public class DashboardRouteTableTest
     public void ToDashboardRelativePathShouldResolveDefaultPathUris(string uri, string baseUri, string? expected)
     {
         DashboardLink.ToDashboardRelativePath(uri, baseUri, DefaultOptions).Should().Be(expected);
+    }
+
+    // a custom DashboardPath whose name collides with a dashboard page route must not be
+    // prefix-stripped on the interactive circuit, where the base URI is already dashboard-rooted
+    [TestCase("https://host/jobs/jobs", "https://host/jobs/", "jobs")]
+    [TestCase("https://host/jobs/jobs/DEFAULT/x", "https://host/jobs/", "jobs/DEFAULT/x")]
+    [TestCase("https://host/jobs", "https://host/jobs/", "")]
+    [TestCase("https://host/jobs/jobs", "https://host/", "jobs")]
+    [TestCase("https://host/jobs", "https://host/", "")]
+    public void ToDashboardRelativePathShouldResolveRouteNameCollidingCustomPath(string uri, string baseUri, string? expected)
+    {
+        var options = new QuartzDashboardOptions { DashboardPath = "/jobs" };
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, options).Should().Be(expected);
+    }
+
+    // browsers emit percent-encoded URIs; the configured path must be compared in encoded form
+    [TestCase("https://host/my%20path/jobs", "https://host/", "jobs")]
+    [TestCase("https://host/my%20path/jobs", "https://host/my%20path/", "jobs")]
+    [TestCase("https://host/my%20path", "https://host/my%20path/", "")]
+    public void ToDashboardRelativePathShouldCompareEncodedForms(string uri, string baseUri, string? expected)
+    {
+        var options = new QuartzDashboardOptions { DashboardPath = "/my path" };
+        DashboardLink.ToDashboardRelativePath(uri, baseUri, options).Should().Be(expected);
     }
 
     // custom path, static SSR shape: the base URI is the application root (or path base); the
@@ -143,5 +169,14 @@ public class DashboardRouteTableTest
     public void HasCustomDashboardPathShouldCompareAgainstDefault(string configured, bool expected)
     {
         new QuartzDashboardOptions { DashboardPath = configured }.HasCustomDashboardPath.Should().Be(expected);
+    }
+
+    [TestCase("/quartz", "/quartz")]
+    [TestCase("/my-api/quartz", "/my-api/quartz")]
+    [TestCase("/my path", "/my%20path")]
+    [TestCase("/työt", "/ty%C3%B6t")]
+    public void EscapedDashboardPathShouldPercentEncode(string configured, string expected)
+    {
+        new QuartzDashboardOptions { DashboardPath = configured }.EscapedDashboardPath.Should().Be(expected);
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
@@ -77,4 +77,22 @@ public class DashboardRouteTableTest
     {
         DashboardRouteTable.Match("quartz/jobs", new QuartzDashboardOptions()).Should().BeNull();
     }
+
+    [Test]
+    public void ResolveLeafShouldStripAmbiguousPrefixOnlyWhenItYieldsARoute()
+    {
+        // used by NavMenu for active-link highlighting; must mirror Match's retry
+        var options = new QuartzDashboardOptions { DashboardPath = "/ops" };
+
+        // path base ends with the dashboard path → static SSR relative carries the prefix
+        DashboardRouteTable.ResolveLeaf("ops/jobs", options).Should().Be("jobs");
+        DashboardRouteTable.ResolveLeaf("ops", options).Should().Be("");
+
+        // a route-colliding leaf resolves directly and is not stripped
+        var collide = new QuartzDashboardOptions { DashboardPath = "/jobs" };
+        DashboardRouteTable.ResolveLeaf("jobs", collide).Should().Be("jobs");
+
+        // no route either way → returns the direct form (no highlight)
+        DashboardRouteTable.ResolveLeaf("ops/nope", options).Should().Be("ops/nope");
+    }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/QuartzDashboardOptionsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/QuartzDashboardOptionsTest.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+public class QuartzDashboardOptionsTest
+{
+    [TestCase("/quartz", "/quartz")]
+    [TestCase("/quartz/", "/quartz")]
+    [TestCase("/my-api/quartz", "/my-api/quartz")]
+    [TestCase("/my-api/quartz/", "/my-api/quartz")]
+    [TestCase("my-api/quartz", "/my-api/quartz")]
+    [TestCase("/", "/quartz")]
+    [TestCase("", "/quartz")]
+    [TestCase("   ", "/quartz")]
+    public void TrimmedDashboardPathShouldNormalize(string configured, string expected)
+    {
+        new QuartzDashboardOptions { DashboardPath = configured }.TrimmedDashboardPath.Should().Be(expected);
+    }
+
+    [TestCase("/quartz", false)]
+    [TestCase("/QUARTZ/", false)]
+    [TestCase("quartz", false)]
+    [TestCase("/", false)]
+    [TestCase("", false)]
+    [TestCase("/my-api/quartz", true)]
+    [TestCase("/scheduler", true)]
+    public void HasCustomDashboardPathShouldCompareAgainstDefault(string configured, bool expected)
+    {
+        new QuartzDashboardOptions { DashboardPath = configured }.HasCustomDashboardPath.Should().Be(expected);
+    }
+
+    [TestCase("/quartz", "/quartz")]
+    [TestCase("/my-api/quartz", "/my-api/quartz")]
+    [TestCase("/my path", "/my%20path")]
+    [TestCase("/työt", "/ty%C3%B6t")]
+    public void EscapedDashboardPathShouldPercentEncode(string configured, string expected)
+    {
+        new QuartzDashboardOptions { DashboardPath = configured }.EscapedDashboardPath.Should().Be(expected);
+    }
+
+    [Test]
+    public void DerivedPathValuesShouldFollowDashboardPathChanges()
+    {
+        // the derived values are cached; the cache must track option mutations during configuration
+        var options = new QuartzDashboardOptions();
+        options.HasCustomDashboardPath.Should().BeFalse();
+
+        options.DashboardPath = "/ops";
+        options.TrimmedDashboardPath.Should().Be("/ops");
+        options.EscapedDashboardPath.Should().Be("/ops");
+        options.HasCustomDashboardPath.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Fixes #3134.

## Problem

When the application sits behind a reverse proxy that forwards only a path prefix (e.g. `/my-api`) **without** setting a request path base, and the dashboard is registered with `DashboardPath = "/my-api/quartz"`, the pages load (#3093) but the shell renders `<base href="/">` from `HttpRequest.PathBase`. Every relative reference then resolves to the domain root, which the proxy never forwards:

```text
GET /_framework/blazor.web.js                            -> 404
GET /_content/Quartz.Dashboard/css/quartz-dashboard.css  -> 404
GET /_blazor                                             -> 404
```

The dashboard renders as an unstyled HTML shell and the interactive circuit never connects.

## Fix

With a **custom** `DashboardPath` (which already implies the standalone `MapQuartzDashboard()` overload — a custom path is rejected in integrated mode), the dashboard is now fully self-contained under the configured path:

- **`<base href>`** is rendered as `PathBase + DashboardPath + "/"` (e.g. `/my-api/quartz/`), so the framework script, stylesheet and circuit URL all resolve under the prefix the proxy forwards. `UsePathBase` composes with it.
- **`/_blazor*` circuit endpoints** are re-rooted under `DashboardPath` via the existing endpoint convention — SignalR dispatch does not depend on the route pattern. Other framework-owned endpoints stay at the root: .NET 9 registers the `blazor.web.js` endpoint through the components endpoint data source and serves it keyed by its original path, so re-rooting it breaks it (verified against a running net9.0 host).
- **Dashboard-owned endpoints mirror `{DashboardPath}/_framework/blazor.web.js`** (web root first, .NET 8/9 embedded manifest as fallback) **and `{DashboardPath}/_content/Quartz.Dashboard/*`**, carrying the same authorization metadata as the existing root asset endpoint (#3097/#3117 semantics preserved; the root asset endpoint stays for backwards compatibility).
- **Links, route matching and nav highlighting** resolve dashboard-root-relative paths in both base URI shapes: during static SSR the base URI is the application path base, on the interactive circuit it is the rendered `<base href>`.

**Default-path behavior is byte-identical** — no endpoint, base href or link changes for existing `/quartz` deployments.

## Verification

- 81 dashboard tests (updated + new endpoint/metadata/E2E coverage incl. `UsePathBase` composition, trailing slash, negotiate dispatch, fail-closed `FallbackPolicy` with custom path).
- Ran `Quartz.Examples.AspNetCore` (net9.0) with `DashboardPath = "/my-api/quartz"`: shell renders `<base href="/my-api/quartz/">`; script/CSS/JS-initializer/negotiate all 200 under the prefix; headless-browser console shows blazor.web.js normalizing `_blazor` to `/my-api/quartz/_blazor` and **`WebSocket connected to ws://localhost:5799/my-api/quartz/_blazor`**; the dashboard and deep links render fully styled with correct active-nav highlighting.

Docs: `quartz-4.x` and `quartz-3.x` dashboard pages gain/extend the "Hosting under a custom path" section with the reverse-proxy guidance (WebSocket forwarding target moves to `{DashboardPath}/_blazor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
