### PR TITLE
Fire interval cron expressions through both DST fall-back passes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,13 @@
 
   * `SystemTime` was removed as way to provide "now", you can inject `TimeProvider` via configuration or `UseTimeProvider(TimeProvider)` on the builder
 
+  * Cron expressions whose second, minute or hour field uses a wildcard, step or range (interval
+    expressions such as `0 * * * * ?` or `0 0/30 * * * ?`) now fire through **both** occurrences of the
+    wall-clock window that repeats when daylight saving time falls back. Previously the repeated window
+    fired only once, so an "every minute" schedule silently skipped an hour of real time. Fixed-time
+    expressions (such as `0 30 2 * * ?`, including comma lists like `0 0,30 2 * * ?`) keep firing once
+    per day, at the first occurrence of an ambiguous wall-clock time.
+
   * The `Equals(StringOperator? other)` method of **StringOperator** is now also virtual to allow it to be
     overridden in pair with `Equals(object? obj)` and `GetHashCode()`.
 

--- a/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
@@ -265,30 +265,18 @@ public class CronExpressionDstTests
         cron.IsSatisfiedBy(insideGapHour).Should().BeTrue("07:15Z is local 03:15 -04:00, an ordinary matching minute");
     }
 
-    #region Current-behavior pins (decision points)
-
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — known deviation, expected to change on main/4.0.
+    /// Interval expressions fire through BOTH occurrences of the repeated fall-back window: an
+    /// "every minute" schedule means 1500 minute fires in a 25 hour day (1499 in this walk, which
+    /// excludes both boundary instants).
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// A sequential walk of an interval (minutely) expression across a fall-back transition
-    /// currently SKIPS the entire repeated standard-pass hour. After the last daylight-pass fire at
-    /// 02:59 +02:00 (00:59Z) the next fire produced is 03:00 +01:00 (02:00Z), so the whole UTC hour
-    /// [01:00Z, 02:00Z) — local 02:00-02:59 +01:00 — never fires. The cause is that the wall clock
-    /// walk advances 02:59 to 03:00 and only then resolves the offset; 03:00 is unambiguous, so the
-    /// standard-offset repeat of 02:xx is never visited.
-    /// </para>
-    /// <para>
-    /// This violates the rule that interval expressions should fire in BOTH fall-back passes (the
-    /// Cronos invariant, and what an "every minute" schedule means to a user: 25 fires per hour-of
-    /// -day on this date, 1500 minute fires in a 25 hour day). The flip target is 1499 fires
-    /// (25 * 60 - 1, the walk excluding both boundary instants) plus PRESENCE of fires inside
-    /// [01:00Z, 02:00Z), replacing the 1439 and the emptiness assertion pinned here.
-    /// </para>
+    /// The wall-clock walk steps from 02:59 +02:00 to 03:00, so on its own it would skip the
+    /// standard-offset repeat of 02:xx entirely; <c>ApplySecondAmbiguousPassIfNeeded</c> re-enters
+    /// the window at the transition instant and the fall-back demotion then walks the second pass.
     /// </remarks>
     [Test]
-    public void SequentialWalk_MinutelyCron_FallBackDay_CurrentlySkipsRepeatedStandardHour()
+    public void SequentialWalk_MinutelyCron_FallBackDay_FiresThroughBothPassesOfRepeatedHour()
     {
         TimeZoneInfo zone = TestTimeZones.CentralEuropean;
         TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
@@ -300,39 +288,22 @@ public class CronExpressionDstTests
 
         List<DateTimeOffset> fireTimes = TestTimeZones.Walk(cron.GetTimeAfter, dayStart, dayEnd);
 
-        // 25 real hours, minus both excluded boundary instants, would be 1499 fires. 60 of them —
-        // the standard pass over local 02:00-02:59 — are currently skipped.
-        fireTimes.Should().HaveCount(1439, "the repeated standard-pass hour is currently skipped entirely");
+        fireTimes.Should().HaveCount(1499, "the 25 hour day fires every real minute, both walk boundaries excluded");
 
         DateTimeOffset repeatedHourStart = TestTimeZones.Local("2018-10-28 01:00 +00:00");
         DateTimeOffset repeatedHourEnd = TestTimeZones.Local("2018-10-28 02:00 +00:00");
 
-        fireTimes.Should().NotContain(
-            fire => fire >= repeatedHourStart && fire < repeatedHourEnd,
-            "the sequential walk currently jumps from 02:59 +02:00 straight to 03:00 +01:00");
+        fireTimes.Count(fire => fire >= repeatedHourStart && fire < repeatedHourEnd)
+            .Should().Be(60, "the standard pass over local 02:00-02:59 fires every minute");
     }
 
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.
+    /// <see cref="CronExpression.IsSatisfiedBy" /> and the sequential walk agree inside the
+    /// repeated standard-pass hour: the instants the walk schedules are the instants the
+    /// expression matches.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <see cref="CronExpression.IsSatisfiedBy" /> answers TRUE for instants inside the repeated
-    /// standard-pass hour that the sequential walk never produces. It is implemented as
-    /// <c>GetTimeAfter(instant - 1s) == instant</c>, and starting the search from just inside that
-    /// hour makes the daylight interpretation land before the "after" instant, which triggers the
-    /// demotion to the standard offset and reproduces the instant exactly. Starting the search from
-    /// BEFORE the transition never reaches it.
-    /// </para>
-    /// <para>
-    /// So the same expression both matches and does not schedule the same instant, depending only
-    /// on where the question is asked from. Pinned here in one place. Once the walk fires in both
-    /// passes this test becomes redundant with the walk simply containing the hour, and the
-    /// emptiness assertion below should be deleted.
-    /// </para>
-    /// </remarks>
     [Test]
-    public void IsSatisfiedBy_RepeatedHourStandardPass_TrueButNeverProducedByWalk()
+    public void IsSatisfiedBy_RepeatedHourStandardPass_AgreesWithSequentialWalk()
     {
         TimeZoneInfo zone = TestTimeZones.CentralEuropean;
         TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
@@ -348,14 +319,99 @@ public class CronExpressionDstTests
             TestTimeZones.Local("2018-10-28 00:55 +02:00"),
             TestTimeZones.Local("2018-10-28 04:00 +01:00"));
 
-        DateTimeOffset repeatedHourStart = TestTimeZones.Local("2018-10-28 01:00 +00:00");
-        DateTimeOffset repeatedHourEnd = TestTimeZones.Local("2018-10-28 02:00 +00:00");
-
-        fireTimes.Should().NotBeEmpty();
-        fireTimes.Should().NotContain(
-            fire => fire >= repeatedHourStart && fire < repeatedHourEnd,
-            "a walk across the transition never schedules the instant IsSatisfiedBy just accepted");
+        fireTimes.Should().Contain(standardPassInstant, "the walk schedules the instant IsSatisfiedBy accepts");
     }
+
+    /// <summary>
+    /// The interval-vs-fixed-time distinction is decided at parse time, from the second, minute
+    /// and hour fields only: a wildcard, step or range means "fire every interval"; plain values
+    /// and comma lists mean "fire at these times of day". Day, month and year fields never
+    /// contribute.
+    /// </summary>
+    [TestCase("0 * * * * ?", true)]
+    [TestCase("*/30 0 2 * * ?", true)]
+    [TestCase("0 0/30 2 * * ?", true)]
+    [TestCase("0 30 1-9 * * ?", true)]
+    [TestCase("0 15,45 2-4 * * ?", true)]
+    [TestCase("0 30 2 * * ?", false)]
+    [TestCase("0 0,30 2 * * ?", false)]
+    [TestCase("0 30 2 1-15 * ?", false)]
+    [TestCase("0 30 2 ? * MON-FRI", false)]
+    public void HasIntervalSemantics_SetForWildcardStepAndRangeInTimeFields(string expression, bool expected)
+    {
+        CronExpression cron = new CronExpression(expression);
+
+        cron.HasIntervalSemantics.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// An hourly interval expression fires every real hour of the 25 hour fall-back day - the
+    /// 02:00 wall clock runs at both of its occurrences.
+    /// </summary>
+    [Test]
+    public void SequentialWalk_HourlyCron_FallBackDay_FiresEveryRealHour()
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
+
+        CronExpression cron = CronIn("0 0 * * * ?", zone);
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            cron.GetTimeAfter,
+            TestTimeZones.Local("2018-10-28 00:00 +02:00"),
+            TestTimeZones.Local("2018-10-29 00:00 +01:00"));
+
+        fireTimes.Should().HaveCount(24, "25 hourly instants in the local day, both walk boundaries excluded");
+        fireTimes.Should().Contain(TestTimeZones.Local("2018-10-28 02:00 +02:00"), "the first occurrence of 02:00 fires");
+        fireTimes.Should().Contain(TestTimeZones.Local("2018-10-28 02:00 +01:00"), "the second occurrence of 02:00 fires too");
+    }
+
+    /// <summary>
+    /// A comma list of plain values is a fixed-time expression: each listed time fires once, at
+    /// its first (daylight) occurrence, and the second pass of the repeated window is skipped.
+    /// </summary>
+    [Test]
+    public void FixedTimeCommaList_FallBackDay_FiresOnlyFirstPass()
+    {
+        TimeZoneInfo zone = TestTimeZones.CentralEuropean;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2018-10-28 02:30"));
+
+        CronExpression cron = CronIn("0 0,30 2 * * ?", zone);
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            cron.GetTimeAfter,
+            TestTimeZones.Local("2018-10-28 00:00 +02:00"),
+            TestTimeZones.Local("2018-10-29 00:00 +01:00"));
+
+        fireTimes.Should().Equal(
+            TestTimeZones.Local("2018-10-28 02:00 +02:00"),
+            TestTimeZones.Local("2018-10-28 02:30 +02:00"));
+    }
+
+    /// <summary>
+    /// The repeated window on Lord Howe Island is only 30 minutes wide (the daylight delta is half
+    /// an hour), and a minutely interval expression fires through both passes of it.
+    /// </summary>
+    [Test]
+    public void SequentialWalk_MinutelyCron_LordHoweFallBack_FiresBothHalfHourPasses()
+    {
+        TimeZoneInfo zone = TestTimeZones.LordHowe;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, WallClock("2019-04-07 01:45"));
+
+        CronExpression cron = CronIn("0 * * * * ?", zone);
+
+        // 2019-04-07 02:00 +11:00 becomes 01:30 +10:30; the walk covers 14:00Z-16:00Z around it
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            cron.GetTimeAfter,
+            TestTimeZones.Local("2019-04-07 01:00 +11:00"),
+            TestTimeZones.Local("2019-04-07 02:30 +10:30"));
+
+        fireTimes.Should().HaveCount(119, "two real hours of minute fires, both walk boundaries excluded");
+        fireTimes.Should().Contain(TestTimeZones.Local("2019-04-07 01:45 +11:00"), "first pass of the repeated half hour");
+        fireTimes.Should().Contain(TestTimeZones.Local("2019-04-07 01:45 +10:30"), "second pass of the repeated half hour");
+    }
+
+    #region Current-behavior pins (decision points)
 
     /// <summary>
     /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -148,6 +148,31 @@ public class TimeZoneUtilTest
         }
     }
 
+    [TestCase("Eastern", "2024-11-03 01:30", "2024-11-03 01:00", "2024-11-03 02:00")]
+    [TestCase("CentralEuropean", "2018-10-28 02:30", "2018-10-28 02:00", "2018-10-28 03:00")]
+    [TestCase("LordHowe", "2019-04-07 01:45", "2019-04-07 01:30", "2019-04-07 02:00")]
+    [TestCase("Santiago", "2019-04-06 23:30", "2019-04-06 23:00", "2019-04-07 00:00")]
+    public void TryGetAmbiguousWindow_ReturnsWallClockWindow(string zoneKey, string ambiguousLocal, string expectedStart, string expectedEnd)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(ambiguousLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        TimeZoneUtil.TryGetAmbiguousWindow(local, zone, out DateTime windowStart, out DateTime windowEnd).Should().BeTrue();
+
+        windowStart.Should().Be(DateTime.Parse(expectedStart, CultureInfo.InvariantCulture));
+        windowEnd.Should().Be(DateTime.Parse(expectedEnd, CultureInfo.InvariantCulture));
+
+        // pairing the window start with the standard (smaller) offset yields the transition instant,
+        // which renders in the zone as the window start itself - the first instant of the second pass
+        TimeSpan standardOffset = zone.GetAmbiguousTimeOffsets(local).Min();
+        DateTimeOffset transition = new DateTimeOffset(windowStart, standardOffset);
+        TimeZoneInfo.ConvertTime(transition, zone).DateTime.Should().Be(windowStart);
+
+        TimeZoneUtil.TryGetAmbiguousWindow(local.Date.AddHours(12), zone, out _, out _)
+            .Should().BeFalse("noon is not ambiguous");
+    }
+
     [TestCase("Eastern", "2024-03-10 02:30", "2024-03-10 03:00")]
     [TestCase("LordHowe", "2019-10-06 02:15", "2019-10-06 02:30")]
     [TestCase("Santiago", "2019-09-08 00:30", "2019-09-08 01:00")]

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -222,6 +222,15 @@ public sealed class CronExpression : ISerializable
     [NonSerialized] private readonly CronField years = [];
 
     /// <summary>
+    /// True when a second, minute or hour field uses a wildcard, step or range - the expression
+    /// means "fire every interval" rather than "fire at this time of day". Set during parsing,
+    /// never serialized (deserialization re-parses the expression string).
+    /// </summary>
+    [NonSerialized] private bool hasIntervalSemantics;
+
+    internal bool HasIntervalSemantics => hasIntervalSemantics;
+
+    /// <summary>
     /// Last day of week.
     /// </summary>
     [NonSerialized] private bool lastDayOfWeek;
@@ -820,6 +829,17 @@ public sealed class CronExpression : ISerializable
                     Throw.FormatException("Support for specifying multiple \"nth\" days is not implemented.");
                 }
 
+                // A second, minute or hour field written as a wildcard, step or range expresses an
+                // interval ("keep firing every ...") rather than a fixed time of day. The
+                // distinction drives the fall-back behavior in GetTimeAfter: interval expressions
+                // fire through both occurrences of the repeated wall-clock window, fixed times only
+                // through the first. Plain values and comma lists of plain values stay fixed-time.
+                if (exprOn <= CronExpressionConstants.Hour
+                    && (expr.IndexOf('*') != -1 || expr.IndexOf('/') != -1 || expr.IndexOf('-') != -1))
+                {
+                    hasIntervalSemantics = true;
+                }
+
                 if (expr.IndexOf(',') != -1)
                 {
                     foreach (var v in expr.SpanSplit(','))
@@ -867,6 +887,7 @@ public sealed class CronExpression : ISerializable
         years.Clear();
         lastDaySpecs = null;
         nearestWeekdays = null;
+        hasIntervalSemantics = false;
     }
 
     private void StoreExpressionQuestionMark(int type, ReadOnlySpan<char> s, int i)
@@ -2391,7 +2412,64 @@ public sealed class CronExpression : ISerializable
             }
         }
 
+        if (hasIntervalSemantics && TimeZone.SupportsDaylightSavingTime)
+        {
+            d = ApplySecondAmbiguousPassIfNeeded(d, afterTimeUtcFloor);
+        }
+
         return d.ToUniversalTime();
+    }
+
+    /// <summary>
+    /// Makes interval expressions fire through both occurrences of the repeated fall-back window.
+    /// </summary>
+    /// <remarks>
+    /// The wall-clock walk in <see cref="GetTimeAfter"/> steps straight from the last wall-clock
+    /// minute of the ambiguous window to the first one after it, so when the search starts inside
+    /// the window's first (daylight) pass the entire second (standard) pass would be skipped - an
+    /// "every minute" schedule would silently not fire for a whole hour of real time. When that
+    /// happens, this re-runs the search from the transition instant: inside that call the
+    /// fall-back demotion resolves the found wall-clock time to its second occurrence, and the
+    /// recursion terminates because the restarted search no longer begins in the daylight pass.
+    /// Fixed-time expressions keep the fire-once-at-first-occurrence rule.
+    /// </remarks>
+    private DateTimeOffset ApplySecondAmbiguousPassIfNeeded(DateTimeOffset candidate, DateTimeOffset afterTimeUtcFloor)
+    {
+        var afterLocal = TimeZoneUtil.ConvertTime(afterTimeUtcFloor, TimeZone);
+        DateTime afterWallClock = afterLocal.DateTime;
+
+        if (!TimeZone.IsAmbiguousTime(afterWallClock))
+        {
+            return candidate;
+        }
+
+        TimeSpan[] offsets = TimeZone.GetAmbiguousTimeOffsets(afterWallClock);
+        TimeSpan daylightOffset = offsets.Max();
+        if (afterLocal.Offset != daylightOffset)
+        {
+            // already inside the second (standard) pass; the demotion in GetTimeAfter walks it
+            return candidate;
+        }
+
+        if (!TimeZoneUtil.TryGetAmbiguousWindow(afterWallClock, TimeZone, out DateTime windowStart, out _))
+        {
+            return candidate;
+        }
+
+        var secondPassStart = new DateTimeOffset(windowStart, offsets.Min());
+        if (candidate.ToUniversalTime() < secondPassStart.ToUniversalTime())
+        {
+            // the next fire is still inside the first pass; nothing was skipped yet
+            return candidate;
+        }
+
+        DateTimeOffset? secondPassFire = GetTimeAfter(secondPassStart.AddSeconds(-1));
+        if (secondPassFire is not null && secondPassFire.Value < candidate.ToUniversalTime())
+        {
+            return secondPassFire.Value;
+        }
+
+        return candidate;
     }
 
     /// <summary>

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -131,6 +131,44 @@ public static class TimeZoneUtil
     }
 
     /// <summary>
+    /// Determines the wall-clock window that occurs twice around a fall-back transition. Returns
+    /// false when the given time is not ambiguous. On success <paramref name="windowStart"/> is the
+    /// first ambiguous wall-clock minute (pairing it with the standard offset yields the transition
+    /// instant, i.e. the first instant of the second pass) and <paramref name="windowEnd"/> is the
+    /// first wall-clock minute after the window. Boundaries are found by scanning a minute at a
+    /// time, which handles transition deltas that are not whole hours.
+    /// </summary>
+    internal static bool TryGetAmbiguousWindow(DateTime dateTime, TimeZoneInfo timeZoneInfo, out DateTime windowStart, out DateTime windowEnd)
+    {
+        if (!timeZoneInfo.IsAmbiguousTime(dateTime))
+        {
+            windowStart = default;
+            windowEnd = default;
+            return false;
+        }
+
+        DateTime minute = new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, 0, dateTime.Kind);
+
+        DateTime start = minute;
+        int guard = 0;
+        while (timeZoneInfo.IsAmbiguousTime(start.AddMinutes(-1)) && guard++ < MaxTransitionScanMinutes)
+        {
+            start = start.AddMinutes(-1);
+        }
+
+        DateTime end = minute;
+        guard = 0;
+        while (timeZoneInfo.IsAmbiguousTime(end) && guard++ < MaxTransitionScanMinutes)
+        {
+            end = end.AddMinutes(1);
+        }
+
+        windowStart = start;
+        windowEnd = end;
+        return true;
+    }
+
+    /// <summary>
     /// Walks forward from a wall-clock time inside a spring-forward gap to the first wall-clock
     /// time that exists in the given zone (the end of the gap). Returns the input unchanged when it
     /// is already valid.


### PR DESCRIPTION
## Summary

4.0 behavior change (approved in the DST campaign plan): **interval cron expressions now fire through both occurrences of the repeated fall-back window**. Previously a sequential `GetTimeAfter` walk skipped the entire standard-offset repeat — an "every minute" schedule silently did not fire for an hour of real time, while `IsSatisfiedBy` answered `true` inside that same hour. The two now agree.

## The rule (matches Cronos / Vixie-cron semantics)

Decided at **parse time**, from the second/minute/hour fields only:

| Expression | Semantics | Fall-back behavior |
|---|---|---|
| `0 * * * * ?`, `0 0/30 * * * ?`, `0 30 1-9 * * ?` | interval | fires through **both** passes (1499 minute fires on a 25h day) |
| `0 30 2 * * ?`, `0 0,30 2 * * ?` | fixed time | fires **once**, at the first (daylight) occurrence — daily jobs do not run twice |

Day/month/year fields never contribute; comma lists of plain values stay fixed-time.

## Implementation

- Parse-time `hasIntervalSemantics` flag in `BuildExpression` (never serialized; deserialization re-parses).
- `TimeZoneUtil.TryGetAmbiguousWindow` (internal), minute-scanned so 30-minute daylight deltas work.
- One targeted addition at the end of `GetTimeAfter`: when the search started inside the first (daylight) pass and the candidate has left the window, re-run once from the transition instant — the existing fall-back demotion resolves the hit to its second occurrence, and the recursion self-terminates (the restarted search no longer begins in the daylight pass). No changes to the wall-clock walk itself.

## Cost

Micro-benchmarked 500k `GetTimeAfter` calls: interval CET 307 ns/call vs fixed-time CET 319 ns/call (the new branch is within noise of the existing per-call zone work); UTC/fixed-offset zones and fixed-time expressions skip the branch entirely (91 ns/call unchanged).

## Tests

Parse-flag grid (9 expressions), minutely fall-back walk flipped from the 1439 pin to 1499 with the repeated hour present, hourly both-02:00s walk, Lord Howe half-hour-window both-pass walk, comma-list fixed-time single-pass pin, `TryGetAmbiguousWindow` unit grid (incl. Santiago''s midnight-crossing window). Full suite: 1846 passed, 0 failed. Changelog entry added under 4.0.0.

**Stacked on #3199** — will retarget to `main` once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)