### PR TITLE
Prepare v3.19.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Test Commands
 
 - **Build:** `dotnet build Quartz.slnx` (solution uses modern `.slnx` format)
-- **Full build (Nuke):** `build.cmd` (Windows) or `build.sh` (Linux/macOS)
+- **Full build (Fallout):** `build.cmd` (Windows) or `build.sh` (Linux/macOS) — thin shims that restore the pinned Fallout CLI (`.config/dotnet-tools.json`) and forward to `dotnet fallout <targets>`
 - **Run all unit tests:** `dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj`
 - **Run single test:** `dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj --filter "FullyQualifiedName~TestName"`
 - **Target framework:** Use `-f net10.0` (or `net472` for .NET Framework; non-Windows only supports `net10.0`)
 - **Integration tests:** `dotnet test src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj -f net10.0` (requires Docker for Testcontainers)
-- **Nuke targets:** `Clean`, `Restore`, `Compile`, `UnitTest`, `IntegrationTest`, `Pack` (defined in `build/Build.cs`)
+- **Fallout targets:** `Clean`, `Restore`, `Compile`, `UnitTest`, `IntegrationTest`, `Pack`, `Publish` (defined in `build/Build.cs`)
 - **Warnings are errors** globally via `src/Directory.Build.props`
 
 ## Documentation

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 
-    <VersionPrefix>3.18.2</VersionPrefix>
+    <VersionPrefix>3.19.0</VersionPrefix>
 
     <CLSCompliant>True</CLSCompliant>
     <ComVisible>False</ComVisible>

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -151,6 +151,9 @@ public class CronExpressionBuilderTest
         Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 0)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 8)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithYearIncrements(2030, 0)).Should().Throw<ArgumentOutOfRangeException>();
+        // An unbounded year increment would overflow the "i += incr" loop in CronExpression.AddToSet
+        // and silently produce a wrong schedule; the builder must reject it up front like every other field.
+        Invoking(x => x.WithYearIncrements(2030, int.MaxValue)).Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Test]

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -489,7 +489,7 @@ public sealed class CronExpressionBuilder
     /// Set the year field to a list of values, e.g. "2030,2032". The values are
     /// emitted in the given order.
     /// </summary>
-    /// <param name="years">the years to fire on</param>
+    /// <param name="years">the years to fire on (each 1970 to circa 100 years from now)</param>
     /// <returns>the updated CronExpressionBuilder</returns>
     public CronExpressionBuilder WithYears(params int[] years)
     {
@@ -525,11 +525,10 @@ public sealed class CronExpressionBuilder
     public CronExpressionBuilder WithYearIncrements(int start, int increment)
     {
         ValidateYear(start, nameof(start));
-        if (increment < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(increment), "Invalid increment (must be >= 1).");
-        }
-
+        // Cap to the year span, as every other field caps to its own range. Without an upper
+        // bound an increment near int.MaxValue overflows the unchecked "i += incr" loop in
+        // CronExpression.AddToSet, silently producing a wrong (near-empty) year set.
+        ValidateIncrement(increment, MaxYear - TriggerConstants.EarliestYear);
         return SetYear($"{start}/{increment}");
     }
 

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -633,9 +633,8 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         // correctly. EnsureOptionalColumnsProbed already swallows and defers connectivity/transient
         // failures (so scheduler construction still succeeds while the database is starting, and the
         // absence is never latched as "column missing"); the probe is retried on the first database
-        // operation and at Start(). It surfaces only a genuine SchedulerConfigException (e.g. a
-        // reserved instance id), which should fail construction fast. Routed through the shared gate
-        // so it cannot race a concurrent lazy retry.
+        // operation and at Start(). It surfaces only a genuine SchedulerConfigException, which should
+        // fail construction fast. Routed through the shared gate so it cannot race a concurrent lazy retry.
         await EnsureOptionalColumnsProbed(cancellationToken).ConfigureAwait(false);
     }
 
@@ -850,12 +849,13 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     private volatile bool suppressPreferredNodeAcquisition;
 
     /// <summary>
-    /// When the PREFERRED_NODE column exists, acquisition would route through the preferred-node
-    /// overload of <c>SelectTriggerToAcquire</c>. A custom delegate that overrides only the legacy
-    /// overload would then be bypassed — which could silently defeat custom acquisition filtering
-    /// (e.g. tenant isolation). Detect that case so the caller can keep such delegates on the
-    /// legacy path (their override wins over the new feature), and warn that preferred-node
-    /// filtering is not applied for them.
+    /// Returns whether SQL-level preferred-node (node affinity) acquisition must be suppressed for a
+    /// custom delegate, keeping it on the legacy acquisition path. Two cases trigger suppression:
+    /// (1) the delegate overrides only the legacy <c>SelectTriggerToAcquire</c> overload, so routing
+    /// through the preferred-node overload would bypass its customization (e.g. tenant isolation);
+    /// (2) the delegate overrides the date/time or time-span storage format, which the preferred-node
+    /// liveness SQL cannot account for. In both cases the caller keeps the delegate on the legacy
+    /// path and a warning explains that node-affinity filtering is not applied for it.
     /// </summary>
     private bool DetectBypassedCustomAcquisitionOverride()
     {
@@ -865,6 +865,22 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
             if (delegateType.Assembly == typeof(StdAdoDelegate).Assembly)
             {
                 return false;
+            }
+
+            // The preferred-node liveness filter (PreferredNodeWhereClause) does its SCHEDULER_STATE
+            // freshness arithmetic in SQL against the raw stored LAST_CHECKIN_TIME / CHECKIN_INTERVAL,
+            // assuming the default tick / millisecond storage format. A delegate that overrides how
+            // those values are written may store a different format, which would make that comparison
+            // meaningless (a wrong liveness verdict could strand a pinned trigger or let a live node be
+            // treated as dead). Keep such delegates on the legacy acquisition path (no SQL-level node
+            // affinity) rather than risk it.
+            Type[] dbDateTimeArgs = [typeof(DateTimeOffset?)];
+            Type[] dbTimeSpanArgs = [typeof(TimeSpan?)];
+            if (IsMethodOverridden(delegateType, nameof(StdAdoDelegate.GetDbDateTimeValue), dbDateTimeArgs, nonPublic: false)
+                || IsMethodOverridden(delegateType, nameof(StdAdoDelegate.GetDbTimeSpanValue), dbTimeSpanArgs, nonPublic: false))
+            {
+                Log.Warn($"Delegate type '{delegateType.FullName}' overrides the database date/time or time-span storage format. The preferred-node (node affinity) liveness check compares raw checkin values in SQL assuming the default tick storage, so SQL-level node affinity is disabled for this delegate. Keep the default storage format, or override the preferred-node acquisition SQL to match your format, to combine a custom storage format with node affinity.");
+                return true;
             }
 
             // A custom delegate can customize acquisition two ways: by overriding a public


### PR DESCRIPTION
Prepares the **v3.19.0** release: bumps the version placeholder and applies pre-release polish surfaced by a correctness/documentation review of everything merged since `v3.18.2`.

The tag is the version authority for a release; this PR is what the `v3.19.0` tag will be cut from once approved and merged.

## Version

* `src/Directory.Build.props`: `VersionPrefix` `3.18.2` → `3.19.0` (keeps post-release preview builds versioned `3.19.0-preview-*`).

## Polish from the pre-release review

* **Cap `CronExpressionBuilder.WithYearIncrements`** — it only rejected `increment < 1`, leaving the upper bound open. A value near `int.MaxValue` passed validation but overflowed the unchecked `i += incr` loop in `CronExpression.AddToSet`, silently producing a near-empty year set (e.g. `WithYearIncrements(2030, int.MaxValue)` fired the next second instead of in 2030). Now capped to the year span like every other field, with a regression assertion. Also fills the missing valid-range doc on `WithYears`. **Also needs to reach `main`** (identical bug there).
* **Harden node affinity against custom datetime storage formats** — the preferred-node liveness filter does its freshness arithmetic in SQL assuming the default tick storage of `LAST_CHECKIN_TIME` / `CHECKIN_INTERVAL`. A third-party delegate overriding `GetDbDateTimeValue` / `GetDbTimeSpanValue` could get a wrong liveness verdict. Extends the existing `DetectBypassedCustomAcquisitionOverride` guard to keep such delegates on the legacy acquisition path with a warning. No built-in delegate is affected (all use tick storage and short-circuit the check). Also drops a now-false "reserved instance id" comment left over from the auto-pin-column change (#3144).
* **`CLAUDE.md`** — build docs still referenced NUKE; updated for the Fallout migration (#3163).

## Review outcome

Four feature areas reviewed — `CronExpressionBuilder` (#3139), cron `L`/`LW`-with-other-days (#2759), node affinity + ADO SQL parity (#3013/#3144), misfire/cluster clock-jump clamp (#3147) + the Fallout/trusted-publishing release mechanics. **No release blockers.** SQL parity across all 8 database dialects, the `INextVersionDelegate` fallback for external delegates, and cron evaluation were all verified clean. The cron `L`/`LW` change intentionally fixes some previously-buggy schedules (`29W` no longer silently skips non-leap February; `L-30W` no longer throws; `1,15W` now applies `W` per-day) and adds `LW-n`/`L-nW` grammar — these will be called out in the release notes.

## Verification

* `dotnet build Quartz.slnx -c Release`: clean, 0 warnings / 0 errors.
* Unit tests (`net10.0`): 1517 passed, 0 failed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
