### PR TITLE
Exclude the build orchestrator from SonarQube analysis (3.x)

### DIFF
--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -53,6 +54,7 @@ namespace Quartz.Build
     /// parameter — the same mechanism <see cref="GitHubActionsAttribute.ImportSecrets"/> uses, so no
     /// custom step needs to be written.
     /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     internal sealed class DatabaseIntegrationGitHubActionsAttribute : GitHubActionsAttribute
     {
         readonly string database;

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,6 +12,7 @@
     <FalloutExcludeDirectoryBuild>true</FalloutExcludeDirectoryBuild>
     <FalloutExcludeLogs>true</FalloutExcludeLogs>
     <IsPackable>false</IsPackable>
+    <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow-up to #3163, which merged before these two fixes landed. SonarCloud's quality gate was failing on that PR and this is what it wanted.

**`SonarQubeExclude` on `_build.csproj`** — main has carried this since before the migration; 3.x never did, so the build orchestrator is analysed as product code. That's what surfaced `S3903` ("move `Build` into a named namespace") against the build script: the class declaration line changed (`NukeBuild` → `FalloutBuild`), which made a long-standing shape count as new code. Excluding the orchestrator is both the existing main-branch treatment and the correct one — putting a Fallout entry-point class into a namespace to satisfy a product-code rule isn't a trade worth making.

**Explicit `[AttributeUsage]`** — `S3993` wants it stated rather than inherited from `GitHubActionsAttribute`. Same values as the base (`AttributeTargets.Class, AllowMultiple = true`). Applied identically on main in #3165 so the two files stay byte-identical.

`./build.ps1 Compile` succeeds and regenerates no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
