### PR TITLE
Fix ADO delegate parameter bindings, cluster recovery priority and LIKE wildcard handling

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateSqlTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateSqlTest.cs
@@ -1,0 +1,492 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FakeItEasy;
+
+using Microsoft.Data.SqlClient;
+
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Impl.Matchers;
+using Quartz.Simpl;
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// Runs delegate members against a recording ADO.NET provider and inspects the statement that was
+/// prepared together with the parameters that were bound to it.
+/// </summary>
+/// <remarks>
+/// The parameter-name checks matter because <see cref="AdoUtil" /> binds by name: a bound name that
+/// does not occur in the statement leaves the statement's own token unbound, which every provider
+/// rejects at execution time. Several of these members have no in-tree caller, so only a test like
+/// this exercises them.
+/// </remarks>
+public class StdAdoDelegateSqlTest
+{
+    private static readonly DateTimeOffset SomeTime = new DateTimeOffset(2024, 5, 6, 7, 8, 9, TimeSpan.Zero);
+
+    [Test]
+    public async Task SelectMisfiredTriggersShouldBindEveryParameterItsStatementNames()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectMisfiredTriggers(harness.Connection, SomeTime);
+
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task HasMisfiredTriggersInStateShouldBindEveryParameterItsStatementNames()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.HasMisfiredTriggersInState(harness.Connection, AdoConstants.StateWaiting, SomeTime);
+
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task SelectMisfiredTriggersInGroupInStateShouldBindEveryParameterItsStatementNames()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectMisfiredTriggersInGroupInState(harness.Connection, "group", AdoConstants.StateWaiting, SomeTime);
+
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task SelectTriggerForFireTimeShouldBindEveryParameterItsStatementNames()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectTriggerForFireTime(harness.Connection, SomeTime);
+
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task CountMisfiredTriggersInStateShouldBindEveryParameterItsStatementNames()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.CountMisfiredTriggersInState(harness.Connection, AdoConstants.StateWaiting, SomeTime);
+
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task HasMisfiredTriggersInStateWithLimitShouldBindEveryParameterItsStatementNames()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.HasMisfiredTriggersInState(harness.Connection, AdoConstants.StateWaiting, SomeTime, 10, new List<TriggerKey>());
+
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task SelectTriggersInGroupWithEqualityMatcherShouldCompareForEquality()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectTriggersInGroup(harness.Connection, GroupMatcher<TriggerKey>.GroupEquals("50%"));
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP = @triggerGroup");
+        harness.Sql.Should().NotContain("LIKE");
+        harness.BoundValue("triggerGroup").Should().Be("50%", "an equality matcher names the group literally");
+    }
+
+    [Test]
+    public async Task SelectTriggersInGroupWithStartsWithMatcherShouldEscapeWildcardsInTheValue()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectTriggersInGroup(harness.Connection, GroupMatcher<TriggerKey>.GroupStartsWith("a_b%c!d"));
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP LIKE @triggerGroup ESCAPE '!'");
+        harness.BoundValue("triggerGroup").Should().Be("a!_b!%c!!d%",
+            "the matcher's own text is a literal, only the trailing '%' the matcher adds stays a wildcard");
+    }
+
+    [Test]
+    public async Task SelectJobsInGroupWithEqualityMatcherShouldCompareForEquality()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectJobsInGroup(harness.Connection, GroupMatcher<JobKey>.GroupEquals("a_b"));
+
+        harness.Sql.Should().Contain("JOB_GROUP = @jobGroup");
+        harness.Sql.Should().NotContain("LIKE");
+        harness.BoundValue("jobGroup").Should().Be("a_b");
+    }
+
+    [Test]
+    public async Task SelectJobsInGroupWithContainsMatcherShouldEscapeWildcardsInTheValue()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectJobsInGroup(harness.Connection, GroupMatcher<JobKey>.GroupContains("50%"));
+
+        harness.Sql.Should().Contain("JOB_GROUP LIKE @jobGroup ESCAPE '!'");
+        harness.BoundValue("jobGroup").Should().Be("%50!%%");
+    }
+
+    [Test]
+    public async Task SelectTriggerGroupsWithEqualityMatcherShouldCompareForEquality()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectTriggerGroups(harness.Connection, GroupMatcher<TriggerKey>.GroupEquals("a_b"));
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP = @triggerGroup");
+        harness.Sql.Should().NotContain("LIKE");
+        harness.BoundValue("triggerGroup").Should().Be("a_b");
+    }
+
+    [Test]
+    public async Task SelectTriggerGroupsWithStartsWithMatcherShouldUseEscapedLike()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.SelectTriggerGroups(harness.Connection, GroupMatcher<TriggerKey>.GroupStartsWith("a_b"));
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP LIKE @triggerGroup ESCAPE '!'");
+        harness.BoundValue("triggerGroup").Should().Be("a!_b%");
+    }
+
+    [Test]
+    public async Task UpdateTriggerGroupStateFromOtherStateWithEqualityMatcherShouldCompareForEquality()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.UpdateTriggerGroupStateFromOtherState(
+            harness.Connection,
+            GroupMatcher<TriggerKey>.GroupEquals("a_b"),
+            AdoConstants.StateWaiting,
+            AdoConstants.StatePaused);
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP = @triggerGroup");
+        harness.Sql.Should().NotContain("LIKE");
+        harness.BoundValue("triggerGroup").Should().Be("a_b");
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task UpdateTriggerGroupStateFromOtherStateWithStartsWithMatcherShouldUseEscapedLike()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.UpdateTriggerGroupStateFromOtherState(
+            harness.Connection,
+            GroupMatcher<TriggerKey>.GroupStartsWith("a_b"),
+            AdoConstants.StateWaiting,
+            AdoConstants.StatePaused);
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP LIKE @triggerGroup ESCAPE '!'");
+        harness.BoundValue("triggerGroup").Should().Be("a!_b%");
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task UpdateTriggerGroupStateFromOtherStatesWithEqualityMatcherShouldCompareForEquality()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.UpdateTriggerGroupStateFromOtherStates(
+            harness.Connection,
+            GroupMatcher<TriggerKey>.GroupEquals("a_b"),
+            AdoConstants.StateWaiting,
+            AdoConstants.StatePaused,
+            AdoConstants.StatePausedBlocked,
+            AdoConstants.StateBlocked);
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP = @groupName");
+        harness.Sql.Should().NotContain("LIKE");
+        harness.BoundValue("groupName").Should().Be("a_b");
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task UpdateTriggerGroupStateFromOtherStatesWithStartsWithMatcherShouldUseEscapedLike()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.UpdateTriggerGroupStateFromOtherStates(
+            harness.Connection,
+            GroupMatcher<TriggerKey>.GroupStartsWith("a_b"),
+            AdoConstants.StateWaiting,
+            AdoConstants.StatePaused,
+            AdoConstants.StatePausedBlocked,
+            AdoConstants.StateBlocked);
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP LIKE @groupName ESCAPE '!'");
+        harness.BoundValue("groupName").Should().Be("a!_b%");
+        harness.AssertBoundParametersMatchStatement();
+    }
+
+    [Test]
+    public async Task DeletePausedTriggerGroupWithEqualityMatcherShouldCompareForEquality()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.DeletePausedTriggerGroup(harness.Connection, GroupMatcher<TriggerKey>.GroupEquals("a_b"));
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP = @triggerGroup");
+        harness.Sql.Should().NotContain("LIKE");
+        harness.BoundValue("triggerGroup").Should().Be("a_b");
+    }
+
+    [Test]
+    public async Task DeletePausedTriggerGroupWithStartsWithMatcherShouldUseEscapedLike()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.DeletePausedTriggerGroup(harness.Connection, GroupMatcher<TriggerKey>.GroupStartsWith("a_b"));
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP LIKE @triggerGroup ESCAPE '!'");
+        harness.BoundValue("triggerGroup").Should().Be("a!_b%");
+    }
+
+    [Test]
+    public async Task DeletePausedTriggerGroupByNameShouldDeleteTheAllGroupsPausedSentinelLiterally()
+    {
+        var harness = TestHarness.Create();
+
+        await harness.Delegate.DeletePausedTriggerGroup(harness.Connection, AdoConstants.AllGroupsPaused);
+
+        harness.Sql.Should().Contain("TRIGGER_GROUP = @triggerGroup");
+        harness.Sql.Should().NotContain("LIKE",
+            "the sentinel's underscores would be wildcards in a LIKE, so ResumeAll could delete other groups");
+        harness.BoundValue("triggerGroup").Should().Be("_$_ALL_GROUPS_PAUSED_$_");
+    }
+
+    [Test]
+    public async Task SelectInstancesFiredTriggerRecordsShouldReadPriority()
+    {
+        var harness = TestHarness.Create();
+        var reader = harness.DataReader;
+
+        A.CallTo(() => reader.ReadAsync(A<CancellationToken>._)).Returns(true).Once();
+        A.CallTo(() => reader[AdoConstants.ColumnEntryId]).Returns("TESTSCHED_1");
+        A.CallTo(() => reader[AdoConstants.ColumnEntryState]).Returns(AdoConstants.StateAcquired);
+        A.CallTo(() => reader[AdoConstants.ColumnFiredTime]).Returns(SomeTime.UtcTicks);
+        A.CallTo(() => reader[AdoConstants.ColumnScheduledTime]).Returns(SomeTime.UtcTicks);
+        A.CallTo(() => reader[AdoConstants.ColumnPriority]).Returns(7);
+        A.CallTo(() => reader[AdoConstants.ColumnInstanceName]).Returns("INSTANCE");
+        A.CallTo(() => reader[AdoConstants.ColumnTriggerName]).Returns("trigger");
+        A.CallTo(() => reader[AdoConstants.ColumnTriggerGroup]).Returns("group");
+
+        var records = await harness.Delegate.SelectInstancesFiredTriggerRecords(harness.Connection, "INSTANCE");
+
+        records.Should().ContainSingle()
+            .Which.Priority.Should().Be(7, "ClusterRecover copies this onto the recovery trigger it builds");
+    }
+
+    [Test]
+    public void AnyGroupMatcherShouldProduceABareWildcard()
+    {
+        var del = new LikeClauseExposingDelegate();
+
+        del.ToSqlLikeClausePublic(GroupMatcher<TriggerKey>.AnyGroup()).Should().Be("%");
+    }
+
+    [TestCase("plain", "plain")]
+    [TestCase("a_b", "a!_b")]
+    [TestCase("50%", "50!%")]
+    [TestCase("wow!", "wow!!")]
+    [TestCase("_%!", "!_!%!!")]
+    public void EqualityLikeClauseShouldEscapeWildcards(string group, string expected)
+    {
+        var del = new LikeClauseExposingDelegate();
+
+        del.ToSqlLikeClausePublic(GroupMatcher<TriggerKey>.GroupEquals(group)).Should().Be(expected);
+    }
+
+    [Test]
+    public void EveryLikeStatementShouldNameTheEscapeCharacter()
+    {
+        string[] statements =
+        {
+            StdAdoConstants.SqlDeletePausedTriggerGroup,
+            StdAdoConstants.SqlSelectJobsInGroupLike,
+            StdAdoConstants.SqlSelectTriggerGroupsFiltered,
+            StdAdoConstants.SqlSelectTriggersInGroupLike,
+            StdAdoConstants.SqlUpdateTriggerGroupStateFromState,
+            StdAdoConstants.SqlUpdateTriggerGroupStateFromStates
+        };
+
+        foreach (string statement in statements)
+        {
+            statement.Should().Contain("LIKE");
+            statement.Should().Contain(" ESCAPE '!'",
+                "a LIKE fed by ToSqlLikeClause has to name the escape character the clause uses");
+        }
+    }
+
+    private sealed class LikeClauseExposingDelegate : StdAdoDelegate
+    {
+        public string ToSqlLikeClausePublic<T>(GroupMatcher<T> matcher) where T : Key<T> => ToSqlLikeClause(matcher);
+    }
+
+    /// <summary>
+    /// A delegate wired to a provider that records the statement text and the parameters bound to it.
+    /// </summary>
+    private sealed class TestHarness
+    {
+        private readonly RecordingParameterCollection parameters;
+
+        private TestHarness(
+            StdAdoDelegate adoDelegate,
+            ConnectionAndTransactionHolder connection,
+            DbCommand command,
+            DbDataReader dataReader,
+            RecordingParameterCollection parameters)
+        {
+            Delegate = adoDelegate;
+            Connection = connection;
+            Command = command;
+            DataReader = dataReader;
+            this.parameters = parameters;
+        }
+
+        public StdAdoDelegate Delegate { get; }
+
+        public ConnectionAndTransactionHolder Connection { get; }
+
+        public DbCommand Command { get; }
+
+        public DbDataReader DataReader { get; }
+
+        public string Sql => Command.CommandText;
+
+        public object BoundValue(string parameterName)
+        {
+            var parameter = parameters.Recorded.SingleOrDefault(x => x.ParameterName == "@" + parameterName);
+            parameter.Should().NotBeNull($"parameter '{parameterName}' should have been bound to: {Sql}");
+            return parameter.Value;
+        }
+
+        /// <summary>
+        /// Asserts that the names bound to the command are exactly the tokens the statement itself
+        /// names — a mismatch either way makes the statement fail on every provider.
+        /// </summary>
+        public void AssertBoundParametersMatchStatement()
+        {
+            var namesInStatement = Regex.Matches(Sql, "@([A-Za-z0-9_]+)")
+                .Cast<Match>()
+                .Select(x => x.Groups[1].Value)
+                .Distinct()
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToArray();
+
+            var boundNames = parameters.Recorded
+                .Select(x => x.ParameterName.TrimStart('@'))
+                .Distinct()
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToArray();
+
+            boundNames.Should().Equal(namesInStatement,
+                $"AdoUtil binds by name, so an unmatched name leaves a token unbound in: {Sql}");
+        }
+
+        public static TestHarness Create()
+        {
+            var command = A.Fake<StubCommand>();
+            var parameters = new RecordingParameterCollection();
+
+            A.CallTo(command).Where(x => x.Method.Name == "get_DbParameterCollection")
+                .WithReturnType<DbParameterCollection>()
+                .Returns(parameters);
+
+            A.CallTo(command).Where(x => x.Method.Name == "CreateDbParameter")
+                .WithReturnType<DbParameter>()
+                .ReturnsLazily(() => new SqlParameter());
+
+            var dataReader = A.Fake<DbDataReader>();
+            A.CallTo(() => dataReader.ReadAsync(A<CancellationToken>._)).Returns(false);
+
+            A.CallTo(command).Where(x => x.Method.Name == "ExecuteDbDataReaderAsync")
+                .WithReturnType<Task<DbDataReader>>()
+                .Returns(Task.FromResult((DbDataReader) dataReader));
+
+            A.CallTo(command).Where(x => x.Method.Name == "ExecuteScalarAsync")
+                .WithReturnType<Task<object>>()
+                .Returns(Task.FromResult<object>(0));
+
+            var dbMetadata = new DbMetadata
+            {
+                BindByName = true,
+                ParameterNamePrefix = "@"
+            };
+            dbMetadata.Init();
+
+            var dbProvider = A.Fake<IDbProvider>();
+            A.CallTo(() => dbProvider.Metadata).Returns(dbMetadata);
+            A.CallTo(() => dbProvider.CreateCommand()).Returns(command);
+
+            var adoDelegate = new StdAdoDelegate();
+            adoDelegate.Initialize(new DelegateInitializationArgs
+            {
+                TablePrefix = "QRTZ_",
+                InstanceId = "INSTANCE",
+                InstanceName = "TESTSCHED",
+                TypeLoadHelper = new SimpleTypeLoadHelper(),
+                UseProperties = false,
+                InitString = "",
+                DbProvider = dbProvider
+            });
+
+            var connection = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), A.Fake<DbTransaction>());
+            return new TestHarness(adoDelegate, connection, command, dataReader, parameters);
+        }
+    }
+
+    private sealed class RecordingParameterCollection : StubParameterCollection
+    {
+        private readonly List<DbParameter> recorded = new List<DbParameter>();
+
+        public IReadOnlyList<DbParameter> Recorded => recorded;
+
+        public override int Add(object value)
+        {
+            recorded.Add((DbParameter) value);
+            return recorded.Count - 1;
+        }
+
+        public override int Count => recorded.Count;
+
+        public override IEnumerator GetEnumerator() => recorded.GetEnumerator();
+
+        protected override DbParameter GetParameter(int index) => recorded[index];
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -34,6 +34,29 @@ public class StdAdoConstants : AdoConstants
 {
     public const string TablePrefixSubst = "{0}";
 
+    /// <summary>
+    /// Escape character for the group-name patterns <c>StdAdoDelegate.ToSqlLikeClause</c> produces, so
+    /// that a group literally named <c>50%</c> or <c>a_b</c> matches itself instead of acting as a
+    /// wildcard.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not the conventional backslash: MySQL applies C-style escaping inside string
+    /// literals, where <c>ESCAPE '\'</c> is a syntax error (it would need <c>ESCAPE '\\'</c>, which in
+    /// turn is wrong everywhere else). <c>!</c> is an ordinary character in a string literal on every
+    /// supported dialect, so one statement text serves them all.
+    /// </remarks>
+    public const char SqlLikeEscapeCharacter = '!';
+
+    /// <summary>
+    /// The ANSI <c>ESCAPE</c> clause naming <see cref="SqlLikeEscapeCharacter" />. Every statement that
+    /// binds a pattern from <c>StdAdoDelegate.ToSqlLikeClause</c> ends its LIKE with this.
+    /// </summary>
+    /// <remarks>
+    /// <c>ESCAPE</c> is ANSI SQL and is accepted by SQL Server, PostgreSQL, MySQL, SQLite, Oracle and
+    /// Firebird alike.
+    /// </remarks>
+    public static readonly string SqlLikeEscapeClause = Invariant($" ESCAPE '{SqlLikeEscapeCharacter}'");
+
     // DELETE
     public static readonly string SqlDeleteBlobTrigger =
         Invariant($"DELETE FROM {TablePrefixSubst}{TableBlobTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");
@@ -62,8 +85,20 @@ public class StdAdoConstants : AdoConstants
     public static readonly string SqlDeleteJobDetail =
         Invariant($"DELETE FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup");
 
+    /// <summary>
+    /// Deletes a paused trigger group named literally. This is what a group name that is not a
+    /// pattern — including the <see cref="AdoConstants.AllGroupsPaused" /> sentinel, whose
+    /// underscores would otherwise act as wildcards — has to run.
+    /// </summary>
+    public static readonly string SqlDeletePausedTriggerGroupEquals =
+        Invariant($"DELETE FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @triggerGroup");
+
+    /// <summary>
+    /// Deletes the paused trigger groups matching a pattern produced by
+    /// <c>StdAdoDelegate.ToSqlLikeClause</c>.
+    /// </summary>
     public static readonly string SqlDeletePausedTriggerGroup =
-        Invariant($"DELETE FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup");
+        Invariant($"DELETE FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");
 
     public static readonly string SqlDeletePausedTriggerGroups =
         Invariant($"DELETE FROM {TablePrefixSubst}{TablePausedTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
@@ -176,7 +211,7 @@ public class StdAdoConstants : AdoConstants
         Invariant($"SELECT DISTINCT({ColumnJobGroup}) FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName");
 
     public static readonly string SqlSelectJobsInGroupLike =
-        Invariant($"SELECT {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobGroup} LIKE @jobGroup");
+        Invariant($"SELECT {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobGroup} LIKE @jobGroup{SqlLikeEscapeClause}");
 
     public static readonly string SqlSelectJobsInGroup =
         Invariant($"SELECT {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobGroup} = @jobGroup");
@@ -281,8 +316,15 @@ public class StdAdoConstants : AdoConstants
     public static readonly string SqlSelectTriggerGroups =
         Invariant($"SELECT DISTINCT({ColumnTriggerGroup}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
 
+    /// <summary>
+    /// Selects the trigger group named literally; the equality form of
+    /// <see cref="SqlSelectTriggerGroupsFiltered" />.
+    /// </summary>
+    public static readonly string SqlSelectTriggerGroupsEquals =
+        Invariant($"SELECT DISTINCT({ColumnTriggerGroup}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @triggerGroup");
+
     public static readonly string SqlSelectTriggerGroupsFiltered =
-        Invariant($"SELECT DISTINCT({ColumnTriggerGroup}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup");
+        Invariant($"SELECT DISTINCT({ColumnTriggerGroup}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");
 
     public static readonly string SqlSelectTriggerState =
         Invariant($"SELECT {ColumnTriggerState} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");
@@ -297,7 +339,7 @@ public class StdAdoConstants : AdoConstants
         Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup");
 
     public static readonly string SqlSelectTriggersInGroupLike =
-        Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup");
+        Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");
 
     public static readonly string SqlSelectTriggersInGroup =
         Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @triggerGroup");
@@ -344,11 +386,23 @@ public class StdAdoConstants : AdoConstants
 
     public static readonly string SqlUpdateFiredTrigger = Invariant($"UPDATE {TablePrefixSubst}{TableFiredTriggers} SET {ColumnInstanceName} = @instanceName, {ColumnFiredTime} = @firedTime, {ColumnScheduledTime} = @scheduledTime, {ColumnEntryState} = @entryState, {ColumnJobName} = @jobName, {ColumnJobGroup} = @jobGroup, {ColumnIsNonConcurrent} = @isNonConcurrent, {ColumnRequestsRecovery} = @requestsRecover WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnEntryId} = @entryId");
 
+    /// <summary>
+    /// Equality form of <see cref="SqlUpdateTriggerGroupStateFromState" />.
+    /// </summary>
+    public static readonly string SqlUpdateTriggerGroupStateFromStateEquals =
+        Invariant($"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @oldState");
+
     public static readonly string SqlUpdateTriggerGroupStateFromState =
-        Invariant($"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup AND {ColumnTriggerState} = @oldState");
+        Invariant($"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause} AND {ColumnTriggerState} = @oldState");
+
+    /// <summary>
+    /// Equality form of <see cref="SqlUpdateTriggerGroupStateFromStates" />.
+    /// </summary>
+    public static readonly string SqlUpdateTriggerGroupStateFromStatesEquals =
+        Invariant($"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} = @groupName AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)");
 
     public static readonly string SqlUpdateTriggerGroupStateFromStates =
-        Invariant($"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @groupName AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)");
+        Invariant($"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnTriggerState} = @newState WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerGroup} LIKE @groupName{SqlLikeEscapeClause} AND ({ColumnTriggerState} = @oldState1 OR {ColumnTriggerState} = @oldState2 OR {ColumnTriggerState} = @oldState3)");
 
     public static readonly string SqlUpdateTriggerSkipData =
         Invariant($@"UPDATE {TablePrefixSubst}{TableTriggers} SET {ColumnJobName} = @triggerJobName, {ColumnJobGroup} = @triggerJobGroup, {ColumnDescription} = @triggerDescription, {ColumnNextFireTime} = @triggerNextFireTime, {ColumnPreviousFireTime} = @triggerPreviousFireTime, 

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -40,7 +40,7 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectMisfiredTriggers));
         AddCommandParameter(cmd, "schedulerName", schedName);
-        AddCommandParameter(cmd, "timestamp", GetDbDateTimeValue(ts));
+        AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         List<TriggerKey> list = new List<TriggerKey>();
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -81,7 +81,7 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectMisfiredTriggersInState));
         AddCommandParameter(cmd, "schedulerName", schedName);
-        AddCommandParameter(cmd, "timestamp", GetDbDateTimeValue(ts));
+        AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
         AddCommandParameter(cmd, "state", state);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -165,7 +165,7 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectMisfiredTriggersInGroupInState));
         AddCommandParameter(cmd, "schedulerName", schedName);
-        AddCommandParameter(cmd, "timestamp", GetDbDateTimeValue(ts));
+        AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
         AddCommandParameter(cmd, "triggerGroup", groupName);
         AddCommandParameter(cmd, "state", state);
 
@@ -915,10 +915,12 @@ public partial class StdAdoDelegate
         string oldState3,
         CancellationToken cancellationToken = default)
     {
-        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerGroupStateFromStates));
+        var (sql, parameter) = MatchGroup(matcher, SqlUpdateTriggerGroupStateFromStatesEquals, SqlUpdateTriggerGroupStateFromStates);
+
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
         AddCommandParameter(cmd, "schedulerName", schedName);
         AddCommandParameter(cmd, "newState", newState);
-        AddCommandParameter(cmd, "groupName", ToSqlLikeClause(matcher));
+        AddCommandParameter(cmd, "groupName", parameter);
         AddCommandParameter(cmd, "oldState1", oldState1);
         AddCommandParameter(cmd, "oldState2", oldState2);
         AddCommandParameter(cmd, "oldState3", oldState3);
@@ -972,10 +974,12 @@ public partial class StdAdoDelegate
         string oldState,
         CancellationToken cancellationToken = default)
     {
-        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateTriggerGroupStateFromState));
+        var (sql, parameter) = MatchGroup(matcher, SqlUpdateTriggerGroupStateFromStateEquals, SqlUpdateTriggerGroupStateFromState);
+
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
         AddCommandParameter(cmd, "schedulerName", schedName);
         AddCommandParameter(cmd, "newState", newState);
-        AddCommandParameter(cmd, "triggerGroup", ToSqlLikeClause(matcher));
+        AddCommandParameter(cmd, "triggerGroup", parameter);
         AddCommandParameter(cmd, "oldState", oldState);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -1389,9 +1393,11 @@ public partial class StdAdoDelegate
         GroupMatcher<TriggerKey> matcher,
         CancellationToken cancellationToken = default)
     {
-        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerGroupsFiltered));
+        var (sql, parameter) = MatchGroup(matcher, SqlSelectTriggerGroupsEquals, SqlSelectTriggerGroupsFiltered);
+
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
         AddCommandParameter(cmd, "schedulerName", schedName);
-        AddCommandParameter(cmd, "triggerGroup", ToSqlLikeClause(matcher));
+        AddCommandParameter(cmd, "triggerGroup", parameter);
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         List<string> list = new List<string>();
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1408,18 +1414,7 @@ public partial class StdAdoDelegate
         GroupMatcher<TriggerKey> matcher,
         CancellationToken cancellationToken = default)
     {
-        string sql;
-        string parameter;
-        if (IsMatcherEquals(matcher))
-        {
-            sql = ReplaceTablePrefix(SqlSelectTriggersInGroup);
-            parameter = ToSqlEqualsClause(matcher);
-        }
-        else
-        {
-            sql = ReplaceTablePrefix(SqlSelectTriggersInGroupLike);
-            parameter = ToSqlLikeClause(matcher);
-        }
+        var (sql, parameter) = MatchGroup(matcher, SqlSelectTriggersInGroup, SqlSelectTriggersInGroupLike);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
         AddCommandParameter(cmd, "schedulerName", schedName);
@@ -1454,7 +1449,9 @@ public partial class StdAdoDelegate
         string groupName,
         CancellationToken cancellationToken = default)
     {
-        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeletePausedTriggerGroup));
+        // A bare group name is a literal, not a pattern — notably AllGroupsPaused, whose underscores
+        // would otherwise be wildcards.
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeletePausedTriggerGroupEquals));
         AddCommandParameter(cmd, "schedulerName", schedName);
         AddCommandParameter(cmd, "triggerGroup", groupName);
         int rows = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -1468,9 +1465,11 @@ public partial class StdAdoDelegate
         GroupMatcher<TriggerKey> matcher,
         CancellationToken cancellationToken = default)
     {
-        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlDeletePausedTriggerGroup));
+        var (sql, parameter) = MatchGroup(matcher, SqlDeletePausedTriggerGroupEquals, SqlDeletePausedTriggerGroup);
+
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
         AddCommandParameter(cmd, "schedulerName", schedName);
-        AddCommandParameter(cmd, "triggerGroup", ToSqlLikeClause(matcher));
+        AddCommandParameter(cmd, "triggerGroup", parameter);
         int rows = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
         return rows;
@@ -1522,7 +1521,7 @@ public partial class StdAdoDelegate
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerForFireTime));
         AddCommandParameter(cmd, "schedulerName", schedName);
         AddCommandParameter(cmd, "state", StateWaiting);
-        AddCommandParameter(cmd, "fireTime", GetDbDateTimeValue(fireTime));
+        AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(fireTime));
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1888,6 +1887,7 @@ public partial class StdAdoDelegate
             rec.FireInstanceState = rs.GetString(ColumnEntryState)!;
             rec.FireTimestamp = GetDateTimeFromDbValue(rs[ColumnFiredTime]) ?? DateTimeOffset.MinValue;
             rec.ScheduleTimestamp = GetDateTimeFromDbValue(rs[ColumnScheduledTime]) ?? DateTimeOffset.MinValue;
+            rec.Priority = Convert.ToInt32(rs[ColumnPriority], CultureInfo.InvariantCulture);
             rec.SchedulerInstanceId = rs.GetString(ColumnInstanceName)!;
             rec.TriggerKey = new TriggerKey(rs.GetString(ColumnTriggerName)!, rs.GetString(ColumnTriggerGroup)!);
             if (!rec.FireInstanceState.Equals(StateAcquired))

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -28,6 +28,7 @@ using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -48,6 +49,8 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
 {
     private const string FileScanListenerName = "FILE_SCAN_LISTENER_NAME";
     private const string DirectoryScanListenerName = "DIRECTORY_SCAN_LISTENER_NAME";
+
+    private static readonly char[] SqlLikeWildcardCharacters = { SqlLikeEscapeCharacter, '%', '_' };
 
     private ILog logger = null!;
     private string tablePrefix = DefaultTablePrefix;
@@ -368,20 +371,9 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
         GroupMatcher<JobKey> matcher,
         CancellationToken cancellationToken = default)
     {
-        string sql;
-        string parameter;
-        if (IsMatcherEquals(matcher))
-        {
-            sql = ReplaceTablePrefix(SqlSelectJobsInGroup);
-            parameter = ToSqlEqualsClause(matcher);
-        }
-        else
-        {
-            sql = ReplaceTablePrefix(SqlSelectJobsInGroupLike);
-            parameter = ToSqlLikeClause(matcher);
-        }
+        var (sql, parameter) = MatchGroup(matcher, SqlSelectJobsInGroup, SqlSelectJobsInGroupLike);
 
-        using var cmd = PrepareCommand(conn, sql);
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
         AddCommandParameter(cmd, "schedulerName", schedName);
         AddCommandParameter(cmd, "jobGroup", parameter);
 
@@ -394,6 +386,25 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
         return list;
     }
 
+    /// <summary>
+    /// Picks the statement a group matcher should run and the value to bind for it: an equality
+    /// matcher gets the '=' form, everything else the LIKE form over the pattern the matcher
+    /// translates to.
+    /// </summary>
+    /// <remarks>
+    /// The equality form is not merely a shortcut — LIKE would treat a group whose name contains
+    /// '%' or '_' as a pattern, and it cannot use an index the way '=' can.
+    /// </remarks>
+    protected (string Sql, string Parameter) MatchGroup<T>(
+        GroupMatcher<T> matcher,
+        string equalsSql,
+        string likeSql) where T : Key<T>
+    {
+        return IsMatcherEquals(matcher)
+            ? (equalsSql, ToSqlEqualsClause(matcher))
+            : (likeSql, ToSqlLikeClause(matcher));
+    }
+
     protected bool IsMatcherEquals<T>(GroupMatcher<T> matcher) where T : Key<T>
     {
         return matcher.CompareWithOperator.Equals(StringOperator.Equality);
@@ -404,34 +415,72 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
         return matcher.CompareToValue;
     }
 
+    /// <summary>
+    /// Translates a group matcher into a LIKE pattern.
+    /// </summary>
+    /// <remarks>
+    /// The matcher's own text is a literal, so its wildcard characters are escaped with
+    /// <see cref="StdAdoConstants.SqlLikeEscapeCharacter" />; the statements this feeds all name that
+    /// character in an ESCAPE clause. Only the '%' this method adds itself stays a wildcard, so a
+    /// group literally named "50%" is found by an exact match and by a "starts with 50" one, and not
+    /// by a "starts with 5" one.
+    /// </remarks>
     protected virtual string ToSqlLikeClause<T>(GroupMatcher<T> matcher) where T : Key<T>
     {
-        string groupName;
+        if (StringOperator.Anything.Equals(matcher.CompareWithOperator))
+        {
+            return "%";
+        }
+
+        string value = EscapeSqlLikeWildcards(matcher.CompareToValue);
+
         if (StringOperator.Equality.Equals(matcher.CompareWithOperator))
         {
-            groupName = matcher.CompareToValue;
+            return value;
         }
-        else if (StringOperator.Contains.Equals(matcher.CompareWithOperator))
+
+        if (StringOperator.Contains.Equals(matcher.CompareWithOperator))
         {
-            groupName = "%" + matcher.CompareToValue + "%";
+            return "%" + value + "%";
         }
-        else if (StringOperator.EndsWith.Equals(matcher.CompareWithOperator))
+
+        if (StringOperator.EndsWith.Equals(matcher.CompareWithOperator))
         {
-            groupName = "%" + matcher.CompareToValue;
+            return "%" + value;
         }
-        else if (StringOperator.StartsWith.Equals(matcher.CompareWithOperator))
+
+        if (StringOperator.StartsWith.Equals(matcher.CompareWithOperator))
         {
-            groupName = matcher.CompareToValue + "%";
+            return value + "%";
         }
-        else if (StringOperator.Anything.Equals(matcher.CompareWithOperator))
+
+        throw new ArgumentOutOfRangeException("Don't know how to translate " + matcher.CompareWithOperator + " into SQL");
+    }
+
+    /// <summary>
+    /// Escapes the LIKE wildcards '%' and '_', and
+    /// <see cref="StdAdoConstants.SqlLikeEscapeCharacter" /> itself, so that the value matches
+    /// literally.
+    /// </summary>
+    protected static string EscapeSqlLikeWildcards(string value)
+    {
+        if (value.IndexOfAny(SqlLikeWildcardCharacters) < 0)
         {
-            groupName = "%";
+            return value;
         }
-        else
+
+        var builder = new StringBuilder(value.Length + 8);
+        foreach (char c in value)
         {
-            throw new ArgumentOutOfRangeException("Don't know how to translate " + matcher.CompareWithOperator + " into SQL");
+            if (c == SqlLikeEscapeCharacter || c == '%' || c == '_')
+            {
+                builder.Append(SqlLikeEscapeCharacter);
+            }
+
+            builder.Append(c);
         }
-        return groupName;
+
+        return builder.ToString();
     }
 
     //---------------------------------------------------------------------------


### PR DESCRIPTION
Backports the correctness fixes found during the 4.x JobStoreQueries campaign (PR #3197), each re-verified against 3.x rather than copied. No public API signature changes; only additive members.

## Fixes

- **Cluster failover recovery triggers lose their priority.** `SelectInstancesFiredTriggerRecords` was the only fired-trigger reader that never read `PRIORITY`, and `ClusterRecover` assigns `rcvryTrig.Priority = ftRec.Priority` from exactly that reader - so every recovery trigger ran at priority 0 (below the default 5), deprioritising recovery work precisely when a node has died. The startup-recovery path was already correct.
- **Four `IDriverDelegate` members failed on every provider** due to parameter names that never matched their SQL (`@nextFireTime` in the statement, `"timestamp"`/`"fireTime"` in the code): `SelectMisfiredTriggers`, the list-returning `HasMisfiredTriggersInState`, `SelectMisfiredTriggersInGroupInState`, `SelectTriggerForFireTime`. Nothing in the scheduler calls them - which is why this never surfaced - but they are public surface reachable from `JobStoreSupport` subclasses. Fixed the bound names; the two structurally identical members the scheduler does call were already correct.
- **Group matcher LIKE handling.** Matcher values are now escaped (`%`, `_`, and the escape char itself; escape character is `!` because `ESCAPE '\'` is a MySQL syntax error, while `!` is a plain literal on all six supported databases), and the four call sites that always used `LIKE` now use `=` for equality matchers (`UpdateTriggerGroupStateFromOtherState(s)`, `SelectTriggerGroups`, `DeletePausedTriggerGroup`). `DeletePausedTriggerGroup` by name also compares literally, so `ResumeAll` deletes only the `_$_ALL_GROUPS_PAUSED_$_` sentinel row rather than a pattern in which all eight underscores were single-character wildcards.

**Behavioral note for release notes:** group names containing `%` or `_` now match literally in group matcher queries. Previously those characters acted as LIKE wildcards, so a matcher could list, pause, resume or delete groups it was not meant to match.

## Verification

- Build clean on all six TFMs (net462/net472/net8.0/net9.0/net10.0/netstandard2.0), 0 warnings.
- Unit suite green on net10.0 (1718 passed) and net472 (1717 passed).
- New `StdAdoDelegateSqlTest` (27 tests, recording provider): asserts bound parameter names match the SQL tokens for all four fixed members plus regression guards on their two correct siblings, the priority read, equality-vs-LIKE SQL and bound values for every matcher call site, wildcard escaping cases, and the sentinel literal delete. The harness was mutation-checked - reverting a fix makes the corresponding test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eMEzyDdXgvgxBSuZBJ6mT