### PR TITLE
Clamp misfire handler and cluster manager sleeps after system clock jumps (#1508)

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/ClusterManagerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/ClusterManagerTest.cs
@@ -77,6 +77,59 @@ public class ClusterManagerTest
         completedTask.Should().Be(shutdownTask, "Shutdown should complete");
     }
 
+    [Test]
+    public void ComputeTimeToSleep_ShouldSubtractTranspiredTime()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            transpiredTime: TimeSpan.FromSeconds(2),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 0);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(5500));
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldUseShortPause_WhenCheckinIsOverdue()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            transpiredTime: TimeSpan.FromSeconds(20),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 0);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(100));
+    }
+
+    /// <summary>
+    /// A backward system clock jump makes the transpired time negative, which used to inflate
+    /// the sleep by the length of the jump and stall check-ins long enough for peer nodes to
+    /// consider this instance failed. See GitHub issue #1508.
+    /// </summary>
+    [Test]
+    public void ComputeTimeToSleep_ShouldClampToCheckinInterval_WhenClockJumpsBackward()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            transpiredTime: TimeSpan.FromDays(-1),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 0);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(7500));
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldPreferDbRetryInterval_WhenCheckinsHaveFailed()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            transpiredTime: TimeSpan.FromDays(-1),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 1);
+
+        timeToSleep.Should().Be(TimeSpan.FromSeconds(15));
+    }
+
     private class TestJobStoreSupport : JobStoreSupport
     {
         public TestJobStoreSupport()

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MisfireHandlerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MisfireHandlerTest.cs
@@ -79,6 +79,76 @@ public class MisfireHandlerTest
     }
 
     [Test]
+    public void ComputeTimeToSleep_ShouldSubtractElapsedScanTime()
+    {
+        TimeSpan timeToSleep = MisfireHandler.ComputeTimeToSleep(
+            hasMoreMisfiredTriggers: false,
+            misfireHandlerFrequency: TimeSpan.FromSeconds(60),
+            elapsed: TimeSpan.FromSeconds(5),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 0);
+
+        timeToSleep.Should().Be(TimeSpan.FromSeconds(55));
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldUseShortPause_WhenScanOverranTheFrequency()
+    {
+        TimeSpan timeToSleep = MisfireHandler.ComputeTimeToSleep(
+            hasMoreMisfiredTriggers: false,
+            misfireHandlerFrequency: TimeSpan.FromSeconds(60),
+            elapsed: TimeSpan.FromSeconds(90),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 0);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(50));
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldUseShortPause_WhenMoreMisfiredTriggersRemain()
+    {
+        TimeSpan timeToSleep = MisfireHandler.ComputeTimeToSleep(
+            hasMoreMisfiredTriggers: true,
+            misfireHandlerFrequency: TimeSpan.FromSeconds(60),
+            elapsed: TimeSpan.FromHours(-1),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 1);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(50));
+    }
+
+    /// <summary>
+    /// A backward system clock jump makes the elapsed time negative, which used to inflate the
+    /// sleep by the length of the jump and stop misfire handling for that whole period, long
+    /// after the clock had been restored. See GitHub issue #1508.
+    /// </summary>
+    [Test]
+    public void ComputeTimeToSleep_ShouldClampToFrequency_WhenClockJumpsBackward()
+    {
+        TimeSpan timeToSleep = MisfireHandler.ComputeTimeToSleep(
+            hasMoreMisfiredTriggers: false,
+            misfireHandlerFrequency: TimeSpan.FromSeconds(60),
+            elapsed: TimeSpan.FromHours(-1),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 0);
+
+        timeToSleep.Should().Be(TimeSpan.FromSeconds(60));
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldPreferDbRetryInterval_WhenScansHaveFailed()
+    {
+        TimeSpan timeToSleep = MisfireHandler.ComputeTimeToSleep(
+            hasMoreMisfiredTriggers: false,
+            misfireHandlerFrequency: TimeSpan.FromSeconds(60),
+            elapsed: TimeSpan.FromSeconds(90),
+            dbRetryInterval: TimeSpan.FromSeconds(15),
+            numFails: 1);
+
+        timeToSleep.Should().Be(TimeSpan.FromSeconds(15));
+    }
+
+    [Test]
     public async Task QueuedTaskScheduler_ShouldNotDeadlock_WhenDisposedBeforeTaskStarts()
     {
         // This test reproduces the exact scenario from the bug report.

--- a/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
+++ b/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
@@ -102,18 +102,11 @@ internal sealed class ClusterManager
         {
             token.ThrowIfCancellationRequested();
 
-            TimeSpan timeToSleep = jobStoreSupport.ClusterCheckinInterval;
-            TimeSpan transpiredTime = SystemTime.UtcNow() - jobStoreSupport.LastCheckin;
-            timeToSleep = timeToSleep - transpiredTime;
-            if (timeToSleep <= TimeSpan.Zero)
-            {
-                timeToSleep = TimeSpan.FromMilliseconds(100);
-            }
-
-            if (numFails > 0)
-            {
-                timeToSleep = jobStoreSupport.DbRetryInterval > timeToSleep ? jobStoreSupport.DbRetryInterval : timeToSleep;
-            }
+            TimeSpan timeToSleep = ComputeTimeToSleep(
+                jobStoreSupport.ClusterCheckinInterval,
+                SystemTime.UtcNow() - jobStoreSupport.LastCheckin,
+                jobStoreSupport.DbRetryInterval,
+                numFails);
 
             await Task.Delay(timeToSleep, token).ConfigureAwait(false);
 
@@ -125,5 +118,39 @@ internal sealed class ClusterManager
             }
         }
         // ReSharper disable once FunctionNeverReturns
+    }
+
+    /// <summary>
+    /// Determines how long to sleep before the next cluster check-in.
+    /// </summary>
+    /// <param name="clusterCheckinInterval">The configured check-in interval.</param>
+    /// <param name="transpiredTime">Wall clock time elapsed since the last successful check-in.</param>
+    /// <param name="dbRetryInterval">The configured retry interval used when the last check-ins have failed.</param>
+    /// <param name="numFails">Number of consecutive failed check-ins.</param>
+    internal static TimeSpan ComputeTimeToSleep(
+        TimeSpan clusterCheckinInterval,
+        TimeSpan transpiredTime,
+        TimeSpan dbRetryInterval,
+        int numFails)
+    {
+        TimeSpan timeToSleep = clusterCheckinInterval - transpiredTime;
+        if (timeToSleep <= TimeSpan.Zero)
+        {
+            timeToSleep = TimeSpan.FromMilliseconds(100);
+        }
+        else if (timeToSleep > clusterCheckinInterval)
+        {
+            // Backward clock jump: 'transpiredTime' went negative. Clamp so check-in resumes
+            // within one interval instead of stalling for the length of the jump, which would
+            // make peer nodes consider this instance failed.
+            timeToSleep = clusterCheckinInterval;
+        }
+
+        if (numFails > 0 && dbRetryInterval > timeToSleep)
+        {
+            timeToSleep = dbRetryInterval;
+        }
+
+        return timeToSleep;
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/MisfireHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/MisfireHandler.cs
@@ -57,23 +57,59 @@ internal sealed class MisfireHandler
 
             token.ThrowIfCancellationRequested();
 
-            TimeSpan timeToSleep = TimeSpan.FromMilliseconds(50); // At least a short pause to help balance threads
-            if (!recoverMisfiredJobsResult.HasMoreMisfiredTriggers)
-            {
-                timeToSleep = jobStoreSupport.MisfireHandlerFrequency - (SystemTime.UtcNow() - sTime);
-                if (timeToSleep <= TimeSpan.Zero)
-                {
-                    timeToSleep = TimeSpan.FromMilliseconds(50);
-                }
-
-                if (numFails > 0)
-                {
-                    timeToSleep = jobStoreSupport.DbRetryInterval > timeToSleep ? jobStoreSupport.DbRetryInterval : timeToSleep;
-                }
-            }
+            TimeSpan timeToSleep = ComputeTimeToSleep(
+                recoverMisfiredJobsResult.HasMoreMisfiredTriggers,
+                jobStoreSupport.MisfireHandlerFrequency,
+                SystemTime.UtcNow() - sTime,
+                jobStoreSupport.DbRetryInterval,
+                numFails);
 
             await Task.Delay(timeToSleep, token).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Determines how long to sleep before the next misfire scan.
+    /// </summary>
+    /// <param name="hasMoreMisfiredTriggers">Whether the last scan left misfired triggers unprocessed.</param>
+    /// <param name="misfireHandlerFrequency">The configured scan frequency.</param>
+    /// <param name="elapsed">Wall clock time consumed by the last scan.</param>
+    /// <param name="dbRetryInterval">The configured retry interval used when the last scans have failed.</param>
+    /// <param name="numFails">Number of consecutive failed scans.</param>
+    internal static TimeSpan ComputeTimeToSleep(
+        bool hasMoreMisfiredTriggers,
+        TimeSpan misfireHandlerFrequency,
+        TimeSpan elapsed,
+        TimeSpan dbRetryInterval,
+        int numFails)
+    {
+        // At least a short pause to help balance threads
+        TimeSpan minimumSleep = TimeSpan.FromMilliseconds(50);
+
+        if (hasMoreMisfiredTriggers)
+        {
+            return minimumSleep;
+        }
+
+        TimeSpan timeToSleep = misfireHandlerFrequency - elapsed;
+        if (timeToSleep <= TimeSpan.Zero)
+        {
+            timeToSleep = minimumSleep;
+        }
+        else if (timeToSleep > misfireHandlerFrequency)
+        {
+            // A negative 'elapsed' means the system clock jumped backward (NTP correction,
+            // manual change, VM migration). Never sleep longer than one full cycle, otherwise
+            // misfire handling stops for the entire duration of the jump.
+            timeToSleep = misfireHandlerFrequency;
+        }
+
+        if (numFails > 0 && dbRetryInterval > timeToSleep)
+        {
+            timeToSleep = dbRetryInterval;
+        }
+
+        return timeToSleep;
     }
 
     public async Task Shutdown()


### PR DESCRIPTION
Follow-up to #2929, closing out the remaining half of #1508 / #1490.

## Problem

The bug behind #1508 is a sleep duration computed by subtracting two **wall-clock** timestamps and then handed to a **monotonic** wait. Jump the system clock backward by `D` (NTP correction, manual change, VM suspend/resume) and the computed duration inflates by `D` — so the thread sleeps for `D` of *real* time, long after the clock has been restored.

#2929 fixed this in `QuartzSchedulerThread`. The same mistake was still present in two other loops:

| Site | Computation | Effect of a backward jump of `D` |
|---|---|---|
| `MisfireHandler.Run` | `MisfireHandlerFrequency - (now - sTime)` | misfire recovery stops for `D` |
| `ClusterManager.Run` | `ClusterCheckinInterval - (now - LastCheckin)` | check-in stops for `D`; peer nodes declare this instance failed and recover its triggers |

The `ClusterManager` one is the more serious of the two — a routine NTP correction on a busy node can turn into a spurious failover.

## Fix

Clamp each sleep to one configured interval, so both loops recover on their own within a single cycle. The clamp is inert under normal operation: it only engages when the elapsed time comes out negative, which cannot happen without a clock discontinuity.

Each computation is extracted into an `internal static ComputeTimeToSleep(...)` on its (already `internal sealed`) class. No public API change, and it makes the logic directly unit-testable without a database.

## Deliberately unchanged

- `JobStoreSupport.CalcFailedIfAfter` also subtracts wall-clock timestamps, but skew there only makes failure detection *more* lenient — it can never cause a spurious failover, and it self-corrects on the next check-in once the clamp above keeps check-ins flowing.
- The stale-acquired-trigger cutoffs in `JobStoreSupport` — a backward jump makes the cutoff earlier, i.e. fewer recoveries, which is the safe direction.

## Tests

Nine unit tests over the two helpers, covering the normal path (clamp inert), the overrun path, the `numFails` / `DbRetryInterval` path, and the backward-jump clamp itself. No database, no timing sensitivity.

`SystemTimeClockJumpTest` continues to cover the `QuartzSchedulerThread` half end-to-end.

Full unit suite: **1517 passed, 0 failed**.

## Behaviour after this change

Recovery is bounded, not instantaneous — and moving the clock backward still genuinely defers triggers until the wall clock catches up, which is by design. What is fixed is that the scheduler now notices when the clock comes back:

- firing resumes within one `quartz.scheduler.idleWaitTime` (30 s default);
- with AdoJobStore, misfire handling within one `misfireHandlerFrequency` and cluster check-in within one `clusterCheckinInterval`.

4.x port: https://github.com/quartznet/quartznet/pull/3148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
