### PR TITLE
Register custom JSON serializers per scheduler instead of in statics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -133,6 +133,22 @@
     instead of reaching for a static. The same applies to data sources: a provider registered with one `IDbConnectionManager`
     is not visible to another. `StdSchedulerFactory.GetSchedulerRepository()` remains as an override point but now returns the
     repository of the factory's own container, and the unused `StdSchedulerFactory.GetDbConnectionManager()` seam was removed.
+  * Custom JSON trigger and calendar serializers are no longer registered in process-global static state (#3173).
+    `SystemTextJsonObjectSerializer.AddTriggerSerializer`, `SystemTextJsonObjectSerializer.AddCalendarSerializer` and the
+    `NewtonsoftJsonObjectSerializer` equivalents have been **removed**. They wrote into static dictionaries inside the JSON
+    converters, so every scheduler in the process shared one set of custom serializers and registration order silently decided
+    which one won. Register through the store builder callback instead — `store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<T>(...))`
+    or `store.UseNewtonsoftJsonSerializer(json => ...)` — which is unchanged and now genuinely per-scheduler. Serializers built
+    by hand take a `SystemTextJsonSerializerRegistry` / `NewtonsoftJsonSerializerRegistry` constructor argument; both registries
+    are seeded with the built-in trigger and calendar types, and the parameterless serializer constructors still work and use
+    just those built-ins.
+
+  * Because the maps are now per-serializer, the parts of Quartz that serialize triggers without belonging to any one scheduler —
+    the HTTP API (`AddHttpApi`), the dashboard and `Quartz.HttpClient` — read a container-wide `SystemTextJsonSerializerRegistry`
+    rather than seeing whatever a scheduler happened to register. Register the registry as a singleton
+    (`services.AddSingleton(new SystemTextJsonSerializerRegistry().AddTriggerSerializer<T>(...))`) to make a custom serializer
+    visible to them. `HttpScheduler`'s constructor gained an optional `serializerRegistry` parameter, and
+    `InProcessQuartzApiClient`'s constructor now takes a `SystemTextJsonSerializerRegistry`.
 
 #### Cron Parser
 

--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -137,6 +137,7 @@ export const sidebarEn: SidebarConfig = [
                 children: [
                   "/documentation/quartz-4.x/packages/dashboard",
                   "/documentation/quartz-4.x/packages/quartz-jobs",
+                  "/documentation/quartz-4.x/packages/system-text-json",
                   "/documentation/quartz-4.x/packages/json-serialization",
                   "/documentation/quartz-4.x/packages/quartz-plugins",
                 ],

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -346,6 +346,50 @@ q.UseNewtonsoftJsonSerializer();
 
 Remove the old `Quartz.Serialization.Json` package reference.
 
+### Custom trigger and calendar serializers are no longer static
+
+The static registration methods have been removed, because they wrote into process-global dictionaries: two
+schedulers in one process could not have different custom serializers, and registration order silently
+decided which one won.
+
+```csharp
+// 3.x
+SystemTextJsonObjectSerializer.AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer());
+NewtonsoftJsonObjectSerializer.AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer());
+
+// 4.x — register through the store builder; what the callback registers belongs to that scheduler alone
+q.UsePersistentStore(store => store.UseSystemTextJsonSerializer(json =>
+{
+    json.AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer());
+    json.AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer());
+}));
+```
+
+If you construct a serializer yourself, pass it a registry instead:
+
+```csharp
+var registry = new SystemTextJsonSerializerRegistry()
+    .AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer());
+
+var serializer = new SystemTextJsonObjectSerializer(registry);
+serializer.Initialize();
+```
+
+The registries start out knowing every built-in trigger and calendar type, so a custom registration adds to
+that set. The parameterless serializer constructors still exist and use the built-ins only.
+
+One consequence worth checking: the HTTP API, the dashboard and `Quartz.HttpClient` also serialize triggers,
+and none of them belongs to a single scheduler, so they no longer inherit a scheduler's custom serializers
+for free. They read a container-wide registry — register it as a singleton to make a custom serializer
+visible there:
+
+```csharp
+services.AddSingleton(new SystemTextJsonSerializerRegistry()
+    .AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer()));
+```
+
+See [Serialization (System.Text.Json)](packages/system-text-json) for the full picture.
+
 ## Sealed and Internalized Types
 
 Many types have been sealed and/or internalized to minimize the API surface that needs to be maintained. If you were extending a type that is now sealed or internal, file an issue to request it be reopened.

--- a/docs/documentation/quartz-4.x/packages/json-serialization.md
+++ b/docs/documentation/quartz-4.x/packages/json-serialization.md
@@ -9,7 +9,8 @@ You should also strongly consider setting useProperties to true to restrict key-
 :::
 
 ::: tip
-System.Text.Json serialization is built into the `Quartz` package; see [Serialization](../configuration/reference#serialization).
+System.Text.Json serialization is built into the `Quartz` package and is the default; see
+[Serialization (System.Text.Json)](system-text-json).
 :::
 
 ## JSON.NET
@@ -228,7 +229,25 @@ config.UsePersistentStore(store =>
         json.AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer());
     });
 });
+```
 
-// or just globally which is what above code calls
-NewtonsoftJsonObjectSerializer.AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer());
+::: warning Changed in 4.0
+`NewtonsoftJsonObjectSerializer.AddCalendarSerializer` and `AddTriggerSerializer` were static in 3.x, so
+every scheduler in the process shared one set of custom serializers and registration order silently
+decided which one won. They have been removed. Register through the `UseNewtonsoftJsonSerializer`
+callback as above: what the callback registers belongs to that scheduler alone, so two schedulers in one
+container can serialize different custom types.
+:::
+
+If you build a serializer yourself rather than through the store builder, hand it a
+`NewtonsoftJsonSerializerRegistry`. A new registry already knows every built-in trigger and calendar type,
+so registering a custom one adds to that set:
+
+```csharp
+var registry = new NewtonsoftJsonSerializerRegistry()
+    .AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer())
+    .AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer());
+
+var serializer = new NewtonsoftJsonObjectSerializer(registry);
+serializer.Initialize();
 ```

--- a/docs/documentation/quartz-4.x/packages/system-text-json.md
+++ b/docs/documentation/quartz-4.x/packages/system-text-json.md
@@ -1,0 +1,208 @@
+---
+
+title : Serialization (System.Text.Json)
+---
+
+::: tip
+JSON is the recommended persistent format to store data in a database for greenfield projects.
+You should also strongly consider setting `UseProperties` to true to restrict key-values to be strings.
+:::
+
+System.Text.Json serialization is built into the `Quartz` package - there is no separate
+`Quartz.Serialization.SystemTextJson` package to reference any more, and it is the serializer a
+persistent store gets when nothing else is configured.
+
+## Configuring
+
+**Code-first configuration**
+
+```csharp
+services.AddQuartz(q =>
+{
+    q.UsePersistentStore(store =>
+    {
+        store.UseSqlServer("my connection string");
+
+        // it's generally recommended to stick with
+        // string property keys and values when serializing
+        store.Configure(options => options.UseProperties = true);
+
+        store.UseSystemTextJsonSerializer();
+    });
+});
+```
+
+**Classic property-based configuration**
+
+```csharp
+var properties = new NameValueCollection
+{
+ ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.JobStoreTX, Quartz",
+ ["quartz.serializer.type"] = "stj"
+};
+ISchedulerFactory schedulerFactory = new StdSchedulerFactory(properties);
+```
+
+## Migrating from binary serialization
+
+Quartz 4 no longer ships the `BinaryObjectSerializer`. See
+[JSON Serialization](json-serialization#migrating-from-binary-serialization) for the migration recipe;
+it applies to System.Text.Json the same way.
+
+## Customizing serialization options
+
+If you need to customize serialization, inherit a custom implementation and override
+`CreateSerializerOptions`.
+
+```csharp
+class CustomJsonSerializer : SystemTextJsonObjectSerializer
+{
+    // Declaring this constructor is what lets the container hand the serializer the registered custom
+    // trigger and calendar serializers; without it only the built-in types are known.
+    public CustomJsonSerializer(SystemTextJsonSerializerRegistry registry) : base(registry)
+    {
+    }
+
+    protected override JsonSerializerOptions CreateSerializerOptions()
+    {
+        var options = base.CreateSerializerOptions();
+        options.Converters.Add(new MyCustomConverter());
+        return options;
+    }
+}
+```
+
+**And then configure it to use**
+
+```csharp
+store.UseSerializer<CustomJsonSerializer>();
+// or
+"quartz.serializer.type" = "MyProject.CustomJsonSerializer, MyProject"
+```
+
+The registry the serializer was built with is available to the subclass through the protected `Registry`
+property.
+
+## Customizing calendar serialization
+
+If you have implemented a custom calendar, you need to implement an `ICalendarSerializer` for it.
+There's a convenience base class `CalendarSerializer` that gives you a strongly-typed experience.
+
+**Custom calendar and serializer**
+
+```csharp
+using System.Text.Json;
+
+using Quartz.Impl.Calendar;
+using Quartz.Serialization.Json.Calendars;
+
+public sealed class CustomCalendar : BaseCalendar
+{
+    public bool SomeCustomProperty { get; set; } = true;
+}
+
+// JSON serialization support
+public sealed class CustomCalendarSerializer : CalendarSerializer<CustomCalendar>
+{
+    public override string CalendarTypeName => "CustomCalendar";
+
+    protected override CustomCalendar Create(JsonElement jsonElement, JsonSerializerOptions options)
+    {
+        return new CustomCalendar();
+    }
+
+    protected override void SerializeFields(Utf8JsonWriter writer, CustomCalendar calendar, JsonSerializerOptions options)
+    {
+        writer.WriteBoolean("SomeCustomProperty", calendar.SomeCustomProperty);
+    }
+
+    protected override void DeserializeFields(CustomCalendar calendar, JsonElement jsonElement, JsonSerializerOptions options)
+    {
+        calendar.SomeCustomProperty = jsonElement.GetProperty("SomeCustomProperty").GetBoolean();
+    }
+}
+```
+
+## Customizing trigger serialization
+
+A custom trigger type works the same way, through `TriggerSerializer` from
+`Quartz.Serialization.Json.Triggers`. Without a serializer a custom trigger is persisted as a reflected
+blob, which can be read back only by the exact same type.
+
+## Registering custom serializers
+
+Both kinds are registered through the `UseSystemTextJsonSerializer` callback:
+
+```csharp
+services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer("my connection string");
+    store.UseSystemTextJsonSerializer(json =>
+    {
+        json.AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer());
+        json.AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer());
+    });
+}));
+```
+
+::: warning Changed in 4.0
+`SystemTextJsonObjectSerializer.AddCalendarSerializer` and `AddTriggerSerializer` were static in 3.x, so
+every scheduler in the process shared one set of custom serializers and registration order silently
+decided which one won. They have been removed - use the callback above.
+:::
+
+**What the callback registers belongs to that scheduler alone.** This is the point of the change: two
+schedulers in one container can now serialize different custom types.
+
+```csharp
+services.AddQuartz("reporting", q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer(reportingDb);
+    store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<ReportTrigger>(new ReportTriggerSerializer()));
+}));
+
+services.AddQuartz("ingest", q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer(ingestDb);
+    store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<IngestTrigger>(new IngestTriggerSerializer()));
+}));
+```
+
+### Making custom serializers visible outside the job store
+
+Serializing a trigger is not something only the job store does: the [HTTP API](http-api),
+the [dashboard](dashboard) and `Quartz.HttpClient` all serialize triggers too, and none of them belongs to
+a single scheduler. They read the container-wide registry instead, so a serializer that only one
+scheduler's callback knows about is invisible to them. Register it on the container to make it visible
+everywhere:
+
+```csharp
+services.AddSingleton(new SystemTextJsonSerializerRegistry()
+    .AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer())
+    .AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer()));
+
+services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer("my connection string");
+    // no callback: the store's serializer reads the container's registry, so the same custom
+    // serializers apply to the job store, the HTTP API and the dashboard
+    store.UseSystemTextJsonSerializer();
+}));
+```
+
+`SystemTextJsonSerializerRegistry` lives in the `Quartz.Serialization.Json` namespace. It always starts
+out knowing every built-in trigger and calendar type, so registering a custom one adds to that set rather
+than replacing it. Both `Add*` methods return the registry, so registrations chain.
+
+A single scheduler can also be given its own registry directly, which is the same thing the callback does
+under the hood:
+
+```csharp
+services.AddKeyedSingleton("reporting", new SystemTextJsonSerializerRegistry()
+    .AddTriggerSerializer<ReportTrigger>(new ReportTriggerSerializer()));
+```
+
+`Quartz.HttpClient` resolves the container's registry when the scheduler is registered with
+`AddQuartzHttpClient`; when a `HttpScheduler` is constructed by hand, pass one to its `serializerRegistry`
+parameter. A remote scheduler's own registrations cannot be discovered over HTTP, so custom types are only
+readable if this process knows their serializers.

--- a/src/Quartz.AspNetCore/AspNetCore/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/QuartzServiceCollectionExtensions.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -11,6 +9,7 @@ using Quartz.AspNetCore.HealthChecks;
 using Quartz.AspNetCore.HttpApi;
 using Quartz.AspNetCore.HttpApi.Endpoints;
 using Quartz.AspNetCore.HttpApi.Util;
+using Quartz.Serialization.Json;
 
 namespace Quartz.AspNetCore;
 
@@ -58,19 +57,21 @@ public static class QuartzServiceCollectionExtensions
         configurator.Services.TryAddSingleton<ExceptionHandler>();
         configurator.Services.TryAddSingleton<EndpointHelper>();
 
+        // The HTTP API serves every scheduler in the container through one set of endpoints, so it cannot
+        // read any single scheduler's serializers. It reads the container's registry instead: register a
+        // custom trigger or calendar serializer there to have the API understand it.
+        configurator.Services.TryAddSingleton<SystemTextJsonSerializerRegistry>();
+
         // Add json converters into ASP.NET Core's default json options
-        configurator.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(options => AddJsonConverters(options.SerializerOptions));
+        configurator.Services
+            .AddOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>()
+            .Configure<SystemTextJsonSerializerRegistry>(AddJsonConverters);
 
         return configurator;
 
-        static void AddJsonConverters(JsonSerializerOptions? options)
+        static void AddJsonConverters(Microsoft.AspNetCore.Http.Json.JsonOptions options, SystemTextJsonSerializerRegistry registry)
         {
-            if (options is null)
-            {
-                return;
-            }
-
-            options.AddQuartzConverters(newtonsoftCompatibilityMode: false);
+            options.SerializerOptions?.AddQuartzConverters(registry, newtonsoftCompatibilityMode: false);
         }
     }
 

--- a/src/Quartz.Dashboard/Components/Shared/DisplayValueHelper.cs
+++ b/src/Quartz.Dashboard/Components/Shared/DisplayValueHelper.cs
@@ -21,12 +21,25 @@ using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 
+using Quartz.Serialization.Json;
+
 namespace Quartz.Dashboard.Components.Shared;
 
 internal static class DisplayValueHelper
 {
+    /// <summary>
+    /// Options for reading a <see cref="JobDataMap"/> out of an already-serialized payload.
+    /// </summary>
+    /// <remarks>
+    /// The built-in registry is enough here, and deliberately so: this is the only thing these options
+    /// deserialize, and a job data map is read by <c>JobDataMapConverter</c> without ever consulting the
+    /// trigger or calendar converters. A custom trigger or calendar serializer registered in the
+    /// container therefore has nothing to contribute — the places that do need it
+    /// (<c>InProcessQuartzApiClient</c> and the HTTP API) resolve the container's registry instead.
+    /// </remarks>
     private static readonly JsonSerializerOptions JobDataMapOptions =
-        new JsonSerializerOptions(JsonSerializerDefaults.Web).AddQuartzConverters(newtonsoftCompatibilityMode: false);
+        new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            .AddQuartzConverters(new SystemTextJsonSerializerRegistry(), newtonsoftCompatibilityMode: false);
 
     public static object? GetObject(object? source, params string[] paths)
     {

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Options;
 
 using Quartz.Dashboard.Plugins;
 using Quartz.Dashboard.Services;
+using Quartz.Serialization.Json;
 using Quartz.Util;
 
 namespace Quartz;
@@ -58,6 +59,11 @@ public static class QuartzDashboardServiceCollectionExtensions
         services.AddSignalR();
         services.AddHttpContextAccessor();
         services.AddHttpClient("QuartzDashboard");
+
+        // The dashboard renders every scheduler in the container, so it cannot read any single scheduler's
+        // serializers; register a custom trigger or calendar serializer here to have the dashboard
+        // understand it.
+        services.TryAddSingleton<SystemTextJsonSerializerRegistry>();
 
         services.TryAddScoped<IQuartzApiClient, InProcessQuartzApiClient>();
         services.TryAddScoped<SchedulerState>();

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -22,6 +22,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Options;
 
 using Quartz.Impl.Matchers;
+using Quartz.Serialization.Json;
 using Quartz.Spi;
 
 namespace Quartz.Dashboard.Services;
@@ -33,20 +34,28 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         WriteIndented = false,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
-    private static readonly JsonSerializerOptions deserializerOptions = CreateDeserializerOptions();
+    private readonly JsonSerializerOptions deserializerOptions;
 
     private readonly ISchedulerRepository schedulerRepository;
     private readonly IOptions<QuartzDashboardOptions> options;
     private readonly IDashboardHistoryStore historyStore;
 
+    /// <remarks>
+    /// The dashboard shows every scheduler in the container through one client, so it reads the
+    /// container's <see cref="SystemTextJsonSerializerRegistry"/> rather than any single scheduler's — a
+    /// custom trigger or calendar serializer registered there is what makes a custom type render as
+    /// something other than a reflected blob.
+    /// </remarks>
     public InProcessQuartzApiClient(
         ISchedulerRepository schedulerRepository,
         IOptions<QuartzDashboardOptions> options,
-        IDashboardHistoryStore historyStore)
+        IDashboardHistoryStore historyStore,
+        SystemTextJsonSerializerRegistry serializerRegistry)
     {
         this.schedulerRepository = schedulerRepository;
         this.options = options;
         this.historyStore = historyStore;
+        deserializerOptions = CreateDeserializerOptions(serializerRegistry);
     }
 
     public ValueTask<List<SchedulerHeaderDto>> GetSchedulers()
@@ -406,14 +415,14 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         return ValueTask.FromResult<JobHistoryPageDto?>(new JobHistoryPageDto(JsonSerializer.SerializeToElement(payload, serializerOptions)));
     }
 
-    private static JsonSerializerOptions CreateDeserializerOptions()
+    private static JsonSerializerOptions CreateDeserializerOptions(SystemTextJsonSerializerRegistry serializerRegistry)
     {
         JsonSerializerOptions options = new(JsonSerializerDefaults.Web);
-        options.AddQuartzConverters(newtonsoftCompatibilityMode: false);
+        options.AddQuartzConverters(serializerRegistry, newtonsoftCompatibilityMode: false);
         return options;
     }
 
-    private static JsonElement SerializeTrigger(ITrigger trigger)
+    private JsonElement SerializeTrigger(ITrigger trigger)
     {
         try
         {
@@ -456,7 +465,7 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         }
     }
 
-    private static JobDataMap DeserializeJobDataMap(JsonElement element)
+    private JobDataMap DeserializeJobDataMap(JsonElement element)
     {
         if (element.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
         {
@@ -467,7 +476,7 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         return dataMap ?? new JobDataMap();
     }
 
-    private static ITrigger DeserializeTrigger(JsonElement element)
+    private ITrigger DeserializeTrigger(JsonElement element)
     {
         ITrigger? trigger = element.Deserialize<ITrigger>(deserializerOptions);
         if (trigger is null)
@@ -478,7 +487,7 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         return trigger;
     }
 
-    private static ICalendar DeserializeCalendar(JsonElement element)
+    private ICalendar DeserializeCalendar(JsonElement element)
     {
         ICalendar? calendar = element.Deserialize<ICalendar>(deserializerOptions);
         if (calendar is null)
@@ -489,7 +498,7 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         return calendar;
     }
 
-    private static IJobDetail BuildJobDetail(JobDetailDto source)
+    private IJobDetail BuildJobDetail(JobDetailDto source)
     {
         Type? jobType = Type.GetType(source.JobType, throwOnError: false);
         if (jobType is null)

--- a/src/Quartz.HttpClient/HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpClient/HttpScheduler.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 
 using Quartz.HttpApiContract;
 using Quartz.Impl.Matchers;
+using Quartz.Serialization.Json;
 using Quartz.Spi;
 
 namespace Quartz.HttpClient;
@@ -11,7 +12,19 @@ public class HttpScheduler : IScheduler
     private readonly System.Net.Http.HttpClient httpClient;
     private readonly JsonSerializerOptions jsonSerializerOptions;
 
-    public HttpScheduler(string schedulerName, System.Net.Http.HttpClient httpClient, JsonSerializerOptions? jsonSerializerOptions = null)
+    /// <param name="schedulerName">Name of the scheduler, must be same as the remote scheduler.</param>
+    /// <param name="httpClient">The client to call the remote scheduler with.</param>
+    /// <param name="jsonSerializerOptions">Optional serializer options; Quartz's own converters are added to them.</param>
+    /// <param name="serializerRegistry">
+    /// The trigger and calendar serializers to understand. Custom types are only readable over HTTP when
+    /// their serializers are given here — the remote scheduler's own registrations are not visible in this
+    /// process. Defaults to the built-in types.
+    /// </param>
+    public HttpScheduler(
+        string schedulerName,
+        System.Net.Http.HttpClient httpClient,
+        JsonSerializerOptions? jsonSerializerOptions = null,
+        SystemTextJsonSerializerRegistry? serializerRegistry = null)
     {
         if (string.IsNullOrWhiteSpace(schedulerName))
         {
@@ -27,7 +40,9 @@ public class HttpScheduler : IScheduler
         }
 
         this.jsonSerializerOptions = jsonSerializerOptions ?? new JsonSerializerOptions(JsonSerializerDefaults.Web);
-        this.jsonSerializerOptions.AddQuartzConverters(newtonsoftCompatibilityMode: false);
+        this.jsonSerializerOptions.AddQuartzConverters(
+            serializerRegistry ?? new SystemTextJsonSerializerRegistry(),
+            newtonsoftCompatibilityMode: false);
     }
 
     public string SchedulerName { get; }

--- a/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
+++ b/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Quartz.Configuration;
 using Quartz.HttpClient;
+using Quartz.Serialization.Json;
 using Quartz.Simpl;
 using Quartz.Spi;
 
@@ -121,10 +122,19 @@ public static class QuartzHttpClientServiceCollectionExtensions
         // and a scheduler registered in one would be invisible in the other.
         services.AddQuartzSharedServices();
 
+        // A remote scheduler's custom trigger and calendar serializers cannot be discovered over HTTP, so
+        // the client reads the container's registry — register a custom serializer there to be able to
+        // read custom types from the remote scheduler.
+        services.TryAddSingleton<SystemTextJsonSerializerRegistry>();
+
         services.AddSingleton<TScheduler>(serviceProvider =>
         {
             var httpClient = options.HttpClient ?? serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(options.HttpClientName!);
-            IScheduler scheduler = new HttpScheduler(options.SchedulerName, httpClient, options.JsonSerializerOptions);
+            IScheduler scheduler = new HttpScheduler(
+                options.SchedulerName,
+                httpClient,
+                options.JsonSerializerOptions,
+                serviceProvider.GetRequiredService<SystemTextJsonSerializerRegistry>());
 
             if (typeof(TScheduler) != typeof(IScheduler))
             {

--- a/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
+++ b/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
@@ -120,12 +120,10 @@ public static class QuartzHttpClientServiceCollectionExtensions
         // The repository the remote scheduler binds itself into is the container's, registered in exactly
         // one place. Creating one here would give a container that also calls AddQuartz two repositories,
         // and a scheduler registered in one would be invisible in the other.
+        // This also registers the container-wide serializer registry the client reads below. A remote
+        // scheduler's custom trigger and calendar serializers cannot be discovered over HTTP, so register
+        // a custom serializer there to be able to read custom types from the remote scheduler.
         services.AddQuartzSharedServices();
-
-        // A remote scheduler's custom trigger and calendar serializers cannot be discovered over HTTP, so
-        // the client reads the container's registry — register a custom serializer there to be able to
-        // read custom types from the remote scheduler.
-        services.TryAddSingleton<SystemTextJsonSerializerRegistry>();
 
         services.AddSingleton<TScheduler>(serviceProvider =>
         {

--- a/src/Quartz.Serialization.Newtonsoft/Converters/CalendarConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/CalendarConverter.cs
@@ -1,36 +1,14 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-using Quartz.Calendars;
 using Quartz.Impl.Calendar;
 using Quartz.Serialization.Newtonsoft;
 using Quartz.Util;
 
 namespace Quartz.Converters;
 
-internal sealed class CalendarConverter : JsonConverter
+internal sealed class CalendarConverter(NewtonsoftJsonSerializerRegistry registry) : JsonConverter
 {
-    private static readonly Dictionary<string, ICalendarSerializer> converters = new()
-    {
-        {typeof(BaseCalendar).AssemblyQualifiedNameWithoutVersion(), new BaseCalendarSerializer()},
-        {typeof(AnnualCalendar).AssemblyQualifiedNameWithoutVersion(), new AnnualCalendarSerializer()},
-        {typeof(CronCalendar).AssemblyQualifiedNameWithoutVersion(), new CronCalendarSerializer()},
-        {typeof(DailyCalendar).AssemblyQualifiedNameWithoutVersion(), new DailyCalendarSerializer()},
-        {typeof(HolidayCalendar).AssemblyQualifiedNameWithoutVersion(), new HolidayCalendarSerializer()},
-        {typeof(MonthlyCalendar).AssemblyQualifiedNameWithoutVersion(), new MonthlyCalendarSerializer()},
-        {typeof(WeeklyCalendar).AssemblyQualifiedNameWithoutVersion(), new WeeklyCalendarSerializer()}
-    };
-
-    private static ICalendarSerializer GetCalendarConverter(string typeName)
-    {
-        if (!converters.TryGetValue(typeName, out var converter))
-        {
-            throw new ArgumentException($"don't know how to handle {typeName}", nameof(typeName));
-        }
-
-        return converter;
-    }
-
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         if (value is not ICalendar calendar)
@@ -63,7 +41,7 @@ internal sealed class CalendarConverter : JsonConverter
             }
         }
 
-        GetCalendarConverter(type).SerializeFields(writer, calendar);
+        registry.GetCalendarSerializer(type).SerializeFields(writer, calendar);
 
         writer.WriteEndObject();
     }
@@ -73,7 +51,7 @@ internal sealed class CalendarConverter : JsonConverter
         JObject jObject = JObject.Load(reader);
         string type = jObject["$type"]!.Value<string>()!;
 
-        var calendarConverter = GetCalendarConverter(type);
+        var calendarConverter = registry.GetCalendarSerializer(type);
         ICalendar calendar = calendarConverter.Create(jObject);
         if (calendar is BaseCalendar target)
         {
@@ -94,10 +72,5 @@ internal sealed class CalendarConverter : JsonConverter
     public override bool CanConvert(Type objectType)
     {
         return typeof(ICalendar).IsAssignableFrom(objectType);
-    }
-
-    internal static void AddCalendarConverter<TCalendar>(ICalendarSerializer serializer)
-    {
-        converters[typeof(TCalendar).AssemblyQualifiedNameWithoutVersion()] = serializer;
     }
 }

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
@@ -1,26 +1,14 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-using Quartz.Impl.Triggers;
+using Quartz.Serialization.Newtonsoft;
 using Quartz.Spi;
-using Quartz.Triggers;
 using Quartz.Util;
 
 namespace Quartz.Converters;
 
-internal sealed class TriggerConverter : JsonConverter
+internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry) : JsonConverter
 {
-    private static readonly Dictionary<string, ITriggerSerializer> converters = new(StringComparer.OrdinalIgnoreCase);
-
-    static TriggerConverter()
-    {
-        AddTriggerSerializer<CalendarIntervalTriggerImpl>(new CalendarIntervalTriggerSerializer());
-        AddTriggerSerializer<CronTriggerImpl>(new CronTriggerSerializer());
-        AddTriggerSerializer<DailyTimeIntervalTriggerImpl>(new DailyTimeIntervalTriggerSerializer());
-        AddTriggerSerializer<SimpleTriggerImpl>(new SimpleTriggerSerializer());
-        AddTriggerSerializer<RecurrenceTriggerImpl>(new RecurrenceTriggerSerializer());
-    }
-
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         try
@@ -29,7 +17,7 @@ internal sealed class TriggerConverter : JsonConverter
 
             writer.WriteStartObject();
             var type = value!.GetType().AssemblyQualifiedNameWithoutVersion();
-            var triggerSerializer = GetTriggerSerializer(type);
+            var triggerSerializer = registry.GetTriggerSerializer(type);
 
             writer.WritePropertyName("TriggerType");
             writer.WriteValue(triggerSerializer.TriggerTypeForJson);
@@ -86,7 +74,7 @@ internal sealed class TriggerConverter : JsonConverter
             var source = JObject.Load(reader);
             var type = source["TriggerType"]!.Value<string>()!;
 
-            var triggerSerializer = GetTriggerSerializer(type);
+            var triggerSerializer = registry.GetTriggerSerializer(type);
             var scheduleBuilder = triggerSerializer.CreateScheduleBuilder(source);
 
             var key = source.GetTriggerKey("Key");
@@ -147,22 +135,4 @@ internal sealed class TriggerConverter : JsonConverter
     }
 
     public override bool CanConvert(Type objectType) => typeof(ITrigger).IsAssignableFrom(objectType);
-
-    private static ITriggerSerializer GetTriggerSerializer(string? typeName)
-    {
-        if (string.IsNullOrWhiteSpace(typeName) || !converters.TryGetValue(typeName!, out var converter))
-        {
-            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
-        }
-
-        return converter;
-    }
-
-    public static void AddTriggerSerializer<TTrigger>(ITriggerSerializer serializer) where TTrigger : ITrigger
-    {
-        converters[serializer.TriggerTypeForJson] = serializer;
-
-        // Support also type name
-        converters[typeof(TTrigger).AssemblyQualifiedNameWithoutVersion()] = serializer;
-    }
 }

--- a/src/Quartz.Serialization.Newtonsoft/JsonConfigurationExtensions.cs
+++ b/src/Quartz.Serialization.Newtonsoft/JsonConfigurationExtensions.cs
@@ -1,8 +1,6 @@
 using Quartz.Serialization.Newtonsoft;
-using Microsoft.Extensions.DependencyInjection;
 
 using Quartz.Simpl;
-using Quartz.Spi;
 using Quartz.Triggers;
 
 namespace Quartz;
@@ -12,6 +10,12 @@ public static class JsonConfigurationExtensions
     /// <summary>
     /// Use Newtonsoft JSON as data serialization strategy.
     /// </summary>
+    /// <param name="builder">The persistent store being configured.</param>
+    /// <param name="configure">
+    /// Optional serializer settings and registration of serializers for custom trigger and calendar
+    /// types. What the callback registers belongs to this scheduler alone — it is not shared with any
+    /// other scheduler in the process.
+    /// </param>
     public static IPersistentStoreBuilder UseNewtonsoftJsonSerializer(
         this IPersistentStoreBuilder builder,
         Action<NewtonsoftJsonSerializerOptions>? configure = null)
@@ -20,7 +24,13 @@ public static class JsonConfigurationExtensions
 
         var options = new NewtonsoftJsonSerializerOptions();
         configure?.Invoke(options);
-        var serializer = new NewtonsoftJsonObjectSerializer { RegisterTriggerConverters = options.RegisterTriggerConverters };
+
+        // The registry the callback filled is captured here rather than published to the container, which
+        // is what keeps two schedulers in one container from sharing each other's custom serializers.
+        var serializer = new NewtonsoftJsonObjectSerializer(options.Registry)
+        {
+            RegisterTriggerConverters = options.RegisterTriggerConverters
+        };
         serializer.Initialize();
         return builder.UseSerializer(_ => serializer);
     }
@@ -36,11 +46,16 @@ public class NewtonsoftJsonSerializerOptions
     public bool RegisterTriggerConverters { get; set; }
 
     /// <summary>
+    /// The serializers registered so far, seeded with the built-in trigger and calendar types.
+    /// </summary>
+    internal NewtonsoftJsonSerializerRegistry Registry { get; } = new();
+
+    /// <summary>
     /// Add serializer for custom trigger
     /// </summary>
     public NewtonsoftJsonSerializerOptions AddTriggerSerializer<TTrigger>(ITriggerSerializer serializer) where TTrigger : ITrigger
     {
-        NewtonsoftJsonObjectSerializer.AddTriggerSerializer<TTrigger>(serializer);
+        Registry.AddTriggerSerializer<TTrigger>(serializer);
         return this;
     }
 
@@ -49,7 +64,7 @@ public class NewtonsoftJsonSerializerOptions
     /// </summary>
     public NewtonsoftJsonSerializerOptions AddCalendarSerializer<TCalendar>(ICalendarSerializer serializer)
     {
-        NewtonsoftJsonObjectSerializer.AddCalendarSerializer<TCalendar>(serializer);
+        Registry.AddCalendarSerializer<TCalendar>(serializer);
         return this;
     }
 }

--- a/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonSerializerRegistry.cs
+++ b/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonSerializerRegistry.cs
@@ -1,0 +1,101 @@
+using Quartz.Calendars;
+using Quartz.Impl.Calendar;
+using Quartz.Impl.Triggers;
+using Quartz.Triggers;
+using Quartz.Util;
+
+namespace Quartz.Serialization.Newtonsoft;
+
+/// <summary>
+/// The trigger and calendar serializers a <see cref="Quartz.Simpl.NewtonsoftJsonObjectSerializer"/>
+/// knows about.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A new instance already knows every trigger and calendar type Quartz ships with, so registering a
+/// custom one adds to that set rather than replacing it.
+/// </para>
+/// <para>
+/// These registrations used to live in process-global dictionaries inside the converters, which meant
+/// two schedulers in one process could not serialize different custom types — whichever registered last
+/// won, silently. Owning them per instance is what makes the choice belong to the scheduler that made it.
+/// Registrations are expected to be complete before the owning serializer is initialized; the maps are
+/// not synchronized for concurrent writes, exactly as the statics they replace were not.
+/// </para>
+/// <para>
+/// The lookup rules deliberately match what the Newtonsoft converters have always done, which is not
+/// quite what the System.Text.Json ones do: a calendar is found by its assembly-qualified type name
+/// only, case-sensitively, because <see cref="ICalendarSerializer"/> here carries no calendar type name
+/// of its own.
+/// </para>
+/// </remarks>
+public sealed class NewtonsoftJsonSerializerRegistry
+{
+    private readonly Dictionary<string, ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, ICalendarSerializer> calendarSerializers = new();
+
+    /// <summary>
+    /// Creates a registry holding the serializers for the built-in trigger and calendar types.
+    /// </summary>
+    public NewtonsoftJsonSerializerRegistry()
+    {
+        AddTriggerSerializer<CalendarIntervalTriggerImpl>(new CalendarIntervalTriggerSerializer());
+        AddTriggerSerializer<CronTriggerImpl>(new CronTriggerSerializer());
+        AddTriggerSerializer<DailyTimeIntervalTriggerImpl>(new DailyTimeIntervalTriggerSerializer());
+        AddTriggerSerializer<SimpleTriggerImpl>(new SimpleTriggerSerializer());
+        AddTriggerSerializer<RecurrenceTriggerImpl>(new RecurrenceTriggerSerializer());
+
+        AddCalendarSerializer<BaseCalendar>(new BaseCalendarSerializer());
+        AddCalendarSerializer<AnnualCalendar>(new AnnualCalendarSerializer());
+        AddCalendarSerializer<CronCalendar>(new CronCalendarSerializer());
+        AddCalendarSerializer<DailyCalendar>(new DailyCalendarSerializer());
+        AddCalendarSerializer<HolidayCalendar>(new HolidayCalendarSerializer());
+        AddCalendarSerializer<MonthlyCalendar>(new MonthlyCalendarSerializer());
+        AddCalendarSerializer<WeeklyCalendar>(new WeeklyCalendarSerializer());
+    }
+
+    /// <summary>
+    /// Adds a serializer for a custom trigger type.
+    /// </summary>
+    public NewtonsoftJsonSerializerRegistry AddTriggerSerializer<TTrigger>(ITriggerSerializer serializer) where TTrigger : ITrigger
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+
+        triggerSerializers[serializer.TriggerTypeForJson] = serializer;
+
+        // Support also type name
+        triggerSerializers[typeof(TTrigger).AssemblyQualifiedNameWithoutVersion()] = serializer;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a serializer for a custom calendar type.
+    /// </summary>
+    public NewtonsoftJsonSerializerRegistry AddCalendarSerializer<TCalendar>(ICalendarSerializer serializer)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+
+        calendarSerializers[typeof(TCalendar).AssemblyQualifiedNameWithoutVersion()] = serializer;
+        return this;
+    }
+
+    internal ITriggerSerializer GetTriggerSerializer(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName) || !triggerSerializers.TryGetValue(typeName!, out var converter))
+        {
+            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
+        }
+
+        return converter;
+    }
+
+    internal ICalendarSerializer GetCalendarSerializer(string typeName)
+    {
+        if (!calendarSerializers.TryGetValue(typeName, out var converter))
+        {
+            throw new ArgumentException($"don't know how to handle {typeName}", nameof(typeName));
+        }
+
+        return converter;
+    }
+}

--- a/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonSerializerRegistry.cs
+++ b/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonSerializerRegistry.cs
@@ -31,8 +31,8 @@ namespace Quartz.Serialization.Newtonsoft;
 /// </remarks>
 public sealed class NewtonsoftJsonSerializerRegistry
 {
-    private readonly Dictionary<string, ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, ICalendarSerializer> calendarSerializers = new();
+    private readonly SerializerMap<ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SerializerMap<ICalendarSerializer> calendarSerializers = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Creates a registry holding the serializers for the built-in trigger and calendar types.
@@ -61,10 +61,8 @@ public sealed class NewtonsoftJsonSerializerRegistry
     {
         ArgumentNullException.ThrowIfNull(serializer);
 
-        triggerSerializers[serializer.TriggerTypeForJson] = serializer;
-
-        // Support also type name
-        triggerSerializers[typeof(TTrigger).AssemblyQualifiedNameWithoutVersion()] = serializer;
+        // Found by its JSON discriminator, and also by its type name.
+        triggerSerializers.Add(serializer, serializer.TriggerTypeForJson, typeof(TTrigger).AssemblyQualifiedNameWithoutVersion());
         return this;
     }
 
@@ -75,27 +73,19 @@ public sealed class NewtonsoftJsonSerializerRegistry
     {
         ArgumentNullException.ThrowIfNull(serializer);
 
-        calendarSerializers[typeof(TCalendar).AssemblyQualifiedNameWithoutVersion()] = serializer;
+        // One name only, and matched case-sensitively, because ICalendarSerializer here carries no
+        // calendar type name of its own — see the remarks above.
+        calendarSerializers.Add(serializer, typeof(TCalendar).AssemblyQualifiedNameWithoutVersion());
         return this;
     }
 
     internal ITriggerSerializer GetTriggerSerializer(string? typeName)
     {
-        if (string.IsNullOrWhiteSpace(typeName) || !triggerSerializers.TryGetValue(typeName!, out var converter))
-        {
-            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
-        }
-
-        return converter;
+        return triggerSerializers.Get(typeName, "Don't know how to handle");
     }
 
     internal ICalendarSerializer GetCalendarSerializer(string typeName)
     {
-        if (!calendarSerializers.TryGetValue(typeName, out var converter))
-        {
-            throw new ArgumentException($"don't know how to handle {typeName}", nameof(typeName));
-        }
-
-        return converter;
+        return calendarSerializers.Get(typeName, "don't know how to handle");
     }
 }

--- a/src/Quartz.Serialization.Newtonsoft/Simpl/NewtonsoftJsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Simpl/NewtonsoftJsonObjectSerializer.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json.Serialization;
 using Quartz.Converters;
 using Quartz.Serialization.Newtonsoft;
 using Quartz.Spi;
-using Quartz.Triggers;
 
 namespace Quartz.Simpl;
 
@@ -17,6 +16,29 @@ namespace Quartz.Simpl;
 public class NewtonsoftJsonObjectSerializer : IObjectSerializer
 {
     private JsonSerializer serializer = null!;
+
+    /// <summary>
+    /// Creates a serializer that knows the built-in trigger and calendar types only.
+    /// </summary>
+    public NewtonsoftJsonObjectSerializer()
+        : this(new NewtonsoftJsonSerializerRegistry())
+    {
+    }
+
+    /// <summary>
+    /// Creates a serializer that resolves trigger and calendar serializers through the given registry,
+    /// so a scheduler's custom types are known to its own serializer and to no other.
+    /// </summary>
+    public NewtonsoftJsonObjectSerializer(NewtonsoftJsonSerializerRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        Registry = registry;
+    }
+
+    /// <summary>
+    /// The trigger and calendar serializers this serializer's converters resolve through.
+    /// </summary>
+    protected NewtonsoftJsonSerializerRegistry Registry { get; }
 
     public void Initialize()
     {
@@ -34,7 +56,7 @@ public class NewtonsoftJsonObjectSerializer : IObjectSerializer
                 new NameValueCollectionConverter(),
                 new StringKeyDirtyFlagMapConverter(),
                 new CronExpressionConverter(),
-                new CalendarConverter()
+                new CalendarConverter(Registry)
             },
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             TypeNameHandling = TypeNameHandling.Auto,
@@ -48,7 +70,7 @@ public class NewtonsoftJsonObjectSerializer : IObjectSerializer
 
         if (RegisterTriggerConverters)
         {
-            settings.Converters.Add(new TriggerConverter());
+            settings.Converters.Add(new TriggerConverter(Registry));
         }
 
         return settings;
@@ -97,15 +119,5 @@ public class NewtonsoftJsonObjectSerializer : IObjectSerializer
             string json = Encoding.UTF8.GetString(data);
             throw new JsonSerializationException($"Could not deserialize JSON: {json}", e);
         }
-    }
-
-    public static void AddCalendarSerializer<TCalendar>(ICalendarSerializer serializer)
-    {
-        CalendarConverter.AddCalendarConverter<TCalendar>(serializer);
-    }
-
-    public static void AddTriggerSerializer<TTrigger>(ITriggerSerializer serializer) where TTrigger : ITrigger
-    {
-        TriggerConverter.AddTriggerSerializer<TTrigger>(serializer);
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -9,6 +9,7 @@ using Quartz.Dashboard.Services;
 using Quartz.Impl;
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
+using Quartz.Serialization.Json;
 
 namespace Quartz.Tests.AspNetCore.Dashboard;
 
@@ -237,7 +238,8 @@ public class InProcessQuartzApiClientTest
         return new InProcessQuartzApiClient(
             repository,
             Options.Create(new QuartzDashboardOptions()),
-            new DashboardHistoryStore());
+            new DashboardHistoryStore(),
+            new SystemTextJsonSerializerRegistry());
     }
 
     private sealed class NoOpJob : IJob

--- a/src/Quartz.Tests.Integration/AdoSchedulerTest.cs
+++ b/src/Quartz.Tests.Integration/AdoSchedulerTest.cs
@@ -16,11 +16,11 @@ public class AdoSchedulerTest : AbstractSchedulerTest
 {
     private readonly IObjectSerializer serializer;
 
-    static AdoSchedulerTest()
-    {
-        SystemTextJsonObjectSerializer.AddTriggerSerializer<TestBlobCronTriggerImpl>(new TestBlobCronTriggerImpl.SystemTextJsonSerializer());
-    }
-
+    // No custom trigger serializer is registered for TestBlobCronTriggerImpl: the scheduler under test is
+    // built by SchedulerHelper.CreateScheduler, which uses the Newtonsoft serializer without the optimized
+    // trigger converters, so an unknown trigger type is persisted as a reflected blob and never reaches a
+    // trigger serializer at all. The registration this fixture used to make went into a process-global
+    // System.Text.Json map that the scheduler under test never read.
     public AdoSchedulerTest(Type serializerType, string provider) : base(provider, serializerType.Name)
     {
         serializer = (IObjectSerializer) Activator.CreateInstance(serializerType);

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
@@ -224,9 +224,10 @@ public class MisfireBatchRecoveryTest
 
     private async Task<TestJobStoreTX> CreateJobStore(int maxMisfiresToHandleAtATime = 20)
     {
-        NewtonsoftJsonObjectSerializer.AddTriggerSerializer<CustomTrigger>(new CustomNewtonsoftTriggerSerializer());
+        var registry = new NewtonsoftJsonSerializerRegistry()
+            .AddTriggerSerializer<CustomTrigger>(new CustomNewtonsoftTriggerSerializer());
 
-        var serializer = new NewtonsoftJsonObjectSerializer();
+        var serializer = new NewtonsoftJsonObjectSerializer(registry);
         serializer.Initialize();
 
         var jobStore = new TestJobStoreTX(serializer, dbProvider, new CountingSQLiteDelegate(), maxMisfiresToHandleAtATime)

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Collections.Specialized;
+using System.Text.Json;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +10,9 @@ using Microsoft.Extensions.Options;
 using Quartz.Core;
 using Quartz.Impl.AdoJobStore;
 using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Impl.Triggers;
+using Quartz.Serialization.Json;
+using Quartz.Serialization.Json.Triggers;
 using Quartz.Simpl;
 using Quartz.Spi;
 
@@ -233,6 +237,97 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         provider.GetRequiredKeyedService<IObjectSerializer>("a").Should().BeOfType<SystemTextJsonObjectSerializer>();
         provider.GetRequiredKeyedService<IObjectSerializer>("b").Should().BeOfType<CountingObjectSerializer>(
             "reading a database written with one serializer using another fails at the first trigger fire");
+    }
+
+    [Test]
+    public void EachNamedSchedulerKeepsItsOwnCustomTriggerSerializers()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz("a", q => q.UsePersistentStore(store =>
+        {
+            store.Configure(options => options.DataSource = "test");
+            store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<TriggerKnownToA>(new TriggerKnownToASerializer()));
+            RegisterStubProvider(store.Services, q.SchedulerName);
+        }));
+        services.AddQuartz("b", q => q.UsePersistentStore(store =>
+        {
+            store.Configure(options => options.DataSource = "test");
+            store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<TriggerKnownToB>(new TriggerKnownToBSerializer()));
+            RegisterStubProvider(store.Services, q.SchedulerName);
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        var a = provider.GetRequiredKeyedService<IObjectSerializer>("a");
+        var b = provider.GetRequiredKeyedService<IObjectSerializer>("b");
+
+        a.Serialize<ITrigger>(NewTrigger<TriggerKnownToA>()).Should().NotBeEmpty();
+        b.Serialize<ITrigger>(NewTrigger<TriggerKnownToB>()).Should().NotBeEmpty();
+
+        // While the maps lived in statics both schedulers saw both registrations, so whichever scheduler
+        // was configured last decided what every scheduler in the process could write.
+        a.Invoking(x => x.Serialize<ITrigger>(NewTrigger<TriggerKnownToB>())).Should().Throw<JsonSerializationException>(
+            "a custom trigger serializer registered for one scheduler must not leak into another");
+        b.Invoking(x => x.Serialize<ITrigger>(NewTrigger<TriggerKnownToA>())).Should().Throw<JsonSerializationException>();
+
+        // The built-ins are still there in both, which is what makes registering a custom serializer an
+        // addition rather than a replacement.
+        a.Serialize<ITrigger>(NewTrigger<SimpleTriggerImpl>()).Should().NotBeEmpty();
+        b.Serialize<ITrigger>(NewTrigger<SimpleTriggerImpl>()).Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void AContainerRegisteredSerializerRegistryReachesTheDefaultSerializer()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new SystemTextJsonSerializerRegistry()
+            .AddTriggerSerializer<TriggerKnownToA>(new TriggerKnownToASerializer()));
+        services.AddQuartz(UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IObjectSerializer>()
+            .Serialize<ITrigger>(NewTrigger<TriggerKnownToA>()).Should().NotBeEmpty(
+                "nothing called UseSystemTextJsonSerializer, so the container's registry is the only place "
+                + "the default serializer can learn a custom trigger type from");
+    }
+
+    [Test]
+    public void AKeyedSerializerRegistryReachesOnlyItsOwnScheduler()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton("a", new SystemTextJsonSerializerRegistry()
+            .AddTriggerSerializer<TriggerKnownToA>(new TriggerKnownToASerializer()));
+        services.AddQuartz("a", UseStubbedPersistentStore);
+        services.AddQuartz("b", UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredKeyedService<IObjectSerializer>("a")
+            .Serialize<ITrigger>(NewTrigger<TriggerKnownToA>()).Should().NotBeEmpty();
+
+        provider.GetRequiredKeyedService<IObjectSerializer>("b")
+            .Invoking(x => x.Serialize<ITrigger>(NewTrigger<TriggerKnownToA>())).Should().Throw<JsonSerializationException>(
+                "a registry registered under one scheduler's key belongs to that scheduler, and the others "
+                + "keep reading the container's");
+    }
+
+    [Test]
+    public void AContainerRegisteredSerializerRegistryReachesAPropertyConfiguredSerializer()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new SystemTextJsonSerializerRegistry()
+            .AddTriggerSerializer<TriggerKnownToA>(new TriggerKnownToASerializer()));
+        services.AddQuartz(
+            new NameValueCollection { ["quartz.serializer.type"] = "stj" },
+            UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IObjectSerializer>()
+            .Serialize<ITrigger>(NewTrigger<TriggerKnownToA>()).Should().NotBeEmpty(
+                "a serializer named by quartz.serializer.type is built without any callback to register "
+                + "custom serializers through, so it has to be handed the container's registry");
     }
 
     [Test]
@@ -580,6 +675,52 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 
         public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default) => default;
+    }
+
+    private static TTrigger NewTrigger<TTrigger>() where TTrigger : SimpleTriggerImpl, new()
+    {
+        return new TTrigger
+        {
+            Key = new TriggerKey("trigger", "group"),
+            JobKey = new JobKey("job", "group"),
+            StartTimeUtc = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+    }
+
+    private sealed class TriggerKnownToA : SimpleTriggerImpl;
+
+    private sealed class TriggerKnownToB : SimpleTriggerImpl;
+
+    private sealed class TriggerKnownToASerializer : TriggerSerializer<TriggerKnownToA>
+    {
+        public override string TriggerTypeForJson => "KnownToA";
+
+        public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
+            => SimpleScheduleBuilder.Create();
+
+        protected override void SerializeFields(Utf8JsonWriter writer, TriggerKnownToA trigger, JsonSerializerOptions options)
+        {
+        }
+
+        protected override void DeserializeFields(TriggerKnownToA trigger, JsonElement jsonElement, JsonSerializerOptions options)
+        {
+        }
+    }
+
+    private sealed class TriggerKnownToBSerializer : TriggerSerializer<TriggerKnownToB>
+    {
+        public override string TriggerTypeForJson => "KnownToB";
+
+        public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
+            => SimpleScheduleBuilder.Create();
+
+        protected override void SerializeFields(Utf8JsonWriter writer, TriggerKnownToB trigger, JsonSerializerOptions options)
+        {
+        }
+
+        protected override void DeserializeFields(TriggerKnownToB trigger, JsonElement jsonElement, JsonSerializerOptions options)
+        {
+        }
     }
 
     private sealed class CountingObjectSerializer : IObjectSerializer

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -15,6 +15,8 @@ using Newtonsoft.Json.Linq;
 
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
+using Quartz.Serialization.Json;
+using Quartz.Serialization.Newtonsoft;
 using Quartz.Simpl;
 using Quartz.Spi;
 
@@ -22,7 +24,6 @@ using StjJsonSerializerOptions = System.Text.Json.JsonSerializerOptions;
 
 namespace Quartz.Tests.Unit.Simpl;
 
-[NonParallelizable]
 public class JsonObjectSerializerTest
 {
     private NewtonsoftJsonObjectSerializer newtonsoftSerializer;
@@ -31,16 +32,23 @@ public class JsonObjectSerializerTest
     [SetUp]
     public void SetUp()
     {
-        newtonsoftSerializer = new IndentingJsonObjectSerializer();
+        // Each serializer owns the serializers for the custom types it has to understand, so the
+        // registrations have to be complete before the serializer is built rather than reaching it
+        // afterwards through process-global state.
+        var newtonsoftRegistry = new NewtonsoftJsonSerializerRegistry()
+            .AddCalendarSerializer<JsonSerializationTestCalendar>(new JsonSerializationTestCalendar.NewtonsoftSerializer())
+            .AddTriggerSerializer<JsonSerializationTestTrigger>(new JsonSerializationTestTrigger.NewtonsoftSerializer());
+
+        newtonsoftSerializer = new IndentingJsonObjectSerializer(newtonsoftRegistry);
         newtonsoftSerializer.RegisterTriggerConverters = true;
         newtonsoftSerializer.Initialize();
-        NewtonsoftJsonObjectSerializer.AddCalendarSerializer<JsonSerializationTestCalendar>(new JsonSerializationTestCalendar.NewtonsoftSerializer());
-        NewtonsoftJsonObjectSerializer.AddTriggerSerializer<JsonSerializationTestTrigger>(new JsonSerializationTestTrigger.NewtonsoftSerializer());
 
-        systemTextJsonSerializer = new IndentingSystemTextJsonObjectSerializer();
+        var systemTextJsonRegistry = new SystemTextJsonSerializerRegistry()
+            .AddCalendarSerializer<JsonSerializationTestCalendar>(new JsonSerializationTestCalendar.SystemTextJsonSerializer())
+            .AddTriggerSerializer<JsonSerializationTestTrigger>(new JsonSerializationTestTrigger.SystemTextJsonSerializer());
+
+        systemTextJsonSerializer = new IndentingSystemTextJsonObjectSerializer(systemTextJsonRegistry);
         systemTextJsonSerializer.Initialize();
-        SystemTextJsonObjectSerializer.AddCalendarSerializer<JsonSerializationTestCalendar>(new JsonSerializationTestCalendar.SystemTextJsonSerializer());
-        SystemTextJsonObjectSerializer.AddTriggerSerializer<JsonSerializationTestTrigger>(new JsonSerializationTestTrigger.SystemTextJsonSerializer());
     }
 
     [Test]
@@ -556,7 +564,7 @@ public class JsonObjectSerializerTest
         field!.SetValue(trigger, timeProvider);
     }
 
-    private class IndentingJsonObjectSerializer : NewtonsoftJsonObjectSerializer
+    private class IndentingJsonObjectSerializer(NewtonsoftJsonSerializerRegistry registry) : NewtonsoftJsonObjectSerializer(registry)
     {
         protected override JsonSerializerSettings CreateSerializerSettings()
         {
@@ -566,7 +574,7 @@ public class JsonObjectSerializerTest
         }
     }
 
-    private class IndentingSystemTextJsonObjectSerializer : SystemTextJsonObjectSerializer
+    private class IndentingSystemTextJsonObjectSerializer(SystemTextJsonSerializerRegistry registry) : SystemTextJsonObjectSerializer(registry)
     {
         protected override StjJsonSerializerOptions CreateSerializerOptions()
         {

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -9,6 +9,7 @@ using Quartz.Core;
 using Quartz.Impl;
 using Quartz.Impl.AdoJobStore;
 using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Serialization.Json;
 using Quartz.Simpl;
 using Quartz.Spi;
 using Quartz.Util;
@@ -57,6 +58,13 @@ internal static class QuartzServiceRegistration
         // built the scheduler rather than by how it was built.
         services.TryAddSingleton<ISchedulerRepository, SchedulerRepository>();
         services.TryAddSingleton<IDbConnectionManager, DBConnectionManager>();
+
+        // The container-wide set of trigger and calendar serializers, holding the built-in types. This is
+        // what the parts of Quartz that are not tied to one scheduler read — the HTTP API, the dashboard
+        // and the HTTP client all serialize triggers without knowing which scheduler they came from — so
+        // a custom serializer that should be visible there is registered here rather than through one
+        // scheduler's UseSystemTextJsonSerializer callback.
+        services.TryAddSingleton<SystemTextJsonSerializerRegistry>();
 
         // The descriptions of the ADO.NET drivers Quartz ships, added last so that a driver described in
         // code or by quartz.dbprovider.* keys — both of which register earlier — wins over a built-in of
@@ -124,9 +132,20 @@ internal static class QuartzServiceRegistration
         services.TryAddKeyed<IDriverDelegate>(key, static (provider, key) =>
             ActivatorUtilities.CreateInstance<StdAdoDelegate>(Scoped(provider, key)));
 
+        // A named scheduler that was not given its own set of custom trigger and calendar serializers
+        // reads the container's. Registered keyed so an application can hand one scheduler a different
+        // set — services.AddKeyedSingleton(schedulerName, registry) — without affecting the others.
+        if (schedulerName is not null)
+        {
+            services.TryAddKeyedSingleton<SystemTextJsonSerializerRegistry>(
+                schedulerName,
+                static (provider, _) => provider.GetRequiredService<SystemTextJsonSerializerRegistry>());
+        }
+
         services.TryAddKeyed<IObjectSerializer>(key, static (provider, key) =>
         {
-            // A serializer is unusable until Initialize builds its converter set.
+            // A serializer is unusable until Initialize builds its converter set. Construction goes
+            // through ActivatorUtilities so this scheduler's SystemTextJsonSerializerRegistry is injected.
             var serializer = ActivatorUtilities.CreateInstance<SystemTextJsonObjectSerializer>(Scoped(provider, key));
             serializer.Initialize();
             return serializer;

--- a/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
+++ b/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
@@ -7,6 +7,7 @@ using Quartz.Core;
 using Quartz.Impl;
 using Quartz.Impl.AdoJobStore;
 using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Serialization.Json;
 using Quartz.Spi;
 
 namespace Quartz.Configuration;
@@ -42,6 +43,7 @@ internal sealed class SchedulerScopedServiceProvider
         typeof(IDriverDelegate),
         typeof(ISemaphore),
         typeof(IObjectSerializer),
+        typeof(SystemTextJsonSerializerRegistry),
         typeof(IThreadPool),
         typeof(IJobFactory),
         typeof(IJobRunShellFactory),

--- a/src/Quartz/JsonConfigurationExtensions.cs
+++ b/src/Quartz/JsonConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 
+using Quartz.Serialization.Json;
 using Quartz.Serialization.Json.Calendars;
 using Quartz.Serialization.Json.Converters;
 using Quartz.Serialization.Json.Triggers;
@@ -12,27 +13,52 @@ public static class JsonConfigurationExtensions
     /// <summary>
     /// Use System.Text.Json as data serialization strategy.
     /// </summary>
+    /// <param name="builder">The persistent store being configured.</param>
+    /// <param name="configure">
+    /// Optional registration of serializers for custom trigger and calendar types. What the callback
+    /// registers belongs to this scheduler alone — it is not shared with any other scheduler in the
+    /// process.
+    /// </param>
     public static IPersistentStoreBuilder UseSystemTextJsonSerializer(
         this IPersistentStoreBuilder builder,
         Action<SystemTextJsonSerializerOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        if (configure is null)
+        {
+            // Nothing scheduler-specific was asked for, so the serializer reads the container's registry
+            // — the same set the HTTP API and dashboard see.
+            return builder.UseSerializer<SystemTextJsonObjectSerializer>();
+        }
+
         var options = new SystemTextJsonSerializerOptions();
-        configure?.Invoke(options);
-        return builder.UseSerializer<SystemTextJsonObjectSerializer>();
+        configure(options);
+
+        // The registry the callback filled is captured here rather than published to the container, which
+        // is what keeps two schedulers in one container from sharing each other's custom serializers.
+        var registry = options.Registry;
+        return builder.UseSerializer(_ =>
+        {
+            var serializer = new SystemTextJsonObjectSerializer(registry);
+            serializer.Initialize();
+            return serializer;
+        });
     }
 
-    internal static JsonSerializerOptions AddQuartzConverters(this JsonSerializerOptions options, bool newtonsoftCompatibilityMode)
+    internal static JsonSerializerOptions AddQuartzConverters(
+        this JsonSerializerOptions options,
+        SystemTextJsonSerializerRegistry registry,
+        bool newtonsoftCompatibilityMode)
     {
-        options.Converters.Add(new CalendarConverter(newtonsoftCompatibilityMode));
+        options.Converters.Add(new CalendarConverter(registry, newtonsoftCompatibilityMode));
         options.Converters.Add(new CronExpressionConverter());
         options.Converters.Add(new DictionaryConverter());
         options.Converters.Add(new JobDataMapConverter());
         options.Converters.Add(new JobKeyConverter());
         options.Converters.Add(new TriggerKeyConverter());
         options.Converters.Add(new NameValueCollectionConverter());
-        options.Converters.Add(new TriggerConverter());
+        options.Converters.Add(new TriggerConverter(registry));
         return options;
     }
 }
@@ -40,11 +66,16 @@ public static class JsonConfigurationExtensions
 public class SystemTextJsonSerializerOptions
 {
     /// <summary>
+    /// The serializers registered so far, seeded with the built-in trigger and calendar types.
+    /// </summary>
+    internal SystemTextJsonSerializerRegistry Registry { get; } = new();
+
+    /// <summary>
     /// Add serializer for custom trigger
     /// </summary>
     public SystemTextJsonSerializerOptions AddTriggerSerializer<TTrigger>(ITriggerSerializer serializer) where TTrigger : ITrigger
     {
-        SystemTextJsonObjectSerializer.AddTriggerSerializer<TTrigger>(serializer);
+        Registry.AddTriggerSerializer<TTrigger>(serializer);
         return this;
     }
 
@@ -53,7 +84,7 @@ public class SystemTextJsonSerializerOptions
     /// </summary>
     public SystemTextJsonSerializerOptions AddCalendarSerializer<TCalendar>(ICalendarSerializer serializer) where TCalendar : ICalendar
     {
-        SystemTextJsonObjectSerializer.AddCalendarSerializer<TCalendar>(serializer);
+        Registry.AddCalendarSerializer<TCalendar>(serializer);
         return this;
     }
 }

--- a/src/Quartz/Serialization/Json/Converters/CalendarConverter.cs
+++ b/src/Quartz/Serialization/Json/Converters/CalendarConverter.cs
@@ -2,29 +2,18 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using Quartz.Impl.Calendar;
-using Quartz.Serialization.Json.Calendars;
 using Quartz.Util;
 
 namespace Quartz.Serialization.Json.Converters;
 
 internal sealed class CalendarConverter : JsonConverter<ICalendar>
 {
-    private static readonly Dictionary<string, ICalendarSerializer> converters = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SystemTextJsonSerializerRegistry registry;
     private readonly bool newtonsoftCompatibilityMode;
 
-    static CalendarConverter()
+    internal CalendarConverter(SystemTextJsonSerializerRegistry registry, bool newtonsoftCompatibilityMode)
     {
-        AddSerializer<BaseCalendar>(new BaseCalendarSerializer());
-        AddSerializer<AnnualCalendar>(new AnnualCalendarSerializer());
-        AddSerializer<CronCalendar>(new CronCalendarSerializer());
-        AddSerializer<DailyCalendar>(new DailyCalendarSerializer());
-        AddSerializer<HolidayCalendar>(new HolidayCalendarSerializer());
-        AddSerializer<MonthlyCalendar>(new MonthlyCalendarSerializer());
-        AddSerializer<WeeklyCalendar>(new WeeklyCalendarSerializer());
-    }
-
-    internal CalendarConverter(bool newtonsoftCompatibilityMode)
-    {
+        this.registry = registry;
         this.newtonsoftCompatibilityMode = newtonsoftCompatibilityMode;
     }
 
@@ -44,7 +33,7 @@ internal sealed class CalendarConverter : JsonConverter<ICalendar>
             {
                 var type = rootElement.GetProperty(newtonsoftCompatibilityMode ? "$type" : options.GetPropertyName("Type")).GetString();
 
-                var calendarSerializer = GetCalendarSerializer(type);
+                var calendarSerializer = registry.GetCalendarSerializer(type);
                 var calendar = calendarSerializer.Create(rootElement, options);
 
                 calendar.Description = rootElement.GetProperty(options.GetPropertyName("Description")).GetString();
@@ -75,7 +64,7 @@ internal sealed class CalendarConverter : JsonConverter<ICalendar>
         {
             writer.WriteStartObject();
             var type = value.GetType().AssemblyQualifiedNameWithoutVersion();
-            var calendarSerializer = GetCalendarSerializer(type);
+            var calendarSerializer = registry.GetCalendarSerializer(type);
 
             string typeProperty = newtonsoftCompatibilityMode ? "$type" : options.GetPropertyName("Type");
             string typeValue = newtonsoftCompatibilityMode ? type : calendarSerializer.CalendarTypeName;
@@ -105,21 +94,5 @@ internal sealed class CalendarConverter : JsonConverter<ICalendar>
         {
             throw new JsonSerializationException("Failed to serialize ICalendar to json", e);
         }
-    }
-
-    private static ICalendarSerializer GetCalendarSerializer(string? typeName)
-    {
-        if (typeName is null || !converters.TryGetValue(typeName, out ICalendarSerializer? converter))
-        {
-            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
-        }
-
-        return converter;
-    }
-
-    internal static void AddSerializer<TCalendar>(ICalendarSerializer serializer) where TCalendar : ICalendar
-    {
-        converters[typeof(TCalendar).AssemblyQualifiedNameWithoutVersion()] = serializer;
-        converters[serializer.CalendarTypeName] = serializer;
     }
 }

--- a/src/Quartz/Serialization/Json/Converters/TriggerConverter.cs
+++ b/src/Quartz/Serialization/Json/Converters/TriggerConverter.cs
@@ -1,26 +1,13 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-using Quartz.Impl.Triggers;
-using Quartz.Serialization.Json.Triggers;
 using Quartz.Spi;
 using Quartz.Util;
 
 namespace Quartz.Serialization.Json.Converters;
 
-internal sealed class TriggerConverter : JsonConverter<ITrigger>
+internal sealed class TriggerConverter(SystemTextJsonSerializerRegistry registry) : JsonConverter<ITrigger>
 {
-    private static readonly Dictionary<string, ITriggerSerializer> converters = new(StringComparer.OrdinalIgnoreCase);
-
-    static TriggerConverter()
-    {
-        AddTriggerSerializer<CalendarIntervalTriggerImpl>(new CalendarIntervalTriggerSerializer());
-        AddTriggerSerializer<CronTriggerImpl>(new CronTriggerSerializer());
-        AddTriggerSerializer<DailyTimeIntervalTriggerImpl>(new DailyTimeIntervalTriggerSerializer());
-        AddTriggerSerializer<SimpleTriggerImpl>(new SimpleTriggerSerializer());
-        AddTriggerSerializer<RecurrenceTriggerImpl>(new RecurrenceTriggerSerializer());
-    }
-
     public override bool CanConvert(Type typeToConvert) => typeof(ITrigger).IsAssignableFrom(typeToConvert);
 
     public override ITrigger Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -30,7 +17,7 @@ internal sealed class TriggerConverter : JsonConverter<ITrigger>
             var rootElement = JsonDocument.ParseValue(ref reader).RootElement;
             var type = rootElement.GetProperty(options.GetPropertyName("TriggerType")).GetString();
 
-            var triggerSerializer = GetTriggerSerializer(type);
+            var triggerSerializer = registry.GetTriggerSerializer(type);
             var scheduleBuilder = triggerSerializer.CreateScheduleBuilder(rootElement, options);
 
             var key = rootElement.GetProperty(options.GetPropertyName("Key")).GetTriggerKey(options);
@@ -96,7 +83,7 @@ internal sealed class TriggerConverter : JsonConverter<ITrigger>
         {
             writer.WriteStartObject();
             var type = value.GetType().AssemblyQualifiedNameWithoutVersion();
-            var triggerSerializer = GetTriggerSerializer(type);
+            var triggerSerializer = registry.GetTriggerSerializer(type);
 
             writer.WriteString(options.GetPropertyName("TriggerType"), triggerSerializer.TriggerTypeForJson);
 
@@ -125,23 +112,5 @@ internal sealed class TriggerConverter : JsonConverter<ITrigger>
         {
             throw new JsonSerializationException("Failed to serialize ITrigger to json", e);
         }
-    }
-
-    private static ITriggerSerializer GetTriggerSerializer(string? typeName)
-    {
-        if (string.IsNullOrWhiteSpace(typeName) || !converters.TryGetValue(typeName!, out var converter))
-        {
-            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
-        }
-
-        return converter;
-    }
-
-    public static void AddTriggerSerializer<TTrigger>(ITriggerSerializer serializer) where TTrigger : ITrigger
-    {
-        converters[serializer.TriggerTypeForJson] = serializer;
-
-        // Support also type name
-        converters[typeof(TTrigger).AssemblyQualifiedNameWithoutVersion()] = serializer;
     }
 }

--- a/src/Quartz/Serialization/Json/SystemTextJsonSerializerRegistry.cs
+++ b/src/Quartz/Serialization/Json/SystemTextJsonSerializerRegistry.cs
@@ -25,8 +25,8 @@ namespace Quartz.Serialization.Json;
 /// </remarks>
 public sealed class SystemTextJsonSerializerRegistry
 {
-    private readonly Dictionary<string, ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, ICalendarSerializer> calendarSerializers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SerializerMap<ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SerializerMap<ICalendarSerializer> calendarSerializers = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Creates a registry holding the serializers for the built-in trigger and calendar types.
@@ -55,10 +55,8 @@ public sealed class SystemTextJsonSerializerRegistry
     {
         ArgumentNullException.ThrowIfNull(serializer);
 
-        triggerSerializers[serializer.TriggerTypeForJson] = serializer;
-
-        // Support also type name
-        triggerSerializers[typeof(TTrigger).AssemblyQualifiedNameWithoutVersion()] = serializer;
+        // Found by its JSON discriminator, and also by its type name.
+        triggerSerializers.Add(serializer, serializer.TriggerTypeForJson, typeof(TTrigger).AssemblyQualifiedNameWithoutVersion());
         return this;
     }
 
@@ -69,28 +67,17 @@ public sealed class SystemTextJsonSerializerRegistry
     {
         ArgumentNullException.ThrowIfNull(serializer);
 
-        calendarSerializers[typeof(TCalendar).AssemblyQualifiedNameWithoutVersion()] = serializer;
-        calendarSerializers[serializer.CalendarTypeName] = serializer;
+        calendarSerializers.Add(serializer, typeof(TCalendar).AssemblyQualifiedNameWithoutVersion(), serializer.CalendarTypeName);
         return this;
     }
 
     internal ITriggerSerializer GetTriggerSerializer(string? typeName)
     {
-        if (string.IsNullOrWhiteSpace(typeName) || !triggerSerializers.TryGetValue(typeName!, out var converter))
-        {
-            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
-        }
-
-        return converter;
+        return triggerSerializers.Get(typeName, "Don't know how to handle");
     }
 
     internal ICalendarSerializer GetCalendarSerializer(string? typeName)
     {
-        if (typeName is null || !calendarSerializers.TryGetValue(typeName, out ICalendarSerializer? converter))
-        {
-            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
-        }
-
-        return converter;
+        return calendarSerializers.Get(typeName, "Don't know how to handle");
     }
 }

--- a/src/Quartz/Serialization/Json/SystemTextJsonSerializerRegistry.cs
+++ b/src/Quartz/Serialization/Json/SystemTextJsonSerializerRegistry.cs
@@ -1,0 +1,96 @@
+using Quartz.Impl.Calendar;
+using Quartz.Impl.Triggers;
+using Quartz.Serialization.Json.Calendars;
+using Quartz.Serialization.Json.Triggers;
+using Quartz.Util;
+
+namespace Quartz.Serialization.Json;
+
+/// <summary>
+/// The trigger and calendar serializers a <see cref="Quartz.Simpl.SystemTextJsonObjectSerializer"/>
+/// knows about.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A new instance already knows every trigger and calendar type Quartz ships with, so registering a
+/// custom one adds to that set rather than replacing it.
+/// </para>
+/// <para>
+/// These registrations used to live in process-global dictionaries inside the converters, which meant
+/// two schedulers in one process could not serialize different custom types — whichever registered last
+/// won, silently. Owning them per instance is what makes the choice belong to the scheduler that made it.
+/// Registrations are expected to be complete before the owning serializer is initialized; the maps are
+/// not synchronized for concurrent writes, exactly as the statics they replace were not.
+/// </para>
+/// </remarks>
+public sealed class SystemTextJsonSerializerRegistry
+{
+    private readonly Dictionary<string, ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, ICalendarSerializer> calendarSerializers = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Creates a registry holding the serializers for the built-in trigger and calendar types.
+    /// </summary>
+    public SystemTextJsonSerializerRegistry()
+    {
+        AddTriggerSerializer<CalendarIntervalTriggerImpl>(new CalendarIntervalTriggerSerializer());
+        AddTriggerSerializer<CronTriggerImpl>(new CronTriggerSerializer());
+        AddTriggerSerializer<DailyTimeIntervalTriggerImpl>(new DailyTimeIntervalTriggerSerializer());
+        AddTriggerSerializer<SimpleTriggerImpl>(new SimpleTriggerSerializer());
+        AddTriggerSerializer<RecurrenceTriggerImpl>(new RecurrenceTriggerSerializer());
+
+        AddCalendarSerializer<BaseCalendar>(new BaseCalendarSerializer());
+        AddCalendarSerializer<AnnualCalendar>(new AnnualCalendarSerializer());
+        AddCalendarSerializer<CronCalendar>(new CronCalendarSerializer());
+        AddCalendarSerializer<DailyCalendar>(new DailyCalendarSerializer());
+        AddCalendarSerializer<HolidayCalendar>(new HolidayCalendarSerializer());
+        AddCalendarSerializer<MonthlyCalendar>(new MonthlyCalendarSerializer());
+        AddCalendarSerializer<WeeklyCalendar>(new WeeklyCalendarSerializer());
+    }
+
+    /// <summary>
+    /// Adds a serializer for a custom trigger type.
+    /// </summary>
+    public SystemTextJsonSerializerRegistry AddTriggerSerializer<TTrigger>(ITriggerSerializer serializer) where TTrigger : ITrigger
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+
+        triggerSerializers[serializer.TriggerTypeForJson] = serializer;
+
+        // Support also type name
+        triggerSerializers[typeof(TTrigger).AssemblyQualifiedNameWithoutVersion()] = serializer;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a serializer for a custom calendar type.
+    /// </summary>
+    public SystemTextJsonSerializerRegistry AddCalendarSerializer<TCalendar>(ICalendarSerializer serializer) where TCalendar : ICalendar
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+
+        calendarSerializers[typeof(TCalendar).AssemblyQualifiedNameWithoutVersion()] = serializer;
+        calendarSerializers[serializer.CalendarTypeName] = serializer;
+        return this;
+    }
+
+    internal ITriggerSerializer GetTriggerSerializer(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName) || !triggerSerializers.TryGetValue(typeName!, out var converter))
+        {
+            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
+        }
+
+        return converter;
+    }
+
+    internal ICalendarSerializer GetCalendarSerializer(string? typeName)
+    {
+        if (typeName is null || !calendarSerializers.TryGetValue(typeName, out ICalendarSerializer? converter))
+        {
+            throw new ArgumentException($"Don't know how to handle {typeName}", nameof(typeName));
+        }
+
+        return converter;
+    }
+}

--- a/src/Quartz/Simpl/SystemTextJsonObjectSerializer.cs
+++ b/src/Quartz/Simpl/SystemTextJsonObjectSerializer.cs
@@ -1,9 +1,7 @@
 using System.Text;
 using System.Text.Json;
 
-using Quartz.Serialization.Json.Calendars;
-using Quartz.Serialization.Json.Converters;
-using Quartz.Serialization.Json.Triggers;
+using Quartz.Serialization.Json;
 using Quartz.Spi;
 
 namespace Quartz.Simpl;
@@ -16,6 +14,29 @@ public class SystemTextJsonObjectSerializer : IObjectSerializer
 {
     private JsonSerializerOptions options = null!;
 
+    /// <summary>
+    /// Creates a serializer that knows the built-in trigger and calendar types only.
+    /// </summary>
+    public SystemTextJsonObjectSerializer()
+        : this(new SystemTextJsonSerializerRegistry())
+    {
+    }
+
+    /// <summary>
+    /// Creates a serializer that resolves trigger and calendar serializers through the given registry,
+    /// so a scheduler's custom types are known to its own serializer and to no other.
+    /// </summary>
+    public SystemTextJsonObjectSerializer(SystemTextJsonSerializerRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        Registry = registry;
+    }
+
+    /// <summary>
+    /// The trigger and calendar serializers this serializer's converters resolve through.
+    /// </summary>
+    protected SystemTextJsonSerializerRegistry Registry { get; }
+
     public void Initialize()
     {
         options = CreateSerializerOptions();
@@ -23,7 +44,7 @@ public class SystemTextJsonObjectSerializer : IObjectSerializer
 
     protected virtual JsonSerializerOptions CreateSerializerOptions()
     {
-        return new JsonSerializerOptions().AddQuartzConverters(newtonsoftCompatibilityMode: true);
+        return new JsonSerializerOptions().AddQuartzConverters(Registry, newtonsoftCompatibilityMode: true);
     }
 
     /// <summary>
@@ -61,15 +82,5 @@ public class SystemTextJsonObjectSerializer : IObjectSerializer
             string json = Encoding.UTF8.GetString(data);
             throw new JsonSerializationException($"Could not deserialize JSON: {json}", e);
         }
-    }
-
-    public static void AddTriggerSerializer<TTrigger>(ITriggerSerializer serializer) where TTrigger : ITrigger
-    {
-        TriggerConverter.AddTriggerSerializer<TTrigger>(serializer);
-    }
-
-    public static void AddCalendarSerializer<TCalendar>(ICalendarSerializer serializer) where TCalendar : ICalendar
-    {
-        CalendarConverter.AddSerializer<TCalendar>(serializer);
     }
 }

--- a/src/Quartz/Util/SerializerMap.cs
+++ b/src/Quartz/Util/SerializerMap.cs
@@ -1,0 +1,49 @@
+namespace Quartz.Util;
+
+/// <summary>
+/// The serializers a JSON serializer knows about, keyed by every name its converters may look one up by.
+/// </summary>
+/// <remarks>
+/// Shared by the System.Text.Json and Newtonsoft serializer registries. Those two do not agree on how a
+/// serializer is found — how many names it answers to, and whether the names are matched case
+/// insensitively — so both are given to the constructor and to <see cref="Add"/> rather than assumed here.
+/// </remarks>
+/// <typeparam name="TSerializer">The serializer abstraction being kept, which differs per assembly.</typeparam>
+internal sealed class SerializerMap<TSerializer> where TSerializer : class
+{
+    private readonly Dictionary<string, TSerializer> serializers;
+
+    public SerializerMap(StringComparer comparer)
+    {
+        serializers = new Dictionary<string, TSerializer>(comparer);
+    }
+
+    /// <summary>
+    /// Registers a serializer under each of the given names, replacing any serializer already under them.
+    /// </summary>
+    public void Add(TSerializer serializer, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            serializers[name] = serializer;
+        }
+    }
+
+    /// <summary>
+    /// Returns the serializer registered for a type name, or throws when there is none.
+    /// </summary>
+    /// <param name="typeName">The name to look up, as it appears in the JSON being read.</param>
+    /// <param name="notFoundMessage">
+    /// The message prefix to throw with, which differs between the two registries only because their
+    /// converters have always worded it differently.
+    /// </param>
+    public TSerializer Get(string? typeName, string notFoundMessage)
+    {
+        if (string.IsNullOrWhiteSpace(typeName) || !serializers.TryGetValue(typeName, out var serializer))
+        {
+            throw new ArgumentException($"{notFoundMessage} {typeName}", nameof(typeName));
+        }
+
+        return serializer;
+    }
+}


### PR DESCRIPTION
## Summary

Custom trigger and calendar serializers belong to the scheduler that configured them, not to the process.

## Details

`SystemTextJsonSerializerOptions` held **zero state** — it was a façade over `SystemTextJsonObjectSerializer.AddTriggerSerializer`, which wrote into `TriggerConverter`'s `private static readonly Dictionary`. `UseSystemTextJsonSerializer` created the options object, invoked the callback purely for its static side effects, and threw the object away. `Quartz.Serialization.Newtonsoft` had the same shape. Two schedulers in one container each got their own job store, thread pool and options, but could not have different custom serializers — registration order decided who won, silently.

Each assembly now has a registry (`SystemTextJsonSerializerRegistry`, `NewtonsoftJsonSerializerRegistry`) seeded with the built-ins, and the converters take one by constructor instead of reading statics. The two assemblies' `ITriggerSerializer`/`ICalendarSerializer` pairs are disjoint types that merely share simple names, so there are deliberately two registries rather than a forced abstraction.

**Per-assembly key and comparer behaviour is preserved exactly**, because it was not uniform: the STJ trigger and calendar maps are two-keyed (discriminator + assembly-qualified name) and `OrdinalIgnoreCase`; the Newtonsoft trigger map likewise; but the Newtonsoft calendar map is single-keyed and case-**sensitive**, since its `ICalendarSerializer` has no `CalendarTypeName` member at all. Getting that wrong would change which JSON already in a database still deserializes.

All three registration paths now get a registry — the two that never go through `UseSystemTextJsonSerializer` were the easy ones to miss:

1. the builder callback, which closes over a registry built at configuration time;
2. the **default** registration, reached when nobody calls `UseSystemTextJsonSerializer` at all — the registry is registered container-wide plus keyed per named scheduler, so `ActivatorUtilities` injects it;
3. the **property-driven** path (`quartz.serializer.type`), which needed no source change because it already used `ActivatorUtilities.CreateInstance` — there is a test so that stays true by intent rather than by luck.

Both serializers keep a parameterless constructor defaulting to the built-ins, so the four `Activator.CreateInstance` sites in the tests are untouched, and `AdoJobStoreSmokeTest`'s use of the intended public shape compiles unchanged.

The registries are `public` rather than `internal sealed`: the property-driven path resolves an arbitrary serializer type through `ActivatorUtilities`, so the registry has to be a public constructor parameter of the public serializer types.

### Four call sites that used to inherit custom serializers for free

Once the maps are per-instance, the HTTP API, `HttpScheduler` and the dashboard have to be *given* a registry. `AddHttpApi`, `AddQuartzHttpClient` and `AddQuartzDashboard` now resolve the container-wide one. `DisplayValueHelper` deliberately keeps a built-in registry, with a comment: its options only ever `Deserialize<JobDataMap>`, which never consults the trigger or calendar converters, so a custom serializer has nothing to contribute there and injecting one would have touched 40+ `.razor` call sites for no behavioural gain.

### Two test fixtures relied on global reach

`AdoSchedulerTest`'s static fixture constructor registered a trigger serializer into the **STJ** map, but `SchedulerHelper.CreateScheduler` uses `UseNewtonsoftJsonSerializer()` with `RegisterTriggerConverters` false — so the scheduler under test never read that map and the registration was already inert. It is deleted rather than translated, with a comment recording why. Same situation at `MisfireBatchRecoveryTest:227`, translated faithfully anyway.

## Linked issue

Fixes #3173

## Test plan

- [x] Added or updated unit tests
- [x] `dotnet build Quartz.slnx` — 0 warnings, 0 errors; `dotnet test src/Quartz.Tests.Unit` — **1573 passed, 4 skipped, 0 failed** (1569 baseline + 4 new); `dotnet test src/Quartz.Tests.AspNetCore` — 165 passed
- [x] **All 17 `Verify/JsonObjectSerializerTest_*.verified.txt` snapshots byte-identical, no `*.received.txt` produced** — the emitted JSON is unchanged, which is the real check that this is plumbing and not a format change
- [ ] Integration tests not run (Docker unavailable here); the solution build proves `Quartz.Tests.Integration` compiles
- [x] Manually verified the change

New tests: two named schedulers holding disjoint custom trigger serializers (each rejects the other's, both still serialize built-ins); a keyed registry reaching only its own scheduler; a container-registered registry reaching both the default serializer and a property-configured one. `JsonObjectSerializerTest` loses its `[NonParallelizable]`, which it only carried because of the shared global state.

## Breaking change?

Yes. `SystemTextJsonObjectSerializer.AddTriggerSerializer`/`AddCalendarSerializer` and the `NewtonsoftJsonObjectSerializer` equivalents are removed; `InProcessQuartzApiClient`'s constructor takes a registry. Recorded in `changelog.md` and the migration guide. Docs: the static form in `json-serialization.md` is replaced, and 4.x finally gets a `system-text-json.md` page (3.x had one, 4.x did not) covering the new API, per-scheduler isolation, and how to make custom serializers visible to the HTTP API and dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf4PASA1HNgF8dEuaWNi9S