### PR TITLE
Cap CronExpressionBuilder year increment; warn on node-affinity storage mismatch

### DIFF
--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -149,6 +149,9 @@ public class CronExpressionBuilderTest
         Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 0)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 8)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithYearIncrements(2030, 0)).Should().Throw<ArgumentOutOfRangeException>();
+        // An unbounded year increment would overflow the "i += incr" loop in CronExpression.AddToSet
+        // and silently produce a wrong schedule; the builder must reject it up front like every other field.
+        Invoking(x => x.WithYearIncrements(2030, int.MaxValue)).Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Test]

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -487,7 +487,7 @@ public sealed class CronExpressionBuilder
     /// Set the year field to a list of values, e.g. "2030,2032". The values are
     /// emitted in the given order.
     /// </summary>
-    /// <param name="years">the years to fire on</param>
+    /// <param name="years">the years to fire on (each 1970 to circa 100 years from now)</param>
     /// <returns>the updated CronExpressionBuilder</returns>
     public CronExpressionBuilder WithYears(params int[] years)
     {
@@ -523,11 +523,10 @@ public sealed class CronExpressionBuilder
     public CronExpressionBuilder WithYearIncrements(int start, int increment)
     {
         ValidateYear(start, nameof(start));
-        if (increment < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(increment), "Invalid increment (must be >= 1).");
-        }
-
+        // Cap to the year span, as every other field caps to its own range. Without an upper
+        // bound an increment near int.MaxValue overflows the unchecked "i += incr" loop in
+        // CronExpression.AddToSet, silently producing a wrong (near-empty) year set.
+        ValidateIncrement(increment, MaxYear - TriggerConstants.EarliestYear);
         return SetYear($"{start}/{increment}");
     }
 

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -600,6 +600,17 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
 
         activityTracer.SetSchedulerContext(InstanceName, InstanceId);
 
+        // The preferred-node (node affinity) liveness check compares raw SCHEDULER_STATE checkin
+        // values in SQL, assuming the default tick / millisecond storage of LAST_CHECKIN_TIME and
+        // CHECKIN_INTERVAL. A clustered delegate that overrides how those values are stored
+        // (GetDbDateTimeValue / GetDbTimeSpanValue) would make that comparison meaningless, so a
+        // pinned trigger might not fail over correctly. Built-in delegates use the default storage
+        // and never trigger this warning.
+        if (Clustered && DelegateOverridesDateTimeStorage())
+        {
+            Logger.LogWarning("Delegate type '{DelegateType}' overrides the database date/time or time-span storage format. The preferred-node (node affinity) liveness check compares raw checkin values in SQL assuming the default tick storage, so a trigger pinned to a node may not fail over correctly. Keep the default storage format, or override the preferred-node acquisition SQL to match your format.", Delegate.GetType().FullName);
+        }
+
         if (PerformSchemaValidation && driverDelegate is StdAdoDelegate adoDelegate)
         {
             try
@@ -617,6 +628,30 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
             }
         }
 
+    }
+
+    // Whether a custom delegate overrides how date/time or time-span values are stored, which the
+    // preferred-node liveness SQL cannot account for. Built-in delegates live in this assembly and
+    // never match, so node affinity is never flagged for them.
+    private bool DelegateOverridesDateTimeStorage()
+    {
+        Type delegateType = Delegate.GetType();
+        if (delegateType.Assembly == typeof(StdAdoDelegate).Assembly)
+        {
+            return false;
+        }
+
+        return IsMethodOverridden(delegateType, nameof(StdAdoDelegate.GetDbDateTimeValue), [typeof(DateTimeOffset?)])
+               || IsMethodOverridden(delegateType, nameof(StdAdoDelegate.GetDbTimeSpanValue), [typeof(TimeSpan?)]);
+    }
+
+    private static bool IsMethodOverridden(Type delegateType, string name, Type[] parameterTypes)
+    {
+        var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public;
+        System.Reflection.MethodInfo? method = delegateType.GetMethod(name, flags, binder: null, parameterTypes, modifiers: null);
+        return method is not null
+               && method.DeclaringType is not null
+               && method.DeclaringType.Assembly != typeof(StdAdoDelegate).Assembly;
     }
 
     /// <seealso cref="IJobStore.SchedulerStarted(CancellationToken)" />


### PR DESCRIPTION
Companion to the 3.x release polish in #3169 — brings the two applicable fixes to `main`.

## 1. Cap `CronExpressionBuilder.WithYearIncrements` (bug, identical on both branches)

`WithYearIncrements` only rejected `increment < 1`, leaving the upper bound open. A value near `int.MaxValue` passed validation but overflowed the unchecked `i += incr` loop in `CronExpression.AddToSet`, silently producing a near-empty year set and a wrong schedule (e.g. `WithYearIncrements(2030, int.MaxValue)` fired the next second instead of in 2030). Caps it to the year span via `ValidateIncrement`, exactly as every other field does, plus the upper-bound regression assertion and the missing valid-range doc on `WithYears`. Byte-identical to the 3.x change (`MaxYear` is the branch-local alias).

## 2. Warn when a custom delegate's datetime storage breaks node affinity

The preferred-node (node affinity) liveness check compares raw `SCHEDULER_STATE` checkin values in SQL, assuming the default tick / millisecond storage of `LAST_CHECKIN_TIME` / `CHECKIN_INTERVAL`. A clustered delegate that overrides `GetDbDateTimeValue` / `GetDbTimeSpanValue` would make that comparison meaningless, so a pinned trigger might not fail over correctly.

On 3.x the `INextVersionDelegate` legacy/new acquisition split lets such a delegate be kept on a legacy path (#3169); 4.x has no legacy path to fall back to, so this logs a one-time startup warning instead. No built-in delegate is affected (all use the default tick storage and short-circuit the check).

## Verification

* `dotnet build` clean; `dotnet publish src/Quartz.Examples.Worker -c Release` (trim/AOT) clean.
* ADO / JobStore / CronExpressionBuilder unit tests: 135 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
