### PR TITLE
Add fluent CronExpressionBuilder for building cron expressions programmatically

### DIFF
--- a/docs/documentation/quartz-3.x/how-tos/crontrigger.md
+++ b/docs/documentation/quartz-3.x/how-tos/crontrigger.md
@@ -133,6 +133,23 @@ tokens are replaced with their computed values. This resolved form is what gets 
 the database, ensuring stability across scheduler restarts.
 :::
 
+## Building cron expressions programmatically
+
+Cron expression strings can also be composed programmatically with the fluent
+`CronExpressionBuilder` - useful when the schedule is assembled from user input:
+
+```csharp
+CronExpression expression = CronExpressionBuilder.Create()
+    .WithSecond(0)
+    .WithMinuteIncrements(0, 15)
+    .WithHourRange(8, 17)
+    .OnWeekdays()
+    .Build(); // "0 0/15 8-17 ? * MON-FRI"
+```
+
+See [Building cron expressions programmatically](../tutorial/crontrigger.md#building-cron-expressions-programmatically)
+in the tutorial for the full API description.
+
 ## Examples
 
 Here are some full examples:

--- a/docs/documentation/quartz-3.x/tutorial/crontrigger.md
+++ b/docs/documentation/quartz-3.x/tutorial/crontrigger.md
@@ -131,6 +131,52 @@ tokens are replaced with their computed values. This resolved form is what gets 
 the database, ensuring stability across scheduler restarts.
 :::
 
+## Building cron expressions programmatically
+
+When a schedule is assembled from user input - for example a scheduling UI that offers
+dropdowns instead of a free-form cron field - you can compose the expression with the fluent
+`CronExpressionBuilder` instead of concatenating strings:
+
+```csharp
+CronExpression expression = CronExpressionBuilder.Create()
+    .WithSecond(0)
+    .WithMinuteIncrements(0, 15) // every 15 minutes
+    .WithHourRange(8, 17)        // between 8:00 and 17:59
+    .OnWeekdays()                // Monday through Friday
+    .Build(); // "0 0/15 8-17 ? * MON-FRI"
+
+ITrigger trigger = TriggerBuilder.Create()
+    .WithIdentity("myTrigger")
+    .WithSchedule(CronScheduleBuilder.CronSchedule(expression))
+    .Build();
+```
+
+Each field offers a single value, list, range and increment form (e.g. `WithHour`,
+`WithHours`, `WithHourRange`, `WithHourIncrements`), and the special characters are
+available through dedicated methods:
+
+```csharp
+CronExpressionBuilder.Create().OnLastDayOfMonth();                         // "* * * L * ?"
+CronExpressionBuilder.Create().OnNearestWeekdayOfMonth(15);                // "* * * 15W * ?"
+CronExpressionBuilder.Create().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3); // "* * * ? * FRI#3"
+CronExpressionBuilder.Create().OnLastDayOfWeekOfMonth(DayOfWeek.Friday);   // "* * * ? * FRIL"
+```
+
+A few rules to be aware of:
+
+- Unconfigured fields default to `*` (every value).
+- Each field can be configured only once; configuring it again throws `InvalidOperationException`.
+- Day-of-month and day-of-week are mutually exclusive per cron syntax - the builder renders
+  the unused one as `?` and throws if you try to configure both.
+- Values are validated eagerly against each field's allowed range, and `Build()` returns a
+  fully validated `CronExpression`; use `ToString()` if you only need the expression string.
+- Days of the week are emitted using their textual names (`MON`, `FRI`, ...), so the produced
+  expressions stay unambiguous across cron dialects that number weekdays differently.
+
+::: tip
+`CronExpressionBuilder` is available from Quartz.NET 3.19 onwards.
+:::
+
 ## Examples
 
 Here are some full examples:

--- a/docs/documentation/quartz-3.x/tutorial/crontriggers.md
+++ b/docs/documentation/quartz-3.x/tutorial/crontriggers.md
@@ -115,6 +115,9 @@ extension method (for the CronTrigger-specific properties).
 
 You can also use `CronScheduleBuilder`'s static methods to create schedules.
 
+To compose the cron expression string itself programmatically, see
+[Building cron expressions programmatically](crontrigger.md#building-cron-expressions-programmatically).
+
 **Build a trigger that will fire every other minute, between 8am and 5pm, every day:**
 
 ```csharp

--- a/docs/documentation/quartz-4.x/how-tos/crontrigger.md
+++ b/docs/documentation/quartz-4.x/how-tos/crontrigger.md
@@ -133,6 +133,23 @@ tokens are replaced with their computed values. This resolved form is what gets 
 the database, ensuring stability across scheduler restarts.
 :::
 
+## Building cron expressions programmatically
+
+Cron expression strings can also be composed programmatically with the fluent
+`CronExpressionBuilder` - useful when the schedule is assembled from user input:
+
+```csharp
+CronExpression expression = CronExpressionBuilder.Create()
+    .WithSecond(0)
+    .WithMinuteIncrements(0, 15)
+    .WithHourRange(8, 17)
+    .OnWeekdays()
+    .Build(); // "0 0/15 8-17 ? * MON-FRI"
+```
+
+See [Building cron expressions programmatically](../tutorial/crontrigger.md#building-cron-expressions-programmatically)
+in the tutorial for the full API description.
+
 ## Examples
 
 Here are some full examples:

--- a/docs/documentation/quartz-4.x/tutorial/crontrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontrigger.md
@@ -135,6 +135,48 @@ tokens are replaced with their computed values. This resolved form is what gets 
 the database, ensuring stability across scheduler restarts.
 :::
 
+## Building cron expressions programmatically
+
+When a schedule is assembled from user input - for example a scheduling UI that offers
+dropdowns instead of a free-form cron field - you can compose the expression with the fluent
+`CronExpressionBuilder` instead of concatenating strings:
+
+```csharp
+CronExpression expression = CronExpressionBuilder.Create()
+    .WithSecond(0)
+    .WithMinuteIncrements(0, 15) // every 15 minutes
+    .WithHourRange(8, 17)        // between 8:00 and 17:59
+    .OnWeekdays()                // Monday through Friday
+    .Build(); // "0 0/15 8-17 ? * MON-FRI"
+
+ITrigger trigger = TriggerBuilder.Create()
+    .WithIdentity("myTrigger")
+    .WithSchedule(CronScheduleBuilder.CronSchedule(expression))
+    .Build();
+```
+
+Each field offers a single value, list, range and increment form (e.g. `WithHour`,
+`WithHours`, `WithHourRange`, `WithHourIncrements`), and the special characters are
+available through dedicated methods:
+
+```csharp
+CronExpressionBuilder.Create().OnLastDayOfMonth();                         // "* * * L * ?"
+CronExpressionBuilder.Create().OnNearestWeekdayOfMonth(15);                // "* * * 15W * ?"
+CronExpressionBuilder.Create().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3); // "* * * ? * FRI#3"
+CronExpressionBuilder.Create().OnLastDayOfWeekOfMonth(DayOfWeek.Friday);   // "* * * ? * FRIL"
+```
+
+A few rules to be aware of:
+
+- Unconfigured fields default to `*` (every value).
+- Each field can be configured only once; configuring it again throws `InvalidOperationException`.
+- Day-of-month and day-of-week are mutually exclusive per cron syntax - the builder renders
+  the unused one as `?` and throws if you try to configure both.
+- Values are validated eagerly against each field's allowed range, and `Build()` returns a
+  fully validated `CronExpression`; use `ToString()` if you only need the expression string.
+- Days of the week are emitted using their textual names (`MON`, `FRI`, ...), so the produced
+  expressions stay unambiguous across cron dialects that number weekdays differently.
+
 ## Examples
 
 Here are some full examples:

--- a/docs/documentation/quartz-4.x/tutorial/crontriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontriggers.md
@@ -116,6 +116,9 @@ extension method (for the CronTrigger-specific properties).
 
 You can also use `CronScheduleBuilder`'s static methods to create schedules.
 
+To compose the cron expression string itself programmatically, see
+[Building cron expressions programmatically](crontrigger.md#building-cron-expressions-programmatically).
+
 **Build a trigger that will fire every other minute, between 8am and 5pm, every day:**
 
 ```csharp

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -153,6 +153,7 @@ public class CronExpressionBuilderTest
         Invoking(x => x.WithDayOfMonthIncrements(1, 32)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithMonthIncrements(1, 13)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 0)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 8)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithYearIncrements(2030, 0)).Should().Throw<ArgumentOutOfRangeException>();
     }
 

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -1,0 +1,238 @@
+using System;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace Quartz.Tests.Unit;
+
+public class CronExpressionBuilderTest
+{
+    [Test]
+    public void TestDefaultExpression()
+    {
+        CronExpressionBuilder builder = CronExpressionBuilder.Create();
+
+        builder.ToString().Should().Be("* * * ? * *");
+        builder.Build().CronExpressionString.Should().Be("* * * ? * *");
+    }
+
+    [Test]
+    public void TestSecondField()
+    {
+        CronExpressionBuilder.Create().WithSecond(10).ToString().Should().Be("10 * * ? * *");
+        CronExpressionBuilder.Create().WithSeconds(30, 0).ToString().Should().Be("30,0 * * ? * *");
+        CronExpressionBuilder.Create().WithSecondRange(20, 30).ToString().Should().Be("20-30 * * ? * *");
+        CronExpressionBuilder.Create().WithSecondRange(55, 5).ToString().Should().Be("55-5 * * ? * *");
+        CronExpressionBuilder.Create().WithSecondIncrements(0, 15).ToString().Should().Be("0/15 * * ? * *");
+    }
+
+    [Test]
+    public void TestMinuteField()
+    {
+        CronExpressionBuilder.Create().WithMinute(10).ToString().Should().Be("* 10 * ? * *");
+        CronExpressionBuilder.Create().WithMinutes(17, 51).ToString().Should().Be("* 17,51 * ? * *");
+        CronExpressionBuilder.Create().WithMinuteRange(20, 30).ToString().Should().Be("* 20-30 * ? * *");
+        CronExpressionBuilder.Create().WithMinuteIncrements(0, 10).ToString().Should().Be("* 0/10 * ? * *");
+    }
+
+    [Test]
+    public void TestHourField()
+    {
+        CronExpressionBuilder.Create().WithHour(10).ToString().Should().Be("* * 10 ? * *");
+        CronExpressionBuilder.Create().WithHours(1, 5).ToString().Should().Be("* * 1,5 ? * *");
+        CronExpressionBuilder.Create().WithHourRange(8, 17).ToString().Should().Be("* * 8-17 ? * *");
+        CronExpressionBuilder.Create().WithHourRange(22, 2).ToString().Should().Be("* * 22-2 ? * *");
+        CronExpressionBuilder.Create().WithHourIncrements(0, 6).ToString().Should().Be("* * 0/6 ? * *");
+    }
+
+    [Test]
+    public void TestDayOfMonthField()
+    {
+        CronExpressionBuilder.Create().WithDayOfMonth(10).ToString().Should().Be("* * * 10 * ?");
+        CronExpressionBuilder.Create().WithDaysOfMonth(1, 15).ToString().Should().Be("* * * 1,15 * ?");
+        CronExpressionBuilder.Create().WithDayOfMonthRange(20, 22).ToString().Should().Be("* * * 20-22 * ?");
+        CronExpressionBuilder.Create().WithDayOfMonthIncrements(1, 5).ToString().Should().Be("* * * 1/5 * ?");
+        CronExpressionBuilder.Create().OnLastDayOfMonth().ToString().Should().Be("* * * L * ?");
+        CronExpressionBuilder.Create().OnNearestWeekdayOfMonth(15).ToString().Should().Be("* * * 15W * ?");
+    }
+
+    [Test]
+    public void TestMonthField()
+    {
+        CronExpressionBuilder.Create().WithMonth(2).ToString().Should().Be("* * * ? 2 *");
+        CronExpressionBuilder.Create().WithMonths(3, 12).ToString().Should().Be("* * * ? 3,12 *");
+        CronExpressionBuilder.Create().WithMonthRange(2, 8).ToString().Should().Be("* * * ? 2-8 *");
+        CronExpressionBuilder.Create().WithMonthIncrements(3, 4).ToString().Should().Be("* * * ? 3/4 *");
+    }
+
+    [Test]
+    public void TestDayOfWeekField()
+    {
+        CronExpressionBuilder.Create().OnDaysOfWeek(DayOfWeek.Thursday).ToString().Should().Be("* * * ? * THU");
+        CronExpressionBuilder.Create().OnDaysOfWeek(DayOfWeek.Sunday, DayOfWeek.Wednesday).ToString().Should().Be("* * * ? * SUN,WED");
+        CronExpressionBuilder.Create().OnDayOfWeekRange(DayOfWeek.Monday, DayOfWeek.Friday).ToString().Should().Be("* * * ? * MON-FRI");
+        CronExpressionBuilder.Create().OnDayOfWeekRange(DayOfWeek.Thursday, DayOfWeek.Sunday).ToString().Should().Be("* * * ? * THU-SUN");
+        CronExpressionBuilder.Create().OnNthDayOfWeekOfMonth(DayOfWeek.Sunday, 3).ToString().Should().Be("* * * ? * SUN#3");
+        CronExpressionBuilder.Create().OnLastDayOfWeekOfMonth(DayOfWeek.Thursday).ToString().Should().Be("* * * ? * THUL");
+        CronExpressionBuilder.Create().OnLastDayOfWeek().ToString().Should().Be("* * * ? * L");
+        CronExpressionBuilder.Create().OnWeekdays().ToString().Should().Be("* * * ? * MON-FRI");
+    }
+
+    [Test]
+    public void TestDayOfWeekIncrementsExpandToExplicitList()
+    {
+        CronExpressionBuilder.Create().OnDayOfWeekIncrements(DayOfWeek.Monday, 2).ToString().Should().Be("* * * ? * MON,WED,FRI");
+        CronExpressionBuilder.Create().OnDayOfWeekIncrements(DayOfWeek.Sunday, 3).ToString().Should().Be("* * * ? * SUN,WED,SAT");
+        CronExpressionBuilder.Create().OnDayOfWeekIncrements(DayOfWeek.Friday, 2).ToString().Should().Be("* * * ? * FRI");
+        CronExpressionBuilder.Create().OnDayOfWeekIncrements(DayOfWeek.Sunday, 1).ToString().Should().Be("* * * ? * SUN,MON,TUE,WED,THU,FRI,SAT");
+    }
+
+    [Test]
+    public void TestDayOfWeekIncrementsMatchNumericIncrementSemantics()
+    {
+        // numeric "2/2" means day 2 (MON) through SAT stepping by 2; the builder emits
+        // the equivalent explicit day name list instead, since textual "MON/2" would
+        // mean Quartz's every-second-week feature
+        CronExpression expanded = CronExpressionBuilder.Create()
+            .WithSecond(0)
+            .WithMinute(0)
+            .WithHour(12)
+            .OnDayOfWeekIncrements(DayOfWeek.Monday, 2)
+            .Build();
+        CronExpression numeric = new CronExpression("0 0 12 ? * 2/2");
+
+        DateTimeOffset after = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        for (int i = 0; i < 20; i++)
+        {
+            DateTimeOffset? expandedNext = expanded.GetNextValidTimeAfter(after);
+            DateTimeOffset? numericNext = numeric.GetNextValidTimeAfter(after);
+
+            expandedNext.Should().NotBeNull();
+            expandedNext.Should().Be(numericNext);
+
+            after = expandedNext.GetValueOrDefault();
+        }
+    }
+
+    [Test]
+    public void TestYearField()
+    {
+        CronExpressionBuilder.Create().WithYear(2030).ToString().Should().Be("* * * ? * * 2030");
+        CronExpressionBuilder.Create().WithYears(2030, 2032).ToString().Should().Be("* * * ? * * 2030,2032");
+        CronExpressionBuilder.Create().WithYearRange(2030, 2035).ToString().Should().Be("* * * ? * * 2030-2035");
+        CronExpressionBuilder.Create().WithYearIncrements(2030, 2).ToString().Should().Be("* * * ? * * 2030/2");
+    }
+
+    [Test]
+    public void TestOutOfRangeValuesAreRejected()
+    {
+        Invoking(x => x.WithSecond(60)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithSeconds(17, 61)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithSecondRange(20, 60)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithMinute(-1)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithHour(24)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithDayOfMonth(0)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithDayOfMonth(32)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.OnNearestWeekdayOfMonth(32)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithMonth(0)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithMonth(13)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithYear(1969)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.OnDaysOfWeek((DayOfWeek) 7)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 0)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 6)).Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void TestInvalidIncrementsAreRejected()
+    {
+        Invoking(x => x.WithSecondIncrements(0, 0)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithSecondIncrements(0, 60)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithMinuteIncrements(0, 60)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithHourIncrements(0, 24)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithDayOfMonthIncrements(1, 32)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithMonthIncrements(1, 13)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 0)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithYearIncrements(2030, 0)).Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void TestEmptyListsAreRejected()
+    {
+        Invoking(x => x.WithSeconds()).Should().Throw<ArgumentException>();
+        Invoking(x => x.WithMinutes()).Should().Throw<ArgumentException>();
+        Invoking(x => x.WithHours()).Should().Throw<ArgumentException>();
+        Invoking(x => x.WithDaysOfMonth()).Should().Throw<ArgumentException>();
+        Invoking(x => x.WithMonths()).Should().Throw<ArgumentException>();
+        Invoking(x => x.OnDaysOfWeek()).Should().Throw<ArgumentException>();
+        Invoking(x => x.WithYears()).Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void TestYearRangeCannotWrap()
+    {
+        Invoking(x => x.WithYearRange(2035, 2030)).Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void TestFieldCannotBeConfiguredTwice()
+    {
+        Invoking(x => x.WithSecond(1).WithSecond(2)).Should().Throw<InvalidOperationException>().WithMessage("Second has already been configured.");
+        Invoking(x => x.WithSecond(1).WithSecondRange(2, 5)).Should().Throw<InvalidOperationException>().WithMessage("Second has already been configured.");
+        Invoking(x => x.WithMinute(1).WithMinuteIncrements(0, 5)).Should().Throw<InvalidOperationException>().WithMessage("Minute has already been configured.");
+        Invoking(x => x.WithHour(1).WithHours(2, 3)).Should().Throw<InvalidOperationException>().WithMessage("Hour has already been configured.");
+        Invoking(x => x.OnLastDayOfMonth().WithDayOfMonth(3)).Should().Throw<InvalidOperationException>().WithMessage("Day-of-month has already been configured.");
+        Invoking(x => x.WithMonth(1).WithMonthRange(2, 5)).Should().Throw<InvalidOperationException>().WithMessage("Month has already been configured.");
+        Invoking(x => x.OnWeekdays().OnDaysOfWeek(DayOfWeek.Sunday)).Should().Throw<InvalidOperationException>().WithMessage("Day-of-week has already been configured.");
+        Invoking(x => x.WithYear(2030).WithYearRange(2031, 2032)).Should().Throw<InvalidOperationException>().WithMessage("Year has already been configured.");
+    }
+
+    [Test]
+    public void TestDayOfMonthAndDayOfWeekAreMutuallyExclusive()
+    {
+        Invoking(x => x.WithDayOfMonth(10).OnDaysOfWeek(DayOfWeek.Monday)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
+        Invoking(x => x.OnDaysOfWeek(DayOfWeek.Monday).WithDayOfMonth(10)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
+        Invoking(x => x.OnLastDayOfMonth().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
+    }
+
+    [Test]
+    public void TestBuildRoundTrip()
+    {
+        CronExpressionBuilder builder = CronExpressionBuilder.Create()
+            .WithSecond(0)
+            .WithMinuteIncrements(0, 15)
+            .WithHourRange(8, 17)
+            .OnWeekdays();
+
+        builder.ToString().Should().Be("0 0/15 8-17 ? * MON-FRI");
+        builder.Build().CronExpressionString.Should().Be(builder.ToString());
+    }
+
+    [Test]
+    public void TestAllSpecialFormsProduceValidExpressions()
+    {
+        CronExpressionBuilder[] builders =
+        [
+            CronExpressionBuilder.Create().OnLastDayOfMonth(),
+            CronExpressionBuilder.Create().OnNearestWeekdayOfMonth(15),
+            CronExpressionBuilder.Create().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3),
+            CronExpressionBuilder.Create().OnLastDayOfWeekOfMonth(DayOfWeek.Thursday),
+            CronExpressionBuilder.Create().OnLastDayOfWeek(),
+            CronExpressionBuilder.Create().OnWeekdays(),
+            CronExpressionBuilder.Create().OnDayOfWeekRange(DayOfWeek.Thursday, DayOfWeek.Sunday),
+            CronExpressionBuilder.Create().WithSecondRange(55, 5).WithHourRange(22, 2),
+            CronExpressionBuilder.Create().WithYearRange(2030, 2035),
+            CronExpressionBuilder.Create().WithYearIncrements(2030, 2)
+        ];
+
+        foreach (CronExpressionBuilder builder in builders)
+        {
+            CronExpression.IsValidExpression(builder.ToString()).Should().BeTrue("expression '{0}' should be valid", builder.ToString());
+        }
+    }
+
+    private static Action Invoking(Action<CronExpressionBuilder> action)
+    {
+        return () => action(CronExpressionBuilder.Create());
+    }
+}

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -10,12 +10,75 @@ public class CronScheduleBuilderTest
             .WithSchedule(CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(10, 0, DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Friday))
             .Build();
 
-        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 0 10 ? * 2,5,6"));
+        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 0 10 ? * MON,THU,FRI"));
 
         trigger = (ICronTrigger) TriggerBuilder.Create().WithIdentity("test")
             .WithSchedule(CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(10, 0, DayOfWeek.Wednesday))
             .Build();
 
-        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 0 10 ? * 4"));
+        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 0 10 ? * WED"));
+    }
+
+    [Test]
+    public void TestAtHourAndMinuteOnGivenDaysOfWeekRejectsInvalidArguments()
+    {
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(25, 0, DayOfWeek.Monday));
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(13, 68, DayOfWeek.Monday));
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(13, 25));
+    }
+
+    [Test]
+    public void TestDailyAtHourAndMinute()
+    {
+        var trigger = (ICronTrigger) TriggerBuilder.Create()
+            .WithIdentity("test")
+            .WithSchedule(CronScheduleBuilder.DailyAtHourAndMinute(10, 20))
+            .Build();
+
+        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 20 10 ? * *"));
+    }
+
+    [Test]
+    public void TestDailyAtHourAndMinuteRejectsInvalidArguments()
+    {
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.DailyAtHourAndMinute(26, 23));
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.DailyAtHourAndMinute(11, 78));
+    }
+
+    [Test]
+    public void TestWeeklyOnDayAndHourAndMinute()
+    {
+        var trigger = (ICronTrigger) TriggerBuilder.Create()
+            .WithIdentity("test")
+            .WithSchedule(CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(DayOfWeek.Saturday, 11, 41))
+            .Build();
+
+        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 41 11 ? * SAT"));
+    }
+
+    [Test]
+    public void TestWeeklyOnDayAndHourAndMinuteRejectsInvalidArguments()
+    {
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(DayOfWeek.Monday, 25, 2));
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(DayOfWeek.Monday, 2, 62));
+    }
+
+    [Test]
+    public void TestMonthlyOnDayAndHourAndMinute()
+    {
+        var trigger = (ICronTrigger) TriggerBuilder.Create()
+            .WithIdentity("test")
+            .WithSchedule(CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(6, 18, 30))
+            .Build();
+
+        Assert.That(trigger.CronExpressionString, Is.EqualTo("0 30 18 6 * ?"));
+    }
+
+    [Test]
+    public void TestMonthlyOnDayAndHourAndMinuteRejectsInvalidArguments()
+    {
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(32, 18, 30));
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(18, 25, 1));
+        Assert.Throws<ArgumentException>(() => CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(16, 19, 61));
     }
 }

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -61,6 +61,9 @@ public class CronScheduleBuilderTest
     {
         Assert.Throws<ArgumentException>(() => CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(DayOfWeek.Monday, 25, 2));
         Assert.Throws<ArgumentException>(() => CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(DayOfWeek.Monday, 2, 62));
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => CronScheduleBuilder.WeeklyOnDayAndHourAndMinute((DayOfWeek) 8, 10, 0));
+        Assert.That(exception.ParamName, Is.EqualTo("dayOfWeek"));
     }
 
     [Test]

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -1,0 +1,705 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+
+namespace Quartz;
+
+/// <summary>
+/// CronExpressionBuilder provides a fluent API for composing cron expression
+/// strings programmatically, one field at a time - useful when a schedule is
+/// assembled from user input (e.g. a scheduling UI) rather than hand-written.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unconfigured fields default to every value ('*'). The day-of-month and
+/// day-of-week fields are mutually exclusive per cron syntax; the unused one
+/// renders as '?'. Each field can be configured only once. Day-of-week values
+/// are emitted using their textual names (SUN-SAT) so that the produced
+/// expressions stay unambiguous across cron dialects that use different
+/// day-of-week numbering.
+/// </para>
+/// <para>
+/// Client code can use the builder to write code such as this:
+/// </para>
+/// <code>
+/// CronExpression expression = CronExpressionBuilder.Create()
+///     .WithSecond(0)
+///     .WithMinuteIncrements(0, 15)
+///     .WithHourRange(8, 17)
+///     .OnWeekdays()
+///     .Build(); // "0 0/15 8-17 ? * MON-FRI"
+///
+/// ITrigger trigger = TriggerBuilder.Create()
+///     .WithIdentity("myTrigger")
+///     .WithSchedule(CronScheduleBuilder.CronSchedule(expression))
+///     .Build();
+/// </code>
+/// </remarks>
+/// <seealso cref="CronExpression" />
+/// <seealso cref="CronScheduleBuilder" />
+public sealed class CronExpressionBuilder
+{
+    private static readonly string[] dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+    private string? second;
+    private string? minute;
+    private string? hour;
+    private string? dayOfMonth;
+    private string? month;
+    private string? dayOfWeek;
+    private string? year;
+
+    private static int MaxYear => TriggerConstants.YearToGiveUpSchedulingAt;
+
+    private CronExpressionBuilder()
+    {
+    }
+
+    /// <summary>
+    /// Create a new CronExpressionBuilder with all fields unconfigured ("* * * ? * *").
+    /// </summary>
+    /// <returns>the new CronExpressionBuilder</returns>
+    public static CronExpressionBuilder Create()
+    {
+        return new CronExpressionBuilder();
+    }
+
+    /// <summary>
+    /// Set the second field to a single value.
+    /// </summary>
+    /// <param name="second">the second to fire on (0-59)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithSecond(int second)
+    {
+        ValidateRange(second, 0, 59, "second", nameof(second));
+        return SetSecond($"{second}");
+    }
+
+    /// <summary>
+    /// Set the second field to a list of values, e.g. "0,30". The values are
+    /// emitted in the given order.
+    /// </summary>
+    /// <param name="seconds">the seconds to fire on (each 0-59)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithSeconds(params int[] seconds)
+    {
+        return SetSecond(JoinValues(seconds, 0, 59, "second", nameof(seconds)));
+    }
+
+    /// <summary>
+    /// Set the second field to a range of values, e.g. "20-30". The range may
+    /// wrap around, e.g. "55-5".
+    /// </summary>
+    /// <param name="start">the first second of the range (0-59)</param>
+    /// <param name="end">the last second of the range (0-59)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithSecondRange(int start, int end)
+    {
+        ValidateRange(start, 0, 59, "second", nameof(start));
+        ValidateRange(end, 0, 59, "second", nameof(end));
+        return SetSecond($"{start}-{end}");
+    }
+
+    /// <summary>
+    /// Set the second field to an incremental list of values, e.g. "0/15"
+    /// (every 15 seconds starting at second 0).
+    /// </summary>
+    /// <param name="start">the second to start at (0-59)</param>
+    /// <param name="increment">the number of seconds between values (1-59)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithSecondIncrements(int start, int increment)
+    {
+        ValidateRange(start, 0, 59, "second", nameof(start));
+        ValidateIncrement(increment, 59);
+        return SetSecond($"{start}/{increment}");
+    }
+
+    /// <summary>
+    /// Set the minute field to a single value.
+    /// </summary>
+    /// <param name="minute">the minute to fire on (0-59)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithMinute(int minute)
+    {
+        ValidateRange(minute, 0, 59, "minute", nameof(minute));
+        return SetMinute($"{minute}");
+    }
+
+    /// <summary>
+    /// Set the minute field to a list of values, e.g. "0,30". The values are
+    /// emitted in the given order.
+    /// </summary>
+    /// <param name="minutes">the minutes to fire on (each 0-59)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithMinutes(params int[] minutes)
+    {
+        return SetMinute(JoinValues(minutes, 0, 59, "minute", nameof(minutes)));
+    }
+
+    /// <summary>
+    /// Set the minute field to a range of values, e.g. "20-30". The range may
+    /// wrap around, e.g. "55-5".
+    /// </summary>
+    /// <param name="start">the first minute of the range (0-59)</param>
+    /// <param name="end">the last minute of the range (0-59)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithMinuteRange(int start, int end)
+    {
+        ValidateRange(start, 0, 59, "minute", nameof(start));
+        ValidateRange(end, 0, 59, "minute", nameof(end));
+        return SetMinute($"{start}-{end}");
+    }
+
+    /// <summary>
+    /// Set the minute field to an incremental list of values, e.g. "0/15"
+    /// (every 15 minutes starting at minute 0).
+    /// </summary>
+    /// <param name="start">the minute to start at (0-59)</param>
+    /// <param name="increment">the number of minutes between values (1-59)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithMinuteIncrements(int start, int increment)
+    {
+        ValidateRange(start, 0, 59, "minute", nameof(start));
+        ValidateIncrement(increment, 59);
+        return SetMinute($"{start}/{increment}");
+    }
+
+    /// <summary>
+    /// Set the hour field to a single value.
+    /// </summary>
+    /// <param name="hour">the hour to fire on (0-23)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithHour(int hour)
+    {
+        ValidateRange(hour, 0, 23, "hour", nameof(hour));
+        return SetHour($"{hour}");
+    }
+
+    /// <summary>
+    /// Set the hour field to a list of values, e.g. "8,12,16". The values are
+    /// emitted in the given order.
+    /// </summary>
+    /// <param name="hours">the hours to fire on (each 0-23)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithHours(params int[] hours)
+    {
+        return SetHour(JoinValues(hours, 0, 23, "hour", nameof(hours)));
+    }
+
+    /// <summary>
+    /// Set the hour field to a range of values, e.g. "8-17". The range may
+    /// wrap around, e.g. "22-2".
+    /// </summary>
+    /// <param name="start">the first hour of the range (0-23)</param>
+    /// <param name="end">the last hour of the range (0-23)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithHourRange(int start, int end)
+    {
+        ValidateRange(start, 0, 23, "hour", nameof(start));
+        ValidateRange(end, 0, 23, "hour", nameof(end));
+        return SetHour($"{start}-{end}");
+    }
+
+    /// <summary>
+    /// Set the hour field to an incremental list of values, e.g. "0/6"
+    /// (every 6 hours starting at hour 0).
+    /// </summary>
+    /// <param name="start">the hour to start at (0-23)</param>
+    /// <param name="increment">the number of hours between values (1-23)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithHourIncrements(int start, int increment)
+    {
+        ValidateRange(start, 0, 23, "hour", nameof(start));
+        ValidateIncrement(increment, 23);
+        return SetHour($"{start}/{increment}");
+    }
+
+    /// <summary>
+    /// Set the day-of-month field to a single value. Cannot be combined with
+    /// configuring the day-of-week field.
+    /// </summary>
+    /// <param name="day">the day of month to fire on (1-31)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithDayOfMonth(int day)
+    {
+        ValidateRange(day, 1, 31, "day-of-month", nameof(day));
+        return SetDayOfMonth($"{day}");
+    }
+
+    /// <summary>
+    /// Set the day-of-month field to a list of values, e.g. "1,15". The values
+    /// are emitted in the given order. Cannot be combined with configuring the
+    /// day-of-week field.
+    /// </summary>
+    /// <param name="days">the days of month to fire on (each 1-31)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithDaysOfMonth(params int[] days)
+    {
+        return SetDayOfMonth(JoinValues(days, 1, 31, "day-of-month", nameof(days)));
+    }
+
+    /// <summary>
+    /// Set the day-of-month field to a range of values, e.g. "20-25". The range
+    /// may wrap around, e.g. "28-3". Cannot be combined with configuring the
+    /// day-of-week field.
+    /// </summary>
+    /// <param name="start">the first day of the range (1-31)</param>
+    /// <param name="end">the last day of the range (1-31)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithDayOfMonthRange(int start, int end)
+    {
+        ValidateRange(start, 1, 31, "day-of-month", nameof(start));
+        ValidateRange(end, 1, 31, "day-of-month", nameof(end));
+        return SetDayOfMonth($"{start}-{end}");
+    }
+
+    /// <summary>
+    /// Set the day-of-month field to an incremental list of values, e.g. "1/5"
+    /// (every 5 days starting on the 1st). Cannot be combined with configuring
+    /// the day-of-week field.
+    /// </summary>
+    /// <param name="start">the day of month to start at (1-31)</param>
+    /// <param name="increment">the number of days between values (1-31)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithDayOfMonthIncrements(int start, int increment)
+    {
+        ValidateRange(start, 1, 31, "day-of-month", nameof(start));
+        ValidateIncrement(increment, 31);
+        return SetDayOfMonth($"{start}/{increment}");
+    }
+
+    /// <summary>
+    /// Set the day-of-month field to the last day of the month ("L"). Cannot be
+    /// combined with configuring the day-of-week field.
+    /// </summary>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnLastDayOfMonth()
+    {
+        return SetDayOfMonth("L");
+    }
+
+    /// <summary>
+    /// Set the day-of-month field to the weekday (Monday-Friday) nearest to the
+    /// given day, e.g. "15W". Cannot be combined with configuring the
+    /// day-of-week field.
+    /// </summary>
+    /// <param name="day">the day of month to fire nearest to (1-31)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnNearestWeekdayOfMonth(int day)
+    {
+        ValidateRange(day, 1, 31, "day-of-month", nameof(day));
+        return SetDayOfMonth($"{day}W");
+    }
+
+    /// <summary>
+    /// Set the month field to a single value.
+    /// </summary>
+    /// <param name="month">the month to fire on (1-12)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithMonth(int month)
+    {
+        ValidateRange(month, 1, 12, "month", nameof(month));
+        return SetMonth($"{month}");
+    }
+
+    /// <summary>
+    /// Set the month field to a list of values, e.g. "3,6,9,12". The values are
+    /// emitted in the given order.
+    /// </summary>
+    /// <param name="months">the months to fire on (each 1-12)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithMonths(params int[] months)
+    {
+        return SetMonth(JoinValues(months, 1, 12, "month", nameof(months)));
+    }
+
+    /// <summary>
+    /// Set the month field to a range of values, e.g. "2-8". The range may wrap
+    /// around, e.g. "11-2".
+    /// </summary>
+    /// <param name="start">the first month of the range (1-12)</param>
+    /// <param name="end">the last month of the range (1-12)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithMonthRange(int start, int end)
+    {
+        ValidateRange(start, 1, 12, "month", nameof(start));
+        ValidateRange(end, 1, 12, "month", nameof(end));
+        return SetMonth($"{start}-{end}");
+    }
+
+    /// <summary>
+    /// Set the month field to an incremental list of values, e.g. "3/4"
+    /// (every 4 months starting in March).
+    /// </summary>
+    /// <param name="start">the month to start at (1-12)</param>
+    /// <param name="increment">the number of months between values (1-12)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithMonthIncrements(int start, int increment)
+    {
+        ValidateRange(start, 1, 12, "month", nameof(start));
+        ValidateIncrement(increment, 12);
+        return SetMonth($"{start}/{increment}");
+    }
+
+    /// <summary>
+    /// Set the day-of-week field to the given days, e.g. "MON,THU,FRI". The
+    /// values are emitted in the given order. Cannot be combined with
+    /// configuring the day-of-month field.
+    /// </summary>
+    /// <param name="daysOfWeek">the days of the week to fire on</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnDaysOfWeek(params DayOfWeek[] daysOfWeek)
+    {
+        if (daysOfWeek is null || daysOfWeek.Length == 0)
+        {
+            throw new ArgumentException("At least one day-of-week must be specified.", nameof(daysOfWeek));
+        }
+
+        string[] names = new string[daysOfWeek.Length];
+        for (int i = 0; i < daysOfWeek.Length; i++)
+        {
+            names[i] = GetDayName(daysOfWeek[i], nameof(daysOfWeek));
+        }
+
+        return SetDayOfWeek(string.Join(",", names));
+    }
+
+    /// <summary>
+    /// Set the day-of-week field to a range of days, e.g. "MON-FRI". The range
+    /// may wrap around, e.g. "FRI-MON". Cannot be combined with configuring the
+    /// day-of-month field.
+    /// </summary>
+    /// <param name="start">the first day of the range</param>
+    /// <param name="end">the last day of the range</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnDayOfWeekRange(DayOfWeek start, DayOfWeek end)
+    {
+        return SetDayOfWeek($"{GetDayName(start, nameof(start))}-{GetDayName(end, nameof(end))}");
+    }
+
+    /// <summary>
+    /// Set the day-of-week field to every <paramref name="increment"/>th day
+    /// starting from the given day, emitted as an explicit list of day names,
+    /// e.g. Monday with increment 2 produces "MON,WED,FRI". Cannot be combined
+    /// with configuring the day-of-month field.
+    /// </summary>
+    /// <remarks>
+    /// The list stops at Saturday and does not wrap around, matching the
+    /// semantics of a numeric cron day-of-week increment. Note that this
+    /// differs from Quartz's textual "MON/2" syntax, which means every second
+    /// week.
+    /// </remarks>
+    /// <param name="start">the day of the week to start at</param>
+    /// <param name="increment">the number of days between values (&gt;= 1)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnDayOfWeekIncrements(DayOfWeek start, int increment)
+    {
+        if (increment < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(increment), "Invalid increment (must be >= 1).");
+        }
+
+        GetDayName(start, nameof(start));
+
+        int startIndex = (int) start;
+        string[] names = new string[(6 - startIndex) / increment + 1];
+        for (int i = 0; i < names.Length; i++)
+        {
+            names[i] = dayNames[startIndex + i * increment];
+        }
+
+        return SetDayOfWeek(string.Join(",", names));
+    }
+
+    /// <summary>
+    /// Set the day-of-week field to the nth occurrence of the given day in the
+    /// month, e.g. "FRI#3" for the third Friday. Cannot be combined with
+    /// configuring the day-of-month field.
+    /// </summary>
+    /// <param name="dayOfWeek">the day of the week</param>
+    /// <param name="nth">the occurrence of the day within the month (1-5)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnNthDayOfWeekOfMonth(DayOfWeek dayOfWeek, int nth)
+    {
+        ValidateRange(nth, 1, 5, "nth occurrence", nameof(nth));
+        return SetDayOfWeek($"{GetDayName(dayOfWeek, nameof(dayOfWeek))}#{nth}");
+    }
+
+    /// <summary>
+    /// Set the day-of-week field to the last occurrence of the given day in the
+    /// month, e.g. "FRIL" for the last Friday. Cannot be combined with
+    /// configuring the day-of-month field.
+    /// </summary>
+    /// <param name="dayOfWeek">the day of the week</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnLastDayOfWeekOfMonth(DayOfWeek dayOfWeek)
+    {
+        return SetDayOfWeek($"{GetDayName(dayOfWeek, nameof(dayOfWeek))}L");
+    }
+
+    /// <summary>
+    /// Set the day-of-week field to the last day of the cron week ("L"), which
+    /// is Saturday. Cannot be combined with configuring the day-of-month field.
+    /// </summary>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnLastDayOfWeek()
+    {
+        return SetDayOfWeek("L");
+    }
+
+    /// <summary>
+    /// Set the day-of-week field to weekdays ("MON-FRI"). Cannot be combined
+    /// with configuring the day-of-month field.
+    /// </summary>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder OnWeekdays()
+    {
+        return SetDayOfWeek("MON-FRI");
+    }
+
+    /// <summary>
+    /// Set the year field to a single value.
+    /// </summary>
+    /// <param name="year">the year to fire on (1970 to circa 100 years from now)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithYear(int year)
+    {
+        ValidateYear(year, nameof(year));
+        return SetYear($"{year}");
+    }
+
+    /// <summary>
+    /// Set the year field to a list of values, e.g. "2030,2032". The values are
+    /// emitted in the given order.
+    /// </summary>
+    /// <param name="years">the years to fire on</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithYears(params int[] years)
+    {
+        if (years is null || years.Length == 0)
+        {
+            throw new ArgumentException("At least one year must be specified.", nameof(years));
+        }
+
+        foreach (int value in years)
+        {
+            ValidateYear(value, nameof(years));
+        }
+
+        return SetYear(string.Join(",", years));
+    }
+
+    /// <summary>
+    /// Set the year field to a range of values, e.g. "2030-2035". Unlike the
+    /// other fields, the year range cannot wrap around.
+    /// </summary>
+    /// <param name="start">the first year of the range</param>
+    /// <param name="end">the last year of the range</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithYearRange(int start, int end)
+    {
+        ValidateYear(start, nameof(start));
+        ValidateYear(end, nameof(end));
+        if (start > end)
+        {
+            throw new ArgumentException("Start year must be less than or equal to end year.", nameof(start));
+        }
+
+        return SetYear($"{start}-{end}");
+    }
+
+    /// <summary>
+    /// Set the year field to an incremental list of values, e.g. "2030/2"
+    /// (every second year starting in 2030).
+    /// </summary>
+    /// <param name="start">the year to start at</param>
+    /// <param name="increment">the number of years between values (&gt;= 1)</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder WithYearIncrements(int start, int increment)
+    {
+        ValidateYear(start, nameof(start));
+        if (increment < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(increment), "Invalid increment (must be >= 1).");
+        }
+
+        return SetYear($"{start}/{increment}");
+    }
+
+    /// <summary>
+    /// Build a validated <see cref="CronExpression" /> from the configured fields.
+    /// </summary>
+    /// <returns>the new CronExpression</returns>
+    /// <exception cref="FormatException">if the composed expression fails final validation</exception>
+    public CronExpression Build()
+    {
+        return new CronExpression(ToString());
+    }
+
+    /// <summary>
+    /// Returns the cron expression string composed from the configured fields.
+    /// </summary>
+    public override string ToString()
+    {
+        string dayOfMonthPart = dayOfMonth ?? "?";
+        string dayOfWeekPart = dayOfWeek ?? (dayOfMonth is not null ? "?" : "*");
+        string expression = $"{second ?? "*"} {minute ?? "*"} {hour ?? "*"} {dayOfMonthPart} {month ?? "*"} {dayOfWeekPart}";
+        return year is null ? expression : $"{expression} {year}";
+    }
+
+    private CronExpressionBuilder SetSecond(string value)
+    {
+        if (second is not null)
+        {
+            throw new InvalidOperationException("Second has already been configured.");
+        }
+
+        second = value;
+        return this;
+    }
+
+    private CronExpressionBuilder SetMinute(string value)
+    {
+        if (minute is not null)
+        {
+            throw new InvalidOperationException("Minute has already been configured.");
+        }
+
+        minute = value;
+        return this;
+    }
+
+    private CronExpressionBuilder SetHour(string value)
+    {
+        if (hour is not null)
+        {
+            throw new InvalidOperationException("Hour has already been configured.");
+        }
+
+        hour = value;
+        return this;
+    }
+
+    private CronExpressionBuilder SetDayOfMonth(string value)
+    {
+        if (dayOfMonth is not null)
+        {
+            throw new InvalidOperationException("Day-of-month has already been configured.");
+        }
+
+        if (dayOfWeek is not null)
+        {
+            throw new InvalidOperationException("Day-of-month cannot be configured because day-of-week has already been configured. Cron expressions do not support specifying both day-of-month and day-of-week.");
+        }
+
+        dayOfMonth = value;
+        return this;
+    }
+
+    private CronExpressionBuilder SetMonth(string value)
+    {
+        if (month is not null)
+        {
+            throw new InvalidOperationException("Month has already been configured.");
+        }
+
+        month = value;
+        return this;
+    }
+
+    private CronExpressionBuilder SetDayOfWeek(string value)
+    {
+        if (dayOfWeek is not null)
+        {
+            throw new InvalidOperationException("Day-of-week has already been configured.");
+        }
+
+        if (dayOfMonth is not null)
+        {
+            throw new InvalidOperationException("Day-of-week cannot be configured because day-of-month has already been configured. Cron expressions do not support specifying both day-of-month and day-of-week.");
+        }
+
+        dayOfWeek = value;
+        return this;
+    }
+
+    private CronExpressionBuilder SetYear(string value)
+    {
+        if (year is not null)
+        {
+            throw new InvalidOperationException("Year has already been configured.");
+        }
+
+        year = value;
+        return this;
+    }
+
+    private static string GetDayName(DayOfWeek dayOfWeek, string paramName)
+    {
+        int index = (int) dayOfWeek;
+        if (index < 0 || index > 6)
+        {
+            throw new ArgumentOutOfRangeException(paramName, $"Invalid day-of-week value: {dayOfWeek}.");
+        }
+
+        return dayNames[index];
+    }
+
+    private static void ValidateRange(int value, int min, int max, string description, string paramName)
+    {
+        if (value < min || value > max)
+        {
+            throw new ArgumentOutOfRangeException(paramName, $"Invalid {description} (must be >= {min} and <= {max}).");
+        }
+    }
+
+    private static void ValidateIncrement(int increment, int max)
+    {
+        if (increment < 1 || increment > max)
+        {
+            throw new ArgumentOutOfRangeException(nameof(increment), $"Invalid increment (must be >= 1 and <= {max}).");
+        }
+    }
+
+    private static void ValidateYear(int year, string paramName)
+    {
+        if (year < TriggerConstants.EarliestYear || year > MaxYear)
+        {
+            throw new ArgumentOutOfRangeException(paramName, $"Invalid year (must be >= {TriggerConstants.EarliestYear} and <= {MaxYear}).");
+        }
+    }
+
+    private static string JoinValues(int[] values, int min, int max, string description, string paramName)
+    {
+        if (values is null || values.Length == 0)
+        {
+            throw new ArgumentException($"At least one {description} must be specified.", paramName);
+        }
+
+        foreach (int value in values)
+        {
+            ValidateRange(value, min, max, description, paramName);
+        }
+
+        return string.Join(",", values);
+    }
+}

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -68,6 +68,8 @@ public sealed class CronExpressionBuilder
     private string? dayOfWeek;
     private string? year;
 
+    // the only intended source difference to the 3.x branch version of this file,
+    // where the year cap is the public CronExpression.MaxYear
     private static int MaxYear => TriggerConstants.YearToGiveUpSchedulingAt;
 
     private CronExpressionBuilder()
@@ -409,15 +411,11 @@ public sealed class CronExpressionBuilder
     /// week.
     /// </remarks>
     /// <param name="start">the day of the week to start at</param>
-    /// <param name="increment">the number of days between values (&gt;= 1)</param>
+    /// <param name="increment">the number of days between values (1-7)</param>
     /// <returns>the updated CronExpressionBuilder</returns>
     public CronExpressionBuilder OnDayOfWeekIncrements(DayOfWeek start, int increment)
     {
-        if (increment < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(increment), "Invalid increment (must be >= 1).");
-        }
-
+        ValidateIncrement(increment, 7);
         GetDayName(start, nameof(start));
 
         int startIndex = (int) start;
@@ -495,17 +493,7 @@ public sealed class CronExpressionBuilder
     /// <returns>the updated CronExpressionBuilder</returns>
     public CronExpressionBuilder WithYears(params int[] years)
     {
-        if (years is null || years.Length == 0)
-        {
-            throw new ArgumentException("At least one year must be specified.", nameof(years));
-        }
-
-        foreach (int value in years)
-        {
-            ValidateYear(value, nameof(years));
-        }
-
-        return SetYear(string.Join(",", years));
+        return SetYear(JoinValues(years, TriggerConstants.EarliestYear, MaxYear, "year", nameof(years)));
     }
 
     /// <summary>
@@ -566,90 +554,44 @@ public sealed class CronExpressionBuilder
         return year is null ? expression : $"{expression} {year}";
     }
 
-    private CronExpressionBuilder SetSecond(string value)
-    {
-        if (second is not null)
-        {
-            throw new InvalidOperationException("Second has already been configured.");
-        }
+    private CronExpressionBuilder SetSecond(string value) => SetField(ref second, "Second", value);
 
-        second = value;
-        return this;
-    }
+    private CronExpressionBuilder SetMinute(string value) => SetField(ref minute, "Minute", value);
 
-    private CronExpressionBuilder SetMinute(string value)
-    {
-        if (minute is not null)
-        {
-            throw new InvalidOperationException("Minute has already been configured.");
-        }
-
-        minute = value;
-        return this;
-    }
-
-    private CronExpressionBuilder SetHour(string value)
-    {
-        if (hour is not null)
-        {
-            throw new InvalidOperationException("Hour has already been configured.");
-        }
-
-        hour = value;
-        return this;
-    }
+    private CronExpressionBuilder SetHour(string value) => SetField(ref hour, "Hour", value);
 
     private CronExpressionBuilder SetDayOfMonth(string value)
     {
-        if (dayOfMonth is not null)
-        {
-            throw new InvalidOperationException("Day-of-month has already been configured.");
-        }
-
         if (dayOfWeek is not null)
         {
             throw new InvalidOperationException("Day-of-month cannot be configured because day-of-week has already been configured. Cron expressions do not support specifying both day-of-month and day-of-week.");
         }
 
-        dayOfMonth = value;
-        return this;
+        return SetField(ref dayOfMonth, "Day-of-month", value);
     }
 
-    private CronExpressionBuilder SetMonth(string value)
-    {
-        if (month is not null)
-        {
-            throw new InvalidOperationException("Month has already been configured.");
-        }
-
-        month = value;
-        return this;
-    }
+    private CronExpressionBuilder SetMonth(string value) => SetField(ref month, "Month", value);
 
     private CronExpressionBuilder SetDayOfWeek(string value)
     {
-        if (dayOfWeek is not null)
-        {
-            throw new InvalidOperationException("Day-of-week has already been configured.");
-        }
-
         if (dayOfMonth is not null)
         {
             throw new InvalidOperationException("Day-of-week cannot be configured because day-of-month has already been configured. Cron expressions do not support specifying both day-of-month and day-of-week.");
         }
 
-        dayOfWeek = value;
-        return this;
+        return SetField(ref dayOfWeek, "Day-of-week", value);
     }
 
-    private CronExpressionBuilder SetYear(string value)
+    private CronExpressionBuilder SetYear(string value) => SetField(ref year, "Year", value);
+
+    private CronExpressionBuilder SetField(ref string? field, string fieldName, string value)
     {
-        if (year is not null)
+        if (field is not null)
         {
-            throw new InvalidOperationException("Year has already been configured.");
+            throw new InvalidOperationException($"{fieldName} has already been configured.");
         }
 
-        year = value;
+        field = value;
         return this;
     }
 
@@ -680,13 +622,7 @@ public sealed class CronExpressionBuilder
         }
     }
 
-    private static void ValidateYear(int year, string paramName)
-    {
-        if (year < TriggerConstants.EarliestYear || year > MaxYear)
-        {
-            throw new ArgumentOutOfRangeException(paramName, $"Invalid year (must be >= {TriggerConstants.EarliestYear} and <= {MaxYear}).");
-        }
-    }
+    private static void ValidateYear(int year, string paramName) => ValidateRange(year, TriggerConstants.EarliestYear, MaxYear, "year", paramName);
 
     private static string JoinValues(int[] values, int min, int max, string description, string paramName)
     {

--- a/src/Quartz/CronScheduleBuilder.cs
+++ b/src/Quartz/CronScheduleBuilder.cs
@@ -216,6 +216,7 @@ public sealed class CronScheduleBuilder : ScheduleBuilder<ICronTrigger>, IHashKe
     /// <seealso cref="CronExpression" />
     public static CronScheduleBuilder DailyAtHourAndMinute(int hour, int minute)
     {
+        // DateBuilder validation first preserves this method's historical plain-ArgumentException contract
         DateBuilder.ValidateHour(hour);
         DateBuilder.ValidateMinute(minute);
 
@@ -239,6 +240,8 @@ public sealed class CronScheduleBuilder : ScheduleBuilder<ICronTrigger>, IHashKe
     /// <seealso cref="CronExpression" />
     public static CronScheduleBuilder AtHourAndMinuteOnGivenDaysOfWeek(int hour, int minute, params DayOfWeek[] daysOfWeek)
     {
+        // these guards run before the builder's own validation to preserve this
+        // method's historical plain-ArgumentException contract and messages
         if (daysOfWeek is null || daysOfWeek.Length == 0)
         {
             Throw.ArgumentException("You must specify at least one day of week.");
@@ -271,6 +274,13 @@ public sealed class CronScheduleBuilder : ScheduleBuilder<ICronTrigger>, IHashKe
     /// <seealso cref="CronExpression" />
     public static CronScheduleBuilder WeeklyOnDayAndHourAndMinute(DayOfWeek dayOfWeek, int hour, int minute)
     {
+        // validate here so an invalid enum value reports this method's own parameter name
+        if (dayOfWeek < DayOfWeek.Sunday || dayOfWeek > DayOfWeek.Saturday)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dayOfWeek), $"Invalid day-of-week value: {dayOfWeek}.");
+        }
+
+        // DateBuilder validation first preserves this method's historical plain-ArgumentException contract
         DateBuilder.ValidateHour(hour);
         DateBuilder.ValidateMinute(minute);
 
@@ -298,6 +308,7 @@ public sealed class CronScheduleBuilder : ScheduleBuilder<ICronTrigger>, IHashKe
     /// <seealso cref="CronExpression" />
     public static CronScheduleBuilder MonthlyOnDayAndHourAndMinute(int dayOfMonth, int hour, int minute)
     {
+        // DateBuilder validation first preserves this method's historical plain-ArgumentException contract
         DateBuilder.ValidateDayOfMonth(dayOfMonth);
         DateBuilder.ValidateHour(hour);
         DateBuilder.ValidateMinute(minute);

--- a/src/Quartz/CronScheduleBuilder.cs
+++ b/src/Quartz/CronScheduleBuilder.cs
@@ -219,7 +219,11 @@ public sealed class CronScheduleBuilder : ScheduleBuilder<ICronTrigger>, IHashKe
         DateBuilder.ValidateHour(hour);
         DateBuilder.ValidateMinute(minute);
 
-        string cronExpression = $"0 {minute} {hour} ? * *";
+        string cronExpression = CronExpressionBuilder.Create()
+            .WithSecond(0)
+            .WithMinute(minute)
+            .WithHour(hour)
+            .ToString();
 
         return CronScheduleNoParseException(cronExpression);
     }
@@ -243,12 +247,12 @@ public sealed class CronScheduleBuilder : ScheduleBuilder<ICronTrigger>, IHashKe
         DateBuilder.ValidateHour(hour);
         DateBuilder.ValidateMinute(minute);
 
-        string cronExpression = $"0 {minute} {hour} ? * {(int) daysOfWeek[0] + 1}";
-
-        for (int i = 1; i < daysOfWeek.Length; i++)
-        {
-            cronExpression = cronExpression + "," + ((int) daysOfWeek[i] + 1);
-        }
+        string cronExpression = CronExpressionBuilder.Create()
+            .WithSecond(0)
+            .WithMinute(minute)
+            .WithHour(hour)
+            .OnDaysOfWeek(daysOfWeek)
+            .ToString();
 
         return CronScheduleNoParseException(cronExpression);
     }
@@ -270,7 +274,12 @@ public sealed class CronScheduleBuilder : ScheduleBuilder<ICronTrigger>, IHashKe
         DateBuilder.ValidateHour(hour);
         DateBuilder.ValidateMinute(minute);
 
-        string cronExpression = $"0 {minute} {hour} ? * {(int) dayOfWeek + 1}";
+        string cronExpression = CronExpressionBuilder.Create()
+            .WithSecond(0)
+            .WithMinute(minute)
+            .WithHour(hour)
+            .OnDaysOfWeek(dayOfWeek)
+            .ToString();
 
         return CronScheduleNoParseException(cronExpression);
     }
@@ -293,7 +302,12 @@ public sealed class CronScheduleBuilder : ScheduleBuilder<ICronTrigger>, IHashKe
         DateBuilder.ValidateHour(hour);
         DateBuilder.ValidateMinute(minute);
 
-        string cronExpression = $"0 {minute} {hour} {dayOfMonth} * ?";
+        string cronExpression = CronExpressionBuilder.Create()
+            .WithSecond(0)
+            .WithMinute(minute)
+            .WithHour(hour)
+            .WithDayOfMonth(dayOfMonth)
+            .ToString();
 
         return CronScheduleNoParseException(cronExpression);
     }


### PR DESCRIPTION
## Summary

Supersedes #283 — a modernized take on the `CronExpressionBuilder` originally contributed by @pstuart2 in 2015 (credited via `Co-authored-by`; that PR's head branch lives in an org-owned fork that maintainers cannot push to, and it has conflicted with `main` over the years).

- New public `CronExpressionBuilder` with a fluent `Create()` / `With*` / `On*` API matching the other Quartz builders: every field supports single value, list, range and increment forms (`WithHour`, `WithHours`, `WithHourRange`, `WithHourIncrements`, ...), and the special characters are exposed as dedicated methods (`OnLastDayOfMonth`, `OnNearestWeekdayOfMonth`, `OnNthDayOfWeekOfMonth`, `OnLastDayOfWeekOfMonth`, `OnWeekdays`, ...).
- `Build()` returns a parse-validated `CronExpression`; `ToString()` yields the raw expression string.
- Eager validation: field ranges, increment caps matching the parser (59/59/23/31/12), `#` occurrence 1–5, year range 1970 through the parser's dynamic cap. Configure-twice and day-of-month/day-of-week conflicts throw `InvalidOperationException` with accurate messages (the original PR reported the wrong field and misused `ArgumentException` for state errors).
- **Day-of-week values are emitted textually** (`MON`, `FRI`, ...) so generated expressions stay unambiguous across cron dialects that number weekdays differently (Quartz `1-7` with `1=SUN` vs Unix/Cronos `0-6`). `OnDayOfWeekIncrements(Monday, 2)` expands to the explicit list `MON,WED,FRI`, because Quartz parses textual `MON/2` as its every-second-week feature, which has different semantics than numeric `2/2`.
- `CronScheduleBuilder`'s convenience methods (`DailyAtHourAndMinute`, `AtHourAndMinuteOnGivenDaysOfWeek`, `WeeklyOnDayAndHourAndMinute`, `MonthlyOnDayAndHourAndMinute`) now compose their expressions through the builder. **Behavioral note:** their `CronExpressionString` output changes from numeric to textual day-of-week — e.g. `0 0 10 ? * MON,THU,FRI` instead of `0 0 10 ? * 2,5,6`. Semantics are identical and existing persisted triggers are unaffected; only newly built triggers store the new form.
- Docs: new "Building cron expressions programmatically" section in both `quartz-3.x` and `quartz-4.x` doc trees (tutorial + how-to cross references).
- Deliberately deferred (all additive later): H-token helpers (`CronScheduleWithHash` covers that use case), `L-offset` day-of-month syntax, `OnEveryNthWeek` for the textual `MON/2` feature.

A companion PR will port the code changes to `3.x` (docs for both versions live on `main`).

## Testing

- New `CronExpressionBuilderTest`: all fields × value/list/range/increment forms, special characters, list order preservation, exclusivity and configure-twice errors, `Build()` round-trip, and a fire-time equivalence test proving the expanded day-of-week increment list matches numeric `2/2` semantics.
- `CronScheduleBuilderTest` extended with exact-string and invalid-argument regressions for all four convenience methods.
- Full unit suite passes: 1740 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xx5mq4Tz4JChPXq6ZtMVP
