### PR TITLE
Start the scheduler thread from Start() rather than the constructor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -86,6 +86,14 @@
 
   * `DirectSchedulerFactory.CreateScheduler` must now be `await`ed
 
+  * **QuartzScheduler** no longer starts its scheduler thread from its constructor; the thread is started by
+    `Start()` instead (#3175). Constructing a scheduler — which the container now does — no longer has the
+    side effect of starting a thread, so resolving the service graph, running a `ValidateOnBuild` pass or
+    asserting on registrations no longer spins one up. The thread has always started paused and done no
+    work until `Start()`, so this changes when the thread exists, not when jobs run.
+
+  * The no-op **QuartzScheduler.Initialize()** method was removed. It did nothing and had no callers.
+
 #### Cron Parser
 
   * Add cron parser support for 'L' and 'LW' in expression combinations for daysOfMonth (#1939) (#1288)

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
@@ -23,6 +23,58 @@ public class QuartzSchedulerThreadTest
         });
     }
 
+    [Test]
+    public void Ctor_DoesNotStartTheLoop()
+    {
+        QuartzSchedulerResources resources = new QuartzSchedulerResources { IdleWaitTime = TimeSpan.FromSeconds(1) };
+        QuartzScheduler scheduler = new QuartzScheduler(resources);
+
+        var thread = new QuartzSchedulerThread(scheduler, resources);
+
+        thread.Running.Should().BeFalse();
+    }
+
+    [Test]
+    public void Start_IsIdempotent()
+    {
+        QuartzSchedulerResources resources = new QuartzSchedulerResources
+        {
+            IdleWaitTime = TimeSpan.FromSeconds(1),
+            JobStore = TestJobStores.Ram()
+        };
+        QuartzScheduler scheduler = new QuartzScheduler(resources);
+        var thread = new QuartzSchedulerThread(scheduler, resources);
+
+        thread.Start();
+        thread.Start();
+
+        thread.Running.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Halt_DoesNothingWhenTheLoopWasNeverStarted()
+    {
+        QuartzSchedulerResources resources = new QuartzSchedulerResources { IdleWaitTime = TimeSpan.FromSeconds(1) };
+        QuartzScheduler scheduler = new QuartzScheduler(resources);
+        var thread = new QuartzSchedulerThread(scheduler, resources);
+
+        await thread.Halt(wait: true);
+
+        thread.Halted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Shutdown_DoesNothingWhenTheLoopWasNeverStarted()
+    {
+        QuartzSchedulerResources resources = new QuartzSchedulerResources { IdleWaitTime = TimeSpan.FromSeconds(1) };
+        QuartzScheduler scheduler = new QuartzScheduler(resources);
+        var thread = new QuartzSchedulerThread(scheduler, resources);
+
+        await thread.Shutdown();
+
+        thread.Running.Should().BeFalse();
+    }
+
     private static IEnumerable<TimeSpan> ValidIdleWaitTimes()
     {
         return QuartzSchedulerResourcesTest.ValidIdleWaitTimes();

--- a/src/Quartz.Tests.Unit/Core/SchedulerConstructionTest.cs
+++ b/src/Quartz.Tests.Unit/Core/SchedulerConstructionTest.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Core;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// Constructing a scheduler must not start its thread. The container is what constructs it, so anything
+/// that merely resolves the graph — a diagnostic, a ValidateOnBuild pass, a test asserting on
+/// registrations — would otherwise spin one up as a side effect.
+/// </summary>
+[NonParallelizable]
+public class SchedulerConstructionTest
+{
+    [Test]
+    public void ResolvingTheSchedulerDoesNotStartItsThread()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz();
+
+        using var provider = services.BuildServiceProvider();
+
+        var scheduler = provider.GetRequiredService<QuartzScheduler>();
+
+        scheduler.schedThread.Running.Should().BeFalse("resolving a scheduler must not start a thread");
+    }
+
+    [Test]
+    public void ValidatingTheContainerDoesNotStartASchedulerThread()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        provider.GetRequiredService<QuartzScheduler>().schedThread.Running.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task StartingTheSchedulerStartsItsThread()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz();
+
+        using var provider = services.BuildServiceProvider();
+
+        var scheduler = provider.GetRequiredService<QuartzScheduler>();
+        await scheduler.Start();
+
+        try
+        {
+            scheduler.schedThread.Running.Should().BeTrue();
+            scheduler.schedThread.Paused.Should().BeFalse();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task ShuttingDownASchedulerThatWasNeverStartedDoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz();
+
+        using var provider = services.BuildServiceProvider();
+
+        var scheduler = provider.GetRequiredService<QuartzScheduler>();
+
+        // Halt and Shutdown used to dereference state that only Start created.
+        await scheduler.Shutdown(waitForJobsToComplete: false);
+
+        scheduler.IsShutdown.Should().BeTrue();
+    }
+}

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -254,8 +254,9 @@ public sealed class QuartzScheduler
 
         logger = LogProvider.CreateLogger<QuartzScheduler>();
 
+        // The thread is created here but not started: constructing a scheduler must not have the side
+        // effect of starting a thread, since the container constructs it. Start does that instead.
         schedThread = new QuartzSchedulerThread(this, resources);
-        schedThread.Start();
 
         jobMgr = new ExecutingJobsManager();
         var errLogger = new ErrorLogger();
@@ -264,12 +265,6 @@ public sealed class QuartzScheduler
         SchedulerSignaler = new SchedulerSignalerImpl(this, schedThread);
 
         logger.LogInformation("Quartz Scheduler created");
-    }
-
-#pragma warning disable CA1822 // Mark members as static
-    public void Initialize()
-#pragma warning restore CA1822
-    {
     }
 
     /// <summary>
@@ -319,6 +314,8 @@ public sealed class QuartzScheduler
             await resources.JobStore.SchedulerResumed(cancellationToken).ConfigureAwait(false);
         }
 
+        // Idempotent, so restarting after Standby is fine.
+        schedThread.Start();
         schedThread.TogglePause(pause: false);
 
         logger.LogInformation("Scheduler {SchedulerIdentifier} started.", resources.GetUniqueIdentifier());

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -57,8 +57,12 @@ internal sealed class QuartzSchedulerThread
 
     private readonly ConcurrentDictionary<string, int> runningExecutionGroupCounts = new(StringComparer.Ordinal);
 
-    private CancellationTokenSource cancellationTokenSource = null!;
-    private Task task = null!;
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+
+    /// <summary>
+    /// The processing loop, or <see langword="null" /> until <see cref="Start" /> has been called.
+    /// </summary>
+    private Task? task;
 
     private const int PausedWaitCheckIntervalMs = 1000;
 
@@ -86,6 +90,14 @@ internal sealed class QuartzSchedulerThread
     internal bool Halted => halted;
 
     /// <summary>
+    /// Gets a value indicating whether the processing loop has been started.
+    /// </summary>
+    /// <value>
+    /// <see langword="true"/> once <see cref="Start"/> has been called; otherwise, <see langword="false"/>.
+    /// </value>
+    internal bool Running => task is not null;
+
+    /// <summary>
     /// Gets the maximum number of milliseconds to subtract from <see cref="QuartzSchedulerResources.IdleWaitTime"/>
     /// to randomize how long the scheduler should wait before checking again when there is no current trigger to
     /// fire.
@@ -110,9 +122,8 @@ internal sealed class QuartzSchedulerThread
         this.qsRsrcs = qsRsrcs;
         idleWaitVariableness = (int) (qsRsrcs.IdleWaitTime.TotalMilliseconds * 0.2);
 
-        // start the underlying thread, but put this object into the 'paused'
-        // state
-        // so processing doesn't start yet...
+        // Construction does not start the loop; QuartzScheduler.Start does. Until then this object is
+        // in the 'paused' state so that processing does not begin even once it is started.
         paused = true;
         halted = false;
     }
@@ -160,7 +171,8 @@ internal sealed class QuartzSchedulerThread
 
         await cancellationTokenSource.CancelAsync().ConfigureAwait(false);
 
-        if (wait)
+        // There is nothing to wait for when the loop was never started.
+        if (wait && task is not null)
         {
             try
             {
@@ -728,9 +740,16 @@ internal sealed class QuartzSchedulerThread
         }
     }
 
+    /// <summary>
+    /// Starts the processing loop. Does nothing if it is already running.
+    /// </summary>
     public void Start()
     {
-        cancellationTokenSource = new CancellationTokenSource();
+        if (task is not null)
+        {
+            return;
+        }
+
         task = Task.Factory.StartNew(
             static state => ((QuartzSchedulerThread) state!).Run(),
             this,
@@ -743,6 +762,13 @@ internal sealed class QuartzSchedulerThread
     public async Task Shutdown()
     {
         cancellationTokenSource.Cancel();
+
+        // Nothing to wait for when the loop was never started.
+        if (task is null)
+        {
+            return;
+        }
+
         try
         {
             await task.ConfigureAwait(false);

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -759,22 +759,27 @@ internal sealed class QuartzSchedulerThread
         ).Unwrap();
     }
 
+    /// <summary>
+    /// Stops the processing loop and releases its resources. Terminal: the loop cannot be started again
+    /// afterwards, which matches the scheduler not being restartable after shutdown.
+    /// </summary>
     public async Task Shutdown()
     {
         cancellationTokenSource.Cancel();
 
         // Nothing to wait for when the loop was never started.
-        if (task is null)
+        if (task is not null)
         {
-            return;
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
         }
 
-        try
-        {
-            await task.ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-        }
+        // Disposed only here, once the loop has been awaited and can no longer read the token.
+        cancellationTokenSource.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

`QuartzScheduler` no longer starts its scheduler thread as a constructor side effect.

## Details

`QuartzScheduler`'s constructor created the scheduler thread and started it. Now that the container constructs the scheduler, resolving `QuartzScheduler` started a thread as a side effect, so anything that merely resolves the graph — a diagnostic, a `ValidateOnBuild` pass, a test asserting on registrations — spun one up.

The thread is still *constructed* in the constructor: it is an implementation detail of the scheduler rather than a service, and injecting it would reintroduce a cycle. Only the `Start()` call moves.

**The part worth reviewing closely:** `QuartzSchedulerThread` was not safe against never having been started. `cancellationTokenSource` and `task` were both `null!` until `Start()` assigned them, so `Halt()` and `Shutdown()` would have thrown a `NullReferenceException` on a scheduler that was resolved but never started — and since `QuartzScheduler.Shutdown()` calls `Halt()`, `closed` would never have been set and the job store and plugins would never have been shut down. So:

- the cancellation token source is created in the constructor and lives for the object's lifetime, which keeps `Run()`'s eight usages non-nullable;
- `task` is nullable, and both `Halt()` and `Shutdown()` no-op on it when the loop was never started;
- `Start()` is idempotent, so restarting after `Standby()` (which goes through `Start()` again) does not leak a second task.

The thread has always started paused and done no work until `Start()`, so this changes when the thread exists, not when jobs run.

Also removes the no-op `QuartzScheduler.Initialize()`, which did nothing and had no callers.

## Linked issue

Fixes #3175

## Test plan

- [x] Added or updated unit tests
- [x] Ran `dotnet build Quartz.slnx` (0 warnings, 0 errors) and `dotnet test src/Quartz.Tests.Unit` — 1569 passed, 4 skipped, 0 failed
- [ ] Ran integration tests (Docker not available in this environment; the solution build proves `Quartz.Tests.Integration` compiles)
- [x] Manually verified the change

New tests: `SchedulerConstructionTest` asserts that resolving the scheduler — including under `ValidateOnBuild`/`ValidateScopes` — leaves the thread unstarted, that `Start()` starts it, and that `Shutdown()` on a never-started scheduler completes and sets `IsShutdown`. `QuartzSchedulerThreadTest` gains cases for construction not starting the loop, `Start()` idempotency, and `Halt`/`Shutdown` on a never-started loop.

## Breaking change?

Yes, mildly. The public no-op `QuartzScheduler.Initialize()` is removed. The thread-start timing change is behavioural rather than API — code that constructed a `QuartzScheduler` and relied on the thread existing before `Start()` would notice, but the thread was paused and idle in that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf4PASA1HNgF8dEuaWNi9S