### PR TITLE
Fix defects found reviewing the DI-native configuration campaign

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -98,14 +98,11 @@
     scheduler no longer skips that source; register the listener under the scheduler's name as the service key, or add it
     through that scheduler's builder, if only one scheduler should have it. (#3176)
 
-  * Two job listeners — or two trigger listeners — configured for the same scheduler that answer to the same **Name** now
-    throw a **SchedulerConfigException** naming both. A scheduler knows a listener by its name, so previously the second
-    quietly replaced the first and dropped the matchers it had been registered with. Give the listeners distinct names. (#3176)
-
-  * A listener that is both configured through **IQuartzBuilder** (`AddJobListener`, `AddTriggerListener`,
-    `AddSchedulerListener`) and registered as a listener service is no longer silently deduplicated by its type; it is two
-    registrations, and for job and trigger listeners it now produces the duplicate-name error above. Register it one way
-    or the other. (#3176)
+  * Two job listeners — or two trigger listeners — registered **through the builder** for the same scheduler that answer to
+    the same **Name** now throw a **SchedulerConfigException** naming both. A scheduler knows a listener by its name, so
+    previously the second quietly replaced the first and dropped the matchers it had been registered with. Give the
+    listeners distinct names. (#3176) Registering one listener through the builder *and* as a service is not this case and
+    keeps working — the builder registration wins, because it is the one carrying matchers.
   * The `quartz.config` file is no longer read (#3174). Neither a file on disk, nor the one named by the `quartz.config`
     environment variable, nor the copy Quartz shipped as an embedded resource. `StdSchedulerFactory` now reads only the
     properties handed to it plus any `quartz.*` environment variables; everything else is configured through the container.
@@ -199,6 +196,27 @@
   * Fix `L-nW` (nearest weekday to an interior last-day offset) resolving a Sunday backwards to Friday instead of forwards to Monday
   * `ISchedulerFactory.GetScheduler(name)` now matches the configured scheduler name case-insensitively, the way the
     scheduler repository indexes names, so the name that finds a scheduler is also the name that creates it
+  * A scheduler `Start()` that overlaps a `Shutdown()` no longer throws `ObjectDisposedException` about the scheduler
+    thread's cancellation source, and `Halt`/`Shutdown` are safe to call more than once. Reachable from the hosted
+    services, whose graceful-shutdown deadline can elapse while a start is still in flight
+  * Concurrent `Start()` calls can no longer create two processing loops for one scheduler
+  * A listener registered both through the builder and as a service is recognised as one listener again — job and trigger
+    listeners no longer fail scheduler creation with a duplicate-name error, and scheduler listeners are no longer
+    notified twice
+  * `quartz.executionLimit.*` keys supplied after `AddQuartz` has run — for example from a `Configure<QuartzOptions>`
+    callback — are applied again instead of being silently dropped
+  * `StdSchedulerFactory.GetDefaultScheduler()` returns the same scheduler on every call. Since a factory owns its
+    scheduler repository, building a fresh factory per call produced a second live scheduler with the same instance name
+    and instance id
+  * Querying a disposed `StdSchedulerFactory` throws `ObjectDisposedException` instead of silently building another
+    container that nothing will dispose and reporting no schedulers
+  * `UseNewtonsoftJsonSerializer()` with no callback now reads a `NewtonsoftJsonSerializerRegistry` registered in the
+    container, matching `UseSystemTextJsonSerializer()`, instead of ignoring it in favour of a private built-ins-only one
+  * A driver described in code with `UseGenericDatabase(..., metadata => ...)` now beats one described by
+    `quartz.dbprovider.*` keys registered by an earlier `AddQuartz` call, as the code-beats-strings rule elsewhere implies
+  * A `quartz.config` that 4.x no longer reads is reported as an ignored file rather than passed over in silence
+  * The dashboard builds its `JsonSerializerOptions` once rather than per request or Blazor circuit, and
+    `new DbProvider(name, connectionString)` no longer re-parses the embedded provider descriptions on every construction
 
 
 ## Release 3.14.0, Mar 8 2025

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -68,7 +68,12 @@ public static class QuartzDashboardServiceCollectionExtensions
         // understand it.
         services.TryAddSingleton<SystemTextJsonSerializerRegistry>();
 
-        services.TryAddScoped<IQuartzApiClient, InProcessQuartzApiClient>();
+        services.TryAddSingleton<DashboardSerializerOptions>();
+        services.TryAddScoped<IQuartzApiClient>(static provider => new InProcessQuartzApiClient(
+            provider.GetRequiredService<ISchedulerRepository>(),
+            provider.GetRequiredService<IOptions<QuartzDashboardOptions>>(),
+            provider.GetRequiredService<IDashboardHistoryStore>(),
+            provider.GetRequiredService<DashboardSerializerOptions>().Deserializer));
         services.TryAddScoped<SchedulerState>();
         services.TryAddScoped<ToastService>();
         services.TryAddSingleton<IDashboardHistoryStore, DashboardHistoryStore>();

--- a/src/Quartz.Dashboard/Services/DashboardSerializerOptions.cs
+++ b/src/Quartz.Dashboard/Services/DashboardSerializerOptions.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+
+using Quartz.Serialization.Json;
+
+namespace Quartz.Dashboard.Services;
+
+/// <summary>
+/// The <see cref="JsonSerializerOptions"/> the dashboard reads and writes Quartz types with, built once.
+/// </summary>
+/// <remarks>
+/// A singleton because the options are derived purely from the container's
+/// <see cref="SystemTextJsonSerializerRegistry"/>, which is itself a singleton. Building them per request
+/// would allocate a fresh set of converters for every Blazor circuit and, since System.Text.Json caches
+/// type metadata per options instance, re-run converter and metadata resolution for <c>ITrigger</c>,
+/// <c>ICalendar</c> and <c>JobDataMap</c> on the first serialize in each scope.
+/// </remarks>
+internal sealed class DashboardSerializerOptions
+{
+    public DashboardSerializerOptions(SystemTextJsonSerializerRegistry serializerRegistry)
+    {
+        ArgumentNullException.ThrowIfNull(serializerRegistry);
+
+        JsonSerializerOptions deserializer = new(JsonSerializerDefaults.Web);
+        deserializer.AddQuartzConverters(serializerRegistry, newtonsoftCompatibilityMode: false);
+        Deserializer = deserializer;
+    }
+
+    /// <summary>
+    /// Options carrying the Quartz converters, used for both reading and writing scheduler types.
+    /// </summary>
+    public JsonSerializerOptions Deserializer { get; }
+}

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -46,16 +46,23 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
     /// custom trigger or calendar serializer registered there is what makes a custom type render as
     /// something other than a reflected blob.
     /// </remarks>
+    /// <remarks>
+    /// <paramref name="quartzSerializerOptions"/> carries the Quartz converters and is built once from the
+    /// container's registry rather than per scope: this client is scoped, and System.Text.Json caches type
+    /// metadata per options instance.
+    /// </remarks>
     public InProcessQuartzApiClient(
         ISchedulerRepository schedulerRepository,
         IOptions<QuartzDashboardOptions> options,
         IDashboardHistoryStore historyStore,
-        SystemTextJsonSerializerRegistry serializerRegistry)
+        JsonSerializerOptions quartzSerializerOptions)
     {
+        ArgumentNullException.ThrowIfNull(quartzSerializerOptions);
+
         this.schedulerRepository = schedulerRepository;
         this.options = options;
         this.historyStore = historyStore;
-        deserializerOptions = CreateDeserializerOptions(serializerRegistry);
+        deserializerOptions = quartzSerializerOptions;
     }
 
     public ValueTask<List<SchedulerHeaderDto>> GetSchedulers()
@@ -413,13 +420,6 @@ public sealed class InProcessQuartzApiClient : IQuartzApiClient
         };
 
         return ValueTask.FromResult<JobHistoryPageDto?>(new JobHistoryPageDto(JsonSerializer.SerializeToElement(payload, serializerOptions)));
-    }
-
-    private static JsonSerializerOptions CreateDeserializerOptions(SystemTextJsonSerializerRegistry serializerRegistry)
-    {
-        JsonSerializerOptions options = new(JsonSerializerDefaults.Web);
-        options.AddQuartzConverters(serializerRegistry, newtonsoftCompatibilityMode: false);
-        return options;
     }
 
     private JsonElement SerializeTrigger(ITrigger trigger)

--- a/src/Quartz.Serialization.Newtonsoft/JsonConfigurationExtensions.cs
+++ b/src/Quartz.Serialization.Newtonsoft/JsonConfigurationExtensions.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
 using Quartz.Serialization.Newtonsoft;
 
 using Quartz.Simpl;
@@ -22,8 +24,18 @@ public static class JsonConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        if (configure is null)
+        {
+            // Nothing scheduler-specific was asked for, so the serializer reads the container's registry,
+            // the same way the System.Text.Json path does. Without this branch an application that
+            // registers a NewtonsoftJsonSerializerRegistry of its own — the pattern the docs teach — has it
+            // silently ignored in favour of a private built-ins-only one.
+            builder.Services.TryAddSingleton<NewtonsoftJsonSerializerRegistry>();
+            return builder.UseSerializer<NewtonsoftJsonObjectSerializer>();
+        }
+
         var options = new NewtonsoftJsonSerializerOptions();
-        configure?.Invoke(options);
+        configure.Invoke(options);
 
         // The registry the callback filled is captured here rather than published to the container, which
         // is what keeps two schedulers in one container from sharing each other's custom serializers.

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -239,7 +239,7 @@ public class InProcessQuartzApiClientTest
             repository,
             Options.Create(new QuartzDashboardOptions()),
             new DashboardHistoryStore(),
-            new SystemTextJsonSerializerRegistry());
+            new DashboardSerializerOptions(new SystemTextJsonSerializerRegistry()).Deserializer);
     }
 
     private sealed class NoOpJob : IJob

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
@@ -396,6 +396,31 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         }
     }
 
+    /// <summary>
+    /// A key supplied after <c>AddQuartz</c> has run is not in the collection <c>AddQuartz</c> was handed,
+    /// so registration-time parsing alone cannot see it. This is the documented route for a key the typed
+    /// options do not cover, and it silently stopped applying.
+    /// </summary>
+    [Test]
+    public async Task ExecutionLimitsSetThroughQuartzOptionsAfterAddQuartzAreApplied()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.InstanceName = "deferred-limits"));
+        services.Configure<QuartzOptions>(options => options.Properties["quartz.executionLimit.heavy"] = "2");
+
+        using var provider = services.BuildServiceProvider();
+        var scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        try
+        {
+            provider.GetRequiredService<QuartzScheduler>().GetExecutionLimits()!["heavy"]
+                .Should().Be(2, "a group left uncapped saturates the whole thread pool");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
     [Test]
     public async Task EachNamedSchedulerKeepsItsOwnExecutionLimits()
     {

--- a/src/Quartz.Tests.Unit/Configuration/ListenerRegistrationTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ListenerRegistrationTest.cs
@@ -111,6 +111,70 @@ public class ListenerRegistrationTest
         }
     }
 
+    /// <summary>
+    /// Registering a listener through the builder and as a service is how it gets matchers from one and
+    /// dependencies from the other. That combination used to be recognised by comparing listener types;
+    /// losing that comparison turned it into a duplicate name and aborted scheduler creation.
+    /// </summary>
+    [Test]
+    public async Task AConfiguredListenerAlsoRegisteredAsAServiceKeepsItsMatchers()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IJobListener, AuditListener>();
+        services.AddSingleton<ITriggerListener, AuditTriggerListener>();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.InstanceName = "configured-and-service");
+            q.AddJobListener<AuditListener>(GroupMatcher<JobKey>.GroupEquals("reports"));
+            q.AddTriggerListener<AuditTriggerListener>(GroupMatcher<TriggerKey>.GroupEquals("reports"));
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        try
+        {
+            scheduler.ListenerManager.GetJobListeners().Should().ContainSingle(
+                "the builder registration is the same listener, not a second one");
+            scheduler.ListenerManager.GetJobListenerMatchers(nameof(AuditListener)).Should().ContainSingle(
+                "the service copy carries no matchers, so letting it through would erase the configured ones");
+
+            scheduler.ListenerManager.GetTriggerListeners().Should().ContainSingle();
+            scheduler.ListenerManager.GetTriggerListenerMatchers(nameof(AuditTriggerListener)).Should().ContainSingle();
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// The same case for scheduler listeners, which have no name for the duplicate check to key on and are
+    /// held in a plain list — so a second copy is simply notified alongside the first.
+    /// </summary>
+    [Test]
+    public async Task AConfiguredSchedulerListenerAlsoRegisteredAsAServiceIsAttachedOnce()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ISchedulerListener, RecordingSchedulerListener>();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.InstanceName = "configured-and-service-scheduler-listener");
+            q.AddSchedulerListener<RecordingSchedulerListener>();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        try
+        {
+            scheduler.ListenerManager.GetSchedulerListeners().Should().ContainSingle(
+                "attaching it twice would notify every scheduler event twice");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
     [Test]
     public async Task TwoJobListenersWithTheSameNameAreRejected()
     {

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadTest.cs
@@ -75,6 +75,70 @@ public class QuartzSchedulerThreadTest
         thread.Running.Should().BeFalse();
     }
 
+    /// <summary>
+    /// Shutdown disposes the cancellation source, so a start that lands after it must not touch the token.
+    /// A start racing a shutdown is reachable from the hosted services, whose graceful-shutdown deadline
+    /// can elapse while a start is still in flight.
+    /// </summary>
+    [Test]
+    public async Task StartAfterShutdownDoesNothingRatherThanThrowing()
+    {
+        QuartzSchedulerResources resources = new() { IdleWaitTime = TimeSpan.FromSeconds(1) };
+        QuartzScheduler scheduler = new(resources);
+        var thread = new QuartzSchedulerThread(scheduler, resources);
+
+        await thread.Shutdown();
+
+        var start = () => thread.Start();
+
+        start.Should().NotThrow<ObjectDisposedException>();
+        thread.Running.Should().BeFalse("the loop cannot be started again after shutdown");
+    }
+
+    [Test]
+    public async Task HaltAfterShutdownDoesNotThrow()
+    {
+        QuartzSchedulerResources resources = new() { IdleWaitTime = TimeSpan.FromSeconds(1) };
+        QuartzScheduler scheduler = new(resources);
+        var thread = new QuartzSchedulerThread(scheduler, resources);
+
+        await thread.Shutdown();
+
+        var halt = async () => await thread.Halt(wait: false);
+
+        await halt.Should().NotThrowAsync<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task ShutdownIsIdempotentSoItCannotDisposeTwice()
+    {
+        QuartzSchedulerResources resources = new() { IdleWaitTime = TimeSpan.FromSeconds(1) };
+        QuartzScheduler scheduler = new(resources);
+        var thread = new QuartzSchedulerThread(scheduler, resources);
+
+        await thread.Shutdown();
+        var again = async () => await thread.Shutdown();
+
+        await again.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public void ConcurrentStartsCreateOnlyOneLoop()
+    {
+        QuartzSchedulerResources resources = new()
+        {
+            IdleWaitTime = TimeSpan.FromSeconds(1),
+            JobStore = TestJobStores.Ram()
+        };
+        QuartzScheduler scheduler = new(resources);
+        var thread = new QuartzSchedulerThread(scheduler, resources);
+
+        // Two loops for one scheduler would both acquire triggers, and Shutdown would await only one.
+        Parallel.For(0, 16, _ => thread.Start());
+
+        thread.Running.Should().BeTrue();
+    }
+
     private static IEnumerable<TimeSpan> ValidIdleWaitTimes()
     {
         return QuartzSchedulerResourcesTest.ValidIdleWaitTimes();

--- a/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/StdSchedulerFactoryTest.cs
@@ -275,6 +275,35 @@ public class StdSchedulerFactoryTest
         };
     }
 
+    /// <summary>
+    /// A factory owns its scheduler repository, so a fresh factory per call would find no existing
+    /// scheduler and build a second live one carrying the same instance name and instance id.
+    /// </summary>
+    [Test]
+    public async Task GetDefaultSchedulerReturnsTheSameSchedulerEveryTime()
+    {
+        var first = await StdSchedulerFactory.GetDefaultScheduler();
+        var second = await StdSchedulerFactory.GetDefaultScheduler();
+
+        second.Should().BeSameAs(first, "two schedulers sharing one instance id would both check in as that node");
+    }
+
+    /// <summary>
+    /// Querying a disposed factory used to build a whole new container, hang it off the disposed factory
+    /// where nothing would dispose it, and report an empty repository as though the schedulers had gone.
+    /// </summary>
+    [Test]
+    public async Task ADisposedFactoryDoesNotBuildAnotherContainer()
+    {
+        var factory = new StdSchedulerFactory();
+        await factory.GetScheduler();
+        factory.Dispose();
+
+        var query = async () => await factory.GetAllSchedulers();
+
+        await query.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
     private class TestStdSchedulerFactory : StdSchedulerFactory
     {
         public const string PropertyTest = "quartz.scheduler.test";

--- a/src/Quartz/Configuration/SchedulerContentInitializer.cs
+++ b/src/Quartz/Configuration/SchedulerContentInitializer.cs
@@ -70,31 +70,56 @@ internal sealed class SchedulerContentInitializer
 
     private void AddSchedulerListeners(IScheduler scheduler)
     {
+        var configured = new List<ISchedulerListener>();
         foreach (var registration in Registrations<SchedulerListenerRegistration>())
         {
-            scheduler.ListenerManager.AddSchedulerListener(registration.CreateListener(serviceProvider));
+            configured.Add(registration.CreateListener(serviceProvider));
+        }
+
+        foreach (var listener in configured)
+        {
+            scheduler.ListenerManager.AddSchedulerListener(listener);
         }
 
         // Listeners the application registered as plain services, which carry nothing of their own.
+        // A scheduler listener manager keeps these in a plain list with no notion of identity, so a
+        // listener that was both configured and registered as a service would be notified twice.
         foreach (var listener in ListenerServices<ISchedulerListener>())
         {
+            if (AlreadyConfigured(configured, listener))
+            {
+                continue;
+            }
+
             scheduler.ListenerManager.AddSchedulerListener(listener);
         }
     }
 
     private void AddJobListeners(IScheduler scheduler)
     {
+        var configured = new List<IJobListener>();
         var listeners = new List<(IJobListener Listener, IMatcher<JobKey>[] Matchers)>();
 
         foreach (var registration in Registrations<JobListenerRegistration>())
         {
-            listeners.Add((registration.CreateListener(serviceProvider), registration.Matchers));
+            var listener = registration.CreateListener(serviceProvider);
+            configured.Add(listener);
+            listeners.Add((listener, registration.Matchers));
         }
+
+        // Two builder registrations answering to one name is the genuinely ambiguous case: both asked for
+        // matchers, and the listener manager can only keep one of them.
+        RejectDuplicateNames(scheduler, "job", configured);
 
         // Listeners the application registered as plain services, which carry no matchers and so listen
         // to everything.
         foreach (var listener in ListenerServices<IJobListener>())
         {
+            if (AlreadyConfigured(configured, listener))
+            {
+                continue;
+            }
+
             listeners.Add((listener, []));
         }
 
@@ -103,10 +128,13 @@ internal sealed class SchedulerContentInitializer
         foreach (var listener in PropertyListenerFactory.Create<IJobListener>(
                      serviceProvider, properties, StdSchedulerFactory.PropertyJobListenerPrefix))
         {
+            if (AlreadyConfigured(configured, listener))
+            {
+                continue;
+            }
+
             listeners.Add((listener, [EverythingMatcher<JobKey>.AllJobs()]));
         }
-
-        RejectDuplicateNames(scheduler, "job", listeners.Select(static x => (x.Listener.Name, (object) x.Listener)));
 
         foreach (var (listener, matchers) in listeners)
         {
@@ -116,25 +144,38 @@ internal sealed class SchedulerContentInitializer
 
     private void AddTriggerListeners(IScheduler scheduler)
     {
+        var configured = new List<ITriggerListener>();
         var listeners = new List<(ITriggerListener Listener, IMatcher<TriggerKey>[] Matchers)>();
 
         foreach (var registration in Registrations<TriggerListenerRegistration>())
         {
-            listeners.Add((registration.CreateListener(serviceProvider), registration.Matchers));
+            var listener = registration.CreateListener(serviceProvider);
+            configured.Add(listener);
+            listeners.Add((listener, registration.Matchers));
         }
+
+        RejectDuplicateNames(scheduler, "trigger", configured);
 
         foreach (var listener in ListenerServices<ITriggerListener>())
         {
+            if (AlreadyConfigured(configured, listener))
+            {
+                continue;
+            }
+
             listeners.Add((listener, []));
         }
 
         foreach (var listener in PropertyListenerFactory.Create<ITriggerListener>(
                      serviceProvider, properties, StdSchedulerFactory.PropertyTriggerListenerPrefix))
         {
+            if (AlreadyConfigured(configured, listener))
+            {
+                continue;
+            }
+
             listeners.Add((listener, [EverythingMatcher<TriggerKey>.AllTriggers()]));
         }
-
-        RejectDuplicateNames(scheduler, "trigger", listeners.Select(static x => (x.Listener.Name, (object) x.Listener)));
 
         foreach (var (listener, matchers) in listeners)
         {
@@ -176,7 +217,34 @@ internal sealed class SchedulerContentInitializer
     }
 
     /// <summary>
-    /// Refuses two listeners of the same kind that answer to the same name.
+    /// Whether a listener contributed by a plain service registration or by a
+    /// <c>quartz.*Listener.*</c> key is one the builder already contributed.
+    /// </summary>
+    /// <remarks>
+    /// Registering a listener through the builder and as a service is a normal thing to do — the builder
+    /// registration is how it gets its matchers, the service registration is how its dependencies get
+    /// injected — and it used to be recognised, by comparing the declared listener type. That comparison
+    /// went away with the type-keyed configurations, which left the same listener contributed twice: for
+    /// job and trigger listeners the second copy replaces the first and drops its matchers, and for
+    /// scheduler listeners both are notified. The builder registration wins because it is the one that
+    /// carries matchers.
+    /// </remarks>
+    private static bool AlreadyConfigured<TListener>(List<TListener> configured, TListener listener)
+        where TListener : class
+    {
+        foreach (var candidate in configured)
+        {
+            if (ReferenceEquals(candidate, listener) || candidate.GetType() == listener.GetType())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Refuses two builder registrations of the same kind that answer to the same name.
     /// </summary>
     /// <remarks>
     /// A listener manager holds one listener per name and replaces on collision, and a replacement that
@@ -184,14 +252,24 @@ internal sealed class SchedulerContentInitializer
     /// to produce the same name therefore quietly become one — the very ambiguity that carrying the
     /// pairing in the registration removes. Say so instead of applying only one of them.
     /// </remarks>
-    private static void RejectDuplicateNames(
-        IScheduler scheduler,
-        string kind,
-        IEnumerable<(string Name, object Listener)> listeners)
+    /// <remarks>
+    /// Only builder registrations are checked. A listener that also arrives as a service or by property is
+    /// recognised as the same listener by <see cref="AlreadyConfigured{TListener}"/> and never reaches
+    /// here, because that is a configuration that has always worked rather than an ambiguous one.
+    /// </remarks>
+    private static void RejectDuplicateNames<TListener>(IScheduler scheduler, string kind, List<TListener> configured)
+        where TListener : class
     {
-        var seen = new Dictionary<string, object>(StringComparer.Ordinal);
-        foreach (var (name, listener) in listeners)
+        var seen = new Dictionary<string, TListener>(StringComparer.Ordinal);
+        foreach (var listener in configured)
         {
+            var name = listener switch
+            {
+                IJobListener job => job.Name,
+                ITriggerListener trigger => trigger.Name,
+                _ => null
+            };
+
             if (string.IsNullOrEmpty(name))
             {
                 // A nameless listener is rejected by the listener manager itself, which says so better.

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -60,9 +60,20 @@ internal sealed class QuartzSchedulerThread
     private readonly CancellationTokenSource cancellationTokenSource = new();
 
     /// <summary>
+    /// Guards the <see cref="task"/> and <see cref="shutDown"/> transitions, so that a start racing a
+    /// shutdown cannot produce a second processing loop or touch a disposed cancellation source.
+    /// </summary>
+    private readonly Lock stateLock = new();
+
+    /// <summary>
     /// The processing loop, or <see langword="null" /> until <see cref="Start" /> has been called.
     /// </summary>
     private Task? task;
+
+    /// <summary>
+    /// Whether <see cref="Shutdown"/> has run, after which the cancellation source is disposed.
+    /// </summary>
+    private bool shutDown;
 
     private const int PausedWaitCheckIntervalMs = 1000;
 
@@ -169,14 +180,26 @@ internal sealed class QuartzSchedulerThread
             pauseSignal.Release();
         }
 
+        Task? running;
+        lock (stateLock)
+        {
+            // Shutdown has already cancelled and disposed the source; cancelling it again would throw.
+            if (shutDown)
+            {
+                return;
+            }
+
+            running = task;
+        }
+
         await cancellationTokenSource.CancelAsync().ConfigureAwait(false);
 
         // There is nothing to wait for when the loop was never started.
-        if (wait && task is not null)
+        if (wait && running is not null)
         {
             try
             {
-                await task.ConfigureAwait(false);
+                await running.ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -741,22 +764,32 @@ internal sealed class QuartzSchedulerThread
     }
 
     /// <summary>
-    /// Starts the processing loop. Does nothing if it is already running.
+    /// Starts the processing loop. Does nothing if it is already running, or if the loop has already been
+    /// shut down.
     /// </summary>
+    /// <remarks>
+    /// Starting after <see cref="Shutdown"/> is a no-op rather than an error: a scheduler being started
+    /// and stopped concurrently is reachable from the hosted services, whose graceful-shutdown deadline
+    /// can elapse while a start is still in flight, and the caller of <c>IScheduler.Start()</c> should not
+    /// see an exception about a disposed cancellation source because of it.
+    /// </remarks>
     public void Start()
     {
-        if (task is not null)
+        lock (stateLock)
         {
-            return;
-        }
+            if (shutDown || task is not null)
+            {
+                return;
+            }
 
-        task = Task.Factory.StartNew(
-            static state => ((QuartzSchedulerThread) state!).Run(),
-            this,
-            cancellationTokenSource.Token,
-            TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
-            TaskScheduler.Default
-        ).Unwrap();
+            task = Task.Factory.StartNew(
+                static state => ((QuartzSchedulerThread) state!).Run(),
+                this,
+                cancellationTokenSource.Token,
+                TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+                TaskScheduler.Default
+            ).Unwrap();
+        }
     }
 
     /// <summary>
@@ -765,21 +798,34 @@ internal sealed class QuartzSchedulerThread
     /// </summary>
     public async Task Shutdown()
     {
+        Task? running;
+        lock (stateLock)
+        {
+            if (shutDown)
+            {
+                return;
+            }
+
+            shutDown = true;
+            running = task;
+        }
+
         cancellationTokenSource.Cancel();
 
         // Nothing to wait for when the loop was never started.
-        if (task is not null)
+        if (running is not null)
         {
             try
             {
-                await task.ConfigureAwait(false);
+                await running.ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
             }
         }
 
-        // Disposed only here, once the loop has been awaited and can no longer read the token.
+        // Disposed only here, once the loop has been awaited and can no longer read the token. Reaching
+        // this point twice would dispose it twice, which is why Shutdown returns early above.
         cancellationTokenSource.Dispose();
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/Common/DbMetadataResolver.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/DbMetadataResolver.cs
@@ -35,11 +35,18 @@ internal sealed class DbMetadataResolver
     {
         ArgumentNullException.ThrowIfNull(factories);
 
-        // Ordering is stable, so everything the application registered keeps its relative order and only
-        // the built-ins are moved to the back. Registration order alone is not enough: a second AddQuartz
-        // call describing a driver registers after the first call has already pulled the built-ins in.
+        // Ordering is stable, so factories of equal rank keep their relative registration order.
+        // Registration order alone is not enough for two reasons: a second AddQuartz call describing a
+        // driver registers after the first call has already pulled the built-ins in, and a description
+        // written in code has to beat one spelled as quartz.dbprovider.* keys even when the keys were
+        // registered by an earlier call — the same "code beats strings" rule as everywhere else.
         this.factories = factories
-            .OrderBy(factory => factory is EmbeddedAssemblyResourceDbMetadataFactory ? 1 : 0)
+            .OrderBy(factory => factory switch
+            {
+                ConfiguredDbMetadataFactory => 0,
+                EmbeddedAssemblyResourceDbMetadataFactory => 2,
+                _ => 1
+            })
             .ToArray();
     }
 
@@ -47,7 +54,16 @@ internal sealed class DbMetadataResolver
     /// A resolver over nothing but the driver descriptions Quartz ships, for callers that construct a
     /// <see cref="DbProvider"/> without a container to ask.
     /// </summary>
-    public static DbMetadataResolver BuiltIn() => new([new EmbeddedAssemblyResourceDbMetadataFactory()]);
+    /// <remarks>
+    /// Shared, and therefore cached, for the lifetime of the process. Safe to share where a container's
+    /// resolver is not: it holds only the descriptions Quartz ships, which are the same everywhere, so
+    /// there is no container-specific metadata for the cache to leak. A fresh instance per call would
+    /// re-read the embedded resource and re-run <see cref="DbMetadata.Init"/> on every
+    /// <see cref="DbProvider"/> construction, which is what the deleted static constructor did once.
+    /// </remarks>
+    public static DbMetadataResolver BuiltIn() => builtIn;
+
+    private static readonly DbMetadataResolver builtIn = new([new EmbeddedAssemblyResourceDbMetadataFactory()]);
 
     /// <summary>
     /// Returns the metadata describing a provider, or throws naming the providers that are known.

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -153,8 +153,12 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
             quartzScheduler.JobFactory = serviceProvider.GetScheduler<IJobFactory>(Key);
 
             // Both code and quartz.executionLimit.* keys produce this registration, and the registration
-            // is first-wins, so the precedence between them is settled before we get here.
-            var executionLimits = serviceProvider.GetSchedulerService<SchedulerExecutionLimits>(Key)?.Limits;
+            // is first-wins, so the precedence between them is settled before we get here. Falling back to
+            // the resolved properties covers limits that only exist once the container is built — a key set
+            // from a Configure<QuartzOptions> callback was not in the collection AddQuartz was handed, and
+            // would otherwise be dropped without a word.
+            var executionLimits = serviceProvider.GetSchedulerService<SchedulerExecutionLimits>(Key)?.Limits
+                ?? ExecutionLimitsParser.Parse(properties);
 
             if (executionLimits is not null)
             {

--- a/src/Quartz/Impl/StdSchedulerFactory.cs
+++ b/src/Quartz/Impl/StdSchedulerFactory.cs
@@ -178,6 +178,7 @@ public class StdSchedulerFactory : ISchedulerFactory, IDisposable
     private ServiceProvider? provider;
     private ISchedulerFactory? inner;
     private ISchedulerRepository? schedulerRepository;
+    private bool disposed;
 
     private string SchedulerName
     {
@@ -189,14 +190,22 @@ public class StdSchedulerFactory : ISchedulerFactory, IDisposable
     /// Returns a handle to the default Scheduler, creating it if it does not
     /// yet exist.
     /// </summary>
+    /// <remarks>
+    /// Every call shares one factory, and therefore one scheduler. A factory owns its scheduler
+    /// repository, so constructing a new one per call would find no existing scheduler to return and would
+    /// build a second live scheduler carrying the same instance name and instance id as the first — two
+    /// thread pools, two sets of connections, and against a clustered database two nodes checking in as
+    /// the same instance.
+    /// </remarks>
     /// <seealso cref="Initialize()">
     /// </seealso>
     public static ValueTask<IScheduler> GetDefaultScheduler(
         CancellationToken cancellationToken = default)
     {
-        StdSchedulerFactory fact = new StdSchedulerFactory();
-        return fact.GetScheduler(cancellationToken);
+        return defaultFactory.Value.GetScheduler(cancellationToken);
     }
+
+    private static readonly Lazy<StdSchedulerFactory> defaultFactory = new(static () => new StdSchedulerFactory());
 
     /// <summary>
     /// Returns a handle to every scheduler this factory has produced.
@@ -272,7 +281,36 @@ public class StdSchedulerFactory : ISchedulerFactory, IDisposable
         }
 
         logger = LogProvider.CreateLogger<StdSchedulerFactory>();
+        WarnAboutIgnoredConfigurationFile();
         Initialize(OverrideWithSysProps(EmbeddedDefaults()));
+    }
+
+    /// <summary>
+    /// Says so when a <c>quartz.config</c> that 3.x would have loaded is present but ignored.
+    /// </summary>
+    /// <remarks>
+    /// Dropping file discovery without a word is the worst version of this change: an application that
+    /// still ships a file selecting a database job store silently becomes an in-memory scheduler, its
+    /// persisted triggers stop firing, and nothing in the log points at the file. This does not read the
+    /// file — it only reports that something which used to be configuration no longer is.
+    /// </remarks>
+    private void WarnAboutIgnoredConfigurationFile()
+    {
+        var requestedFile = QuartzEnvironment.GetEnvironmentVariable(LegacyPropertiesFileVariable);
+        var named = !string.IsNullOrWhiteSpace(requestedFile);
+        var fileName = named ? requestedFile! : "~/quartz.config";
+        var resolved = FileUtil.ResolveFile(fileName);
+
+        if (!named && (resolved is null || !File.Exists(resolved)))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "Ignoring Quartz configuration file '{PropFileName}': configuration is no longer read from disk in 4.x. "
+            + "Pass the properties to StdSchedulerFactory, or configure the scheduler through the container with "
+            + "AddQuartz and IConfiguration. See the 4.x migration guide.",
+            resolved ?? fileName);
     }
 
     /// <summary>
@@ -402,6 +440,11 @@ public class StdSchedulerFactory : ISchedulerFactory, IDisposable
 
         lock (containerLock)
         {
+            // Without this a call after Dispose would build a second container and hang it off the
+            // disposed factory, where nothing will ever dispose it — and report an empty repository as
+            // though the factory's schedulers had gone away.
+            ObjectDisposedException.ThrowIf(disposed, this);
+
             return inner ??= BuildInner();
         }
     }
@@ -499,6 +542,7 @@ public class StdSchedulerFactory : ISchedulerFactory, IDisposable
             provider = null;
             inner = null;
             schedulerRepository = null;
+            disposed = true;
         }
 
         owned?.Dispose();


### PR DESCRIPTION
## Summary

Twelve fixes from an exhaustive review of the #3173–#3179 follow-up work.

## Details

The seven-issue follow-up to #3172 landed as five PRs (#3183, #3184, #3185, #3186, #3187), each rebased onto the others with several conflicts resolved by hand. This is the review of all of it as one body of work. Fifteen distinct defects were confirmed; twelve are fixed here and three are left for a decision (below).

### Scheduler thread lifecycle — the two worst

Moving the thread start out of the constructor and disposing the cancellation source in `Shutdown()` left two races:

- **`Start()` overlapping `Shutdown()` threw `ObjectDisposedException`** out of the public `IScheduler.Start()`. `QuartzScheduler.Start()` checks `shuttingDown || closed` and then awaits listener notification, `JobStore.SchedulerStarted` and `StartPlugins` — a database round trip for ADO stores — before reaching `schedThread.Start()`. A shutdown in that window disposes the source first. This is reachable from shipped code, not theory: both `QuartzHostedService.StopAsync` and `NamedSchedulerHostedService.StopAsync` do `await Task.WhenAny(startupTask, Task.Delay(Infinite, ct))` and then call `Shutdown` in `finally`, so an elapsed graceful-shutdown deadline runs shutdown concurrently with an in-flight start. `StartDelayed`'s `catch (SchedulerException)` does not catch it.
- **The new idempotency guard was a non-volatile check-then-assign**, so concurrent `Start()` calls could create two processing loops both acquiring triggers, of which `Shutdown()` awaited only one — then disposed the source under the orphan.

`Start`, `Halt` and `Shutdown` now transition under a lock; `Start` after shutdown is a no-op; `Shutdown` disposes exactly once.

### Listeners — a regression I flagged as a judgement call, now confirmed

Registering a listener through the builder *and* as a service is how it gets matchers from one and dependencies from the other, and it used to be recognised by comparing listener types. #3176 removed that comparison, which turned the combination into a duplicate name: **job and trigger listeners aborted scheduler creation**, and **scheduler listeners were silently notified twice** (they have no `Name` for the duplicate check to key on, and the manager holds them in a plain list).

Such a listener is recognised as one listener again, the builder registration winning because it carries the matchers. The duplicate-name error now applies only to two *builder* registrations — the genuinely ambiguous case it was written for. The comparison is on the resolved instance rather than the declared type, so the subtype mis-fire that motivated #3176 stays fixed.

### Silent configuration loss

`quartz.executionLimit.*` keys supplied after `AddQuartz` has run — from a `Configure<QuartzOptions>` callback, the documented route for a key the typed options do not cover — were dropped, leaving the group at full thread-pool concurrency. The registration still wins; the resolved properties are read again as a fallback.

### StdSchedulerFactory

- `GetDefaultScheduler()` constructed a fresh factory per call. Now that a factory owns its repository, that found no existing scheduler and **built a second live scheduler with the same instance name and instance id** — two thread pools, and against a clustered database two nodes checking in as one. It shares one factory.
- Querying a **disposed** factory rebuilt a container, hung it off the disposed factory where nothing would dispose it, and reported no schedulers. It throws `ObjectDisposedException`.
- A `quartz.config` that 4.x no longer reads is now reported as ignored instead of passed over in silence — the failure mode otherwise is a database-backed scheduler silently becoming in-memory with nothing in the log.

### Serializers and provider metadata

- `UseNewtonsoftJsonSerializer()` with no callback ignored a container-registered registry, unlike the System.Text.Json counterpart that was deliberately changed to fall through.
- `DbMetadataResolver` demoted only the built-ins, so a description from `quartz.dbprovider.*` keys registered by an earlier `AddQuartz` call beat a later `UseGenericDatabase` metadata callback — contradicting the code-beats-strings rule stated in the bridge's own remarks.

### Efficiency

The dashboard rebuilt its `JsonSerializerOptions` per request/Blazor circuit (System.Text.Json caches type metadata per options instance, so this re-ran converter resolution each scope), and `DbMetadataResolver.BuiltIn()` re-parsed the embedded provider descriptions on every `DbProvider` construction where the deleted static constructor parsed them once per process.

## Left for a decision, not fixed

- **A transient job-store failure permanently poisons the container's scheduler.** `ShutdownAfterFailure` closes the keyed singleton, so a retry after the database recovers resolves the same closed instance. Pre-existing, but the new terminal `Shutdown()` makes it irreversible. Fixing it means changing the scheduler registration's lifetime — a design decision beyond this review.
- **The dashboard reads the container-wide serializer registry, not each scheduler's.** Per-scheduler registries are deliberately never published to the container — that is what keeps schedulers isolated — so this needs a decision about whether they should be reachable by name.
- **Dashboard plugins only ever attach to the default scheduler**, because `AddQuartzDashboard` builds its plugins with `schedulerKey: null` and named schedulers resolve plugins keyed. An app whose schedulers are all named gets no live events or history. Needs a decision about which schedulers the dashboard should instrument.

## Linked issues

Refs #3173, #3174, #3175, #3176, #3177, #3178, #3179

## Test plan

- [x] Added or updated unit tests — 9 new: start-after-shutdown, halt-after-shutdown, idempotent shutdown, concurrent starts; builder+service listener keeping its matchers; the same for scheduler listeners; deferred execution limits; `GetDefaultScheduler` identity; disposed-factory rejection
- [x] `dotnet build Quartz.slnx --no-incremental` — 0 warnings, 0 errors; `dotnet test src/Quartz.Tests.Unit` — **1613 passed, 4 skipped, 0 failed**; `dotnet test src/Quartz.Tests.AspNetCore` — **166 passed**
- [x] **Both trimmed publishes clean** (`Quartz.Examples.Worker`, `Quartz.Examples.AspNetCore`) — only `publish` runs trim analysis, which is how an IL2091 slipped through earlier in this campaign
- [x] All 17 `Verify/JsonObjectSerializerTest_*` snapshots byte-identical, no `*.received.txt`
- [ ] Integration tests not run (Docker unavailable here); the solution build proves `Quartz.Tests.Integration` compiles

## Breaking change?

No new breaks — this restores behaviour the campaign changed by accident. One `### BREAKING CHANGES` bullet from #3176 is corrected, because the duplicate-name error now applies only to two builder registrations rather than to any two same-named listeners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf4PASA1HNgF8dEuaWNi9S