### PR TITLE
Fix npm security alerts and add regex timeout in build

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -46,7 +46,7 @@ partial class Build : FalloutBuild, ICompile, IPack
     AbsolutePath VersionPropsFile => RootDirectory / "Directory.Build.props";
 
     string PropsVersionPrefix =>
-        Regex.Match(VersionPropsFile.ReadAllText(), "<VersionPrefix>(.+)</VersionPrefix>").Groups[1].Value;
+        Regex.Match(VersionPropsFile.ReadAllText(), "<VersionPrefix>(.+)</VersionPrefix>", RegexOptions.None, TimeSpan.FromSeconds(5)).Groups[1].Value;
 
     static bool IsRunningOnWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5274,9 +5274,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -6065,9 +6065,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -6868,9 +6868,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -7946,9 +7946,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -8481,9 +8481,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8500,7 +8500,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10646,9 +10646,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
     "http-proxy-middleware": "^3.0.6",
     "js-yaml": "^4.3.0",
     "websocket-driver": "^0.7.5",
-    "body-parser": "^1.20.6"
+    "body-parser": "^1.20.6",
+    "postcss": "^8.5.18",
+    "fast-uri": "^3.1.4",
+    "svgo": "^4.0.2",
+    "linkify-it": "^5.0.2",
+    "immutable": "^5.1.8"
   }
 }


### PR DESCRIPTION
Clears the seven open Dependabot advisories in the VuePress docs dependency tree, plus one SonarCloud finding.

## npm advisories

All seven are transitive, so they are pinned through the existing `overrides` block. Each patched version falls inside its parents' declared ranges — drop-in bumps within the current major, no forced upgrades:

| Package | Was | Override | Advisory |
| --- | --- | --- | --- |
| `postcss` | 8.5.15 | `^8.5.18` | Path traversal in source-map auto-loading (`sourceMappingURL`) leaking arbitrary `.map` files |
| `fast-uri` | 3.1.2 | `^3.1.4` | Host confusion via literal backslash authority delimiter, and via failed IDN canonicalization (two alerts) |
| `svgo` | 4.0.1 | `^4.0.2` | `removeScripts` plugin leaves some executable scripts intact |
| `linkify-it` | 5.0.1 | `^5.0.2` | Quadratic-complexity DoS in the `mailto:` validator scan-loop |
| `immutable` | 5.1.5 | `^5.1.8` | Hash-collision DoS in `Map`/`Set`, and `List` 32-bit trie overflow (two alerts) |

## Regex timeout

`build/Build.cs` reads `<VersionPrefix>` out of `Directory.Build.props` with an untimed `Regex.Match` (SonarCloud `csharpsquid:S6444`). The input is our own props file, never attacker-controlled, so there is no real exposure — but a five second timeout costs nothing and clears the alert.

## Verification

- `npm install` → `found 0 vulnerabilities`, `patch-package` still applies `gray-matter@4.0.3` cleanly
- `npm run docs:build` → succeeds, renders 199 pages
- `dotnet build build/_build.csproj` → succeeds, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)