### PR TITLE
Port DST test corpus, EndTimeUtc overshoot fix and TimeZoneUtil DST centralization to main

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,13 @@
 
   * `SystemTime` was removed as way to provide "now", you can inject `TimeProvider` via configuration or `UseTimeProvider(TimeProvider)` on the builder
 
+  * Cron expressions whose second, minute or hour field uses a wildcard, step or range (interval
+    expressions such as `0 * * * * ?` or `0 0/30 * * * ?`) now fire through **both** occurrences of the
+    wall-clock window that repeats when daylight saving time falls back. Previously the repeated window
+    fired only once, so an "every minute" schedule silently skipped an hour of real time. Fixed-time
+    expressions (such as `0 30 2 * * ?`, including comma lists like `0 0,30 2 * * ?`) keep firing once
+    per day, at the first occurrence of an ambiguous wall-clock time.
+
   * The `Equals(StringOperator? other)` method of **StringOperator** is now also virtual to allow it to be
     overridden in pair with `Equals(object? obj)` and `GetHashCode()`.
 

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerDstTests.cs
@@ -1,0 +1,423 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Daylight saving time coverage for <see cref="CalendarIntervalTriggerImpl" /> around fall-back
+/// transitions and midnight gaps. The existing <see cref="CalendarIntervalTriggerTest" /> only covers
+/// spring-forward, so these tests deliberately stay on the other side of the year: the repeated hour,
+/// the midnight gap, the sub-day units that never see a transition at all, and the behaviour of the
+/// default (non preserving) configuration.
+///
+/// Every expectation here pins the behaviour that ships today. Where that behaviour is arguably the
+/// wrong answer it lives in the "current-behavior pins" region at the bottom with the reasoning
+/// spelled out, so that a deliberate change shows up as a failing pin rather than a silent shift.
+///
+/// These tests never touch <see cref="SystemTime" />, so the fixture is safe to run in parallel.
+/// </summary>
+public class CalendarIntervalTriggerDstTests
+{
+    /// <summary>
+    /// Builds a trigger with every DST relevant knob stated explicitly. <c>StartTimeUtc</c> is always
+    /// supplied by the caller: the implementation defaults it to the current time, which would silently
+    /// turn every expectation in this file into a vacuous assertion about "now".
+    /// </summary>
+    private static CalendarIntervalTriggerImpl CreateTrigger(
+        TimeZoneInfo zone,
+        IntervalUnit unit,
+        int interval,
+        DateTimeOffset startTimeUtc,
+        bool preserveHourOfDay,
+        bool skipDayIfHourDoesNotExist)
+    {
+        return new CalendarIntervalTriggerImpl
+        {
+            StartTimeUtc = startTimeUtc,
+            RepeatIntervalUnit = unit,
+            RepeatInterval = interval,
+            TimeZone = zone,
+            PreserveHourOfDayAcrossDaylightSavings = preserveHourOfDay,
+            SkipDayIfHourDoesNotExist = skipDayIfHourDoesNotExist
+        };
+    }
+
+    /// <summary>
+    /// Collects the fire times in <c>[start, untilExclusive)</c>. Walking from one second before the
+    /// start makes the start time itself the first collected fire, and <see cref="TestTimeZones.Walk" />
+    /// fails the test if the trigger ever stops moving forward.
+    /// </summary>
+    private static List<DateTimeOffset> WalkFrom(
+        CalendarIntervalTriggerImpl trigger,
+        DateTimeOffset start,
+        DateTimeOffset untilExclusive)
+    {
+        return TestTimeZones.Walk(after => trigger.GetFireTimeAfter(after), start.AddSeconds(-1), untilExclusive);
+    }
+
+    /// <summary>
+    /// With the hour preserved, a fall-back day must produce exactly one fire even though the scheduled
+    /// wall-clock time happens twice, and the next occurrence must be back at the same wall-clock time
+    /// under the new (standard) offset.
+    /// </summary>
+    [TestCase(IntervalUnit.Day, "2024-11-01 01:30 -04:00", "2024-11-05 00:00 -05:00", "2024-11-04 01:30 -05:00")]
+    [TestCase(IntervalUnit.Week, "2024-10-27 01:30 -04:00", "2024-11-11 00:00 -05:00", "2024-11-10 01:30 -05:00")]
+    [TestCase(IntervalUnit.Month, "2024-10-03 01:30 -04:00", "2024-12-04 00:00 -05:00", "2024-12-03 01:30 -05:00")]
+    [TestCase(IntervalUnit.Year, "2023-11-03 01:30 -04:00", "2025-11-04 00:00 -05:00", "2025-11-03 01:30 -05:00")]
+    public void PreserveHour_FallBack_FiresOnceAtScheduledLocalHour(
+        IntervalUnit unit,
+        string start,
+        string untilExclusive,
+        string followingOccurrence)
+    {
+        AssertFallBackFiresOnceAtScheduledLocalHour(unit, start, untilExclusive, followingOccurrence, skipDayIfHourDoesNotExist: false);
+    }
+
+    /// <summary>
+    /// <c>SkipDayIfHourDoesNotExist</c> is about spring-forward gaps only. On a fall-back day the
+    /// scheduled hour exists twice over, so turning the flag on must change nothing at all: the results
+    /// are identical to <see cref="PreserveHour_FallBack_FiresOnceAtScheduledLocalHour" />.
+    /// </summary>
+    [TestCase(IntervalUnit.Day, "2024-11-01 01:30 -04:00", "2024-11-05 00:00 -05:00", "2024-11-04 01:30 -05:00")]
+    [TestCase(IntervalUnit.Week, "2024-10-27 01:30 -04:00", "2024-11-11 00:00 -05:00", "2024-11-10 01:30 -05:00")]
+    [TestCase(IntervalUnit.Month, "2024-10-03 01:30 -04:00", "2024-12-04 00:00 -05:00", "2024-12-03 01:30 -05:00")]
+    [TestCase(IntervalUnit.Year, "2023-11-03 01:30 -04:00", "2025-11-04 00:00 -05:00", "2025-11-03 01:30 -05:00")]
+    public void PreserveHour_SkipDayFlag_FallBack_IsNoOp(
+        IntervalUnit unit,
+        string start,
+        string untilExclusive,
+        string followingOccurrence)
+    {
+        AssertFallBackFiresOnceAtScheduledLocalHour(unit, start, untilExclusive, followingOccurrence, skipDayIfHourDoesNotExist: true);
+    }
+
+    private static void AssertFallBackFiresOnceAtScheduledLocalHour(
+        IntervalUnit unit,
+        string start,
+        string untilExclusive,
+        string followingOccurrence,
+        bool skipDayIfHourDoesNotExist)
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2024, 11, 3, 1, 30, 0));
+
+        // each start is chosen so that one occurrence lands exactly on the fall-back day 2024-11-03:
+        // daily from two days before, weekly from the previous Sunday, monthly/yearly from the same
+        // day-of-month one period earlier. All of them are still on -04:00 (2023 fell back on 11-05).
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            unit,
+            interval: 1,
+            TestTimeZones.Local(start),
+            preserveHourOfDay: true,
+            skipDayIfHourDoesNotExist);
+
+        List<DateTimeOffset> fires = WalkFrom(trigger, TestTimeZones.Local(start), TestTimeZones.Local(untilExclusive));
+
+        List<DateTimeOffset> onTransitionDay = fires
+            .Where(fireTime => TimeZoneInfo.ConvertTime(fireTime, zone).Date == new DateTime(2024, 11, 3))
+            .ToList();
+
+        // 01:30 happens twice on 2024-11-03. The trigger fires once, and on the first (daylight, -04:00)
+        // occurrence, because the re-anchoring goes through TimeZoneUtil.GetUtcOffset(DateTime, ...)
+        // which resolves an ambiguous wall-clock time to the daylight offset.
+        onTransitionDay.Should().Equal(TestTimeZones.Local("2024-11-03 01:30 -04:00"));
+
+        int transitionIndex = fires.IndexOf(onTransitionDay[0]);
+        fires.Should().HaveCountGreaterThan(transitionIndex + 1, "the walk window must extend past the transition day");
+
+        DateTimeOffset next = fires[transitionIndex + 1];
+        next.Should().Be(TestTimeZones.Local(followingOccurrence));
+
+        DateTimeOffset nextLocal = TimeZoneInfo.ConvertTime(next, zone);
+        nextLocal.TimeOfDay.Should().Be(new TimeSpan(1, 30, 0), "the scheduled wall-clock time is preserved across the transition");
+        nextLocal.Offset.Should().Be(TimeSpan.FromHours(-5), "the zone is on standard time after the fall back");
+    }
+
+    /// <summary>
+    /// Sub-day units are pure elapsed-time arithmetic off the start instant, so a DST transition is
+    /// simply not visible to them: the spacing between consecutive fires stays exactly the configured
+    /// interval in both directions, and the repeated hour shows up only as a 25 hour local day.
+    /// </summary>
+    [TestCase(IntervalUnit.Hour, 1)]
+    [TestCase(IntervalUnit.Minute, 90)]
+    [TestCase(IntervalUnit.Second, 3600)]
+    public void SubDayUnits_AreDstAgnostic(IntervalUnit unit, int interval)
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2018, 3, 25, 2, 30, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2018, 10, 28, 2, 30, 0));
+
+        TimeSpan expectedInterval = unit switch
+        {
+            IntervalUnit.Hour => TimeSpan.FromHours(interval),
+            IntervalUnit.Minute => TimeSpan.FromMinutes(interval),
+            _ => TimeSpan.FromSeconds(interval)
+        };
+
+        // spring forward: 2018-03-25 02:00 +01:00 becomes 03:00 +02:00
+        AssertUniformSpacing(zone, unit, interval, "2018-03-24 23:00 +01:00", "2018-03-25 08:00 +02:00", expectedInterval);
+
+        // fall back: 2018-10-28 03:00 +02:00 becomes 02:00 +01:00
+        AssertUniformSpacing(zone, unit, interval, "2018-10-28 00:00 +02:00", "2018-10-28 07:00 +01:00", expectedInterval);
+
+        if (unit == IntervalUnit.Hour && interval == 1)
+        {
+            // the fall-back local day is 25 hours long, so an hourly trigger fires 25 times on it
+            CalendarIntervalTriggerImpl hourly = CreateTrigger(
+                zone,
+                IntervalUnit.Hour,
+                interval: 1,
+                TestTimeZones.Local("2018-10-28 00:00 +02:00"),
+                preserveHourOfDay: true,
+                skipDayIfHourDoesNotExist: false);
+
+            List<DateTimeOffset> fires = WalkFrom(
+                hourly,
+                TestTimeZones.Local("2018-10-28 00:00 +02:00"),
+                TestTimeZones.Local("2018-10-29 00:00 +01:00"));
+
+            fires
+                .Count(fireTime => TimeZoneInfo.ConvertTime(fireTime, zone).Date == new DateTime(2018, 10, 28))
+                .Should().Be(25, "the repeated hour makes the fall-back local day 25 hours long");
+        }
+    }
+
+    private static void AssertUniformSpacing(
+        TimeZoneInfo zone,
+        IntervalUnit unit,
+        int interval,
+        string start,
+        string untilExclusive,
+        TimeSpan expectedInterval)
+    {
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            unit,
+            interval,
+            TestTimeZones.Local(start),
+            preserveHourOfDay: true,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> fires = WalkFrom(trigger, TestTimeZones.Local(start), TestTimeZones.Local(untilExclusive));
+
+        fires.Should().HaveCountGreaterThan(1, "the walk window must span the transition");
+
+        for (int i = 1; i < fires.Count; i++)
+        {
+            (fires[i] - fires[i - 1]).Should().Be(
+                expectedInterval,
+                $"fire {i} at {fires[i]:O} must be exactly one interval after {fires[i - 1]:O}");
+        }
+    }
+
+    /// <summary>
+    /// When the preserved wall-clock time is itself the ambiguous one, the trigger fires on the first
+    /// (daylight) occurrence of it, not the second. The re-anchoring resolves the local time through
+    /// <c>TimeZoneUtil.GetUtcOffset(DateTime, ...)</c>, which prefers the daylight offset.
+    /// </summary>
+    [Test]
+    public void PreserveHour_AmbiguousScheduledHour_Sydney_PicksFirstOccurrence()
+    {
+        TimeZoneInfo zone = TestTimeZones.Sydney;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2024, 4, 7, 2, 30, 0));
+
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            IntervalUnit.Day,
+            interval: 1,
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            preserveHourOfDay: true,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> fires = WalkFrom(
+            trigger,
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-09 00:00 +10:00"));
+
+        fires.Should().Equal(
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-06 02:30 +11:00"),
+            // 02:30 exists twice on 2024-04-07; the daylight (+11:00) one is chosen
+            TestTimeZones.Local("2024-04-07 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-08 02:30 +10:00"));
+    }
+
+    /// <summary>
+    /// Santiago moves its clocks at midnight, so on 2019-09-08 the date's own 00:00 does not exist and
+    /// the day starts at 01:00 -03:00. This pins both halves of the gap handling: crawl forward to the
+    /// first valid minute, or skip the day entirely.
+    /// </summary>
+    [Test]
+    public void PreserveHour_MidnightGap_Santiago_Daily()
+    {
+        TimeZoneInfo zone = TestTimeZones.Santiago;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2019, 9, 8, 0, 0, 0));
+
+        DateTimeOffset start = TestTimeZones.Local("2019-09-06 00:00 -04:00");
+        DateTimeOffset untilExclusive = TestTimeZones.Local("2019-09-11 00:00 -03:00");
+
+        CalendarIntervalTriggerImpl crawling = CreateTrigger(
+            zone, IntervalUnit.Day, interval: 1, start, preserveHourOfDay: true, skipDayIfHourDoesNotExist: false);
+
+        WalkFrom(crawling, start, untilExclusive).Should().Equal(
+            TestTimeZones.Local("2019-09-06 00:00 -04:00"),
+            TestTimeZones.Local("2019-09-07 00:00 -04:00"),
+            // 00:00 does not exist on the transition day, so the trigger crawls forward a minute at a
+            // time until it lands on the first instant the day actually has
+            TestTimeZones.Local("2019-09-08 01:00 -03:00"),
+            TestTimeZones.Local("2019-09-09 00:00 -03:00"),
+            TestTimeZones.Local("2019-09-10 00:00 -03:00"));
+
+        CalendarIntervalTriggerImpl skipping = CreateTrigger(
+            zone, IntervalUnit.Day, interval: 1, start, preserveHourOfDay: true, skipDayIfHourDoesNotExist: true);
+
+        WalkFrom(skipping, start, untilExclusive).Should().Equal(
+            TestTimeZones.Local("2019-09-06 00:00 -04:00"),
+            TestTimeZones.Local("2019-09-07 00:00 -04:00"),
+            // the transition day is dropped and the schedule resumes on the following day at 00:00
+            TestTimeZones.Local("2019-09-09 00:00 -03:00"),
+            TestTimeZones.Local("2019-09-10 00:00 -03:00"));
+    }
+
+    /// <summary>
+    /// <c>ComputeFirstFireTimeUtc</c> applies no DST correction: the first fire is the start instant
+    /// itself, whichever side of a transition it sits on and regardless of the preserve flag. Note that
+    /// <c>StartTimeUtc</c> is an instant rather than a wall-clock time, so it can never be invalid or
+    /// ambiguous - there is nothing for the trigger to correct here in the first place.
+    /// </summary>
+    [TestCase("2024-03-10 06:59 +00:00", false)]
+    [TestCase("2024-03-10 06:59 +00:00", true)]
+    [TestCase("2024-03-10 07:01 +00:00", false)]
+    [TestCase("2024-03-10 07:01 +00:00", true)]
+    [TestCase("2024-11-03 05:59 +00:00", false)]
+    [TestCase("2024-11-03 05:59 +00:00", true)]
+    [TestCase("2024-11-03 06:01 +00:00", false)]
+    [TestCase("2024-11-03 06:01 +00:00", true)]
+    public void FirstFireTime_EqualsStartInstant_AdjacentToTransitions(string startTimeUtc, bool preserveHourOfDay)
+    {
+        // Eastern springs forward at 2024-03-10 07:00Z and falls back at 2024-11-03 06:00Z, so each of
+        // these start instants is a minute either side of a transition.
+        DateTimeOffset start = TestTimeZones.Local(startTimeUtc);
+
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            TestTimeZones.Eastern,
+            IntervalUnit.Day,
+            interval: 1,
+            start,
+            preserveHourOfDay,
+            skipDayIfHourDoesNotExist: false);
+
+        trigger.ComputeFirstFireTimeUtc(null).Should().Be(start);
+    }
+
+    #region Current-behavior pins (decision points)
+
+    /// <summary>
+    /// PINNED DELIBERATELY - this is the behaviour of the DEFAULT configuration and it is the opposite
+    /// of what cron and daily-time-interval triggers do.
+    ///
+    /// With <c>PreserveHourOfDayAcrossDaylightSavings</c> left at its default of <c>false</c>, a day (or
+    /// larger) interval is pure instant arithmetic: consecutive fires stay exactly 24 hours apart in UTC
+    /// and the local wall-clock time therefore slides by an hour when the zone falls back. Cron and
+    /// <c>DailyTimeIntervalTrigger</c> anchor to the wall clock instead and would keep firing at 01:30
+    /// local. Whether a calendar-interval trigger should default to instant spacing or to wall-clock
+    /// spacing is a genuine design question; this test exists so that changing the answer is a conscious
+    /// act rather than an accident.
+    /// </summary>
+    [Test]
+    public void NoPreserveHour_FallBack_LocalTimeDriftsOneHour_UtcStable()
+    {
+        TimeZoneInfo eastern = TestTimeZones.Eastern;
+        TestTimeZones.AssumeAmbiguousLocalTime(eastern, new DateTime(2024, 11, 3, 1, 30, 0));
+
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            eastern,
+            IntervalUnit.Day,
+            interval: 1,
+            TestTimeZones.Local("2024-11-01 01:30 -04:00"),
+            preserveHourOfDay: false,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> fires = WalkFrom(
+            trigger,
+            TestTimeZones.Local("2024-11-01 01:30 -04:00"),
+            TestTimeZones.Local("2024-11-06 00:00 -05:00"));
+
+        // Note where the drift actually lands. The transition is at 2024-11-03 06:00Z, and the trigger
+        // fires at 05:30Z, so the 2024-11-03 fire is still on daylight time at 01:30 -04:00 - it is the
+        // FOLLOWING day, 2024-11-04, that first shows the drifted 00:30 -05:00 wall-clock time.
+        fires.Should().Equal(
+            TestTimeZones.Local("2024-11-01 01:30 -04:00"),
+            TestTimeZones.Local("2024-11-02 01:30 -04:00"),
+            TestTimeZones.Local("2024-11-03 01:30 -04:00"),
+            TestTimeZones.Local("2024-11-04 00:30 -05:00"),
+            TestTimeZones.Local("2024-11-05 00:30 -05:00"));
+
+        AssertConstantUtcSpacing(fires, TimeSpan.FromHours(24));
+
+        // the whole run sits on the same UTC time of day, which is exactly the point
+        fires.Should().OnlyContain(fireTime => fireTime.UtcDateTime.TimeOfDay == new TimeSpan(5, 30, 0));
+
+        // Southern hemisphere mirror: Sydney falls back on 2024-04-07 and the same drift appears one day
+        // later, on 2024-04-08, for the same reason.
+        TimeZoneInfo sydney = TestTimeZones.Sydney;
+        TestTimeZones.AssumeAmbiguousLocalTime(sydney, new DateTime(2024, 4, 7, 2, 30, 0));
+
+        CalendarIntervalTriggerImpl sydneyTrigger = CreateTrigger(
+            sydney,
+            IntervalUnit.Day,
+            interval: 1,
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            preserveHourOfDay: false,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> sydneyFires = WalkFrom(
+            sydneyTrigger,
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-10 00:00 +10:00"));
+
+        sydneyFires.Should().Equal(
+            TestTimeZones.Local("2024-04-05 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-06 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-07 02:30 +11:00"),
+            TestTimeZones.Local("2024-04-08 01:30 +10:00"),
+            TestTimeZones.Local("2024-04-09 01:30 +10:00"));
+
+        AssertConstantUtcSpacing(sydneyFires, TimeSpan.FromHours(24));
+    }
+
+    private static void AssertConstantUtcSpacing(List<DateTimeOffset> fires, TimeSpan expectedInterval)
+    {
+        for (int i = 1; i < fires.Count; i++)
+        {
+            (fires[i] - fires[i - 1]).Should().Be(
+                expectedInterval,
+                $"fire {i} at {fires[i]:O} must be exactly one interval after {fires[i - 1]:O}");
+        }
+    }
+
+    #endregion
+}

--- a/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
@@ -1,0 +1,484 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Daylight saving time corner cases for <see cref="CronExpression" /> itself, exercised through
+/// <see cref="CronExpression.GetTimeAfter" />, <see cref="CronExpression.GetTimeBefore" /> and
+/// <see cref="CronExpression.IsSatisfiedBy" /> across zones with differing transition shapes
+/// (northern and southern hemisphere, a midnight gap, and a 30 minute delta).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The mechanics being pinned live at the end of <see cref="CronExpression.GetTimeAfter" />: the
+/// search converts the "after" instant into the target zone once, then advances purely in wall
+/// clock terms with the offset frozen, and only at the very end re-resolves the offset for the
+/// resulting local date and time. That re-resolution prefers the DAYLIGHT (first) occurrence of an
+/// ambiguous local time, and demotes to the standard offset only when the daylight interpretation
+/// would land at or before the "after" instant. Local times that fall inside a spring-forward gap
+/// do not exist, so the re-resolution yields the pre-transition offset and the fire lands shifted
+/// forward in real time by the transition delta.
+/// </para>
+/// <para>
+/// These tests never touch <c>SystemTime</c>, so they are safe to run in parallel with the rest of
+/// the suite.
+/// </para>
+/// </remarks>
+public class CronExpressionDstTests
+{
+    /// <summary>
+    /// Attributes cannot carry a <see cref="TimeZoneInfo" />, so test case grids name the zone and
+    /// resolve it here. Zones that may be missing from an old OS install ignore the test from
+    /// inside <see cref="TestTimeZones" /> rather than failing it.
+    /// </summary>
+    private static TimeZoneInfo ResolveZone(string zoneKey)
+    {
+        switch (zoneKey)
+        {
+            case "Eastern":
+                return TestTimeZones.Eastern;
+            case "CentralEuropean":
+                return TestTimeZones.CentralEuropean;
+            case "Santiago":
+                return TestTimeZones.Santiago;
+            case "Sydney":
+                return TestTimeZones.Sydney;
+            case "LordHowe":
+                return TestTimeZones.LordHowe;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test time zone key");
+        }
+    }
+
+    private static CronExpression CronIn(string expression, TimeZoneInfo zone)
+    {
+        CronExpression cron = new CronExpression(expression);
+        cron.TimeZone = zone;
+        return cron;
+    }
+
+    /// <summary>
+    /// Parses a wall clock time with no offset, for stating an invalid or ambiguous premise.
+    /// </summary>
+    private static DateTime WallClock(string value)
+    {
+        return DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.None);
+    }
+
+    /// <summary>
+    /// A daily trigger whose fire time falls inside the spring-forward gap still fires exactly once
+    /// on the transition day, but shifted forward in real time by the transition delta: the
+    /// non-existent local time is resolved with the pre-transition offset, so 02:30 -05:00 becomes
+    /// the instant that reads 03:30 -04:00. The following day is back to the nominal wall clock
+    /// time, which shows the shift is confined to the transition day.
+    /// </summary>
+    /// <remarks>
+    /// This is a deliberate deviation from Cronos-style semantics, which fire such a trigger at the
+    /// END of the gap (03:00 in the Eastern case, i.e. the moment the skipped wall clock time would
+    /// have been reached). Quartz.NET instead fires delta-shifted (03:30) to keep parity with Java
+    /// Quartz, whose <c>CronExpression</c> performs the same "advance in wall clock, resolve the
+    /// offset last" walk. The Lord Howe case is the one that tells the two rules apart beyond
+    /// doubt: its delta is 30 minutes, so a gap-END rule would fire at 02:30 while the delta-shift
+    /// rule fires at 02:45.
+    /// </remarks>
+    [TestCase("0 30 2 * * ?", "Eastern", "2024-03-10 02:30", "2024-03-10 00:00 -05:00", "2024-03-10 03:30 -04:00", "2024-03-11 02:30 -04:00")]
+    [TestCase("0 15 2 * * ?", "LordHowe", "2019-10-06 02:15", "2019-10-06 00:00 +10:30", "2019-10-06 02:45 +11:00", "2019-10-07 02:15 +11:00")]
+    [TestCase("0 0 0 * * ?", "Santiago", "2019-09-08 00:00", "2019-09-07 12:00 -04:00", "2019-09-08 01:00 -03:00", "2019-09-09 00:00 -03:00")]
+    public void GetTimeAfter_FixedTimeInsideGap_FiresOnceShiftedByTransitionDelta(
+        string cronExpression,
+        string zoneKey,
+        string gapLocalTime,
+        string fromLocal,
+        string expectedFire,
+        string expectedNextDayFire)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock(gapLocalTime));
+
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset? fire = cron.GetTimeAfter(TestTimeZones.Local(fromLocal));
+
+        fire.Should().NotBeNull();
+        fire!.Value.Should().Be(TestTimeZones.Local(expectedFire));
+
+        DateTimeOffset? nextFire = cron.GetTimeAfter(fire.Value);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(TestTimeZones.Local(expectedNextDayFire), "the trigger fires only once on the transition day");
+    }
+
+    /// <summary>
+    /// A daily trigger whose fire time is repeated by the fall-back transition fires once, at the
+    /// FIRST (daylight) occurrence, and not again at the second (standard) occurrence of the same
+    /// wall clock time. Southern hemisphere zones and a transition that crosses backwards over the
+    /// date boundary behave the same way.
+    /// </summary>
+    [TestCase("0 30 1 * * ?", "Eastern", "2024-11-03 01:30", "2024-11-03 00:00 -04:00", "2024-11-03 01:30 -04:00", "2024-11-04 01:30 -05:00")]
+    [TestCase("0 30 2 * * ?", "CentralEuropean", "2018-10-28 02:30", "2018-10-28 00:00 +02:00", "2018-10-28 02:30 +02:00", "2018-10-29 02:30 +01:00")]
+    [TestCase("0 30 2 * * ?", "Sydney", "2024-04-07 02:30", "2024-04-07 00:00 +11:00", "2024-04-07 02:30 +11:00", "2024-04-08 02:30 +10:00")]
+    [TestCase("0 30 23 * * ?", "Santiago", "2019-04-06 23:30", "2019-04-06 00:00 -03:00", "2019-04-06 23:30 -03:00", "2019-04-07 23:30 -04:00")]
+    public void GetTimeAfter_DailyFixedTime_FallBackDay_FiresOnlyOnce_AtDaylightOccurrence(
+        string cronExpression,
+        string zoneKey,
+        string ambiguousLocalTime,
+        string fromLocal,
+        string expectedFire,
+        string expectedNextDayFire)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock(ambiguousLocalTime));
+
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset? fire = cron.GetTimeAfter(TestTimeZones.Local(fromLocal));
+
+        fire.Should().NotBeNull();
+        fire!.Value.Should().Be(TestTimeZones.Local(expectedFire), "the daylight occurrence comes first and time moves forward");
+
+        DateTimeOffset? nextFire = cron.GetTimeAfter(fire.Value);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(TestTimeZones.Local(expectedNextDayFire), "the repeated wall clock time must not fire a second time");
+    }
+
+    /// <summary>
+    /// Real time never stops, so a minutely trigger keeps firing every minute right through the
+    /// spring-forward transition. What disappears is the local hour 02, not the fires: the walk
+    /// produces an unbroken minutely sequence whose local reading jumps from 01:59 straight to
+    /// 03:00, and the UTC hour that contains the transition is fully populated.
+    /// </summary>
+    [Test]
+    public void SequentialWalk_MinutelyCron_SpringForwardDay_FireCountAndNoLocalGapHour()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset dayStart = TestTimeZones.Local("2024-03-10 00:00 -05:00");
+        DateTimeOffset dayEnd = TestTimeZones.Local("2024-03-11 00:00 -04:00");
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(cron.GetTimeAfter, dayStart, dayEnd);
+
+        // The spring-forward day is 23 real hours long; the walk excludes both boundary instants,
+        // so a fire on every minute boundary in between is 23 * 60 - 1.
+        fireTimes.Should().HaveCount(1379, "the day is 23 real hours long and every minute boundary fires");
+
+        fireTimes.Should().NotContain(
+            fire => TimeZoneInfo.ConvertTime(fire, zone).Hour == 2,
+            "local hour 02 does not exist on the spring-forward day");
+
+        DateTimeOffset gapHourStart = TestTimeZones.Local("2024-03-10 07:00 +00:00");
+        DateTimeOffset gapHourEnd = TestTimeZones.Local("2024-03-10 08:00 +00:00");
+
+        fireTimes.Should().Contain(
+            fire => fire >= gapHourStart && fire < gapHourEnd,
+            "real time does not stop during the gap; those fires simply read as local 03:xx");
+    }
+
+    /// <summary>
+    /// <see cref="CronExpression.GetTimeBefore" /> is a binary search layered on top of
+    /// <see cref="CronExpression.GetTimeAfter" />, so it must agree with it around transitions.
+    /// Asserted as properties rather than pinned instants: the returned time is strictly before the
+    /// probe, it is a genuine fire time (asking for the next fire one second earlier reproduces it),
+    /// and asking for the next fire from it makes progress rather than wedging.
+    /// </summary>
+    /// <remarks>
+    /// The probe set is per case rather than a fixed grid because the -5 minute probe on a
+    /// FALL-BACK transition currently breaks the round trip: see
+    /// <see cref="GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_CurrentlyReturnsNonFireTime" />
+    /// in the pins region below, and the root cause pinned next to it. Restore -5 to those two
+    /// cases once that is fixed.
+    /// </remarks>
+    [TestCase("0 * * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-03-25 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-03-25 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, 5, 60 })]
+    public void GetTimeBefore_RoundTripsWithGetTimeAfter_AroundTransitions(
+        string cronExpression,
+        string zoneKey,
+        string transitionUtc,
+        int[] probeOffsetsInMinutes)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset transition = TestTimeZones.Local(transitionUtc);
+
+        foreach (int probeOffsetInMinutes in probeOffsetsInMinutes)
+        {
+            DateTimeOffset probe = transition.AddMinutes(probeOffsetInMinutes);
+            string context = $"probe {probe:O} ({probeOffsetInMinutes:+#;-#;0} min from the transition)";
+
+            DateTimeOffset? previous = cron.GetTimeBefore(probe);
+
+            previous.Should().NotBeNull(context);
+            previous!.Value.Should().BeBefore(probe, "GetTimeBefore must return a time strictly before the probe; " + context);
+
+            cron.GetTimeAfter(previous.Value.AddSeconds(-1))
+                .Should().Be(previous.Value, "the time before must itself be a fire time; " + context);
+
+            cron.GetTimeAfter(previous.Value)
+                .Should().BeAfter(previous.Value, "asking again from a fire time must make progress; " + context);
+        }
+    }
+
+    /// <summary>
+    /// Spring-forward counterpart to the fall-back <c>IsSatisfiedBy</c> coverage: the instants that
+    /// make up the "missing" hour are ordinary instants that read as local 03:xx, and a minutely
+    /// expression matches them.
+    /// </summary>
+    [Test]
+    public void IsSatisfiedBy_MinutelyCron_TrueForInstantsInsideGapHourUtc()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset insideGapHour = TestTimeZones.Local("2024-03-10 07:15 +00:00");
+
+        cron.IsSatisfiedBy(insideGapHour).Should().BeTrue("07:15Z is local 03:15 -04:00, an ordinary matching minute");
+    }
+
+    #region Current-behavior pins (decision points)
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — known deviation, expected to change on main/4.0.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A sequential walk of an interval (minutely) expression across a fall-back transition
+    /// currently SKIPS the entire repeated standard-pass hour. After the last daylight-pass fire at
+    /// 02:59 +02:00 (00:59Z) the next fire produced is 03:00 +01:00 (02:00Z), so the whole UTC hour
+    /// [01:00Z, 02:00Z) — local 02:00-02:59 +01:00 — never fires. The cause is that the wall clock
+    /// walk advances 02:59 to 03:00 and only then resolves the offset; 03:00 is unambiguous, so the
+    /// standard-offset repeat of 02:xx is never visited.
+    /// </para>
+    /// <para>
+    /// This violates the rule that interval expressions should fire in BOTH fall-back passes (the
+    /// Cronos invariant, and what an "every minute" schedule means to a user: 25 fires per hour-of
+    /// -day on this date, 1500 minute fires in a 25 hour day). The flip target is 1499 fires
+    /// (25 * 60 - 1, the walk excluding both boundary instants) plus PRESENCE of fires inside
+    /// [01:00Z, 02:00Z), replacing the 1439 and the emptiness assertion pinned here.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void SequentialWalk_MinutelyCron_FallBackDay_CurrentlySkipsRepeatedStandardHour()
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset dayStart = TestTimeZones.Local("2018-10-28 00:00 +02:00");
+        DateTimeOffset dayEnd = TestTimeZones.Local("2018-10-29 00:00 +01:00");
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(cron.GetTimeAfter, dayStart, dayEnd);
+
+        // 25 real hours, minus both excluded boundary instants, would be 1499 fires. 60 of them —
+        // the standard pass over local 02:00-02:59 — are currently skipped.
+        fireTimes.Should().HaveCount(1439, "the repeated standard-pass hour is currently skipped entirely");
+
+        DateTimeOffset repeatedHourStart = TestTimeZones.Local("2018-10-28 01:00 +00:00");
+        DateTimeOffset repeatedHourEnd = TestTimeZones.Local("2018-10-28 02:00 +00:00");
+
+        fireTimes.Should().NotContain(
+            fire => fire >= repeatedHourStart && fire < repeatedHourEnd,
+            "the sequential walk currently jumps from 02:59 +02:00 straight to 03:00 +01:00");
+    }
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CronExpression.IsSatisfiedBy" /> answers TRUE for instants inside the repeated
+    /// standard-pass hour that the sequential walk never produces. It is implemented as
+    /// <c>GetTimeAfter(instant - 1s) == instant</c>, and starting the search from just inside that
+    /// hour makes the daylight interpretation land before the "after" instant, which triggers the
+    /// demotion to the standard offset and reproduces the instant exactly. Starting the search from
+    /// BEFORE the transition never reaches it.
+    /// </para>
+    /// <para>
+    /// So the same expression both matches and does not schedule the same instant, depending only
+    /// on where the question is asked from. Pinned here in one place. Once the walk fires in both
+    /// passes this test becomes redundant with the walk simply containing the hour, and the
+    /// emptiness assertion below should be deleted.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void IsSatisfiedBy_RepeatedHourStandardPass_TrueButNeverProducedByWalk()
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset standardPassInstant = TestTimeZones.Local("2018-10-28 01:30 +00:00");
+
+        cron.IsSatisfiedBy(standardPassInstant).Should().BeTrue("01:30Z is local 02:30 +01:00, which the expression matches");
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            cron.GetTimeAfter,
+            TestTimeZones.Local("2018-10-28 00:55 +02:00"),
+            TestTimeZones.Local("2018-10-28 04:00 +01:00"));
+
+        DateTimeOffset repeatedHourStart = TestTimeZones.Local("2018-10-28 01:00 +00:00");
+        DateTimeOffset repeatedHourEnd = TestTimeZones.Local("2018-10-28 02:00 +00:00");
+
+        fireTimes.Should().NotBeEmpty();
+        fireTimes.Should().NotContain(
+            fire => fire >= repeatedHourStart && fire < repeatedHourEnd,
+            "a walk across the transition never schedules the instant IsSatisfiedBy just accepted");
+    }
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The mirror image of the fall-back inconsistency, on the spring-forward side. For a fixed
+    /// time inside the gap, <see cref="CronExpression.GetTimeAfter" /> returns the delta-shifted
+    /// instant 03:30 -04:00 (07:30Z), yet <see cref="CronExpression.IsSatisfiedBy" /> returns FALSE
+    /// for that very instant, because its local reading is hour 03 and the expression asks for hour
+    /// 02. The trigger therefore fires at an instant its own expression does not match.
+    /// </para>
+    /// <para>
+    /// Whatever rule replaces the delta shift on main/4.0 should make these two agree: either the
+    /// fire moves to the gap END (03:00, which the expression still does not match literally, so
+    /// <c>IsSatisfiedBy</c> would need to special-case the gap), or <c>IsSatisfiedBy</c> learns to
+    /// accept the shifted instant. Flip target: this assertion becomes <c>BeTrue</c>.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void IsSatisfiedBy_InstantReturnedForInGapFixedTime_IsCurrentlyFalse()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
+
+        CronExpression cron = CronIn("0 30 2 * * ?", zone);
+
+        DateTimeOffset? fire = cron.GetTimeAfter(TestTimeZones.Local("2024-03-10 00:00 -05:00"));
+
+        fire.Should().NotBeNull();
+        fire!.Value.Should().Be(TestTimeZones.Local("2024-03-10 03:30 -04:00"));
+
+        cron.IsSatisfiedBy(fire.Value).Should().BeFalse("the fire instant reads as local 03:30, and the expression asks for hour 02");
+    }
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — this one looks like a plain defect rather than a semantic choice.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CronExpression.GetTimeAfter" /> starts by adding one second to the requested
+    /// instant KEEPING its sub-second ticks, then truncates a separate copy to whole seconds for
+    /// the search. At the very end the fall-back demotion asks whether the resolved fire is before
+    /// the requested instant, and compares the truncated fire against the UNTRUNCATED copy
+    /// (<c>CronExpression.cs</c>: <c>if (d.ToUniversalTime() &lt; afterTimeUtc &amp;&amp;
+    /// TimeZone.IsAmbiguousTime(localDateTime))</c>). Any sub-second remainder therefore makes a
+    /// perfectly good fire look "too early" while the local time is ambiguous, and the result is
+    /// demoted a whole hour forward to the standard pass.
+    /// </para>
+    /// <para>
+    /// The effect: asking for the next fire after 05:53:59.000Z gives 05:54:00Z, but asking after
+    /// 05:53:59.500Z — half a second LATER — skips that fire entirely and gives 06:54:00Z. The
+    /// comparison should use the truncated instant, at which point both answers are 05:54:00Z.
+    /// Flip target: both assertions below expect 05:54:00Z.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void GetTimeAfter_SubSecondInstantInsideRepeatedHour_CurrentlySkipsAnHourToStandardPass()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2024-11-03 01:30"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        DateTimeOffset wholeSecond = new DateTimeOffset(2024, 11, 3, 5, 53, 59, 0, TimeSpan.Zero);
+        DateTimeOffset withMilliseconds = new DateTimeOffset(2024, 11, 3, 5, 53, 59, 500, TimeSpan.Zero);
+
+        cron.GetTimeAfter(wholeSecond)
+            .Should().Be(TestTimeZones.Local("2024-11-03 05:54 +00:00"), "local 01:54 -04:00 is the very next minute");
+
+        cron.GetTimeAfter(withMilliseconds)
+            .Should().Be(TestTimeZones.Local("2024-11-03 06:54 +00:00"), "the sub-second remainder currently forces the demotion to local 01:54 -05:00");
+    }
+
+    /// <summary>
+    /// CURRENT BEHAVIOR PIN — the user-visible consequence of the sub-second defect above.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CronExpression.GetTimeBefore" /> binary searches on "does the next fire after this
+    /// probe land before the end time", over arbitrary tick values. The sub-second demotion makes
+    /// that predicate NON-MONOTONIC in the second immediately preceding a fire whose local time is
+    /// ambiguous: it holds at the whole second, then flips false a fraction later. The search
+    /// converges on that false crossover instead of the real one, and the result — truncated to a
+    /// whole second — comes out one second early, on a value the expression never fires at.
+    /// </para>
+    /// <para>
+    /// So <c>GetTimeBefore</c> can return a NON-FIRE time: the pinned results below all end in
+    /// :59 for expressions that only ever fire at second 0. Flip target: the expected value becomes
+    /// the real preceding fire time (the third argument), and the -5 minute probe can be restored
+    /// to the fall-back cases of
+    /// <see cref="GetTimeBefore_RoundTripsWithGetTimeAfter_AroundTransitions" />.
+    /// </para>
+    /// </remarks>
+    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:54:00 +00:00", "2024-11-03 05:53:59 +00:00")]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:00:00 +00:00", "2024-11-03 04:59:59 +00:00")]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:54:00 +00:00", "2018-10-28 00:53:59 +00:00")]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:00:00 +00:00", "2018-10-27 23:59:59 +00:00")]
+    public void GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_CurrentlyReturnsNonFireTime(
+        string cronExpression,
+        string zoneKey,
+        string probeUtc,
+        string realPrecedingFire,
+        string currentlyReturned)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset probe = TestTimeZones.Local(probeUtc);
+
+        // The real preceding fire is what a forward walk produces, and it is a genuine fire time.
+        DateTimeOffset expectedFire = TestTimeZones.Local(realPrecedingFire);
+        cron.GetTimeAfter(expectedFire.AddSeconds(-1)).Should().Be(expectedFire);
+        cron.IsSatisfiedBy(expectedFire).Should().BeTrue();
+
+        DateTimeOffset? previous = cron.GetTimeBefore(probe);
+
+        previous.Should().NotBeNull();
+        previous!.Value.Should().Be(TestTimeZones.Local(currentlyReturned), "the binary search converges on the sub-second demotion crossover");
+        cron.IsSatisfiedBy(previous.Value).Should().BeFalse("the returned time is not a time the expression ever fires at");
+    }
+
+    #endregion
+}

--- a/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
@@ -265,30 +265,18 @@ public class CronExpressionDstTests
         cron.IsSatisfiedBy(insideGapHour).Should().BeTrue("07:15Z is local 03:15 -04:00, an ordinary matching minute");
     }
 
-    #region Current-behavior pins (decision points)
-
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — known deviation, expected to change on main/4.0.
+    /// Interval expressions fire through BOTH occurrences of the repeated fall-back window: an
+    /// "every minute" schedule means 1500 minute fires in a 25 hour day (1499 in this walk, which
+    /// excludes both boundary instants).
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// A sequential walk of an interval (minutely) expression across a fall-back transition
-    /// currently SKIPS the entire repeated standard-pass hour. After the last daylight-pass fire at
-    /// 02:59 +02:00 (00:59Z) the next fire produced is 03:00 +01:00 (02:00Z), so the whole UTC hour
-    /// [01:00Z, 02:00Z) — local 02:00-02:59 +01:00 — never fires. The cause is that the wall clock
-    /// walk advances 02:59 to 03:00 and only then resolves the offset; 03:00 is unambiguous, so the
-    /// standard-offset repeat of 02:xx is never visited.
-    /// </para>
-    /// <para>
-    /// This violates the rule that interval expressions should fire in BOTH fall-back passes (the
-    /// Cronos invariant, and what an "every minute" schedule means to a user: 25 fires per hour-of
-    /// -day on this date, 1500 minute fires in a 25 hour day). The flip target is 1499 fires
-    /// (25 * 60 - 1, the walk excluding both boundary instants) plus PRESENCE of fires inside
-    /// [01:00Z, 02:00Z), replacing the 1439 and the emptiness assertion pinned here.
-    /// </para>
+    /// The wall-clock walk steps from 02:59 +02:00 to 03:00, so on its own it would skip the
+    /// standard-offset repeat of 02:xx entirely; <c>ApplySecondAmbiguousPassIfNeeded</c> re-enters
+    /// the window at the transition instant and the fall-back demotion then walks the second pass.
     /// </remarks>
     [Test]
-    public void SequentialWalk_MinutelyCron_FallBackDay_CurrentlySkipsRepeatedStandardHour()
+    public void SequentialWalk_MinutelyCron_FallBackDay_FiresThroughBothPassesOfRepeatedHour()
     {
         TimeZoneInfo zone = TestTimeZones.CentralEuropean;
         TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
@@ -300,39 +288,22 @@ public class CronExpressionDstTests
 
         List<DateTimeOffset> fireTimes = TestTimeZones.Walk(cron.GetTimeAfter, dayStart, dayEnd);
 
-        // 25 real hours, minus both excluded boundary instants, would be 1499 fires. 60 of them —
-        // the standard pass over local 02:00-02:59 — are currently skipped.
-        fireTimes.Should().HaveCount(1439, "the repeated standard-pass hour is currently skipped entirely");
+        fireTimes.Should().HaveCount(1499, "the 25 hour day fires every real minute, both walk boundaries excluded");
 
         DateTimeOffset repeatedHourStart = TestTimeZones.Local("2018-10-28 01:00 +00:00");
         DateTimeOffset repeatedHourEnd = TestTimeZones.Local("2018-10-28 02:00 +00:00");
 
-        fireTimes.Should().NotContain(
-            fire => fire >= repeatedHourStart && fire < repeatedHourEnd,
-            "the sequential walk currently jumps from 02:59 +02:00 straight to 03:00 +01:00");
+        fireTimes.Count(fire => fire >= repeatedHourStart && fire < repeatedHourEnd)
+            .Should().Be(60, "the standard pass over local 02:00-02:59 fires every minute");
     }
 
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.
+    /// <see cref="CronExpression.IsSatisfiedBy" /> and the sequential walk agree inside the
+    /// repeated standard-pass hour: the instants the walk schedules are the instants the
+    /// expression matches.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <see cref="CronExpression.IsSatisfiedBy" /> answers TRUE for instants inside the repeated
-    /// standard-pass hour that the sequential walk never produces. It is implemented as
-    /// <c>GetTimeAfter(instant - 1s) == instant</c>, and starting the search from just inside that
-    /// hour makes the daylight interpretation land before the "after" instant, which triggers the
-    /// demotion to the standard offset and reproduces the instant exactly. Starting the search from
-    /// BEFORE the transition never reaches it.
-    /// </para>
-    /// <para>
-    /// So the same expression both matches and does not schedule the same instant, depending only
-    /// on where the question is asked from. Pinned here in one place. Once the walk fires in both
-    /// passes this test becomes redundant with the walk simply containing the hour, and the
-    /// emptiness assertion below should be deleted.
-    /// </para>
-    /// </remarks>
     [Test]
-    public void IsSatisfiedBy_RepeatedHourStandardPass_TrueButNeverProducedByWalk()
+    public void IsSatisfiedBy_RepeatedHourStandardPass_AgreesWithSequentialWalk()
     {
         TimeZoneInfo zone = TestTimeZones.CentralEuropean;
         TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
@@ -348,14 +319,99 @@ public class CronExpressionDstTests
             TestTimeZones.Local("2018-10-28 00:55 +02:00"),
             TestTimeZones.Local("2018-10-28 04:00 +01:00"));
 
-        DateTimeOffset repeatedHourStart = TestTimeZones.Local("2018-10-28 01:00 +00:00");
-        DateTimeOffset repeatedHourEnd = TestTimeZones.Local("2018-10-28 02:00 +00:00");
-
-        fireTimes.Should().NotBeEmpty();
-        fireTimes.Should().NotContain(
-            fire => fire >= repeatedHourStart && fire < repeatedHourEnd,
-            "a walk across the transition never schedules the instant IsSatisfiedBy just accepted");
+        fireTimes.Should().Contain(standardPassInstant, "the walk schedules the instant IsSatisfiedBy accepts");
     }
+
+    /// <summary>
+    /// The interval-vs-fixed-time distinction is decided at parse time, from the second, minute
+    /// and hour fields only: a wildcard, step or range means "fire every interval"; plain values
+    /// and comma lists mean "fire at these times of day". Day, month and year fields never
+    /// contribute.
+    /// </summary>
+    [TestCase("0 * * * * ?", true)]
+    [TestCase("*/30 0 2 * * ?", true)]
+    [TestCase("0 0/30 2 * * ?", true)]
+    [TestCase("0 30 1-9 * * ?", true)]
+    [TestCase("0 15,45 2-4 * * ?", true)]
+    [TestCase("0 30 2 * * ?", false)]
+    [TestCase("0 0,30 2 * * ?", false)]
+    [TestCase("0 30 2 1-15 * ?", false)]
+    [TestCase("0 30 2 ? * MON-FRI", false)]
+    public void HasIntervalSemantics_SetForWildcardStepAndRangeInTimeFields(string expression, bool expected)
+    {
+        CronExpression cron = new CronExpression(expression);
+
+        cron.HasIntervalSemantics.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// An hourly interval expression fires every real hour of the 25 hour fall-back day - the
+    /// 02:00 wall clock runs at both of its occurrences.
+    /// </summary>
+    [Test]
+    public void SequentialWalk_HourlyCron_FallBackDay_FiresEveryRealHour()
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
+
+        CronExpression cron = CronIn("0 0 * * * ?", zone);
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            cron.GetTimeAfter,
+            TestTimeZones.Local("2018-10-28 00:00 +02:00"),
+            TestTimeZones.Local("2018-10-29 00:00 +01:00"));
+
+        fireTimes.Should().HaveCount(24, "25 hourly instants in the local day, both walk boundaries excluded");
+        fireTimes.Should().Contain(TestTimeZones.Local("2018-10-28 02:00 +02:00"), "the first occurrence of 02:00 fires");
+        fireTimes.Should().Contain(TestTimeZones.Local("2018-10-28 02:00 +01:00"), "the second occurrence of 02:00 fires too");
+    }
+
+    /// <summary>
+    /// A comma list of plain values is a fixed-time expression: each listed time fires once, at
+    /// its first (daylight) occurrence, and the second pass of the repeated window is skipped.
+    /// </summary>
+    [Test]
+    public void FixedTimeCommaList_FallBackDay_FiresOnlyFirstPass()
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
+
+        CronExpression cron = CronIn("0 0,30 2 * * ?", zone);
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            cron.GetTimeAfter,
+            TestTimeZones.Local("2018-10-28 00:00 +02:00"),
+            TestTimeZones.Local("2018-10-29 00:00 +01:00"));
+
+        fireTimes.Should().Equal(
+            TestTimeZones.Local("2018-10-28 02:00 +02:00"),
+            TestTimeZones.Local("2018-10-28 02:30 +02:00"));
+    }
+
+    /// <summary>
+    /// The repeated window on Lord Howe Island is only 30 minutes wide (the daylight delta is half
+    /// an hour), and a minutely interval expression fires through both passes of it.
+    /// </summary>
+    [Test]
+    public void SequentialWalk_MinutelyCron_LordHoweFallBack_FiresBothHalfHourPasses()
+    {
+        TimeZoneInfo zone = TestTimeZones.LordHowe;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2019-04-07 01:45"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        // 2019-04-07 02:00 +11:00 becomes 01:30 +10:30; the walk covers 14:00Z-16:00Z around it
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            cron.GetTimeAfter,
+            TestTimeZones.Local("2019-04-07 01:00 +11:00"),
+            TestTimeZones.Local("2019-04-07 02:30 +10:30"));
+
+        fireTimes.Should().HaveCount(119, "two real hours of minute fires, both walk boundaries excluded");
+        fireTimes.Should().Contain(TestTimeZones.Local("2019-04-07 01:45 +11:00"), "first pass of the repeated half hour");
+        fireTimes.Should().Contain(TestTimeZones.Local("2019-04-07 01:45 +10:30"), "second pass of the repeated half hour");
+    }
+
+    #region Current-behavior pins (decision points)
 
     /// <summary>
     /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.

--- a/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
@@ -206,20 +206,18 @@ public class CronExpressionDstTests
     /// and asking for the next fire from it makes progress rather than wedging.
     /// </summary>
     /// <remarks>
-    /// The probe set is per case rather than a fixed grid because the -5 minute probe on a
-    /// FALL-BACK transition currently breaks the round trip: see
-    /// <see cref="GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_CurrentlyReturnsNonFireTime" />
-    /// in the pins region below, and the root cause pinned next to it. Restore -5 to those two
-    /// cases once that is fixed.
+    /// The -5 minute probes on the fall-back transitions land just after a fire inside the repeated
+    /// hour; they used to break the round trip until the sub-second demotion defect was fixed (see
+    /// <see cref="GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_ReturnsRealPrecedingFire" />).
     /// </remarks>
     [TestCase("0 * * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 0 * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
-    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, 5, 60 })]
-    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 * * * * ?", "CentralEuropean", "2018-03-25 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 0 * * * ?", "CentralEuropean", "2018-03-25 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
-    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, 5, 60 })]
-    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, 5, 60 })]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 01:00 +00:00", new int[] { -60, -5, 5, 60 })]
     public void GetTimeBefore_RoundTripsWithGetTimeAfter_AroundTransitions(
         string cronExpression,
         string zoneKey,
@@ -393,29 +391,22 @@ public class CronExpressionDstTests
         cron.IsSatisfiedBy(fire.Value).Should().BeFalse("the fire instant reads as local 03:30, and the expression asks for hour 02");
     }
 
+    #endregion
+
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — this one looks like a plain defect rather than a semantic choice.
+    /// Regression test: a sub-second after-time inside the repeated fall-back hour must return the
+    /// same fire as its whole-second floor.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// <see cref="CronExpression.GetTimeAfter" /> starts by adding one second to the requested
-    /// instant KEEPING its sub-second ticks, then truncates a separate copy to whole seconds for
-    /// the search. At the very end the fall-back demotion asks whether the resolved fire is before
-    /// the requested instant, and compares the truncated fire against the UNTRUNCATED copy
-    /// (<c>CronExpression.cs</c>: <c>if (d.ToUniversalTime() &lt; afterTimeUtc &amp;&amp;
-    /// TimeZone.IsAmbiguousTime(localDateTime))</c>). Any sub-second remainder therefore makes a
-    /// perfectly good fire look "too early" while the local time is ambiguous, and the result is
-    /// demoted a whole hour forward to the standard pass.
-    /// </para>
-    /// <para>
-    /// The effect: asking for the next fire after 05:53:59.000Z gives 05:54:00Z, but asking after
-    /// 05:53:59.500Z — half a second LATER — skips that fire entirely and gives 06:54:00Z. The
-    /// comparison should use the truncated instant, at which point both answers are 05:54:00Z.
-    /// Flip target: both assertions below expect 05:54:00Z.
-    /// </para>
+    /// The fall-back demotion in <see cref="CronExpression.GetTimeAfter" /> used to compare the
+    /// truncated candidate fire against the UNTRUNCATED after-time, so any sub-second remainder made
+    /// a perfectly good fire look "too early" while the local time was ambiguous and demoted it a
+    /// whole hour forward: the next fire after 05:53:59.000Z was 05:54:00Z, but after 05:53:59.500Z
+    /// — half a second later — it was 06:54:00Z, making the result non-monotonic in the input. The
+    /// comparison now uses the whole-second floor the search starts from.
     /// </remarks>
     [Test]
-    public void GetTimeAfter_SubSecondInstantInsideRepeatedHour_CurrentlySkipsAnHourToStandardPass()
+    public void GetTimeAfter_SubSecondInstantInsideRepeatedHour_ReturnsSameFireAsWholeSecond()
     {
         TimeZoneInfo zone = TestTimeZones.Eastern;
         TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2024-11-03 01:30"));
@@ -425,43 +416,32 @@ public class CronExpressionDstTests
         DateTimeOffset wholeSecond = new DateTimeOffset(2024, 11, 3, 5, 53, 59, 0, TimeSpan.Zero);
         DateTimeOffset withMilliseconds = new DateTimeOffset(2024, 11, 3, 5, 53, 59, 500, TimeSpan.Zero);
 
-        cron.GetTimeAfter(wholeSecond)
-            .Should().Be(TestTimeZones.Local("2024-11-03 05:54 +00:00"), "local 01:54 -04:00 is the very next minute");
+        DateTimeOffset expected = TestTimeZones.Local("2024-11-03 05:54 +00:00");
 
-        cron.GetTimeAfter(withMilliseconds)
-            .Should().Be(TestTimeZones.Local("2024-11-03 06:54 +00:00"), "the sub-second remainder currently forces the demotion to local 01:54 -05:00");
+        cron.GetTimeAfter(wholeSecond).Should().Be(expected, "local 01:54 -04:00 is the very next minute");
+        cron.GetTimeAfter(withMilliseconds).Should().Be(expected, "sub-second ticks on the after-time must not demote the fire to the standard pass");
     }
 
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — the user-visible consequence of the sub-second defect above.
+    /// Regression test: <see cref="CronExpression.GetTimeBefore" /> must return a real fire time
+    /// for probes just after a fire inside the repeated fall-back hour.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// <see cref="CronExpression.GetTimeBefore" /> binary searches on "does the next fire after this
-    /// probe land before the end time", over arbitrary tick values. The sub-second demotion makes
-    /// that predicate NON-MONOTONIC in the second immediately preceding a fire whose local time is
-    /// ambiguous: it holds at the whole second, then flips false a fraction later. The search
-    /// converges on that false crossover instead of the real one, and the result — truncated to a
-    /// whole second — comes out one second early, on a value the expression never fires at.
-    /// </para>
-    /// <para>
-    /// So <c>GetTimeBefore</c> can return a NON-FIRE time: the pinned results below all end in
-    /// :59 for expressions that only ever fire at second 0. Flip target: the expected value becomes
-    /// the real preceding fire time (the third argument), and the -5 minute probe can be restored
-    /// to the fall-back cases of
-    /// <see cref="GetTimeBefore_RoundTripsWithGetTimeAfter_AroundTransitions" />.
-    /// </para>
+    /// Its binary search probes arbitrary tick values, and the sub-second demotion described in
+    /// <see cref="GetTimeAfter_SubSecondInstantInsideRepeatedHour_ReturnsSameFireAsWholeSecond" />
+    /// used to make the search predicate non-monotonic in the second preceding such a fire, so the
+    /// search converged one second early on a value the expression never fires at (:59 results for
+    /// expressions that only fire at second 0).
     /// </remarks>
-    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:54:00 +00:00", "2024-11-03 05:53:59 +00:00")]
-    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:00:00 +00:00", "2024-11-03 04:59:59 +00:00")]
-    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:54:00 +00:00", "2018-10-28 00:53:59 +00:00")]
-    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:00:00 +00:00", "2018-10-27 23:59:59 +00:00")]
-    public void GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_CurrentlyReturnsNonFireTime(
+    [TestCase("0 * * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:54:00 +00:00")]
+    [TestCase("0 0 * * * ?", "Eastern", "2024-11-03 05:55 +00:00", "2024-11-03 05:00:00 +00:00")]
+    [TestCase("0 * * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:54:00 +00:00")]
+    [TestCase("0 0 * * * ?", "CentralEuropean", "2018-10-28 00:55 +00:00", "2018-10-28 00:00:00 +00:00")]
+    public void GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_ReturnsRealPrecedingFire(
         string cronExpression,
         string zoneKey,
         string probeUtc,
-        string realPrecedingFire,
-        string currentlyReturned)
+        string realPrecedingFire)
     {
         TimeZoneInfo zone = ResolveZone(zoneKey);
         CronExpression cron = CronIn(cronExpression, zone);
@@ -476,9 +456,7 @@ public class CronExpressionDstTests
         DateTimeOffset? previous = cron.GetTimeBefore(probe);
 
         previous.Should().NotBeNull();
-        previous!.Value.Should().Be(TestTimeZones.Local(currentlyReturned), "the binary search converges on the sub-second demotion crossover");
-        cron.IsSatisfiedBy(previous.Value).Should().BeFalse("the returned time is not a time the expression ever fires at");
+        previous!.Value.Should().Be(expectedFire);
+        cron.IsSatisfiedBy(previous.Value).Should().BeTrue("GetTimeBefore must return a time the expression fires at");
     }
-
-    #endregion
 }

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerDstTests.cs
@@ -254,6 +254,121 @@ public class DailyTimeIntervalTriggerDstTests
         fallBackDay.Should().OnlyContain(t => t.Offset == TimeSpan.FromHours(-3), "the standard-time pass of the day is never reached");
     }
 
+    /// <summary>
+    /// Regression test for the offset resolution in <c>AdvanceToNextDayOfWeekIfNecessary</c>: when
+    /// the day-of-week walk crosses a spring-forward transition, the advanced day's start-of-day
+    /// must resolve through the wall-clock policy before it is compared against
+    /// <see cref="ITrigger.EndTimeUtc" />.
+    /// </summary>
+    /// <remarks>
+    /// On Sunday 2018-03-25 the local start-of-day 02:30 does not exist; the wall-clock policy
+    /// resolves it to 02:30 +01:00 = 01:30 UTC. Resolving the offset from the walked instant instead
+    /// yields 02:30 +02:00 = 00:30 UTC — one transition delta too early — and an EndTimeUtc between
+    /// the two instants lets the trigger fire once past its configured end.
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void AdvanceAcrossSpringForwardGap_RespectsEndTimeUtc()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2018, 3, 25, 2, 30, 0));
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(2, 30))
+            .EndingDailyAt(TimeOfDay.HourAndMinuteOfDay(3, 30))
+            .OnDaysOfTheWeek(DayOfWeek.Saturday, DayOfWeek.Sunday)
+            .WithIntervalInHours(1)
+            .InTimeZone(timeZone)
+            .Build();
+
+        // Friday 2018-03-23 22:00 UTC, before the Saturday window opens
+        trigger.StartTimeUtc = new DateTimeOffset(2018, 3, 23, 22, 0, 0, TimeSpan.Zero);
+        // between the mis-resolved Sunday window start (00:30 UTC) and the correctly resolved one (01:30 UTC)
+        trigger.EndTimeUtc = new DateTimeOffset(2018, 3, 25, 1, 0, 0, TimeSpan.Zero);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        DateTimeOffset? saturdayFirst = trigger.GetFireTimeAfter(trigger.StartTimeUtc);
+        saturdayFirst.Should().Be(TestTimeZones.Local("2018-03-24 02:30 +01:00"));
+
+        DateTimeOffset? saturdayLast = trigger.GetFireTimeAfter(saturdayFirst);
+        saturdayLast.Should().Be(TestTimeZones.Local("2018-03-24 03:30 +01:00"));
+
+        DateTimeOffset? afterSaturday = trigger.GetFireTimeAfter(saturdayLast);
+        afterSaturday.Should().BeNull("Sunday's window start resolves to 01:30 UTC, which is past EndTimeUtc 01:00 UTC");
+    }
+
+    /// <summary>
+    /// A trigger that only runs on Sundays advances six days at a time through
+    /// <c>AdvanceToNextDayOfWeekIfNecessary</c>, so every transition Sunday exercises the day-of-week
+    /// walk landing directly on a gap or an ambiguous window start.
+    /// </summary>
+    [Test]
+    [Category("windowstimezoneid")]
+    [TestCase("CentralEuropean", "2018-03-25 02:30", true, 2, 30, "2018-03-25 03:30 +02:00", "2018-04-01 02:30 +02:00")]
+    [TestCase("Eastern", "2024-03-10 02:30", true, 2, 30, "2024-03-10 03:30 -04:00", "2024-03-17 02:30 -04:00")]
+    [TestCase("Eastern", "2024-11-03 01:30", false, 1, 30, "2024-11-03 01:30 -04:00", "2024-11-10 01:30 -05:00")]
+    [TestCase("Santiago", "2019-09-08 00:00", true, 0, 0, "2019-09-08 01:00 -03:00", "2019-09-15 00:00 -03:00")]
+    public void SundayOnlyTrigger_TransitionSunday_FiresAtResolvedTime(
+        string zoneKey,
+        string premiseLocal,
+        bool premiseIsGap,
+        int startHour,
+        int startMinute,
+        string expectedTransitionSundayFire,
+        string expectedNextSundayFire)
+    {
+        TimeZoneInfo timeZone = ResolveZone(zoneKey);
+        DateTime premise = DateTime.Parse(premiseLocal, System.Globalization.CultureInfo.InvariantCulture);
+        if (premiseIsGap)
+        {
+            TestTimeZones.AssumeInvalidLocalTime(timeZone, premise);
+        }
+        else
+        {
+            TestTimeZones.AssumeAmbiguousLocalTime(timeZone, premise);
+        }
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(startHour, startMinute))
+            .EndingDailyAt(TimeOfDay.HourAndMinuteOfDay(startHour + 2, startMinute))
+            .OnDaysOfTheWeek(DayOfWeek.Sunday)
+            .WithIntervalInHours(1)
+            .InTimeZone(timeZone)
+            .Build();
+
+        DateTime transitionSunday = premise.Date;
+        trigger.StartTimeUtc = new DateTimeOffset(transitionSunday.AddDays(-3), TimeSpan.Zero).AddHours(12);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        List<DateTimeOffset> local = TestTimeZones
+            .Walk(after => trigger.GetFireTimeAfter(after),
+                trigger.StartTimeUtc,
+                new DateTimeOffset(transitionSunday.AddDays(8), TimeSpan.Zero).AddHours(12))
+            .Select(t => TimeZoneInfo.ConvertTime(t, timeZone))
+            .ToList();
+
+        local[0].Should().Be(TestTimeZones.Local(expectedTransitionSundayFire));
+        local.Should().OnlyContain(t => t.DayOfWeek == DayOfWeek.Sunday);
+
+        DateTimeOffset firstOnNextSunday = local.First(t => t.Date == transitionSunday.AddDays(7));
+        firstOnNextSunday.Should().Be(TestTimeZones.Local(expectedNextSundayFire));
+    }
+
+    private static TimeZoneInfo ResolveZone(string zoneKey)
+    {
+        switch (zoneKey)
+        {
+            case "Eastern":
+                return TestTimeZones.Eastern;
+            case "CentralEuropean":
+                return TestTimeZones.CentralEuropean;
+            case "Santiago":
+                return TestTimeZones.Santiago;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test zone");
+        }
+    }
+
     private static IOperableTrigger CreateHalfHourlyTrigger(TimeZoneInfo timeZone, DateTimeOffset startTimeUtc)
     {
         IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerDstTests.cs
@@ -1,0 +1,285 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Quartz.Impl.Triggers;
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Impl.Triggers;
+
+/// <summary>
+/// Daylight saving time coverage for <see cref="DailyTimeIntervalTriggerImpl" />, pinning the
+/// behaviour that <see cref="DailyTimeIntervalTriggerImplTest" /> only covers for spring-forward.
+/// </summary>
+/// <remarks>
+/// The trigger resolves each day's window start and end from wall-clock times (preferring the
+/// daylight occurrence for an ambiguous local time and the pre-transition offset for one that does
+/// not exist), but steps through the window by adding the interval in UTC ticks. Every expectation
+/// below follows from that: a day yields <c>floor(windowLengthInSeconds / intervalInSeconds) + 1</c>
+/// fires, where the window length is measured between the two resolved instants, not in wall-clock
+/// hours.
+/// </remarks>
+public class DailyTimeIntervalTriggerDstTests
+{
+    /// <summary>
+    /// Fall-back mirror of <c>DailyTimeIntervalTriggerImplTest.TestSpringForwardFireTimesAreStrictlyIncreasing</c>.
+    /// </summary>
+    /// <remarks>
+    /// On 2018-10-28 in Central European time the window runs from local 00:00 +02:00
+    /// (2018-10-27 22:00 UTC) to local 23:59:59 +01:00 (2018-10-28 22:59:59 UTC), which is
+    /// 89999 elapsed seconds - a 25 hour day. Every expected count is
+    /// <c>floor(89999 / interval) + 1</c>, so a sub-hour interval fires through both passes of the
+    /// ambiguous 02:00-02:59 hour and the day yields one interval's worth of extra fires.
+    /// The 24 hour row is the exception: it is the only interval that trips the
+    /// <c>RepeatIntervalSpan &gt;= 1 day</c> fall-back correction, which pushes the second fire of the
+    /// day (local 23:00, exactly 24 UTC hours after the window start) onto the next local date.
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    [TestCase(IntervalUnit.Second, 900, 100)]
+    [TestCase(IntervalUnit.Minute, 1, 1500)]
+    [TestCase(IntervalUnit.Minute, 5, 300)]
+    [TestCase(IntervalUnit.Minute, 15, 100)]
+    [TestCase(IntervalUnit.Minute, 30, 50)]
+    [TestCase(IntervalUnit.Minute, 45, 34)]
+    [TestCase(IntervalUnit.Hour, 1, 25)]
+    [TestCase(IntervalUnit.Hour, 2, 13)]
+    [TestCase(IntervalUnit.Hour, 4, 7)]
+    [TestCase(IntervalUnit.Hour, 24, 1)]
+    public void FallBackFireTimesAreStrictlyIncreasing(IntervalUnit unit, int interval, int expectedFireCountOnFallBackDay)
+    {
+        TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2018, 10, 28, 2, 30, 0));
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+            .EndingDailyAt(TimeOfDay.HourMinuteAndSecondOfDay(23, 59, 59))
+            .OnEveryDay()
+            .WithInterval(interval, unit)
+            .InTimeZone(timeZone)
+            .Build();
+
+        // Oct 27 22:00 UTC is Oct 28 00:00 CEST, the start of the fall-back day
+        trigger.StartTimeUtc = new DateTimeOffset(2018, 10, 27, 22, 0, 0, TimeSpan.Zero);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        // walk the fall-back day and the ordinary day after it; Walk fails the test if the trigger
+        // ever moves backwards, repeats itself or runs away
+        List<DateTimeOffset> local = TestTimeZones
+            .Walk(after => trigger.GetFireTimeAfter(after),
+                trigger.StartTimeUtc.AddSeconds(-1),
+                new DateTimeOffset(2018, 10, 29, 23, 0, 0, TimeSpan.Zero))
+            .Select(t => TimeZoneInfo.ConvertTime(t, timeZone))
+            .ToList();
+
+        local[0].TimeOfDay.Should().Be(TimeSpan.Zero, "the first fire of the day is startTimeOfDay");
+        local.Count(t => t.Date == new DateTime(2018, 10, 28)).Should().Be(expectedFireCountOnFallBackDay);
+        local.Select(t => t.Date).Distinct().Should().HaveCountGreaterThan(1, "the trigger must advance past the fall-back day");
+    }
+
+    /// <summary>
+    /// <see cref="IDailyTimeIntervalTrigger.RepeatCount" /> caps the fires <em>per local day</em>
+    /// ("setting to N means fire N+1 times per day"), and the cap counts interval steps rather than
+    /// wall-clock time.
+    /// </summary>
+    /// <remarks>
+    /// So the 25 hour fall-back day gets exactly as many fires as an ordinary day - the extra hour
+    /// buys nothing. It only shifts where the run ends on the clock: 30 steps of 30 minutes is
+    /// 15 UTC hours from the window start, which is local 15:00 on an ordinary day but local 14:00
+    /// on the fall-back day, because one of those 15 hours was spent repeating 02:00-02:59.
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void RepeatCountLimitsFires_AcrossFallBackDay()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2018, 10, 28, 2, 30, 0));
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+            .EndingDailyAt(TimeOfDay.HourMinuteAndSecondOfDay(23, 59, 59))
+            .OnEveryDay()
+            .WithIntervalInMinutes(30)
+            .WithRepeatCount(30)
+            .InTimeZone(timeZone)
+            .Build();
+
+        // Oct 26 22:00 UTC is Oct 27 00:00 CEST, the start of the day before the fall-back day
+        trigger.StartTimeUtc = new DateTimeOffset(2018, 10, 26, 22, 0, 0, TimeSpan.Zero);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        List<DateTimeOffset> local = TestTimeZones
+            .Walk(after => trigger.GetFireTimeAfter(after),
+                trigger.StartTimeUtc.AddSeconds(-1),
+                new DateTimeOffset(2018, 10, 29, 23, 0, 0, TimeSpan.Zero))
+            .Select(t => TimeZoneInfo.ConvertTime(t, timeZone))
+            .ToList();
+
+        List<DateTimeOffset> dayBefore = local.Where(t => t.Date == new DateTime(2018, 10, 27)).ToList();
+        List<DateTimeOffset> fallBackDay = local.Where(t => t.Date == new DateTime(2018, 10, 28)).ToList();
+        List<DateTimeOffset> dayAfter = local.Where(t => t.Date == new DateTime(2018, 10, 29)).ToList();
+
+        dayBefore.Should().HaveCount(31, "repeatCount 30 means 31 fires per day");
+        fallBackDay.Should().HaveCount(31, "the 25 hour day gets no extra fires, the cap counts interval steps");
+        dayAfter.Should().HaveCount(31);
+
+        dayBefore[^1].Should().Be(TestTimeZones.Local("2018-10-27 15:00 +02:00"));
+        fallBackDay[^1].Should().Be(TestTimeZones.Local("2018-10-28 14:00 +01:00"), "an hour of the run was spent repeating 02:00-02:59");
+        dayAfter[^1].Should().Be(TestTimeZones.Local("2018-10-29 15:00 +01:00"));
+
+        fallBackDay.Where(t => t.Hour == 2).Should().HaveCount(4, "the ambiguous hour occurs twice and holds two 30 minute slots each time");
+
+        // FinalFireTimeUtc is derived from EndTimeUtc only; a per-day repeat count never ends the trigger
+        trigger.FinalFireTimeUtc.Should().BeNull("without an end time the trigger repeats its daily run forever");
+    }
+
+    /// <summary>
+    /// An <c>endTimeOfDay</c> that lands inside the spring-forward gap still bounds the day, but it
+    /// bounds it as an <em>instant</em>, not as a wall-clock time.
+    /// </summary>
+    /// <remarks>
+    /// On 2018-03-25 the local times 02:00-02:59 do not exist. The gap end resolves with the
+    /// pre-transition offset, so local 02:30 becomes 02:30 +01:00 = 01:30 UTC. The third hourly slot
+    /// falls on 01:00 UTC, which is still before that bound, and 01:00 UTC is the transition instant
+    /// itself - so the trigger fires at local 03:00 +02:00, half an hour past the wall-clock
+    /// endTimeOfDay it was given. That is the only slot that behaves that way: the fourth is
+    /// 02:00 UTC, past the bound, and the day ends cleanly. There is no loop and no wedge.
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void EndTimeOfDayInsideSpringForwardGap_DayEndsCleanly()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2018, 3, 25, 2, 0, 0));
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2018, 3, 25, 2, 30, 0));
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+            .EndingDailyAt(TimeOfDay.HourAndMinuteOfDay(2, 30))
+            .OnEveryDay()
+            .WithIntervalInHours(1)
+            .InTimeZone(timeZone)
+            .Build();
+
+        // Mar 24 23:00 UTC is Mar 25 00:00 CET, the start of the spring-forward day
+        trigger.StartTimeUtc = new DateTimeOffset(2018, 3, 24, 23, 0, 0, TimeSpan.Zero);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        List<DateTimeOffset> times = TestTimeZones.Walk(
+            after => trigger.GetFireTimeAfter(after),
+            trigger.StartTimeUtc.AddSeconds(-1),
+            new DateTimeOffset(2018, 3, 26, 12, 0, 0, TimeSpan.Zero));
+
+        times.Should().Equal(
+        [
+            TestTimeZones.Local("2018-03-25 00:00 +01:00"),
+            TestTimeZones.Local("2018-03-25 01:00 +01:00"),
+            // 02:00 does not exist, and 03:00 +02:00 is the same instant the skipped 02:00 +01:00
+            // slot would have been - still inside the resolved end of day, so it fires
+            TestTimeZones.Local("2018-03-25 03:00 +02:00"),
+            // the ordinary day that follows honours endTimeOfDay as written
+            TestTimeZones.Local("2018-03-26 00:00 +02:00"),
+            TestTimeZones.Local("2018-03-26 01:00 +02:00"),
+            TestTimeZones.Local("2018-03-26 02:00 +02:00")
+        ]);
+    }
+
+    /// <summary>
+    /// Chile moves the clock at midnight, so the transition sits on the edge of the local day rather
+    /// than in the middle of it, and the two directions come out asymmetric.
+    /// </summary>
+    /// <remarks>
+    /// Spring forward (2019-09-08): 00:00 does not exist, the day starts at 01:00 -03:00 and is
+    /// 23 hours long, so a 30 minute trigger fires 46 times and never at local hour 0.
+    /// <para>
+    /// Fall back (Saturday 2019-04-06): the repeated hour is 23:00-23:59, i.e. the last hour of the
+    /// local day. Unlike the Central European case - where the repeated hour is in the middle of the
+    /// day and the day really does yield 25 hours of fires - <c>endTimeOfDay</c> 23:59:59 is itself
+    /// ambiguous here, and it resolves to the <em>daylight</em> (first) occurrence. The window
+    /// therefore closes at 2019-04-07 02:59:59 UTC, one hour before the local day ends: 48 fires,
+    /// and the second pass of 23:00-23:59 is skipped entirely even though those instants still map
+    /// to local date 2019-04-06.
+    /// </para>
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void MidnightGapZone_SubHourInterval_Santiago()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.Santiago;
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2019, 9, 8, 0, 0, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2019, 4, 6, 23, 30, 0));
+
+        // Sep 8 04:00 UTC is Sep 8 01:00 -03:00, the first instant of the spring-forward day
+        List<DateTimeOffset> springForwardDay = LocalFiresOnDate(
+            CreateHalfHourlyTrigger(timeZone, new DateTimeOffset(2019, 9, 8, 4, 0, 0, TimeSpan.Zero)),
+            timeZone,
+            new DateTime(2019, 9, 8),
+            new DateTimeOffset(2019, 9, 9, 12, 0, 0, TimeSpan.Zero));
+
+        springForwardDay.Should().HaveCount(46, "the local day is 23 hours long, so 22:59:59 / 30 min + 1");
+        springForwardDay.Should().NotContain(t => t.Hour == 0, "00:00-00:59 does not exist on the spring-forward day");
+        springForwardDay[0].Should().Be(TestTimeZones.Local("2019-09-08 01:00 -03:00"));
+        springForwardDay[^1].Should().Be(TestTimeZones.Local("2019-09-08 23:30 -03:00"));
+
+        // Apr 6 03:00 UTC is Apr 6 00:00 -03:00, the start of the fall-back Saturday
+        List<DateTimeOffset> fallBackDay = LocalFiresOnDate(
+            CreateHalfHourlyTrigger(timeZone, new DateTimeOffset(2019, 4, 6, 3, 0, 0, TimeSpan.Zero)),
+            timeZone,
+            new DateTime(2019, 4, 6),
+            new DateTimeOffset(2019, 4, 7, 12, 0, 0, TimeSpan.Zero));
+
+        fallBackDay.Should().HaveCount(48, "endTimeOfDay 23:59:59 is ambiguous and resolves to the first occurrence, closing the window after 24 hours");
+        fallBackDay[0].Should().Be(TestTimeZones.Local("2019-04-06 00:00 -03:00"));
+        fallBackDay[^1].Should().Be(TestTimeZones.Local("2019-04-06 23:30 -03:00"));
+        fallBackDay.Where(t => t.Hour == 23).Should().HaveCount(2, "only the first pass of the repeated last hour is inside the window");
+        fallBackDay.Should().OnlyContain(t => t.Offset == TimeSpan.FromHours(-3), "the standard-time pass of the day is never reached");
+    }
+
+    private static IOperableTrigger CreateHalfHourlyTrigger(TimeZoneInfo timeZone, DateTimeOffset startTimeUtc)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+            .EndingDailyAt(TimeOfDay.HourMinuteAndSecondOfDay(23, 59, 59))
+            .OnEveryDay()
+            .WithIntervalInMinutes(30)
+            .InTimeZone(timeZone)
+            .Build();
+
+        trigger.StartTimeUtc = startTimeUtc;
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        return trigger;
+    }
+
+    private static List<DateTimeOffset> LocalFiresOnDate(
+        IOperableTrigger trigger,
+        TimeZoneInfo timeZone,
+        DateTime localDate,
+        DateTimeOffset untilExclusive)
+    {
+        return TestTimeZones
+            .Walk(after => trigger.GetFireTimeAfter(after), trigger.StartTimeUtc.AddSeconds(-1), untilExclusive)
+            .Select(t => TimeZoneInfo.ConvertTime(t, timeZone))
+            .Where(t => t.Date == localDate)
+            .ToList();
+    }
+}

--- a/src/Quartz.Tests.Unit/SimpleTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/SimpleTriggerDstTests.cs
@@ -1,0 +1,121 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Pins that <see cref="SimpleTriggerImpl" /> is daylight saving time agnostic.
+/// </summary>
+/// <remarks>
+/// The trigger has no time zone at all: its fire times are <c>startTimeUtc + n * repeatInterval</c>
+/// in ticks. That means an "hourly" simple trigger repeats every hour of real elapsed time, so a
+/// local day that gains or loses an hour to a DST transition simply contains one more or one fewer
+/// fire. This is deliberately different from <see cref="DailyTimeIntervalTriggerImpl" />, which
+/// re-anchors its window to the local wall clock every day.
+/// </remarks>
+public class SimpleTriggerDstTests
+{
+    /// <summary>
+    /// A 25 hour local day holds 25 hourly fires and a 23 hour local day holds 23, while the
+    /// spacing between consecutive fires stays exactly one hour of real time throughout.
+    /// </summary>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void HourlySimpleTrigger_FallBackLocalDayHas25Fires_SpringDay23()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2024, 11, 3, 1, 30, 0));
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2024, 3, 10, 2, 30, 0));
+
+        // Nov 1 04:00 UTC is Nov 1 00:00 EDT, so every fire lands on a whole local hour
+        List<DateTimeOffset> acrossFallBack = WalkHourly(
+            new DateTimeOffset(2024, 11, 1, 4, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 11, 5, 5, 0, 0, TimeSpan.Zero));
+
+        AssertExactlyOneHourApart(acrossFallBack);
+        acrossFallBack.Count(t => TimeZoneInfo.ConvertTime(t, timeZone).Date == new DateTime(2024, 11, 3))
+            .Should().Be(25, "the fall-back day is 25 hours of real time long");
+
+        // Mar 8 05:00 UTC is Mar 8 00:00 EST
+        List<DateTimeOffset> acrossSpringForward = WalkHourly(
+            new DateTimeOffset(2024, 3, 8, 5, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 3, 12, 4, 0, 0, TimeSpan.Zero));
+
+        AssertExactlyOneHourApart(acrossSpringForward);
+        acrossSpringForward.Count(t => TimeZoneInfo.ConvertTime(t, timeZone).Date == new DateTime(2024, 3, 10))
+            .Should().Be(23, "the spring-forward day is 23 hours of real time long");
+    }
+
+    /// <summary>
+    /// <see cref="SimpleTriggerImpl.FinalFireTimeUtc" /> is <c>startTimeUtc + repeatCount * interval</c>
+    /// in ticks even when the run spans a transition, so it drifts against the wall clock on purpose.
+    /// </summary>
+    [Test]
+    [Category("windowstimezoneid")]
+    public void FinalFireTimeUtc_IsPureTickArithmetic_AcrossTransition()
+    {
+        TimeZoneInfo timeZone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2024, 3, 10, 2, 30, 0));
+
+        DateTimeOffset startTimeUtc = new DateTimeOffset(2024, 3, 8, 5, 0, 0, TimeSpan.Zero);
+        TimeSpan interval = TimeSpan.FromHours(1);
+        int repeatCount = 100;
+
+        SimpleTriggerImpl trigger = CreateTrigger(startTimeUtc, repeatCount, interval);
+
+        trigger.FinalFireTimeUtc.Should().Be(startTimeUtc.AddTicks(repeatCount * interval.Ticks));
+        trigger.FinalFireTimeUtc.Should().Be(new DateTimeOffset(2024, 3, 12, 9, 0, 0, TimeSpan.Zero));
+
+        // 100 hours of real time after local Mar 8 00:00 is local Mar 12 05:00, not 04:00: the run
+        // crossed the spring-forward gap and the trigger did not compensate for it
+        TimeZoneInfo.ConvertTime(trigger.FinalFireTimeUtc!.Value, timeZone).DateTime
+            .Should().Be(new DateTime(2024, 3, 12, 5, 0, 0));
+
+        trigger.GetFireTimeAfter(trigger.FinalFireTimeUtc).Should().BeNull("the final fire time is the last one");
+    }
+
+    private static List<DateTimeOffset> WalkHourly(DateTimeOffset startTimeUtc, DateTimeOffset untilExclusive)
+    {
+        SimpleTriggerImpl trigger = CreateTrigger(startTimeUtc, SimpleTriggerImpl.RepeatIndefinitely, TimeSpan.FromHours(1));
+
+        // GetFireTimeAfter(startTimeUtc) already skips to the second fire, so start one tick earlier
+        return TestTimeZones.Walk(after => trigger.GetFireTimeAfter(after), startTimeUtc.AddTicks(-1), untilExclusive);
+    }
+
+    private static SimpleTriggerImpl CreateTrigger(DateTimeOffset startTimeUtc, int repeatCount, TimeSpan repeatInterval)
+    {
+        return new SimpleTriggerImpl("dstTrigger", "dstGroup", "dstJob", "dstJobGroup", startTimeUtc, null, repeatCount, repeatInterval);
+    }
+
+    private static void AssertExactlyOneHourApart(List<DateTimeOffset> fireTimes)
+    {
+        fireTimes.Should().NotBeEmpty();
+
+        for (int i = 1; i < fireTimes.Count; i++)
+        {
+            (fireTimes[i] - fireTimes[i - 1]).Should().Be(TimeSpan.FromHours(1), $"fire {i} must follow fire {i - 1} by exactly one hour of real time");
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/TestTimeZones.cs
+++ b/src/Quartz.Tests.Unit/TestTimeZones.cs
@@ -1,0 +1,158 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using TimeZoneConverter;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Shared time zones and helpers for daylight saving time (DST) tests. Zones are resolved via
+/// TimeZoneConverter from Windows ids, which works on every supported OS. Each zone is chosen for a
+/// specific DST corner it exercises; tests should state their transition premise with the Assume
+/// helpers so that a changed time zone database skips the test instead of failing it.
+/// </summary>
+internal static class TestTimeZones
+{
+    /// <summary>
+    /// America/New_York: the classic US transition at 02:00 with a one hour delta.
+    /// Spring forward 2024-03-10 (02:30 invalid), fall back 2024-11-03 (01:30 ambiguous).
+    /// </summary>
+    public static TimeZoneInfo Eastern { get; } = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
+
+    /// <summary>
+    /// Europe/Warsaw: EU transition at 02:00/03:00 local with a one hour delta.
+    /// Spring forward 2018-03-25 (02:30 invalid), fall back 2018-10-28 (02:30 ambiguous).
+    /// </summary>
+    public static TimeZoneInfo CentralEuropean { get; } = TZConvert.GetTimeZoneInfo("Central European Standard Time");
+
+    /// <summary>
+    /// America/Santiago: southern hemisphere and the transition happens at midnight, so on
+    /// spring-forward day the date's own 00:00 does not exist (2019-09-08, 00:30 invalid) and on
+    /// fall-back day the repeated hour crosses backwards over the date boundary
+    /// (Saturday 2019-04-06 23:30 is ambiguous).
+    /// </summary>
+    public static TimeZoneInfo Santiago { get; } = TZConvert.GetTimeZoneInfo("Pacific SA Standard Time");
+
+    /// <summary>
+    /// Australia/Sydney: southern hemisphere with the usual 02:00/03:00 transitions.
+    /// Fall back 2024-04-07 (02:30 ambiguous), spring forward 2024-10-06 (02:30 invalid).
+    /// </summary>
+    public static TimeZoneInfo Sydney { get; } = TZConvert.GetTimeZoneInfo("AUS Eastern Standard Time");
+
+    /// <summary>
+    /// Australia/Lord_Howe: DST delta is only 30 minutes (+10:30 to +11:00), which catches any
+    /// code that assumes a one hour correction. Spring forward 2019-10-06 (02:15 invalid),
+    /// fall back 2019-04-07 (01:45 ambiguous). May be missing from old OS installations, in which
+    /// case tests using it are ignored.
+    /// </summary>
+    public static TimeZoneInfo LordHowe => GetOrIgnore("Lord Howe Standard Time");
+
+    /// <summary>
+    /// Asia/Amman: historically the spring-forward gap started at midnight, so the transition
+    /// day started at 01:00 (2017-03-31, 00:30 invalid) and on fall-back day the first hour of the
+    /// day repeated (2017-10-27, 00:30 ambiguous). Jordan abolished DST in 2022, so this history is
+    /// frozen. May be missing from old OS installations, in which case tests using it are ignored.
+    /// </summary>
+    public static TimeZoneInfo Amman => GetOrIgnore("Jordan Standard Time");
+
+    private static TimeZoneInfo GetOrIgnore(string windowsId)
+    {
+        try
+        {
+            return TZConvert.GetTimeZoneInfo(windowsId);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            NUnit.Framework.Assert.Ignore($"time zone {windowsId} is not available on this system");
+            throw; // unreachable, Assert.Ignore throws
+        }
+    }
+
+    /// <summary>
+    /// States a test's premise that the given wall-clock time does not exist in the zone (it falls
+    /// into a spring-forward gap). If the time zone database no longer agrees, the test is skipped
+    /// as inconclusive instead of failing.
+    /// </summary>
+    public static void AssumeInvalidLocalTime(TimeZoneInfo zone, DateTime localTime)
+    {
+        Assume.That(zone.IsInvalidTime(localTime), $"test premise: {localTime:yyyy-MM-dd HH:mm} should not exist in zone {zone.Id}");
+    }
+
+    /// <summary>
+    /// States a test's premise that the given wall-clock time is ambiguous in the zone (it occurs
+    /// twice around a fall-back transition). If the time zone database no longer agrees, the test
+    /// is skipped as inconclusive instead of failing.
+    /// </summary>
+    public static void AssumeAmbiguousLocalTime(TimeZoneInfo zone, DateTime localTime)
+    {
+        Assume.That(zone.IsAmbiguousTime(localTime), $"test premise: {localTime:yyyy-MM-dd HH:mm} should be ambiguous in zone {zone.Id}");
+    }
+
+    /// <summary>
+    /// Parses strings like "2024-11-03 01:30 -04:00" so that test case grids can assert the fire
+    /// instant and its offset in a single value, mirroring how the two occurrences of an ambiguous
+    /// local time differ only by offset.
+    /// </summary>
+    public static DateTimeOffset Local(string value)
+    {
+        return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.None);
+    }
+
+    /// <summary>
+    /// Collects fire times by repeatedly calling <paramref name="getNextAfter"/>, starting after
+    /// <paramref name="after"/> and stopping at the first result at or beyond
+    /// <paramref name="untilExclusive"/> (which is not included). Fails the test if the produced
+    /// times are not strictly increasing or the safety limit is exceeded, so any fire-count test
+    /// also guards against the trigger wedging or looping around a DST transition.
+    /// </summary>
+    public static List<DateTimeOffset> Walk(
+        Func<DateTimeOffset, DateTimeOffset?> getNextAfter,
+        DateTimeOffset after,
+        DateTimeOffset untilExclusive,
+        int safetyLimit = 10_000)
+    {
+        List<DateTimeOffset> fireTimes = new List<DateTimeOffset>();
+        DateTimeOffset current = after;
+        while (true)
+        {
+            DateTimeOffset? next = getNextAfter(current);
+            if (next is null || next.Value >= untilExclusive)
+            {
+                return fireTimes;
+            }
+
+            if (next.Value <= current)
+            {
+                NUnit.Framework.Assert.Fail($"fire times must strictly increase: got {next.Value:O} after {current:O}");
+            }
+
+            if (fireTimes.Count >= safetyLimit)
+            {
+                NUnit.Framework.Assert.Fail($"more than {safetyLimit} fire times produced before {untilExclusive:O}; trigger is likely looping");
+            }
+
+            fireTimes.Add(next.Value);
+            current = next.Value;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/TriggerDstMisfireTests.cs
+++ b/src/Quartz.Tests.Unit/TriggerDstMisfireTests.cs
@@ -1,0 +1,406 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Quartz.Impl.Triggers;
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Misfire handling when the scheduler catches up while "now" sits on a daylight saving time
+/// boundary: either at the instant a naive wall-clock computation would call a time that never
+/// existed (spring forward), or during the hour that happens twice (fall back).
+/// <para>
+/// Every misfire instruction that reschedules reads the trigger's <see cref="TimeProvider"/> clock,
+/// so each trigger is constructed with a fixed one. The tests pin the current behaviour - they are
+/// a regression net, not a specification of what is ideal.
+/// </para>
+/// </summary>
+public class TriggerDstMisfireTests
+{
+    private static readonly TimeZoneInfo Eastern = TestTimeZones.Eastern;
+
+    /// <summary>
+    /// Eastern springs forward on 2024-03-10: local 02:00 EST becomes 03:00 EDT at 07:00Z, so the
+    /// wall clock 02:30 never happens on that date. This instant is the one that a naive
+    /// "02:30 at the standard offset" computation would pick, and its real local time is 03:30 EDT.
+    /// </summary>
+    private static readonly DateTimeOffset NowInGapHour = new DateTimeOffset(2024, 3, 10, 7, 30, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Eastern falls back on 2024-11-03: local 02:00 EDT becomes 01:00 EST at 06:00Z, so the wall
+    /// clock 01:30 happens twice - first at 05:30Z (daylight pass) and again at 06:30Z (standard
+    /// pass). This is the second, standard-offset occurrence.
+    /// </summary>
+    private static readonly DateTimeOffset NowInAmbiguousHourStandardPass = new DateTimeOffset(2024, 11, 3, 6, 30, 0, TimeSpan.Zero);
+
+    /// <summary>The first occurrence of the ambiguous 01:30 wall clock, still on daylight time.</summary>
+    private static readonly DateTimeOffset NowInAmbiguousHourDaylightPass = new DateTimeOffset(2024, 11, 3, 5, 30, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// States the transition premises of this fixture. A changed time zone database skips the tests
+    /// instead of failing them.
+    /// </summary>
+    private static void AssumeEasternTransitions()
+    {
+        TestTimeZones.AssumeInvalidLocalTime(Eastern, new DateTime(2024, 3, 10, 2, 30, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(Eastern, new DateTime(2024, 11, 3, 1, 30, 0));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Trigger factories. Every trigger starts well before the frozen "now", so the fire time that
+    // ComputeFirstFireTimeUtc produces is badly past due by the time misfire handling runs.
+    // ---------------------------------------------------------------------------------------
+
+    private static CronTriggerImpl CreateCronTrigger(int misfireInstruction, DateTimeOffset frozenNow)
+    {
+        CronTriggerImpl trigger = new CronTriggerImpl(new FixedTimeProvider(frozenNow))
+        {
+            Key = new TriggerKey("test", "test"),
+            CronExpressionString = "0 30 2 * * ?",
+            TimeZone = Eastern,
+            StartTimeUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            MisfireInstruction = misfireInstruction
+        };
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    private static CalendarIntervalTriggerImpl CreateCalendarIntervalTrigger(int misfireInstruction, DateTimeOffset frozenNow)
+    {
+        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl(new FixedTimeProvider(frozenNow))
+        {
+            Key = new TriggerKey("test", "test"),
+            // 2024-01-15 02:30 EST, i.e. the same wall clock the Eastern transitions attack.
+            StartTimeUtc = new DateTimeOffset(2024, 1, 15, 7, 30, 0, TimeSpan.Zero),
+            RepeatInterval = 1,
+            RepeatIntervalUnit = IntervalUnit.Day,
+            TimeZone = Eastern,
+            PreserveHourOfDayAcrossDaylightSavings = true,
+            MisfireInstruction = misfireInstruction
+        };
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    private static DailyTimeIntervalTriggerImpl CreateDailyTimeIntervalTrigger(int misfireInstruction, DateTimeOffset frozenNow)
+    {
+        DailyTimeIntervalTriggerImpl trigger = new DailyTimeIntervalTriggerImpl(new FixedTimeProvider(frozenNow))
+        {
+            Key = new TriggerKey("test", "test"),
+            StartTimeUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            StartTimeOfDay = new TimeOfDay(0, 0, 0),
+            EndTimeOfDay = new TimeOfDay(23, 59, 59),
+            RepeatInterval = 15,
+            RepeatIntervalUnit = IntervalUnit.Minute,
+            TimeZone = Eastern,
+            MisfireInstruction = misfireInstruction
+        };
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    private static SimpleTriggerImpl CreateSimpleTrigger(int misfireInstruction, DateTimeOffset frozenNow)
+    {
+        SimpleTriggerImpl trigger = new SimpleTriggerImpl(new FixedTimeProvider(frozenNow))
+        {
+            Key = new TriggerKey("test", "test"),
+            StartTimeUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            RepeatInterval = TimeSpan.FromHours(1),
+            RepeatCount = SimpleTriggerImpl.RepeatIndefinitely,
+            MisfireInstruction = misfireInstruction
+        };
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Assertions shared by the per-type tests.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Runs misfire handling and returns the rescheduled fire time. The frozen "now" is the
+    /// <see cref="FixedTimeProvider"/> the trigger was constructed with.
+    /// </summary>
+    private static DateTimeOffset? Misfire(IOperableTrigger trigger)
+    {
+        trigger.UpdateAfterMisfire(null);
+        return trigger.GetNextFireTimeUtc();
+    }
+
+    /// <summary>
+    /// Collects <paramref name="count"/> further fire times, asserting strict progress at each step
+    /// so that a trigger that wedges on a DST boundary fails here rather than looping forever.
+    /// </summary>
+    private static List<DateTimeOffset> StepForward(ITrigger trigger, DateTimeOffset from, int count)
+    {
+        List<DateTimeOffset> fireTimes = new List<DateTimeOffset>(count);
+        DateTimeOffset current = from;
+        for (int i = 0; i < count; i++)
+        {
+            DateTimeOffset? next = trigger.GetFireTimeAfter(current);
+            next.Should().NotBeNull("the trigger must keep producing fire times after {0:O}", current);
+            next!.Value.Should().BeAfter(current, "fire times must strictly increase, step {0}", i + 1);
+            fireTimes.Add(next.Value);
+            current = next.Value;
+        }
+
+        return fireTimes;
+    }
+
+    /// <summary>
+    /// States the invariant that a rescheduled fire time reads back as a wall clock the zone really
+    /// has. This is a shape check only - a well formed instant can never normalise onto a skipped
+    /// wall clock - so the pinned exact fire times below carry the weight of the DST assertions.
+    /// </summary>
+    private static void AssertLocalTimeExists(DateTimeOffset instant)
+    {
+        DateTime local = TimeZoneInfo.ConvertTime(instant, Eastern).DateTime;
+        Eastern.IsInvalidTime(local).Should().BeFalse(
+            "the fire time {0:O} maps to Eastern wall clock {1:yyyy-MM-dd HH:mm:ss}, which must exist", instant, local);
+    }
+
+    /// <summary>
+    /// The two passes of an ambiguous hour share a wall clock. A trigger that fires on both would
+    /// run the job twice for what the user reads as one scheduled time.
+    /// </summary>
+    private static void AssertNoRepeatedWallClock(IEnumerable<DateTimeOffset> fireTimes)
+    {
+        List<DateTime> localTimes = fireTimes.Select(t => TimeZoneInfo.ConvertTime(t, Eastern).DateTime).ToList();
+        localTimes.Should().OnlyHaveUniqueItems("no wall clock may be fired twice across the ambiguous hour");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Spring forward: misfire handling runs at the instant whose would-be wall clock never existed.
+    // ---------------------------------------------------------------------------------------
+
+    [Test]
+    public void Cron_DoNothing_MisfireNowInGapHour_NextFireIsStrictlyFutureAndValid()
+    {
+        AssumeEasternTransitions();
+
+        CronTriggerImpl trigger = CreateCronTrigger(MisfireInstruction.CronTrigger.DoNothing, NowInGapHour);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().BeAfter(NowInGapHour, "DoNothing must skip all past-due fire times");
+        nextFire.Value.Should().Be(new DateTimeOffset(2024, 3, 11, 6, 30, 0, TimeSpan.Zero),
+            "02:30 does not exist on the spring forward day, so the next daily fire is 2024-03-11 02:30 EDT");
+        AssertLocalTimeExists(nextFire.Value);
+
+        StepForward(trigger, nextFire.Value, 2);
+    }
+
+    [Test]
+    public void CalendarInterval_DoNothing_MisfireNowInGapHour_NextFireIsStrictlyFutureAndValid()
+    {
+        AssumeEasternTransitions();
+
+        CalendarIntervalTriggerImpl trigger = CreateCalendarIntervalTrigger(MisfireInstruction.CalendarIntervalTrigger.DoNothing, NowInGapHour);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().BeAfter(NowInGapHour, "DoNothing must skip all past-due fire times");
+        nextFire.Value.Should().Be(new DateTimeOffset(2024, 3, 11, 6, 30, 0, TimeSpan.Zero),
+            "PreserveHourOfDayAcrossDaylightSavings keeps the 02:30 wall clock, now at the daylight offset");
+        nextFire.Value.Offset.Should().Be(TimeSpan.FromHours(-4),
+            "unlike the other three trigger types, CalendarIntervalTriggerImpl hands back values carrying " +
+            "the trigger time zone's offset rather than UTC; equality is by instant, so this only matters " +
+            "to callers that read Offset or DateTime off the result");
+        AssertLocalTimeExists(nextFire.Value);
+
+        StepForward(trigger, nextFire.Value, 2);
+    }
+
+    [Test]
+    public void DailyTimeInterval_DoNothing_MisfireNowInGapHour_NextFireIsStrictlyFutureAndValid()
+    {
+        AssumeEasternTransitions();
+
+        DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger(MisfireInstruction.DailyTimeIntervalTrigger.DoNothing, NowInGapHour);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().BeAfter(NowInGapHour, "DoNothing must skip all past-due fire times");
+        nextFire.Value.Should().Be(new DateTimeOffset(2024, 3, 10, 7, 45, 0, TimeSpan.Zero),
+            "the quarter hour grid continues at 03:45 EDT, the first slot after the frozen now");
+        AssertLocalTimeExists(nextFire.Value);
+
+        StepForward(trigger, nextFire.Value, 2);
+    }
+
+    [Test]
+    public void Simple_RescheduleNextWithRemainingCount_MisfireNowInGapHour_NextFireIsStrictlyFutureAndValid()
+    {
+        AssumeEasternTransitions();
+
+        // SimpleTrigger has no DoNothing instruction; RescheduleNextWithRemainingCount is the
+        // closest equivalent - it also picks the next scheduled time strictly after now instead of
+        // firing immediately.
+        SimpleTriggerImpl trigger = CreateSimpleTrigger(MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount, NowInGapHour);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().BeAfter(NowInGapHour, "the trigger must not fire immediately after misfire handling");
+        nextFire.Value.Should().Be(new DateTimeOffset(2024, 3, 10, 8, 0, 0, TimeSpan.Zero),
+            "SimpleTrigger counts absolute intervals from the start time, so DST does not shift the grid");
+        AssertLocalTimeExists(nextFire.Value);
+
+        StepForward(trigger, nextFire.Value, 2);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Fall back: misfire handling runs during the hour that happens twice.
+    // ---------------------------------------------------------------------------------------
+
+    [Test]
+    public void Cron_FireOnceNow_MisfireNowInAmbiguousHour_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        CronTriggerImpl trigger = CreateCronTrigger(MisfireInstruction.CronTrigger.FireOnceNow, NowInAmbiguousHourStandardPass);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourStandardPass, "FireOnceNow schedules the trigger for exactly now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 7, 30, 0, TimeSpan.Zero),
+            "the regular 02:30 fire on the fall back day happens once, at the standard offset");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    [Test]
+    public void Cron_FireOnceNow_MisfireNowInAmbiguousHourDaylightPass_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        CronTriggerImpl trigger = CreateCronTrigger(MisfireInstruction.CronTrigger.FireOnceNow, NowInAmbiguousHourDaylightPass);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourDaylightPass, "FireOnceNow schedules the trigger for exactly now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 7, 30, 0, TimeSpan.Zero),
+            "stepping out of the first pass of the repeated hour must not revisit it");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    [Test]
+    public void CalendarInterval_FireOnceNow_MisfireNowInAmbiguousHour_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        CalendarIntervalTriggerImpl trigger = CreateCalendarIntervalTrigger(MisfireInstruction.CalendarIntervalTrigger.FireOnceNow, NowInAmbiguousHourStandardPass);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourStandardPass, "FireOnceNow schedules the trigger for exactly now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 7, 30, 0, TimeSpan.Zero),
+            "the preserved 02:30 wall clock resumes at the standard offset");
+        onward[0].Offset.Should().Be(TimeSpan.FromHours(-5),
+            "the fire time that FireOnceNow stores is whatever the trigger clock returned, but the times " +
+            "computed afterwards carry the trigger time zone's offset");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    [Test]
+    public void DailyTimeInterval_FireOnceNow_MisfireNowInAmbiguousHour_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger(MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow, NowInAmbiguousHourStandardPass);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourStandardPass, "FireOnceNow schedules the trigger for exactly now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 6, 45, 0, TimeSpan.Zero),
+            "the quarter hour grid continues inside the repeated hour at 01:45 EST");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    [Test]
+    public void DailyTimeInterval_FireOnceNow_MisfireNowInAmbiguousHourDaylightPass_RepeatsTheAmbiguousWallClock()
+    {
+        AssumeEasternTransitions();
+
+        // The counterpart of the test above, pinning the behaviour that makes the standard pass the
+        // interesting case: when misfire handling lands on the *first* pass of the repeated hour,
+        // the quarter hour grid walks straight through the fall back and serves 01:30 a second time.
+        // Both fires are distinct instants an hour apart, so nothing here is a wedge - but a job
+        // scheduled for 01:30 does run twice.
+        DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger(MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow, NowInAmbiguousHourDaylightPass);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourDaylightPass);
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 4);
+        onward[3].Should().Be(NowInAmbiguousHourStandardPass,
+            "the fourth step is 01:30 again, this time at the standard offset");
+        TimeZoneInfo.ConvertTime(onward[3], Eastern).DateTime.Should().Be(
+            TimeZoneInfo.ConvertTime(nextFire.Value, Eastern).DateTime,
+            "both fires read as the same 01:30 wall clock");
+    }
+
+    [Test]
+    public void Simple_FireNow_MisfireNowInAmbiguousHour_ProgressesWithoutDuplicate()
+    {
+        AssumeEasternTransitions();
+
+        // For a repeating SimpleTrigger, FireNow is rewritten to RescheduleNowWithRemainingRepeatCount,
+        // which also fires now but additionally re-anchors StartTimeUtc to now.
+        SimpleTriggerImpl trigger = CreateSimpleTrigger(MisfireInstruction.SimpleTrigger.FireNow, NowInAmbiguousHourStandardPass);
+
+        DateTimeOffset? nextFire = Misfire(trigger);
+
+        nextFire.Should().NotBeNull();
+        nextFire!.Value.Should().Be(NowInAmbiguousHourStandardPass, "FireNow schedules the trigger for exactly now");
+        trigger.StartTimeUtc.Should().Be(NowInAmbiguousHourStandardPass,
+            "RescheduleNowWithRemainingRepeatCount re-anchors the interval grid to now");
+
+        List<DateTimeOffset> onward = StepForward(trigger, nextFire.Value, 3);
+        onward[0].Should().Be(new DateTimeOffset(2024, 11, 3, 7, 30, 0, TimeSpan.Zero),
+            "the hourly interval is absolute, so the next fire is one real hour later");
+        AssertNoRepeatedWallClock(onward.Prepend(nextFire.Value));
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/src/Quartz.Tests.Unit/TriggerDstMonotonicityTests.cs
+++ b/src/Quartz.Tests.Unit/TriggerDstMonotonicityTests.cs
@@ -1,0 +1,304 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Property tests over daylight saving time transitions: whatever a trigger decides to do with a
+/// wall clock that vanishes or repeats, walking its fire times must make monotonic progress and
+/// must not stall. Each case walks one trigger kind across one transition and asserts that every
+/// step strictly increases, that no step jumps further than the schedule plus the transition delta
+/// could explain, and that the walk actually gets past the transition instant.
+/// <para>
+/// These tests never touch <see cref="SystemTime"/>, so the fixture is parallel safe.
+/// </para>
+/// </summary>
+public class TriggerDstMonotonicityTests
+{
+    private const int StepCount = 150;
+
+    /// <summary>
+    /// A window that starts two hours before a transition instant, so a walk of 150 steps of any of
+    /// the schedules below is guaranteed to cross it.
+    /// </summary>
+    private sealed class DstWindow
+    {
+        public DstWindow(TimeZoneInfo zone, DateTimeOffset start, Action assumePremise)
+        {
+            Zone = zone;
+            Start = start;
+            AssumePremise = assumePremise;
+        }
+
+        public TimeZoneInfo Zone { get; }
+
+        public DateTimeOffset Start { get; }
+
+        public DateTimeOffset Transition => Start.AddHours(2);
+
+        public Action AssumePremise { get; }
+    }
+
+    /// <summary>
+    /// Resolved lazily per test case: <see cref="TestTimeZones.LordHowe"/> ignores the test when the
+    /// zone is missing, which must not happen while building a shared static table.
+    /// </summary>
+    private static DstWindow ResolveWindow(string windowKey)
+    {
+        switch (windowKey)
+        {
+            case "EasternSpring":
+                // 02:00 EST -> 03:00 EDT at 2024-03-10 07:00Z.
+                return new DstWindow(
+                    TestTimeZones.Eastern,
+                    new DateTimeOffset(2024, 3, 10, 5, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Eastern, new DateTime(2024, 3, 10, 2, 30, 0)));
+
+            case "EasternFall":
+                // 02:00 EDT -> 01:00 EST at 2024-11-03 06:00Z.
+                return new DstWindow(
+                    TestTimeZones.Eastern,
+                    new DateTimeOffset(2024, 11, 3, 4, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Eastern, new DateTime(2024, 11, 3, 1, 30, 0)));
+
+            case "CentralEuropeanFall":
+                // 03:00 CEST -> 02:00 CET at 2018-10-28 01:00Z.
+                return new DstWindow(
+                    TestTimeZones.CentralEuropean,
+                    new DateTimeOffset(2018, 10, 27, 23, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.CentralEuropean, new DateTime(2018, 10, 28, 2, 30, 0)));
+
+            case "SantiagoSpring":
+                // Midnight transition: 2019-09-08 never has a 00:00 local, the day starts at 01:00.
+                return new DstWindow(
+                    TestTimeZones.Santiago,
+                    new DateTimeOffset(2019, 9, 8, 2, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Santiago, new DateTime(2019, 9, 8, 0, 30, 0)));
+
+            case "LordHoweSpring":
+                // Half hour delta: 02:00 -> 02:30 local at 2019-10-05 15:30Z.
+                return new DstWindow(
+                    TestTimeZones.LordHowe,
+                    new DateTimeOffset(2019, 10, 5, 13, 30, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.LordHowe, new DateTime(2019, 10, 6, 2, 15, 0)));
+
+            case "LordHoweFall":
+                // Half hour delta: 02:00 -> 01:30 local at 2019-04-06 15:00Z.
+                return new DstWindow(
+                    TestTimeZones.LordHowe,
+                    new DateTimeOffset(2019, 4, 6, 13, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.LordHowe, new DateTime(2019, 4, 7, 1, 45, 0)));
+
+            case "SydneyFall":
+                // 03:00 AEDT -> 02:00 AEST at 2024-04-06 16:00Z.
+                return new DstWindow(
+                    TestTimeZones.Sydney,
+                    new DateTimeOffset(2024, 4, 6, 14, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Sydney, new DateTime(2024, 4, 7, 2, 30, 0)));
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(windowKey), windowKey, "unknown DST window");
+        }
+    }
+
+    private static ITrigger CreateTrigger(string triggerKind, TimeZoneInfo zone, DateTimeOffset windowStart)
+    {
+        switch (triggerKind)
+        {
+            case "CronMinutely":
+                return new CronTriggerImpl
+                {
+                    Key = new TriggerKey(triggerKind, "dst"),
+                    CronExpressionString = "0 * * * * ?",
+                    TimeZone = zone,
+                    StartTimeUtc = windowStart
+                };
+
+            case "CronHourly":
+                return new CronTriggerImpl
+                {
+                    Key = new TriggerKey(triggerKind, "dst"),
+                    CronExpressionString = "0 0 * * * ?",
+                    TimeZone = zone,
+                    StartTimeUtc = windowStart
+                };
+
+            case "CalendarIntervalHourly":
+                return new CalendarIntervalTriggerImpl
+                {
+                    Key = new TriggerKey(triggerKind, "dst"),
+                    StartTimeUtc = windowStart,
+                    RepeatInterval = 1,
+                    RepeatIntervalUnit = IntervalUnit.Hour,
+                    TimeZone = zone
+                };
+
+            case "CalendarIntervalDailyPreserve":
+                return new CalendarIntervalTriggerImpl
+                {
+                    Key = new TriggerKey(triggerKind, "dst"),
+                    StartTimeUtc = AnchorAtLocalHalfPastTwo(zone, windowStart),
+                    RepeatInterval = 1,
+                    RepeatIntervalUnit = IntervalUnit.Day,
+                    TimeZone = zone,
+                    PreserveHourOfDayAcrossDaylightSavings = true
+                };
+
+            case "DailyTimeIntervalQuarterHour":
+                return new DailyTimeIntervalTriggerImpl
+                {
+                    Key = new TriggerKey(triggerKind, "dst"),
+                    StartTimeUtc = windowStart,
+                    StartTimeOfDay = new TimeOfDay(0, 0, 0),
+                    EndTimeOfDay = new TimeOfDay(23, 59, 59),
+                    RepeatInterval = 15,
+                    RepeatIntervalUnit = IntervalUnit.Minute,
+                    TimeZone = zone
+                };
+
+            case "SimpleHalfHour":
+                return new SimpleTriggerImpl
+                {
+                    Key = new TriggerKey(triggerKind, "dst"),
+                    StartTimeUtc = windowStart,
+                    RepeatInterval = TimeSpan.FromMinutes(30),
+                    RepeatCount = SimpleTriggerImpl.RepeatIndefinitely
+                };
+
+            case "RecurrenceHourly":
+                return new RecurrenceTriggerImpl
+                {
+                    Key = new TriggerKey(triggerKind, "dst"),
+                    RecurrenceRule = "FREQ=HOURLY;INTERVAL=1",
+                    TimeZone = zone,
+                    StartTimeUtc = windowStart
+                };
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(triggerKind), triggerKind, "unknown trigger kind");
+        }
+    }
+
+    /// <summary>
+    /// Anchors a daily schedule at 02:30 local a few days before the window, so that the daily fire
+    /// lands squarely on the wall clock the transition attacks.
+    /// </summary>
+    private static DateTimeOffset AnchorAtLocalHalfPastTwo(TimeZoneInfo zone, DateTimeOffset windowStart)
+    {
+        DateTime localWindowStart = TimeZoneInfo.ConvertTime(windowStart, zone).DateTime;
+        DateTime anchorLocal = localWindowStart.Date.AddDays(-3).AddHours(2).AddMinutes(30);
+        return new DateTimeOffset(anchorLocal, zone.GetUtcOffset(anchorLocal));
+    }
+
+    [TestCase("CronMinutely", "EasternSpring", "2024-03-10 05:00 +00:00", 90)]
+    [TestCase("CronMinutely", "EasternFall", "2024-11-03 04:00 +00:00", 90)]
+    [TestCase("CronMinutely", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 90)]
+    [TestCase("CronMinutely", "SantiagoSpring", "2019-09-08 02:00 +00:00", 90)]
+    [TestCase("CronMinutely", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
+    [TestCase("CronMinutely", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
+    [TestCase("CronMinutely", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    [TestCase("CronHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 150)]
+    [TestCase("CronHourly", "EasternFall", "2024-11-03 04:00 +00:00", 150)]
+    [TestCase("CronHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 150)]
+    [TestCase("CronHourly", "SantiagoSpring", "2019-09-08 02:00 +00:00", 150)]
+    [TestCase("CronHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 150)]
+    [TestCase("CronHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 150)]
+    [TestCase("CronHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 150)]
+    [TestCase("CalendarIntervalHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "EasternFall", "2024-11-03 04:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "SantiagoSpring", "2019-09-08 02:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    // A daily schedule that preserves its wall clock spans the 25 hour fall back day, so the bound
+    // is 26 hours. Observed maximum across these seven windows is exactly 25 hours (Central European
+    // and Sydney fall back); the spare hour absorbs a zone whose delta is larger than one hour.
+    [TestCase("CalendarIntervalDailyPreserve", "EasternSpring", "2024-03-10 05:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "EasternFall", "2024-11-03 04:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "SantiagoSpring", "2019-09-08 02:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "LordHoweSpring", "2019-10-05 13:30 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "LordHoweFall", "2019-04-06 13:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "SydneyFall", "2024-04-06 14:00 +00:00", 26 * 60)]
+    [TestCase("DailyTimeIntervalQuarterHour", "EasternSpring", "2024-03-10 05:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "EasternFall", "2024-11-03 04:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "SantiagoSpring", "2019-09-08 02:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    [TestCase("SimpleHalfHour", "EasternSpring", "2024-03-10 05:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "EasternFall", "2024-11-03 04:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "SantiagoSpring", "2019-09-08 02:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "LordHoweSpring", "2019-10-05 13:30 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "LordHoweFall", "2019-04-06 13:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "SydneyFall", "2024-04-06 14:00 +00:00", 31)]
+    [TestCase("RecurrenceHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "EasternFall", "2024-11-03 04:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "SantiagoSpring", "2019-09-08 02:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 150)]
+    public void FireTimesProgressMonotonicallyAcrossTransition(
+        string triggerKind,
+        string windowKey,
+        string windowStart,
+        int maxStepMinutes)
+    {
+        DstWindow window = ResolveWindow(windowKey);
+        DateTimeOffset start = TestTimeZones.Local(windowStart);
+        start.Should().Be(window.Start, "the test case row and the window table must agree on the window start");
+        window.AssumePremise();
+
+        ITrigger trigger = CreateTrigger(triggerKind, window.Zone, start);
+        TimeSpan maxStep = TimeSpan.FromMinutes(maxStepMinutes);
+
+        List<DateTimeOffset> fireTimes = new List<DateTimeOffset>(StepCount);
+        DateTimeOffset current = start;
+        for (int i = 0; i < StepCount; i++)
+        {
+            DateTimeOffset? next = trigger.GetFireTimeAfter(current);
+
+            next.Should().NotBeNull(
+                "{0} must keep producing fire times in {1}, but stopped after {2:O} (step {3})",
+                triggerKind, window.Zone.Id, current, i + 1);
+
+            next.Value.Should().BeAfter(current,
+                "{0} fire times must strictly increase in {1} (step {2})", triggerKind, window.Zone.Id, i + 1);
+
+            (next.Value - current).Should().BeLessThanOrEqualTo(maxStep,
+                "{0} must not skip a whole schedule period around the {1} transition: {2:O} -> {3:O} (step {4})",
+                triggerKind, windowKey, current, next.Value, i + 1);
+
+            fireTimes.Add(next.Value);
+            current = next.Value;
+        }
+
+        fireTimes[fireTimes.Count - 1].Should().BeAfter(window.Transition,
+            "{0} steps of {1} must carry the walk past the {2} transition", StepCount, triggerKind, windowKey);
+    }
+}

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Globalization;
+
 using Quartz.Impl.Calendar;
 using Quartz.Util;
 
@@ -40,5 +41,77 @@ public class TimeZoneUtilTest
 
         var d = holidayCalendar.GetNextIncludedTimeUtc(time);
         d.Should().Be(expected);
+    }
+
+    // The wall-clock overload GetUtcOffset(DateTime, ..) implements the trigger-wide DST policy:
+    // an ambiguous local time resolves to the DAYLIGHT offset, i.e. the first of the two occurrences.
+    [TestCase("Eastern", "2024-11-03 01:30", -4.0)]
+    [TestCase("CentralEuropean", "2018-10-28 02:30", 2.0)]
+    [TestCase("LordHowe", "2019-04-07 01:45", 11.0)]
+    [TestCase("Santiago", "2019-04-06 23:30", -3.0)]
+    public void GetUtcOffset_AmbiguousLocalTime_ReturnsDaylightOffset(string zoneKey, string localTime, double expectedOffsetHours)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        TimeZoneUtil.GetUtcOffset(local, zone).Should().Be(TimeSpan.FromHours(expectedOffsetHours));
+    }
+
+    // An invalid (spring-forward gap) local time is not special-cased: it resolves to the
+    // pre-transition offset, which places the resulting instant at the first wall-clock time that
+    // does exist, shifted forward by the transition delta. Every trigger type inherits this rule.
+    [TestCase("Eastern", "2024-03-10 02:30", -5.0)]
+    [TestCase("LordHowe", "2019-10-06 02:15", 10.5)]
+    [TestCase("Santiago", "2019-09-08 00:30", -4.0)]
+    public void GetUtcOffset_InvalidLocalTime_ReturnsPreTransitionOffset(string zoneKey, string localTime, double expectedOffsetHours)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, local);
+
+        TimeZoneUtil.GetUtcOffset(local, zone).Should().Be(TimeSpan.FromHours(expectedOffsetHours));
+    }
+
+    [Test]
+    public void GetUtcOffset_InstantOverload_AppliesNoAmbiguityPolicy()
+    {
+        // The DateTimeOffset overload resolves from the instant and never consults the ambiguity
+        // policy, so for the second (standard) occurrence of an ambiguous wall-clock time the two
+        // overloads disagree. Call sites that mean "resolve this wall-clock time" must pass
+        // .DateTime explicitly or they silently lose the policy.
+        TimeZoneInfo eastern = TestTimeZones.Eastern;
+        DateTimeOffset standardPassInstant = TestTimeZones.Local("2024-11-03 01:30 -05:00");
+        TestTimeZones.AssumeAmbiguousLocalTime(eastern, standardPassInstant.DateTime);
+
+        TimeZoneUtil.GetUtcOffset(standardPassInstant, eastern).Should().Be(TimeSpan.FromHours(-5));
+        TimeZoneUtil.GetUtcOffset(standardPassInstant.DateTime, eastern).Should().Be(TimeSpan.FromHours(-4));
+    }
+
+    [TestCase("US/Eastern", "Eastern Standard Time")]
+    [TestCase("CET", "Central European Standard Time")]
+    public void FindTimeZoneById_ResolvesAliasPairsOnAnyPlatform(string first, string second)
+    {
+        TimeZoneInfo firstZone = TimeZoneUtil.FindTimeZoneById(first);
+        TimeZoneInfo secondZone = TimeZoneUtil.FindTimeZoneById(second);
+
+        firstZone.BaseUtcOffset.Should().Be(secondZone.BaseUtcOffset);
+    }
+
+    private static TimeZoneInfo ResolveZone(string zoneKey)
+    {
+        switch (zoneKey)
+        {
+            case "Eastern":
+                return TestTimeZones.Eastern;
+            case "CentralEuropean":
+                return TestTimeZones.CentralEuropean;
+            case "Santiago":
+                return TestTimeZones.Santiago;
+            case "LordHowe":
+                return TestTimeZones.LordHowe;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test zone");
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -88,6 +88,114 @@ public class TimeZoneUtilTest
         TimeZoneUtil.GetUtcOffset(standardPassInstant.DateTime, eastern).Should().Be(TimeSpan.FromHours(-4));
     }
 
+    // ResolveLocal must agree with the wall-clock GetUtcOffset policy for every time that exists
+    [TestCase("Eastern", "2024-11-03 01:30")]
+    [TestCase("CentralEuropean", "2018-10-28 02:30")]
+    [TestCase("LordHowe", "2019-04-07 01:45")]
+    [TestCase("Santiago", "2019-04-06 23:30")]
+    public void ResolveLocal_AmbiguousLocalTime_MatchesDaylightPolicy(string zoneKey, string localTime)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(local, zone);
+
+        resolved.DateTime.Should().Be(local, "the wall clock must be kept as given");
+        resolved.Offset.Should().Be(TimeZoneUtil.GetUtcOffset(local, zone), "an ambiguous time resolves to the daylight/first occurrence");
+    }
+
+    // An in-gap time pairs with the pre-transition offset, which renders in the zone as the same
+    // wall clock shifted forward by the transition delta
+    [TestCase("Eastern", "2024-03-10 02:30", -5.0, "2024-03-10 03:30")]
+    [TestCase("LordHowe", "2019-10-06 02:15", 10.5, "2019-10-06 02:45")]
+    [TestCase("Santiago", "2019-09-08 00:30", -4.0, "2019-09-08 01:30")]
+    public void ResolveLocal_InvalidLocalTime_ShiftsForwardByTransitionDelta(string zoneKey, string localTime, double expectedOffsetHours, string expectedRenderedLocal)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, local);
+
+        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(local, zone);
+
+        resolved.Offset.Should().Be(TimeSpan.FromHours(expectedOffsetHours), "an in-gap time pairs with the offset in effect just before the gap");
+        TimeZoneInfo.ConvertTime(resolved, zone).DateTime
+            .Should().Be(DateTime.Parse(expectedRenderedLocal, CultureInfo.InvariantCulture), "the instant renders in the zone at the delta-shifted wall clock");
+    }
+
+    // Differential guard: for every wall-clock minute around each transition of the test zones,
+    // ResolveLocal must produce exactly the instant the trigger code produced before it existed
+    // (pairing the local time with the wall-clock GetUtcOffset policy). Positive-daylight-delta
+    // zones must be bit-identical, gaps included.
+    [TestCase("Eastern", "2024-03-10 02:00")]
+    [TestCase("Eastern", "2024-11-03 01:30")]
+    [TestCase("CentralEuropean", "2018-03-25 02:30")]
+    [TestCase("CentralEuropean", "2018-10-28 02:30")]
+    [TestCase("Santiago", "2019-09-08 00:30")]
+    [TestCase("Santiago", "2019-04-06 23:30")]
+    [TestCase("LordHowe", "2019-10-06 02:15")]
+    [TestCase("LordHowe", "2019-04-07 01:45")]
+    public void ResolveLocal_MatchesLegacyResolution_AroundTransition(string zoneKey, string transitionLocal)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime center = DateTime.Parse(transitionLocal, CultureInfo.InvariantCulture);
+
+        for (int minute = -180; minute <= 180; minute++)
+        {
+            DateTime probe = center.AddMinutes(minute);
+            DateTimeOffset legacy = new DateTimeOffset(probe, TimeZoneUtil.GetUtcOffset(probe, zone));
+            TimeZoneUtil.ResolveLocal(probe, zone).Should().Be(legacy, $"probe {probe:yyyy-MM-dd HH:mm} must resolve exactly as the previous inline logic did");
+        }
+    }
+
+    [TestCase("Eastern", "2024-03-10 02:30", "2024-03-10 03:00")]
+    [TestCase("LordHowe", "2019-10-06 02:15", "2019-10-06 02:30")]
+    [TestCase("Santiago", "2019-09-08 00:30", "2019-09-08 01:00")]
+    public void WalkToGapEnd_ReturnsFirstValidWallClockTime(string zoneKey, string invalidLocal, string expectedGapEnd)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(invalidLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, local);
+
+        TimeZoneUtil.WalkToGapEnd(local, zone).Should().Be(DateTime.Parse(expectedGapEnd, CultureInfo.InvariantCulture));
+
+        // noon, not midnight - in a midnight-gap zone like Santiago the date's own 00:00 is invalid
+        DateTime alreadyValid = local.Date.AddHours(12);
+        TimeZoneUtil.WalkToGapEnd(alreadyValid, zone).Should().Be(alreadyValid, "a valid time is returned unchanged");
+    }
+
+    [Test]
+    public void ResolveLocal_NegativeDaylightDeltaZone_DoesNotMoveBackwards()
+    {
+        // Europe/Dublin as modeled by TZif data (Linux/macOS) flags WINTER as the daylight period
+        // with a negative delta, so TimeZoneInfo.GetUtcOffset for an in-gap time returns the
+        // POST-gap offset there; pairing with it would produce an instant before the gap. On
+        // Windows the zone is modeled with a positive delta and this test self-skips.
+        TimeZoneInfo dublin;
+        try
+        {
+            dublin = TimeZoneUtil.FindTimeZoneById("Europe/Dublin");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            Assert.Ignore("Europe/Dublin is not available on this system");
+            return;
+        }
+
+        DateTime inGap = new DateTime(2024, 3, 31, 1, 30, 0);
+        Assume.That(dublin.IsInvalidTime(inGap), "test premise: 2024-03-31 01:30 should not exist in Europe/Dublin");
+
+        bool negativeDelta = dublin.GetAdjustmentRules()
+            .Any(rule => rule.DateStart <= inGap && inGap <= rule.DateEnd && rule.DaylightDelta < TimeSpan.Zero);
+        Assume.That(negativeDelta, "test premise: the zone data models Dublin with a negative daylight delta (TZif); on Windows this is positive and the hazard does not exist");
+
+        DateTimeOffset justBeforeGap = new DateTimeOffset(new DateTime(2024, 3, 31, 0, 59, 0), dublin.GetUtcOffset(new DateTime(2024, 3, 31, 0, 59, 0)));
+        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(inGap, dublin);
+
+        resolved.Should().BeAfter(justBeforeGap, "an in-gap time must resolve forward across the gap, never backwards");
+        TimeZoneInfo.ConvertTime(resolved, dublin).DateTime.Should().Be(new DateTime(2024, 3, 31, 2, 30, 0), "the instant renders at the delta-shifted wall clock after the gap");
+    }
+
     [TestCase("US/Eastern", "Eastern Standard Time")]
     [TestCase("CET", "Central European Standard Time")]
     public void FindTimeZoneById_ResolvesAliasPairsOnAnyPlatform(string first, string second)

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -148,6 +148,31 @@ public class TimeZoneUtilTest
         }
     }
 
+    [TestCase("Eastern", "2024-11-03 01:30", "2024-11-03 01:00", "2024-11-03 02:00")]
+    [TestCase("CentralEuropean", "2018-10-28 02:30", "2018-10-28 02:00", "2018-10-28 03:00")]
+    [TestCase("LordHowe", "2019-04-07 01:45", "2019-04-07 01:30", "2019-04-07 02:00")]
+    [TestCase("Santiago", "2019-04-06 23:30", "2019-04-06 23:00", "2019-04-07 00:00")]
+    public void TryGetAmbiguousWindow_ReturnsWallClockWindow(string zoneKey, string ambiguousLocal, string expectedStart, string expectedEnd)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(ambiguousLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        TimeZoneUtil.TryGetAmbiguousWindow(local, zone, out DateTime windowStart, out DateTime windowEnd).Should().BeTrue();
+
+        windowStart.Should().Be(DateTime.Parse(expectedStart, CultureInfo.InvariantCulture));
+        windowEnd.Should().Be(DateTime.Parse(expectedEnd, CultureInfo.InvariantCulture));
+
+        // pairing the window start with the standard (smaller) offset yields the transition instant,
+        // which renders in the zone as the window start itself - the first instant of the second pass
+        TimeSpan standardOffset = zone.GetAmbiguousTimeOffsets(local).Min();
+        DateTimeOffset transition = new DateTimeOffset(windowStart, standardOffset);
+        TimeZoneInfo.ConvertTime(transition, zone).DateTime.Should().Be(windowStart);
+
+        TimeZoneUtil.TryGetAmbiguousWindow(local.Date.AddHours(12), zone, out _, out _)
+            .Should().BeFalse("noon is not ambiguous");
+    }
+
     [TestCase("Eastern", "2024-03-10 02:30", "2024-03-10 03:00")]
     [TestCase("LordHowe", "2019-10-06 02:15", "2019-10-06 02:30")]
     [TestCase("Santiago", "2019-09-08 00:30", "2019-09-08 01:00")]

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -222,6 +222,15 @@ public sealed class CronExpression : ISerializable
     [NonSerialized] private readonly CronField years = [];
 
     /// <summary>
+    /// True when a second, minute or hour field uses a wildcard, step or range - the expression
+    /// means "fire every interval" rather than "fire at this time of day". Set during parsing,
+    /// never serialized (deserialization re-parses the expression string).
+    /// </summary>
+    [NonSerialized] private bool hasIntervalSemantics;
+
+    internal bool HasIntervalSemantics => hasIntervalSemantics;
+
+    /// <summary>
     /// Last day of week.
     /// </summary>
     [NonSerialized] private bool lastDayOfWeek;
@@ -820,6 +829,17 @@ public sealed class CronExpression : ISerializable
                     Throw.FormatException("Support for specifying multiple \"nth\" days is not implemented.");
                 }
 
+                // A second, minute or hour field written as a wildcard, step or range expresses an
+                // interval ("keep firing every ...") rather than a fixed time of day. The
+                // distinction drives the fall-back behavior in GetTimeAfter: interval expressions
+                // fire through both occurrences of the repeated wall-clock window, fixed times only
+                // through the first. Plain values and comma lists of plain values stay fixed-time.
+                if (exprOn <= CronExpressionConstants.Hour
+                    && (expr.IndexOf('*') != -1 || expr.IndexOf('/') != -1 || expr.IndexOf('-') != -1))
+                {
+                    hasIntervalSemantics = true;
+                }
+
                 if (expr.IndexOf(',') != -1)
                 {
                     foreach (var v in expr.SpanSplit(','))
@@ -867,6 +887,7 @@ public sealed class CronExpression : ISerializable
         years.Clear();
         lastDaySpecs = null;
         nearestWeekdays = null;
+        hasIntervalSemantics = false;
     }
 
     private void StoreExpressionQuestionMark(int type, ReadOnlySpan<char> s, int i)
@@ -2391,7 +2412,64 @@ public sealed class CronExpression : ISerializable
             }
         }
 
+        if (hasIntervalSemantics && TimeZone.SupportsDaylightSavingTime)
+        {
+            d = ApplySecondAmbiguousPassIfNeeded(d, afterTimeUtcFloor);
+        }
+
         return d.ToUniversalTime();
+    }
+
+    /// <summary>
+    /// Makes interval expressions fire through both occurrences of the repeated fall-back window.
+    /// </summary>
+    /// <remarks>
+    /// The wall-clock walk in <see cref="GetTimeAfter"/> steps straight from the last wall-clock
+    /// minute of the ambiguous window to the first one after it, so when the search starts inside
+    /// the window's first (daylight) pass the entire second (standard) pass would be skipped - an
+    /// "every minute" schedule would silently not fire for a whole hour of real time. When that
+    /// happens, this re-runs the search from the transition instant: inside that call the
+    /// fall-back demotion resolves the found wall-clock time to its second occurrence, and the
+    /// recursion terminates because the restarted search no longer begins in the daylight pass.
+    /// Fixed-time expressions keep the fire-once-at-first-occurrence rule.
+    /// </remarks>
+    private DateTimeOffset ApplySecondAmbiguousPassIfNeeded(DateTimeOffset candidate, DateTimeOffset afterTimeUtcFloor)
+    {
+        var afterLocal = TimeZoneUtil.ConvertTime(afterTimeUtcFloor, TimeZone);
+        DateTime afterWallClock = afterLocal.DateTime;
+
+        if (!TimeZone.IsAmbiguousTime(afterWallClock))
+        {
+            return candidate;
+        }
+
+        TimeSpan[] offsets = TimeZone.GetAmbiguousTimeOffsets(afterWallClock);
+        TimeSpan daylightOffset = offsets.Max();
+        if (afterLocal.Offset != daylightOffset)
+        {
+            // already inside the second (standard) pass; the demotion in GetTimeAfter walks it
+            return candidate;
+        }
+
+        if (!TimeZoneUtil.TryGetAmbiguousWindow(afterWallClock, TimeZone, out DateTime windowStart, out _))
+        {
+            return candidate;
+        }
+
+        var secondPassStart = new DateTimeOffset(windowStart, offsets.Min());
+        if (candidate.ToUniversalTime() < secondPassStart.ToUniversalTime())
+        {
+            // the next fire is still inside the first pass; nothing was skipped yet
+            return candidate;
+        }
+
+        DateTimeOffset? secondPassFire = GetTimeAfter(secondPassStart.AddSeconds(-1));
+        if (secondPassFire is not null && secondPassFire.Value < candidate.ToUniversalTime())
+        {
+            return secondPassFire.Value;
+        }
+
+        return candidate;
     }
 
     /// <summary>

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -2324,6 +2324,13 @@ public sealed class CronExpression : ISerializable
     /// <summary>
     /// Gets the next fire time after the given time.
     /// </summary>
+    /// <remarks>
+    /// Daylight saving time transitions in the configured <see cref="TimeZone"/> are handled as
+    /// follows: a scheduled wall-clock time that does not exist (spring-forward gap) fires exactly
+    /// once, shifted forward by the transition delta — a daily 02:30 schedule over a 02:00-03:00
+    /// gap fires at 03:30. This matches Java Quartz. A wall-clock time that occurs twice
+    /// (fall-back overlap) fires at its first occurrence.
+    /// </remarks>
     /// <param name="afterTimeUtc">The UTC time to start searching from.</param>
     /// <returns></returns>
     public DateTimeOffset? GetTimeAfter(DateTimeOffset afterTimeUtc)
@@ -2334,6 +2341,10 @@ public sealed class CronExpression : ISerializable
 
         // CronTrigger does not deal with milliseconds
         var d = CreateDateTimeWithoutMilliseconds(afterTimeUtc);
+
+        // the whole-second floor the search starts from; sub-second ticks on afterTimeUtc must not
+        // influence the fall-back demotion below or the result stops being monotonic in the input
+        var afterTimeUtcFloor = d;
 
         // change to specified time zone
         d = TimeZoneUtil.ConvertTime(d, TimeZone);
@@ -2361,20 +2372,22 @@ public sealed class CronExpression : ISerializable
 
             // apply the proper offset for this date
             var localDateTime = nextFireTimeCursor.Date.Value.DateTime;
-            d = new DateTimeOffset(localDateTime, TimeZoneUtil.GetUtcOffset(localDateTime, TimeZone));
+            d = TimeZoneUtil.ResolveLocal(localDateTime, TimeZone);
             foundNextFireTime = true;
 
-            // During DST fall-back transitions, an ambiguous local time may have been
-            // assigned the DST (summer) offset by GetUtcOffset, which picks the first
-            // (DST) occurrence. This can result in a UTC time that is before afterTimeUtc,
-            // causing infinite trigger fires. In that case, use the standard (non-DST)
-            // offset instead, which corresponds to the second occurrence of the local time.
-            // DST always shifts the offset by +1 hour, so the standard offset is always
-            // Min() and the DST offset is always Max() of the two ambiguous offsets.
-            if (d.ToUniversalTime() < afterTimeUtc && TimeZone.IsAmbiguousTime(localDateTime))
+            // During DST fall-back transitions an ambiguous local time resolves to its first
+            // occurrence. When the search started inside the repeated interval, that occurrence
+            // can precede the search floor, which would make the trigger fire endlessly. In that
+            // case use the other occurrence of the same wall-clock time: the earlier occurrence
+            // always carries the greater offset, so the later one is Min() of the two ambiguous
+            // offsets, whatever the size or sign of the zone's daylight delta. Compare against
+            // the whole-second floor the search actually started from - comparing against a
+            // sub-second afterTimeUtc would demote a valid fire, making the result non-monotonic
+            // in the input and breaking GetTimeBefore's binary search.
+            if (d.ToUniversalTime() < afterTimeUtcFloor && TimeZone.IsAmbiguousTime(localDateTime))
             {
-                TimeSpan standardOffset = TimeZone.GetAmbiguousTimeOffsets(localDateTime).Min();
-                d = new DateTimeOffset(localDateTime, standardOffset);
+                TimeSpan laterOccurrenceOffset = TimeZone.GetAmbiguousTimeOffsets(localDateTime).Min();
+                d = new DateTimeOffset(localDateTime, laterOccurrenceOffset);
             }
         }
 

--- a/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
+++ b/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
@@ -373,8 +373,8 @@ public sealed class DailyTimeIntervalScheduleBuilder : ScheduleBuilder<IDailyTim
 
         //apply proper offsets according to timezone
         TimeZoneInfo targetTimeZone = timeZone ?? TimeZoneInfo.Local;
-        startTimeOfDayDate = new DateTimeOffset(startTimeOfDayDate.DateTime, TimeZoneUtil.GetUtcOffset(startTimeOfDayDate.DateTime, targetTimeZone));
-        tomorrow = new DateTimeOffset(tomorrow.DateTime, TimeZoneUtil.GetUtcOffset(tomorrow.DateTime, targetTimeZone));
+        startTimeOfDayDate = TimeZoneUtil.ResolveLocal(startTimeOfDayDate.DateTime, targetTimeZone);
+        tomorrow = TimeZoneUtil.ResolveLocal(tomorrow.DateTime, targetTimeZone);
 
         TimeSpan remainingMillisInDay = tomorrow - startTimeOfDayDate;
         TimeSpan intervalInMillis;

--- a/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
+++ b/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
@@ -808,36 +808,17 @@ internal sealed class RecurrenceRule
         // Check if time falls in a DST gap (spring forward)
         if (tz.IsInvalidTime(local))
         {
-            // Advance past the gap by computing the DST transition delta
-            TimeSpan adjustment = tz.GetUtcOffset(local.AddHours(2)) - tz.GetUtcOffset(local.AddHours(-2));
-            if (adjustment > TimeSpan.Zero)
-            {
-                local = local.Add(adjustment);
-            }
-            else
-            {
-                local = local.AddHours(1);
-            }
+            // Resolve the nonexistent wall-clock time to its shifted instant, then take the zone's
+            // canonical rendering so the returned value carries a valid wall clock (e.g. a daily
+            // 02:30 in a one hour gap comes back as 03:30 at the post-transition offset). Deriving
+            // the shift this way is robust for transition deltas that are not whole hours and for
+            // zones modeled with a negative daylight delta.
+            return TimeZoneInfo.ConvertTime(TimeZoneUtil.ResolveLocal(local, tz), tz);
         }
 
-        TimeSpan offset = tz.GetUtcOffset(local);
-
-        // For ambiguous times (DST overlap / fall back), use the daylight offset
-        // (the larger UTC offset = earlier UTC instant), matching CalendarIntervalTriggerImpl behavior
-        if (tz.IsAmbiguousTime(local))
-        {
-            TimeSpan[] offsets = tz.GetAmbiguousTimeOffsets(local);
-            offset = offsets[0];
-            for (int i = 1; i < offsets.Length; i++)
-            {
-                if (offsets[i] > offset)
-                {
-                    offset = offsets[i];
-                }
-            }
-        }
-
-        return new DateTimeOffset(local, offset);
+        // Ambiguous times (DST overlap / fall back) resolve to the daylight offset - the first of
+        // the two occurrences - matching the shared scheduler-wide policy.
+        return TimeZoneUtil.ResolveLocal(local, tz);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -837,7 +837,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
         {
             //first apply the date, and then find the proper timezone offset
             newTime = new DateTimeOffset(newTime.Year, newTime.Month, newTime.Day, initialHourOfDay, newTime.Minute, newTime.Second, newTime.Millisecond, TimeSpan.Zero);
-            newTime = new DateTimeOffset(newTime.DateTime, TimeZoneUtil.GetUtcOffset(newTime.DateTime, TimeZone));
+            newTime = TimeZoneUtil.ResolveLocal(newTime.DateTime, TimeZone);
 
             //TimeZone.IsInvalidTime is true, if this hour does not exist in the specified timezone
             bool isInvalid = TimeZone.IsInvalidTime(newTime.DateTime);
@@ -846,14 +846,13 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
             {
                 return SkipDayIfHourDoesNotExist;
             }
-            //don't skip this day, instead find closest valid time by adding minutes.
-            while (TimeZone.IsInvalidTime(newTime.DateTime))
-            {
-                newTime = newTime.AddMinutes(1);
-            }
 
-            //apply proper offset for the adjusted time
-            newTime = new DateTimeOffset(newTime.DateTime, TimeZoneUtil.GetUtcOffset(newTime.DateTime, TimeZone));
+            if (isInvalid)
+            {
+                //don't skip this day, instead find the closest valid time after the gap
+                //and apply the proper offset for the adjusted time
+                newTime = TimeZoneUtil.ResolveLocal(TimeZoneUtil.WalkToGapEnd(newTime.DateTime, TimeZone), TimeZone);
+            }
         }
         return false;
     }
@@ -875,7 +874,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
         {
             //first apply the date, and then find the proper timezone offset
             sTime = new DateTimeOffset(initalYear, initalMonth, initialDay, initialHourOfDay, sTime.Minute, sTime.Second, sTime.Millisecond, TimeSpan.Zero);
-            sTime = new DateTimeOffset(sTime.DateTime, TimeZoneUtil.GetUtcOffset(sTime.DateTime, TimeZone));
+            sTime = TimeZoneUtil.ResolveLocal(sTime.DateTime, TimeZone);
         }
     }
 

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -850,8 +850,12 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
                 if (daysOfWeek.Contains(dayOfWeekOfFireTime))
                 {
                     fireTime = fireTimeStartDateCal;
-                    // apply timezone for this date & time
-                    fireTime = new DateTimeOffset(fireTime.DateTime, TimeZoneUtil.GetUtcOffset(fireTime, TimeZone));
+                    // apply timezone for this date & time; resolve from the wall-clock time, not the
+                    // carried instant - the offset inherited through AddDays is stale when the walk
+                    // crosses a DST transition, and the instant-based overload would resolve an
+                    // in-gap start-of-day one transition delta too early, before the EndTimeUtc
+                    // check below sees it
+                    fireTime = new DateTimeOffset(fireTime.DateTime, TimeZoneUtil.GetUtcOffset(fireTime.DateTime, TimeZone));
                     break;
                 }
             }

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -669,13 +669,13 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         }
 
         // apply the proper offset for the end date
-        fireTimeEndDate = new DateTimeOffset(fireTimeEndDate.DateTime, TimeZoneUtil.GetUtcOffset(fireTimeEndDate.DateTime, TimeZone));
+        fireTimeEndDate = TimeZoneUtil.ResolveLocal(fireTimeEndDate.DateTime, TimeZone);
 
         // e. Check fireTime against startTime or startTimeOfDay to see which go first.
         DateTimeOffset fireTimeStartDate = startTimeOfDay.GetTimeOfDayForDate(fireTime.Value);
 
         // apply the proper offset for the start date
-        fireTimeStartDate = new DateTimeOffset(fireTimeStartDate.DateTime, TimeZoneUtil.GetUtcOffset(fireTimeStartDate.DateTime, TimeZone));
+        fireTimeStartDate = TimeZoneUtil.ResolveLocal(fireTimeStartDate.DateTime, TimeZone);
 
         if (fireTime < fireTimeStartDate)
         {
@@ -753,7 +753,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
 
             if (expectedLocalTime.Date != fireTime.Value.DateTime.Date)
             {
-                DateTimeOffset corrected = new DateTimeOffset(expectedLocalTime, TimeZoneUtil.GetUtcOffset(expectedLocalTime, TimeZone));
+                DateTimeOffset corrected = TimeZoneUtil.ResolveLocal(expectedLocalTime, TimeZone);
 
                 // GetFireTimeAfter must never move backwards
                 if (corrected > fireTime.Value)
@@ -797,8 +797,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
 
         // For a local time that does not exist (skipped by a spring-forward transition) the resolved
         // offset is the one from before the transition, which lands on the first instant that does exist.
-        DateTime localTime = startOfDay.Value.DateTime;
-        return new DateTimeOffset(localTime, TimeZoneUtil.GetUtcOffset(localTime, TimeZone));
+        return TimeZoneUtil.ResolveLocal(startOfDay.Value.DateTime, TimeZone);
     }
 
     /// <summary>
@@ -852,10 +851,10 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
                     fireTime = fireTimeStartDateCal;
                     // apply timezone for this date & time; resolve from the wall-clock time, not the
                     // carried instant - the offset inherited through AddDays is stale when the walk
-                    // crosses a DST transition, and the instant-based overload would resolve an
+                    // crosses a DST transition, and an instant-based resolution would place an
                     // in-gap start-of-day one transition delta too early, before the EndTimeUtc
                     // check below sees it
-                    fireTime = new DateTimeOffset(fireTime.DateTime, TimeZoneUtil.GetUtcOffset(fireTime.DateTime, TimeZone));
+                    fireTime = TimeZoneUtil.ResolveLocal(fireTime.DateTime, TimeZone);
                     break;
                 }
             }

--- a/src/Quartz/TimeOfDay.cs
+++ b/src/Quartz/TimeOfDay.cs
@@ -188,6 +188,12 @@ public sealed class TimeOfDay
     /// <summary>
     /// Return a date with time of day reset to this object values. The millisecond value will be zero.
     /// </summary>
+    /// <remarks>
+    /// The returned value inherits the offset carried by <paramref name="dateTime"/> without
+    /// consulting any time zone. Around a daylight saving transition that inherited offset can be
+    /// wrong for the produced wall-clock time (see #3190), so callers that cross transitions must
+    /// re-resolve the result, for example with <c>TimeZoneUtil.ResolveLocal</c>.
+    /// </remarks>
     /// <param name="dateTime"></param>
     public DateTimeOffset GetTimeOfDayForDate(DateTimeOffset dateTime)
     {

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -92,6 +92,62 @@ public static class TimeZoneUtil
     }
 
     /// <summary>
+    /// Transition scans are bounded so that a pathological time zone cannot loop forever;
+    /// no real transition gap or overlap is anywhere near this wide.
+    /// </summary>
+    private const int MaxTransitionScanMinutes = 48 * 60;
+
+    /// <summary>
+    /// Resolves a wall-clock time in the given zone to a <see cref="DateTimeOffset"/> using the
+    /// scheduler-wide daylight saving policy:
+    /// an ambiguous local time (fall-back overlap) resolves to the daylight offset — the first of
+    /// the two occurrences; a local time that does not exist (spring-forward gap) is paired with
+    /// the offset in effect just before the gap, which places the instant at the first wall-clock
+    /// time after the gap, shifted forward by the transition delta.
+    /// </summary>
+    /// <remarks>
+    /// For an in-gap time this differs from pairing with <see cref="TimeZoneInfo.GetUtcOffset(DateTime)"/>
+    /// only in zones whose daylight delta is negative (for example Europe/Dublin as modeled by TZif
+    /// data, where winter time is the daylight-flagged period): there the base offset is the
+    /// post-gap offset and pairing with it would produce an instant before the gap, moving time
+    /// backwards. The offset just before the gap is found by scanning backwards a minute at a time,
+    /// which also handles transition deltas that are not whole hours.
+    /// </remarks>
+    internal static DateTimeOffset ResolveLocal(DateTime dateTime, TimeZoneInfo timeZoneInfo)
+    {
+        if (timeZoneInfo.IsInvalidTime(dateTime))
+        {
+            DateTime probe = dateTime;
+            int guard = 0;
+            do
+            {
+                probe = probe.AddMinutes(-1);
+            } while (timeZoneInfo.IsInvalidTime(probe) && ++guard < MaxTransitionScanMinutes);
+
+            return new DateTimeOffset(dateTime, timeZoneInfo.GetUtcOffset(probe));
+        }
+
+        return new DateTimeOffset(dateTime, GetUtcOffset(dateTime, timeZoneInfo));
+    }
+
+    /// <summary>
+    /// Walks forward from a wall-clock time inside a spring-forward gap to the first wall-clock
+    /// time that exists in the given zone (the end of the gap). Returns the input unchanged when it
+    /// is already valid.
+    /// </summary>
+    internal static DateTime WalkToGapEnd(DateTime dateTime, TimeZoneInfo timeZoneInfo)
+    {
+        DateTime probe = dateTime;
+        int guard = 0;
+        while (timeZoneInfo.IsInvalidTime(probe) && guard++ < MaxTransitionScanMinutes)
+        {
+            probe = probe.AddMinutes(1);
+        }
+
+        return probe;
+    }
+
+    /// <summary>
     /// Tries to find time zone with given id, has ability do some fallbacks when necessary.
     /// </summary>
     /// <param name="id">System id of the time zone.</param>

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -131,6 +131,44 @@ public static class TimeZoneUtil
     }
 
     /// <summary>
+    /// Determines the wall-clock window that occurs twice around a fall-back transition. Returns
+    /// false when the given time is not ambiguous. On success <paramref name="windowStart"/> is the
+    /// first ambiguous wall-clock minute (pairing it with the standard offset yields the transition
+    /// instant, i.e. the first instant of the second pass) and <paramref name="windowEnd"/> is the
+    /// first wall-clock minute after the window. Boundaries are found by scanning a minute at a
+    /// time, which handles transition deltas that are not whole hours.
+    /// </summary>
+    internal static bool TryGetAmbiguousWindow(DateTime dateTime, TimeZoneInfo timeZoneInfo, out DateTime windowStart, out DateTime windowEnd)
+    {
+        if (!timeZoneInfo.IsAmbiguousTime(dateTime))
+        {
+            windowStart = default;
+            windowEnd = default;
+            return false;
+        }
+
+        DateTime minute = new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, 0, dateTime.Kind);
+
+        DateTime start = minute;
+        int guard = 0;
+        while (timeZoneInfo.IsAmbiguousTime(start.AddMinutes(-1)) && guard++ < MaxTransitionScanMinutes)
+        {
+            start = start.AddMinutes(-1);
+        }
+
+        DateTime end = minute;
+        guard = 0;
+        while (timeZoneInfo.IsAmbiguousTime(end) && guard++ < MaxTransitionScanMinutes)
+        {
+            end = end.AddMinutes(1);
+        }
+
+        windowStart = start;
+        windowEnd = end;
+        return true;
+    }
+
+    /// <summary>
     /// Walks forward from a wall-clock time inside a spring-forward gap to the first wall-clock
     /// time that exists in the given zone (the end of the gap). Returns the input unchanged when it
     /// is already valid.


### PR DESCRIPTION
## Summary

Port of the 3.x DST campaign to main, as three cherry-picked commits (#3195, #3196, #3198) with 4.0 adaptations kept inside the commits they belong to.

## What 4.0 adaptation was needed

- `IOperableTrigger` moved to `Quartz.Extensibility`.
- Trigger identity via `Key = new TriggerKey(..)` (the `Name`/`Group` setters are gone).
- `TriggerDstMisfireTests` reworked from the static `SystemTime` freeze onto main''s `TimeProvider` constructor injection (per-trigger `FixedTimeProvider`, same pattern as the existing misfire tests) — the fixture no longer needs `[NonParallelizable]`.
- `CronExpression.GetTimeAfter` was refactored on main (`NextFireTimeCursor` walk), so the #3198 changes there were applied by hand to the new structure: the whole-second `afterTimeUtcFloor` for the fall-back demotion, `TimeZoneUtil.ResolveLocal` at the offset-resolution site, and the corrected demotion comment.
- Test usings trimmed to main''s implicit-usings model.

## Verified on main, not assumed

- The full ported test corpus (~150 DST tests) passed on main **before** the fix commits — every fire-count pin (1439 fall-back walk, 276/300 day counts, Santiago 48-fire last-hour edge) holds identically on the 4.0 implementations.
- The two #3198 defects exist on main too: the sub-second demotion pins passed pre-fix in their "defect" form and the flipped regression tests pass post-fix; the #3196 `EndTimeUtc` overshoot cherry-picked onto an identical buggy line.
- Full unit suite: 1830 passed, 0 failed. Full solution build clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)