### PR TITLE
Centralize trigger DST resolution in TimeZoneUtil and fix two latent defects

### DIFF
--- a/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
@@ -206,20 +206,18 @@ public class CronExpressionDstTests
     /// and asking for the next fire from it makes progress rather than wedging.
     /// </summary>
     /// <remarks>
-    /// The probe set is per case rather than a fixed grid because the -5 minute probe on a
-    /// FALL-BACK transition currently breaks the round trip: see
-    /// <see cref="GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_CurrentlyReturnsNonFireTime" />
-    /// in the pins region below, and the root cause pinned next to it. Restore -5 to those two
-    /// cases once that is fixed.
+    /// The -5 minute probes on the fall-back transitions land just after a fire inside the repeated
+    /// hour; they used to break the round trip until the sub-second demotion defect was fixed (see
+    /// <see cref="GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_ReturnsRealPrecedingFire" />).
     /// </remarks>
     [TestCase("0 * * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 0 * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
-    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, 5, 60 })]
-    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 * * * * ?", "CentralEuropean", "2018-03-25 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 0 * * * ?", "CentralEuropean", "2018-03-25 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
-    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, 5, 60 })]
-    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
     public void GetTimeBefore_RoundTripsWithGetTimeAfter_AroundTransitions(
         string cronExpression,
         string zoneKey,
@@ -393,29 +391,22 @@ public class CronExpressionDstTests
         cron.IsSatisfiedBy(fire.Value).Should().BeFalse("the fire instant reads as local 03:30, and the expression asks for hour 02");
     }
 
+    #endregion
+
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — this one looks like a plain defect rather than a semantic choice.
+    /// Regression test: a sub-second after-time inside the repeated fall-back hour must return the
+    /// same fire as its whole-second floor.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// <see cref="CronExpression.GetTimeAfter" /> starts by adding one second to the requested
-    /// instant KEEPING its sub-second ticks, then truncates a separate copy to whole seconds for
-    /// the search. At the very end the fall-back demotion asks whether the resolved fire is before
-    /// the requested instant, and compares the truncated fire against the UNTRUNCATED copy
-    /// (<c>CronExpression.cs</c>: <c>if (d.ToUniversalTime() &lt; afterTimeUtc &amp;&amp;
-    /// TimeZone.IsAmbiguousTime(localDateTime))</c>). Any sub-second remainder therefore makes a
-    /// perfectly good fire look "too early" while the local time is ambiguous, and the result is
-    /// demoted a whole hour forward to the standard pass.
-    /// </para>
-    /// <para>
-    /// The effect: asking for the next fire after 05:53:59.000Z gives 05:54:00Z, but asking after
-    /// 05:53:59.500Z — half a second LATER — skips that fire entirely and gives 06:54:00Z. The
-    /// comparison should use the truncated instant, at which point both answers are 05:54:00Z.
-    /// Flip target: both assertions below expect 05:54:00Z.
-    /// </para>
+    /// The fall-back demotion in <see cref="CronExpression.GetTimeAfter" /> used to compare the
+    /// truncated candidate fire against the UNTRUNCATED after-time, so any sub-second remainder made
+    /// a perfectly good fire look "too early" while the local time was ambiguous and demoted it a
+    /// whole hour forward: the next fire after 05:53:59.000Z was 05:54:00Z, but after 05:53:59.500Z
+    /// — half a second later — it was 06:54:00Z, making the result non-monotonic in the input. The
+    /// comparison now uses the whole-second floor the search starts from.
     /// </remarks>
     [Test]
-    public void GetTimeAfter_SubSecondInstantInsideRepeatedHour_CurrentlySkipsAnHourToStandardPass()
+    public void GetTimeAfter_SubSecondInstantInsideRepeatedHour_ReturnsSameFireAsWholeSecond()
     {
         TimeZoneInfo zone = TestTimeZones.Eastern;
         TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2024-11-03 01:30"));
@@ -425,43 +416,32 @@ public class CronExpressionDstTests
         DateTimeOffset wholeSecond = new DateTimeOffset(2024, 11, 3, 5, 53, 59, 0, TimeSpan.Zero);
         DateTimeOffset withMilliseconds = new DateTimeOffset(2024, 11, 3, 5, 53, 59, 500, TimeSpan.Zero);
 
-        cron.GetTimeAfter(wholeSecond)
-            .Should().Be(TestTimeZones.Local("2024-11-03 05:54 +00:00"), "local 01:54 -04:00 is the very next minute");
+        DateTimeOffset expected = TestTimeZones.Local("2024-11-03 05:54 +00:00");
 
-        cron.GetTimeAfter(withMilliseconds)
-            .Should().Be(TestTimeZones.Local("2024-11-03 06:54 +00:00"), "the sub-second remainder currently forces the demotion to local 01:54 -05:00");
+        cron.GetTimeAfter(wholeSecond).Should().Be(expected, "local 01:54 -04:00 is the very next minute");
+        cron.GetTimeAfter(withMilliseconds).Should().Be(expected, "sub-second ticks on the after-time must not demote the fire to the standard pass");
     }
 
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — the user-visible consequence of the sub-second defect above.
+    /// Regression test: <see cref="CronExpression.GetTimeBefore" /> must return a real fire time
+    /// for probes just after a fire inside the repeated fall-back hour.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// <see cref="CronExpression.GetTimeBefore" /> binary searches on "does the next fire after this
-    /// probe land before the end time", over arbitrary tick values. The sub-second demotion makes
-    /// that predicate NON-MONOTONIC in the second immediately preceding a fire whose local time is
-    /// ambiguous: it holds at the whole second, then flips false a fraction later. The search
-    /// converges on that false crossover instead of the real one, and the result — truncated to a
-    /// whole second — comes out one second early, on a value the expression never fires at.
-    /// </para>
-    /// <para>
-    /// So <c>GetTimeBefore</c> can return a NON-FIRE time: the pinned results below all end in
-    /// :59 for expressions that only ever fire at second 0. Flip target: the expected value becomes
-    /// the real preceding fire time (the third argument), and the -5 minute probe can be restored
-    /// to the fall-back cases of
-    /// <see cref="GetTimeBefore_RoundTripsWithGetTimeAfter_AroundTransitions" />.
-    /// </para>
+    /// Its binary search probes arbitrary tick values, and the sub-second demotion described in
+    /// <see cref="GetTimeAfter_SubSecondInstantInsideRepeatedHour_ReturnsSameFireAsWholeSecond" />
+    /// used to make the search predicate non-monotonic in the second preceding such a fire, so the
+    /// search converged one second early on a value the expression never fires at (:59 results for
+    /// expressions that only fire at second 0).
     /// </remarks>
-    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:54:00 +00:00", "2024-11-03 05:53:59 +00:00")]
-    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:00:00 +00:00", "2024-11-03 04:59:59 +00:00")]
-    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:54:00 +00:00", "2018-10-28 00:53:59 +00:00")]
-    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:00:00 +00:00", "2018-10-27 23:59:59 +00:00")]
-    public void GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_CurrentlyReturnsNonFireTime(
+    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:54:00 +00:00")]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:00:00 +00:00")]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:54:00 +00:00")]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:00:00 +00:00")]
+    public void GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_ReturnsRealPrecedingFire(
         string cronExpression,
         string zoneKey,
         string probeUtc,
-        string realPrecedingFire,
-        string currentlyReturned)
+        string realPrecedingFire)
     {
         TimeZoneInfo zone = ResolveZone(zoneKey);
         CronExpression cron = CronIn(cronExpression, zone);
@@ -476,9 +456,7 @@ public class CronExpressionDstTests
         DateTimeOffset? previous = cron.GetTimeBefore(probe);
 
         previous.Should().NotBeNull();
-        previous!.Value.Should().Be(TestTimeZones.Local(currentlyReturned), "the binary search converges on the sub-second demotion crossover");
-        cron.IsSatisfiedBy(previous.Value).Should().BeFalse("the returned time is not a time the expression ever fires at");
+        previous!.Value.Should().Be(expectedFire);
+        cron.IsSatisfiedBy(previous.Value).Should().BeTrue("GetTimeBefore must return a time the expression fires at");
     }
-
-    #endregion
 }

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 
 using Quartz.Impl.Calendar;
 using Quartz.Util;
@@ -87,6 +88,114 @@ public class TimeZoneUtilTest
 
         TimeZoneUtil.GetUtcOffset(standardPassInstant, eastern).Should().Be(TimeSpan.FromHours(-5));
         TimeZoneUtil.GetUtcOffset(standardPassInstant.DateTime, eastern).Should().Be(TimeSpan.FromHours(-4));
+    }
+
+    // ResolveLocal must agree with the wall-clock GetUtcOffset policy for every time that exists
+    [TestCase("Eastern", "2024-11-03 01:30")]
+    [TestCase("CentralEuropean", "2018-10-28 02:30")]
+    [TestCase("LordHowe", "2019-04-07 01:45")]
+    [TestCase("Santiago", "2019-04-06 23:30")]
+    public void ResolveLocal_AmbiguousLocalTime_MatchesDaylightPolicy(string zoneKey, string localTime)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(local, zone);
+
+        resolved.DateTime.Should().Be(local, "the wall clock must be kept as given");
+        resolved.Offset.Should().Be(TimeZoneUtil.GetUtcOffset(local, zone), "an ambiguous time resolves to the daylight/first occurrence");
+    }
+
+    // An in-gap time pairs with the pre-transition offset, which renders in the zone as the same
+    // wall clock shifted forward by the transition delta
+    [TestCase("Eastern", "2024-03-10 02:30", -5.0, "2024-03-10 03:30")]
+    [TestCase("LordHowe", "2019-10-06 02:15", 10.5, "2019-10-06 02:45")]
+    [TestCase("Santiago", "2019-09-08 00:30", -4.0, "2019-09-08 01:30")]
+    public void ResolveLocal_InvalidLocalTime_ShiftsForwardByTransitionDelta(string zoneKey, string localTime, double expectedOffsetHours, string expectedRenderedLocal)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, local);
+
+        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(local, zone);
+
+        resolved.Offset.Should().Be(TimeSpan.FromHours(expectedOffsetHours), "an in-gap time pairs with the offset in effect just before the gap");
+        TimeZoneInfo.ConvertTime(resolved, zone).DateTime
+            .Should().Be(DateTime.Parse(expectedRenderedLocal, CultureInfo.InvariantCulture), "the instant renders in the zone at the delta-shifted wall clock");
+    }
+
+    // Differential guard: for every wall-clock minute around each transition of the test zones,
+    // ResolveLocal must produce exactly the instant the trigger code produced before it existed
+    // (pairing the local time with the wall-clock GetUtcOffset policy). Positive-daylight-delta
+    // zones must be bit-identical, gaps included.
+    [TestCase("Eastern", "2024-03-10 02:00")]
+    [TestCase("Eastern", "2024-11-03 01:30")]
+    [TestCase("CentralEuropean", "2018-03-25 02:30")]
+    [TestCase("CentralEuropean", "2018-10-28 02:30")]
+    [TestCase("Santiago", "2019-09-08 00:30")]
+    [TestCase("Santiago", "2019-04-06 23:30")]
+    [TestCase("LordHowe", "2019-10-06 02:15")]
+    [TestCase("LordHowe", "2019-04-07 01:45")]
+    public void ResolveLocal_MatchesLegacyResolution_AroundTransition(string zoneKey, string transitionLocal)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime center = DateTime.Parse(transitionLocal, CultureInfo.InvariantCulture);
+
+        for (int minute = -180; minute <= 180; minute++)
+        {
+            DateTime probe = center.AddMinutes(minute);
+            DateTimeOffset legacy = new DateTimeOffset(probe, TimeZoneUtil.GetUtcOffset(probe, zone));
+            TimeZoneUtil.ResolveLocal(probe, zone).Should().Be(legacy, $"probe {probe:yyyy-MM-dd HH:mm} must resolve exactly as the previous inline logic did");
+        }
+    }
+
+    [TestCase("Eastern", "2024-03-10 02:30", "2024-03-10 03:00")]
+    [TestCase("LordHowe", "2019-10-06 02:15", "2019-10-06 02:30")]
+    [TestCase("Santiago", "2019-09-08 00:30", "2019-09-08 01:00")]
+    public void WalkToGapEnd_ReturnsFirstValidWallClockTime(string zoneKey, string invalidLocal, string expectedGapEnd)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(invalidLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, local);
+
+        TimeZoneUtil.WalkToGapEnd(local, zone).Should().Be(DateTime.Parse(expectedGapEnd, CultureInfo.InvariantCulture));
+
+        // noon, not midnight - in a midnight-gap zone like Santiago the date's own 00:00 is invalid
+        DateTime alreadyValid = local.Date.AddHours(12);
+        TimeZoneUtil.WalkToGapEnd(alreadyValid, zone).Should().Be(alreadyValid, "a valid time is returned unchanged");
+    }
+
+    [Test]
+    public void ResolveLocal_NegativeDaylightDeltaZone_DoesNotMoveBackwards()
+    {
+        // Europe/Dublin as modeled by TZif data (Linux/macOS) flags WINTER as the daylight period
+        // with a negative delta, so TimeZoneInfo.GetUtcOffset for an in-gap time returns the
+        // POST-gap offset there; pairing with it would produce an instant before the gap. On
+        // Windows the zone is modeled with a positive delta and this test self-skips.
+        TimeZoneInfo dublin;
+        try
+        {
+            dublin = TimeZoneUtil.FindTimeZoneById("Europe/Dublin");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            Assert.Ignore("Europe/Dublin is not available on this system");
+            return;
+        }
+
+        DateTime inGap = new DateTime(2024, 3, 31, 1, 30, 0);
+        Assume.That(dublin.IsInvalidTime(inGap), "test premise: 2024-03-31 01:30 should not exist in Europe/Dublin");
+
+        bool negativeDelta = dublin.GetAdjustmentRules()
+            .Any(rule => rule.DateStart <= inGap && inGap <= rule.DateEnd && rule.DaylightDelta < TimeSpan.Zero);
+        Assume.That(negativeDelta, "test premise: the zone data models Dublin with a negative daylight delta (TZif); on Windows this is positive and the hazard does not exist");
+
+        DateTimeOffset justBeforeGap = new DateTimeOffset(new DateTime(2024, 3, 31, 0, 59, 0), dublin.GetUtcOffset(new DateTime(2024, 3, 31, 0, 59, 0)));
+        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(inGap, dublin);
+
+        resolved.Should().BeAfter(justBeforeGap, "an in-gap time must resolve forward across the gap, never backwards");
+        TimeZoneInfo.ConvertTime(resolved, dublin).DateTime.Should().Be(new DateTime(2024, 3, 31, 2, 30, 0), "the instant renders at the delta-shifted wall clock after the gap");
     }
 
     [TestCase("US/Eastern", "Eastern Standard Time")]

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -2108,6 +2108,13 @@ public class CronExpression : IDeserializationCallback, ISerializable
     /// <summary>
     /// Gets the next fire time after the given time.
     /// </summary>
+    /// <remarks>
+    /// Daylight saving time transitions in the configured <see cref="TimeZone"/> are handled as
+    /// follows: a scheduled wall-clock time that does not exist (spring-forward gap) fires exactly
+    /// once, shifted forward by the transition delta — a daily 02:30 schedule over a 02:00-03:00
+    /// gap fires at 03:30. This matches Java Quartz. A wall-clock time that occurs twice
+    /// (fall-back overlap) fires at its first occurrence.
+    /// </remarks>
     /// <param name="afterTimeUtc">The UTC time to start searching from.</param>
     /// <returns></returns>
     public virtual DateTimeOffset? GetTimeAfter(DateTimeOffset afterTimeUtc)
@@ -2118,6 +2125,10 @@ public class CronExpression : IDeserializationCallback, ISerializable
 
         // CronTrigger does not deal with milliseconds
         DateTimeOffset d = CreateDateTimeWithoutMillis(afterTimeUtc);
+
+        // the whole-second floor the search starts from; sub-second ticks on afterTimeUtc must not
+        // influence the fall-back demotion below or the result stops being monotonic in the input
+        DateTimeOffset afterTimeUtcFloor = d;
 
         // change to specified time zone
         d = TimeZoneUtil.ConvertTime(d, TimeZone);
@@ -2543,21 +2554,23 @@ public class CronExpression : IDeserializationCallback, ISerializable
 
             //apply the proper offset for this date
             var localDateTime = d.DateTime;
-            d = new DateTimeOffset(localDateTime, TimeZoneUtil.GetUtcOffset(localDateTime, TimeZone));
+            d = TimeZoneUtil.ResolveLocal(localDateTime, TimeZone);
 
             gotOne = true;
 
-            // During DST fall-back transitions, an ambiguous local time may have been
-            // assigned the DST (summer) offset by GetUtcOffset, which picks the first
-            // (DST) occurrence. This can result in a UTC time that is before afterTimeUtc,
-            // causing infinite trigger fires. In that case, use the standard (non-DST)
-            // offset instead, which corresponds to the second occurrence of the local time.
-            // DST always shifts the offset by +1 hour, so the standard offset is always
-            // Min() and the DST offset is always Max() of the two ambiguous offsets.
-            if (d.ToUniversalTime() < afterTimeUtc && TimeZone.IsAmbiguousTime(localDateTime))
+            // During DST fall-back transitions an ambiguous local time resolves to its first
+            // occurrence. When the search started inside the repeated interval, that occurrence
+            // can precede the search floor, which would make the trigger fire endlessly. In that
+            // case use the other occurrence of the same wall-clock time: the earlier occurrence
+            // always carries the greater offset, so the later one is Min() of the two ambiguous
+            // offsets, whatever the size or sign of the zone's daylight delta. Compare against
+            // the whole-second floor the search actually started from - comparing against a
+            // sub-second afterTimeUtc would demote a valid fire, making the result non-monotonic
+            // in the input and breaking GetTimeBefore's binary search.
+            if (d.ToUniversalTime() < afterTimeUtcFloor && TimeZone.IsAmbiguousTime(localDateTime))
             {
-                TimeSpan standardOffset = TimeZone.GetAmbiguousTimeOffsets(localDateTime).Min();
-                d = new DateTimeOffset(localDateTime, standardOffset);
+                TimeSpan laterOccurrenceOffset = TimeZone.GetAmbiguousTimeOffsets(localDateTime).Min();
+                d = new DateTimeOffset(localDateTime, laterOccurrenceOffset);
             }
         } // while( !done )
 

--- a/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
+++ b/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
@@ -370,8 +370,8 @@ public class DailyTimeIntervalScheduleBuilder : ScheduleBuilder<IDailyTimeInterv
 
         //apply proper offsets according to timezone
         TimeZoneInfo targetTimeZone = timeZone ?? TimeZoneInfo.Local;
-        startTimeOfDayDate = new DateTimeOffset(startTimeOfDayDate.DateTime, TimeZoneUtil.GetUtcOffset(startTimeOfDayDate.DateTime, targetTimeZone));
-        tomorrow = new DateTimeOffset(tomorrow.DateTime, TimeZoneUtil.GetUtcOffset(tomorrow.DateTime, targetTimeZone));
+        startTimeOfDayDate = TimeZoneUtil.ResolveLocal(startTimeOfDayDate.DateTime, targetTimeZone);
+        tomorrow = TimeZoneUtil.ResolveLocal(tomorrow.DateTime, targetTimeZone);
 
         TimeSpan remainingMillisInDay = tomorrow - startTimeOfDayDate;
         TimeSpan intervalInMillis;

--- a/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
+++ b/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
@@ -810,36 +810,17 @@ internal sealed class RecurrenceRule
         // Check if time falls in a DST gap (spring forward)
         if (tz.IsInvalidTime(local))
         {
-            // Advance past the gap by computing the DST transition delta
-            TimeSpan adjustment = tz.GetUtcOffset(local.AddHours(2)) - tz.GetUtcOffset(local.AddHours(-2));
-            if (adjustment > TimeSpan.Zero)
-            {
-                local = local.Add(adjustment);
-            }
-            else
-            {
-                local = local.AddHours(1);
-            }
+            // Resolve the nonexistent wall-clock time to its shifted instant, then take the zone's
+            // canonical rendering so the returned value carries a valid wall clock (e.g. a daily
+            // 02:30 in a one hour gap comes back as 03:30 at the post-transition offset). Deriving
+            // the shift this way is robust for transition deltas that are not whole hours and for
+            // zones modeled with a negative daylight delta.
+            return TimeZoneInfo.ConvertTime(TimeZoneUtil.ResolveLocal(local, tz), tz);
         }
 
-        TimeSpan offset = tz.GetUtcOffset(local);
-
-        // For ambiguous times (DST overlap / fall back), use the daylight offset
-        // (the larger UTC offset = earlier UTC instant), matching CalendarIntervalTriggerImpl behavior
-        if (tz.IsAmbiguousTime(local))
-        {
-            TimeSpan[] offsets = tz.GetAmbiguousTimeOffsets(local);
-            offset = offsets[0];
-            for (int i = 1; i < offsets.Length; i++)
-            {
-                if (offsets[i] > offset)
-                {
-                    offset = offsets[i];
-                }
-            }
-        }
-
-        return new DateTimeOffset(local, offset);
+        // Ambiguous times (DST overlap / fall back) resolve to the daylight offset - the first of
+        // the two occurrences - matching the shared scheduler-wide policy.
+        return TimeZoneUtil.ResolveLocal(local, tz);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -819,7 +819,7 @@ public class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarIntervalTri
         {
             //first apply the date, and then find the proper timezone offset
             newTime = new DateTimeOffset(newTime.Year, newTime.Month, newTime.Day, initialHourOfDay, newTime.Minute, newTime.Second, newTime.Millisecond, TimeSpan.Zero);
-            newTime = new DateTimeOffset(newTime.DateTime, TimeZoneUtil.GetUtcOffset(newTime.DateTime, TimeZone));
+            newTime = TimeZoneUtil.ResolveLocal(newTime.DateTime, TimeZone);
 
             //TimeZone.IsInvalidTime is true, if this hour does not exist in the specified timezone
             bool isInvalid = TimeZone.IsInvalidTime(newTime.DateTime);
@@ -828,14 +828,13 @@ public class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarIntervalTri
             {
                 return SkipDayIfHourDoesNotExist;
             }
-            //don't skip this day, instead find closest valid time by adding minutes.
-            while (TimeZone.IsInvalidTime(newTime.DateTime))
-            {
-                newTime = newTime.AddMinutes(1);
-            }
 
-            //apply proper offset for the adjusted time
-            newTime = new DateTimeOffset(newTime.DateTime, TimeZoneUtil.GetUtcOffset(newTime.DateTime, TimeZone));
+            if (isInvalid)
+            {
+                //don't skip this day, instead find the closest valid time after the gap
+                //and apply the proper offset for the adjusted time
+                newTime = TimeZoneUtil.ResolveLocal(TimeZoneUtil.WalkToGapEnd(newTime.DateTime, TimeZone), TimeZone);
+            }
         }
         return false;
     }
@@ -857,7 +856,7 @@ public class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarIntervalTri
         {
             //first apply the date, and then find the proper timezone offset
             sTime = new DateTimeOffset(initalYear, initalMonth, initialDay, initialHourOfDay, sTime.Minute, sTime.Second, sTime.Millisecond, TimeSpan.Zero);
-            sTime = new DateTimeOffset(sTime.DateTime, TimeZoneUtil.GetUtcOffset(sTime.DateTime, TimeZone));
+            sTime = TimeZoneUtil.ResolveLocal(sTime.DateTime, TimeZone);
         }
     }
 

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -668,13 +668,13 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
         }
 
         // apply the proper offset for the end date
-        fireTimeEndDate = new DateTimeOffset(fireTimeEndDate.DateTime, TimeZoneUtil.GetUtcOffset(fireTimeEndDate.DateTime, TimeZone));
+        fireTimeEndDate = TimeZoneUtil.ResolveLocal(fireTimeEndDate.DateTime, TimeZone);
 
         // e. Check fireTime against startTime or startTimeOfDay to see which go first.
         DateTimeOffset fireTimeStartDate = startTimeOfDay.GetTimeOfDayForDate(fireTime.Value);
 
         // apply the proper offset for the start date
-        fireTimeStartDate = new DateTimeOffset(fireTimeStartDate.DateTime, TimeZoneUtil.GetUtcOffset(fireTimeStartDate.DateTime, TimeZone));
+        fireTimeStartDate = TimeZoneUtil.ResolveLocal(fireTimeStartDate.DateTime, TimeZone);
 
         if (fireTime < fireTimeStartDate)
         {
@@ -752,7 +752,7 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
 
             if (expectedLocalTime.Date != fireTime.Value.DateTime.Date)
             {
-                DateTimeOffset corrected = new DateTimeOffset(expectedLocalTime, TimeZoneUtil.GetUtcOffset(expectedLocalTime, TimeZone));
+                DateTimeOffset corrected = TimeZoneUtil.ResolveLocal(expectedLocalTime, TimeZone);
 
                 // GetFireTimeAfter must never move backwards
                 if (corrected > fireTime.Value)
@@ -796,8 +796,7 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
 
         // For a local time that does not exist (skipped by a spring-forward transition) the resolved
         // offset is the one from before the transition, which lands on the first instant that does exist.
-        DateTime localTime = startOfDay.Value.DateTime;
-        return new DateTimeOffset(localTime, TimeZoneUtil.GetUtcOffset(localTime, TimeZone));
+        return TimeZoneUtil.ResolveLocal(startOfDay.Value.DateTime, TimeZone);
     }
 
     /// <summary>
@@ -851,10 +850,10 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
                     fireTime = fireTimeStartDateCal;
                     // apply timezone for this date & time; resolve from the wall-clock time, not the
                     // carried instant - the offset inherited through AddDays is stale when the walk
-                    // crosses a DST transition, and the instant-based overload would resolve an
+                    // crosses a DST transition, and an instant-based resolution would place an
                     // in-gap start-of-day one transition delta too early, before the EndTimeUtc
                     // check below sees it
-                    fireTime = new DateTimeOffset(fireTime.DateTime, TimeZoneUtil.GetUtcOffset(fireTime.DateTime, TimeZone));
+                    fireTime = TimeZoneUtil.ResolveLocal(fireTime.DateTime, TimeZone);
                     break;
                 }
             }

--- a/src/Quartz/TimeOfDay.cs
+++ b/src/Quartz/TimeOfDay.cs
@@ -192,6 +192,12 @@ public class TimeOfDay
     /// <summary>
     /// Return a date with time of day reset to this object values. The millisecond value will be zero.
     /// </summary>
+    /// <remarks>
+    /// The returned value inherits the offset carried by <paramref name="dateTime"/> without
+    /// consulting any time zone. Around a daylight saving transition that inherited offset can be
+    /// wrong for the produced wall-clock time (see #3190), so callers that cross transitions must
+    /// re-resolve the result, for example with <c>TimeZoneUtil.ResolveLocal</c>.
+    /// </remarks>
     /// <param name="dateTime"></param>
     public DateTimeOffset GetTimeOfDayForDate(DateTimeOffset dateTime)
     {

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -99,6 +99,62 @@ public static class TimeZoneUtil
     }
 
     /// <summary>
+    /// Transition scans are bounded so that a pathological time zone cannot loop forever;
+    /// no real transition gap or overlap is anywhere near this wide.
+    /// </summary>
+    private const int MaxTransitionScanMinutes = 48 * 60;
+
+    /// <summary>
+    /// Resolves a wall-clock time in the given zone to a <see cref="DateTimeOffset"/> using the
+    /// scheduler-wide daylight saving policy:
+    /// an ambiguous local time (fall-back overlap) resolves to the daylight offset — the first of
+    /// the two occurrences; a local time that does not exist (spring-forward gap) is paired with
+    /// the offset in effect just before the gap, which places the instant at the first wall-clock
+    /// time after the gap, shifted forward by the transition delta.
+    /// </summary>
+    /// <remarks>
+    /// For an in-gap time this differs from pairing with <see cref="TimeZoneInfo.GetUtcOffset(DateTime)"/>
+    /// only in zones whose daylight delta is negative (for example Europe/Dublin as modeled by TZif
+    /// data, where winter time is the daylight-flagged period): there the base offset is the
+    /// post-gap offset and pairing with it would produce an instant before the gap, moving time
+    /// backwards. The offset just before the gap is found by scanning backwards a minute at a time,
+    /// which also handles transition deltas that are not whole hours.
+    /// </remarks>
+    internal static DateTimeOffset ResolveLocal(DateTime dateTime, TimeZoneInfo timeZoneInfo)
+    {
+        if (timeZoneInfo.IsInvalidTime(dateTime))
+        {
+            DateTime probe = dateTime;
+            int guard = 0;
+            do
+            {
+                probe = probe.AddMinutes(-1);
+            } while (timeZoneInfo.IsInvalidTime(probe) && ++guard < MaxTransitionScanMinutes);
+
+            return new DateTimeOffset(dateTime, timeZoneInfo.GetUtcOffset(probe));
+        }
+
+        return new DateTimeOffset(dateTime, GetUtcOffset(dateTime, timeZoneInfo));
+    }
+
+    /// <summary>
+    /// Walks forward from a wall-clock time inside a spring-forward gap to the first wall-clock
+    /// time that exists in the given zone (the end of the gap). Returns the input unchanged when it
+    /// is already valid.
+    /// </summary>
+    internal static DateTime WalkToGapEnd(DateTime dateTime, TimeZoneInfo timeZoneInfo)
+    {
+        DateTime probe = dateTime;
+        int guard = 0;
+        while (timeZoneInfo.IsInvalidTime(probe) && guard++ < MaxTransitionScanMinutes)
+        {
+            probe = probe.AddMinutes(1);
+        }
+
+        return probe;
+    }
+
+    /// <summary>
     /// Tries to find time zone with given id, has ability do some fallbacks when necessary.
     /// </summary>
     /// <param name="id">System id of the time zone.</param>


### PR DESCRIPTION
## Summary

Follow-up to #3195/#3196: centralizes the trigger-wide DST policy into two internal `TimeZoneUtil` helpers and migrates all five call-site families onto them. Until now the policy existed in one explicit place (`GetUtcOffset(DateTime, ..)` for ambiguous times) and was otherwise *implicit* — invalid (spring-forward gap) times were handled only by the accident of `TimeZoneInfo.GetUtcOffset` returning the pre-gap offset for positive-delta zones.

- **`TimeZoneUtil.ResolveLocal(DateTime, tz)`** — ambiguous → daylight/first occurrence; nonexistent → pair with the pre-gap offset (= shift forward by the transition delta), found by scanning backwards a minute at a time (handles 30-minute deltas and negative-delta zone models).
- **`TimeZoneUtil.WalkToGapEnd(DateTime, tz)`** — first valid wall-clock time after a gap (the CalendarIntervalTrigger preserve-hour crawl).
- Migrated: `CronExpression`, `DailyTimeIntervalTriggerImpl` (5 sites), `CalendarIntervalTriggerImpl`, `DailyTimeIntervalScheduleBuilder`, `RecurrenceRule.ToDateTimeOffset` (drops its hard-coded ±2h gap probe).

## Two latent defects fixed

1. **Negative-daylight-delta gap hazard.** For zones modeled with a negative delta (Europe/Dublin on TZif data — Linux/macOS), `TimeZoneInfo.GetUtcOffset` returns the *post*-gap offset for an in-gap time, so the old pairing produced an instant **before** the gap — a scheduler hot-loop hazard the ambiguity demotion doesn''t cover. Covered by an `Assume`-guarded test that self-skips on Windows zone data.
2. **Sub-second demotion defect** (discovered while pinning in #3195). `CronExpression.GetTimeAfter` compared its whole-second candidate against the untruncated after-time, so a sub-second after-time inside the repeated fall-back hour demoted a valid fire a whole hour forward — making `GetTimeAfter` non-monotonic in its input and letting `GetTimeBefore` return instants the expression never fires at. The comparison now uses the whole-second floor the search starts from. The two pin tests now assert the fixed contract, and the previously excluded −5 min round-trip probes are restored.

## Behavior-neutrality

For every positive-delta zone the migrations are bit-identical to the old inline logic, guarded by a minute-by-minute differential test (`ResolveLocal_MatchesLegacyResolution_AroundTransition`) across ±3h of all eight test-zone transitions, plus the full DST corpus from #3195 passing unchanged. Only the two defects above change observable behavior.

Also documents the DST contract on `CronExpression.GetTimeAfter` (fixed times in a gap fire once, delta-shifted — Java Quartz parity) and the offset-inheritance pitfall on `TimeOfDay.GetTimeOfDayForDate` (#3190).

## Verification

- `dotnet test src/Quartz.Tests.Unit -f net10.0`: 1691 passed, 0 failed
- `dotnet test src/Quartz.Tests.Unit -f net472`: 1690 passed, 0 failed
- Before the sub-second fix, exactly the 5 defect-pin tests failed and nothing else — confirming the migrations alone are behavior-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)