### PR TITLE
Add clustered PostgreSQL integration tests for preferred node

### DIFF
--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredPostgresTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredPostgresTestBase.cs
@@ -1,0 +1,182 @@
+using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Text;
+
+using Npgsql;
+
+using NUnit.Framework;
+
+using Quartz.Impl;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Reusable base class for PostgreSQL-backed clustered integration tests.
+/// Provides scheduler creation, job execution recording, and polling helpers.
+/// Uses the assembly-wide PostgreSQL database (started once by TestAssemblySetup,
+/// connection via <see cref="TestConstants.PostgresConnectionString"/>); it does not
+/// provision its own container. All derived fixtures share that single database, with
+/// <see cref="SchedulerName"/> as the only isolation axis — derived fixtures must use
+/// a unique scheduler name and be marked <c>[NonParallelizable]</c> because they also
+/// share the static <see cref="RecordingJob.Executions"/> queue.
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public abstract class ClusteredPostgresTestBase
+{
+    protected virtual string SchedulerName => "ClusteredTest";
+
+    [SetUp]
+    public void ResetRecordingJob() => RecordingJob.Reset();
+
+    [TearDown]
+    public async Task CleanUpDatabaseState()
+    {
+        // Tests shut their schedulers down in finally blocks, but a clustered node's own
+        // SCHEDULER_STATE row survives Shutdown (it is only deleted by another node's
+        // ClusterRecover), and scheduler.Clear() does not touch it either. Remove all
+        // rows for this fixture's scheduler so later tests start against a clean cluster.
+        using var connection = new NpgsqlConnection(TestConstants.PostgresConnectionString);
+        await connection.OpenAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "DELETE FROM qrtz_fired_triggers WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_simple_triggers WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_cron_triggers WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_simprop_triggers WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_blob_triggers WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_triggers WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_job_details WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_calendars WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_paused_trigger_grps WHERE sched_name = @sched;" +
+            "DELETE FROM qrtz_scheduler_state WHERE sched_name = @sched;";
+        command.Parameters.AddWithValue("sched", SchedulerName);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    protected async Task<IScheduler> CreateScheduler(
+        string instanceId,
+        int checkinIntervalMs = 1000,
+        int checkinMisfireThresholdMs = 2000,
+        Action<NameValueCollection> configure = null)
+    {
+        var properties = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = SchedulerName,
+            ["quartz.scheduler.instanceId"] = instanceId,
+            // Short idle wait so nodes notice remote changes (re-pins, failover resets)
+            // within seconds instead of the 30 s default acquisition cycle
+            ["quartz.scheduler.idleWaitTime"] = "2000",
+            ["quartz.threadPool.maxConcurrency"] = "2",
+            ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.JobStoreTX, Quartz",
+            ["quartz.jobStore.driverDelegateType"] = "Quartz.Impl.AdoJobStore.PostgreSQLDelegate, Quartz",
+            ["quartz.jobStore.dataSource"] = "default",
+            ["quartz.jobStore.tablePrefix"] = "QRTZ_",
+            ["quartz.jobStore.clustered"] = "true",
+            ["quartz.jobStore.clusterCheckinInterval"] = checkinIntervalMs.ToString(),
+            ["quartz.jobStore.clusterCheckinMisfireThreshold"] = checkinMisfireThresholdMs.ToString(),
+            ["quartz.dataSource.default.provider"] = TestConstants.PostgresProvider,
+            ["quartz.dataSource.default.connectionString"] = TestConstants.PostgresConnectionString,
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+        };
+
+        configure?.Invoke(properties);
+
+        var factory = new StdSchedulerFactory(properties);
+        var scheduler = await factory.GetScheduler();
+
+        // Cluster nodes share the scheduler (instance) name, but StdSchedulerFactory's
+        // non-proxy repository lookup is name-only: a second CreateScheduler call would
+        // silently return the first, still-running node instead of creating a new one —
+        // collapsing multi-node tests to a single node. Unbind each node right away so
+        // every call builds a genuinely separate scheduler.
+        SchedulerRepository.Instance.Remove(SchedulerName, scheduler.SchedulerInstanceId);
+
+        return scheduler;
+    }
+
+    protected static async Task WaitForCondition(
+        Func<Task<bool>> condition,
+        int timeoutMs,
+        string message)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await condition())
+            {
+                return;
+            }
+            await Task.Delay(200);
+        }
+        Assert.Fail($"Timed out waiting for condition: {message}");
+    }
+
+    /// <summary>
+    /// Returns a snapshot of this scheduler's trigger, scheduler-state, and fired-trigger
+    /// rows for diagnosing failed cluster assertions.
+    /// </summary>
+    protected async Task<string> DumpDatabaseState()
+    {
+        using var connection = new NpgsqlConnection(TestConstants.PostgresConnectionString);
+        await connection.OpenAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT 'TRIGGER: ' || trigger_name || ' state=' || trigger_state || ' pin=' || COALESCE(preferred_node, '<null>') || ' auto=' || preferred_node_auto || ' group=' || COALESCE(execution_group, '<null>') || ' next=' || next_fire_time FROM qrtz_triggers WHERE sched_name = @sched " +
+            "UNION ALL SELECT 'STATE: ' || instance_name || ' lastCheckin=' || last_checkin_time FROM qrtz_scheduler_state WHERE sched_name = @sched " +
+            "UNION ALL SELECT 'FIRED: ' || trigger_name || ' instance=' || instance_name || ' state=' || state FROM qrtz_fired_triggers WHERE sched_name = @sched";
+        command.Parameters.AddWithValue("sched", SchedulerName);
+        var result = new StringBuilder();
+        using (var reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                result.AppendLine(reader.GetString(0));
+            }
+        }
+        return result.Length > 0 ? result.ToString() : "<no rows>";
+    }
+
+    protected static async Task WaitForTriggerCompletion(
+        IScheduler scheduler,
+        TriggerKey triggerKey,
+        int timeoutMs)
+    {
+        await WaitForCondition(
+            async () =>
+            {
+                var state = await scheduler.GetTriggerState(triggerKey);
+                return state is TriggerState.Complete or TriggerState.None;
+            },
+            timeoutMs,
+            $"trigger {triggerKey} to complete");
+    }
+
+    protected static async Task WaitForExecutionCount(int count, int timeoutMs)
+    {
+        await WaitForCondition(
+            () => Task.FromResult(RecordingJob.Executions.Count >= count),
+            timeoutMs,
+            $"at least {count} execution(s)");
+    }
+
+    /// <summary>
+    /// Job that records which scheduler instance executed it, proving placement.
+    /// Thread-safe via <see cref="ConcurrentQueue{T}"/>.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class RecordingJob : IJob
+    {
+        private static volatile ConcurrentQueue<string> executions = new();
+
+        public static ConcurrentQueue<string> Executions => executions;
+
+        public static void Reset() => Interlocked.Exchange(ref executions, new ConcurrentQueue<string>());
+
+        public ValueTask Execute(IJobExecutionContext context)
+        {
+            Executions.Enqueue(context.Scheduler.SchedulerInstanceId);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/PreferredNodeClusteredPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/PreferredNodeClusteredPostgresTest.cs
@@ -1,0 +1,253 @@
+using System.Linq;
+
+using NUnit.Framework;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Two-node clustered tests for preferred-node behavior using PostgreSQL.
+/// Covers pin exclusion while the preferred node is alive, auto-pin on first
+/// fire, and sticky failover re-pin via ClusterRecover.
+/// Runs against the assembly-wide PostgreSQL database (see ClusteredPostgresTestBase).
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class PreferredNodeClusteredPostgresTest : ClusteredPostgresTestBase
+{
+    protected override string SchedulerName => "PreferredNodeClusterTest";
+
+    [Test]
+    public async Task AutoPin_PinsToFirstFiringNode()
+    {
+        IScheduler scheduler = await CreateScheduler("autopin-node");
+        try
+        {
+            await scheduler.Start();
+            await Task.Delay(500);
+
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity("autoPinJob", "clusteredTest")
+                .StoreDurably()
+                .Build();
+            await scheduler.AddJob(job, true);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("autoPinTrigger", "clusteredTest")
+                .ForJob(job)
+                .WithPreferredNode("*")
+                .WithSimpleSchedule(s => s
+                    .WithIntervalInSeconds(1)
+                    .RepeatForever())
+                .StartNow()
+                .Build();
+            await scheduler.ScheduleJob(trigger);
+
+            // Wait for at least one fire (trigger persists because RepeatForever)
+            await WaitForExecutionCount(1, 10_000);
+
+            Assert.That(RecordingJob.Executions, Does.Contain("autopin-node"),
+                "The job should have executed on the autopin-node scheduler");
+
+            // Poll until the auto-pin claim is observable (node name stored verbatim,
+            // with the auto-claim recorded in its own column)
+            await WaitForCondition(async () =>
+            {
+                ITrigger t = await scheduler.GetTrigger(trigger.Key);
+                return t != null
+                    && t.PreferredNode == "autopin-node"
+                    && t.IsPreferredNodeAuto;
+            }, 10_000, "auto-pin to resolve to the firing node's instance id");
+        }
+        finally
+        {
+            await scheduler.Clear();
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    [Test]
+    public async Task LiveNodePin_ExecutesOnPinnedNode()
+    {
+        IScheduler nodeA = await CreateScheduler("nodeA");
+        IScheduler nodeB = await CreateScheduler("nodeB");
+        try
+        {
+            await nodeA.Start();
+            await nodeB.Start();
+            await Task.Delay(2000);
+
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity("exclusionJob", "clusteredTest")
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, true);
+
+            // Pin to nodeA, repeating so we can observe multiple fires
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("exclusionTrigger", "clusteredTest")
+                .ForJob(job)
+                .WithPreferredNode("nodeA")
+                .WithSimpleSchedule(s => s
+                    .WithIntervalInSeconds(1)
+                    .WithRepeatCount(3))
+                .StartNow()
+                .Build();
+            await nodeA.ScheduleJob(trigger);
+
+            // Wait for several fires (RepeatCount(3) yields up to 4 executions)
+            await WaitForExecutionCount(3, 15_000);
+
+            // All recorded executions should be on nodeA, none on nodeB
+            Assert.That(RecordingJob.Executions, Has.All.EqualTo("nodeA"),
+                "While nodeA is alive, pinned trigger should only execute on nodeA");
+
+            ITrigger retrieved = await nodeA.GetTrigger(trigger.Key);
+            if (retrieved != null)
+            {
+                Assert.That(retrieved.PreferredNode, Is.EqualTo("nodeA"));
+            }
+        }
+        finally
+        {
+            await nodeA.Clear();
+            await nodeA.Shutdown(false);
+            await nodeB.Shutdown(false);
+        }
+    }
+
+    [Test]
+    public async Task Failover_DeadNodeTriggerRepinnedToSurvivor()
+    {
+        IScheduler nodeA = await CreateScheduler("nodeA");
+        try
+        {
+            await nodeA.Start();
+            await Task.Delay(2000);
+
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity("failoverJob", "clusteredTest")
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, true);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("failoverTrigger", "clusteredTest")
+                .ForJob(job)
+                .WithPreferredNode("*")
+                .WithSimpleSchedule(s => s
+                    .WithIntervalInSeconds(1)
+                    .RepeatForever())
+                .StartAt(DateTimeOffset.UtcNow.AddSeconds(3))
+                .Build();
+            await nodeA.ScheduleJob(trigger);
+
+            await nodeA.Shutdown(false);
+        }
+        catch
+        {
+            await nodeA.Shutdown(false);
+            throw;
+        }
+
+        // Reset recordings so any nodeA executions don't satisfy nodeB's assertions
+        RecordingJob.Reset();
+
+        // Wait for nodeA's checkin to become stale
+        await Task.Delay(10_000);
+
+        IScheduler nodeB = await CreateScheduler("nodeB");
+        try
+        {
+            await nodeB.Start();
+
+            // Wait for nodeB to execute the trigger (proves failover worked)
+            await WaitForExecutionCount(1, 15_000);
+
+            Assert.That(RecordingJob.Executions, Does.Contain("nodeB"),
+                "The job should have executed on nodeB after failover");
+
+            // Poll until auto-pin settles (sentinel "*" resolved to "nodeB" after first fire)
+            TriggerKey failoverKey = new TriggerKey("failoverTrigger", "clusteredTest");
+            await WaitForCondition(async () =>
+            {
+                ITrigger t = await nodeB.GetTrigger(failoverKey);
+                return t != null && t.PreferredNode == "nodeB";
+            }, 10_000, "auto-pin to settle on nodeB");
+
+            // Regression for the auto-pin write-back race: a fire that acquired the trigger
+            // while it was still auto-claimed by the dead nodeA (before ClusterRecover reset it
+            // to "*") must not write the dead node back. The pin must stay on nodeB across
+            // subsequent fires.
+            RecordingJob.Reset();
+            await WaitForExecutionCount(2, 10_000);
+            ITrigger settled = await nodeB.GetTrigger(failoverKey);
+            Assert.That(settled.PreferredNode, Is.EqualTo("nodeB"),
+                "Pin must remain on the surviving node and never revert to the dead node");
+            Assert.That(settled.IsPreferredNodeAuto, Is.True,
+                "The stolen pin must remain auto-claimed so it can fail over again");
+        }
+        finally
+        {
+            await nodeB.Clear();
+            await nodeB.Shutdown(false);
+        }
+    }
+
+    [Test]
+    public async Task UpdateTriggerDetails_PinChange_RedirectsExecutionToNewNode()
+    {
+        IScheduler nodeA = await CreateScheduler("nodeA");
+        IScheduler nodeB = await CreateScheduler("nodeB");
+        try
+        {
+            await nodeA.Start();
+            await nodeB.Start();
+            await Task.Delay(2000);
+
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity("redirectJob", "clusteredTest")
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, true);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("redirectTrigger", "clusteredTest")
+                .ForJob(job)
+                .WithPreferredNode("nodeA")
+                .WithSimpleSchedule(s => s
+                    .WithIntervalInSeconds(1)
+                    .RepeatForever())
+                .StartNow()
+                .Build();
+            await nodeA.ScheduleJob(trigger);
+
+            // Establish baseline: pinned trigger executes on nodeA only
+            await WaitForExecutionCount(2, 15_000);
+            Assert.That(RecordingJob.Executions, Has.All.EqualTo("nodeA"),
+                "Before the update, the pinned trigger should execute only on nodeA");
+
+            // Redirect the pin to nodeB at runtime
+            await nodeA.UpdateTriggerDetails(
+                trigger.Key,
+                new TriggerDetailsUpdate().WithPreferredNode("nodeB"));
+
+            // A fire already acquired by nodeA at update time is tolerated; wait until
+            // nodeB takes over, then verify the takeover is stable.
+            await WaitForCondition(
+                () => Task.FromResult(RecordingJob.Executions.Contains("nodeB")),
+                15_000,
+                "execution to move to nodeB after pin update");
+
+            RecordingJob.Reset();
+            await WaitForExecutionCount(2, 10_000);
+            Assert.That(RecordingJob.Executions, Has.All.EqualTo("nodeB"),
+                "After the pin update, the trigger should execute only on nodeB");
+        }
+        finally
+        {
+            await nodeA.Clear();
+            await nodeA.Shutdown(false);
+            await nodeB.Shutdown(false);
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/PreferredNodeFailoverPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/PreferredNodeFailoverPostgresTest.cs
@@ -1,0 +1,360 @@
+using System.Linq;
+
+using NUnit.Framework;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Tests for preferred-node failover semantics using PostgreSQL.
+/// Validates that auto-pinned triggers are re-pinned during ClusterRecover
+/// while explicitly pinned triggers are preserved through failover.
+/// Runs against the assembly-wide PostgreSQL database (see ClusteredPostgresTestBase).
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class PreferredNodeFailoverPostgresTest : ClusteredPostgresTestBase
+{
+    protected override string SchedulerName => "FailoverTest";
+
+    [Test]
+    public async Task ExplicitPin_PreservedThroughFailover()
+    {
+        // Explicit pin to nodeA — should NOT be re-pinned during failover.
+        IScheduler nodeA = await CreateScheduler("nodeA");
+        try
+        {
+            await nodeA.Start();
+            await Task.Delay(2000);
+
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity("explicitPinJob", "failoverTest")
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, true);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("explicitPinTrigger", "failoverTest")
+                .ForJob(job)
+                .WithPreferredNode("nodeA")
+                .WithSimpleSchedule(s => s
+                    .WithIntervalInSeconds(1)
+                    .RepeatForever())
+                .StartAt(DateTimeOffset.UtcNow.AddSeconds(3))
+                .Build();
+            await nodeA.ScheduleJob(trigger);
+
+            await nodeA.Shutdown(false);
+        }
+        catch
+        {
+            await nodeA.Shutdown(false);
+            throw;
+        }
+
+        // Wait for nodeA's checkin to become stale
+        await Task.Delay(10_000);
+
+        IScheduler nodeB = await CreateScheduler("nodeB");
+        try
+        {
+            await nodeB.Start();
+
+            // The trigger should fire on nodeB via the NOT IN failover SQL
+            await WaitForExecutionCount(1, 15_000);
+            Assert.That(RecordingJob.Executions, Does.Contain("nodeB"),
+                "The job should have executed on nodeB via NOT IN failover");
+
+            ITrigger retrieved = await nodeB.GetTrigger(new TriggerKey("explicitPinTrigger", "failoverTest"));
+            Assert.That(retrieved, Is.Not.Null, "Repeating trigger should still exist after failover");
+
+            // Explicit pin should NOT be re-pinned — stays as "nodeA" even after nodeB fired it
+            Assert.That(retrieved.PreferredNode, Is.EqualTo("nodeA"),
+                "Explicit pin should be preserved through failover, not re-pinned to nodeB");
+        }
+        finally
+        {
+            RecordingJob.Reset();
+            await nodeB.Clear();
+            await nodeB.Shutdown(false);
+        }
+    }
+
+    [Test]
+    public async Task AutoPin_RepinnedThroughFailover()
+    {
+        // Auto-pin (*) to nodeA — should be re-pinned to nodeB during failover.
+        IScheduler nodeA = await CreateScheduler("nodeA");
+        try
+        {
+            await nodeA.Start();
+            await Task.Delay(2000);
+
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity("autoPinFailoverJob", "failoverTest")
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, true);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("autoPinFailoverTrigger", "failoverTest")
+                .ForJob(job)
+                .WithPreferredNode("*")
+                .WithSimpleSchedule(s => s
+                    .WithIntervalInSeconds(1)
+                    .RepeatForever())
+                .StartNow()
+                .Build();
+            await nodeA.ScheduleJob(trigger);
+
+            // Wait for auto-pin to happen (first fire pins to nodeA)
+            await WaitForExecutionCount(1, 10_000);
+
+            ITrigger pinnedTrigger = await nodeA.GetTrigger(trigger.Key);
+            Assert.That(pinnedTrigger, Is.Not.Null);
+            // The node name is stored verbatim; the auto-claim is recorded out-of-band
+            Assert.That(pinnedTrigger.PreferredNode, Is.EqualTo("nodeA"),
+                "Auto-pin should resolve to 'nodeA' after first fire");
+            Assert.That(pinnedTrigger.IsPreferredNodeAuto, Is.True,
+                "A pin claimed by auto-pin should be flagged as auto-claimed");
+
+            await nodeA.Shutdown(false);
+        }
+        catch
+        {
+            await nodeA.Shutdown(false);
+            throw;
+        }
+
+        // Reset recordings so nodeA's earlier executions don't satisfy nodeB's assertions
+        RecordingJob.Reset();
+
+        // Wait for nodeA's checkin to become stale
+        await Task.Delay(10_000);
+
+        IScheduler nodeB = await CreateScheduler("nodeB");
+        try
+        {
+            await nodeB.Start();
+
+            // Wait for nodeB to execute the trigger (proves failover worked)
+            await WaitForExecutionCount(1, 15_000);
+
+            Assert.That(RecordingJob.Executions, Does.Contain("nodeB"),
+                "The job should have executed on nodeB after failover");
+
+            // Poll until auto-pin settles (sentinel "*" resolved to "nodeB" after first fire)
+            TriggerKey failoverKey = new TriggerKey("autoPinFailoverTrigger", "failoverTest");
+            await WaitForCondition(async () =>
+            {
+                ITrigger t = await nodeB.GetTrigger(failoverKey);
+                return t != null && t.PreferredNode == "nodeB";
+            }, 10_000, "auto-pin to settle on nodeB");
+
+            // Regression for the auto-pin write-back race: a fire that acquired the trigger while
+            // it was still auto-claimed by the dead nodeA (before ClusterRecover reset it) must not
+            // write the dead node back. The pin must remain on nodeB across subsequent fires.
+            RecordingJob.Reset();
+            await WaitForExecutionCount(2, 10_000);
+            Assert.That(RecordingJob.Executions, Has.All.EqualTo("nodeB"));
+            ITrigger settled = await nodeB.GetTrigger(failoverKey);
+            Assert.That(settled.PreferredNode, Is.EqualTo("nodeB"),
+                "Pin must remain on the surviving node and never revert to the dead node");
+        }
+        finally
+        {
+            RecordingJob.Reset();
+            await nodeB.Clear();
+            await nodeB.Shutdown(false);
+        }
+    }
+
+    [Test]
+    public async Task ThreeNode_AutoPinnedTrigger_SettlesOnSingleSurvivorAfterFailover()
+    {
+        IScheduler nodeA = await CreateScheduler("nodeA");
+        IScheduler nodeB = await CreateScheduler("nodeB");
+        IScheduler survivor = null;
+        string survivorId = null;
+        try
+        {
+            await nodeA.Start();
+            await nodeB.Start();
+            await Task.Delay(2000);
+
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity("threeNodeJob", "failoverTest")
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, true);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("threeNodeTrigger", "failoverTest")
+                .ForJob(job)
+                .WithPreferredNode("*")
+                .WithSimpleSchedule(s => s
+                    .WithIntervalInSeconds(1)
+                    .RepeatForever())
+                .StartNow()
+                .Build();
+            await nodeA.ScheduleJob(trigger);
+
+            // Wait for auto-pin to first fire on whichever node acquires it
+            await WaitForExecutionCount(1, 10_000);
+
+            // Shut down the pinned node; the other original node keeps running as a survivor
+            string pinnedNodeId = RecordingJob.Executions.First();
+            if (pinnedNodeId == "nodeA")
+            {
+                await nodeA.Shutdown(false);
+                survivor = nodeB;
+                survivorId = "nodeB";
+            }
+            else
+            {
+                await nodeB.Shutdown(false);
+                survivor = nodeA;
+                survivorId = "nodeA";
+            }
+        }
+        catch
+        {
+            await nodeA.Shutdown(false);
+            await nodeB.Shutdown(false);
+            throw;
+        }
+
+        RecordingJob.Reset();
+
+        // Start nodeC so two nodes are live while the pinned node's checkin goes stale
+        IScheduler nodeC = await CreateScheduler("nodeC");
+        try
+        {
+            await nodeC.Start();
+
+            // Wait for the dead node's checkin to go stale + ClusterRecover + takeover fires
+            await WaitForExecutionCount(3, 30_000);
+
+            // The trigger must settle on exactly one of the two live survivors
+            TriggerKey threeNodeKey = new TriggerKey("threeNodeTrigger", "failoverTest");
+            string[] liveNodes = { survivorId, "nodeC" };
+            await WaitForCondition(async () =>
+            {
+                ITrigger t = await nodeC.GetTrigger(threeNodeKey);
+                string pin = t != null ? t.PreferredNode : null;
+                return pin != null && pin != "*" && liveNodes.Contains(pin);
+            }, 15_000, "auto-pin to settle on a live survivor");
+
+            // Let any fire acquired just before the claim landed drain (such a fire may
+            // legitimately move the claim once more), then snapshot the settled pin.
+            await Task.Delay(2000);
+            ITrigger claimed = await nodeC.GetTrigger(threeNodeKey);
+            string settledPin = claimed.PreferredNode;
+            Assert.That(liveNodes, Does.Contain(settledPin));
+
+            // Stability: once claimed, all further executions happen on the claimant only
+            RecordingJob.Reset();
+            await WaitForExecutionCount(3, 10_000);
+            Assert.That(RecordingJob.Executions, Has.All.EqualTo(settledPin),
+                "After the claim settles, the trigger must not bounce between survivors");
+
+            ITrigger settled = await nodeC.GetTrigger(threeNodeKey);
+            Assert.That(settled.PreferredNode, Is.EqualTo(settledPin),
+                "The settled pin must be stable across subsequent fires");
+        }
+        finally
+        {
+            RecordingJob.Reset();
+            await nodeC.Clear();
+            await nodeC.Shutdown(false);
+            if (survivor != null)
+            {
+                await survivor.Shutdown(false);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Failover_ExecutionGroupSaturatedSurvivor_DoesNotClaimTrigger()
+    {
+        // ClusterRecover resets auto-pins to "*" (instead of re-pinning to the recovering
+        // node) precisely so that execution group limits are respected: a survivor that is
+        // not allowed to run the trigger's group must not end up owning it.
+        IScheduler nodeA = await CreateScheduler("nodeA");
+        try
+        {
+            await nodeA.Start();
+            await Task.Delay(2000);
+
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity("saturationJob", "failoverTest")
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, true);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("saturationTrigger", "failoverTest")
+                .ForJob(job)
+                .WithPreferredNode("*")
+                .WithExecutionGroup("heavy")
+                .WithSimpleSchedule(s => s
+                    .WithIntervalInSeconds(1)
+                    .RepeatForever())
+                .StartNow()
+                .Build();
+            await nodeA.ScheduleJob(trigger);
+
+            // First fire auto-pins the trigger to nodeA
+            await WaitForExecutionCount(1, 10_000);
+
+            await nodeA.Shutdown(false);
+        }
+        catch
+        {
+            await nodeA.Shutdown(false);
+            throw;
+        }
+
+        RecordingJob.Reset();
+
+        // Two survivors: one forbidden from running group "heavy" (limit 0), one eligible
+        IScheduler saturated = await CreateScheduler(
+            "saturatedNode",
+            configure: p => p["quartz.executionLimit.heavy"] = "0");
+        IScheduler eligible = await CreateScheduler("eligibleNode");
+        try
+        {
+            await saturated.Start();
+            await eligible.Start();
+
+            // Wait for the dead node to go stale, ClusterRecover to reset the pin, and the
+            // eligible node to take over
+            try
+            {
+                await WaitForExecutionCount(2, 30_000);
+            }
+            catch (Exception)
+            {
+                TestContext.Out.WriteLine("DB state at timeout:\n" + await DumpDatabaseState());
+                throw;
+            }
+            Assert.That(RecordingJob.Executions, Has.All.EqualTo("eligibleNode"),
+                "Only the node allowed to run group 'heavy' may execute the trigger");
+
+            TriggerKey saturationKey = new TriggerKey("saturationTrigger", "failoverTest");
+            await WaitForCondition(async () =>
+            {
+                ITrigger t = await eligible.GetTrigger(saturationKey);
+                return t != null && t.PreferredNode == "eligibleNode";
+            }, 10_000, "auto-pin to settle on the eligible node");
+        }
+        finally
+        {
+            RecordingJob.Reset();
+            await eligible.Clear();
+            await saturated.Shutdown(false);
+            await eligible.Shutdown(false);
+        }
+    }
+}


### PR DESCRIPTION
Ports the multi-node PostgreSQL cluster tests from 3.x, completing the 4.x node affinity work started in #3145.

These were deliberately left out of that PR: `main` had **no clustered-Postgres test infrastructure at all** (only `PostgreSQLLockTest`), so bringing it over is its own change rather than a footnote to the port.

## What's here

`ClusteredPostgresTestBase` gives multi-node fixtures scheduler creation, execution recording and polling helpers on top of the assembly-wide PostgreSQL container. It carries over the patterns those tests needed in order to be *reliable* — each of these was learned the hard way on 3.x:

- **Each created scheduler is unbound from `SchedulerRepository` immediately.** `StdSchedulerFactory`'s non-proxy lookup is name-only, so a second `CreateScheduler` call would otherwise return the first, still-running node — silently collapsing a multi-node test into a single node while still appearing to pass.
- **Short `idleWaitTime` (2 s)** so nodes notice remote re-pins and failover resets within the test timeout, instead of the 30 s default acquisition cycle.
- **A `TearDown` that clears `SCHEDULER_STATE`** for the fixture's scheduler. A clustered node's own state row survives `Shutdown` (only another node's `ClusterRecover` deletes it) and `scheduler.Clear()` doesn't touch it — so without this, a later test starts against a cluster that still contains phantom nodes.
- **Polling helpers rather than fixed delays**, plus a `DumpDatabaseState` helper that snapshots trigger/state/fired rows (including the pin and its auto-claim flag) for diagnosing failed cluster assertions.

## Coverage

Eight tests across two fixtures:

| Fixture | Tests |
|---|---|
| `PreferredNodeClusteredPostgresTest` | pin exclusion while the preferred node is alive; auto-pin on first fire; failover re-pin; runtime re-pin redirect via `UpdateTriggerDetails` |
| `PreferredNodeFailoverPostgresTest` | explicit pins preserved through failover; auto-pin stolen and settled on a survivor; three-node cluster settling on a single survivor; execution-group-saturated survivor declining to claim |

Reading a pin no longer needs an `AbstractTrigger` cast now that `PreferredNode` and `IsPreferredNodeAuto` are on `ITrigger`, so assertions read directly off the retrieved trigger.

## Validation

Against a real PostgreSQL server:

- **8/8 passing**, and **run twice with no flake** (these are timing-sensitive by nature)
- Full solution build clean; unit tests **1807** passing

They independently confirm the 4.x semantics ported in #3145 — auto-pin claim, compare-and-swap steal, `ClusterRecover` release, and execution-group interaction — all passed on the first run against the new implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
