### PR TITLE
Batch misfire recovery reads and writes (#758)

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -210,6 +210,29 @@ The cron expression parser now supports additional syntax:
 * **H (hash) token in cron expressions** — deterministic load distribution across triggers using the trigger identity as seed
 * **HTTP API** — optional REST API for managing the scheduler remotely (see [HTTP API](packages/http-api.md))
 
+## Batched Misfire Recovery
+
+Misfire recovery now handles a whole batch of misfired triggers with a handful of statements instead of a
+few per trigger. Nothing needs configuring — the read side is a single set-based query, and the write side
+uses ADO.NET batching automatically on providers that support it (`DbConnection.CanCreateBatch`), falling
+back to individual statements on those that do not.
+
+This matters if you implement `IDriverDelegate` yourself, which now has two more members:
+
+| Member | Purpose |
+|--------|---------|
+| `SelectMisfiredTriggersToRecover` | Reads a whole misfire batch as populated triggers in one round-trip |
+| `UpdateMisfiredTriggers` | Applies a batch of misfire updates, batching the statements where supported |
+
+If you subclass `StdAdoDelegate` you get both for free. A driver delegate for a database with its own
+row-limiting syntax should also override `GetSelectMisfiredTriggersToRecoverSql`, alongside the existing
+`GetSelectNextMisfiredTriggersInStateToAcquireSql`.
+
+One behavioral note: `ITriggerListener.TriggerMisfired` is now raised for every trigger in a batch before
+any of that batch's database updates are written, where previously the notification and the update were
+interleaved per trigger. Everything still happens inside the same transaction and under the same lock, so
+what other nodes observe is unchanged.
+
 ## Other Breaking Changes
 
 | Change | Details |

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
@@ -1,0 +1,323 @@
+using System.Data.Common;
+
+using FakeItEasy;
+
+using Microsoft.Data.Sqlite;
+
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Serialization.Newtonsoft;
+using Quartz.Simpl;
+using Quartz.Spi;
+using Quartz.Util;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// End-to-end coverage of batched misfire recovery against a real database. Runs on SQLite so it needs
+/// no container, and exercises the batch SELECT for every trigger flavour: the SIMPLE/CRON fast path
+/// that comes back on the joined row, the simple-properties types that need the follow-up query, and
+/// blob-stored triggers.
+/// </summary>
+[NonParallelizable]
+public class MisfireBatchRecoveryTest
+{
+    private const string TablePrefix = "QRTZ_";
+    private const string DataSourceName = "misfire-batch-sqlite";
+    private const string SchedulerName = "MisfireBatchRecoveryTest";
+
+    private string dbFileName;
+    private CountingSQLiteDelegate.Counter commandCounter;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        dbFileName = $"test-misfire-batch-{Guid.NewGuid():N}.db";
+
+        await using (var connection = new SqliteConnection($"Data Source={dbFileName};"))
+        {
+            await connection.OpenAsync();
+            await using var command = new SqliteCommand(LoadSqliteTableScript(), connection);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        DBConnectionManager.Instance.AddConnectionProvider(
+            DataSourceName,
+            new DbProvider("SQLite-Microsoft", $"Data Source={dbFileName};"));
+
+        commandCounter = new CountingSQLiteDelegate.Counter();
+        CountingSQLiteDelegate.CurrentCounter = commandCounter;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        CountingSQLiteDelegate.CurrentCounter = null;
+
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(dbFileName))
+        {
+            try
+            {
+                File.Delete(dbFileName);
+            }
+            catch (IOException)
+            {
+                // the file is only test scratch space, leaving it behind is not worth failing over
+            }
+        }
+    }
+
+    [Test]
+    public async Task RecoversMisfiredTriggersOfEveryType()
+    {
+        TestJobStoreTX jobStore = await CreateJobStore();
+
+        // One of each shape the batch read has to deal with:
+        //  - SIMPLE and CRON arrive complete on the joined row
+        //  - DAILY_I and CAL_INT need the SIMPROP_TRIGGERS follow-up query
+        await StoreMisfiredTrigger(jobStore, "simple", TriggerBuilder.Create()
+            .WithSimpleSchedule(x => x.WithIntervalInMinutes(1).RepeatForever().WithMisfireHandlingInstructionFireNow()));
+
+        await StoreMisfiredTrigger(jobStore, "cron", TriggerBuilder.Create()
+            .WithCronSchedule("0 * * * * ?", x => x.WithMisfireHandlingInstructionFireAndProceed()));
+
+        await StoreMisfiredTrigger(jobStore, "daily", TriggerBuilder.Create()
+            .WithDailyTimeIntervalSchedule(x => x.WithIntervalInMinutes(1).WithMisfireHandlingInstructionFireAndProceed()));
+
+        await StoreMisfiredTrigger(jobStore, "calint", TriggerBuilder.Create()
+            .WithCalendarIntervalSchedule(x => x.WithIntervalInMinutes(1).WithMisfireHandlingInstructionFireAndProceed()));
+
+        //  - a custom trigger with no persistence delegate, which lands in BLOB_TRIGGERS
+        await StoreMisfiredBlobTrigger(jobStore, "blob");
+
+        RecoverMisfiredJobsResult result = await jobStore.RecoverMisfires();
+
+        result.ProcessedMisfiredTriggerCount.Should().Be(5, "every misfired trigger should have been materialized and handled");
+        result.HasMoreMisfiredTriggers.Should().BeFalse();
+
+        // The blob trigger round-tripped through serialization with its custom state intact.
+        var recoveredBlobTrigger = (CustomTrigger) await jobStore.RetrieveTrigger(new TriggerKey("blob", "misfire-test"));
+        recoveredBlobTrigger.Should().NotBeNull();
+        recoveredBlobTrigger.SomeCustomProperty.Should().BeTrue();
+
+        // All of them are back in WAITING with a next fire time in the future.
+        foreach (var name in new[] { "simple", "cron", "daily", "calint", "blob" })
+        {
+            var key = new TriggerKey(name, "misfire-test");
+
+            (await jobStore.GetTriggerState(key)).Should().Be(TriggerState.Normal, "trigger '{0}' should be rescheduled, not left misfired", name);
+
+            IOperableTrigger trigger = await jobStore.RetrieveTrigger(key);
+            trigger.Should().NotBeNull();
+            trigger.GetNextFireTimeUtc().Should().NotBeNull("trigger '{0}' should have a next fire time", name);
+            trigger.GetNextFireTimeUtc().Value.Should().BeAfter(DateTimeOffset.UtcNow.AddMinutes(-1), "trigger '{0}' should have moved forward", name);
+        }
+    }
+
+    /// <summary>
+    /// The read side is what this asserts: the whole batch is materialized by one statement rather than
+    /// one per trigger, so the read count does not grow with the batch size. (SQLite reports
+    /// CanCreateBatch = false, so the writes here still go out individually — the batched write path is
+    /// covered by the unit tests.)
+    /// </summary>
+    [Test]
+    public async Task ReadCountDoesNotGrowWithBatchSize()
+    {
+        int readsForTwo = await CountReadsRecovering(2);
+        int readsForForty = await CountReadsRecovering(40);
+
+        readsForForty.Should().Be(readsForTwo,
+            "recovering 40 triggers took {0} reads against {1} for two, so it is still reading per trigger",
+            readsForForty, readsForTwo);
+    }
+
+    private async Task<int> CountReadsRecovering(int triggerCount)
+    {
+        TestJobStoreTX jobStore = await CreateJobStore(maxMisfiresToHandleAtATime: triggerCount);
+        await jobStore.ClearAllSchedulingData();
+
+        for (var i = 0; i < triggerCount; i++)
+        {
+            await StoreMisfiredTrigger(jobStore, "simple" + i, TriggerBuilder.Create()
+                .WithSimpleSchedule(x => x.WithIntervalInMinutes(1).RepeatForever().WithMisfireHandlingInstructionFireNow()));
+        }
+
+        commandCounter.Reset();
+        RecoverMisfiredJobsResult result = await jobStore.RecoverMisfires();
+
+        result.ProcessedMisfiredTriggerCount.Should().Be(triggerCount);
+
+        commandCounter.Commands.Should().NotContain(x => x.Contains("LEFT JOIN") && x.Contains("@triggerName"),
+            "the per-trigger SelectTrigger read should not be used during batch recovery");
+
+        return commandCounter.Commands.Count(x => x.TrimStart().StartsWith("SELECT", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public async Task ReportsHasMoreWhenBatchIsTruncated()
+    {
+        TestJobStoreTX jobStore = await CreateJobStore(maxMisfiresToHandleAtATime: 2);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await StoreMisfiredTrigger(jobStore, "simple" + i, TriggerBuilder.Create()
+                .WithSimpleSchedule(x => x.WithIntervalInMinutes(1).RepeatForever().WithMisfireHandlingInstructionFireNow()));
+        }
+
+        RecoverMisfiredJobsResult result = await jobStore.RecoverMisfires();
+
+        result.ProcessedMisfiredTriggerCount.Should().Be(2);
+        result.HasMoreMisfiredTriggers.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Stores a job and a trigger whose start time is well in the past, which is what puts it in the
+    /// WAITING state with an overdue next fire time — exactly what misfire recovery looks for.
+    /// </summary>
+    private static async Task StoreMisfiredTrigger(TestJobStoreTX jobStore, string name, TriggerBuilder builder)
+    {
+        IJobDetail job = JobBuilder.Create<MisfireTestJob>()
+            .WithIdentity(name, "misfire-test")
+            .Build();
+
+        var trigger = (IOperableTrigger) builder
+            .WithIdentity(name, "misfire-test")
+            .ForJob(job)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(-2))
+            .Build();
+
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        // A past start time is not enough on its own — a cron schedule, for one, just recomputes forward
+        // to the next matching time. Pin the stored next fire time into the past, which is what a trigger
+        // that nobody got around to firing actually looks like.
+        trigger.SetNextFireTimeUtc(DateTimeOffset.UtcNow.AddHours(-1));
+
+        await jobStore.StoreJobAndTrigger(job, trigger);
+    }
+
+    /// <summary>
+    /// Stores an overdue trigger that has no <see cref="ITriggerPersistenceDelegate" />, so it is
+    /// persisted as a blob and has to be picked up by the batch read's blob follow-up query.
+    /// </summary>
+    private static async Task StoreMisfiredBlobTrigger(TestJobStoreTX jobStore, string name)
+    {
+        IJobDetail job = JobBuilder.Create<MisfireTestJob>()
+            .WithIdentity(name, "misfire-test")
+            .Build();
+
+        var trigger = new CustomTrigger
+        {
+            Key = new TriggerKey(name, "misfire-test"),
+            JobKey = job.Key,
+            CronExpressionString = "0 * * * * ?",
+            StartTimeUtc = DateTimeOffset.UtcNow.AddHours(-2),
+            MisfireInstruction = MisfireInstruction.CronTrigger.FireOnceNow
+        };
+
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.SetNextFireTimeUtc(DateTimeOffset.UtcNow.AddHours(-1));
+
+        await jobStore.StoreJobAndTrigger(job, trigger);
+    }
+
+    private static async Task<TestJobStoreTX> CreateJobStore(int maxMisfiresToHandleAtATime = 20)
+    {
+        NewtonsoftJsonObjectSerializer.AddTriggerSerializer<CustomTrigger>(new CustomNewtonsoftTriggerSerializer());
+
+        var serializer = new NewtonsoftJsonObjectSerializer();
+        serializer.Initialize();
+
+        var jobStore = new TestJobStoreTX
+        {
+            DataSource = DataSourceName,
+            TablePrefix = TablePrefix,
+            InstanceId = "AUTO",
+            InstanceName = SchedulerName,
+            DriverDelegateType = typeof(CountingSQLiteDelegate).AssemblyQualifiedName,
+            ObjectSerializer = serializer,
+            MaxMisfiresToHandleAtATime = maxMisfiresToHandleAtATime,
+            // Anything overdue by more than a moment counts as misfired.
+            MisfireThreshold = TimeSpan.FromSeconds(1)
+        };
+
+        await jobStore.Initialize(new SimpleTypeLoadHelper(), A.Fake<ISchedulerSignaler>());
+        await jobStore.SchedulerStarted();
+        await jobStore.ClearAllSchedulingData();
+
+        return jobStore;
+    }
+
+    private static string LoadSqliteTableScript()
+    {
+        var path = File.Exists("../../../../database/tables/tables_sqlite.sql")
+            ? "../../../../database/tables/tables_sqlite.sql"
+            : "../../../../../database/tables/tables_sqlite.sql";
+
+        return File.ReadAllText(path);
+    }
+
+    public sealed class MisfireTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context) => default;
+    }
+
+    private sealed class TestJobStoreTX : JobStoreTX
+    {
+        public ValueTask<RecoverMisfiredJobsResult> RecoverMisfires()
+            => DoRecoverMisfires(Guid.NewGuid(), CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Counts every statement the delegate issues through <see cref="StdAdoDelegate.PrepareCommand" />,
+    /// which is how the tests tell a batched pass from a per-trigger one. Batched statements do not go
+    /// through here, so a batching provider reads as an even lower count.
+    /// </summary>
+    private sealed class CountingSQLiteDelegate : SQLiteDelegate
+    {
+        internal sealed class Counter
+        {
+            private readonly List<string> commands = [];
+
+            public IReadOnlyList<string> Commands
+            {
+                get
+                {
+                    lock (commands)
+                    {
+                        return commands.ToArray();
+                    }
+                }
+            }
+
+            public void Record(string commandText)
+            {
+                lock (commands)
+                {
+                    commands.Add(commandText);
+                }
+            }
+
+            public void Reset()
+            {
+                lock (commands)
+                {
+                    commands.Clear();
+                }
+            }
+        }
+
+        // The delegate is constructed reflectively from DriverDelegateType, so the counter is handed
+        // over out of band.
+        internal static Counter CurrentCounter;
+
+        private readonly Counter counter = CurrentCounter;
+
+        public override DbCommand PrepareCommand(ConnectionAndTransactionHolder cth, string commandText)
+        {
+            counter?.Record(commandText);
+            return base.PrepareCommand(cth, commandText);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoUtilTest.cs
@@ -1,0 +1,77 @@
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+public class AdoUtilTest
+{
+    [TestCase(1, 1)]
+    [TestCase(2, 2)]
+    [TestCase(3, 4)]
+    [TestCase(5, 8)]
+    [TestCase(20, 32)]
+    [TestCase(129, 200)]
+    [TestCase(200, 200)]
+    public void RoundUpTriggerKeyCount_ShouldRoundToBucket(int count, int expected)
+    {
+        AdoUtil.RoundUpTriggerKeyCount(count).Should().Be(expected);
+    }
+
+    [Test]
+    public void RoundUpTriggerKeyCount_ShouldProduceFewDistinctStatements()
+    {
+        // The point of bucketing: a plan cache should see a handful of statements, not one per batch size.
+        var distinct = Enumerable.Range(1, AdoUtil.MaxTriggerKeysPerPredicate)
+            .Select(AdoUtil.RoundUpTriggerKeyCount)
+            .Distinct()
+            .ToArray();
+
+        distinct.Should().HaveCountLessThan(12);
+    }
+
+    [Test]
+    public void BuildTriggerKeyPredicate_ShouldProduceParameterizedDisjunction()
+    {
+        AdoUtil.BuildTriggerKeyPredicate(2).Should().Be(
+            "((TRIGGER_NAME = @tkn000 AND TRIGGER_GROUP = @tkg000) OR (TRIGGER_NAME = @tkn001 AND TRIGGER_GROUP = @tkg001))");
+    }
+
+    [Test]
+    public void BuildTriggerKeyPredicate_ShouldRejectUnroundedCount()
+    {
+        var act = () => AdoUtil.BuildTriggerKeyPredicate(3);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// Parameter placeholders are rewritten in the statement text by substring replacement for providers
+    /// that do not use the '@' prefix, so no generated name may be a prefix of another one — otherwise
+    /// replacing @tkn001 would also corrupt @tkn0010.
+    /// </summary>
+    [Test]
+    public void TriggerKeyParameterNames_ShouldBeFixedWidth()
+    {
+        var names = Enumerable.Range(0, AdoUtil.MaxTriggerKeysPerPredicate)
+            .SelectMany(i => new[] { AdoUtil.TriggerKeyNameParameter(i), AdoUtil.TriggerKeyGroupParameter(i) })
+            .ToArray();
+
+        names.Should().OnlyHaveUniqueItems();
+        names.Select(x => x.Length).Distinct().Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// The predicate is appended to SQL that later goes through <see cref="AdoJobStoreUtil.ReplaceTablePrefix" />,
+    /// which runs string.Format over it — so it must not contain unescaped braces.
+    /// </summary>
+    [Test]
+    public void BuildTriggerKeyPredicate_ShouldSurviveTablePrefixSubstitution()
+    {
+        var sql = StdAdoConstants.SqlSelectSimpropTriggersByKeysPrefix + AdoUtil.BuildTriggerKeyPredicate(8);
+
+        var act = () => AdoJobStoreUtil.ReplaceTablePrefix(sql, "QRTZ_");
+
+        act.Should().NotThrow();
+        AdoJobStoreUtil.ReplaceTablePrefix(sql, "QRTZ_").Should().StartWith("SELECT * FROM QRTZ_SIMPROP_TRIGGERS WHERE");
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -24,61 +24,114 @@ public class JobStoreSupportTest
         jobStoreSupport.DirectSignaler = A.Fake<ISchedulerSignaler>();
     }
 
+    /// <summary>
+    /// Arranges the batch read so that <paramref name="triggers" /> come back as one misfire batch.
+    /// </summary>
+    private void GivenMisfiredTriggers(bool hasMore = false, params IOperableTrigger[] triggers)
+    {
+        A.CallTo(() => driverDelegate.SelectMisfiredTriggersToRecover(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<string>.Ignored,
+                A<DateTimeOffset>.Ignored,
+                A<int>.Ignored,
+                A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<MisfiredTriggerBatch>(new MisfiredTriggerBatch(triggers.ToList(), hasMore)));
+    }
+
+    private static IOperableTrigger CreateMisfiredTrigger(string name, int minutesLate = 10)
+    {
+        IOperableTrigger trigger = CreateTestTrigger(name);
+        trigger.SetNextFireTimeUtc(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(minutesLate));
+        return trigger;
+    }
+
     [Test]
     public async Task TestRecoverMisfiredJobs_ShouldCheckForMisfiredTriggersInStateWaiting()
     {
+        GivenMisfiredTriggers();
+
         await jobStoreSupport.RecoverMisfiredJobs(null, false);
 
-        A.CallTo(() => driverDelegate.HasMisfiredTriggersInState(
+        A.CallTo(() => driverDelegate.SelectMisfiredTriggersToRecover(
             A<ConnectionAndTransactionHolder>.Ignored,
             A<string>.That.IsEqualTo(AdoConstants.StateWaiting),
             A<DateTimeOffset>.Ignored,
             A<int>.Ignored,
-            A<IList<TriggerKey>>.Ignored,
             CancellationToken.None)).MustHaveHappened();
     }
 
     [Test]
-    public async Task RecoverMisfiredJobs_ShouldUseOptimizedPath()
+    public async Task RecoverMisfiredJobs_ShouldReadWholeBatchInOneCall()
     {
-        var triggerKey = new TriggerKey("misfired1", "g1");
-        IOperableTrigger trigger = CreateTestTrigger("misfired1");
-        trigger.SetNextFireTimeUtc(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(10));
+        GivenMisfiredTriggers(false, CreateMisfiredTrigger("misfired1"), CreateMisfiredTrigger("misfired2"));
 
-        A.CallTo(() => driverDelegate.HasMisfiredTriggersInState(
+        await jobStoreSupport.RecoverMisfiredJobs(null, false);
+
+        // Assert: the batch read replaces the per-trigger reads entirely
+        A.CallTo(() => driverDelegate.SelectMisfiredTriggersToRecover(
             A<ConnectionAndTransactionHolder>.Ignored,
             A<string>.Ignored,
             A<DateTimeOffset>.Ignored,
             A<int>.Ignored,
-            A<ICollection<TriggerKey>>.Ignored,
-            A<CancellationToken>.Ignored))
-            .Invokes((ConnectionAndTransactionHolder _, string _, DateTimeOffset _, int _, ICollection<TriggerKey> list, CancellationToken _) =>
-            {
-                list.Add(triggerKey);
-            })
-            .Returns(new ValueTask<bool>(false));
+            A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
 
         A.CallTo(() => driverDelegate.SelectTrigger(
             A<ConnectionAndTransactionHolder>.Ignored,
-            triggerKey,
-            A<CancellationToken>.Ignored))
-            .Returns(new ValueTask<IOperableTrigger>(trigger));
-
-        await jobStoreSupport.RecoverMisfiredJobs(null, false);
-
-        // Assert: optimized delegate method called
-        A.CallTo(() => driverDelegate.UpdateMisfiredTrigger(
-            A<ConnectionAndTransactionHolder>.Ignored,
-            A<IOperableTrigger>.Ignored,
-            A<string>.Ignored,
-            A<DateTimeOffset?>.Ignored,
-            A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+            A<TriggerKey>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
 
         // Assert: StoreTrigger path NOT taken (no TriggerExists check)
         A.CallTo(() => driverDelegate.TriggerExists(
             A<ConnectionAndTransactionHolder>.Ignored,
             A<TriggerKey>.Ignored,
             A<CancellationToken>.Ignored)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task RecoverMisfiredJobs_ShouldWriteWholeBatchInOneCall()
+    {
+        GivenMisfiredTriggers(false, CreateMisfiredTrigger("misfired1"), CreateMisfiredTrigger("misfired2"));
+
+        List<MisfiredTriggerUpdate> captured = null;
+        A.CallTo(() => driverDelegate.UpdateMisfiredTriggers(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<IReadOnlyList<MisfiredTriggerUpdate>>.Ignored,
+                A<CancellationToken>.Ignored))
+            .Invokes((ConnectionAndTransactionHolder _, IReadOnlyList<MisfiredTriggerUpdate> updates, CancellationToken _) =>
+            {
+                captured = updates.ToList();
+            });
+
+        await jobStoreSupport.RecoverMisfiredJobs(null, false);
+
+        A.CallTo(() => driverDelegate.UpdateMisfiredTriggers(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<IReadOnlyList<MisfiredTriggerUpdate>>.Ignored,
+            A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+
+        captured.Should().NotBeNull();
+        captured.Should().HaveCount(2);
+        captured.Select(x => x.Trigger.Key.Name).Should().BeEquivalentTo(["misfired1", "misfired2"]);
+        captured.Should().OnlyContain(x => x.NewState == AdoConstants.StateWaiting);
+
+        // Assert: the single-trigger write path is not used for batch recovery
+        A.CallTo(() => driverDelegate.UpdateMisfiredTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<IOperableTrigger>.Ignored,
+            A<string>.Ignored,
+            A<DateTimeOffset?>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task RecoverMisfiredJobs_ShouldPropagateHasMoreToResult()
+    {
+        GivenMisfiredTriggers(true, CreateMisfiredTrigger("misfired1"));
+
+        RecoverMisfiredJobsResult result = await jobStoreSupport.RecoverMisfiredJobs(null, false);
+
+        result.HasMoreMisfiredTriggers.Should().BeTrue();
+        result.ProcessedMisfiredTriggerCount.Should().Be(1);
     }
 
     [Test]
@@ -90,42 +143,13 @@ public class JobStoreSupportTest
 
         string calendarName = "shared-cal";
 
-        var key1 = new TriggerKey("misfired1", "g1");
-        var key2 = new TriggerKey("misfired2", "g1");
-
-        IOperableTrigger trigger1 = CreateTestTrigger("misfired1");
-        trigger1.SetNextFireTimeUtc(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(10));
+        IOperableTrigger trigger1 = CreateMisfiredTrigger("misfired1");
         trigger1.CalendarName = calendarName;
 
-        IOperableTrigger trigger2 = CreateTestTrigger("misfired2");
-        trigger2.SetNextFireTimeUtc(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(5));
+        IOperableTrigger trigger2 = CreateMisfiredTrigger("misfired2", minutesLate: 5);
         trigger2.CalendarName = calendarName;
 
-        A.CallTo(() => driverDelegate.HasMisfiredTriggersInState(
-            A<ConnectionAndTransactionHolder>.Ignored,
-            A<string>.Ignored,
-            A<DateTimeOffset>.Ignored,
-            A<int>.Ignored,
-            A<ICollection<TriggerKey>>.Ignored,
-            A<CancellationToken>.Ignored))
-            .Invokes((ConnectionAndTransactionHolder _, string _, DateTimeOffset _, int _, ICollection<TriggerKey> list, CancellationToken _) =>
-            {
-                list.Add(key1);
-                list.Add(key2);
-            })
-            .Returns(new ValueTask<bool>(false));
-
-        A.CallTo(() => driverDelegate.SelectTrigger(
-            A<ConnectionAndTransactionHolder>.Ignored,
-            key1,
-            A<CancellationToken>.Ignored))
-            .Returns(new ValueTask<IOperableTrigger>(trigger1));
-
-        A.CallTo(() => driverDelegate.SelectTrigger(
-            A<ConnectionAndTransactionHolder>.Ignored,
-            key2,
-            A<CancellationToken>.Ignored))
-            .Returns(new ValueTask<IOperableTrigger>(trigger2));
+        GivenMisfiredTriggers(false, trigger1, trigger2);
 
         A.CallTo(() => driverDelegate.SelectCalendar(
             A<ConnectionAndTransactionHolder>.Ignored,
@@ -140,14 +164,6 @@ public class JobStoreSupportTest
             A<ConnectionAndTransactionHolder>.Ignored,
             calendarName,
             A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
-
-        // Assert: both triggers updated via optimized path
-        A.CallTo(() => driverDelegate.UpdateMisfiredTrigger(
-            A<ConnectionAndTransactionHolder>.Ignored,
-            A<IOperableTrigger>.Ignored,
-            A<string>.Ignored,
-            A<DateTimeOffset?>.Ignored,
-            A<CancellationToken>.Ignored)).MustHaveHappenedTwiceExactly();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
@@ -85,6 +85,44 @@ public class MySQLDelegateTest
         sql.Should().NotContain("IDX_common.");
     }
 
+    [Test]
+    public void GetSelectMisfiredTriggersToRecoverSql_ShouldContainForceIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var sql = del.GetSelectMisfiredTriggersToRecoverSqlPublic(20);
+
+        // This statement joins the type tables onto TRIGGERS, so the hint has to attach to the alias
+        // rather than to a bare "TRIGGERS WHERE".
+        sql.Should().Contain("{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
+        sql.Should().Contain("LIMIT 20");
+    }
+
+    [Test]
+    public void GetSelectMisfiredTriggersToRecoverSql_WithMinusOne_ShouldNotContainLimit()
+    {
+        var del = new TestMySQLDelegate();
+
+        var sql = del.GetSelectMisfiredTriggersToRecoverSqlPublic(-1);
+
+        sql.Should().NotContain("LIMIT");
+        sql.Should().NotContain("FORCE INDEX");
+    }
+
+    [Test]
+    public void GetSelectMisfiredTriggersToRecoverSql_WithSchemaQualifiedPrefix_ProducesValidIndexHint()
+    {
+        var del = new TestMySQLDelegate();
+
+        var template = del.GetSelectMisfiredTriggersToRecoverSqlPublic(20);
+        var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
+
+        sql.Should().Contain("common.QRTZ_TRIGGERS t FORCE INDEX (IDX_QRTZ_T_NFT_ST_MISFIRE)");
+        // The joined type tables must not have picked up the hint
+        sql.Should().Contain("common.QRTZ_SIMPLE_TRIGGERS st ON");
+        sql.Should().NotContain("IDX_common.");
+    }
+
     private sealed class TestMySQLDelegate : MySQLDelegate
     {
         public string GetSelectNextTriggerToAcquireSqlPublic(int maxCount)
@@ -95,5 +133,8 @@ public class MySQLDelegateTest
 
         public string GetCountMisfiredTriggersInStateSqlPublic()
             => GetCountMisfiredTriggersInStateSql();
+
+        public string GetSelectMisfiredTriggersToRecoverSqlPublic(int count)
+            => GetSelectMisfiredTriggersToRecoverSql(count);
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
@@ -16,4 +16,60 @@ public class StdAdoConstantsTest
 
         sql.Should().Be("SELECT * FROM {0}TRIGGERS WHERE SCHED_NAME = @schedulerName AND MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME < @nextFireTime ORDER BY NEXT_FIRE_TIME ASC, PRIORITY DESC");
     }
+
+    /// <summary>
+    /// <see cref="StdAdoDelegate" /> reads JOB_DATA positionally out of this result set, so the column
+    /// order is load-bearing. New columns belong at the end.
+    /// </summary>
+    [Test]
+    public void SqlSelectTrigger_ShouldKeepJobDataAtOrdinal11()
+    {
+        SelectedColumns(StdAdoConstants.SqlSelectTrigger)[11].Should().Be("JOB_DATA");
+    }
+
+    [Test]
+    public void SqlSelectMisfiredTriggersToRecover_ShouldSelectSameColumnsAsSqlSelectTrigger()
+    {
+        // The batch read materializes triggers with the same code as the single read, so it has to hand
+        // that code the same columns in the same order, plus the keys it needs to tell the rows apart.
+        var expected = SelectedColumns(StdAdoConstants.SqlSelectTrigger)
+            .Concat(["t.TRIGGER_NAME", "t.TRIGGER_GROUP"]);
+
+        SelectedColumns(StdAdoConstants.SqlSelectMisfiredTriggersToRecover).Should().Equal(expected);
+    }
+
+    /// <summary>
+    /// SqlServerDelegate splices its <c>TOP n</c> in at offset 6, so the statement has to start with
+    /// exactly <c>SELECT </c>.
+    /// </summary>
+    [Test]
+    public void SqlSelectMisfiredTriggersToRecover_ShouldStartWithSelectKeyword()
+    {
+        StdAdoConstants.SqlSelectMisfiredTriggersToRecover.Substring(0, 7).Should().Be("SELECT ");
+    }
+
+    [Test]
+    public void SqlSelectMisfiredTriggersToRecover_ShouldUseSameMisfirePredicateAsKeyOnlyQuery()
+    {
+        var sql = StdAdoConstants.SqlSelectMisfiredTriggersToRecover;
+
+        sql.Should().Contain("t.MISFIRE_INSTR <> -1");
+        sql.Should().Contain("t.NEXT_FIRE_TIME < @nextFireTime");
+        sql.Should().Contain("t.TRIGGER_STATE = @state1");
+        sql.Should().Contain("ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC");
+    }
+
+    /// <summary>
+    /// Returns the selected column expressions, in order, of a single-SELECT statement.
+    /// </summary>
+    private static string[] SelectedColumns(string sql)
+    {
+        var start = sql.IndexOf("SELECT", StringComparison.Ordinal) + "SELECT".Length;
+        var end = sql.IndexOf("FROM", StringComparison.Ordinal);
+
+        return sql.Substring(start, end - start)
+            .Split(',')
+            .Select(x => x.Trim())
+            .ToArray();
+    }
 }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateMisfiredTriggersBatchTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateMisfiredTriggersBatchTest.cs
@@ -1,0 +1,351 @@
+using System.Data;
+using System.Data.Common;
+
+using FakeItEasy;
+
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Impl.Triggers;
+using Quartz.Simpl;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// Covers the batched misfire write path. SQLite reports CanCreateBatch = false so the integration
+/// tests cannot reach it, and the providers that can batch all need a live server.
+/// </summary>
+public class UpdateMisfiredTriggersBatchTest
+{
+    [Test]
+    public async Task UsesOneBatchForTheWholeUpdate_WhenProviderSupportsBatching()
+    {
+        var connection = new StubBatchingConnection();
+        var conn = new ConnectionAndTransactionHolder(connection, null);
+        CountingDelegate del = CreateDelegate();
+
+        await del.UpdateMisfiredTriggers(conn, CreateUpdates(5));
+
+        connection.Batches.Should().HaveCount(1, "the whole batch should go out as one round-trip");
+        connection.Batches[0].ExecuteCount.Should().Be(1);
+
+        // One narrow TRIGGERS update plus one SIMPLE_TRIGGERS update per trigger.
+        connection.Batches[0].Commands.Should().HaveCount(10);
+        connection.Batches[0].Commands.Count(x => x.CommandText.Contains("UPDATE {0}TRIGGERS".Replace("{0}", "QRTZ_"))).Should().Be(5);
+        connection.Batches[0].Commands.Count(x => x.CommandText.Contains("QRTZ_SIMPLE_TRIGGERS")).Should().Be(5);
+
+        del.PreparedCommands.Should().BeEmpty("nothing should have been issued as a standalone command");
+    }
+
+    [Test]
+    public async Task BindsParametersOnBatchCommands_WhenProviderCannotCreateThemItself()
+    {
+        // DbBatchCommand.CreateParameter throws by default and several providers still have not
+        // implemented it, so the delegate has to mint parameters from a command instead.
+        var connection = new StubBatchingConnection();
+        var conn = new ConnectionAndTransactionHolder(connection, null);
+        CountingDelegate del = CreateDelegate();
+
+        await del.UpdateMisfiredTriggers(conn, CreateUpdates(1));
+
+        StubBatchCommand triggerUpdate = connection.Batches[0].Commands[0];
+        triggerUpdate.Parameters.Count.Should().BeGreaterThan(0, "the statement must not go out unbound");
+
+        var names = triggerUpdate.Parameters.Cast<DbParameter>().Select(x => x.ParameterName).ToArray();
+        names.Should().Contain("@triggerState");
+        names.Should().Contain("@triggerName");
+        names.Should().Contain("@triggerGroup");
+    }
+
+    [Test]
+    public async Task FallsBackToIndividualStatements_WhenProviderCannotBatch()
+    {
+        var connection = new StubBatchingConnection { SupportsBatching = false };
+        var conn = new ConnectionAndTransactionHolder(connection, null);
+        CountingDelegate del = CreateDelegate();
+
+        await del.UpdateMisfiredTriggers(conn, CreateUpdates(3));
+
+        connection.Batches.Should().BeEmpty();
+        del.PreparedCommands.Should().HaveCount(6, "each trigger still needs its two statements");
+    }
+
+    /// <summary>
+    /// A batch fails as a unit, so one bad trigger would otherwise block the whole recovery pass.
+    /// </summary>
+    [Test]
+    public async Task FallsBackToIndividualStatements_WhenBatchExecutionFails()
+    {
+        var connection = new StubBatchingConnection { FailBatchExecution = true };
+        var conn = new ConnectionAndTransactionHolder(connection, null);
+        CountingDelegate del = CreateDelegate();
+
+        await del.UpdateMisfiredTriggers(conn, CreateUpdates(3));
+
+        connection.Batches.Should().HaveCount(1, "the batch should have been attempted");
+        del.PreparedCommands.Should().HaveCount(6, "every statement should still have been issued after the batch failed");
+    }
+
+    /// <summary>
+    /// Full recovery runs unbounded, so a pass can produce thousands of statements. They must not all be
+    /// handed to the provider as one batch.
+    /// </summary>
+    [Test]
+    public async Task ChunksLargeBatches()
+    {
+        var connection = new StubBatchingConnection();
+        var conn = new ConnectionAndTransactionHolder(connection, null);
+        CountingDelegate del = CreateDelegate();
+
+        // 250 triggers is 500 statements, which has to span more than one batch.
+        await del.UpdateMisfiredTriggers(conn, CreateUpdates(250));
+
+        connection.Batches.Should().HaveCountGreaterThan(1);
+        connection.Batches.Should().OnlyContain(x => x.Commands.Count <= 100);
+        connection.Batches.Sum(x => x.Commands.Count).Should().Be(500, "every statement should still be issued exactly once");
+        del.PreparedCommands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task DoesNothingForAnEmptyBatch()
+    {
+        var connection = new StubBatchingConnection();
+        var conn = new ConnectionAndTransactionHolder(connection, null);
+        CountingDelegate del = CreateDelegate();
+
+        await del.UpdateMisfiredTriggers(conn, []);
+
+        connection.Batches.Should().BeEmpty();
+        del.PreparedCommands.Should().BeEmpty();
+    }
+
+    private static List<MisfiredTriggerUpdate> CreateUpdates(int count)
+    {
+        var updates = new List<MisfiredTriggerUpdate>();
+        for (var i = 0; i < count; i++)
+        {
+            var trigger = new SimpleTriggerImpl("t" + i, "g", DateTimeOffset.UtcNow)
+            {
+                JobKey = new JobKey("j" + i, "jg"),
+                RepeatCount = SimpleTriggerImpl.RepeatIndefinitely,
+                RepeatInterval = TimeSpan.FromMinutes(1)
+            };
+            trigger.SetNextFireTimeUtc(DateTimeOffset.UtcNow.AddMinutes(1));
+
+            updates.Add(new MisfiredTriggerUpdate(trigger, AdoConstants.StateWaiting, null));
+        }
+
+        return updates;
+    }
+
+    private static CountingDelegate CreateDelegate()
+    {
+        var dbProvider = A.Fake<IDbProvider>();
+        A.CallTo(() => dbProvider.Metadata).Returns(new DbMetadata { ParameterNamePrefix = "@", BindByName = true });
+        A.CallTo(() => dbProvider.CreateCommand()).ReturnsLazily(() => new StubDbCommand());
+
+        var del = new CountingDelegate();
+        del.Initialize(new DelegateInitializationArgs
+        {
+            TablePrefix = "QRTZ_",
+            InstanceId = "TESTSCHED",
+            InstanceName = "INSTANCE",
+            TypeLoadHelper = new SimpleTypeLoadHelper(),
+            UseProperties = false,
+            InitString = "",
+            DbProvider = dbProvider,
+            ObjectSerializer = A.Fake<IObjectSerializer>(),
+            TimeProvider = TimeProvider.System
+        });
+
+        return del;
+    }
+
+    /// <summary>
+    /// Records every statement issued as a standalone command, which is how the tests tell the batched
+    /// path from the fallback.
+    /// </summary>
+    private sealed class CountingDelegate : StdAdoDelegate
+    {
+        public List<string> PreparedCommands { get; } = [];
+
+        public override DbCommand PrepareCommand(ConnectionAndTransactionHolder cth, string commandText)
+        {
+            PreparedCommands.Add(commandText);
+            var cmd = new StubDbCommand { CommandText = commandText };
+            cth.Attach(cmd);
+            return cmd;
+        }
+    }
+
+    private sealed class StubBatchingConnection : DbConnection
+    {
+        public bool SupportsBatching { get; init; } = true;
+
+        public bool FailBatchExecution { get; init; }
+
+        public List<StubBatch> Batches { get; } = [];
+
+        public override bool CanCreateBatch => SupportsBatching;
+
+        protected override DbBatch CreateDbBatch()
+        {
+            var batch = new StubBatch { Fail = FailBatchExecution };
+            Batches.Add(batch);
+            return batch;
+        }
+
+        protected override DbCommand CreateDbCommand() => new StubDbCommand();
+
+        public override string ConnectionString { get; set; } = "";
+        public override string Database => "";
+        public override string DataSource => "";
+        public override string ServerVersion => "";
+        public override ConnectionState State => ConnectionState.Open;
+        public override void ChangeDatabase(string databaseName) { }
+        public override void Close() { }
+        public override void Open() { }
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+    }
+
+    private sealed class StubBatch : DbBatch
+    {
+        private readonly StubBatchCommandCollection commands = [];
+
+        public bool Fail { get; init; }
+
+        public int ExecuteCount { get; private set; }
+
+        public List<StubBatchCommand> Commands => commands.Items;
+
+        protected override DbBatchCommandCollection DbBatchCommands => commands;
+
+        protected override DbBatchCommand CreateDbBatchCommand() => new StubBatchCommand();
+
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken = default)
+        {
+            ExecuteCount++;
+            if (Fail)
+            {
+                throw new InvalidOperationException("batch execution failed");
+            }
+
+            return Task.FromResult(commands.Count);
+        }
+
+        public override int ExecuteNonQuery() => throw new NotSupportedException();
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+        protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public override object ExecuteScalar() => throw new NotSupportedException();
+        public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override int Timeout { get; set; }
+        protected override DbConnection DbConnection { get; set; }
+        protected override DbTransaction DbTransaction { get; set; }
+        public override void Prepare() { }
+        public override Task PrepareAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public override void Cancel() { }
+        public override void Dispose() { }
+    }
+
+    private sealed class StubBatchCommandCollection : DbBatchCommandCollection
+    {
+        public List<StubBatchCommand> Items { get; } = [];
+
+        public override int Count => Items.Count;
+        public override bool IsReadOnly => false;
+        public override void Add(DbBatchCommand item) => Items.Add((StubBatchCommand) item);
+        public override void Clear() => Items.Clear();
+        public override bool Contains(DbBatchCommand item) => Items.Contains(item);
+        public override void CopyTo(DbBatchCommand[] array, int arrayIndex) => Items.CopyTo(array.Cast<StubBatchCommand>().ToArray(), arrayIndex);
+        public override IEnumerator<DbBatchCommand> GetEnumerator() => Items.Cast<DbBatchCommand>().GetEnumerator();
+        public override int IndexOf(DbBatchCommand item) => Items.IndexOf((StubBatchCommand) item);
+        public override void Insert(int index, DbBatchCommand item) => Items.Insert(index, (StubBatchCommand) item);
+        public override bool Remove(DbBatchCommand item) => Items.Remove((StubBatchCommand) item);
+        public override void RemoveAt(int index) => Items.RemoveAt(index);
+        protected override DbBatchCommand GetBatchCommand(int index) => Items[index];
+        protected override void SetBatchCommand(int index, DbBatchCommand batchCommand) => Items[index] = (StubBatchCommand) batchCommand;
+    }
+
+    private sealed class StubBatchCommand : DbBatchCommand
+    {
+        private readonly RecordingParameterCollection parameters = new();
+
+        public override string CommandText { get; set; } = "";
+        public override CommandType CommandType { get; set; }
+        public override int RecordsAffected => 0;
+        protected override DbParameterCollection DbParameterCollection => parameters;
+
+        // Left at the default (false) on purpose: the delegate has to cope with providers that have not
+        // implemented CreateParameter on batch commands.
+        public override bool CanCreateParameter => false;
+    }
+
+    private sealed class StubDbCommand : DbCommand
+    {
+        private readonly RecordingParameterCollection parameters = new();
+
+        public override string CommandText { get; set; } = "";
+        public override int CommandTimeout { get; set; }
+        public override CommandType CommandType { get; set; }
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        protected override DbConnection DbConnection { get; set; }
+        protected override DbParameterCollection DbParameterCollection => parameters;
+        protected override DbTransaction DbTransaction { get; set; }
+        public override bool DesignTimeVisible { get; set; }
+        public override void Cancel() { }
+        public override int ExecuteNonQuery() => 0;
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken) => Task.FromResult(0);
+        public override object ExecuteScalar() => null;
+        public override void Prepare() { }
+        protected override DbParameter CreateDbParameter() => new StubDbParameter();
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingParameterCollection : DbParameterCollection
+    {
+        private readonly List<DbParameter> items = [];
+
+        public override int Count => items.Count;
+        public override object SyncRoot => items;
+        public override int Add(object value)
+        {
+            items.Add((DbParameter) value);
+            return items.Count - 1;
+        }
+        public override void AddRange(Array values)
+        {
+            foreach (var value in values)
+            {
+                Add(value);
+            }
+        }
+        public override void Clear() => items.Clear();
+        public override bool Contains(object value) => items.Contains((DbParameter) value);
+        public override bool Contains(string value) => IndexOf(value) >= 0;
+        public override void CopyTo(Array array, int index) => ((System.Collections.ICollection) items).CopyTo(array, index);
+        public override System.Collections.IEnumerator GetEnumerator() => items.GetEnumerator();
+        public override int IndexOf(object value) => items.IndexOf((DbParameter) value);
+        public override int IndexOf(string parameterName) => items.FindIndex(x => x.ParameterName == parameterName);
+        public override void Insert(int index, object value) => items.Insert(index, (DbParameter) value);
+        public override void Remove(object value) => items.Remove((DbParameter) value);
+        public override void RemoveAt(int index) => items.RemoveAt(index);
+        public override void RemoveAt(string parameterName) => items.RemoveAt(IndexOf(parameterName));
+        protected override DbParameter GetParameter(int index) => items[index];
+        protected override DbParameter GetParameter(string parameterName) => items[IndexOf(parameterName)];
+        protected override void SetParameter(int index, DbParameter value) => items[index] = value;
+        protected override void SetParameter(string parameterName, DbParameter value) => items[IndexOf(parameterName)] = value;
+    }
+
+    private sealed class StubDbParameter : DbParameter
+    {
+        public override DbType DbType { get; set; }
+        public override ParameterDirection Direction { get; set; }
+        public override bool IsNullable { get; set; }
+        public override string ParameterName { get; set; } = "";
+        public override string SourceColumn { get; set; } = "";
+        public override bool SourceColumnNullMapping { get; set; }
+        public override object Value { get; set; }
+        public override int Size { get; set; }
+        public override void ResetDbType() { }
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/AdoUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoUtil.cs
@@ -19,6 +19,8 @@
 
 using System.Data;
 using System.Data.Common;
+using System.Globalization;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Quartz.Diagnostics;
 using Quartz.Impl.AdoJobStore.Common;
@@ -68,6 +70,48 @@ internal sealed class AdoUtil : IAdoUtil
         int? size)
     {
         IDbDataParameter param = cmd.CreateParameter();
+        ConfigureParameter(param, paramName, paramValue, dataType, size);
+        cmd.Parameters.Add(param);
+        cmd.CommandText = RewriteParameterName(cmd.CommandText, paramName);
+    }
+
+    /// <summary>
+    /// Adds a parameter to a <see cref="DbBatchCommand" />. <see cref="DbBatchCommand" /> is not an
+    /// <see cref="IDbCommand" />, so it needs its own entry point, but it shares all of the parameter
+    /// naming and rewriting rules with the single-command path above.
+    /// </summary>
+    /// <param name="cmd">The batch command to add the parameter to.</param>
+    /// <param name="parameterFactory">
+    /// Command used to mint provider parameter instances when the provider has not implemented
+    /// <see cref="DbBatchCommand.CreateParameter" /> (it throws by default, and several providers still
+    /// do). Parameter objects are not bound to the command that created them, so one throwaway command
+    /// can serve a whole batch.
+    /// </param>
+    /// <param name="paramName">Name of the parameter, without the provider's prefix.</param>
+    /// <param name="paramValue">Value to bind, <see langword="null" /> binding as <see cref="DBNull" />.</param>
+    /// <param name="dataType">Optional provider-specific parameter type.</param>
+    /// <param name="size">Optional parameter size.</param>
+    public void AddCommandParameter(
+        DbBatchCommand cmd,
+        DbCommand parameterFactory,
+        string paramName,
+        object? paramValue,
+        Enum? dataType = null,
+        int? size = null)
+    {
+        DbParameter param = cmd.CanCreateParameter ? cmd.CreateParameter() : parameterFactory.CreateParameter();
+        ConfigureParameter(param, paramName, paramValue, dataType, size);
+        cmd.Parameters.Add(param);
+        cmd.CommandText = RewriteParameterName(cmd.CommandText, paramName);
+    }
+
+    private void ConfigureParameter(
+        IDbDataParameter param,
+        string paramName,
+        object? paramValue,
+        Enum? dataType,
+        int? size)
+    {
         if (dataType is not null)
         {
             SetDataTypeToCommandParameter(param, dataType);
@@ -80,22 +124,121 @@ internal sealed class AdoUtil : IAdoUtil
 
         param.ParameterName = dbProvider.Metadata.GetParameterName(paramName);
         param.Value = paramValue ?? DBNull.Value;
-        cmd.Parameters.Add(param);
+    }
 
+    /// <summary>
+    /// Rewrites the <c>@name</c> placeholder in the statement text for providers that do not use the
+    /// <c>@</c> prefix, or that bind positionally.
+    /// </summary>
+    /// <remarks>
+    /// This is a plain substring replace, so a parameter name that is a prefix of another one in the same
+    /// statement would corrupt it (<c>@p1</c> matching inside <c>@p10</c>). Generated parameter names must
+    /// therefore be fixed width — see <see cref="BuildTriggerKeyPredicate" />.
+    /// </remarks>
+    private string RewriteParameterName(string commandText, string paramName)
+    {
         if (!dbProvider.Metadata.BindByName)
         {
-            cmd.CommandText = cmd.CommandText.Replace("@" + paramName, dbProvider.Metadata.ParameterNamePrefix);
+            return commandText.Replace("@" + paramName, dbProvider.Metadata.ParameterNamePrefix);
         }
-        else if (dbProvider.Metadata.ParameterNamePrefix != "@")
+
+        if (dbProvider.Metadata.ParameterNamePrefix != "@")
         {
             // we need to replace
-            cmd.CommandText = cmd.CommandText.Replace("@" + paramName, dbProvider.Metadata.ParameterNamePrefix + paramName);
+            return commandText.Replace("@" + paramName, dbProvider.Metadata.ParameterNamePrefix + paramName);
         }
+
+        return commandText;
     }
+
     private void SetDataTypeToCommandParameter(IDbDataParameter param, object parameterType)
     {
         dbProvider.Metadata.ParameterDbTypeProperty!.SetMethod!.Invoke(param, [parameterType]);
     }
+
+    /// <summary>
+    /// Largest number of trigger keys put into a single key-set predicate. Bounds both the provider
+    /// parameter ceiling (SQL Server allows 2100; 200 keys is 401 parameters) and the size of the
+    /// statement text. Callers chunk larger key sets.
+    /// </summary>
+    internal const int MaxTriggerKeysPerPredicate = 200;
+
+    /// <summary>
+    /// Key counts a predicate is built for. Rounding up to one of these and padding the key list with a
+    /// repeat of its last key keeps the number of distinct statement texts down to the length of this
+    /// array, so the database plan cache sees a handful of statements instead of one per batch size.
+    /// Repeating a key is safe because the predicate is a disjunction — a duplicate term cannot change
+    /// which rows match.
+    /// </summary>
+    private static readonly int[] triggerKeyPredicateBuckets = [1, 2, 4, 8, 16, 32, 64, 128, MaxTriggerKeysPerPredicate];
+
+    // Unsynchronized on purpose: two threads racing here just build the same string twice and one
+    // reference assignment wins, which costs nothing and cannot produce a wrong value.
+    private static readonly string?[] triggerKeyPredicateCache = new string?[triggerKeyPredicateBuckets.Length];
+
+    /// <summary>
+    /// Rounds a key count up to the next predicate bucket. Callers must then supply exactly this many
+    /// key parameter pairs, repeating the last key as padding.
+    /// </summary>
+    internal static int RoundUpTriggerKeyCount(int count)
+    {
+        foreach (var bucket in triggerKeyPredicateBuckets)
+        {
+            if (count <= bucket)
+            {
+                return bucket;
+            }
+        }
+
+        return MaxTriggerKeysPerPredicate;
+    }
+
+    /// <summary>
+    /// Builds a parameterized <c>(TRIGGER_NAME = @tkn000 AND TRIGGER_GROUP = @tkg000) OR (...)</c>
+    /// predicate for <paramref name="keyCount" /> trigger keys.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not a row-value <c>IN ((a, b), ...)</c>, which SQL Server does not support, and
+    /// deliberately not interpolated literals. Parameter names are fixed width so that no name is a
+    /// prefix of another — see the remarks on the parameter name rewriting above.
+    /// </remarks>
+    internal static string BuildTriggerKeyPredicate(int keyCount)
+    {
+        var bucketIndex = Array.IndexOf(triggerKeyPredicateBuckets, keyCount);
+        if (bucketIndex < 0)
+        {
+            Throw.ArgumentOutOfRangeException(nameof(keyCount), "Key count must be rounded via RoundUpTriggerKeyCount first");
+        }
+
+        var cached = triggerKeyPredicateCache[bucketIndex];
+        if (cached is not null)
+        {
+            return cached;
+        }
+
+        var sb = new StringBuilder("(");
+        for (var i = 0; i < keyCount; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(" OR ");
+            }
+
+            sb.Append('(').Append(AdoConstants.ColumnTriggerName).Append(" = @").Append(TriggerKeyNameParameter(i))
+                .Append(" AND ").Append(AdoConstants.ColumnTriggerGroup).Append(" = @").Append(TriggerKeyGroupParameter(i))
+                .Append(')');
+        }
+
+        sb.Append(')');
+
+        var predicate = sb.ToString();
+        triggerKeyPredicateCache[bucketIndex] = predicate;
+        return predicate;
+    }
+
+    internal static string TriggerKeyNameParameter(int index) => "tkn" + index.ToString("000", CultureInfo.InvariantCulture);
+
+    internal static string TriggerKeyGroupParameter(int index) => "tkg" + index.ToString("000", CultureInfo.InvariantCulture);
 
     public DbCommand PrepareCommand(ConnectionAndTransactionHolder cth, string commandText)
     {

--- a/src/Quartz/Impl/AdoJobStore/ConnectionAndTransactionHolder.cs
+++ b/src/Quartz/Impl/AdoJobStore/ConnectionAndTransactionHolder.cs
@@ -60,6 +60,26 @@ public sealed class ConnectionAndTransactionHolder : IDisposable
         cmd.Transaction = transaction;
     }
 
+    /// <summary>
+    /// Whether the underlying provider can execute several statements as one <see cref="DbBatch" />,
+    /// i.e. in a single round-trip. Defaults to <see langword="false" /> on <see cref="DbConnection" />,
+    /// so providers without batching support simply report no support and callers fall back to issuing
+    /// the statements one at a time.
+    /// </summary>
+    public bool CanCreateBatch => connection.CanCreateBatch;
+
+    /// <summary>
+    /// Creates a <see cref="DbBatch" /> enlisted in this unit of work. Only valid when
+    /// <see cref="CanCreateBatch" /> is <see langword="true" />.
+    /// </summary>
+    public DbBatch CreateBatch()
+    {
+        DbBatch batch = connection.CreateBatch();
+        batch.Connection = connection;
+        batch.Transaction = transaction;
+        return batch;
+    }
+
     public async ValueTask Commit(bool openNewTransaction)
     {
         if (transaction is not null)

--- a/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
@@ -23,4 +23,13 @@ public class FirebirdDelegate : StdAdoDelegate
         }
         return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
     }
+
+    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
+    {
+        if (count != -1)
+        {
+            return SqlSelectMisfiredTriggersToRecover + " ROWS " + count;
+        }
+        return base.GetSelectMisfiredTriggersToRecoverSql(count);
+    }
 }

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -1137,6 +1137,36 @@ public interface IDriverDelegate
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Selects the misfired triggers to recover as fully populated triggers, rather than as keys that the
+    /// caller then has to read back one at a time. Same predicate, ordering and limit semantics as
+    /// <see cref="HasMisfiredTriggersInState(ConnectionAndTransactionHolder,string,DateTimeOffset,int,ICollection{TriggerKey},CancellationToken)" />.
+    /// </summary>
+    /// <param name="conn">The DB connection.</param>
+    /// <param name="state">The trigger state to scan (WAITING).</param>
+    /// <param name="ts">Triggers whose next fire time is before this are misfired.</param>
+    /// <param name="count">Maximum number of triggers to return, or -1 for all of them.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask<MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(
+        ConnectionAndTransactionHolder conn,
+        string state,
+        DateTimeOffset ts,
+        int count,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies a whole batch of misfire updates. Semantically identical to calling
+    /// <see cref="UpdateMisfiredTrigger" /> once per entry, but collapses the statements into a single
+    /// round-trip on providers that support batching.
+    /// </summary>
+    /// <param name="conn">The DB connection.</param>
+    /// <param name="updates">The triggers, after <c>UpdateAfterMisfire</c> has been applied in-memory.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask UpdateMisfiredTriggers(
+        ConnectionAndTransactionHolder conn,
+        IReadOnlyList<MisfiredTriggerUpdate> updates,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Selects the next triggers to acquire, filtering by execution group constraints.
     /// </summary>
     /// <param name="conn">The DB connection.</param>

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -802,13 +802,15 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         // triggers right away.
         int maxMisfiresToHandleAtATime = recovering ? -1 : MaxMisfiresToHandleAtATime;
 
-        List<TriggerKey> misfiredTriggers = new List<TriggerKey>();
         DateTimeOffset earliestNewTime = DateTimeOffset.MaxValue;
 
-        // We must still look for the MISFIRED state in case triggers were left
-        // in this state when upgrading to this version that does not support it.
-        bool hasMoreMisfiredTriggers =
-            await Delegate.HasMisfiredTriggersInState(conn, StateWaiting, MisfireTime, maxMisfiresToHandleAtATime, misfiredTriggers, cancellationToken).ConfigureAwait(false);
+        // Read the whole batch as fully populated triggers in one round-trip, rather than reading keys
+        // and then reading each trigger back individually.
+        MisfiredTriggerBatch batch =
+            await Delegate.SelectMisfiredTriggersToRecover(conn, StateWaiting, MisfireTime, maxMisfiresToHandleAtATime, cancellationToken).ConfigureAwait(false);
+
+        List<IOperableTrigger> misfiredTriggers = batch.Triggers;
+        bool hasMoreMisfiredTriggers = batch.HasMore;
 
         if (hasMoreMisfiredTriggers)
         {
@@ -832,42 +834,107 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         // when multiple triggers reference the same calendar.
         Dictionary<string, ICalendar?> batchCalendarCache = new();
 
-        foreach (TriggerKey triggerKey in misfiredTriggers)
+        List<MisfiredTriggerUpdate> updates = new(misfiredTriggers.Count);
+        List<IOperableTrigger>? finalized = null;
+
+        foreach (IOperableTrigger trig in misfiredTriggers)
         {
-            IOperableTrigger? trig;
             try
             {
-                trig = await RetrieveTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false);
+                updates.Add(await PrepareMisfiredTriggerUpdate(conn, trig, StateWaiting, batchCalendarCache, cancellationToken).ConfigureAwait(false));
             }
             catch (Exception e)
             {
-                Logger.LogError(e, "Error retrieving the misfired trigger: '{TriggerKey}'", triggerKey);
-                continue;
-            }
-
-            if (trig is null)
-            {
-                continue;
-            }
-
-            try
-            {
-                await DoUpdateOfMisfiredTriggerOptimized(conn, trig, StateWaiting, batchCalendarCache, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                Logger.LogError(e, "Error updating misfired trigger: '{TriggerKey}'", trig.Key);
+                Logger.LogError(e, "Error preparing misfire update for trigger: '{TriggerKey}'", trig.Key);
                 continue;
             }
 
             DateTimeOffset? nextTime = trig.GetNextFireTimeUtc();
-            if (nextTime.HasValue && nextTime.Value < earliestNewTime)
+            if (nextTime.HasValue)
             {
-                earliestNewTime = nextTime.Value;
+                if (nextTime.Value < earliestNewTime)
+                {
+                    earliestNewTime = nextTime.Value;
+                }
+            }
+            else
+            {
+                (finalized ??= []).Add(trig);
+            }
+        }
+
+        try
+        {
+            await Delegate.UpdateMisfiredTriggers(conn, updates, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Error updating {Count} misfired trigger(s)", updates.Count);
+            return new RecoverMisfiredJobsResult(hasMoreMisfiredTriggers, misfiredTriggers.Count, earliestNewTime);
+        }
+
+        if (finalized is not null)
+        {
+            foreach (IOperableTrigger trig in finalized)
+            {
+                await schedSignaler.NotifySchedulerListenersFinalized(trig, cancellationToken).ConfigureAwait(false);
             }
         }
 
         return new RecoverMisfiredJobsResult(hasMoreMisfiredTriggers, misfiredTriggers.Count, earliestNewTime);
+    }
+
+    /// <summary>
+    /// Runs the in-memory half of misfire handling for one trigger — notify the listeners, apply the
+    /// trigger's misfire policy, and work out the state and misfire-original-fire-time to persist — and
+    /// returns the resulting update for the caller to apply as part of a batch.
+    /// </summary>
+    /// <remarks>
+    /// Shares its logic with <see cref="DoUpdateOfMisfiredTriggerOptimized" />, which is the same thing
+    /// for a single trigger that is written immediately.
+    /// </remarks>
+    private async ValueTask<MisfiredTriggerUpdate> PrepareMisfiredTriggerUpdate(
+        ConnectionAndTransactionHolder conn,
+        IOperableTrigger trig,
+        string newStateIfNotComplete,
+        Dictionary<string, ICalendar?>? calendarCache,
+        CancellationToken cancellationToken)
+    {
+        // Calendar lookup with batch-local cache (when available).
+        ICalendar? cal = null;
+        if (trig.CalendarName is not null)
+        {
+            if (calendarCache is null || !calendarCache.TryGetValue(trig.CalendarName, out cal))
+            {
+                cal = await RetrieveCalendar(conn, trig.CalendarName, cancellationToken).ConfigureAwait(false);
+                if (calendarCache is not null)
+                {
+                    calendarCache[trig.CalendarName] = cal;
+                }
+            }
+        }
+
+        await schedSignaler.NotifyTriggerListenersMisfired(trig, cancellationToken).ConfigureAwait(false);
+
+        DateTimeOffset? originalFireTime = trig.GetNextFireTimeUtc();
+        DateTimeOffset now = timeProvider.GetUtcNow();
+
+        trig.UpdateAfterMisfire(cal);
+
+        // Determine new state.
+        DateTimeOffset? newFireTime = trig.GetNextFireTimeUtc();
+        string newState = newFireTime.HasValue ? newStateIfNotComplete : StateComplete;
+
+        // Compute misfire-original-fire-time for "fire now" policies (folded into the single UPDATE).
+        DateTimeOffset? misfireOrigFireTime = null;
+        if (originalFireTime.HasValue && newFireTime.HasValue
+            && originalFireTime.Value != newFireTime.Value
+            && Math.Abs((newFireTime.Value - now).TotalMilliseconds) < AbstractTrigger.FireNowMisfireDetectionThresholdMs)
+        {
+            misfireOrigFireTime = originalFireTime;
+        }
+
+        return new MisfiredTriggerUpdate(trig, newState, misfireOrigFireTime);
     }
 
     /// <summary>
@@ -979,7 +1046,7 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
                 return false;
             }
 
-            await DoUpdateOfMisfiredTriggerOptimized(conn, trig, newStateIfNotComplete, calendarCache: null, cancellationToken).ConfigureAwait(false);
+            await DoUpdateOfMisfiredTriggerOptimized(conn, trig, newStateIfNotComplete, cancellationToken).ConfigureAwait(false);
 
             return true;
         }
@@ -1041,45 +1108,12 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         ConnectionAndTransactionHolder conn,
         IOperableTrigger trig,
         string newStateIfNotComplete,
-        Dictionary<string, ICalendar?>? calendarCache,
         CancellationToken cancellationToken)
     {
-        // Calendar lookup with batch-local cache (when available).
-        ICalendar? cal = null;
-        if (trig.CalendarName is not null)
-        {
-            if (calendarCache is null || !calendarCache.TryGetValue(trig.CalendarName, out cal))
-            {
-                cal = await RetrieveCalendar(conn, trig.CalendarName, cancellationToken).ConfigureAwait(false);
-                if (calendarCache is not null)
-                {
-                    calendarCache[trig.CalendarName] = cal;
-                }
-            }
-        }
-
-        await schedSignaler.NotifyTriggerListenersMisfired(trig, cancellationToken).ConfigureAwait(false);
-
-        DateTimeOffset? originalFireTime = trig.GetNextFireTimeUtc();
-        DateTimeOffset now = timeProvider.GetUtcNow();
-
-        trig.UpdateAfterMisfire(cal);
-
-        // Determine new state.
-        string newState = trig.GetNextFireTimeUtc().HasValue ? newStateIfNotComplete : StateComplete;
-
-        // Compute misfire-original-fire-time for "fire now" policies (folded into the single UPDATE).
-        DateTimeOffset? misfireOrigFireTime = null;
-        DateTimeOffset? newFireTime = trig.GetNextFireTimeUtc();
-        if (originalFireTime.HasValue && newFireTime.HasValue
-            && originalFireTime.Value != newFireTime.Value
-            && Math.Abs((newFireTime.Value - now).TotalMilliseconds) < AbstractTrigger.FireNowMisfireDetectionThresholdMs)
-        {
-            misfireOrigFireTime = originalFireTime;
-        }
+        MisfiredTriggerUpdate update = await PrepareMisfiredTriggerUpdate(conn, trig, newStateIfNotComplete, calendarCache: null, cancellationToken).ConfigureAwait(false);
 
         // Single targeted UPDATE (1-2 DB round-trips) instead of StoreTrigger's 7-12.
-        await Delegate.UpdateMisfiredTrigger(conn, trig, newState, misfireOrigFireTime, cancellationToken).ConfigureAwait(false);
+        await Delegate.UpdateMisfiredTrigger(conn, trig, update.NewState, update.MisfireOriginalFireTime, cancellationToken).ConfigureAwait(false);
 
         if (!trig.GetNextFireTimeUtc().HasValue)
         {

--- a/src/Quartz/Impl/AdoJobStore/MisfiredTriggerBatch.cs
+++ b/src/Quartz/Impl/AdoJobStore/MisfiredTriggerBatch.cs
@@ -1,0 +1,53 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Spi;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// One pass worth of misfired triggers, as returned by
+/// <see cref="IDriverDelegate.SelectMisfiredTriggersToRecover" />.
+/// </summary>
+/// <param name="Triggers">The misfired triggers, ordered by next fire time then descending priority.</param>
+/// <param name="HasMore">
+/// Whether more misfired triggers were left behind by the row limit, meaning recovery should run again
+/// promptly rather than waiting out the misfire handler's normal interval.
+/// </param>
+public readonly record struct MisfiredTriggerBatch(
+    List<IOperableTrigger> Triggers,
+    bool HasMore);
+
+/// <summary>
+/// A single trigger's pending misfire update, as applied in a batch by
+/// <see cref="IDriverDelegate.UpdateMisfiredTriggers" />.
+/// </summary>
+/// <param name="Trigger">The trigger, after <c>UpdateAfterMisfire</c> has been applied in-memory.</param>
+/// <param name="NewState">The new trigger state to persist (e.g. WAITING, COMPLETE, BLOCKED).</param>
+/// <param name="MisfireOriginalFireTime">
+/// The original scheduled fire time for "fire now" misfire policies. When non-<c>null</c>, the value is
+/// written to the MISFIRE_ORIG_FIRE_TIME column. <c>null</c> leaves the column unchanged, preserving any
+/// previously stored original fire time.
+/// </param>
+public readonly record struct MisfiredTriggerUpdate(
+    IOperableTrigger Trigger,
+    string NewState,
+    DateTimeOffset? MisfireOriginalFireTime);

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -47,6 +47,22 @@ public class MySQLDelegate : StdAdoDelegate
         return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
     }
 
+    /// <summary>
+    /// MySQL version with LIMIT support and a FORCE INDEX hint pointing at IDX_*_T_NFT_ST_MISFIRE.
+    /// The hint attaches to the aliased TRIGGERS table, since this statement joins the type tables onto
+    /// it rather than selecting from TRIGGERS alone.
+    /// </summary>
+    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
+    {
+        if (count != -1)
+        {
+            return SqlSelectMisfiredTriggersToRecover
+                .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)")
+                + " LIMIT " + count;
+        }
+        return base.GetSelectMisfiredTriggersToRecoverSql(count);
+    }
+
     protected override string GetCountMisfiredTriggersInStateSql()
     {
         return SqlCountMisfiredTriggersInStates

--- a/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
@@ -44,6 +44,15 @@ public class OracleDelegate : StdAdoDelegate
         return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
     }
 
+    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
+    {
+        if (count != -1)
+        {
+            return "SELECT * FROM (" + SqlSelectMisfiredTriggersToRecover + ") WHERE rownum <= " + count;
+        }
+        return base.GetSelectMisfiredTriggersToRecoverSql(count);
+    }
+
     /// <summary>
     /// Gets the db presentation for boolean value. For Oracle we use true/false of "1"/"0".
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
@@ -45,4 +45,13 @@ public class PostgreSQLDelegate : StdAdoDelegate
         }
         return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
     }
+
+    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
+    {
+        if (count != -1)
+        {
+            return SqlSelectMisfiredTriggersToRecover + " LIMIT " + count;
+        }
+        return base.GetSelectMisfiredTriggersToRecoverSql(count);
+    }
 }

--- a/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
@@ -41,4 +41,13 @@ public class SQLiteDelegate : StdAdoDelegate
         }
         return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
     }
+
+    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
+    {
+        if (count != -1)
+        {
+            return SqlSelectMisfiredTriggersToRecover + " LIMIT " + count;
+        }
+        return base.GetSelectMisfiredTriggersToRecoverSql(count);
+    }
 }

--- a/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
@@ -58,6 +58,16 @@ public class SqlServerDelegate : StdAdoDelegate
         return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
     }
 
+    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
+    {
+        if (count != -1)
+        {
+            // add limit clause to correct place
+            return "SELECT TOP " + count + " " + SqlSelectMisfiredTriggersToRecover.Substring(6);
+        }
+        return base.GetSelectMisfiredTriggersToRecoverSql(count);
+    }
+
     public override void AddCommandParameter(
         DbCommand cmd,
         string paramName,

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -121,6 +121,23 @@ public class StdAdoConstants : AdoConstants
     public static readonly string SqlSelectBlobTrigger =
         Invariant($"SELECT {ColumnBlob} FROM {TablePrefixSubst}{TableBlobTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");
 
+    /// <summary>
+    /// Prefix of the batch blob-trigger lookup; the caller appends a key-set predicate built by
+    /// <c>AdoUtil.BuildTriggerKeyPredicate</c>. The key columns follow the blob so the reader
+    /// can stay in sequential-access mode.
+    /// </summary>
+    public static readonly string SqlSelectBlobTriggersByKeysPrefix =
+        Invariant($"SELECT {ColumnBlob}, {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableBlobTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND ");
+
+    /// <summary>
+    /// Prefix of the batch simple-properties trigger lookup; the caller appends a key-set predicate built
+    /// by <c>AdoUtil.BuildTriggerKeyPredicate</c>. All simple-properties trigger types
+    /// (calendar-interval, daily-time-interval, recurrence, and any custom ones) share this one table, so a
+    /// single query covers them all — the per-row discriminator comes from TRIGGERS.TRIGGER_TYPE.
+    /// </summary>
+    public static readonly string SqlSelectSimpropTriggersByKeysPrefix =
+        Invariant($"SELECT * FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {ColumnSchedulerName} = @schedulerName AND ");
+
     public static readonly string SqlSelectCalendar =
         Invariant($"SELECT {ColumnCalendar} FROM {TablePrefixSubst}{TableCalendars} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnCalendarName} = @calendarName");
 
@@ -273,8 +290,15 @@ public class StdAdoConstants : AdoConstants
     public static readonly string SqlSelectSimpleTrigger =
         Invariant($"SELECT * FROM {TablePrefixSubst}{TableSimpleTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");
 
-    public static readonly string SqlSelectTrigger =
-        Invariant($@"SELECT 
+    /// <summary>
+    /// Column list shared by <see cref="SqlSelectTrigger" /> and <see cref="SqlSelectMisfiredTriggersToRecover" />,
+    /// so the single-trigger and batch read paths cannot drift apart.
+    /// </summary>
+    /// <remarks>
+    /// Ordinals matter here: <c>ReadMapFromReader(rs, 11)</c> reads JOB_DATA positionally. Append new
+    /// columns to the end of this list, never insert into the middle.
+    /// </remarks>
+    private const string TriggerSelectColumns = $@"
                 {ColumnJobName},
                 {ColumnJobGroup},
                 {ColumnDescription},
@@ -295,15 +319,42 @@ public class StdAdoConstants : AdoConstants
                 t.{ColumnMisfireOriginalFireTime},
                 t.{ColumnExecutionGroup},
                 t.{ColumnPreferredNode},
-                t.{ColumnPreferredNodeAuto}
+                t.{ColumnPreferredNodeAuto}";
+
+    /// <summary>
+    /// FROM clause that left-joins the SIMPLE and CRON type tables onto TRIGGERS, letting the two most
+    /// common trigger types be materialized from a single row without a follow-up query.
+    /// </summary>
+    private const string TriggerSelectFastPathFrom = $@"
             FROM
                 {TablePrefixSubst}{TableTriggers} t
             LEFT JOIN
                 {TablePrefixSubst}{TableSimpleTriggers} st ON (st.{ColumnSchedulerName} = t.{ColumnSchedulerName} AND st.{ColumnTriggerGroup} = t.{ColumnTriggerGroup} AND st.{ColumnTriggerName} = t.{ColumnTriggerName})
             LEFT JOIN
-                {TablePrefixSubst}{TableCronTriggers} ct ON (ct.{ColumnSchedulerName} = t.{ColumnSchedulerName} AND ct.{ColumnTriggerGroup} = t.{ColumnTriggerGroup} AND ct.{ColumnTriggerName} = t.{ColumnTriggerName})
+                {TablePrefixSubst}{TableCronTriggers} ct ON (ct.{ColumnSchedulerName} = t.{ColumnSchedulerName} AND ct.{ColumnTriggerGroup} = t.{ColumnTriggerGroup} AND ct.{ColumnTriggerName} = t.{ColumnTriggerName})";
+
+    public static readonly string SqlSelectTrigger =
+        Invariant($@"SELECT {TriggerSelectColumns}{TriggerSelectFastPathFrom}
             WHERE
                 t.{ColumnSchedulerName} = @schedulerName AND t.{ColumnTriggerName} = @triggerName AND t.{ColumnTriggerGroup} = @triggerGroup");
+
+    /// <summary>
+    /// Selects the misfired triggers to recover as fully populated rows, so a whole misfire recovery
+    /// batch costs one round-trip instead of one per trigger. Same predicate and ordering as
+    /// <see cref="SqlSelectHasMisfiredTriggersInState" />, same columns as <see cref="SqlSelectTrigger" />
+    /// with the key columns appended (they are ambiguous across the joined tables, hence the alias).
+    /// </summary>
+    /// <remarks>
+    /// Must start with the <c>SELECT</c> keyword — <see cref="SqlServerDelegate" /> splices its
+    /// <c>TOP n</c> in at that offset.
+    /// </remarks>
+    public static readonly string SqlSelectMisfiredTriggersToRecover =
+        Invariant($@"SELECT {TriggerSelectColumns},
+                t.{ColumnTriggerName},
+                t.{ColumnTriggerGroup}{TriggerSelectFastPathFrom}
+            WHERE
+                t.{ColumnSchedulerName} = @schedulerName AND t.{ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND t.{ColumnNextFireTime} < @nextFireTime AND t.{ColumnTriggerState} = @state1
+            ORDER BY t.{ColumnNextFireTime} ASC, t.{ColumnPriority} DESC");
 
     public static readonly string SqlSelectTriggerData =
         Invariant($"SELECT {ColumnJobDataMap} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -130,6 +130,12 @@ public partial class StdAdoDelegate
         return SqlSelectHasMisfiredTriggersInState;
     }
 
+    protected virtual string GetSelectMisfiredTriggersToRecoverSql(int count)
+    {
+        // by default we don't support limits, this is db specific
+        return SqlSelectMisfiredTriggersToRecover;
+    }
+
     /// <inheritdoc />
     public virtual async ValueTask<int> CountMisfiredTriggersInState(
         ConnectionAndTransactionHolder conn,
@@ -719,33 +725,157 @@ public partial class StdAdoDelegate
         await DeleteBlobTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Everything read from one row of the trigger select. That select left-joins the SIMPLE and CRON
+    /// type tables, so for those two types <see cref="Props" /> comes back populated from the same row
+    /// and no follow-up query is needed.
+    /// </summary>
+    private sealed class TriggerRow
+    {
+        public string JobName = null!;
+        public string JobGroup = null!;
+        public string? Description;
+        public string TriggerType = null!;
+        public string? CalendarName;
+        public int MisfireInstruction;
+        public int Priority;
+        public IDictionary? JobDataMap;
+        public DateTimeOffset? NextFireTimeUtc;
+        public DateTimeOffset? PreviousFireTimeUtc;
+        public DateTimeOffset StartTimeUtc;
+        public DateTimeOffset? EndTimeUtc;
+        public DateTimeOffset? MisfireOriginalFireTime;
+        public string? ExecutionGroup;
+        public string? PreferredNode;
+        public bool PreferredNodeAuto;
+
+        /// <summary>Populated from the joined row for SIMPLE and CRON triggers, <c>null</c> otherwise.</summary>
+        public TriggerPropertyBundle? Props;
+    }
+
+    /// <summary>
+    /// Reads the current row of a trigger select. Shared by the single-trigger and batch read paths so
+    /// the two cannot drift apart.
+    /// </summary>
+    private async ValueTask<TriggerRow> ReadTriggerRow(DbDataReader rs)
+    {
+        var row = new TriggerRow
+        {
+            JobName = rs.GetString(ColumnJobName)!,
+            JobGroup = rs.GetString(ColumnJobGroup)!,
+            Description = rs.GetString(ColumnDescription),
+            TriggerType = rs.GetString(ColumnTriggerType)!,
+            CalendarName = rs.GetString(ColumnCalendarName),
+            MisfireInstruction = rs.GetInt32(ColumnMifireInstruction),
+            Priority = rs.GetInt32(ColumnPriority)
+        };
+
+        row.JobDataMap = await ReadMapFromReader(rs, 11).ConfigureAwait(false);
+
+        row.NextFireTimeUtc = GetDateTimeFromDbValue(rs[ColumnNextFireTime]);
+        row.PreviousFireTimeUtc = GetDateTimeFromDbValue(rs[ColumnPreviousFireTime]);
+        row.StartTimeUtc = GetDateTimeFromDbValue(rs[ColumnStartTime]) ?? DateTimeOffset.MinValue;
+        row.EndTimeUtc = GetDateTimeFromDbValue(rs[ColumnEndTime]);
+
+        // check if we access fast path
+        if (row.TriggerType is TriggerTypeCron or TriggerTypeSimple)
+        {
+            row.Props = FindTriggerPersistenceDelegate(row.TriggerType)!.ReadTriggerPropertyBundle(rs);
+        }
+
+        row.MisfireOriginalFireTime = GetDateTimeFromDbValue(rs[ColumnMisfireOriginalFireTime]);
+
+        int execGroupOrdinal = rs.GetOrdinal(ColumnExecutionGroup);
+        row.ExecutionGroup = rs.IsDBNull(execGroupOrdinal) ? null : rs.GetString(execGroupOrdinal);
+
+        int preferredNodeOrdinal = rs.GetOrdinal(ColumnPreferredNode);
+        row.PreferredNode = rs.IsDBNull(preferredNodeOrdinal) ? null : rs.GetString(preferredNodeOrdinal);
+        int preferredNodeAutoOrdinal = rs.GetOrdinal(ColumnPreferredNodeAuto);
+        row.PreferredNodeAuto = !rs.IsDBNull(preferredNodeAutoOrdinal) && GetBooleanFromDbValue(rs.GetValue(preferredNodeAutoOrdinal));
+
+        return row;
+    }
+
+    /// <summary>
+    /// Applies the fire-time state carried on the TRIGGERS row. Applies to blob-deserialized triggers
+    /// just as much as to built ones.
+    /// </summary>
+    private static void ApplyTriggerFireState(IOperableTrigger trigger, TriggerRow row)
+    {
+        trigger.MisfireInstruction = row.MisfireInstruction;
+        trigger.SetNextFireTimeUtc(row.NextFireTimeUtc);
+        trigger.SetPreviousFireTimeUtc(row.PreviousFireTimeUtc);
+
+        if (row.MisfireOriginalFireTime.HasValue && trigger is AbstractTrigger at)
+        {
+            at.MisfiredFromFireTimeUtc = row.MisfireOriginalFireTime;
+        }
+    }
+
+    /// <summary>
+    /// Applies the routing state carried on the TRIGGERS row. Applied last, so that it cannot be
+    /// overwritten by a persistence delegate's state properties.
+    /// </summary>
+    private static void ApplyTriggerRoutingState(IOperableTrigger trigger, TriggerRow row)
+    {
+        trigger.ExecutionGroup = row.ExecutionGroup;
+
+        // Populating from the trigger's own row — not a change, so it must not mark the pin
+        // dirty (that would make the next store write it back and clobber concurrent re-pins).
+        (trigger as AbstractTrigger)?.SetPreferredNodeRaw(row.PreferredNode, row.PreferredNodeAuto, markDirty: false);
+    }
+
+    /// <summary>
+    /// Applies the TRIGGERS row state onto a trigger deserialized from BLOB_TRIGGERS. The schedule
+    /// itself came out of the blob, so there are no extended properties to apply in between.
+    /// </summary>
+    private static void ApplyBlobTriggerRowState(IOperableTrigger trigger, TriggerRow row)
+    {
+        ApplyTriggerFireState(trigger, row);
+        ApplyTriggerRoutingState(trigger, row);
+    }
+
+    /// <summary>
+    /// Builds a non-blob trigger from its TRIGGERS row and its type-specific extended properties.
+    /// </summary>
+    private static IOperableTrigger BuildTrigger(TriggerKey triggerKey, TriggerRow row, TriggerPropertyBundle triggerProps)
+    {
+        TriggerBuilder tb = TriggerBuilder.Create()
+            .WithDescription(row.Description)
+            .WithPriority(row.Priority)
+            .StartAt(row.StartTimeUtc)
+            .EndAt(row.EndTimeUtc)
+            .WithIdentity(triggerKey)
+            .ModifiedByCalendar(row.CalendarName)
+            .WithSchedule(triggerProps.ScheduleBuilder)
+            .ForJob(new JobKey(row.JobName, row.JobGroup));
+
+        if (row.JobDataMap is not null)
+        {
+            bool clearDirtyFlag = !row.JobDataMap.Contains(SchedulerConstants.ForceJobDataMapDirty);
+            tb.UsingJobData(new JobDataMap(row.JobDataMap));
+            if (clearDirtyFlag)
+            {
+                tb.ClearDirty();
+            }
+        }
+
+        var trigger = (IOperableTrigger) tb.Build();
+
+        ApplyTriggerFireState(trigger, row);
+        SetTriggerStateProperties(trigger, triggerProps);
+        ApplyTriggerRoutingState(trigger, row);
+
+        return trigger;
+    }
+
     /// <inheritdoc />
     public virtual async ValueTask<IOperableTrigger?> SelectTrigger(
         ConnectionAndTransactionHolder conn,
         TriggerKey triggerKey,
         CancellationToken cancellationToken = default)
     {
-        string jobName;
-        string jobGroup;
-        string? description;
-        string triggerType;
-        string? calendarName;
-        int misFireInstr;
-        int priority;
-
-        IDictionary? map;
-
-        DateTimeOffset? nextFireTimeUtc;
-        DateTimeOffset? previousFireTimeUtc;
-        DateTimeOffset startTimeUtc;
-        DateTimeOffset? endTimeUtc;
-        DateTimeOffset? misfireOrigFireTime;
-        string? executionGroup;
-        string? preferredNode;
-        bool preferredNodeAuto;
-
-        ITriggerPersistenceDelegate? tDel = null;
-        TriggerPropertyBundle? triggerProps = null;
+        TriggerRow row;
 
         using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTrigger)))
         {
@@ -753,144 +883,67 @@ public partial class StdAdoDelegate
             AddCommandParameter(cmd, "triggerName", triggerKey.Name);
             AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
 
-            using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                if (!await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    return null;
-                }
-
-                jobName = rs.GetString(ColumnJobName)!;
-                jobGroup = rs.GetString(ColumnJobGroup)!;
-                description = rs.GetString(ColumnDescription);
-                triggerType = rs.GetString(ColumnTriggerType)!;
-                calendarName = rs.GetString(ColumnCalendarName);
-                misFireInstr = rs.GetInt32(ColumnMifireInstruction);
-                priority = rs.GetInt32(ColumnPriority);
-
-                map = await ReadMapFromReader(rs, 11).ConfigureAwait(false);
-
-                nextFireTimeUtc = GetDateTimeFromDbValue(rs[ColumnNextFireTime]);
-                previousFireTimeUtc = GetDateTimeFromDbValue(rs[ColumnPreviousFireTime]);
-                startTimeUtc = GetDateTimeFromDbValue(rs[ColumnStartTime]) ?? DateTimeOffset.MinValue;
-                endTimeUtc = GetDateTimeFromDbValue(rs[ColumnEndTime]);
-
-                // check if we access fast path
-                if (triggerType is TriggerTypeCron or TriggerTypeSimple)
-                {
-                    tDel = FindTriggerPersistenceDelegate(triggerType);
-                    triggerProps = tDel!.ReadTriggerPropertyBundle(rs);
-                }
-
-                misfireOrigFireTime = GetDateTimeFromDbValue(rs[ColumnMisfireOriginalFireTime]);
-
-                int execGroupOrdinal = rs.GetOrdinal(ColumnExecutionGroup);
-                executionGroup = rs.IsDBNull(execGroupOrdinal) ? null : rs.GetString(execGroupOrdinal);
-
-                int preferredNodeOrdinal = rs.GetOrdinal(ColumnPreferredNode);
-                preferredNode = rs.IsDBNull(preferredNodeOrdinal) ? null : rs.GetString(preferredNodeOrdinal);
-                int preferredNodeAutoOrdinal = rs.GetOrdinal(ColumnPreferredNodeAuto);
-                preferredNodeAuto = !rs.IsDBNull(preferredNodeAutoOrdinal) && GetBooleanFromDbValue(rs.GetValue(preferredNodeAutoOrdinal));
+                return null;
             }
+
+            row = await ReadTriggerRow(rs).ConfigureAwait(false);
         }
 
-        IOperableTrigger? trigger = null;
-        if (triggerType == TriggerTypeBlob)
+        if (row.TriggerType == TriggerTypeBlob)
         {
-            using var cmd2 = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectBlobTrigger));
-            AddCommandParameter(cmd2, "schedulerName", schedName);
-            AddCommandParameter(cmd2, "triggerName", triggerKey.Name);
-            AddCommandParameter(cmd2, "triggerGroup", triggerKey.Group);
-            using var rs2 = await cmd2.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            if (await rs2.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                trigger = await GetObjectFromBlob<IOperableTrigger>(rs2, 0, cancellationToken).ConfigureAwait(false);
-            }
+            IOperableTrigger? blobTrigger = null;
 
-            if (trigger is not null)
+            using (var cmd2 = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectBlobTrigger)))
             {
-                trigger.MisfireInstruction = misFireInstr;
-                trigger.SetNextFireTimeUtc(nextFireTimeUtc);
-                trigger.SetPreviousFireTimeUtc(previousFireTimeUtc);
-
-                if (misfireOrigFireTime.HasValue && trigger is AbstractTrigger at)
+                AddCommandParameter(cmd2, "schedulerName", schedName);
+                AddCommandParameter(cmd2, "triggerName", triggerKey.Name);
+                AddCommandParameter(cmd2, "triggerGroup", triggerKey.Group);
+                using var rs2 = await cmd2.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+                if (await rs2.ReadAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    at.MisfiredFromFireTimeUtc = misfireOrigFireTime;
+                    blobTrigger = await GetObjectFromBlob<IOperableTrigger>(rs2, 0, cancellationToken).ConfigureAwait(false);
                 }
             }
+
+            if (blobTrigger is not null)
+            {
+                ApplyBlobTriggerRowState(blobTrigger, row);
+            }
+
+            return blobTrigger;
         }
-        else
+
+        TriggerPropertyBundle? triggerProps = row.Props;
+        if (triggerProps is null)
         {
-            if (triggerProps is null)
+            // fast path didn't succeed
+            var tDel = FindTriggerPersistenceDelegate(row.TriggerType);
+
+            if (tDel is null)
             {
-                // fast path didn't succeed
-                tDel ??= FindTriggerPersistenceDelegate(triggerType);
-
-                if (tDel is null)
-                {
-                    Throw.JobPersistenceException("No TriggerPersistenceDelegate for trigger discriminator type: " + triggerType);
-                }
-
-                try
-                {
-                    triggerProps = await tDel.LoadExtendedTriggerProperties(conn, triggerKey, cancellationToken).ConfigureAwait(false);
-                }
-                catch (InvalidOperationException)
-                {
-                    if (await IsTriggerStillPresent(conn, triggerKey, cancellationToken).ConfigureAwait(false))
-                    {
-                        throw;
-                    }
-
-                    // QTZ-386 Trigger has been deleted
-                    return null;
-                }
+                Throw.JobPersistenceException("No TriggerPersistenceDelegate for trigger discriminator type: " + row.TriggerType);
             }
 
-            TriggerBuilder tb = TriggerBuilder.Create()
-                .WithDescription(description)
-                .WithPriority(priority)
-                .StartAt(startTimeUtc)
-                .EndAt(endTimeUtc)
-                .WithIdentity(triggerKey)
-                .ModifiedByCalendar(calendarName)
-                .WithSchedule(triggerProps.ScheduleBuilder)
-                .ForJob(new JobKey(jobName, jobGroup));
-
-            if (map is not null)
+            try
             {
-                bool clearDirtyFlag = !map.Contains(SchedulerConstants.ForceJobDataMapDirty);
-                tb.UsingJobData(new JobDataMap(map));
-                if (clearDirtyFlag)
+                triggerProps = await tDel.LoadExtendedTriggerProperties(conn, triggerKey, cancellationToken).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException)
+            {
+                if (await IsTriggerStillPresent(conn, triggerKey, cancellationToken).ConfigureAwait(false))
                 {
-                    tb.ClearDirty();
+                    throw;
                 }
+
+                // QTZ-386 Trigger has been deleted
+                return null;
             }
-
-            trigger = (IOperableTrigger) tb.Build();
-
-            trigger.MisfireInstruction = misFireInstr;
-            trigger.SetNextFireTimeUtc(nextFireTimeUtc);
-            trigger.SetPreviousFireTimeUtc(previousFireTimeUtc);
-
-            if (misfireOrigFireTime.HasValue && trigger is AbstractTrigger at)
-            {
-                at.MisfiredFromFireTimeUtc = misfireOrigFireTime;
-            }
-
-            SetTriggerStateProperties(trigger, triggerProps);
         }
 
-        if (trigger is not null)
-        {
-            trigger.ExecutionGroup = executionGroup;
-
-            // Populating from the trigger's own row — not a change, so it must not mark the pin
-            // dirty (that would make the next store write it back and clobber concurrent re-pins).
-            (trigger as AbstractTrigger)?.SetPreferredNodeRaw(preferredNode, preferredNodeAuto, markDirty: false);
-        }
-
-        return trigger;
+        return BuildTrigger(triggerKey, row, triggerProps);
     }
 
     private async ValueTask<bool> IsTriggerStillPresent(
@@ -1773,52 +1826,415 @@ public partial class StdAdoDelegate
         DateTimeOffset? misfireOriginalFireTime,
         CancellationToken cancellationToken = default)
     {
+        List<SqlStatement> statements = [];
+        List<IOperableTrigger> blobTriggers = [];
+        BuildMisfireUpdateStatements(new MisfiredTriggerUpdate(trigger, newState, misfireOriginalFireTime), statements, blobTriggers);
+
+        await ExecuteStatementsIndividually(conn, statements, 0, statements.Count, cancellationToken).ConfigureAwait(false);
+
+        foreach (var blobTrigger in blobTriggers)
+        {
+            await UpdateBlobTrigger(conn, blobTrigger, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    //---------------------------------------------------------------------------
+    // batched misfire recovery
+    //---------------------------------------------------------------------------
+
+    /// <inheritdoc />
+    public virtual async ValueTask<MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(
+        ConnectionAndTransactionHolder conn,
+        string state,
+        DateTimeOffset ts,
+        int count,
+        CancellationToken cancellationToken = default)
+    {
+        // Always read one past the limit so we can tell the caller whether the limit truncated the
+        // result, the same way HasMisfiredTriggersInState does.
+        var sql = ReplaceTablePrefix(GetSelectMisfiredTriggersToRecoverSql(count != -1 ? count + 1 : count));
+
+        List<TriggerKey> keys = [];
+        List<TriggerRow> rows = [];
+        bool hasMore = false;
+
+        using (var cmd = PrepareCommand(conn, sql))
+        {
+            AddCommandParameter(cmd, "schedulerName", schedName);
+            AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
+            AddCommandParameter(cmd, "state1", state);
+
+            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (count != -1 && keys.Count == count)
+                {
+                    hasMore = true;
+                    break;
+                }
+
+                keys.Add(new TriggerKey(rs.GetString(ColumnTriggerName)!, rs.GetString(ColumnTriggerGroup)!));
+                rows.Add(await ReadTriggerRow(rs).ConfigureAwait(false));
+            }
+        }
+
+        // Slots stay index-aligned with keys/rows while the follow-up queries fill them in; a slot left
+        // null means the type-specific row was missing, and the trigger is dropped from the result.
+        var built = new IOperableTrigger?[rows.Count];
+        List<TriggerKey>? blobKeys = null;
+        List<TriggerKey>? simpropKeys = null;
+
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var row = rows[i];
+
+            // SIMPLE and CRON triggers came back complete from the joined row.
+            if (row.Props is not null)
+            {
+                built[i] = BuildTrigger(keys[i], row, row.Props);
+                continue;
+            }
+
+            if (row.TriggerType == TriggerTypeBlob)
+            {
+                (blobKeys ??= []).Add(keys[i]);
+                continue;
+            }
+
+            var tDel = FindTriggerPersistenceDelegate(row.TriggerType);
+            if (tDel is null)
+            {
+                Throw.JobPersistenceException("No TriggerPersistenceDelegate for trigger discriminator type: " + row.TriggerType);
+            }
+
+            if (tDel is SimplePropertiesTriggerPersistenceDelegateSupport)
+            {
+                (simpropKeys ??= []).Add(keys[i]);
+                continue;
+            }
+
+            // A custom persistence delegate storing into its own table. There is no batch read for
+            // those, so fall back to reading it on its own rather than dropping the trigger.
+            try
+            {
+                var props = await tDel.LoadExtendedTriggerProperties(conn, keys[i], cancellationToken).ConfigureAwait(false);
+                built[i] = BuildTrigger(keys[i], row, props);
+            }
+            catch (InvalidOperationException)
+            {
+                // No row for this trigger (QTZ-386, deleted concurrently). Leave the slot empty so this
+                // one trigger is skipped, rather than failing the whole batch over it.
+            }
+        }
+
+        if (blobKeys is not null)
+        {
+            await SelectBlobTriggersForBatch(conn, keys, rows, built, blobKeys, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (simpropKeys is not null)
+        {
+            await SelectSimpropTriggersForBatch(conn, keys, rows, built, simpropKeys, cancellationToken).ConfigureAwait(false);
+        }
+
+        List<IOperableTrigger> triggers = new(rows.Count);
+        for (var i = 0; i < built.Length; i++)
+        {
+            if (built[i] is not null)
+            {
+                triggers.Add(built[i]!);
+            }
+            else
+            {
+                logger.LogWarning("Misfired trigger '{TriggerKey}' has no {TriggerType} row and is skipped", keys[i], rows[i].TriggerType);
+            }
+        }
+
+        return new MisfiredTriggerBatch(triggers, hasMore);
+    }
+
+    /// <summary>
+    /// Prepares a statement matching a chunk of trigger keys, by appending the parameterized key-set
+    /// predicate to <paramref name="sqlPrefix" />.
+    /// </summary>
+    private DbCommand PrepareTriggerKeySetCommand(
+        ConnectionAndTransactionHolder conn,
+        string sqlPrefix,
+        List<TriggerKey> keys,
+        int offset,
+        int length)
+    {
+        var paddedCount = AdoUtil.RoundUpTriggerKeyCount(length);
+        var cmd = PrepareCommand(conn, ReplaceTablePrefix(sqlPrefix + AdoUtil.BuildTriggerKeyPredicate(paddedCount)));
+        AddCommandParameter(cmd, "schedulerName", schedName);
+
+        for (var i = 0; i < paddedCount; i++)
+        {
+            // Pad up to the bucket size by repeating the chunk's last key. The predicate is a
+            // disjunction, so a repeated term cannot change which rows match.
+            var key = keys[offset + Math.Min(i, length - 1)];
+            AddCommandParameter(cmd, AdoUtil.TriggerKeyNameParameter(i), key.Name);
+            AddCommandParameter(cmd, AdoUtil.TriggerKeyGroupParameter(i), key.Group);
+        }
+
+        return cmd;
+    }
+
+    private async ValueTask SelectBlobTriggersForBatch(
+        ConnectionAndTransactionHolder conn,
+        List<TriggerKey> keys,
+        List<TriggerRow> rows,
+        IOperableTrigger?[] built,
+        List<TriggerKey> blobKeys,
+        CancellationToken cancellationToken)
+    {
+        var slotByKey = BuildSlotLookup(keys);
+
+        for (var offset = 0; offset < blobKeys.Count; offset += AdoUtil.MaxTriggerKeysPerPredicate)
+        {
+            var length = Math.Min(AdoUtil.MaxTriggerKeysPerPredicate, blobKeys.Count - offset);
+
+            using var cmd = PrepareTriggerKeySetCommand(conn, SqlSelectBlobTriggersByKeysPrefix, blobKeys, offset, length);
+            using var rs = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+            while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                // Sequential access: the blob is selected first, the key columns after it.
+                var trigger = await GetObjectFromBlob<IOperableTrigger>(rs, 0, cancellationToken).ConfigureAwait(false);
+                var key = new TriggerKey(rs.GetString(1), rs.GetString(2));
+
+                if (trigger is not null && slotByKey.TryGetValue(key, out var slot))
+                {
+                    ApplyBlobTriggerRowState(trigger, rows[slot]);
+                    built[slot] = trigger;
+                }
+            }
+        }
+    }
+
+    private async ValueTask SelectSimpropTriggersForBatch(
+        ConnectionAndTransactionHolder conn,
+        List<TriggerKey> keys,
+        List<TriggerRow> rows,
+        IOperableTrigger?[] built,
+        List<TriggerKey> simpropKeys,
+        CancellationToken cancellationToken)
+    {
+        var slotByKey = BuildSlotLookup(keys);
+
+        for (var offset = 0; offset < simpropKeys.Count; offset += AdoUtil.MaxTriggerKeysPerPredicate)
+        {
+            var length = Math.Min(AdoUtil.MaxTriggerKeysPerPredicate, simpropKeys.Count - offset);
+
+            using var cmd = PrepareTriggerKeySetCommand(conn, SqlSelectSimpropTriggersByKeysPrefix, simpropKeys, offset, length);
+            using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var key = new TriggerKey(rs.GetString(ColumnTriggerName)!, rs.GetString(ColumnTriggerGroup)!);
+                if (!slotByKey.TryGetValue(key, out var slot))
+                {
+                    continue;
+                }
+
+                // All simple-properties types share this table, so the delegate to read the row with is
+                // the one matching that trigger's own discriminator.
+                var tDel = FindTriggerPersistenceDelegate(rows[slot].TriggerType)!;
+                built[slot] = BuildTrigger(key, rows[slot], tDel.ReadTriggerPropertyBundle(rs));
+            }
+        }
+    }
+
+    private static Dictionary<TriggerKey, int> BuildSlotLookup(List<TriggerKey> keys)
+    {
+        var slotByKey = new Dictionary<TriggerKey, int>(keys.Count);
+        for (var i = 0; i < keys.Count; i++)
+        {
+            slotByKey[keys[i]] = i;
+        }
+
+        return slotByKey;
+    }
+
+    /// <summary>
+    /// A statement and its parameters, kept as data so that the same definition can be issued either as a
+    /// standalone command or as one command inside a <see cref="DbBatch" />.
+    /// </summary>
+    private readonly record struct SqlStatement(string Sql, List<SqlStatementParameter> Parameters);
+
+    private readonly record struct SqlStatementParameter(string Name, object? Value, Enum? DataType = null);
+
+    /// <summary>
+    /// Builds the statements one misfire update needs. Single source of truth for
+    /// <see cref="UpdateMisfiredTrigger" /> and <see cref="UpdateMisfiredTriggers" />.
+    /// </summary>
+    /// <param name="update">The pending update.</param>
+    /// <param name="into">Statements to execute, appended to.</param>
+    /// <param name="blobTriggers">
+    /// Blob-stored triggers needing re-serialization, appended to. Those are written through the
+    /// <see cref="UpdateBlobTrigger" /> virtual rather than inlined as a statement here, so that
+    /// subclasses overriding it keep control of how blobs are persisted.
+    /// </param>
+    private void BuildMisfireUpdateStatements(
+        in MisfiredTriggerUpdate update,
+        List<SqlStatement> into,
+        List<IOperableTrigger> blobTriggers)
+    {
+        var trigger = update.Trigger;
+
         // Narrow UPDATE: only columns that change during misfire recovery.
         // Only include MISFIRE_ORIG_FIRE_TIME when we have a value to write;
         // null means "leave unchanged" (matches DoUpdateOfMisfiredTrigger which
         // only calls UpdateMisfireOriginalFireTime on fire-now detection).
-        bool writeMisfireOrigFireTime = misfireOriginalFireTime.HasValue;
-        string sql = writeMisfireOrigFireTime
-            ? SqlUpdateTriggerMisfireWithOrigFireTime
-            : SqlUpdateTriggerMisfire;
+        bool writeMisfireOrigFireTime = update.MisfireOriginalFireTime.HasValue;
 
-        using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql)))
+        List<SqlStatementParameter> parameters =
+        [
+            new("schedulerName", schedName),
+            new("triggerNextFireTime", GetDbDateTimeValue(trigger.GetNextFireTimeUtc())),
+            new("triggerPreviousFireTime", GetDbDateTimeValue(trigger.GetPreviousFireTimeUtc())),
+            new("triggerState", update.NewState),
+            new("triggerStartTime", GetDbDateTimeValue(trigger.StartTimeUtc))
+        ];
+
+        if (writeMisfireOrigFireTime)
         {
-            AddCommandParameter(cmd, "schedulerName", schedName);
-            AddCommandParameter(cmd, "triggerNextFireTime", GetDbDateTimeValue(trigger.GetNextFireTimeUtc()));
-            AddCommandParameter(cmd, "triggerPreviousFireTime", GetDbDateTimeValue(trigger.GetPreviousFireTimeUtc()));
-            AddCommandParameter(cmd, "triggerState", newState);
-            AddCommandParameter(cmd, "triggerStartTime", GetDbDateTimeValue(trigger.StartTimeUtc));
-            if (writeMisfireOrigFireTime)
-            {
-                AddCommandParameter(cmd, "triggerMisfireOrigFireTime", GetDbDateTimeValue(misfireOriginalFireTime));
-            }
-            AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
-            AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
-
-            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            parameters.Add(new SqlStatementParameter("triggerMisfireOrigFireTime", GetDbDateTimeValue(update.MisfireOriginalFireTime)));
         }
+
+        parameters.Add(new SqlStatementParameter("triggerName", trigger.Key.Name));
+        parameters.Add(new SqlStatementParameter("triggerGroup", trigger.Key.Group));
+
+        into.Add(new SqlStatement(
+            ReplaceTablePrefix(writeMisfireOrigFireTime ? SqlUpdateTriggerMisfireWithOrigFireTime : SqlUpdateTriggerMisfire),
+            parameters));
 
         // Update type-specific table: SimpleTrigger may have modified RepeatCount/TimesTriggered
         // via RescheduleNowWith* policies; blob triggers need re-serialization to persist all
         // in-memory changes. Other built-in types (Cron, CalendarInterval, DailyTimeInterval)
         // do not change extended properties during misfire.
-        if (trigger is ISimpleTrigger simpleTrigger && FindTriggerPersistenceDelegate(trigger) is not null)
+        var persistenceDelegate = FindTriggerPersistenceDelegate(trigger);
+        if (trigger is ISimpleTrigger simpleTrigger && persistenceDelegate is not null)
         {
-            using var cmd2 = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateSimpleTrigger));
-            AddCommandParameter(cmd2, "schedulerName", schedName);
-            AddCommandParameter(cmd2, "triggerRepeatCount", simpleTrigger.RepeatCount);
-            AddCommandParameter(cmd2, "triggerRepeatInterval", GetDbTimeSpanValue(simpleTrigger.RepeatInterval));
-            AddCommandParameter(cmd2, "triggerTimesTriggered", simpleTrigger.TimesTriggered);
-            AddCommandParameter(cmd2, "triggerName", trigger.Key.Name);
-            AddCommandParameter(cmd2, "triggerGroup", trigger.Key.Group);
-
-            await cmd2.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            into.Add(new SqlStatement(ReplaceTablePrefix(SqlUpdateSimpleTrigger),
+            [
+                new SqlStatementParameter("schedulerName", schedName),
+                new SqlStatementParameter("triggerRepeatCount", simpleTrigger.RepeatCount),
+                new SqlStatementParameter("triggerRepeatInterval", GetDbTimeSpanValue(simpleTrigger.RepeatInterval)),
+                new SqlStatementParameter("triggerTimesTriggered", simpleTrigger.TimesTriggered),
+                new SqlStatementParameter("triggerName", trigger.Key.Name),
+                new SqlStatementParameter("triggerGroup", trigger.Key.Group)
+            ]));
         }
-        else if (FindTriggerPersistenceDelegate(trigger) is null)
+        else if (persistenceDelegate is null)
         {
             // Blob-stored trigger: re-serialize to persist all in-memory misfire changes.
-            await UpdateBlobTrigger(conn, trigger, cancellationToken).ConfigureAwait(false);
+            blobTriggers.Add(trigger);
+        }
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask UpdateMisfiredTriggers(
+        ConnectionAndTransactionHolder conn,
+        IReadOnlyList<MisfiredTriggerUpdate> updates,
+        CancellationToken cancellationToken = default)
+    {
+        if (updates.Count == 0)
+        {
+            return;
+        }
+
+        List<SqlStatement> statements = [];
+        List<IOperableTrigger> blobTriggers = [];
+        foreach (var update in updates)
+        {
+            BuildMisfireUpdateStatements(update, statements, blobTriggers);
+        }
+
+        // Providers that cannot batch report CanCreateBatch = false (the DbConnection default), and get
+        // exactly the behaviour they had before batching existed.
+        if (!conn.CanCreateBatch)
+        {
+            await ExecuteStatementsIndividually(conn, statements, 0, statements.Count, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            // Recovery runs unbounded (maxMisfiresToHandleAtATime is -1), so cap how much goes into one
+            // batch rather than handing the provider an arbitrarily large one.
+            for (var offset = 0; offset < statements.Count; offset += MaxStatementsPerBatch)
+            {
+                var length = Math.Min(MaxStatementsPerBatch, statements.Count - offset);
+                await ExecuteStatementBatch(conn, statements, offset, length, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        foreach (var blobTrigger in blobTriggers)
+        {
+            await UpdateBlobTrigger(conn, blobTrigger, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Statements put into a single <see cref="DbBatch" />. Keeps one batch's size — and the amount
+    /// re-run individually if it fails — bounded.
+    /// </summary>
+    private const int MaxStatementsPerBatch = 100;
+
+    private async ValueTask ExecuteStatementBatch(
+        ConnectionAndTransactionHolder conn,
+        List<SqlStatement> statements,
+        int offset,
+        int length,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var batch = conn.CreateBatch();
+
+            // Providers are not required to implement DbBatchCommand.CreateParameter, so keep one
+            // throwaway command around to mint parameter instances for those that do not.
+            using var parameterFactory = DbProvider.CreateCommand();
+
+            for (var i = offset; i < offset + length; i++)
+            {
+                var statement = statements[i];
+                var batchCommand = batch.CreateBatchCommand();
+                batchCommand.CommandText = statement.Sql;
+                foreach (var parameter in statement.Parameters)
+                {
+                    adoUtil.AddCommandParameter(batchCommand, parameterFactory, parameter.Name, parameter.Value, parameter.DataType);
+                }
+
+                batch.BatchCommands.Add(batchCommand);
+            }
+
+            await batch.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            // A batch fails as a unit, which would let one bad trigger block the whole recovery pass.
+            // Retry statement by statement so the others still get through, and so the exception that
+            // surfaces names the statement that actually failed.
+            logger.LogWarning(e, "Batched misfire update failed, retrying {StatementCount} statement(s) individually", length);
+            await ExecuteStatementsIndividually(conn, statements, offset, length, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask ExecuteStatementsIndividually(
+        ConnectionAndTransactionHolder conn,
+        List<SqlStatement> statements,
+        int offset,
+        int length,
+        CancellationToken cancellationToken)
+    {
+        for (var i = offset; i < offset + length; i++)
+        {
+            var statement = statements[i];
+            using var cmd = PrepareCommand(conn, statement.Sql);
+            foreach (var parameter in statement.Parameters)
+            {
+                AddCommandParameter(cmd, parameter.Name, parameter.Value, parameter.DataType);
+            }
+
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Closes the remaining half of #758. Supersedes #759 by @nicsur, which raised the idea originally — that PR predates the current SQL and delegate shape, so this is a fresh implementation rather than a rebase.

## Why

[#2994](https://github.com/quartznet/quartznet/pull/2994) already cut the misfire **write** path from 7–12 round-trips per trigger down to 1–2. What was left is that recovery still read triggers one at a time, and still issued its updates one statement at a time:

| step | round-trips, per trigger |
|---|---|
| `RetrieveTrigger` → `SelectTrigger` | 1 (SIMPLE/CRON fast path), 2 otherwise |
| `Delegate.UpdateMisfiredTrigger` | 1, +1 for SIMPLE extended props or blob |

At the default `MaxMisfiresToHandleAtATime` of 20 that is 40–60 round-trips per pass, all under `LockTriggerAccess`. Recovery (`recovering: true`) runs unbounded, so a large backlog took proportionally long to clear.

After this change a pass costs at most three reads plus one batched write, regardless of how many triggers it handles.

## Read side

`IDriverDelegate.SelectMisfiredTriggersToRecover` returns the whole batch as populated triggers from a single query, replacing "select keys, then read each trigger back".

`SqlSelectMisfiredTriggersToRecover` reuses `SqlSelectTrigger`'s column list and LEFT JOINs via shared `const` fragments, so the two cannot drift — SIMPLE and CRON triggers arrive complete on the joined row via the existing `ReadTriggerPropertyBundle` fast path. The remaining types need at most two follow-up queries between them: all simple-properties types (calendar-interval, daily-time-interval, recurrence, custom) share `SIMPROP_TRIGGERS`, and blob triggers have their own.

Row limiting follows the existing per-provider pattern — `GetSelectMisfiredTriggersToRecoverSql` is overridden alongside `GetSelectNextMisfiredTriggersInStateToAcquireSql` in all six delegates. MySQL's `FORCE INDEX` hint had to be re-targeted at the aliased table, since this statement joins rather than selecting from `TRIGGERS` alone.

`SelectTrigger` was refactored onto the same row-read and trigger-construction helpers so the single and batch paths share one definition. Property application order is preserved exactly, including `SetTriggerStateProperties` running between the fire state and the routing state.

## Write side

`IDriverDelegate.UpdateMisfiredTriggers` applies a batch through an ADO.NET `DbBatch`. Support is probed at runtime with `DbConnection.CanCreateBatch`, which is `false` by default, so providers without batching keep exactly the behaviour they had — **no configuration switch and no per-delegate capability flag**. Verified supported: Microsoft.Data.SqlClient 6.0.1, Npgsql 10, MySqlConnector 2.5. Oracle, Firebird and SQLite fall back.

Each batch command carries the **same parameterized SQL text** as the single-trigger path, so plan caching is unaffected. Batches are chunked at 100 statements, and a failed batch is retried statement by statement — a batch fails as a unit, and one bad trigger must not block the rest of a recovery pass.

Blob triggers are still written through the `UpdateBlobTrigger` virtual rather than inlined, so subclasses overriding it keep control.

## Key-set predicate

The follow-up queries need to match a set of trigger keys. That is a parameterized `(TRIGGER_NAME = @tkn000 AND TRIGGER_GROUP = @tkg000) OR (...)` disjunction, chunked at 200 keys — deliberately not a row-value `IN ((a,b), ...)`, which SQL Server does not support, and never interpolated literals.

Two details worth pointing out:

- The key count is rounded up to one of nine buckets, padding by repeating a key. A disjunction cannot notice a duplicate term, so the result set is unchanged, and the database sees a handful of distinct statements instead of one per batch size.
- Parameter names are **fixed width**. `AdoUtil` rewrites placeholders by substring replace for providers that do not use `@` (Oracle) or that bind positionally, where `@p1` would otherwise corrupt `@p10`.

This all lives on the internal `AdoUtil`; `IAdoUtil` is untouched.

## API surface

`IDriverDelegate` gains the two members above. Subclasses of `StdAdoDelegate` get both for free; a driver delegate for a database with its own row-limiting syntax should also override `GetSelectMisfiredTriggersToRecoverSql`. Documented in the 4.x migration guide.

One behavioural note, also documented: `ITriggerListener.TriggerMisfired` now fires for every trigger in a batch before any of that batch's writes, where it previously interleaved per trigger. Everything remains inside the same transaction under the same lock, so what other nodes observe is unchanged.

## Not proposed for 3.x

This needs new `IDriverDelegate` members and a new per-provider SQL hook on every delegate. On 3.x that would mean `INextVersionDelegate`-style side interfaces (as #2993 did) for the smaller remaining share of the win — 3.x already has the write-path optimization.

## Testing

- **1843 unit tests pass.** New coverage: batch read replaces per-trigger reads and `hasMore` propagates (`JobStoreSupportTest`); `DbBatch` selection, parameter binding when the provider has not implemented `DbBatchCommand.CreateParameter`, chunking, and both fallbacks — unsupported provider and failing batch (`UpdateMisfiredTriggersBatchTest`); bucket rounding, fixed-width names and table-prefix survival (`AdoUtilTest`); SQL column/ordinal drift guards and the MySQL hint (`StdAdoConstantsTest`, `MySQLDelegateTest`).
- **End-to-end against a real database** (`MisfireBatchRecoveryTest`, SQLite, no container): recovers SIMPLE, CRON, DAILY_I, CAL_INT and blob triggers, asserts the blob trigger round-trips with its custom state intact, and asserts the read count is *identical* for 2 vs 40 triggers.
- The existing SQLite smoke tests pass, which exercise the refactored `SelectTrigger` across every trigger type, custom blob triggers and calendars.
- The batched write path cannot be reached from SQLite (`CanCreateBatch` is `false` there — verified), so it is covered by unit tests with a real fake `DbBatch`. **The containerized SQL Server / PostgreSQL / MySQL legs are what will exercise it for real.**

## Follow-up, not in scope

`AcquireNextTriggers` has the same N+1 shape: `SelectTriggerToAcquire` returns keys and each is then read individually. The machinery added here generalizes to it directly.

Also noted while working here: `JobStoreSupport.DoUpdateOfMisfiredTrigger` has had no callers since #2994 and is dead code. Left alone to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
