### PR TITLE
Declare AttributeUsage on the workflow preset attribute

### DIFF
--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -56,6 +57,7 @@ namespace Quartz.Build
     /// parameter — the same mechanism <see cref="GitHubActionsAttribute.ImportSecrets"/> uses, so no
     /// custom step needs to be written.
     /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     internal sealed class DatabaseIntegrationGitHubActionsAttribute : GitHubActionsAttribute
     {
         readonly string database;


### PR DESCRIPTION
Follow-up to #3162, which merged before this landed.

SonarCloud's `S3993` wants `[AttributeUsage]` stated explicitly rather than inherited from `GitHubActionsAttribute`. Same values as the base (`AttributeTargets.Class, AllowMultiple = true`).

main's gate passes without it — `_build.csproj` sets `SonarQubeExclude`, so the orchestrator isn't analysed here. It's flagged on 3.x, which didn't have that property; #3166 adds it there. This carries the same two lines on main so both branches' `Build.CI.GitHubActions.cs` stay byte-identical.

`./build.ps1 Compile` succeeds and regenerates no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
