### PR TITLE
Create the scheduler when it is looked up by its own name (#360)

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
@@ -197,6 +197,85 @@ public class StdSchedulerFactoryTest
         Assert.ThrowsAsync<SchedulerException>(() => factory.GetScheduler());
     }
 
+    [Test]
+    public async Task ShouldCreateSchedulerWhenLookedUpByItsConfiguredName()
+    {
+        const string SchedulerName = "NamedLookupCreatesScheduler";
+        var factory = new StdSchedulerFactory(PropertiesForScheduler(SchedulerName));
+
+        // no GetScheduler() call first, which used to be the only way to get a non-null result here
+        IScheduler scheduler = await factory.GetScheduler(SchedulerName);
+
+        try
+        {
+            scheduler.Should().NotBeNull();
+            scheduler.SchedulerName.Should().Be(SchedulerName);
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ShouldReturnSameSchedulerForNamedAndDefaultLookup()
+    {
+        const string SchedulerName = "NamedLookupReturnsSameScheduler";
+        var factory = new StdSchedulerFactory(PropertiesForScheduler(SchedulerName));
+
+        IScheduler defaultScheduler = await factory.GetScheduler();
+
+        try
+        {
+            IScheduler namedScheduler = await factory.GetScheduler(SchedulerName);
+            namedScheduler.Should().BeSameAs(defaultScheduler);
+        }
+        finally
+        {
+            await defaultScheduler.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ShouldMatchConfiguredSchedulerNameCaseInsensitively()
+    {
+        const string SchedulerName = "NamedLookupIgnoresCase";
+        var factory = new StdSchedulerFactory(PropertiesForScheduler(SchedulerName));
+
+        IScheduler scheduler = await factory.GetScheduler(SchedulerName.ToLowerInvariant());
+
+        try
+        {
+            scheduler.Should().NotBeNull("SchedulerRepository indexes names case-insensitively, so creating by name should too");
+            scheduler.SchedulerName.Should().Be(SchedulerName);
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ShouldNotCreateSchedulerWhenLookedUpByAnotherName()
+    {
+        const string SchedulerName = "NamedLookupOtherName";
+        var factory = new StdSchedulerFactory(PropertiesForScheduler(SchedulerName));
+
+        IScheduler scheduler = await factory.GetScheduler("SchedulerThisFactoryDoesNotProduce");
+
+        scheduler.Should().BeNull();
+        SchedulerRepository.Instance.Lookup(SchedulerName).Should().BeNull("asking for another name must not create this factory's own scheduler");
+    }
+
+    private static NameValueCollection PropertiesForScheduler(string schedulerName)
+    {
+        return new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = schedulerName,
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
+        };
+    }
+
     private class TestStdSchedulerFactory : StdSchedulerFactory
     {
         public const string PropertyTest = "quartz.scheduler.test";

--- a/src/Quartz/ISchedulerFactory.cs
+++ b/src/Quartz/ISchedulerFactory.cs
@@ -47,7 +47,8 @@ public interface ISchedulerFactory
     Task<IScheduler> GetScheduler(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns a handle to the Scheduler with the given name, if it exists.
+    /// Returns a handle to the Scheduler with the given name. A factory can create the scheduler it is
+    /// configured to produce; any other name is returned only if that scheduler already exists.
     /// </summary>
     Task<IScheduler?> GetScheduler(string schedName, CancellationToken cancellationToken = default);
 }

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -1247,13 +1247,28 @@ Please add configuration to your application config file to correctly initialize
     }
 
     /// <summary> <para>
-    /// Returns a handle to the Scheduler with the given name, if it exists (if
-    /// it has already been instantiated).
+    /// Returns a handle to the Scheduler with the given name, creating it if the name is the one this
+    /// factory is configured to produce, and otherwise returning it only if it has already been
+    /// instantiated.
     /// </para>
     /// </summary>
-    public virtual Task<IScheduler?> GetScheduler(string schedName, CancellationToken cancellationToken = default)
+    public virtual async Task<IScheduler?> GetScheduler(string schedName, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(GetSchedulerRepository().Lookup(schedName));
+        if (cfg == null)
+        {
+            Initialize();
+        }
+
+        // Asking this factory for its own scheduler by name has to be able to create it; a plain
+        // repository lookup would only ever find a scheduler somebody had already asked for. The
+        // comparison is case-insensitive because that is how SchedulerRepository indexes names, so the
+        // create path and the lookup path agree on what counts as the same scheduler.
+        if (string.Equals(schedName, SchedulerName, StringComparison.OrdinalIgnoreCase))
+        {
+            return await GetScheduler(cancellationToken).ConfigureAwait(false);
+        }
+
+        return GetSchedulerRepository().Lookup(schedName);
     }
 
     /// <summary>


### PR DESCRIPTION
`StdSchedulerFactory.GetScheduler(schedName)` only looked in the scheduler repository, so it returned `null` until somebody had called `GetScheduler()` first — even when the requested name was the very scheduler the factory was configured to produce:

```csharp
var factory = new StdSchedulerFactory(new NameValueCollection
{
    ["quartz.scheduler.instanceName"] = "MyScheduler"
});

var scheduler = await factory.GetScheduler("MyScheduler"); // null
```

The DI factory stopped behaving that way in #2845, so today the two configuration paths disagree: `AddQuartz` creates on a named lookup, property configuration does not.

Asking a factory for **its own** scheduler by name now creates it. Any other name stays a pure lookup, so probing for a scheduler somebody else owns still has no side effects — no thread pool, no job store, no connections. The name comparison is case-insensitive, matching how `SchedulerRepository` indexes names, so the create path and the lookup path agree on what counts as the same scheduler.

`GetScheduler(string)` now initializes the factory when it has not been initialized yet, the same way `GetScheduler()` already does — reading the configured name requires it, and 3.x falls back to the embedded `quartz.config`, so this does not throw merely because an application has no config file.

This is what #360 proposed back in 2016 (credit to @tarasMelnichuk); the same complaint was filed again as #2786. 4.0 already behaves this way through `DefaultSchedulerFactory`.

Four tests in `StdSchedulerFactoryTest` cover creation by the configured name without a prior `GetScheduler()` call, that both overloads hand back the same instance, the case-insensitive match, and that an unknown name still returns `null` without creating anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
