### PR TITLE
Group Dependabot NuGet updates by category

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,62 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    # Dependencies are matched against groups in the order they are declared here,
+    # and each dependency ends up in the first group it matches.
+    groups:
+      # Test frameworks, assertion libraries, mocks, containers and benchmarking.
+      testing:
+        patterns:
+          - "NUnit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "Microsoft.AspNetCore.Mvc.Testing"
+          - "Microsoft.Extensions.TimeProvider.Testing"
+          - "FakeItEasy"
+          - "AwesomeAssertions*"
+          - "Verify*"
+          - "Testcontainers*"
+          - "MELT"
+          - "GitHubActionsTestLogger"
+          - "BenchmarkDotNet*"
+      # Compile-time only tooling: analyzers, source generators, polyfills.
+      analyzers:
+        patterns:
+          - "*.Analyzers"
+          - "Meziantou.Analyzer"
+          - "Microsoft.CodeAnalysis*"
+          - "PolySharp"
+      # ADO.NET providers and other data store clients used by the job stores.
+      database-providers:
+        patterns:
+          - "Microsoft.Data.SqlClient"
+          - "Microsoft.Data.SQLite*"
+          - "System.Data.SQLite*"
+          - "MySqlConnector"
+          - "Npgsql*"
+          - "Oracle.ManagedDataAccess*"
+          - "FirebirdSql.Data.FirebirdClient"
+          - "StackExchange.Redis"
+      logging:
+        patterns:
+          - "Serilog*"
+          - "NLog*"
+          - "log4net"
+          - "Microsoft.Extensions.Logging*"
+      telemetry:
+        patterns:
+          - "OpenTelemetry*"
+          - "OpenTracing"
+          - "System.Diagnostics.DiagnosticSource"
+      # Everything else shipped out of dotnet/runtime and dotnet/aspnetcore.
+      microsoft:
+        patterns:
+          - "Microsoft.Extensions.*"
+          - "Microsoft.AspNetCore.*"
+          - "System.*"
+      # Web/API packages used by the samples and the server host.
+      web:
+        patterns:
+          - "AspNetCore.HealthChecks*"
+          - "NSwag*"
+          - "Swashbuckle*"


### PR DESCRIPTION
## Summary

Group Dependabot's NuGet version updates into seven logical categories to cut weekly PR noise.

## Details

Dependabot opens one PR per package today, so a normal week produces a handful of near-identical
PRs (`Microsoft.Extensions.TimeProvider.Testing`, `Microsoft.Extensions.Hosting.Abstractions`,
`Meziantou.Analyzer`, ... all separately). Packages that always move together — the six
`Testcontainers.*` packages, the six `OpenTelemetry.*` packages, the Serilog family — each get their
own PR, which is the bulk of the noise.

This adds `groups` to the existing nuget entry. Dependabot matches a dependency against the groups in
declaration order and puts it in the first one that matches, so the ordering here is deliberate:
`Microsoft.Extensions.TimeProvider.Testing` lands in `testing` rather than `microsoft`, and
`Microsoft.Extensions.Logging.Console` lands in `logging`.

Groups, and how the current `Directory.Packages.props` maps onto them:

| Group | Packages |
| --- | --- |
| `testing` (19) | NUnit\*, NUnit3TestAdapter, Microsoft.NET.Test.Sdk, Microsoft.AspNetCore.Mvc.Testing, Microsoft.Extensions.TimeProvider.Testing, FakeItEasy, AwesomeAssertions\*, Verify.NUnit, Testcontainers.\*, MELT, GitHubActionsTestLogger, BenchmarkDotNet |
| `analyzers` (3) | Microsoft.CodeAnalysis.BannedApiAnalyzers, Meziantou.Analyzer, PolySharp |
| `database-providers` (10) | Microsoft.Data.SqlClient, Microsoft.Data.SQLite, System.Data.SQLite.Core, MySqlConnector, Npgsql\*, Oracle.ManagedDataAccess\*, FirebirdSql.Data.FirebirdClient, StackExchange.Redis |
| `logging` (7) | log4net, NLog.Extensions.Logging, Serilog\*, Microsoft.Extensions.Logging.Console |
| `telemetry` (8) | OpenTelemetry.\*, OpenTracing, System.Diagnostics.DiagnosticSource |
| `microsoft` (6) | remaining Microsoft.Extensions.\*, Microsoft.AspNetCore.SignalR.Client, System.Text.Json |
| `web` (5) | AspNetCore.HealthChecks.\*, NSwag.AspNetCore, Swashbuckle.AspNetCore |

Four packages stay ungrouped on purpose — `Newtonsoft.Json`, `Spectre.Console`, `TimeZoneConverter`
and `Topshelf` are one-offs that affect the shipped libraries, so they're worth reviewing on their own.

Worst case drops from ~62 possible PRs to ~11. `open-pull-requests-limit: 10` is added so a busy week
can still surface every group in one go (default is 5).

Notes on what this deliberately does *not* change:

- Groups apply to version updates only; **security** updates keep opening individual PRs so they stay
  easy to merge fast. That is Dependabot's default and the behaviour we want here.
- No `update-types` restriction, so a major bump inside a family (e.g. all `Testcontainers.*` going
  4.x → 5.x) still lands as one PR instead of six.
- The `github-actions` and `npm` ecosystems are still not configured. Adding `github-actions` would be
  a reasonable follow-up (workflow actions are pinned at a mix of `@v4`/`@v6` today and nothing bumps
  them), but it adds PRs rather than removing them, so it's left out of this change.

## Linked issue

n/a

## Test plan

- [x] Config parses as valid YAML and matches the documented schema
- [x] Group patterns simulated against every entry in `Directory.Packages.props` (table above)
- [ ] Confirmed in practice on the next weekly Dependabot run

## Breaking change?

No — CI/repo configuration only, no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
