### PR TITLE
Match the scheduler name case-insensitively when creating by name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -197,6 +197,8 @@
     added to the constructor `CronExpression(SerializationInfo info, StreamingContext context)`.
   * Support multiple `L` instances in the day-of-month field (e.g. `L-1,L-2`), lifting the previous one-instance limitation
   * Fix `L-nW` (nearest weekday to an interior last-day offset) resolving a Sunday backwards to Friday instead of forwards to Monday
+  * `ISchedulerFactory.GetScheduler(name)` now matches the configured scheduler name case-insensitively, the way the
+    scheduler repository indexes names, so the name that finds a scheduler is also the name that creates it
 
 
 ## Release 3.14.0, Mar 8 2025

--- a/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
@@ -196,6 +196,85 @@ public class StdSchedulerFactoryTest
         Assert.ThrowsAsync<SchedulerConfigException>(async () => await factory.GetScheduler());
     }
 
+    [Test]
+    public async Task ShouldCreateSchedulerWhenLookedUpByItsConfiguredName()
+    {
+        const string SchedulerName = "NamedLookupCreatesScheduler";
+        using var factory = new StdSchedulerFactory(PropertiesForScheduler(SchedulerName));
+
+        // no GetScheduler() call first, which used to be the only way to get a non-null result here
+        var scheduler = await factory.GetScheduler(SchedulerName);
+
+        try
+        {
+            scheduler.Should().NotBeNull();
+            scheduler.SchedulerName.Should().Be(SchedulerName);
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ShouldReturnSameSchedulerForNamedAndDefaultLookup()
+    {
+        const string SchedulerName = "NamedLookupReturnsSameScheduler";
+        using var factory = new StdSchedulerFactory(PropertiesForScheduler(SchedulerName));
+
+        var defaultScheduler = await factory.GetScheduler();
+
+        try
+        {
+            var namedScheduler = await factory.GetScheduler(SchedulerName);
+            namedScheduler.Should().BeSameAs(defaultScheduler);
+        }
+        finally
+        {
+            await defaultScheduler.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ShouldMatchConfiguredSchedulerNameCaseInsensitively()
+    {
+        const string SchedulerName = "NamedLookupIgnoresCase";
+        using var factory = new StdSchedulerFactory(PropertiesForScheduler(SchedulerName));
+
+        var scheduler = await factory.GetScheduler(SchedulerName.ToLowerInvariant());
+
+        try
+        {
+            scheduler.Should().NotBeNull("the repository indexes names case-insensitively, so creating by name should too");
+            scheduler.SchedulerName.Should().Be(SchedulerName);
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ShouldNotCreateSchedulerWhenLookedUpByAnotherName()
+    {
+        const string SchedulerName = "NamedLookupOtherName";
+        using var factory = new StdSchedulerFactory(PropertiesForScheduler(SchedulerName));
+
+        var scheduler = await factory.GetScheduler("SchedulerThisFactoryDoesNotProduce");
+
+        scheduler.Should().BeNull();
+        (await factory.GetAllSchedulers()).Should().BeEmpty("asking for another name must not create this factory's own scheduler");
+    }
+
+    private static NameValueCollection PropertiesForScheduler(string schedulerName)
+    {
+        return new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = schedulerName,
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
+        };
+    }
+
     private class TestStdSchedulerFactory : StdSchedulerFactory
     {
         public const string PropertyTest = "quartz.scheduler.test";

--- a/src/Quartz/ISchedulerFactory.cs
+++ b/src/Quartz/ISchedulerFactory.cs
@@ -43,7 +43,8 @@ public interface ISchedulerFactory
     ValueTask<IScheduler> GetScheduler(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns a handle to the Scheduler with the given name, if it exists.
+    /// Returns a handle to the Scheduler with the given name. A factory can create the scheduler it is
+    /// configured to produce; any other name is returned only if that scheduler already exists.
     /// </summary>
     ValueTask<IScheduler?> GetScheduler(string schedName, CancellationToken cancellationToken = default);
 }

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -55,9 +55,11 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
     public async ValueTask<IScheduler?> GetScheduler(string schedName, CancellationToken cancellationToken = default)
     {
         // Asking for this factory's scheduler by name has to be able to create it. Looking straight in
-        // the repository would only ever find a scheduler somebody else had already asked for.
+        // the repository would only ever find a scheduler somebody else had already asked for. The
+        // comparison ignores case because that is how the repository indexes names, so the create path
+        // and the lookup path agree on what counts as the same scheduler.
         var options = serviceProvider.GetSchedulerOptions<QuartzSchedulerOptions>(Key);
-        if (string.Equals(schedName, options.InstanceName, StringComparison.Ordinal))
+        if (string.Equals(schedName, options.InstanceName, StringComparison.OrdinalIgnoreCase))
         {
             return await GetScheduler(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
Follow-up to #3188, which brings the same "a factory can create its own scheduler when you ask for it by name" behaviour to 3.x. 4.0 already behaves that way through `DefaultSchedulerFactory` — but with two loose ends.

**The name match disagreed with the repository.** `DefaultSchedulerFactory.GetScheduler(name)` compared the requested name to `InstanceName` with `StringComparison.Ordinal`, while `SchedulerRepository` indexes names with `StringComparer.OrdinalIgnoreCase`. So `GetScheduler("testscheduler")` refused to create `TestScheduler`, yet handed it back once something else had created it. The name that finds a scheduler is now also the name that creates it.

**The property-configured path had no test.** The create-by-name behaviour is covered for `AddQuartz` in `ServiceCollectionExtensionsTests`, but nothing pinned it for `new StdSchedulerFactory(props)` — which is exactly the shape reported in #2786 and originally proposed in #360 back in 2016 (credit to @tarasMelnichuk). Four tests in `StdSchedulerFactoryTest` now cover creation by the configured name without a prior `GetScheduler()` call, both overloads returning the same instance, the case-insensitive match, and an unknown name still returning `null` without creating anything. Three of the four pass on `main` as it stands; the case-insensitive one is what this change fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
