### PR TITLE
Add comprehensive DST corner-case test coverage for all trigger types

### DIFF
--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerDstTests.cs
@@ -1,0 +1,423 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Daylight saving time coverage for <see cref="CalendarIntervalTriggerImpl" /> around fall-back
+/// transitions and midnight gaps. The existing <see cref="CalendarIntervalTriggerTest" /> only covers
+/// spring-forward, so these tests deliberately stay on the other side of the year: the repeated hour,
+/// the midnight gap, the sub-day units that never see a transition at all, and the behaviour of the
+/// default (non preserving) configuration.
+///
+/// Every expectation here pins the behaviour that ships today. Where that behaviour is arguably the
+/// wrong answer it lives in the "current-behavior pins" region at the bottom with the reasoning
+/// spelled out, so that a deliberate change shows up as a failing pin rather than a silent shift.
+///
+/// These tests never touch <see cref="SystemTime" />, so the fixture is safe to run in parallel.
+/// </summary>
+public class CalendarIntervalTriggerDstTests
+{
+    /// <summary>
+    /// Builds a trigger with every DST relevant knob stated explicitly. <c>StartTimeUtc</c> is always
+    /// supplied by the caller: the implementation defaults it to the current time, which would silently
+    /// turn every expectation in this file into a vacuous assertion about "now".
+    /// </summary>
+    private static CalendarIntervalTriggerImpl CreateTrigger(
+        TimeZoneInfo zone,
+        IntervalUnit unit,
+        int interval,
+        DateTimeOffset startTimeUtc,
+        bool preserveHourOfDay,
+        bool skipDayIfHourDoesNotExist)
+    {
+        return new CalendarIntervalTriggerImpl
+        {
+            StartTimeUtc = startTimeUtc,
+            RepeatIntervalUnit = unit,
+            RepeatInterval = interval,
+            TimeZone = zone,
+            PreserveHourOfDayAcrossDaylightSavings = preserveHourOfDay,
+            SkipDayIfHourDoesNotExist = skipDayIfHourDoesNotExist
+        };
+    }
+
+    /// <summary>
+    /// Collects the fire times in <c>[start, untilExclusive)</c>. Walking from one second before the
+    /// start makes the start time itself the first collected fire, and <see cref="TestTimeZones.Walk" />
+    /// fails the test if the trigger ever stops moving forward.
+    /// </summary>
+    private static List<DateTimeOffset> WalkFrom(
+        CalendarIntervalTriggerImpl trigger,
+        DateTimeOffset start,
+        DateTimeOffset untilExclusive)
+    {
+        return TestTimeZones.Walk(after => trigger.GetFireTimeAfter(after), start.AddSeconds(-1), untilExclusive);
+    }
+
+    /// <summary>
+    /// With the hour preserved, a fall-back day must produce exactly one fire even though the scheduled
+    /// wall-clock time happens twice, and the next occurrence must be back at the same wall-clock time
+    /// under the new (standard) offset.
+    /// </summary>
+    [TestCase(IntervalUnit.Day, "2024-11-01 01:30 -04:00", "2024-11-05 00:00 -05:00", "2024-11-04 01:30 -05:00")]
+    [TestCase(IntervalUnit.Week, "2024-10-27 01:30 -04:00", "2024-11-11 00:00 -05:00", "2024-11-10 01:30 -05:00")]
+    [TestCase(IntervalUnit.Month, "2024-10-03 01:30 -04:00", "2024-12-04 00:00 -05:00", "2024-12-03 01:30 -05:00")]
+    [TestCase(IntervalUnit.Year, "2023-11-03 01:30 -04:00", "2025-11-04 00:00 -05:00", "2025-11-03 01:30 -05:00")]
+    public void PreserveHour_FallBack_FiresOnceAtScheduledLocalHour(
+        IntervalUnit unit,
+        string start,
+        string untilExclusive,
+        string followingOccurrence)
+    {
+        AssertFallBackFiresOnceAtScheduledLocalHour(unit, start, untilExclusive, followingOccurrence, skipDayIfHourDoesNotExist: false);
+    }
+
+    /// <summary>
+    /// <c>SkipDayIfHourDoesNotExist</c> is about spring-forward gaps only. On a fall-back day the
+    /// scheduled hour exists twice over, so turning the flag on must change nothing at all: the results
+    /// are identical to <see cref="PreserveHour_FallBack_FiresOnceAtScheduledLocalHour" />.
+    /// </summary>
+    [TestCase(IntervalUnit.Day, "2024-11-01 01:30 -04:00", "2024-11-05 00:00 -05:00", "2024-11-04 01:30 -05:00")]
+    [TestCase(IntervalUnit.Week, "2024-10-27 01:30 -04:00", "2024-11-11 00:00 -05:00", "2024-11-10 01:30 -05:00")]
+    [TestCase(IntervalUnit.Month, "2024-10-03 01:30 -04:00", "2024-12-04 00:00 -05:00", "2024-12-03 01:30 -05:00")]
+    [TestCase(IntervalUnit.Year, "2023-11-03 01:30 -04:00", "2025-11-04 00:00 -05:00", "2025-11-03 01:30 -05:00")]
+    public void PreserveHour_SkipDayFlag_FallBack_IsNoOp(
+        IntervalUnit unit,
+        string start,
+        string untilExclusive,
+        string followingOccurrence)
+    {
+        AssertFallBackFiresOnceAtScheduledLocalHour(unit, start, untilExclusive, followingOccurrence, skipDayIfHourDoesNotExist: true);
+    }
+
+    private static void AssertFallBackFiresOnceAtScheduledLocalHour(
+        IntervalUnit unit,
+        string start,
+        string untilExclusive,
+        string followingOccurrence,
+        bool skipDayIfHourDoesNotExist)
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2024, 11, 3, 1, 30, 0));
+
+        // each start is chosen so that one occurrence lands exactly on the fall-back day 2024-11-03:
+        // daily from two days before, weekly from the previous Sunday, monthly/yearly from the same
+        // day-of-month one period earlier. All of them are still on -04:00 (2023 fell back on 11-05).
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            unit,
+            interval: 1,
+            TestTimeZones.Local(start),
+            preserveHourOfDay: true,
+            skipDayIfHourDoesNotExist);
+
+        List<DateTimeOffset> fires = WalkFrom(trigger, TestTimeZones.Local(start), TestTimeZones.Local(untilExclusive));
+
+        List<DateTimeOffset> onTransitionDay = fires
+            .Where(fireTime => TimeZoneInfo.ConvertTime(fireTime, zone).Date == new DateTime(2024, 11, 3))
+            .ToList();
+
+        // 01:30 happens twice on 2024-11-03. The trigger fires once, and on the first (daylight, -04:00)
+        // occurrence, because the re-anchoring goes through TimeZoneUtil.GetUtcOffset(DateTime, ...)
+        // which resolves an ambiguous wall-clock time to the daylight offset.
+        onTransitionDay.Should().Equal(TestTimeZones.Local("2024-11-03 01:30 -04:00"));
+
+        int transitionIndex = fires.IndexOf(onTransitionDay[0]);
+        fires.Should().HaveCountGreaterThan(transitionIndex + 1, "the walk window must extend past the transition day");
+
+        DateTimeOffset next = fires[transitionIndex + 1];
+        next.Should().Be(TestTimeZones.Local(followingOccurrence));
+
+        DateTimeOffset nextLocal = TimeZoneInfo.ConvertTime(next, zone);
+        nextLocal.TimeOfDay.Should().Be(new TimeSpan(1, 30, 0), "the scheduled wall-clock time is preserved across the transition");
+        nextLocal.Offset.Should().Be(TimeSpan.FromHours(-5), "the zone is on standard time after the fall back");
+    }
+
+    /// <summary>
+    /// Sub-day units are pure elapsed-time arithmetic off the start instant, so a DST transition is
+    /// simply not visible to them: the spacing between consecutive fires stays exactly the configured
+    /// interval in both directions, and the repeated hour shows up only as a 25 hour local day.
+    /// </summary>
+    [TestCase(IntervalUnit.Hour, 1)]
+    [TestCase(IntervalUnit.Minute, 90)]
+    [TestCase(IntervalUnit.Second, 3600)]
+    public void SubDayUnits_AreDstAgnostic(IntervalUnit unit, int interval)
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2018, 3, 25, 2, 30, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2018, 10, 28, 2, 30, 0));
+
+        TimeSpan expectedInterval = unit switch
+        {
+            IntervalUnit.Hour => TimeSpan.FromHours(interval),
+            IntervalUnit.Minute => TimeSpan.FromMinutes(interval),
+            _ => TimeSpan.FromSeconds(interval)
+        };
+
+        // spring forward: 2018-03-25 02:00 +01:00 becomes 03:00 +02:00
+        AssertUniformSpacing(zone, unit, interval, "2018-03-24 23:00 +01:00", "2018-03-25 08:00 +02:00", expectedInterval);
+
+        // fall back: 2018-10-28 03:00 +02:00 becomes 02:00 +01:00
+        AssertUniformSpacing(zone, unit, interval, "2018-10-28 00:00 +02:00", "2018-10-28 07:00 +01:00", expectedInterval);
+
+        if (unit == IntervalUnit.Hour && interval == 1)
+        {
+            // the fall-back local day is 25 hours long, so an hourly trigger fires 25 times on it
+            CalendarIntervalTriggerImpl hourly = CreateTrigger(
+                zone,
+                IntervalUnit.Hour,
+                interval: 1,
+                TestTimeZones.Local("2018-10-28 00:00 +02:00"),
+                preserveHourOfDay: true,
+                skipDayIfHourDoesNotExist: false);
+
+            List<DateTimeOffset> fires = WalkFrom(
+                hourly,
+                TestTimeZones.Local("2018-10-28 00:00 +02:00"),
+                TestTimeZones.Local("2018-10-29 00:00 +01:00"));
+
+            fires
+                .Count(fireTime => TimeZoneInfo.ConvertTime(fireTime, zone).Date == new DateTime(2018, 10, 28))
+                .Should().Be(25, "the repeated hour makes the fall-back local day 25 hours long");
+        }
+    }
+
+    private static void AssertUniformSpacing(
+        TimeZoneInfo zone,
+        IntervalUnit unit,
+        int interval,
+        string start,
+        string untilExclusive,
+        TimeSpan expectedInterval)
+    {
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            unit,
+            interval,
+            TestTimeZones.Local(start),
+            preserveHourOfDay: true,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> fires = WalkFrom(trigger, TestTimeZones.Local(start), TestTimeZones.Local(untilExclusive));
+
+        fires.Should().HaveCountGreaterThan(1, "the walk window must span the transition");
+
+        for (int i = 1; i < fires.Count; i++)
+        {
+            (fires[i] - fires[i - 1]).Should().Be(
+                expectedInterval,
+                $"fire {i} at {fires[i]:O} must be exactly one interval after {fires[i - 1]:O}");
+        }
+    }
+
+    /// <summary>
+    /// When the preserved wall-clock time is itself the ambiguous one, the trigger fires on the first
+    /// (daylight) occurrence of it, not the second. The re-anchoring resolves the local time through
+    /// <c>TimeZoneUtil.GetUtcOffset(DateTime, ...)</c>, which prefers the daylight offset.
+    /// </summary>
+    [Test]
+    public void PreserveHour_AmbiguousScheduledHour_Sydney_PicksFirstOccurrence()
+    {
+        TimeZoneInfo zone = TestTimeZones.Sydney;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2024, 4, 7, 2, 30, 0));
+
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            IntervalUnit.Day,
+            interval: 1,
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            preserveHourOfDay: true,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> fires = WalkFrom(
+            trigger,
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-09 00:00 +10:00"));
+
+        fires.Should().Equal(
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-06 02:30 +11:00"),
+            // 02:30 exists twice on 2024-04-07; the daylight (+11:00) one is chosen
+            TestTimeZones.Local("2024-04-07 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-08 02:30 +10:00"));
+    }
+
+    /// <summary>
+    /// Santiago moves its clocks at midnight, so on 2019-09-08 the date's own 00:00 does not exist and
+    /// the day starts at 01:00 -03:00. This pins both halves of the gap handling: crawl forward to the
+    /// first valid minute, or skip the day entirely.
+    /// </summary>
+    [Test]
+    public void PreserveHour_MidnightGap_Santiago_Daily()
+    {
+        TimeZoneInfo zone = TestTimeZones.Santiago;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2019, 9, 8, 0, 0, 0));
+
+        DateTimeOffset start = TestTimeZones.Local("2019-09-06 00:00 -04:00");
+        DateTimeOffset untilExclusive = TestTimeZones.Local("2019-09-11 00:00 -03:00");
+
+        CalendarIntervalTriggerImpl crawling = CreateTrigger(
+            zone, IntervalUnit.Day, interval: 1, start, preserveHourOfDay: true, skipDayIfHourDoesNotExist: false);
+
+        WalkFrom(crawling, start, untilExclusive).Should().Equal(
+            TestTimeZones.Local("2019-09-06 00:00 -04:00"),
+            TestTimeZones.Local("2019-09-07 00:00 -04:00"),
+            // 00:00 does not exist on the transition day, so the trigger crawls forward a minute at a
+            // time until it lands on the first instant the day actually has
+            TestTimeZones.Local("2019-09-08 01:00 -03:00"),
+            TestTimeZones.Local("2019-09-09 00:00 -03:00"),
+            TestTimeZones.Local("2019-09-10 00:00 -03:00"));
+
+        CalendarIntervalTriggerImpl skipping = CreateTrigger(
+            zone, IntervalUnit.Day, interval: 1, start, preserveHourOfDay: true, skipDayIfHourDoesNotExist: true);
+
+        WalkFrom(skipping, start, untilExclusive).Should().Equal(
+            TestTimeZones.Local("2019-09-06 00:00 -04:00"),
+            TestTimeZones.Local("2019-09-07 00:00 -04:00"),
+            // the transition day is dropped and the schedule resumes on the following day at 00:00
+            TestTimeZones.Local("2019-09-09 00:00 -03:00"),
+            TestTimeZones.Local("2019-09-10 00:00 -03:00"));
+    }
+
+    /// <summary>
+    /// <c>ComputeFirstFireTimeUtc</c> applies no DST correction: the first fire is the start instant
+    /// itself, whichever side of a transition it sits on and regardless of the preserve flag. Note that
+    /// <c>StartTimeUtc</c> is an instant rather than a wall-clock time, so it can never be invalid or
+    /// ambiguous - there is nothing for the trigger to correct here in the first place.
+    /// </summary>
+    [TestCase("2024-03-10 06:59 +00:00", false)]
+    [TestCase("2024-03-10 06:59 +00:00", true)]
+    [TestCase("2024-03-10 07:01 +00:00", false)]
+    [TestCase("2024-03-10 07:01 +00:00", true)]
+    [TestCase("2024-11-03 05:59 +00:00", false)]
+    [TestCase("2024-11-03 05:59 +00:00", true)]
+    [TestCase("2024-11-03 06:01 +00:00", false)]
+    [TestCase("2024-11-03 06:01 +00:00", true)]
+    public void FirstFireTime_EqualsStartInstant_AdjacentToTransitions(string startTimeUtc, bool preserveHourOfDay)
+    {
+        // Eastern springs forward at 2024-03-10 07:00Z and falls back at 2024-11-03 06:00Z, so each of
+        // these start instants is a minute either side of a transition.
+        DateTimeOffset start = TestTimeZones.Local(startTimeUtc);
+
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            TestTimeZones.Eastern,
+            IntervalUnit.Day,
+            interval: 1,
+            start,
+            preserveHourOfDay,
+            skipDayIfHourDoesNotExist: false);
+
+        trigger.ComputeFirstFireTimeUtc(null).Should().Be(start);
+    }
+
+    #region Current-behavior pins (decision points)
+
+    /// <summary>
+    /// PINNED DELIBERATELY - this is the behaviour of the DEFAULT configuration and it is the opposite
+    /// of what cron and daily-time-interval triggers do.
+    ///
+    /// With <c>PreserveHourOfDayAcrossDaylightSavings</c> left at its default of <c>false</c>, a day (or
+    /// larger) interval is pure instant arithmetic: consecutive fires stay exactly 24 hours apart in UTC
+    /// and the local wall-clock time therefore slides by an hour when the zone falls back. Cron and
+    /// <c>DailyTimeIntervalTrigger</c> anchor to the wall clock instead and would keep firing at 01:30
+    /// local. Whether a calendar-interval trigger should default to instant spacing or to wall-clock
+    /// spacing is a genuine design question; this test exists so that changing the answer is a conscious
+    /// act rather than an accident.
+    /// </summary>
+    [Test]
+    public void NoPreserveHour_FallBack_LocalTimeDriftsOneHour_UtcStable()
+    {
+        TimeZoneInfo eastern = TestTimeZones.Eastern;
+        TestTimeZones.AssumeAmbiguousLocalTime(eastern, new DateTime(2024, 11, 3, 1, 30, 0));
+
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            eastern,
+            IntervalUnit.Day,
+            interval: 1,
+            TestTimeZones.Local("2024-11-01 01:30 -04:00"),
+            preserveHourOfDay: false,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> fires = WalkFrom(
+            trigger,
+            TestTimeZones.Local("2024-11-01 01:30 -04:00"),
+            TestTimeZones.Local("2024-11-06 00:00 -05:00"));
+
+        // Note where the drift actually lands. The transition is at 2024-11-03 06:00Z, and the trigger
+        // fires at 05:30Z, so the 2024-11-03 fire is still on daylight time at 01:30 -04:00 - it is the
+        // FOLLOWING day, 2024-11-04, that first shows the drifted 00:30 -05:00 wall-clock time.
+        fires.Should().Equal(
+            TestTimeZones.Local("2024-11-01 01:30 -04:00"),
+            TestTimeZones.Local("2024-11-02 01:30 -04:00"),
+            TestTimeZones.Local("2024-11-03 01:30 -04:00"),
+            TestTimeZones.Local("2024-11-04 00:30 -05:00"),
+            TestTimeZones.Local("2024-11-05 00:30 -05:00"));
+
+        AssertConstantUtcSpacing(fires, TimeSpan.FromHours(24));
+
+        // the whole run sits on the same UTC time of day, which is exactly the point
+        fires.Should().OnlyContain(fireTime => fireTime.UtcDateTime.TimeOfDay == new TimeSpan(5, 30, 0));
+
+        // Southern hemisphere mirror: Sydney falls back on 2024-04-07 and the same drift appears one day
+        // later, on 2024-04-08, for the same reason.
+        TimeZoneInfo sydney = TestTimeZones.Sydney;
+        TestTimeZones.AssumeAmbiguousLocalTime(sydney, new DateTime(2024, 4, 7, 2, 30, 0));
+
+        CalendarIntervalTriggerImpl sydneyTrigger = CreateTrigger(
+            sydney,
+            IntervalUnit.Day,
+            interval: 1,
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            preserveHourOfDay: false,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> sydneyFires = WalkFrom(
+            sydneyTrigger,
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-10 00:00 +10:00"));
+
+        sydneyFires.Should().Equal(
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-06 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-07 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-08 01:30 +10:00"),
+            TestTimeZones.Local("2024-04-09 01:30 +10:00"));
+
+        AssertConstantUtcSpacing(sydneyFires, TimeSpan.FromHours(24));
+    }
+
+    private static void AssertConstantUtcSpacing(List<DateTimeOffset> fires, TimeSpan expectedInterval)
+    {
+        for (int i = 1; i < fires.Count; i++)
+        {
+            (fires[i] - fires[i - 1]).Should().Be(
+                expectedInterval,
+                $"fire {i} at {fires[i]:O} must be exactly one interval after {fires[i - 1]:O}");
+        }
+    }
+
+    #endregion
+}

--- a/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
@@ -1,0 +1,484 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Daylight saving time corner cases for <see cref="CronExpression" /> itself, exercised through
+/// <see cref="CronExpression.GetTimeAfter" />, <see cref="CronExpression.GetTimeBefore" /> and
+/// <see cref="CronExpression.IsSatisfiedBy" /> across zones with differing transition shapes
+/// (northern and southern hemisphere, a midnight gap, and a 30 minute delta).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The mechanics being pinned live at the end of <see cref="CronExpression.GetTimeAfter" />: the
+/// search converts the "after" instant into the target zone once, then advances purely in wall
+/// clock terms with the offset frozen, and only at the very end re-resolves the offset for the
+/// resulting local date and time. That re-resolution prefers the DAYLIGHT (first) occurrence of an
+/// ambiguous local time, and demotes to the standard offset only when the daylight interpretation
+/// would land at or before the "after" instant. Local times that fall inside a spring-forward gap
+/// do not exist, so the re-resolution yields the pre-transition offset and the fire lands shifted
+/// forward in real time by the transition delta.
+/// </para>
+/// <para>
+/// These tests never touch <c>SystemTime</c>, so they are safe to run in parallel with the rest of
+/// the suite.
+/// </para>
+/// </remarks>
+public class CronExpressionDstTests
+{
+    /// <summary>
+    /// Attributes cannot carry a <see cref="TimeZoneInfo" />, so test case grids name the zone and
+    /// resolve it here. Zones that may be missing from an old OS install ignore the test from
+    /// inside <see cref="TestTimeZones" /> rather than failing it.
+    /// </summary>
+    private static TimeZoneInfo ResolveZone(string zoneKey)
+    {
+        switch (zoneKey)
+        {
+            case "Eastern":
+                return TestTimeZones.Eastern;
+            case "CentralEuropean":
+                return TestTimeZones.CentralEuropean;
+            case "Santiago":
+                return TestTimeZones.Santiago;
+            case "Sydney":
+                return TestTimeZones.Sydney;
+            case "LordHowe":
+                return TestTimeZones.LordHowe;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test time zone key");
+        }
+    }
+
+    private static CronExpression CronIn(string expression, TimeZoneInfo zone)
+    {
+        CronExpression cron = new CronExpression(expression);
+        cron.TimeZone = zone;
+        return cron;
+    }
+
+    /// <summary>
+    /// Parses a wall clock time with no offset, for stating an invalid or ambiguous premise.
+    /// </summary>
+    private static DateTime WallClock(string value)
+    {
+        return DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.None);
+    }
+
+    /// <summary>
+    /// A daily trigger whose fire time falls inside the spring-forward gap still fires exactly once
+    /// on the transition day, but shifted forward in real time by the transition delta: the
+    /// non-existent local time is resolved with the pre-transition offset, so 02:30 -05:00 becomes
+    /// the instant that reads 03:30 -04:00. The following day is back to the nominal wall clock
+    /// time, which shows the shift is confined to the transition day.
+    /// </summary>
+    /// <remarks>
+    /// This is a deliberate deviation from Cronos-style semantics, which fire such a trigger at the
+    /// END of the gap (03:00 in the Eastern case, i.e. the moment the skipped wall clock time would
+    /// have been reached). Quartz.NET instead fires delta-shifted (03:30) to keep parity with Java
+    /// Quartz, whose <c>CronExpression</c> performs the same "advance in wall clock, resolve the
+    /// offset last" walk. The Lord Howe case is the one that tells the two rules apart beyond
+    /// doubt: its delta is 30 minutes, so a gap-END rule would fire at 02:30 while the delta-shift
+    /// rule fires at 02:45.
+    /// </remarks>
+    [TestCase("0 30 2 * * ?", "Eastern", "2024-03-10 02:30", "2024-03-10 00:00 -05:00", "2024-03-10 03:30 -04:00", "2024-03-11 02:30 -04:00")]
+    [TestCase("0 15 2 * * ?", "LordHowe", "2019-10-06 02:15", "2019-10-06 00:00 +10:30", "2019-10-06 02:45 +11:00", "2019-10-07 02:15 +11:00")]
+    [TestCase("0 0 0 * * ?", "Santiago", "2019-09-08 00:00", "2019-09-07 12:00 -04:00", "2019-09-08 01:00 -03:00", "2019-09-09 00:00 -03:00")]
+    public void GetTimeAfter_FixedTimeInsideGap_FiresOnceShiftedByTransitionDelta(
+        string cronExpression,
+        string zoneKey,
+        string gapLocalTime,
+        string fromLocal,
+        string expectedFire,
+        string expectedNextDayFire)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock(gapLocalTime));
+
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset? fire = cron.GetTimeAfter(TestTimeZones.Local(fromLocal));
+
+        fire.Should().NotBeNull();
+        fire!.Value.Should().Be(TestTimeZones.Local(expectedFire));
+
+        DateTimeOffset? nextFire = cron.GetTimeAfter(fire.Value);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(TestTimeZones.Local(expectedNextDayFire), "the trigger fires only once on the transition day");
+    }
+
+    /// <summary>
+    /// A daily trigger whose fire time is repeated by the fall-back transition fires once, at the
+    /// FIRST (daylight) occurrence, and not again at the second (standard) occurrence of the same
+    /// wall clock time. Southern hemisphere zones and a transition that crosses backwards over the
+    /// date boundary behave the same way.
+    /// </summary>
+    [TestCase("0 30 1 * * ?", "Eastern", "2024-11-03 01:30", "2024-11-03 00:00 -04:00", "2024-11-03 01:30 -04:00", "2024-11-04 01:30 -05:00")]
+    [TestCase("0 30 2 * * ?", "CentralEuropean", "2018-10-28 02:30", "2018-10-28 00:00 +02:00", "2018-10-28 02:30 +02:00", "2018-10-29 02:30 +01:00")]
+    [TestCase("0 30 2 * * ?", "Sydney", "2024-04-07 02:30", "2024-04-07 00:00 +11:00", "2024-04-07 02:30 +11:00", "2024-04-08 02:30 +10:00")]
+    [TestCase("0 30 23 * * ?", "Santiago", "2019-04-06 23:30", "2019-04-06 00:00 -03:00", "2019-04-06 23:30 -03:00", "2019-04-07 23:30 -04:00")]
+    public void GetTimeAfter_DailyFixedTime_FallBackDay_FiresOnlyOnce_AtDaylightOccurrence(
+        string cronExpression,
+        string zoneKey,
+        string ambiguousLocalTime,
+        string fromLocal,
+        string expectedFire,
+        string expectedNextDayFire)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock(ambiguousLocalTime));
+
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset? fire = cron.GetTimeAfter(TestTimeZones.Local(fromLocal));
+
+        fire.Should().NotBeNull();
+        fire!.Value.Should().Be(TestTimeZones.Local(expectedFire), "the daylight occurrence comes first and time moves forward");
+
+        DateTimeOffset? nextFire = cron.GetTimeAfter(fire.Value);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(TestTimeZones.Local(expectedNextDayFire), "the repeated wall clock time must not fire a second time");
+    }
+
+    /// <summary>
+    /// Real time never stops, so a minutely trigger keeps firing every minute right through the
+    /// spring-forward transition. What disappears is the local hour 02, not the fires: the walk
+    /// produces an unbroken minutely sequence whose local reading jumps from 01:59 straight to
+    /// 03:00, and the UTC hour that contains the transition is fully populated.
+    /// </summary>
+    [Test]
+    public void SequentialWalk_MinutelyCron_SpringForwardDay_FireCountAndNoLocalGapHour()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset dayStart = TestTimeZones.Local("2024-03-10 00:00 -05:00");
+        DateTimeOffset dayEnd = TestTimeZones.Local("2024-03-11 00:00 -04:00");
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(cron.GetTimeAfter, dayStart, dayEnd);
+
+        // The spring-forward day is 23 real hours long; the walk excludes both boundary instants,
+        // so a fire on every minute boundary in between is 23 * 60 - 1.
+        fireTimes.Should().HaveCount(1379, "the day is 23 real hours long and every minute boundary fires");
+
+        fireTimes.Should().NotContain(
+            fire => TimeZoneInfo.ConvertTime(fire, zone).Hour == 2,
+            "local hour 02 does not exist on the spring-forward day");
+
+        DateTimeOffset gapHourStart = TestTimeZones.Local("2024-03-10 07:00 +00:00");
+        DateTimeOffset gapHourEnd = TestTimeZones.Local("2024-03-10 08:00 +00:00");
+
+        fireTimes.Should().Contain(
+            fire => fire >= gapHourStart && fire < gapHourEnd,
+            "real time does not stop during the gap; those fires simply read as local 03:xx");
+    }
+
+    /// <summary>
+    /// <see cref="CronExpression.GetTimeBefore" /> is a binary search layered on top of
+    /// <see cref="CronExpression.GetTimeAfter" />, so it must agree with it around transitions.
+    /// Asserted as properties rather than pinned instants: the returned time is strictly before the
+    /// probe, it is a genuine fire time (asking for the next fire one second earlier reproduces it),
+    /// and asking for the next fire from it makes progress rather than wedging.
+    /// </summary>
+    /// <remarks>
+    /// The probe set is per case rather than a fixed grid because the -5 minute probe on a
+    /// FALL-BACK transition currently breaks the round trip: see
+    /// <see cref="GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_CurrentlyReturnsNonFireTime" />
+    /// in the pins region below, and the root cause pinned next to it. Restore -5 to those two
+    /// cases once that is fixed.
+    /// </remarks>
+    [TestCase("0 * * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-03-25 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-03-25 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, 5, 60 })]
+    public void GetTimeBefore_RoundTripsWithGetTimeAfter_AroundTransitions(
+        string cronExpression,
+        string zoneKey,
+        string transitionUtc,
+        int[] probeOffsetsInMinutes)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset transition = TestTimeZones.Local(transitionUtc);
+
+        foreach (int probeOffsetInMinutes in probeOffsetsInMinutes)
+        {
+            DateTimeOffset probe = transition.AddMinutes(probeOffsetInMinutes);
+            string context = $"probe {probe:O} ({probeOffsetInMinutes:+#;-#;0} min from the transition)";
+
+            DateTimeOffset? previous = cron.GetTimeBefore(probe);
+
+            previous.Should().NotBeNull(context);
+            previous!.Value.Should().BeBefore(probe, "GetTimeBefore must return a time strictly before the probe; " + context);
+
+            cron.GetTimeAfter(previous.Value.AddSeconds(-1))
+                .Should().Be(previous.Value, "the time before must itself be a fire time; " + context);
+
+            cron.GetTimeAfter(previous.Value)
+                .Should().BeAfter(previous.Value, "asking again from a fire time must make progress; " + context);
+        }
+    }
+
+    /// <summary>
+    /// Spring-forward counterpart to the fall-back <c>IsSatisfiedBy</c> coverage: the instants that
+    /// make up the "missing" hour are ordinary instants that read as local 03:xx, and a minutely
+    /// expression matches them.
+    /// </summary>
+    [Test]
+    public void IsSatisfiedBy_MinutelyCron_TrueForInstantsInsideGapHourUtc()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset insideGapHour = TestTimeZones.Local("2024-03-10 07:15 +00:00");
+
+        cron.IsSatisfiedBy(insideGapHour).Should().BeTrue("07:15Z is local 03:15 -04:00, an ordinary matching minute");
+    }
+
+    #region Current-behavior pins (decision points)
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — known deviation, expected to change on main/4.0.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A sequential walk of an interval (minutely) expression across a fall-back transition
+    /// currently SKIPS the entire repeated standard-pass hour. After the last daylight-pass fire at
+    /// 02:59 +02:00 (00:59Z) the next fire produced is 03:00 +01:00 (02:00Z), so the whole UTC hour
+    /// [01:00Z, 02:00Z) — local 02:00-02:59 +01:00 — never fires. The cause is that the wall clock
+    /// walk advances 02:59 to 03:00 and only then resolves the offset; 03:00 is unambiguous, so the
+    /// standard-offset repeat of 02:xx is never visited.
+    /// </para>
+    /// <para>
+    /// This violates the rule that interval expressions should fire in BOTH fall-back passes (the
+    /// Cronos invariant, and what an "every minute" schedule means to a user: 25 fires per hour-of
+    /// -day on this date, 1500 minute fires in a 25 hour day). The flip target is 1499 fires
+    /// (25 * 60 - 1, the walk excluding both boundary instants) plus PRESENCE of fires inside
+    /// [01:00Z, 02:00Z), replacing the 1439 and the emptiness assertion pinned here.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void SequentialWalk_MinutelyCron_FallBackDay_CurrentlySkipsRepeatedStandardHour()
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset dayStart = TestTimeZones.Local("2018-10-28 00:00 +02:00");
+        DateTimeOffset dayEnd = TestTimeZones.Local("2018-10-29 00:00 +01:00");
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(cron.GetTimeAfter, dayStart, dayEnd);
+
+        // 25 real hours, minus both excluded boundary instants, would be 1499 fires. 60 of them —
+        // the standard pass over local 02:00-02:59 — are currently skipped.
+        fireTimes.Should().HaveCount(1439, "the repeated standard-pass hour is currently skipped entirely");
+
+        DateTimeOffset repeatedHourStart = TestTimeZones.Local("2018-10-28 01:00 +00:00");
+        DateTimeOffset repeatedHourEnd = TestTimeZones.Local("2018-10-28 02:00 +00:00");
+
+        fireTimes.Should().NotContain(
+            fire => fire >= repeatedHourStart && fire < repeatedHourEnd,
+            "the sequential walk currently jumps from 02:59 +02:00 straight to 03:00 +01:00");
+    }
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CronExpression.IsSatisfiedBy" /> answers TRUE for instants inside the repeated
+    /// standard-pass hour that the sequential walk never produces. It is implemented as
+    /// <c>GetTimeAfter(instant - 1s) == instant</c>, and starting the search from just inside that
+    /// hour makes the daylight interpretation land before the "after" instant, which triggers the
+    /// demotion to the standard offset and reproduces the instant exactly. Starting the search from
+    /// BEFORE the transition never reaches it.
+    /// </para>
+    /// <para>
+    /// So the same expression both matches and does not schedule the same instant, depending only
+    /// on where the question is asked from. Pinned here in one place. Once the walk fires in both
+    /// passes this test becomes redundant with the walk simply containing the hour, and the
+    /// emptiness assertion below should be deleted.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void IsSatisfiedBy_RepeatedHourStandardPass_TrueButNeverProducedByWalk()
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset standardPassInstant = TestTimeZones.Local("2018-10-28 01:30 +00:00");
+
+        cron.IsSatisfiedBy(standardPassInstant).Should().BeTrue("01:30Z is local 02:30 +01:00, which the expression matches");
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            cron.GetTimeAfter,
+            TestTimeZones.Local("2018-10-28 00:55 +02:00"),
+            TestTimeZones.Local("2018-10-28 04:00 +01:00"));
+
+        DateTimeOffset repeatedHourStart = TestTimeZones.Local("2018-10-28 01:00 +00:00");
+        DateTimeOffset repeatedHourEnd = TestTimeZones.Local("2018-10-28 02:00 +00:00");
+
+        fireTimes.Should().NotBeEmpty();
+        fireTimes.Should().NotContain(
+            fire => fire >= repeatedHourStart && fire < repeatedHourEnd,
+            "a walk across the transition never schedules the instant IsSatisfiedBy just accepted");
+    }
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The mirror image of the fall-back inconsistency, on the spring-forward side. For a fixed
+    /// time inside the gap, <see cref="CronExpression.GetTimeAfter" /> returns the delta-shifted
+    /// instant 03:30 -04:00 (07:30Z), yet <see cref="CronExpression.IsSatisfiedBy" /> returns FALSE
+    /// for that very instant, because its local reading is hour 03 and the expression asks for hour
+    /// 02. The trigger therefore fires at an instant its own expression does not match.
+    /// </para>
+    /// <para>
+    /// Whatever rule replaces the delta shift on main/4.0 should make these two agree: either the
+    /// fire moves to the gap END (03:00, which the expression still does not match literally, so
+    /// <c>IsSatisfiedBy</c> would need to special-case the gap), or <c>IsSatisfiedBy</c> learns to
+    /// accept the shifted instant. Flip target: this assertion becomes <c>BeTrue</c>.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void IsSatisfiedBy_InstantReturnedForInGapFixedTime_IsCurrentlyFalse()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
+
+        CronExpression cron = CronIn("0 30 2 * * ?", zone);
+
+        DateTimeOffset? fire = cron.GetTimeAfter(TestTimeZones.Local("2024-03-10 00:00 -05:00"));
+
+        fire.Should().NotBeNull();
+        fire!.Value.Should().Be(TestTimeZones.Local("2024-03-10 03:30 -04:00"));
+
+        cron.IsSatisfiedBy(fire.Value).Should().BeFalse("the fire instant reads as local 03:30, and the expression asks for hour 02");
+    }
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — this one looks like a plain defect rather than a semantic choice.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CronExpression.GetTimeAfter" /> starts by adding one second to the requested
+    /// instant KEEPING its sub-second ticks, then truncates a separate copy to whole seconds for
+    /// the search. At the very end the fall-back demotion asks whether the resolved fire is before
+    /// the requested instant, and compares the truncated fire against the UNTRUNCATED copy
+    /// (<c>CronExpression.cs</c>: <c>if (d.ToUniversalTime() &lt; afterTimeUtc &amp;&amp;
+    /// TimeZone.IsAmbiguousTime(localDateTime))</c>). Any sub-second remainder therefore makes a
+    /// perfectly good fire look "too early" while the local time is ambiguous, and the result is
+    /// demoted a whole hour forward to the standard pass.
+    /// </para>
+    /// <para>
+    /// The effect: asking for the next fire after 05:53:59.000Z gives 05:54:00Z, but asking after
+    /// 05:53:59.500Z — half a second LATER — skips that fire entirely and gives 06:54:00Z. The
+    /// comparison should use the truncated instant, at which point both answers are 05:54:00Z.
+    /// Flip target: both assertions below expect 05:54:00Z.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void GetTimeAfter_SubSecondInstantInsideRepeatedHour_CurrentlySkipsAnHourToStandardPass()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2024-11-03 01:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset wholeSecond = new DateTimeOffset(2024, 11, 3, 5, 53, 59, 0, TimeSpan.Zero);
+        DateTimeOffset withMilliseconds = new DateTimeOffset(2024, 11, 3, 5, 53, 59, 500, TimeSpan.Zero);
+
+        cron.GetTimeAfter(wholeSecond)
+            .Should().Be(TestTimeZones.Local("2024-11-03 05:54 +00:00"), "local 01:54 -04:00 is the very next minute");
+
+        cron.GetTimeAfter(withMilliseconds)
+            .Should().Be(TestTimeZones.Local("2024-11-03 06:54 +00:00"), "the sub-second remainder currently forces the demotion to local 01:54 -05:00");
+    }
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — the user-visible consequence of the sub-second defect above.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CronExpression.GetTimeBefore" /> binary searches on "does the next fire after this
+    /// probe land before the end time", over arbitrary tick values. The sub-second demotion makes
+    /// that predicate NON-MONOTONIC in the second immediately preceding a fire whose local time is
+    /// ambiguous: it holds at the whole second, then flips false a fraction later. The search
+    /// converges on that false crossover instead of the real one, and the result — truncated to a
+    /// whole second — comes out one second early, on a value the expression never fires at.
+    /// </para>
+    /// <para>
+    /// So <c>GetTimeBefore</c> can return a NON-FIRE time: the pinned results below all end in
+    /// :59 for expressions that only ever fire at second 0. Flip target: the expected value becomes
+    /// the real preceding fire time (the third argument), and the -5 minute probe can be restored
+    /// to the fall-back cases of
+    /// <see cref="GetTimeBefore_RoundTripsWithGetTimeAfter_AroundTransitions" />.
+    /// </para>
+    /// </remarks>
+    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:54:00 +00:00", "2024-11-03 05:53:59 +00:00")]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:00:00 +00:00", "2024-11-03 04:59:59 +00:00")]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:54:00 +00:00", "2018-10-28 00:53:59 +00:00")]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:00:00 +00:00", "2018-10-27 23:59:59 +00:00")]
+    public void GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_CurrentlyReturnsNonFireTime(
+        string cronExpression,
+        string zoneKey,
+        string probeUtc,
+        string realPrecedingFire,
+        string currentlyReturned)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset probe = TestTimeZones.Local(probeUtc);
+
+        // The real preceding fire is what a forward walk produces, and it is a genuine fire time.
+        DateTimeOffset expectedFire = TestTimeZones.Local(realPrecedingFire);
+        cron.GetTimeAfter(expectedFire.AddSeconds(-1)).Should().Be(expectedFire);
+        cron.IsSatisfiedBy(expectedFire).Should().BeTrue();
+
+        DateTimeOffset? previous = cron.GetTimeBefore(probe);
+
+        previous.Should().NotBeNull();
+        previous!.Value.Should().Be(TestTimeZones.Local(currentlyReturned), "the binary search converges on the sub-second demotion crossover");
+        cron.IsSatisfiedBy(previous.Value).Should().BeFalse("the returned time is not a time the expression ever fires at");
+    }
+
+    #endregion
+}

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerDstTests.cs
@@ -1,0 +1,285 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Quartz.Impl.Triggers;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Impl.Triggers;
+
+/// <summary>
+/// Daylight saving time coverage for <see cref="DailyTimeIntervalTriggerImpl" />, pinning the
+/// behaviour that <see cref="DailyTimeIntervalTriggerImplTest" /> only covers for spring-forward.
+/// </summary>
+/// <remarks>
+/// The trigger resolves each day's window start and end from wall-clock times (preferring the
+/// daylight occurrence for an ambiguous local time and the pre-transition offset for one that does
+/// not exist), but steps through the window by adding the interval in UTC ticks. Every expectation
+/// below follows from that: a day yields <c>floor(windowLengthInSeconds / intervalInSeconds) + 1</c>
+/// fires, where the window length is measured between the two resolved instants, not in wall-clock
+/// hours.
+/// </remarks>
+public class DailyTimeIntervalTriggerDstTests
+{
+    /// <summary>
+    /// Fall-back mirror of <c>DailyTimeIntervalTriggerImplTest.TestSpringForwardFireTimesAreStrictlyIncreasing</c>.
+    /// </summary>
+    /// <remarks>
+    /// On 2018-10-28 in Central European time the window runs from local 00:00 +02:00
+    /// (2018-10-27 22:00 UTC) to local 23:59:59 +01:00 (2018-10-28 22:59:59 UTC), which is
+    /// 89999 elapsed seconds - a 25 hour day. Every expected count is
+    /// <c>floor(89999 / interval) + 1</c>, so a sub-hour interval fires through both passes of the
+    /// ambiguous 02:00-02:59 hour and the day yields one interval's worth of extra fires.
+    /// The 24 hour row is the exception: it is the only interval that trips the
+    /// <c>RepeatIntervalSpan &gt;= 1 day</c> fall-back correction, which pushes the second fire of the
+    /// day (local 23:00, exactly 24 UTC hours after the window start) onto the next local date.
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    [TestCase(IntervalUnit.Second, 900, 100)]
+    [TestCase(IntervalUnit.Minute, 1, 1500)]
+    [TestCase(IntervalUnit.Minute, 5, 300)]
+    [TestCase(IntervalUnit.Minute, 15, 100)]
+    [TestCase(IntervalUnit.Minute, 30, 50)]
+    [TestCase(IntervalUnit.Minute, 45, 34)]
+    [TestCase(IntervalUnit.Hour, 1, 25)]
+    [TestCase(IntervalUnit.Hour, 2, 13)]
+    [TestCase(IntervalUnit.Hour, 4, 7)]
+    [TestCase(IntervalUnit.Hour, 24, 1)]
+    public void FallBackFireTimesAreStrictlyIncreasing(IntervalUnit unit, int interval, int expectedFireCountOnFallBackDay)
+    {
+        TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2018, 10, 28, 2, 30, 0));
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+            .EndingDailyAt(TimeOfDay.HourMinuteAndSecondOfDay(23, 59, 59))
+            .OnEveryDay()
+            .WithInterval(interval, unit)
+            .InTimeZone(timeZone)
+            .Build();
+
+        // Oct 27 22:00 UTC is Oct 28 00:00 CEST, the start of the fall-back day
+        trigger.StartTimeUtc = new DateTimeOffset(2018, 10, 27, 22, 0, 0, TimeSpan.Zero);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        // walk the fall-back day and the ordinary day after it; Walk fails the test if the trigger
+        // ever moves backwards, repeats itself or runs away
+        List<DateTimeOffset> local = TestTimeZones
+            .Walk(after => trigger.GetFireTimeAfter(after),
+                trigger.StartTimeUtc.AddSeconds(-1),
+                new DateTimeOffset(2018, 10, 29, 23, 0, 0, TimeSpan.Zero))
+            .Select(t => TimeZoneInfo.ConvertTime(t, timeZone))
+            .ToList();
+
+        local[0].TimeOfDay.Should().Be(TimeSpan.Zero, "the first fire of the day is startTimeOfDay");
+        local.Count(t => t.Date == new DateTime(2018, 10, 28)).Should().Be(expectedFireCountOnFallBackDay);
+        local.Select(t => t.Date).Distinct().Should().HaveCountGreaterThan(1, "the trigger must advance past the fall-back day");
+    }
+
+    /// <summary>
+    /// <see cref="IDailyTimeIntervalTrigger.RepeatCount" /> caps the fires <em>per local day</em>
+    /// ("setting to N means fire N+1 times per day"), and the cap counts interval steps rather than
+    /// wall-clock time.
+    /// </summary>
+    /// <remarks>
+    /// So the 25 hour fall-back day gets exactly as many fires as an ordinary day - the extra hour
+    /// buys nothing. It only shifts where the run ends on the clock: 30 steps of 30 minutes is
+    /// 15 UTC hours from the window start, which is local 15:00 on an ordinary day but local 14:00
+    /// on the fall-back day, because one of those 15 hours was spent repeating 02:00-02:59.
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void RepeatCountLimitsFires_AcrossFallBackDay()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2018, 10, 28, 2, 30, 0));
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+            .EndingDailyAt(TimeOfDay.HourMinuteAndSecondOfDay(23, 59, 59))
+            .OnEveryDay()
+            .WithIntervalInMinutes(30)
+            .WithRepeatCount(30)
+            .InTimeZone(timeZone)
+            .Build();
+
+        // Oct 26 22:00 UTC is Oct 27 00:00 CEST, the start of the day before the fall-back day
+        trigger.StartTimeUtc = new DateTimeOffset(2018, 10, 26, 22, 0, 0, TimeSpan.Zero);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        List<DateTimeOffset> local = TestTimeZones
+            .Walk(after => trigger.GetFireTimeAfter(after),
+                trigger.StartTimeUtc.AddSeconds(-1),
+                new DateTimeOffset(2018, 10, 29, 23, 0, 0, TimeSpan.Zero))
+            .Select(t => TimeZoneInfo.ConvertTime(t, timeZone))
+            .ToList();
+
+        List<DateTimeOffset> dayBefore = local.Where(t => t.Date == new DateTime(2018, 10, 27)).ToList();
+        List<DateTimeOffset> fallBackDay = local.Where(t => t.Date == new DateTime(2018, 10, 28)).ToList();
+        List<DateTimeOffset> dayAfter = local.Where(t => t.Date == new DateTime(2018, 10, 29)).ToList();
+
+        dayBefore.Should().HaveCount(31, "repeatCount 30 means 31 fires per day");
+        fallBackDay.Should().HaveCount(31, "the 25 hour day gets no extra fires, the cap counts interval steps");
+        dayAfter.Should().HaveCount(31);
+
+        dayBefore[^1].Should().Be(TestTimeZones.Local("2018-10-27 15:00 +02:00"));
+        fallBackDay[^1].Should().Be(TestTimeZones.Local("2018-10-28 14:00 +01:00"), "an hour of the run was spent repeating 02:00-02:59");
+        dayAfter[^1].Should().Be(TestTimeZones.Local("2018-10-29 15:00 +01:00"));
+
+        fallBackDay.Where(t => t.Hour == 2).Should().HaveCount(4, "the ambiguous hour occurs twice and holds two 30 minute slots each time");
+
+        // FinalFireTimeUtc is derived from EndTimeUtc only; a per-day repeat count never ends the trigger
+        trigger.FinalFireTimeUtc.Should().BeNull("without an end time the trigger repeats its daily run forever");
+    }
+
+    /// <summary>
+    /// An <c>endTimeOfDay</c> that lands inside the spring-forward gap still bounds the day, but it
+    /// bounds it as an <em>instant</em>, not as a wall-clock time.
+    /// </summary>
+    /// <remarks>
+    /// On 2018-03-25 the local times 02:00-02:59 do not exist. The gap end resolves with the
+    /// pre-transition offset, so local 02:30 becomes 02:30 +01:00 = 01:30 UTC. The third hourly slot
+    /// falls on 01:00 UTC, which is still before that bound, and 01:00 UTC is the transition instant
+    /// itself - so the trigger fires at local 03:00 +02:00, half an hour past the wall-clock
+    /// endTimeOfDay it was given. That is the only slot that behaves that way: the fourth is
+    /// 02:00 UTC, past the bound, and the day ends cleanly. There is no loop and no wedge.
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void EndTimeOfDayInsideSpringForwardGap_DayEndsCleanly()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2018, 3, 25, 2, 0, 0));
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2018, 3, 25, 2, 30, 0));
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+            .EndingDailyAt(TimeOfDay.HourAndMinuteOfDay(2, 30))
+            .OnEveryDay()
+            .WithIntervalInHours(1)
+            .InTimeZone(timeZone)
+            .Build();
+
+        // Mar 24 23:00 UTC is Mar 25 00:00 CET, the start of the spring-forward day
+        trigger.StartTimeUtc = new DateTimeOffset(2018, 3, 24, 23, 0, 0, TimeSpan.Zero);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        List<DateTimeOffset> times = TestTimeZones.Walk(
+            after => trigger.GetFireTimeAfter(after),
+            trigger.StartTimeUtc.AddSeconds(-1),
+            new DateTimeOffset(2018, 3, 26, 12, 0, 0, TimeSpan.Zero));
+
+        times.Should().Equal(
+        [
+            TestTimeZones.Local("2018-03-25 00:00 +01:00"),
+            TestTimeZones.Local("2018-03-25 01:00 +01:00"),
+            // 02:00 does not exist, and 03:00 +02:00 is the same instant the skipped 02:00 +01:00
+            // slot would have been - still inside the resolved end of day, so it fires
+            TestTimeZones.Local("2018-03-25 03:00 +02:00"),
+            // the ordinary day that follows honours endTimeOfDay as written
+            TestTimeZones.Local("2018-03-26 00:00 +02:00"),
+            TestTimeZones.Local("2018-03-26 01:00 +02:00"),
+            TestTimeZones.Local("2018-03-26 02:00 +02:00")
+        ]);
+    }
+
+    /// <summary>
+    /// Chile moves the clock at midnight, so the transition sits on the edge of the local day rather
+    /// than in the middle of it, and the two directions come out asymmetric.
+    /// </summary>
+    /// <remarks>
+    /// Spring forward (2019-09-08): 00:00 does not exist, the day starts at 01:00 -03:00 and is
+    /// 23 hours long, so a 30 minute trigger fires 46 times and never at local hour 0.
+    /// <para>
+    /// Fall back (Saturday 2019-04-06): the repeated hour is 23:00-23:59, i.e. the last hour of the
+    /// local day. Unlike the Central European case - where the repeated hour is in the middle of the
+    /// day and the day really does yield 25 hours of fires - <c>endTimeOfDay</c> 23:59:59 is itself
+    /// ambiguous here, and it resolves to the <em>daylight</em> (first) occurrence. The window
+    /// therefore closes at 2019-04-07 02:59:59 UTC, one hour before the local day ends: 48 fires,
+    /// and the second pass of 23:00-23:59 is skipped entirely even though those instants still map
+    /// to local date 2019-04-06.
+    /// </para>
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void MidnightGapZone_SubHourInterval_Santiago()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.Santiago;
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2019, 9, 8, 0, 0, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2019, 4, 6, 23, 30, 0));
+
+        // Sep 8 04:00 UTC is Sep 8 01:00 -03:00, the first instant of the spring-forward day
+        List<DateTimeOffset> springForwardDay = LocalFiresOnDate(
+            CreateHalfHourlyTrigger(timeZone, new DateTimeOffset(2019, 9, 8, 4, 0, 0, TimeSpan.Zero)),
+            timeZone,
+            new DateTime(2019, 9, 8),
+            new DateTimeOffset(2019, 9, 9, 12, 0, 0, TimeSpan.Zero));
+
+        springForwardDay.Should().HaveCount(46, "the local day is 23 hours long, so 22:59:59 / 30 min + 1");
+        springForwardDay.Should().NotContain(t => t.Hour == 0, "00:00-00:59 does not exist on the spring-forward day");
+        springForwardDay[0].Should().Be(TestTimeZones.Local("2019-09-08 01:00 -03:00"));
+        springForwardDay[^1].Should().Be(TestTimeZones.Local("2019-09-08 23:30 -03:00"));
+
+        // Apr 6 03:00 UTC is Apr 6 00:00 -03:00, the start of the fall-back Saturday
+        List<DateTimeOffset> fallBackDay = LocalFiresOnDate(
+            CreateHalfHourlyTrigger(timeZone, new DateTimeOffset(2019, 4, 6, 3, 0, 0, TimeSpan.Zero)),
+            timeZone,
+            new DateTime(2019, 4, 6),
+            new DateTimeOffset(2019, 4, 7, 12, 0, 0, TimeSpan.Zero));
+
+        fallBackDay.Should().HaveCount(48, "endTimeOfDay 23:59:59 is ambiguous and resolves to the first occurrence, closing the window after 24 hours");
+        fallBackDay[0].Should().Be(TestTimeZones.Local("2019-04-06 00:00 -03:00"));
+        fallBackDay[^1].Should().Be(TestTimeZones.Local("2019-04-06 23:30 -03:00"));
+        fallBackDay.Where(t => t.Hour == 23).Should().HaveCount(2, "only the first pass of the repeated last hour is inside the window");
+        fallBackDay.Should().OnlyContain(t => t.Offset == TimeSpan.FromHours(-3), "the standard-time pass of the day is never reached");
+    }
+
+    private static IOperableTrigger CreateHalfHourlyTrigger(TimeZoneInfo timeZone, DateTimeOffset startTimeUtc)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+            .EndingDailyAt(TimeOfDay.HourMinuteAndSecondOfDay(23, 59, 59))
+            .OnEveryDay()
+            .WithIntervalInMinutes(30)
+            .InTimeZone(timeZone)
+            .Build();
+
+        trigger.StartTimeUtc = startTimeUtc;
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        return trigger;
+    }
+
+    private static List<DateTimeOffset> LocalFiresOnDate(
+        IOperableTrigger trigger,
+        TimeZoneInfo timeZone,
+        DateTime localDate,
+        DateTimeOffset untilExclusive)
+    {
+        return TestTimeZones
+            .Walk(after => trigger.GetFireTimeAfter(after), trigger.StartTimeUtc.AddSeconds(-1), untilExclusive)
+            .Select(t => TimeZoneInfo.ConvertTime(t, timeZone))
+            .Where(t => t.Date == localDate)
+            .ToList();
+    }
+}

--- a/src/Quartz.Tests.Unit/SimpleTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/SimpleTriggerDstTests.cs
@@ -1,0 +1,121 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Pins that <see cref="SimpleTriggerImpl" /> is daylight saving time agnostic.
+/// </summary>
+/// <remarks>
+/// The trigger has no time zone at all: its fire times are <c>startTimeUtc + n * repeatInterval</c>
+/// in ticks. That means an "hourly" simple trigger repeats every hour of real elapsed time, so a
+/// local day that gains or loses an hour to a DST transition simply contains one more or one fewer
+/// fire. This is deliberately different from <see cref="DailyTimeIntervalTriggerImpl" />, which
+/// re-anchors its window to the local wall clock every day.
+/// </remarks>
+public class SimpleTriggerDstTests
+{
+    /// <summary>
+    /// A 25 hour local day holds 25 hourly fires and a 23 hour local day holds 23, while the
+    /// spacing between consecutive fires stays exactly one hour of real time throughout.
+    /// </summary>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void HourlySimpleTrigger_FallBackLocalDayHas25Fires_SpringDay23()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2024, 11, 3, 1, 30, 0));
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2024, 3, 10, 2, 30, 0));
+
+        // Nov 1 04:00 UTC is Nov 1 00:00 EDT, so every fire lands on a whole local hour
+        List<DateTimeOffset> acrossFallBack = WalkHourly(
+            new DateTimeOffset(2024, 11, 1, 4, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 11, 5, 5, 0, 0, TimeSpan.Zero));
+
+        AssertExactlyOneHourApart(acrossFallBack);
+        acrossFallBack.Count(t => TimeZoneInfo.ConvertTime(t, timeZone).Date == new DateTime(2024, 11, 3))
+            .Should().Be(25, "the fall-back day is 25 hours of real time long");
+
+        // Mar 8 05:00 UTC is Mar 8 00:00 EST
+        List<DateTimeOffset> acrossSpringForward = WalkHourly(
+            new DateTimeOffset(2024, 3, 8, 5, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 3, 12, 4, 0, 0, TimeSpan.Zero));
+
+        AssertExactlyOneHourApart(acrossSpringForward);
+        acrossSpringForward.Count(t => TimeZoneInfo.ConvertTime(t, timeZone).Date == new DateTime(2024, 3, 10))
+            .Should().Be(23, "the spring-forward day is 23 hours of real time long");
+    }
+
+    /// <summary>
+    /// <see cref="SimpleTriggerImpl.FinalFireTimeUtc" /> is <c>startTimeUtc + repeatCount * interval</c>
+    /// in ticks even when the run spans a transition, so it drifts against the wall clock on purpose.
+    /// </summary>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void FinalFireTimeUtc_IsPureTickArithmetic_AcrossTransition()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2024, 3, 10, 2, 30, 0));
+
+        DateTimeOffset startTimeUtc = new DateTimeOffset(2024, 3, 8, 5, 0, 0, TimeSpan.Zero);
+        TimeSpan interval = TimeSpan.FromHours(1);
+        int repeatCount = 100;
+
+        SimpleTriggerImpl trigger = CreateTrigger(startTimeUtc, repeatCount, interval);
+
+        trigger.FinalFireTimeUtc.Should().Be(startTimeUtc.AddTicks(repeatCount * interval.Ticks));
+        trigger.FinalFireTimeUtc.Should().Be(new DateTimeOffset(2024, 3, 12, 9, 0, 0, TimeSpan.Zero));
+
+        // 100 hours of real time after local Mar 8 00:00 is local Mar 12 05:00, not 04:00: the run
+        // crossed the spring-forward gap and the trigger did not compensate for it
+        TimeZoneInfo.ConvertTime(trigger.FinalFireTimeUtc!.Value, timeZone).DateTime
+            .Should().Be(new DateTime(2024, 3, 12, 5, 0, 0));
+
+        trigger.GetFireTimeAfter(trigger.FinalFireTimeUtc).Should().BeNull("the final fire time is the last one");
+    }
+
+    private static List<DateTimeOffset> WalkHourly(DateTimeOffset startTimeUtc, DateTimeOffset untilExclusive)
+    {
+        SimpleTriggerImpl trigger = CreateTrigger(startTimeUtc, SimpleTriggerImpl.RepeatIndefinitely, TimeSpan.FromHours(1));
+
+        // GetFireTimeAfter(startTimeUtc) already skips to the second fire, so start one tick earlier
+        return TestTimeZones.Walk(after => trigger.GetFireTimeAfter(after), startTimeUtc.AddTicks(-1), untilExclusive);
+    }
+
+    private static SimpleTriggerImpl CreateTrigger(DateTimeOffset startTimeUtc, int repeatCount, TimeSpan repeatInterval)
+    {
+        return new SimpleTriggerImpl("dstTrigger", "dstGroup", "dstJob", "dstJobGroup", startTimeUtc, null, repeatCount, repeatInterval);
+    }
+
+    private static void AssertExactlyOneHourApart(List<DateTimeOffset> fireTimes)
+    {
+        fireTimes.Should().NotBeEmpty();
+
+        for (int i = 1; i < fireTimes.Count; i++)
+        {
+            (fireTimes[i] - fireTimes[i - 1]).Should().Be(TimeSpan.FromHours(1), $"fire {i} must follow fire {i - 1} by exactly one hour of real time");
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/TestTimeZones.cs
+++ b/src/Quartz.Tests.Unit/TestTimeZones.cs
@@ -1,0 +1,158 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using TimeZoneConverter;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Shared time zones and helpers for daylight saving time (DST) tests. Zones are resolved via
+/// TimeZoneConverter from Windows ids, which works on every supported OS. Each zone is chosen for a
+/// specific DST corner it exercises; tests should state their transition premise with the Assume
+/// helpers so that a changed time zone database skips the test instead of failing it.
+/// </summary>
+internal static class TestTimeZones
+{
+    /// <summary>
+    /// America/New_York: the classic US transition at 02:00 with a one hour delta.
+    /// Spring forward 2024-03-10 (02:30 invalid), fall back 2024-11-03 (01:30 ambiguous).
+    /// </summary>
+    public static TimeZoneInfo Eastern { get; } = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
+
+    /// <summary>
+    /// Europe/Warsaw: EU transition at 02:00/03:00 local with a one hour delta.
+    /// Spring forward 2018-03-25 (02:30 invalid), fall back 2018-10-28 (02:30 ambiguous).
+    /// </summary>
+    public static TimeZoneInfo CentralEuropean { get; } = TZConvert.GetTimeZoneInfo("Central European Standard Time");
+
+    /// <summary>
+    /// America/Santiago: southern hemisphere and the transition happens at midnight, so on
+    /// spring-forward day the date's own 00:00 does not exist (2019-09-08, 00:30 invalid) and on
+    /// fall-back day the repeated hour crosses backwards over the date boundary
+    /// (Saturday 2019-04-06 23:30 is ambiguous).
+    /// </summary>
+    public static TimeZoneInfo Santiago { get; } = TZConvert.GetTimeZoneInfo("Pacific SA Standard Time");
+
+    /// <summary>
+    /// Australia/Sydney: southern hemisphere with the usual 02:00/03:00 transitions.
+    /// Fall back 2024-04-07 (02:30 ambiguous), spring forward 2024-10-06 (02:30 invalid).
+    /// </summary>
+    public static TimeZoneInfo Sydney { get; } = TZConvert.GetTimeZoneInfo("AUS Eastern Standard Time");
+
+    /// <summary>
+    /// Australia/Lord_Howe: DST delta is only 30 minutes (+10:30 to +11:00), which catches any
+    /// code that assumes a one hour correction. Spring forward 2019-10-06 (02:15 invalid),
+    /// fall back 2019-04-07 (01:45 ambiguous). May be missing from old OS installations, in which
+    /// case tests using it are ignored.
+    /// </summary>
+    public static TimeZoneInfo LordHowe => GetOrIgnore("Lord Howe Standard Time");
+
+    /// <summary>
+    /// Asia/Amman: historically the spring-forward gap started at midnight, so the transition
+    /// day started at 01:00 (2017-03-31, 00:30 invalid) and on fall-back day the first hour of the
+    /// day repeated (2017-10-27, 00:30 ambiguous). Jordan abolished DST in 2022, so this history is
+    /// frozen. May be missing from old OS installations, in which case tests using it are ignored.
+    /// </summary>
+    public static TimeZoneInfo Amman => GetOrIgnore("Jordan Standard Time");
+
+    private static TimeZoneInfo GetOrIgnore(string windowsId)
+    {
+        try
+        {
+            return TZConvert.GetTimeZoneInfo(windowsId);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            NUnit.Framework.Assert.Ignore($"time zone {windowsId} is not available on this system");
+            throw; // unreachable, Assert.Ignore throws
+        }
+    }
+
+    /// <summary>
+    /// States a test's premise that the given wall-clock time does not exist in the zone (it falls
+    /// into a spring-forward gap). If the time zone database no longer agrees, the test is skipped
+    /// as inconclusive instead of failing.
+    /// </summary>
+    public static void AssumeInvalidLocalTime(TimeZoneInfo zone, DateTime localTime)
+    {
+        Assume.That(zone.IsInvalidTime(localTime), $"test premise: {localTime:yyyy-MM-dd HH:mm} should not exist in zone {zone.Id}");
+    }
+
+    /// <summary>
+    /// States a test's premise that the given wall-clock time is ambiguous in the zone (it occurs
+    /// twice around a fall-back transition). If the time zone database no longer agrees, the test
+    /// is skipped as inconclusive instead of failing.
+    /// </summary>
+    public static void AssumeAmbiguousLocalTime(TimeZoneInfo zone, DateTime localTime)
+    {
+        Assume.That(zone.IsAmbiguousTime(localTime), $"test premise: {localTime:yyyy-MM-dd HH:mm} should be ambiguous in zone {zone.Id}");
+    }
+
+    /// <summary>
+    /// Parses strings like "2024-11-03 01:30 -04:00" so that test case grids can assert the fire
+    /// instant and its offset in a single value, mirroring how the two occurrences of an ambiguous
+    /// local time differ only by offset.
+    /// </summary>
+    public static DateTimeOffset Local(string value)
+    {
+        return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.None);
+    }
+
+    /// <summary>
+    /// Collects fire times by repeatedly calling <paramref name="getNextAfter"/>, starting after
+    /// <paramref name="after"/> and stopping at the first result at or beyond
+    /// <paramref name="untilExclusive"/> (which is not included). Fails the test if the produced
+    /// times are not strictly increasing or the safety limit is exceeded, so any fire-count test
+    /// also guards against the trigger wedging or looping around a DST transition.
+    /// </summary>
+    public static List<DateTimeOffset> Walk(
+        Func<DateTimeOffset, DateTimeOffset?> getNextAfter,
+        DateTimeOffset after,
+        DateTimeOffset untilExclusive,
+        int safetyLimit = 10_000)
+    {
+        List<DateTimeOffset> fireTimes = new List<DateTimeOffset>();
+        DateTimeOffset current = after;
+        while (true)
+        {
+            DateTimeOffset? next = getNextAfter(current);
+            if (next is null || next.Value >= untilExclusive)
+            {
+                return fireTimes;
+            }
+
+            if (next.Value <= current)
+            {
+                NUnit.Framework.Assert.Fail($"fire times must strictly increase: got {next.Value:O} after {current:O}");
+            }
+
+            if (fireTimes.Count >= safetyLimit)
+            {
+                NUnit.Framework.Assert.Fail($"more than {safetyLimit} fire times produced before {untilExclusive:O}; trigger is likely looping");
+            }
+
+            fireTimes.Add(next.Value);
+            current = next.Value;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/TriggerDstMisfireTests.cs
+++ b/src/Quartz.Tests.Unit/TriggerDstMisfireTests.cs
@@ -1,0 +1,415 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Quartz.Impl.Triggers;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Misfire handling when the scheduler catches up while "now" sits on a daylight saving time
+/// boundary: either at the instant a naive wall-clock computation would call a time that never
+/// existed (spring forward), or during the hour that happens twice (fall back).
+/// <para>
+/// Every misfire instruction that reschedules reads <see cref="SystemTime.UtcNow"/>, so these tests
+/// freeze it; the fixture is therefore <see cref="NonParallelizableAttribute"/>. The tests pin the
+/// current behaviour - they are a regression net, not a specification of what is ideal.
+/// </para>
+/// </summary>
+[NonParallelizable]
+public class TriggerDstMisfireTests
+{
+    private static readonly TimeZoneInfo Eastern = TestTimeZones.Eastern;
+
+    /// <summary>
+    /// Eastern springs forward on 2024-03-10: local 02:00 EST becomes 03:00 EDT at 07:00Z, so the
+    /// wall clock 02:30 never happens on that date. This instant is the one that a naive
+    /// "02:30 at the standard offset" computation would pick, and its real local time is 03:30 EDT.
+    /// </summary>
+    private static readonly DateTimeOffset NowInGapHour = new DateTimeOffset(2024, 3, 10, 7, 30, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Eastern falls back on 2024-11-03: local 02:00 EDT becomes 01:00 EST at 06:00Z, so the wall
+    /// clock 01:30 happens twice - first at 05:30Z (daylight pass) and again at 06:30Z (standard
+    /// pass). This is the second, standard-offset occurrence.
+    /// </summary>
+    private static readonly DateTimeOffset NowInAmbiguousHourStandardPass = new DateTimeOffset(2024, 11, 3, 6, 30, 0, TimeSpan.Zero);
+
+    /// <summary>The first occurrence of the ambiguous 01:30 wall clock, still on daylight time.</summary>
+    private static readonly DateTimeOffset NowInAmbiguousHourDaylightPass = new DateTimeOffset(2024, 11, 3, 5, 30, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// States the transition premises of this fixture. A changed time zone database skips the tests
+    /// instead of failing them.
+    /// </summary>
+    private static void AssumeEasternTransitions()
+    {
+        TestTimeZones.AssumeInvalidLocalTime(Eastern, new DateTime(2024, 3, 10, 2, 30, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(Eastern, new DateTime(2024, 11, 3, 1, 30, 0));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Trigger factories. Every trigger starts well before the frozen "now", so the fire time that
+    // ComputeFirstFireTimeUtc produces is badly past due by the time misfire handling runs.
+    // ---------------------------------------------------------------------------------------
+
+    private static CronTriggerImpl CreateCronTrigger(int misfireInstruction)
+    {
+        CronTriggerImpl trigger = new CronTriggerImpl
+        {
+            Name = "test",
+            Group = "test",
+            CronExpressionString = "0 30 2 * * ?",
+            TimeZone = Eastern,
+            StartTimeUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            MisfireInstruction = misfireInstruction
+        };
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    private static CalendarIntervalTriggerImpl CreateCalendarIntervalTrigger(int misfireInstruction)
+    {
+        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl
+        {
+            Name = "test",
+            Group = "test",
+            // 2024-01-15 02:30 EST, i.e. the same wall clock the Eastern transitions attack.
+            StartTimeUtc = new DateTimeOffset(2024, 1, 15, 7, 30, 0, TimeSpan.Zero),
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Day,
+            TimeZone = Eastern,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            MisfireInstruction = misfireInstruction
+        };
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    private static DailyTimeIntervalTriggerImpl CreateDailyTimeIntervalTrigger(int misfireInstruction)
+    {
+        DailyTimeIntervalTriggerImpl trigger = new DailyTimeIntervalTriggerImpl
+        {
+            Name = "test",
+            Group = "test",
+            StartTimeUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            StartTimeOfDay = new TimeOfDay(0, 0, 0),
+            EndTimeOfDay = new TimeOfDay(23, 59, 59),
+            RepeatInterval = 15,
+            RepeatIntervalUnit = IntervalUnit.Minute,
+            TimeZone = Eastern,
+            MisfireInstruction = misfireInstruction
+        };
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    private static SimpleTriggerImpl CreateSimpleTrigger(int misfireInstruction)
+    {
+        SimpleTriggerImpl trigger = new SimpleTriggerImpl
+        {
+            Name = "test",
+            Group = "test",
+            StartTimeUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            RepeatInterval = TimeSpan.FromHours(1),
+            RepeatCount = SimpleTriggerImpl.RepeatIndefinitely,
+            MisfireInstruction = misfireInstruction
+        };
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Assertions shared by the per-type tests.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Runs misfire handling with <see cref="SystemTime.UtcNow"/> frozen at <paramref name="frozenNow"/>
+    /// and returns the rescheduled fire time.
+    /// </summary>
+    private static DateTimeOffset? MisfireAt(IOperableTrigger trigger, DateTimeOffset frozenNow)
+    {
+        Func<DateTimeOffset> original = SystemTime.UtcNow;
+        try
+        {
+            SystemTime.UtcNow = () => frozenNow;
+            trigger.UpdateAfterMisfire(null);
+            return trigger.GetNextFireTimeUtc();
+        }
+        finally
+        {
+            SystemTime.UtcNow = original;
+        }
+    }
+
+    /// <summary>
+    /// Collects <paramref name="count"/> further fire times, asserting strict progress at each step
+    /// so that a trigger that wedges on a DST boundary fails here rather than looping forever.
+    /// </summary>
+    private static List<DateTimeOffset> StepForward(ITrigger trigger, DateTimeOffset from, int count)
+    {
+        List<DateTimeOffset> fireTimes = new List<DateTimeOffset>(count);
+        DateTimeOffset current = from;
+        for (int i = 0; i < count; i++)
+        {
+            DateTimeOffset? next = trigger.GetFireTimeAfter(current);
+            next.Should().NotBeNull("the trigger must keep producing fire times after {0:O}", current);
+            next!.Value.Should().BeAfter(current, "fire times must strictly increase, step {0}", i + 1);
+            fireTimes.Add(next.Value);
+            current = next.Value;
+        }
+
+        return fireTimes;
+    }
+
+    /// <summary>
+    /// States the invariant that a rescheduled fire time reads back as a wall clock the zone really
+    /// has. This is a shape check only - a well formed instant can never normalise onto a skipped
+    /// wall clock - so the pinned exact fire times below carry the weight of the DST assertions.
+    /// </summary>
+    private static void AssertLocalTimeExists(DateTimeOffset instant)
+    {
+        DateTime local = TimeZoneInfo.ConvertTime(instant, Eastern).DateTime;
+        Eastern.IsInvalidTime(local).Should().BeFalse(
+            "the fire time {0:O} maps to Eastern wall clock {1:yyyy-MM-dd HH:mm:ss}, which must exist", instant, local);
+    }
+
+    /// <summary>
+    /// The two passes of an ambiguous hour share a wall clock. A trigger that fires on both would
+    /// run the job twice for what the user reads as one scheduled time.
+    /// </summary>
+    private static void AssertNoRepeatedWallClock(IEnumerable<DateTimeOffset> fireTimes)
+    {
+        List<DateTime> localTimes = fireTimes.Select(t => TimeZoneInfo.ConvertTime(t, Eastern).DateTime).ToList();
+        localTimes.Should().OnlyHaveUniqueItems("no wall clock may be fired twice across the ambiguous hour");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Spring forward: misfire handling runs at the instant whose would-be wall clock never existed.
+    // ---------------------------------------------------------------------------------------
+
+    [Test]
+    public void Cron_DoNothing_MisfireNowInGapHour_NextFireIsStrictlyFutureAndValid()
+    {
+        AssumeEasternTransitions();
+
+        CronTriggerImpl trigger = CreateCronTrigger(MisfireInstruction.CronTrigger.DoNothing);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInGapHour);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().BeAfter(NowInGapHour, "DoNothing must skip all past-due fire times");
+        nextFire.Value.Should().Be(new DateTimeOffset(2024, 3, 11, 6, 30, 0, TimeSpan.Zero),
+            "02:30 does not exist on the spring forward day, so the next daily fire is 2024-03-11 02:30 EDT");
+        AssertLocalTimeExists(nextFire.Value);
+
+        StepForward(trigger, nextFire.Value, 2);
+    }
+
+    [Test]
+    public void CalendarInterval_DoNothing_MisfireNowInGapHour_NextFireIsStrictlyFutureAndValid()
+    {
+        AssumeEasternTransitions();
+
+        CalendarIntervalTriggerImpl trigger = CreateCalendarIntervalTrigger(MisfireInstruction.CalendarIntervalTrigger.DoNothing);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInGapHour);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().BeAfter(NowInGapHour, "DoNothing must skip all past-due fire times");
+        nextFire.Value.Should().Be(new DateTimeOffset(2024, 3, 11, 6, 30, 0, TimeSpan.Zero),
+            "PreserveHourOfDayAcrossDaylightSavings keeps the 02:30 wall clock, now at the daylight offset");
+        nextFire.Value.Offset.Should().Be(TimeSpan.FromHours(-4),
+            "unlike the other three trigger types, CalendarIntervalTriggerImpl hands back values carrying " +
+            "the trigger time zone's offset rather than UTC; equality is by instant, so this only matters " +
+            "to callers that read Offset or DateTime off the result");
+        AssertLocalTimeExists(nextFire.Value);
+
+        StepForward(trigger, nextFire.Value, 2);
+    }
+
+    [Test]
+    public void DailyTimeInterval_DoNothing_MisfireNowInGapHour_NextFireIsStrictlyFutureAndValid()
+    {
+        AssumeEasternTransitions();
+
+        DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger(MisfireInstruction.DailyTimeIntervalTrigger.DoNothing);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInGapHour);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().BeAfter(NowInGapHour, "DoNothing must skip all past-due fire times");
+        nextFire.Value.Should().Be(new DateTimeOffset(2024, 3, 10, 7, 45, 0, TimeSpan.Zero),
+            "the quarter hour grid continues at 03:45 EDT, the first slot after the frozen now");
+        AssertLocalTimeExists(nextFire.Value);
+
+        StepForward(trigger, nextFire.Value, 2);
+    }
+
+    [Test]
+    public void Simple_RescheduleNextWithRemainingCount_MisfireNowInGapHour_NextFireIsStrictlyFutureAndValid()
+    {
+        AssumeEasternTransitions();
+
+        // SimpleTrigger has no DoNothing instruction; RescheduleNextWithRemainingCount is the
+        // closest equivalent - it also picks the next scheduled time strictly after now instead of
+        // firing immediately.
+        SimpleTriggerImpl trigger = CreateSimpleTrigger(MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInGapHour);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().BeAfter(NowInGapHour, "the trigger must not fire immediately after misfire handling");
+        nextFire.Value.Should().Be(new DateTimeOffset(2024, 3, 10, 8, 0, 0, TimeSpan.Zero),
+            "SimpleTrigger counts absolute intervals from the start time, so DST does not shift the grid");
+        AssertLocalTimeExists(nextFire.Value);
+
+        StepForward(trigger, nextFire.Value, 2);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Fall back: misfire handling runs during the hour that happens twice.
+    // ---------------------------------------------------------------------------------------
+
+    [Test]
+    public void Cron_FireOnceNow_MisfireNowInAmbiguousHour_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        CronTriggerImpl trigger = CreateCronTrigger(MisfireInstruction.CronTrigger.FireOnceNow);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInAmbiguousHourStandardPass);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourStandardPass, "FireOnceNow schedules the trigger for exactly now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 7, 30, 0, TimeSpan.Zero),
+            "the regular 02:30 fire on the fall back day happens once, at the standard offset");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    [Test]
+    public void Cron_FireOnceNow_MisfireNowInAmbiguousHourDaylightPass_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        CronTriggerImpl trigger = CreateCronTrigger(MisfireInstruction.CronTrigger.FireOnceNow);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInAmbiguousHourDaylightPass);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourDaylightPass, "FireOnceNow schedules the trigger for exactly now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 7, 30, 0, TimeSpan.Zero),
+            "stepping out of the first pass of the repeated hour must not revisit it");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    [Test]
+    public void CalendarInterval_FireOnceNow_MisfireNowInAmbiguousHour_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        CalendarIntervalTriggerImpl trigger = CreateCalendarIntervalTrigger(MisfireInstruction.CalendarIntervalTrigger.FireOnceNow);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInAmbiguousHourStandardPass);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourStandardPass, "FireOnceNow schedules the trigger for exactly now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 7, 30, 0, TimeSpan.Zero),
+            "the preserved 02:30 wall clock resumes at the standard offset");
+        onward[0].Offset.Should().Be(TimeSpan.FromHours(-5),
+            "the fire time that FireOnceNow stores is whatever SystemTime.UtcNow returned, but the times " +
+            "computed afterwards carry the trigger time zone's offset");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    [Test]
+    public void DailyTimeInterval_FireOnceNow_MisfireNowInAmbiguousHour_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger(MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInAmbiguousHourStandardPass);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourStandardPass, "FireOnceNow schedules the trigger for exactly now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 6, 45, 0, TimeSpan.Zero),
+            "the quarter hour grid continues inside the repeated hour at 01:45 EST");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    [Test]
+    public void DailyTimeInterval_FireOnceNow_MisfireNowInAmbiguousHourDaylightPass_RepeatsTheAmbiguousWallClock()
+    {
+        AssumeEasternTransitions();
+
+        // The counterpart of the test above, pinning the behaviour that makes the standard pass the
+        // interesting case: when misfire handling lands on the *first* pass of the repeated hour,
+        // the quarter hour grid walks straight through the fall back and serves 01:30 a second time.
+        // Both fires are distinct instants an hour apart, so nothing here is a wedge - but a job
+        // scheduled for 01:30 does run twice.
+        DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger(MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInAmbiguousHourDaylightPass);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourDaylightPass);
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 4);
+        onward[3].Should().Be(NowInAmbiguousHourStandardPass,
+            "the fourth step is 01:30 again, this time at the standard offset");
+        TimeZoneInfo.ConvertTime(onward[3], Eastern).DateTime.Should().Be(
+            TimeZoneInfo.ConvertTime(nextFire.Value, Eastern).DateTime,
+            "both fires read as the same 01:30 wall clock");
+    }
+
+    [Test]
+    public void Simple_FireNow_MisfireNowInAmbiguousHour_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        // For a repeating SimpleTrigger, FireNow is rewritten to RescheduleNowWithRemainingRepeatCount,
+        // which also fires now but additionally re-anchors StartTimeUtc to now.
+        SimpleTriggerImpl trigger = CreateSimpleTrigger(MisfireInstruction.SimpleTrigger.FireNow);
+
+        DateTimeOffset? nextFire = MisfireAt(trigger, NowInAmbiguousHourStandardPass);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourStandardPass, "FireNow schedules the trigger for exactly now");
+        trigger.StartTimeUtc.Should().Be(NowInAmbiguousHourStandardPass,
+            "RescheduleNowWithRemainingRepeatCount re-anchors the interval grid to now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 7, 30, 0, TimeSpan.Zero),
+            "the hourly interval is absolute, so the next fire is one real hour later");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+}

--- a/src/Quartz.Tests.Unit/TriggerDstMonotonicityTests.cs
+++ b/src/Quartz.Tests.Unit/TriggerDstMonotonicityTests.cs
@@ -1,0 +1,311 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Property tests over daylight saving time transitions: whatever a trigger decides to do with a
+/// wall clock that vanishes or repeats, walking its fire times must make monotonic progress and
+/// must not stall. Each case walks one trigger kind across one transition and asserts that every
+/// step strictly increases, that no step jumps further than the schedule plus the transition delta
+/// could explain, and that the walk actually gets past the transition instant.
+/// <para>
+/// These tests never touch <see cref="SystemTime"/>, so the fixture is parallel safe.
+/// </para>
+/// </summary>
+public class TriggerDstMonotonicityTests
+{
+    private const int StepCount = 150;
+
+    /// <summary>
+    /// A window that starts two hours before a transition instant, so a walk of 150 steps of any of
+    /// the schedules below is guaranteed to cross it.
+    /// </summary>
+    private sealed class DstWindow
+    {
+        public DstWindow(TimeZoneInfo zone, DateTimeOffset start, Action assumePremise)
+        {
+            Zone = zone;
+            Start = start;
+            AssumePremise = assumePremise;
+        }
+
+        public TimeZoneInfo Zone { get; }
+
+        public DateTimeOffset Start { get; }
+
+        public DateTimeOffset Transition => Start.AddHours(2);
+
+        public Action AssumePremise { get; }
+    }
+
+    /// <summary>
+    /// Resolved lazily per test case: <see cref="TestTimeZones.LordHowe"/> ignores the test when the
+    /// zone is missing, which must not happen while building a shared static table.
+    /// </summary>
+    private static DstWindow ResolveWindow(string windowKey)
+    {
+        switch (windowKey)
+        {
+            case "EasternSpring":
+                // 02:00 EST -> 03:00 EDT at 2024-03-10 07:00Z.
+                return new DstWindow(
+                    TestTimeZones.Eastern,
+                    new DateTimeOffset(2024, 3, 10, 5, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Eastern, new DateTime(2024, 3, 10, 2, 30, 0)));
+
+            case "EasternFall":
+                // 02:00 EDT -> 01:00 EST at 2024-11-03 06:00Z.
+                return new DstWindow(
+                    TestTimeZones.Eastern,
+                    new DateTimeOffset(2024, 11, 3, 4, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Eastern, new DateTime(2024, 11, 3, 1, 30, 0)));
+
+            case "CentralEuropeanFall":
+                // 03:00 CEST -> 02:00 CET at 2018-10-28 01:00Z.
+                return new DstWindow(
+                    TestTimeZones.CentralEuropean,
+                    new DateTimeOffset(2018, 10, 27, 23, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.CentralEuropean, new DateTime(2018, 10, 28, 2, 30, 0)));
+
+            case "SantiagoSpring":
+                // Midnight transition: 2019-09-08 never has a 00:00 local, the day starts at 01:00.
+                return new DstWindow(
+                    TestTimeZones.Santiago,
+                    new DateTimeOffset(2019, 9, 8, 2, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Santiago, new DateTime(2019, 9, 8, 0, 30, 0)));
+
+            case "LordHoweSpring":
+                // Half hour delta: 02:00 -> 02:30 local at 2019-10-05 15:30Z.
+                return new DstWindow(
+                    TestTimeZones.LordHowe,
+                    new DateTimeOffset(2019, 10, 5, 13, 30, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.LordHowe, new DateTime(2019, 10, 6, 2, 15, 0)));
+
+            case "LordHoweFall":
+                // Half hour delta: 02:00 -> 01:30 local at 2019-04-06 15:00Z.
+                return new DstWindow(
+                    TestTimeZones.LordHowe,
+                    new DateTimeOffset(2019, 4, 6, 13, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.LordHowe, new DateTime(2019, 4, 7, 1, 45, 0)));
+
+            case "SydneyFall":
+                // 03:00 AEDT -> 02:00 AEST at 2024-04-06 16:00Z.
+                return new DstWindow(
+                    TestTimeZones.Sydney,
+                    new DateTimeOffset(2024, 4, 6, 14, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Sydney, new DateTime(2024, 4, 7, 2, 30, 0)));
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(windowKey), windowKey, "unknown DST window");
+        }
+    }
+
+    private static ITrigger CreateTrigger(string triggerKind, TimeZoneInfo zone, DateTimeOffset windowStart)
+    {
+        switch (triggerKind)
+        {
+            case "CronMinutely":
+                return new CronTriggerImpl
+                {
+                    Name = triggerKind,
+                    Group = "dst",
+                    CronExpressionString = "0 * * * * ?",
+                    TimeZone = zone,
+                    StartTimeUtc = windowStart
+                };
+
+            case "CronHourly":
+                return new CronTriggerImpl
+                {
+                    Name = triggerKind,
+                    Group = "dst",
+                    CronExpressionString = "0 0 * * * ?",
+                    TimeZone = zone,
+                    StartTimeUtc = windowStart
+                };
+
+            case "CalendarIntervalHourly":
+                return new CalendarIntervalTriggerImpl
+                {
+                    Name = triggerKind,
+                    Group = "dst",
+                    StartTimeUtc = windowStart,
+                    RepeatInterval = 1,
+                    RepeatIntervalUnit = IntervalUnit.Hour,
+                    TimeZone = zone
+                };
+
+            case "CalendarIntervalDailyPreserve":
+                return new CalendarIntervalTriggerImpl
+                {
+                    Name = triggerKind,
+                    Group = "dst",
+                    StartTimeUtc = AnchorAtLocalHalfPastTwo(zone, windowStart),
+                    RepeatInterval = 1,
+                    RepeatIntervalUnit = IntervalUnit.Day,
+                    TimeZone = zone,
+                    PreserveHourOfDayAcrossDaylightSavings = true
+                };
+
+            case "DailyTimeIntervalQuarterHour":
+                return new DailyTimeIntervalTriggerImpl
+                {
+                    Name = triggerKind,
+                    Group = "dst",
+                    StartTimeUtc = windowStart,
+                    StartTimeOfDay = new TimeOfDay(0, 0, 0),
+                    EndTimeOfDay = new TimeOfDay(23, 59, 59),
+                    RepeatInterval = 15,
+                    RepeatIntervalUnit = IntervalUnit.Minute,
+                    TimeZone = zone
+                };
+
+            case "SimpleHalfHour":
+                return new SimpleTriggerImpl
+                {
+                    Name = triggerKind,
+                    Group = "dst",
+                    StartTimeUtc = windowStart,
+                    RepeatInterval = TimeSpan.FromMinutes(30),
+                    RepeatCount = SimpleTriggerImpl.RepeatIndefinitely
+                };
+
+            case "RecurrenceHourly":
+                return new RecurrenceTriggerImpl
+                {
+                    Name = triggerKind,
+                    Group = "dst",
+                    RecurrenceRule = "FREQ=HOURLY;INTERVAL=1",
+                    TimeZone = zone,
+                    StartTimeUtc = windowStart
+                };
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(triggerKind), triggerKind, "unknown trigger kind");
+        }
+    }
+
+    /// <summary>
+    /// Anchors a daily schedule at 02:30 local a few days before the window, so that the daily fire
+    /// lands squarely on the wall clock the transition attacks.
+    /// </summary>
+    private static DateTimeOffset AnchorAtLocalHalfPastTwo(TimeZoneInfo zone, DateTimeOffset windowStart)
+    {
+        DateTime localWindowStart = TimeZoneInfo.ConvertTime(windowStart, zone).DateTime;
+        DateTime anchorLocal = localWindowStart.Date.AddDays(-3).AddHours(2).AddMinutes(30);
+        return new DateTimeOffset(anchorLocal, zone.GetUtcOffset(anchorLocal));
+    }
+
+    [TestCase("CronMinutely", "EasternSpring", "2024-03-10 05:00 +00:00", 90)]
+    [TestCase("CronMinutely", "EasternFall", "2024-11-03 04:00 +00:00", 90)]
+    [TestCase("CronMinutely", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 90)]
+    [TestCase("CronMinutely", "SantiagoSpring", "2019-09-08 02:00 +00:00", 90)]
+    [TestCase("CronMinutely", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
+    [TestCase("CronMinutely", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
+    [TestCase("CronMinutely", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    [TestCase("CronHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 150)]
+    [TestCase("CronHourly", "EasternFall", "2024-11-03 04:00 +00:00", 150)]
+    [TestCase("CronHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 150)]
+    [TestCase("CronHourly", "SantiagoSpring", "2019-09-08 02:00 +00:00", 150)]
+    [TestCase("CronHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 150)]
+    [TestCase("CronHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 150)]
+    [TestCase("CronHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 150)]
+    [TestCase("CalendarIntervalHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "EasternFall", "2024-11-03 04:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "SantiagoSpring", "2019-09-08 02:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    // A daily schedule that preserves its wall clock spans the 25 hour fall back day, so the bound
+    // is 26 hours. Observed maximum across these seven windows is exactly 25 hours (Central European
+    // and Sydney fall back); the spare hour absorbs a zone whose delta is larger than one hour.
+    [TestCase("CalendarIntervalDailyPreserve", "EasternSpring", "2024-03-10 05:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "EasternFall", "2024-11-03 04:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "SantiagoSpring", "2019-09-08 02:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "LordHoweSpring", "2019-10-05 13:30 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "LordHoweFall", "2019-04-06 13:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "SydneyFall", "2024-04-06 14:00 +00:00", 26 * 60)]
+    [TestCase("DailyTimeIntervalQuarterHour", "EasternSpring", "2024-03-10 05:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "EasternFall", "2024-11-03 04:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "SantiagoSpring", "2019-09-08 02:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    [TestCase("SimpleHalfHour", "EasternSpring", "2024-03-10 05:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "EasternFall", "2024-11-03 04:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "SantiagoSpring", "2019-09-08 02:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "LordHoweSpring", "2019-10-05 13:30 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "LordHoweFall", "2019-04-06 13:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "SydneyFall", "2024-04-06 14:00 +00:00", 31)]
+    [TestCase("RecurrenceHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "EasternFall", "2024-11-03 04:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "SantiagoSpring", "2019-09-08 02:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 150)]
+    public void FireTimesProgressMonotonicallyAcrossTransition(
+        string triggerKind,
+        string windowKey,
+        string windowStart,
+        int maxStepMinutes)
+    {
+        DstWindow window = ResolveWindow(windowKey);
+        DateTimeOffset start = TestTimeZones.Local(windowStart);
+        start.Should().Be(window.Start, "the test case row and the window table must agree on the window start");
+        window.AssumePremise();
+
+        ITrigger trigger = CreateTrigger(triggerKind, window.Zone, start);
+        TimeSpan maxStep = TimeSpan.FromMinutes(maxStepMinutes);
+
+        List<DateTimeOffset> fireTimes = new List<DateTimeOffset>(StepCount);
+        DateTimeOffset current = start;
+        for (int i = 0; i < StepCount; i++)
+        {
+            DateTimeOffset? next = trigger.GetFireTimeAfter(current);
+
+            next.Should().NotBeNull(
+                "{0} must keep producing fire times in {1}, but stopped after {2:O} (step {3})",
+                triggerKind, window.Zone.Id, current, i + 1);
+
+            next.Value.Should().BeAfter(current,
+                "{0} fire times must strictly increase in {1} (step {2})", triggerKind, window.Zone.Id, i + 1);
+
+            (next.Value - current).Should().BeLessThanOrEqualTo(maxStep,
+                "{0} must not skip a whole schedule period around the {1} transition: {2:O} -> {3:O} (step {4})",
+                triggerKind, windowKey, current, next.Value, i + 1);
+
+            fireTimes.Add(next.Value);
+            current = next.Value;
+        }
+
+        fireTimes[fireTimes.Count - 1].Should().BeAfter(window.Transition,
+            "{0} steps of {1} must carry the walk past the {2} transition", StepCount, triggerKind, windowKey);
+    }
+}

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 using Quartz.Impl.Calendar;
 using Quartz.Util;
@@ -41,5 +42,77 @@ public class TimeZoneUtilTest
 
         var d = holidayCalendar.GetNextIncludedTimeUtc(time);
         d.Should().Be(expected);
+    }
+
+    // The wall-clock overload GetUtcOffset(DateTime, ..) implements the trigger-wide DST policy:
+    // an ambiguous local time resolves to the DAYLIGHT offset, i.e. the first of the two occurrences.
+    [TestCase("Eastern", "2024-11-03 01:30", -4.0)]
+    [TestCase("CentralEuropean", "2018-10-28 02:30", 2.0)]
+    [TestCase("LordHowe", "2019-04-07 01:45", 11.0)]
+    [TestCase("Santiago", "2019-04-06 23:30", -3.0)]
+    public void GetUtcOffset_AmbiguousLocalTime_ReturnsDaylightOffset(string zoneKey, string localTime, double expectedOffsetHours)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        TimeZoneUtil.GetUtcOffset(local, zone).Should().Be(TimeSpan.FromHours(expectedOffsetHours));
+    }
+
+    // An invalid (spring-forward gap) local time is not special-cased: it resolves to the
+    // pre-transition offset, which places the resulting instant at the first wall-clock time that
+    // does exist, shifted forward by the transition delta. Every trigger type inherits this rule.
+    [TestCase("Eastern", "2024-03-10 02:30", -5.0)]
+    [TestCase("LordHowe", "2019-10-06 02:15", 10.5)]
+    [TestCase("Santiago", "2019-09-08 00:30", -4.0)]
+    public void GetUtcOffset_InvalidLocalTime_ReturnsPreTransitionOffset(string zoneKey, string localTime, double expectedOffsetHours)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, local);
+
+        TimeZoneUtil.GetUtcOffset(local, zone).Should().Be(TimeSpan.FromHours(expectedOffsetHours));
+    }
+
+    [Test]
+    public void GetUtcOffset_InstantOverload_AppliesNoAmbiguityPolicy()
+    {
+        // The DateTimeOffset overload resolves from the instant and never consults the ambiguity
+        // policy, so for the second (standard) occurrence of an ambiguous wall-clock time the two
+        // overloads disagree. Call sites that mean "resolve this wall-clock time" must pass
+        // .DateTime explicitly or they silently lose the policy.
+        TimeZoneInfo eastern = TestTimeZones.Eastern;
+        DateTimeOffset standardPassInstant = TestTimeZones.Local("2024-11-03 01:30 -05:00");
+        TestTimeZones.AssumeAmbiguousLocalTime(eastern, standardPassInstant.DateTime);
+
+        TimeZoneUtil.GetUtcOffset(standardPassInstant, eastern).Should().Be(TimeSpan.FromHours(-5));
+        TimeZoneUtil.GetUtcOffset(standardPassInstant.DateTime, eastern).Should().Be(TimeSpan.FromHours(-4));
+    }
+
+    [TestCase("US/Eastern", "Eastern Standard Time")]
+    [TestCase("CET", "Central European Standard Time")]
+    public void FindTimeZoneById_ResolvesAliasPairsOnAnyPlatform(string first, string second)
+    {
+        TimeZoneInfo firstZone = TimeZoneUtil.FindTimeZoneById(first);
+        TimeZoneInfo secondZone = TimeZoneUtil.FindTimeZoneById(second);
+
+        firstZone.BaseUtcOffset.Should().Be(secondZone.BaseUtcOffset);
+    }
+
+    private static TimeZoneInfo ResolveZone(string zoneKey)
+    {
+        switch (zoneKey)
+        {
+            case "Eastern":
+                return TestTimeZones.Eastern;
+            case "CentralEuropean":
+                return TestTimeZones.CentralEuropean;
+            case "Santiago":
+                return TestTimeZones.Santiago;
+            case "LordHowe":
+                return TestTimeZones.LordHowe;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test zone");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Systematic DST corner-case test coverage for all trigger types, informed by a comparison against the [Cronos](https://github.com/HangfireIO/Cronos) library's DST rule set. All tests **pin current behavior** — including a few deliberately questionable behaviors that are marked as decision points for possible changes on `main`/4.0. Test-only PR; no production code changes.

## What's covered

- **`TestTimeZones`** — shared helper: six zones resolved cross-platform via TimeZoneConverter (Eastern, CET/Warsaw, Santiago midnight-gap, Sydney southern-hemisphere, Lord Howe 30-minute delta, Amman historical midnight transitions), tzdb-drift `Assume` premise guards, and a fire-time walker with built-in strict-monotonicity failure (every fire-count test doubles as an infinite-loop tripwire, the #332 bug class).
- **`CronExpressionDstTests`** — gap fires once delta-shifted (incl. Lord Howe 30-min shift); fall-back daily fires once at the first/daylight occurrence; minutely spring day = 1379 fires with no local hour 2; `GetTimeBefore`/`GetTimeAfter` round-trip properties; `IsSatisfiedBy` spring-forward.
- **`CalendarIntervalTriggerDstTests`** — first-ever fall-back coverage: preserve-hour fires once at the scheduled local hour for Day/Week/Month/Year; `SkipDayIfHourDoesNotExist` is a no-op on fall-back; sub-day units are DST-agnostic; Santiago midnight-gap daily (crawl vs skip); `ComputeFirstFireTimeUtc` returns the start instant.
- **`DailyTimeIntervalTriggerDstTests`** — 10-interval fall-back matrix mirroring the existing spring matrix (e.g. 5-min = 300 fires on the 25h day, both ambiguous passes fire); `endTimeOfDay` inside the gap; per-day `RepeatCount` semantics across the 25h day; Santiago sub-hour edge where the repeated hour is the last hour of the day.
- **`SimpleTriggerDstTests`** — pins that simple triggers are and stay DST-invisible (25/23 fires per local day, exact 1h UTC deltas, pure tick-arithmetic `FinalFireTimeUtc`).
- **`TriggerDstMisfireTests`** — first misfire-during-DST coverage: all four trigger types with `SystemTime.UtcNow` frozen inside a spring-forward gap and inside the ambiguous fall-back hour, for DoNothing- and FireOnceNow-style instructions.
- **`TriggerDstMonotonicityTests`** — 49-row property matrix: 7 trigger kinds x 7 zone-transition windows, 150 iterations each, asserting strict increase and bounded step sizes.
- **`TimeZoneUtilTest`** — the DST policy pinned as a unit: ambiguous -> daylight/first occurrence, invalid -> pre-transition offset (shift-by-delta), and that the instant-based overload applies no ambiguity policy.

## Decision-point pins (marked in `#region Current-behavior pins`)

- A sequential minutely cron walk **skips the entire repeated fall-back hour** (1439 fires, not 1499) while `IsSatisfiedBy` returns `true` inside that same hour.
- Fixed-time cron in a gap fires delta-shifted (02:30 -> 03:30), not at the gap end, and the returned instant does not satisfy its own expression.
- `CalendarIntervalTrigger` default (`PreserveHourOfDayAcrossDaylightSavings=false`) drifts the local fire hour across transitions.

## Defect discovered while pinning (fix planned as follow-up)

`CronExpression.GetTimeAfter` compares its truncated candidate against the **untruncated** after-time in the fall-back demotion, so a sub-second after-time inside the ambiguous window spuriously demotes a valid fire a full hour. This makes `GetTimeAfter` non-monotonic in its argument and `GetTimeBefore` can return instants the expression never fires at. Pinned by two tests with flip targets documented; fix will come in the follow-up hardening PR.

## Verification

- `dotnet test src/Quartz.Tests.Unit -f net10.0`: 1668 passed, 0 failed
- `dotnet test src/Quartz.Tests.Unit -f net472`: 1667 passed, 0 failed
- Expected values were derived empirically and several were mutation-tested for non-vacuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)