### PR TITLE
Fix "Calender" misspelling of "Calendar" in error messages and docs

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -173,7 +173,7 @@ As an example of possible issues, scheduling in the United States within TimeZon
 
 Again, specifics of time and amount of adjustment varies by locale.
 
-Other trigger types that are based on sliding along a calendar (rather than exact amounts of time), such as CalenderIntervalTrigger, will be similarly affected - but rather than missing a firing, or firing twice, may end up having it's fire time shifted by an hour.
+Other trigger types that are based on sliding along a calendar (rather than exact amounts of time), such as CalendarIntervalTrigger, will be similarly affected - but rather than missing a firing, or firing twice, may end up having it's fire time shifted by an hour.
 
 ## Jobs
 

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -2121,7 +2121,7 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         {
             if (await Delegate.CalendarIsReferenced(conn, calName, cancellationToken).ConfigureAwait(false))
             {
-                Throw.JobPersistenceException("Calender cannot be removed if it referenced by a trigger!");
+                Throw.JobPersistenceException("Calendar cannot be removed if it is referenced by a trigger!");
             }
 
             if (!Clustered)

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1005,7 +1005,7 @@ public class RAMJobStore : IJobStore
 
         if (numRefs > 0)
         {
-            Throw.JobPersistenceException("Calender cannot be removed if it referenced by a Trigger!");
+            Throw.JobPersistenceException("Calendar cannot be removed if it is referenced by a Trigger!");
         }
 
         return calendarsByName.TryRemove(name, out _);


### PR DESCRIPTION
Fix "Calender" misspelling of "Calendar" in error messages and docs

 - Correct "Calender" -> "Calendar" in the JobPersistenceException thrown by
   RAMJobStore when a calendar is removed while still referenced by a trigger
 - Correct the same misspelling in the equivalent AdoJobStore
   (JobStoreSupport.RemoveCalendar) message so both job stores agree
 - Fix the grammar of both messages: "if it referenced" -> "if it is referenced"
 - Fix the "CalenderIntervalTrigger" -> "CalendarIntervalTrigger" reference in
   docs/documentation/best-practices.md (the real type is CalendarIntervalTrigger)
 - Message/text only: no behavioral change, no public API change, and no tests
   assert on these strings