### PR TITLE
Let AdoJobStore take part in the application's transaction (#2038)

### DIFF
--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistedTransactionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistedTransactionTest.cs
@@ -1,0 +1,405 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Specialized;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+
+using Microsoft.Data.SqlClient;
+
+using Npgsql;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Job;
+using Quartz.Util;
+
+using IsolationLevel = System.Transactions.IsolationLevel;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Verifies that scheduling can take part in a transaction the application owns: the schedule is
+/// committed together with the application's own work, and is discarded together with it when that
+/// work is rolled back. Reported as https://github.com/quartznet/quartznet/issues/2038.
+/// </summary>
+[NonParallelizable]
+public class EnlistedTransactionTest
+{
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresRollingBackTheApplicationTransactionDiscardsTheSchedule()
+    {
+        return RollingBackTheApplicationTransactionDiscardsTheSchedule(Postgres(), "EnlistedRollbackPg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresCommittingTheApplicationTransactionKeepsTheSchedule()
+    {
+        return CommittingTheApplicationTransactionKeepsTheSchedule(Postgres(), "EnlistedCommitPg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresIncompleteAmbientScopeDiscardsTheSchedule()
+    {
+        return IncompleteAmbientScopeDiscardsTheSchedule(Postgres(), "AmbientScopePg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresRunningSchedulerFiresTheJobRightAfterTheApplicationCommits()
+    {
+        return RunningSchedulerFiresTheJobRightAfterTheApplicationCommits(Postgres(), "EnlistedRunningPg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresEnlistingIsRefusedWhenTheStoreDoesNotAcceptIt()
+    {
+        return EnlistingIsRefusedWhenTheStoreDoesNotAcceptIt(Postgres(), "EnlistedRefusedPg");
+    }
+
+    [Test]
+    [Category("db-sqlserver")]
+    public Task SqlServerRollingBackTheApplicationTransactionDiscardsTheSchedule()
+    {
+        return RollingBackTheApplicationTransactionDiscardsTheSchedule(SqlServer(), "EnlistedRollbackMssql");
+    }
+
+    [Test]
+    [Category("db-sqlserver")]
+    public Task SqlServerCommittingTheApplicationTransactionKeepsTheSchedule()
+    {
+        return CommittingTheApplicationTransactionKeepsTheSchedule(SqlServer(), "EnlistedCommitMssql");
+    }
+
+    [Test]
+    [Category("db-sqlserver")]
+    public Task SqlServerIncompleteAmbientScopeDiscardsTheSchedule()
+    {
+        return IncompleteAmbientScopeDiscardsTheSchedule(SqlServer(), "AmbientScopeMssql");
+    }
+
+    private static async Task RollingBackTheApplicationTransactionDiscardsTheSchedule(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName);
+        JobKey jobKey = new JobKey("enlisted", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+
+            using (DbConnection connection = provider.CreateConnection())
+            {
+                await connection.OpenAsync();
+                using (DbTransaction transaction = connection.BeginTransaction())
+                {
+                    using (scheduler.EnlistTransaction(transaction))
+                    {
+                        await scheduler.ScheduleJob(CreateJob(jobKey), CreateTrigger(jobKey));
+
+                        bool visibleInsideTheTransaction = await scheduler.CheckExists(jobKey);
+                        visibleInsideTheTransaction.Should().BeTrue("the job store wrote through the enlisted transaction");
+                    }
+
+                    transaction.Rollback();
+                }
+            }
+
+            bool survivedTheRollback = await scheduler.CheckExists(jobKey);
+            survivedTheRollback.Should().BeFalse("the schedule belongs to the transaction the application rolled back");
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    private static async Task CommittingTheApplicationTransactionKeepsTheSchedule(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName);
+        JobKey jobKey = new JobKey("enlisted", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+
+            using (DbConnection connection = provider.CreateConnection())
+            {
+                await connection.OpenAsync();
+                using (DbTransaction transaction = connection.BeginTransaction())
+                {
+                    using (scheduler.EnlistTransaction(transaction))
+                    {
+                        await scheduler.ScheduleJob(CreateJob(jobKey), CreateTrigger(jobKey));
+                        transaction.Commit();
+                    }
+                }
+            }
+
+            IJobDetail persisted = await scheduler.GetJobDetail(jobKey);
+            persisted.Should().NotBeNull("the application committed the transaction the schedule was written in");
+            (await scheduler.GetTriggersOfJob(jobKey)).Should().HaveCount(1);
+
+            await scheduler.Clear();
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    private static async Task IncompleteAmbientScopeDiscardsTheSchedule(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName);
+        JobKey jobKey = new JobKey("ambient", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+
+            TransactionOptions options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+            using (new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled))
+            {
+                // Sharing the one connection is what keeps the scope from being promoted to a
+                // distributed transaction, which Npgsql does not support at all.
+                using (DbConnection connection = provider.CreateConnection())
+                {
+                    await connection.OpenAsync();
+
+                    using (scheduler.EnlistConnection(connection))
+                    {
+                        await scheduler.ScheduleJob(CreateJob(jobKey), CreateTrigger(jobKey));
+                    }
+                }
+
+                // scope is disposed without Complete, so the ambient transaction rolls back
+            }
+
+            bool survivedTheRollback = await scheduler.CheckExists(jobKey);
+            survivedTheRollback.Should().BeFalse("the ambient transaction was never completed");
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    /// <summary>
+    /// The scheduler runs for real here, which is what exercises the parts the other tests cannot:
+    /// the scheduler thread contending for the locks the application transaction holds, and the
+    /// scheduling change signal that has to wait for the commit. A job scheduled to fire immediately
+    /// must run promptly after the application commits - not an idle interval later.
+    /// </summary>
+    private static async Task RunningSchedulerFiresTheJobRightAfterTheApplicationCommits(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName, idleWaitTime: TimeSpan.FromMinutes(2));
+        JobKey jobKey = new JobKey("running", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+            SignallingJob.Reset();
+            await scheduler.Start();
+
+            using (DbConnection connection = provider.CreateConnection())
+            {
+                await connection.OpenAsync();
+                using (DbTransaction transaction = connection.BeginTransaction())
+                {
+                    IJobDetail job = JobBuilder.Create<SignallingJob>()
+                        .WithIdentity(jobKey)
+                        .StoreDurably()
+                        .Build();
+
+                    ITrigger trigger = TriggerBuilder.Create()
+                        .WithIdentity(jobKey.Name, jobKey.Group)
+                        .ForJob(jobKey)
+                        .StartNow()
+                        .Build();
+
+                    using (scheduler.EnlistTransaction(transaction))
+                    {
+                        await scheduler.ScheduleJob(job, trigger);
+                        transaction.Commit();
+                    }
+                }
+            }
+
+            // Comfortably below the two minute idle wait, so passing means the post-commit signal
+            // woke the scheduler rather than the idle timer expiring.
+            bool fired = SignallingJob.Fired.Wait(TimeSpan.FromSeconds(30));
+            fired.Should().BeTrue("the scheduler must be signalled once the application's commit makes the trigger visible");
+
+            await scheduler.Clear();
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    private static async Task EnlistingIsRefusedWhenTheStoreDoesNotAcceptIt(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName, acceptEnlistedTransactions: false);
+
+        try
+        {
+            using (DbConnection connection = provider.CreateConnection())
+            {
+                await connection.OpenAsync();
+                using DbTransaction transaction = connection.BeginTransaction();
+
+                Action enlist = () => scheduler.EnlistTransaction(transaction);
+
+                enlist.Should().Throw<InvalidOperationException>()
+                    .WithMessage("*acceptEnlistedTransactions*",
+                        "silently ignoring the enlistment would let scheduling commit outside the application's transaction");
+            }
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    private static IJobDetail CreateJob(JobKey jobKey)
+    {
+        return JobBuilder.Create<NoOpJob>()
+            .WithIdentity(jobKey)
+            .StoreDurably()
+            .Build();
+    }
+
+    private static ITrigger CreateTrigger(JobKey jobKey)
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity(jobKey.Name, jobKey.Group)
+            .ForJob(jobKey)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+            .Build();
+    }
+
+    private static async Task<IScheduler> CreateScheduler(
+        TestProvider provider,
+        string schedulerName,
+        bool acceptEnlistedTransactions = true,
+        TimeSpan? idleWaitTime = null)
+    {
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = schedulerName,
+            ["quartz.scheduler.instanceId"] = "AUTO",
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+            ["quartz.jobStore.type"] = typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion(),
+            ["quartz.jobStore.useProperties"] = "true",
+            ["quartz.jobStore.dataSource"] = "default",
+            ["quartz.jobStore.tablePrefix"] = "QRTZ_",
+            ["quartz.jobStore.acceptEnlistedTransactions"] = acceptEnlistedTransactions.ToString().ToLowerInvariant(),
+            ["quartz.jobStore.driverDelegateType"] = provider.DriverDelegateType.AssemblyQualifiedNameWithoutVersion(),
+            ["quartz.dataSource.default.connectionString"] = provider.ConnectionString,
+            ["quartz.dataSource.default.provider"] = provider.ProviderName,
+            ["quartz.threadPool.maxConcurrency"] = "2"
+        };
+
+        if (idleWaitTime != null)
+        {
+            properties["quartz.scheduler.idleWaitTime"] = ((int) idleWaitTime.Value.TotalMilliseconds).ToString();
+        }
+
+        // Most of these tests never start the scheduler - they are about what reaches the database,
+        // and a running scheduler thread would contend for the locks the application transaction
+        // holds. RunningSchedulerFiresTheJobRightAfterTheApplicationCommits is the one that does.
+        return await new StdSchedulerFactory(properties).GetScheduler();
+    }
+
+    private static TestProvider Postgres()
+    {
+        return new TestProvider(
+            TestConstants.PostgresProvider,
+            TestConstants.PostgresConnectionString,
+            typeof(PostgreSQLDelegate),
+            () => new NpgsqlConnection(TestConstants.PostgresConnectionString));
+    }
+
+    private static TestProvider SqlServer()
+    {
+        return new TestProvider(
+            TestConstants.DefaultSqlServerProvider,
+            TestConstants.SqlServerConnectionString,
+            typeof(SqlServerDelegate),
+            () => new SqlConnection(TestConstants.SqlServerConnectionString));
+    }
+
+    [DisallowConcurrentExecution]
+    public sealed class SignallingJob : IJob
+    {
+        internal static readonly ManualResetEventSlim Fired = new ManualResetEventSlim(false);
+
+        internal static void Reset() => Fired.Reset();
+
+        public Task Execute(IJobExecutionContext context)
+        {
+            Fired.Set();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestProvider
+    {
+        private readonly Func<DbConnection> connectionFactory;
+
+        internal TestProvider(
+            string providerName,
+            string connectionString,
+            Type driverDelegateType,
+            Func<DbConnection> connectionFactory)
+        {
+            ProviderName = providerName;
+            ConnectionString = connectionString;
+            DriverDelegateType = driverDelegateType;
+            this.connectionFactory = connectionFactory;
+        }
+
+        internal string ProviderName { get; }
+
+        internal string ConnectionString { get; }
+
+        internal Type DriverDelegateType { get; }
+
+        internal DbConnection CreateConnection() => connectionFactory();
+    }
+}

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Transactions" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="23.26.100" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AmbientConnectionTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AmbientConnectionTest.cs
@@ -1,0 +1,507 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using System.Transactions;
+
+using FakeItEasy;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Util;
+
+using IsolationLevel = System.Data.IsolationLevel;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// Covers the job store joining a transaction the application owns, either through a connection it
+/// enlisted or through an ambient <see cref="TransactionScope" />.
+/// </summary>
+[NonParallelizable]
+public sealed class AmbientConnectionTest
+{
+    private const string SchedulerName = "AmbientConnectionTestScheduler";
+
+    [Test]
+    public void EnlistTransaction_MakesTheJobStoreUseTheApplicationsConnection()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        applicationConnection.Open();
+        DbTransaction applicationTransaction = applicationConnection.BeginTransaction();
+
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out RecordingDbConnection ownConnection);
+
+        using (CreateScheduler().EnlistTransaction(applicationTransaction))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection);
+            holder.Transaction.Should().BeSameAs(applicationTransaction);
+            holder.OwnsResources.Should().BeFalse("the application owns what it enlisted");
+        }
+
+        ownConnection.OpenCount.Should().Be(0, "the job store should not have opened a connection of its own");
+        applicationConnection.BeginTransactionCount.Should().Be(1, "only the application's own transaction was started");
+    }
+
+    [Test]
+    public void EnlistConnection_OpensTheConnectionWhenItIsClosed()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistConnection(applicationConnection))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection);
+            holder.Transaction.Should().BeNull("the ambient scope owns the transaction");
+        }
+
+        applicationConnection.OpenCount.Should().Be(1);
+        applicationConnection.BeginTransactionCount.Should().Be(0, "an enlisted connection joins the transaction the application already has");
+    }
+
+    [Test]
+    public void EnlistConnection_WithNothingToJoin_IsRefused()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+
+        Action enlist = () => CreateScheduler().EnlistConnection(applicationConnection);
+
+        enlist.Should().Throw<ArgumentException>()
+            .WithParameterName("connection")
+            .WithMessage("*no transaction to join*",
+                "without one every statement would commit on the spot while looking like a working enlistment");
+    }
+
+    [Test]
+    public void Enlistment_EndsWhenTheScopeIsDisposed()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out RecordingDbConnection ownConnection);
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+        }
+
+        ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+        holder.Connection.Should().BeSameAs(ownConnection);
+        holder.OwnsResources.Should().BeTrue();
+    }
+
+    [Test]
+    public void Enlistment_IsScopedToTheScheduler()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out RecordingDbConnection ownConnection);
+
+        using (Enlist(CreateScheduler("SomeOtherScheduler"), applicationConnection))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(ownConnection, "the enlistment belongs to a different scheduler");
+        }
+    }
+
+    [Test]
+    public void Enlistment_Nests()
+    {
+        RecordingDbConnection outerConnection = new RecordingDbConnection();
+        RecordingDbConnection innerConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (Enlist(CreateScheduler(), outerConnection))
+        {
+            using (Enlist(CreateScheduler(), innerConnection))
+            {
+                jobStore.CallGetConnection().Connection.Should().BeSameAs(innerConnection);
+            }
+
+            jobStore.CallGetConnection().Connection.Should().BeSameAs(outerConnection, "disposing the inner scope restores the outer one");
+        }
+    }
+
+    [Test]
+    public async Task Enlistment_DoesNotLeakIntoFlowsStartedOutsideIt()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out RecordingDbConnection ownConnection);
+
+        // Started outside the scope, so it must never see the enlistment however long it runs. The
+        // gate makes the enlistment exist before the flow does any work, which a plain static field
+        // would fail.
+        TaskCompletionSource<bool> enlisted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<DbConnection> unrelatedFlow = Task.Run(async () =>
+        {
+            await enlisted.Task;
+            return jobStore.CallGetConnection().Connection;
+        });
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+            enlisted.SetResult(true);
+
+            (await unrelatedFlow).Should().BeSameAs(ownConnection);
+        }
+    }
+
+    [Test]
+    public async Task ForkingInsideAnEnlistment_RefusesTheSecondConcurrentUse()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+            // Both children inherit the enlistment - that is the point of AsyncLocal - and one
+            // connection cannot serve two operations, so the loser is told why rather than left to
+            // hit "a command is already in progress" from the provider.
+            ConnectionAndTransactionHolder held = jobStore.CallGetConnection();
+
+            Func<Task> forked = () => Task.Run(() => jobStore.CallGetConnection());
+
+            await forked.Should().ThrowAsync<JobPersistenceException>()
+                .WithMessage("*cannot be used concurrently*");
+
+            jobStore.CallCleanupConnection(held);
+        }
+    }
+
+    [Test]
+    public void Enlistment_IsIgnoredWhenTheStoreDoesNotAcceptIt()
+    {
+        // A local scheduler refuses the enlistment outright (see EnlistedTransactionTest); this
+        // covers the job store side of the same guard, which is what a remote or custom-store
+        // scheduler falls back on.
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: false, out RecordingDbConnection ownConnection);
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(ownConnection, "the job store was not configured to join application transactions");
+            holder.OwnsResources.Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void UsingAnEnlistmentAfterItsTransactionCompleted_IsRefused()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        applicationConnection.Open();
+        DbTransaction applicationTransaction = applicationConnection.BeginTransaction();
+
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (CreateScheduler().EnlistTransaction(applicationTransaction))
+        {
+            applicationTransaction.Commit();
+
+            Action afterCommit = () => jobStore.CallGetConnection();
+
+            // Carrying on would attach a completed transaction, or - worse - run in autocommit where
+            // a half-finished write can no longer be rolled back.
+            afterCommit.Should().Throw<JobPersistenceException>()
+                .WithMessage("*already been committed or rolled back*");
+        }
+    }
+
+    [Test]
+    public void ConcurrentUseOfOneEnlistedConnection_IsRefusedWithAnExplanation()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+            ConnectionAndTransactionHolder first = jobStore.CallGetConnection();
+
+            Action second = () => jobStore.CallGetConnection();
+            second.Should().Throw<JobPersistenceException>().WithMessage("*cannot be used concurrently*");
+
+            jobStore.CallCleanupConnection(first);
+
+            // Once the first operation is done the connection can be claimed again.
+            jobStore.CallGetConnection().Connection.Should().BeSameAs(applicationConnection);
+        }
+    }
+
+    [Test]
+    public void Suppress_HidesTheEnlistmentFromSchedulerOwnedWork()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out RecordingDbConnection ownConnection);
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+            using (AmbientConnection.Suppress())
+            {
+                ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+                holder.Connection.Should().BeSameAs(ownConnection, "suppressed work must not borrow the application's connection");
+                holder.OwnsResources.Should().BeTrue();
+            }
+
+            jobStore.CallGetConnection().Connection.Should().BeSameAs(applicationConnection, "suppression ends with its scope");
+        }
+    }
+
+    [Test]
+    public void AmbientTransactionScopeAlone_DoesNotMakeTheJobStoreJoinIt()
+    {
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out RecordingDbConnection ownConnection);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            // Taking part means handing over a connection. Joining the scope with a connection of our
+            // own would put a second connection in it - a distributed transaction, which not every
+            // provider supports - and leave the commit outside our control.
+            holder.Connection.Should().BeSameAs(ownConnection);
+            holder.Transaction.Should().NotBeNull("the job store manages its own connection's transaction");
+            holder.OwnsResources.Should().BeTrue();
+            ownConnection.BeginTransactionCount.Should().Be(1);
+            ownConnection.EnlistedIn.Should().BeNull("the job store's own connection stays out of the ambient transaction");
+        }
+    }
+
+    [Test]
+    public void WithoutAnApplicationTransaction_TheJobStoreStartsItsOwn()
+    {
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out RecordingDbConnection ownConnection);
+
+        ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+        holder.Connection.Should().BeSameAs(ownConnection);
+        holder.Transaction.Should().NotBeNull();
+        holder.OwnsResources.Should().BeTrue();
+        ownConnection.BeginTransactionCount.Should().Be(1);
+    }
+
+    [Test]
+    public void AmbientTransactionScope_IsLeftAloneWhenTheFeatureIsOff()
+    {
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: false, out RecordingDbConnection ownConnection);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            holder.Transaction.Should().NotBeNull("behaviour must not change unless the feature is switched on");
+            ownConnection.BeginTransactionCount.Should().Be(1);
+            ownConnection.EnlistedIn.Should().NotBeNull(
+                "with the feature off the connection enlists as it always did - suppressing it would be a behaviour change of its own");
+        }
+    }
+
+    [Test]
+    public void EnlistTransaction_RejectsATransactionThatLostItsConnection()
+    {
+        DbTransaction orphaned = new OrphanedDbTransaction();
+
+        Action enlist = () => CreateScheduler().EnlistTransaction(orphaned);
+
+        enlist.Should().Throw<ArgumentException>().WithParameterName("transaction");
+    }
+
+    [Test]
+    public void SchedulerOwnedWorkInsideAnAmbientScope_StaysOutOfIt()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out RecordingDbConnection ownConnection);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistConnection(applicationConnection))
+        using (AmbientConnection.Suppress())
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            // A probe is expected to fail when a column is absent, and on PostgreSQL a failed
+            // statement aborts the whole transaction - so this connection must be in neither the
+            // enlisted transaction nor the ambient one.
+            holder.Connection.Should().BeSameAs(ownConnection, "suppressed work must not borrow the application's connection");
+            holder.Transaction.Should().NotBeNull("suppressed work runs in a transaction of its own");
+            ownConnection.EnlistedIn.Should().BeNull("and that transaction must not be the application's");
+        }
+    }
+
+    [Test]
+    public async Task EnlistingOnAScheduler_WithoutAPersistentStore_IsRefused()
+    {
+        // The fakes used elsewhere in this fixture are not StdScheduler, so the fail-fast guard
+        // short-circuits for them; this drives it through a real one.
+        DirectSchedulerFactory.Instance.CreateVolatileScheduler(1);
+        IScheduler scheduler = SchedulerRepository.Instance.Lookup(DirectSchedulerFactory.DefaultSchedulerName);
+
+        RecordingDbConnection connection = new RecordingDbConnection();
+        connection.Open();
+
+        try
+        {
+            Action enlist = () => scheduler.EnlistTransaction(connection.BeginTransaction());
+
+            enlist.Should().Throw<InvalidOperationException>()
+                .WithMessage("*does not store anything in the application's database*",
+                    "an in-memory store would let the scheduling survive the application's rollback");
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    /// <summary>
+    /// Enlists a connection together with a transaction of its own, the shape most callers use.
+    /// </summary>
+    private static IDisposable Enlist(IScheduler scheduler, RecordingDbConnection connection)
+    {
+        if (connection.State == ConnectionState.Closed)
+        {
+            connection.Open();
+        }
+
+        return scheduler.EnlistTransaction(connection.BeginTransaction());
+    }
+
+    private static IScheduler CreateScheduler(string name = SchedulerName)
+    {
+        IScheduler scheduler = A.Fake<IScheduler>();
+        A.CallTo(() => scheduler.SchedulerName).Returns(name);
+        return scheduler;
+    }
+
+    private static TestJobStore CreateJobStore(bool acceptEnlistedTransactions, out RecordingDbConnection ownConnection)
+    {
+        RecordingDbConnection connection = new RecordingDbConnection();
+        ownConnection = connection;
+
+        IDbConnectionManager connectionManager = A.Fake<IDbConnectionManager>();
+        A.CallTo(() => connectionManager.GetConnection("default")).Returns(connection);
+
+        return new TestJobStore
+        {
+            InstanceName = SchedulerName,
+            DataSource = "default",
+            ConnectionManager = connectionManager,
+            AcceptEnlistedTransactions = acceptEnlistedTransactions
+        };
+    }
+
+    private sealed class TestJobStore : JobStoreTX
+    {
+        internal ConnectionAndTransactionHolder CallGetConnection() => GetConnection();
+
+        internal void CallCleanupConnection(ConnectionAndTransactionHolder conn) => CleanupConnection(conn);
+    }
+
+    private sealed class RecordingDbConnection : DbConnection
+    {
+        private ConnectionState state = ConnectionState.Closed;
+
+        internal int OpenCount { get; private set; }
+
+        internal int BeginTransactionCount { get; private set; }
+
+        /// <summary>
+        /// The ambient transaction this connection would have auto-enlisted in when it was opened,
+        /// which is how ADO.NET providers behave unless enlistment is suppressed or switched off.
+        /// </summary>
+        internal System.Transactions.Transaction EnlistedIn { get; private set; }
+
+        public override string ConnectionString { get; set; } = "";
+
+        public override string Database => "";
+
+        public override string DataSource => "";
+
+        public override string ServerVersion => "";
+
+        public override ConnectionState State => state;
+
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
+
+        public override void Close() => state = ConnectionState.Closed;
+
+        public override void Open()
+        {
+            OpenCount++;
+            state = ConnectionState.Open;
+            EnlistedIn = System.Transactions.Transaction.Current;
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            BeginTransactionCount++;
+            return new RecordingDbTransaction(this, isolationLevel);
+        }
+
+        protected override DbCommand CreateDbCommand() => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingDbTransaction : DbTransaction
+    {
+        private readonly IsolationLevel isolationLevel;
+        private DbConnection connection;
+
+        internal RecordingDbTransaction(DbConnection connection, IsolationLevel isolationLevel)
+        {
+            this.connection = connection;
+            this.isolationLevel = isolationLevel;
+        }
+
+        // ADO.NET providers drop the connection reference once the transaction completes, which is
+        // how a completed transaction is recognised.
+        protected override DbConnection DbConnection => connection;
+
+        public override IsolationLevel IsolationLevel => isolationLevel;
+
+        public override void Commit() => connection = null;
+
+        public override void Rollback() => connection = null;
+    }
+
+    private sealed class OrphanedDbTransaction : DbTransaction
+    {
+        protected override DbConnection DbConnection => null;
+
+        public override IsolationLevel IsolationLevel => IsolationLevel.ReadCommitted;
+
+        public override void Commit()
+        {
+        }
+
+        public override void Rollback()
+        {
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/ConnectionAndTransactionHolderTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/ConnectionAndTransactionHolderTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using System.Data.Common;
 
@@ -45,6 +46,96 @@ public sealed class ConnectionAndTransactionHolderTest
         holder.Rollback(transientError: false);
     }
 
+    [Test]
+    public void OwnsResources_DefaultsToTrue()
+    {
+        DbConnection connection = A.Fake<DbConnection>();
+
+        ConnectionAndTransactionHolder holder = new ConnectionAndTransactionHolder(connection, transaction: null);
+
+        holder.OwnsResources.Should().BeTrue("a holder that opened its own connection is responsible for it");
+    }
+
+    [Test]
+    public void BorrowedHolder_LeavesTheApplicationsTransactionAlone()
+    {
+        DbConnection connection = A.Fake<DbConnection>();
+        TestDbTransaction transaction = new TestDbTransaction(dbConnection: connection);
+
+        ConnectionAndTransactionHolder holder = new ConnectionAndTransactionHolder(connection, transaction, ownsResources: false);
+
+        holder.Commit(openNewTransaction: false);
+        holder.Rollback(transientError: false);
+
+        holder.OwnsResources.Should().BeFalse();
+        transaction.CommitCalled.Should().BeFalse("the application decides when its transaction commits");
+        transaction.RollbackCalled.Should().BeFalse("rolling back here would discard the application's own work too");
+    }
+
+    [Test]
+    public void BorrowedHolder_LeavesTheApplicationsConnectionOpen()
+    {
+        TestDbConnection connection = new TestDbConnection();
+        TestDbTransaction transaction = new TestDbTransaction(dbConnection: connection);
+
+        ConnectionAndTransactionHolder holder = new ConnectionAndTransactionHolder(connection, transaction, ownsResources: false);
+
+        holder.Close();
+        holder.Dispose();
+
+        connection.CloseCalled.Should().BeFalse("the application keeps using its connection after we are done");
+        connection.DisposeCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public void OwnedHolder_ClosesItsConnection()
+    {
+        TestDbConnection connection = new TestDbConnection();
+
+        ConnectionAndTransactionHolder holder = new ConnectionAndTransactionHolder(connection, transaction: null);
+
+        holder.Close();
+
+        connection.CloseCalled.Should().BeTrue();
+    }
+
+    private sealed class TestDbConnection : DbConnection
+    {
+        public bool CloseCalled { get; private set; }
+
+        public bool DisposeCalled { get; private set; }
+
+        public override string ConnectionString { get; set; } = "";
+
+        public override string Database => "";
+
+        public override string DataSource => "";
+
+        public override string ServerVersion => "";
+
+        public override ConnectionState State => ConnectionState.Open;
+
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
+
+        public override void Close() => CloseCalled = true;
+
+        public override void Open()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalled = true;
+            base.Dispose(disposing);
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+
+        protected override DbCommand CreateDbCommand() => throw new NotSupportedException();
+    }
+
     private sealed class TestDbTransaction : DbTransaction
     {
         private readonly DbConnection dbConnection;
@@ -56,12 +147,15 @@ public sealed class ConnectionAndTransactionHolderTest
 
         public bool RollbackCalled { get; private set; }
 
+        public bool CommitCalled { get; private set; }
+
         protected override DbConnection DbConnection => dbConnection;
 
         public override IsolationLevel IsolationLevel => IsolationLevel.ReadCommitted;
 
         public override void Commit()
         {
+            CommitCalled = true;
         }
 
         public override void Rollback()

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -52,6 +52,9 @@
     <ProjectReference Include="..\Quartz.Plugins.TimeZoneConverter\Quartz.Plugins.TimeZoneConverter.csproj" />
     <ProjectReference Include="..\Quartz.Serialization.Json\Quartz.Serialization.Json.csproj" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -157,6 +157,11 @@ public class QuartzScheduler :
     public virtual Type JobStoreClass => resources.JobStore.GetType();
 
     /// <summary>
+    /// The job store backing this scheduler.
+    /// </summary>
+    internal IJobStore JobStore => resources.JobStore;
+
+    /// <summary>
     /// Gets the thread pool class.
     /// </summary>
     /// <value>The thread pool class.</value>
@@ -363,8 +368,23 @@ public class QuartzScheduler :
         if (!initialStart.HasValue)
         {
             initialStart = SystemTime.UtcNow();
-            await resources.JobStore.SchedulerStarted(cancellationToken).ConfigureAwait(false);
-            await StartPlugins(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await resources.JobStore.SchedulerStarted(cancellationToken).ConfigureAwait(false);
+                await StartPlugins(cancellationToken).ConfigureAwait(false);
+            }
+            catch (SchedulerStartRefusedException)
+            {
+                // Refused before the job store set anything up, so starting again is safe once the
+                // caller has fixed the cause. Leaving the marker latched would send the retry down
+                // the "already started" path, skipping job recovery, the misfire handler and cluster
+                // check-in while still starting the acquire loop. Only this one exception un-latches:
+                // a failure further in may already have created those, and re-running would orphan
+                // them - the abandoned misfire handler owns a foreground thread that outlives
+                // Shutdown and keeps the process alive.
+                initialStart = null;
+                throw;
+            }
         }
         else
         {

--- a/src/Quartz/Core/SchedulerStartRefusedException.cs
+++ b/src/Quartz/Core/SchedulerStartRefusedException.cs
@@ -1,0 +1,38 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+
+namespace Quartz.Core;
+
+/// <summary>
+/// Thrown by a job store that declines to start at all, before it has created anything. It is a
+/// <see cref="SchedulerException" /> to the caller; the distinct type only tells
+/// <see cref="QuartzScheduler.Start" /> that nothing was set up, so the start marker can be released
+/// and a corrected retry can run the full start-up sequence rather than the resume path.
+/// </summary>
+[Serializable]
+internal sealed class SchedulerStartRefusedException : SchedulerException
+{
+    internal SchedulerStartRefusedException(string message) : base(message)
+    {
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/AmbientConnection.cs
+++ b/src/Quartz/Impl/AdoJobStore/AmbientConnection.cs
@@ -1,0 +1,285 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Data.Common;
+using System.Threading;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// Keeps track of the connection and transaction that the current asynchronous flow has enlisted
+/// for a given scheduler, so that <see cref="JobStoreSupport" /> can join the unit of work the
+/// application already owns instead of opening a connection and starting a transaction of its own.
+/// </summary>
+/// <remarks>
+/// The state flows with <see cref="AsyncLocal{T}" />, the same mechanism that carries
+/// <see cref="System.Transactions.Transaction.Current" />. Entries form an immutable chain so that
+/// nested enlistments - possibly for different schedulers - restore the previous value when disposed.
+/// </remarks>
+/// <seealso cref="SchedulerEnlistmentExtensions" />
+internal static class AmbientConnection
+{
+    private static readonly AsyncLocal<EnlistedConnection?> current = new AsyncLocal<EnlistedConnection?>();
+
+    /// <summary>
+    /// Returns the connection enlisted for the given scheduler in the current asynchronous flow,
+    /// or <see langword="null" /> when there is none.
+    /// </summary>
+    internal static EnlistedConnection? Get(string schedulerName)
+    {
+        EnlistedConnection? entry = current.Value;
+        while (entry != null)
+        {
+            if (!entry.Disposed && string.Equals(entry.SchedulerName, schedulerName, StringComparison.Ordinal))
+            {
+                return entry;
+            }
+
+            entry = entry.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Enlists the given connection and transaction for the given scheduler until the returned
+    /// scope is disposed.
+    /// </summary>
+    internal static IDisposable Enlist(
+        string schedulerName,
+        DbConnection connection,
+        DbTransaction? transaction,
+        System.Transactions.Transaction? ambient = null)
+    {
+        EnlistedConnection entry = new EnlistedConnection(schedulerName, connection, transaction, current.Value, ambient);
+        current.Value = entry;
+        return new EnlistmentScope(entry);
+    }
+
+    /// <summary>
+    /// Hides every enlistment from the current asynchronous flow until the returned scope is
+    /// disposed. Used for work that belongs to the scheduler rather than to the caller - optional
+    /// column probing, cluster check-in, misfire recovery - which must run on a connection of its
+    /// own whatever the caller enlisted.
+    /// </summary>
+    /// <remarks>
+    /// Only the enlistment is hidden; keeping the connection the job store then opens out of an
+    /// ambient transaction is handled where that connection is opened, so it applies to every job
+    /// store connection and not just to suppressed work.
+    /// </remarks>
+    internal static IDisposable Suppress()
+    {
+        EnlistedConnection? previous = current.Value;
+        if (previous == null)
+        {
+            return NullScope.Instance;
+        }
+
+        current.Value = null;
+        return new SuppressionScope(previous);
+    }
+
+    private sealed class SuppressionScope : IDisposable
+    {
+        private readonly EnlistedConnection previous;
+        private bool disposed;
+
+        internal SuppressionScope(EnlistedConnection previous)
+        {
+            this.previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            current.Value = previous;
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        internal static readonly NullScope Instance = new NullScope();
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class EnlistmentScope : IDisposable
+    {
+        private readonly EnlistedConnection entry;
+
+        internal EnlistmentScope(EnlistedConnection entry)
+        {
+            this.entry = entry;
+        }
+
+        public void Dispose()
+        {
+            if (entry.Disposed)
+            {
+                return;
+            }
+
+            entry.Disposed = true;
+
+            // Only unwind when we are the innermost entry; out-of-order disposal leaves the chain
+            // alone and relies on the disposed flag to hide the entry from lookups.
+            if (ReferenceEquals(current.Value, entry))
+            {
+                current.Value = entry.Parent;
+            }
+
+            if (!entry.SignalOwnedByAmbient)
+            {
+                entry.FlushSignal();
+            }
+        }
+    }
+}
+
+/// <summary>
+/// A connection and transaction that application code has enlisted for a scheduler, together with
+/// the scheduling change signal that is deferred until the enlistment ends.
+/// </summary>
+internal sealed class EnlistedConnection
+{
+    private readonly object signalLock = new object();
+    private DateTimeOffset? pendingSignalTime;
+    private bool signalPending;
+    private Action<DateTimeOffset?>? signaler;
+    private int inUse;
+
+    internal EnlistedConnection(
+        string schedulerName,
+        DbConnection connection,
+        DbTransaction? transaction,
+        EnlistedConnection? parent,
+        System.Transactions.Transaction? ambient)
+    {
+        SchedulerName = schedulerName;
+        Connection = connection;
+        Transaction = transaction;
+        Parent = parent;
+        Ambient = ambient;
+    }
+
+    internal string SchedulerName { get; }
+
+    internal DbConnection Connection { get; }
+
+    internal DbTransaction? Transaction { get; }
+
+    /// <summary>
+    /// The ambient transaction the connection was enlisted under, when the caller supplied no
+    /// <see cref="DbTransaction" /> of its own. Kept so that a scope which has since ended can be
+    /// recognised instead of letting the operation quietly autocommit.
+    /// </summary>
+    internal System.Transactions.Transaction? Ambient { get; }
+
+    internal EnlistedConnection? Parent { get; }
+
+    internal bool Disposed { get; set; }
+
+    /// <summary>
+    /// Whether a post-commit signal has already been hooked onto the ambient transaction, so that a
+    /// scope containing many scheduling calls ends up with one handler rather than one per call.
+    /// </summary>
+    internal bool AmbientSignalHooked { get; set; }
+
+    /// <summary>
+    /// Whether an ambient transaction has taken over raising the deferred signal. It reports whether
+    /// the work actually committed, which disposing this scope cannot, so the scope stays quiet and
+    /// a rollback raises nothing.
+    /// </summary>
+    internal bool SignalOwnedByAmbient { get; set; }
+
+    /// <summary>
+    /// Claims the enlisted connection for one job store operation. A single connection cannot serve
+    /// two operations at once, so a second concurrent claim is refused here with an explanation
+    /// rather than left to surface as a provider-specific "a command is already in progress".
+    /// </summary>
+    internal bool TryClaim() => Interlocked.CompareExchange(ref inUse, 1, 0) == 0;
+
+    internal void Release() => Interlocked.Exchange(ref inUse, 0);
+
+    /// <summary>
+    /// Remembers that the scheduler should be told about a scheduling change, but only once the
+    /// application has committed. Signalling while the rows are still uncommitted would send the
+    /// scheduler thread looking for a trigger it cannot see yet.
+    /// </summary>
+    internal void DeferSignal(DateTimeOffset? signalTime, Action<DateTimeOffset?> signalAction)
+    {
+        lock (signalLock)
+        {
+            signaler = signalAction;
+
+            if (!signalPending)
+            {
+                signalPending = true;
+                pendingSignalTime = signalTime;
+                return;
+            }
+
+            // Keep the earliest candidate. A null candidate means "recompute from scratch" and wins
+            // over any concrete time, since it makes the scheduler re-evaluate unconditionally.
+            if (signalTime == null || pendingSignalTime == null)
+            {
+                pendingSignalTime = null;
+            }
+            else if (signalTime < pendingSignalTime)
+            {
+                pendingSignalTime = signalTime;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fires the deferred scheduling change signal, if any. Called when the enlistment scope is
+    /// disposed, which the caller is expected to do once it has committed.
+    /// </summary>
+    internal void FlushSignal()
+    {
+        Action<DateTimeOffset?>? signalAction;
+        DateTimeOffset? signalTime;
+        bool pending;
+        lock (signalLock)
+        {
+            signalAction = signaler;
+            signalTime = pendingSignalTime;
+            pending = signalPending;
+            signaler = null;
+            pendingSignalTime = null;
+            signalPending = false;
+        }
+
+        if (pending && signalAction != null)
+        {
+            signalAction(signalTime);
+        }
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/ConnectionAndTransactionHolder.cs
+++ b/src/Quartz/Impl/AdoJobStore/ConnectionAndTransactionHolder.cs
@@ -37,6 +37,7 @@ public class ConnectionAndTransactionHolder : IDisposable
 
     private readonly DbConnection connection;
     private DbTransaction? transaction;
+    private readonly bool ownsResources;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConnectionAndTransactionHolder"/> class.
@@ -44,14 +45,52 @@ public class ConnectionAndTransactionHolder : IDisposable
     /// <param name="connection">The connection.</param>
     /// <param name="transaction">The transaction.</param>
     public ConnectionAndTransactionHolder(DbConnection connection, DbTransaction? transaction)
+        : this(connection, transaction, ownsResources: true)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionAndTransactionHolder"/> class.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="transaction">The transaction.</param>
+    /// <param name="ownsResources">
+    /// Whether this unit of work owns the connection and transaction. When <see langword="false" />
+    /// they belong to the caller, who enlisted them via
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistTransaction" />, and this holder will neither
+    /// commit, roll back, close nor dispose them.
+    /// </param>
+    /// <param name="borrowedFrom">
+    /// The enlistment the connection was borrowed from, so its single-use claim can be returned to
+    /// that exact entry when this unit of work is cleaned up.
+    /// </param>
+    internal ConnectionAndTransactionHolder(
+        DbConnection connection,
+        DbTransaction? transaction,
+        bool ownsResources,
+        EnlistedConnection? borrowedFrom = null)
     {
         this.connection = connection;
         this.transaction = transaction;
+        this.ownsResources = ownsResources;
+        BorrowedFrom = borrowedFrom;
     }
+
+    /// <summary>
+    /// The enlistment this unit of work borrowed its connection from, so that the claim is returned
+    /// to that exact entry rather than to whatever is enlisted by the time cleanup runs.
+    /// </summary>
+    internal EnlistedConnection? BorrowedFrom { get; }
 
     public DbConnection Connection => connection;
 
     public DbTransaction? Transaction => transaction;
+
+    /// <summary>
+    /// Whether this unit of work owns the connection and the transaction. When it does not, the
+    /// application enlisted them and is responsible for committing, rolling back and disposing them.
+    /// </summary>
+    internal bool OwnsResources => ownsResources;
 
     public void Attach(DbCommand cmd)
     {
@@ -61,6 +100,12 @@ public class ConnectionAndTransactionHolder : IDisposable
 
     public void Commit(bool openNewTransaction)
     {
+        if (!ownsResources)
+        {
+            // The application owns the transaction and decides when it commits.
+            return;
+        }
+
         if (transaction != null)
         {
             try
@@ -83,6 +128,12 @@ public class ConnectionAndTransactionHolder : IDisposable
 
     public void Close()
     {
+        if (!ownsResources)
+        {
+            // Borrowed connection, the application keeps using it after we are done.
+            return;
+        }
+
         try
         {
             connection.Close();
@@ -99,6 +150,14 @@ public class ConnectionAndTransactionHolder : IDisposable
 
     public void Dispose()
     {
+        if (!ownsResources)
+        {
+            // Hand the enlistment back even when disposed directly rather than through
+            // CleanupConnection, or its single-use claim would stay held for the rest of the scope.
+            BorrowedFrom?.Release();
+            return;
+        }
+
         try
         {
             connection?.Dispose();
@@ -139,6 +198,13 @@ public class ConnectionAndTransactionHolder : IDisposable
 
     public void Rollback(bool transientError)
     {
+        if (!ownsResources)
+        {
+            // The application owns the transaction; the failure propagates to it and it decides
+            // whether to roll back. Rolling back here would silently discard its work as well.
+            return;
+        }
+
         if (transaction != null)
         {
             if (transaction.Connection == null)

--- a/src/Quartz/Impl/AdoJobStore/JobStoreCMT.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreCMT.cs
@@ -23,6 +23,7 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Transactions;
 
 using Quartz.Logging;
 using Quartz.Spi;
@@ -94,9 +95,18 @@ public class JobStoreCMT : JobStoreSupport
     /// <returns></returns>
     protected override ConnectionAndTransactionHolder GetNonManagedTXConnection()
     {
+        ConnectionAndTransactionHolder? enlisted = GetEnlistedConnection();
+        if (enlisted != null)
+        {
+            return enlisted;
+        }
+
         DbConnection conn;
         try
         {
+            // Deliberately not kept out of an ambient transaction the way JobStoreSupport does it:
+            // this store exists precisely to run inside a transaction its container manages, so the
+            // connection auto-enlisting is the contract rather than an accident.
             conn = ConnectionManager.GetConnection(DataSource);
             if (OpenConnection)
             {
@@ -168,7 +178,24 @@ public class JobStoreCMT : JobStoreSupport
                 conn = GetNonManagedTXConnection();
             }
 
-            return await txCallback(conn).ConfigureAwait(false);
+            T result = await txCallback(conn).ConfigureAwait(false);
+
+            // Only for a connection the application enlisted, and only for operations that took the
+            // lock - those are the ones that can have changed the schedule. There the change becomes
+            // visible when its owner commits, and the scheduler is otherwise notified solely before
+            // that - by QuartzScheduler, as soon as the store call returns - finds nothing, and waits
+            // out a whole idle interval. Signalling for reads as well would announce an unknown
+            // earlier time on every query and keep bouncing acquired triggers back to waiting, and
+            // deployments that never opted in must keep the behaviour they had, which for this store
+            // is no signal from here at all.
+            DateTimeOffset? sigTime = conn.SignalSchedulingChangeOnTxCompletion;
+            if (conn.BorrowedFrom != null
+                && (sigTime != null || lockName != null && !LockAllOperations))
+            {
+                SignalSchedulingChangeOnApplicationCommit(conn, sigTime);
+            }
+
+            return result;
         }
         finally
         {

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -37,6 +37,13 @@ using Quartz.Logging;
 using Quartz.Spi;
 using Quartz.Util;
 
+// aliased to keep System.Data.IsolationLevel unambiguous in this file
+using Transaction = System.Transactions.Transaction;
+using TransactionStatus = System.Transactions.TransactionStatus;
+using TransactionScope = System.Transactions.TransactionScope;
+using TransactionScopeOption = System.Transactions.TransactionScopeOption;
+using TransactionScopeAsyncFlowOption = System.Transactions.TransactionScopeAsyncFlowOption;
+
 namespace Quartz.Impl.AdoJobStore;
 
 /// <summary>
@@ -226,6 +233,35 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     public bool UseDBLocks { get; set; }
 
     /// <summary>
+    /// Get or set whether this instance should take part in a transaction the application already
+    /// owns, rather than always managing an ADO.NET transaction of its own. Defaults to
+    /// <see langword="false" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, the job store uses the connection the application enlisted with
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistTransaction" /> or
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistConnection" /> for operations on that
+    /// asynchronous flow. The application owns the commit, so the job store neither commits nor
+    /// rolls back, and scheduling either happens together with the rest of the application's work or
+    /// not at all.
+    /// </para>
+    /// <para>
+    /// Taking part always means handing over a connection. Operations with nothing enlisted keep
+    /// using a connection of the job store's own, and that connection is deliberately kept out of any
+    /// ambient <see cref="System.Transactions.Transaction" />: joining a scope whose outcome the job
+    /// store does not control would also put a second connection in that transaction, which needs a
+    /// distributed transaction and is not available on every provider.
+    /// </para>
+    /// <para>
+    /// Because locks taken during an application-owned transaction are only released when that
+    /// transaction completes, enabling this switches locking to database locks
+    /// (<see cref="UseDBLocks" />) unless an explicit lock handler was configured.
+    /// </para>
+    /// </remarks>
+    public bool AcceptEnlistedTransactions { get; set; }
+
+    /// <summary>
     /// Whether or not to obtain locks when inserting new jobs/triggers.
     /// </summary>
     /// <remarks>
@@ -363,17 +399,115 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     protected abstract ConnectionAndTransactionHolder GetNonManagedTXConnection();
 
     /// <summary>
+    /// Returns the connection the application enlisted for this scheduler on the current
+    /// asynchronous flow, or <see langword="null" /> when ambient transactions are disabled or
+    /// nothing is enlisted. The returned holder does not own the connection or the transaction.
+    /// </summary>
+    private protected ConnectionAndTransactionHolder? GetEnlistedConnection()
+    {
+        if (!AcceptEnlistedTransactions)
+        {
+            return null;
+        }
+
+        EnlistedConnection? enlisted = AmbientConnection.Get(InstanceName);
+        if (enlisted == null)
+        {
+            return null;
+        }
+
+        // The enlisted transaction may have finished while its scope was still open - the application
+        // committed or rolled back, or its TransactionScope ended. Carrying on would run this
+        // operation in autocommit, where a half-finished write can no longer be rolled back, so refuse
+        // rather than quietly drop the transactional guarantee the caller asked for.
+        if (enlisted.Transaction != null && enlisted.Transaction.Connection == null)
+        {
+            throw new JobPersistenceException(
+                $"The transaction enlisted for scheduler '{InstanceName}' has already been committed or rolled back, "
+                + "so this operation would run with no transaction at all. Dispose the enlistment scope once the "
+                + "transaction completes, and enlist a new one for any further scheduling.");
+        }
+
+        // Compared with == rather than by reference: a dependent clone is a different object standing
+        // for the same transaction, and refusing those would break legitimate fan-out.
+        if (enlisted.Ambient != null && enlisted.Ambient != Transaction.Current)
+        {
+            throw new JobPersistenceException(
+                $"The transaction the connection enlisted for scheduler '{InstanceName}' belongs to is no longer the "
+                + "current one, so this operation would run with no transaction at all. Keep the enlistment scope inside "
+                + "the transaction scope it was created in, and dispose it before that scope ends.");
+        }
+
+        if (!enlisted.TryClaim())
+        {
+            throw new JobPersistenceException(
+                $"The connection enlisted for scheduler '{InstanceName}' is already serving another job store operation. "
+                + "An enlisted connection carries a single transaction and cannot be used concurrently, so scheduler calls "
+                + "made inside an enlistment scope must be awaited one at a time.");
+        }
+
+        try
+        {
+            if (enlisted.Connection.State == ConnectionState.Closed)
+            {
+                enlisted.Connection.Open();
+            }
+        }
+        catch (Exception e)
+        {
+            enlisted.Release();
+            throw new JobPersistenceException($"Failed to open the connection enlisted for scheduler '{InstanceName}': {e}", e);
+        }
+
+        return new ConnectionAndTransactionHolder(enlisted.Connection, enlisted.Transaction, ownsResources: false, borrowedFrom: enlisted);
+    }
+
+    /// <summary>
+    /// Whether the current operation runs inside a transaction the application owns. That is the
+    /// case only when the application enlisted a connection: a connection the job store opens for
+    /// itself deliberately stays outside whatever the caller has in flight.
+    /// </summary>
+    private bool InApplicationOwnedTransaction =>
+        AcceptEnlistedTransactions && AmbientConnection.Get(InstanceName) != null;
+
+    /// <summary>
+    /// Opens a connection that belongs to the job store.
+    /// </summary>
+    /// <remarks>
+    /// While <see cref="AcceptEnlistedTransactions" /> is on, such a connection is kept out of any ambient
+    /// <see cref="System.Transactions.Transaction" />. The application takes part by enlisting a
+    /// connection, not by the job store quietly joining a scope whose outcome it does not control;
+    /// letting it enlist would also put a second connection in that transaction, which needs a
+    /// distributed transaction and is not available on every provider.
+    /// </remarks>
+    private DbConnection OpenOwnConnection()
+    {
+        using TransactionScope? ambientSuppression = AcceptEnlistedTransactions && Transaction.Current != null
+            ? new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled)
+            : null;
+
+        DbConnection conn = ConnectionManager.GetConnection(DataSource);
+        conn.Open();
+        return conn;
+    }
+
+    /// <summary>
     /// Gets the connection and starts a new transaction.
     /// </summary>
     /// <returns></returns>
     protected virtual ConnectionAndTransactionHolder GetConnection()
     {
+        ConnectionAndTransactionHolder? enlisted = GetEnlistedConnection();
+        if (enlisted != null)
+        {
+            return enlisted;
+        }
+
         DbConnection conn;
         DbTransaction tx;
         try
         {
-            conn = ConnectionManager.GetConnection(DataSource);
-            conn.Open();
+            conn = OpenOwnConnection();
         }
         catch (Exception e)
         {
@@ -490,6 +624,26 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
 
     private IDbProvider DbProvider => ConnectionManager.GetDbProvider(DataSource);
 
+    /// <summary>
+    /// The connection type this store's configured provider produces, or <see langword="null" /> when
+    /// the provider does not report one.
+    /// </summary>
+    internal Type? ConnectionType
+    {
+        get
+        {
+            try
+            {
+                return DbProvider.Metadata.ConnectionType;
+            }
+            catch (Exception)
+            {
+                // No data source configured yet; nothing to check against.
+                return null;
+            }
+        }
+    }
+
     protected internal virtual ISemaphore LockHandler { get; set; } = null!;
 
     /// <summary>
@@ -543,6 +697,13 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
             }
         }
 
+        // The job store's own connections still honour this; a connection the application enlisted
+        // was begun at whatever level the application chose, and cannot be changed after the fact.
+        if (AcceptEnlistedTransactions && TxIsolationLevelSerializable && Delegate is not SQLiteDelegate)
+        {
+            Log.Warn("'quartz.jobStore.txIsolationLevelSerializable' applies only to connections the job store opens itself: an operation running on a connection enlisted by the application uses that transaction's isolation level instead.");
+        }
+
         // If the user hasn't specified an explicit lock handler, then
         // choose one based on CMT/Clustered/UseDBLocks.
         if (LockHandler == null)
@@ -550,6 +711,14 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
             // If the user hasn't specified an explicit lock handler,
             // then we *must* use DB locks with clustering
             if (Clustered)
+            {
+                UseDBLocks = true;
+            }
+
+            // The same applies when the application owns the transaction: SimpleSemaphore releases
+            // its in-process lock as soon as our work is done, which is before the application has
+            // committed, so another caller could act on scheduling data that is not visible yet.
+            if (AcceptEnlistedTransactions)
             {
                 UseDBLocks = true;
             }
@@ -585,6 +754,22 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         }
         else
         {
+            // be ready to give a friendly warning if locks would be released before the application commits
+            if (AcceptEnlistedTransactions && !LockHandler.RequiresConnection)
+            {
+                if (LockHandler is SQLiteSemaphore)
+                {
+                    // SQLite gets this handler unconditionally, before the ambient-mode upgrade to
+                    // database locks can be applied, and it cannot be swapped for one - so this is a
+                    // property of the combination rather than something to reconfigure away.
+                    Log.Warn("'quartz.jobStore.acceptEnlistedTransactions' with SQLite keeps in-process locking: SQLiteSemaphore releases the lock when the scheduling call returns, while the application's transaction still holds SQLite's writer lock, so a concurrent scheduler operation can fail with 'database is locked' until that transaction completes. Keep enlisted transactions short, or use a database that supports row locking.");
+                }
+                else
+                {
+                    Log.Warn($"Detected usage of 'quartz.jobStore.acceptEnlistedTransactions' with lock handler {LockHandler.GetType().Name}, which does not lock in the database. Its locks are released before the application commits its transaction, so concurrent callers can act on scheduling data that is not visible to them yet.");
+                }
+            }
+
             // be ready to give a friendly warning if SQL Server is used and sub-optimal locking
             if (LockHandler is UpdateLockRowSemaphore && Delegate is SqlServerDelegate)
             {
@@ -642,6 +827,26 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     public virtual async Task SchedulerStarted(
         CancellationToken cancellationToken = default)
     {
+        // Recovery below competes for the same TRIGGER_ACCESS lock that a scheduling call made
+        // earlier in this scope is still holding on the caller's uncommitted transaction, and the
+        // caller cannot commit while awaiting Start(). That deadlock has no diagnostic of its own,
+        // so refuse the call instead of hanging.
+        if (AcceptEnlistedTransactions && AmbientConnection.Get(InstanceName) != null)
+        {
+            // Nothing has been created yet, so this refusal leaves the scheduler startable again once
+            // the caller moves the call outside the scope.
+            throw new Core.SchedulerStartRefusedException(
+                $"The scheduler '{InstanceName}' cannot be started from inside an enlistment scope: startup work waits for "
+                + "locks the enlisted transaction holds until the application commits, which it cannot do while starting. "
+                + "Start the scheduler outside the scope.");
+        }
+
+        // Everything below belongs to the scheduler, not to whoever called Start(). Suppressing here
+        // keeps job recovery and the first cluster check-in off an enlisted connection, and - because
+        // the misfire handler and cluster manager loops capture the execution context when they are
+        // started - keeps those loops from ever seeing an enlistment either.
+        using IDisposable suppression = AmbientConnection.Suppress();
+
         await EnsureOptionalColumnsProbed(cancellationToken).ConfigureAwait(false);
 
         if (Clustered)
@@ -939,6 +1144,15 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         bool rethrowOnFailure,
         CancellationToken cancellationToken)
     {
+        // A probe is expected to fail when the column is absent, and on PostgreSQL a failed statement
+        // aborts the whole transaction. It must never run on anything the application owns: not on a
+        // connection it enlisted, and not inside its ambient transaction either - JobStoreCMT opens
+        // its connections without suppressing that, so the probe has to do it here.
+        using IDisposable suppression = AmbientConnection.Suppress();
+        using TransactionScope? ambientSuppression = Transaction.Current != null
+            ? new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled)
+            : null;
+
         ConnectionAndTransactionHolder conn = GetNonManagedTXConnection();
         try
         {
@@ -4226,14 +4440,20 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     /// in the given <see cref="IJobDetail" /> should be updated if the <see cref="IJob" />
     /// is stateful.
     /// </summary>
-    public virtual Task TriggeredJobComplete(
+    public virtual async Task TriggeredJobComplete(
         IOperableTrigger trigger,
         IJobDetail jobDetail,
         SchedulerInstruction triggerInstCode,
         CancellationToken cancellationToken = default)
     {
+        // Completion bookkeeping belongs to the scheduler, not to the job, and it retries a failing
+        // JobPersistenceException until it succeeds. If a job body left an enlistment behind, this
+        // would borrow a connection whose transaction is long gone and retry against it forever,
+        // leaving the fired trigger uncleaned and its DisallowConcurrentExecution siblings blocked.
+        using IDisposable suppression = AmbientConnection.Suppress();
+
 #if DIAGNOSTICS_SOURCE
-        return jobStoreDiagnostics.Trace(
+        await jobStoreDiagnostics.Trace(
             OperationName.JobStore.TriggeredJobComplete,
             () => RetryExecuteInNonManagedTXLock(
                 LockTriggerAccess,
@@ -4245,12 +4465,12 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
                 activity.AddTag(DiagnosticHeaders.TriggerName, trigger.Key.Name);
                 activity.AddTag(DiagnosticHeaders.JobGroup, jobDetail.Key.Group);
                 activity.AddTag(DiagnosticHeaders.JobName, jobDetail.Key.Name);
-            });
+            }).ConfigureAwait(false);
 #else
-        return RetryExecuteInNonManagedTXLock(
+        await RetryExecuteInNonManagedTXLock(
             LockTriggerAccess,
             conn => TriggeredJobComplete(conn, trigger, jobDetail, triggerInstCode, cancellationToken),
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
 #endif
     }
 
@@ -4380,6 +4600,10 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         Guid requestorId,
         CancellationToken cancellationToken)
     {
+        // Misfire recovery is the scheduler's own work and commits on its own schedule, so it must
+        // not run inside a transaction the application owns.
+        using IDisposable suppression = AmbientConnection.Suppress();
+
         bool transOwner = false;
         ConnectionAndTransactionHolder? conn = null;
         try
@@ -4470,6 +4694,58 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         schedSignaler.SignalSchedulingChange(candidateNewNextFireTime);
     }
 
+    /// <summary>
+    /// Holds back a scheduling change signal until the transaction the application owns has
+    /// completed. Signalling while our rows are still uncommitted would send the scheduler thread
+    /// looking for a trigger it cannot see yet, and it would then wait out the idle interval before
+    /// looking again.
+    /// </summary>
+    internal void SignalSchedulingChangeOnApplicationCommit(
+        ConnectionAndTransactionHolder conn,
+        DateTimeOffset? candidateNewNextFireTime)
+    {
+        EnlistedConnection? enlisted = conn.BorrowedFrom;
+        if (enlisted == null)
+        {
+            SignalSchedulingChangeImmediately(candidateNewNextFireTime);
+            return;
+        }
+
+        // Accumulate on the enlistment rather than in the handler, so every operation in the scope
+        // contributes and the earliest candidate wins. Capturing one operation's time in a closure
+        // would let a later, sooner trigger go unannounced until the idle wait expired.
+        enlisted.DeferSignal(candidateNewNextFireTime, SignalSchedulingChangeImmediately);
+
+        Transaction? ambient = Transaction.Current;
+        if (ambient == null)
+        {
+            // A bare DbTransaction reports no outcome, so the enlistment scope's disposal is the only
+            // moment we have; the caller is documented to dispose it after committing.
+            return;
+        }
+
+        // An ambient transaction does report its outcome, and reports it after the enlistment scope is
+        // disposed, so let it own the signal: nothing is raised when the application rolls back.
+        // Hooked once per enlistment - a scope that schedules hundreds of jobs would otherwise
+        // accumulate that many handlers and fire them all back to back, each able to knock the
+        // scheduler off its acquired triggers.
+        enlisted.SignalOwnedByAmbient = true;
+
+        if (enlisted.AmbientSignalHooked)
+        {
+            return;
+        }
+
+        enlisted.AmbientSignalHooked = true;
+        ambient.TransactionCompleted += (_, e) =>
+        {
+            if (e.Transaction?.TransactionInformation.Status == TransactionStatus.Committed)
+            {
+                enlisted.FlushSignal();
+            }
+        };
+    }
+
     //---------------------------------------------------------------------------
     // Cluster management methods
     //---------------------------------------------------------------------------
@@ -4482,6 +4758,10 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         Guid requestorId,
         CancellationToken cancellationToken = default)
     {
+        // Cluster check-in has to run in a transaction of its own to avoid deadlocking under
+        // recovery, so it must never borrow a connection the application enlisted.
+        using IDisposable suppression = AmbientConnection.Suppress();
+
         int maxRetries = MaxTransientRetries;
         int totalAttempts = maxRetries + 1;
         for (int attempt = 1; attempt <= totalAttempts; attempt++)
@@ -4959,6 +5239,11 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     {
         if (conn != null)
         {
+            // Hand the enlisted connection back so the next operation on this flow can claim it.
+            // Released through the holder rather than by looking the enlistment up again, which with
+            // nested scopes can resolve to a different entry than the one that was claimed.
+            conn.BorrowedFrom?.Release();
+
             CloseConnection(conn);
         }
     }
@@ -5379,7 +5664,11 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
             }
         }
 
-        int maxRetries = MaxTransientRetries;
+        // Retrying inside a transaction the application owns is pointless and harmful: the first
+        // failure has already doomed that transaction on most providers, so a second attempt would
+        // only pile another error on top of it. Let the caller decide what to do instead.
+        bool applicationOwnedTransaction = InApplicationOwnedTransaction;
+        int maxRetries = applicationOwnedTransaction ? 0 : MaxTransientRetries;
         int totalAttempts = maxRetries + 1;
         for (int attempt = 1; attempt <= totalAttempts; attempt++)
         {
@@ -5427,7 +5716,20 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
                 }
 
                 DateTimeOffset? sigTime = conn.SignalSchedulingChangeOnTxCompletion;
-                if (sigTime != null)
+                // Arrange a signal for after the commit even when the job store did not ask for one:
+                // QuartzScheduler notifies the scheduler thread as soon as the store call returns,
+                // which here is still before the application commits, so that notification finds
+                // nothing and the thread settles down for a whole idle interval. Taking the lock
+                // stands in for "this may have changed the schedule" - doing it for reads as well
+                // would signal an unknown earlier time on every query and keep bouncing acquired
+                // triggers back to waiting. That proxy does not hold once LockAllOperations routes
+                // reads through the lock too, so there we fall back to an explicit request only.
+                if (applicationOwnedTransaction
+                    && (sigTime != null || lockName != null && !LockAllOperations))
+                {
+                    SignalSchedulingChangeOnApplicationCommit(conn, sigTime);
+                }
+                else if (sigTime != null)
                 {
                     SignalSchedulingChangeImmediately(sigTime);
                 }

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -18,6 +18,7 @@
   <ItemGroup Condition=" '$(FullFramework)' == 'true' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />

--- a/src/Quartz/SchedulerBuilder.cs
+++ b/src/Quartz/SchedulerBuilder.cs
@@ -415,6 +415,31 @@ public class SchedulerBuilder : PropertiesHolder, IPropertyConfigurationRoot
         }
 
         /// <summary>
+        /// Let the job store take part in a transaction the application already owns, instead of
+        /// always managing an ADO.NET transaction of its own, so that scheduling commits together
+        /// with the rest of the application's work.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The job store then uses a connection enlisted with
+        /// <see cref="SchedulerEnlistmentExtensions.EnlistTransaction" /> or
+        /// <see cref="SchedulerEnlistmentExtensions.EnlistConnection" />. Handing over a connection
+        /// is the only way to take part, and the one that works on every provider: a connection the
+        /// job store opens for itself stays out of any ambient
+        /// <see cref="System.Transactions.TransactionScope" />, since a second connection in that
+        /// transaction would require it to be promoted to a distributed one.
+        /// </para>
+        /// <para>
+        /// Locks are held until the application commits, so keep such transactions short. This also
+        /// switches locking to database locks unless an explicit lock handler was configured.
+        /// </para>
+        /// </remarks>
+        public void AcceptEnlistedTransactions()
+        {
+            SetProperty("quartz.jobStore.acceptEnlistedTransactions", "true");
+        }
+
+        /// <summary>
         /// Sets the database retry interval.
         /// </summary>
         /// <remarks>

--- a/src/Quartz/SchedulerEnlistmentExtensions.cs
+++ b/src/Quartz/SchedulerEnlistmentExtensions.cs
@@ -1,0 +1,240 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Data.Common;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Spi;
+
+namespace Quartz;
+
+/// <summary>
+/// Lets application code hand its own ADO.NET connection and transaction to the persistent job
+/// store, so that scheduling operations take part in a unit of work the application already owns.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Requires the job store to be configured with <c>quartz.jobStore.acceptEnlistedTransactions</c> set to
+/// <see langword="true" /> (<c>AcceptEnlistedTransactions()</c> when configuring with
+/// <see cref="SchedulerBuilder" />). Without it the job store keeps opening its own connection and
+/// managing its own transaction, and the enlistment is ignored.
+/// </para>
+/// <para>
+/// Enlisting is the only way to take part: an ambient
+/// <see cref="System.Transactions.TransactionScope" /> on its own is not enough, because a
+/// connection the job store opens for itself is deliberately kept out of it. Open the connection
+/// inside the scope and enlist that, which also keeps the transaction from having to be promoted to
+/// a distributed one.
+/// </para>
+/// <para>
+/// The enlistment flows with the current asynchronous context, so it must be established in the
+/// same scope as the scheduler calls it should cover - the same rule that applies to
+/// <see cref="System.Transactions.TransactionScope" />, and for the same reason. In particular,
+/// establishing it inside an <c>async</c> helper does not carry it back out to the caller.
+/// </para>
+/// <para>
+/// While the enlistment is in effect the job store holds its locks in the caller's transaction, so
+/// they are only released once that transaction completes. Keep enlisted transactions short: a long
+/// running one blocks trigger acquisition, the misfire handler and cluster check-in.
+/// </para>
+/// <example>
+/// <code>
+/// await using var tx = await dbContext.Database.BeginTransactionAsync();
+/// dbContext.Add(entity);
+/// await dbContext.SaveChangesAsync();
+///
+/// using (scheduler.EnlistTransaction(tx.GetDbTransaction()))
+/// {
+///     await scheduler.ScheduleJob(job, trigger);
+///     await tx.CommitAsync();
+/// }
+/// </code>
+/// </example>
+/// </remarks>
+public static class SchedulerEnlistmentExtensions
+{
+    /// <summary>
+    /// Makes the persistent job store use the given transaction, and the connection it belongs to,
+    /// for every operation performed on the current asynchronous flow until the returned scope is
+    /// disposed.
+    /// </summary>
+    /// <param name="scheduler">The scheduler whose job store should join the transaction.</param>
+    /// <param name="transaction">The transaction to join. Must still be associated with a connection.</param>
+    /// <returns>
+    /// A scope that ends the enlistment when disposed. Dispose it after committing, so that any
+    /// scheduling change the job store recorded is signalled to the scheduler once it is visible.
+    /// </returns>
+    public static IDisposable EnlistTransaction(this IScheduler scheduler, DbTransaction transaction)
+    {
+        if (scheduler is null)
+        {
+            throw new ArgumentNullException(nameof(scheduler));
+        }
+
+        if (transaction is null)
+        {
+            throw new ArgumentNullException(nameof(transaction));
+        }
+
+        DbConnection connection = transaction.Connection
+                                  ?? throw new ArgumentException(
+                                      "The transaction is not associated with a connection, it has already been committed, rolled back or disposed.",
+                                      nameof(transaction));
+
+        EnsureEnlistmentAccepted(scheduler, connection);
+
+        return AmbientConnection.Enlist(scheduler.SchedulerName, connection, transaction);
+    }
+
+    /// <summary>
+    /// Makes the persistent job store use the given connection, and optionally the given
+    /// transaction, for every operation performed on the current asynchronous flow until the
+    /// returned scope is disposed.
+    /// </summary>
+    /// <remarks>
+    /// Pass only a connection when the transaction is an ambient
+    /// <see cref="System.Transactions.TransactionScope" /> the connection is already enlisted in.
+    /// Sharing the one connection is what keeps such a scope from being promoted to a distributed
+    /// transaction, which providers like Npgsql do not support at all.
+    /// </remarks>
+    /// <param name="scheduler">The scheduler whose job store should use the connection.</param>
+    /// <param name="connection">The connection to use. Opened if it is not open already.</param>
+    /// <param name="transaction">The transaction to enlist in, if any.</param>
+    /// <returns>
+    /// A scope that ends the enlistment when disposed. Dispose it after committing, so that any
+    /// scheduling change the job store recorded is signalled to the scheduler once it is visible.
+    /// </returns>
+    public static IDisposable EnlistConnection(
+        this IScheduler scheduler,
+        DbConnection connection,
+        DbTransaction? transaction = null)
+    {
+        if (scheduler is null)
+        {
+            throw new ArgumentNullException(nameof(scheduler));
+        }
+
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        // A transaction from some other connection governs nothing here: providers take the
+        // connection's own transaction and ignore the one on the command, so every statement would
+        // commit on the spot while the caller believes rolling that transaction back undoes them.
+        if (transaction is not null && !ReferenceEquals(transaction.Connection, connection))
+        {
+            throw new ArgumentException(
+                "The transaction belongs to a different connection, so it would not govern anything the job store does on "
+                + "this one. Pass the transaction that was begun on this connection.",
+                nameof(transaction));
+        }
+
+        // With neither a transaction of its own nor an ambient one to enlist in, every statement the
+        // job store issues on this connection commits on the spot. That looks exactly like a working
+        // enlistment right up to the point where the caller rolls back and the job fires anyway.
+        if (transaction is null && System.Transactions.Transaction.Current is null)
+        {
+            throw new ArgumentException(
+                "The connection has no transaction to join: pass the DbTransaction, or call this from inside a "
+                + "TransactionScope created with TransactionScopeAsyncFlowOption.Enabled. Enlisting a connection with "
+                + "neither would let scheduling commit on its own.",
+                nameof(connection));
+        }
+
+        EnsureEnlistmentAccepted(scheduler, connection);
+
+        // Remembered so a later operation can tell that the scope has since ended, instead of
+        // quietly running with no transaction at all.
+        return AmbientConnection.Enlist(
+            scheduler.SchedulerName,
+            connection,
+            transaction,
+            transaction is null ? System.Transactions.Transaction.Current : null);
+    }
+
+    /// <summary>
+    /// Fails fast when the job store would ignore the enlistment. Without this the scheduling would
+    /// quietly commit in a transaction of its own while the caller believes it is part of theirs -
+    /// the exact split unit of work these methods exist to prevent, and one that only shows up as a
+    /// job firing for an entity that was rolled back.
+    /// </summary>
+    private static void EnsureEnlistmentAccepted(IScheduler scheduler, DbConnection connection)
+    {
+#if REMOTING
+        // A remoting proxy's job store lives in another process, so an enlistment on this side can
+        // never reach it - the one case where the answer is knowable without inspecting anything.
+        if (scheduler is Quartz.Impl.RemoteScheduler)
+        {
+            throw new InvalidOperationException(
+                $"Scheduler '{scheduler.SchedulerName}' is a remote proxy, so its job store cannot use a connection from "
+                + "this process and the enlistment would be ignored. Take part in the application's transaction only "
+                + "through a scheduler backed by a local persistent job store.");
+        }
+#endif
+
+        // A decorator - logging, tenant routing, metrics - forwards SchedulerName, so look the real
+        // scheduler up by name rather than giving up on anything that is not StdScheduler. Giving up
+        // would silently skip every check below for exactly the wrappers that are common in the
+        // applications this feature is aimed at.
+        StdScheduler? local = scheduler as StdScheduler
+                              ?? SchedulerRepository.Instance.Lookup(scheduler.SchedulerName) as StdScheduler;
+
+        if (local is null)
+        {
+            return;
+        }
+
+        IJobStore jobStore = local.sched.JobStore;
+
+        if (jobStore is not JobStoreSupport adoJobStore)
+        {
+            throw new InvalidOperationException(
+                $"Scheduler '{scheduler.SchedulerName}' uses {jobStore.GetType().Name}, which does not store anything in the "
+                + "application's database, so the enlistment would be ignored and scheduling would survive a rollback. "
+                + "Taking part in the application's transaction requires a persistent ADO.NET job store.");
+        }
+
+        if (!adoJobStore.AcceptEnlistedTransactions)
+        {
+            throw new InvalidOperationException(
+                $"Scheduler '{scheduler.SchedulerName}' is not configured to take part in transactions the application owns, "
+                + "so the enlistment would be ignored and scheduling would commit on its own. Set "
+                + "'quartz.jobStore.acceptEnlistedTransactions' to true, or call AcceptEnlistedTransactions() when configuring the persistent store.");
+        }
+
+        // The job store builds its commands from its own configured provider, and assigning a
+        // connection of a different provider's type to one of those commands throws a cast error deep
+        // in the first statement, naming two identically-named connection types and nothing else.
+        Type? expected = adoJobStore.ConnectionType;
+        if (expected != null && !expected.IsInstanceOfType(connection))
+        {
+            throw new ArgumentException(
+                $"Scheduler '{scheduler.SchedulerName}' is configured with a data source that produces {expected.FullName} "
+                + $"({expected.Assembly.GetName().Name}), but the enlisted connection is {connection.GetType().FullName} "
+                + $"({connection.GetType().Assembly.GetName().Name}). The job store cannot use a connection from a "
+                + "different provider - configure both against the same one.",
+                nameof(connection));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2038.

## The problem

Scheduling cannot be made atomic with the application's own database work. `JobStoreSupport.GetConnection()` always opens a connection of its own and calls `BeginTransaction` on it. Inside an ambient `TransactionScope` the freshly opened connection auto-enlists, and the `BeginTransaction` that follows is either rejected outright — Npgsql: *"A transaction is already in progress; nested/concurrent transactions aren't supported"*, surfaced as `JobPersistenceException: Failure setting up connection` — or produces a local transaction that commits regardless of the scope's outcome.

Even past that, the job store is using a *second* connection, so the ambient transaction has to be promoted to a distributed one. That needs MSDTC (Windows only, and since .NET 10 also `TransactionManager.ImplicitDistributedTransactions`), and it is impossible with Npgsql, which has no distributed transaction support at all. That is the wall the recent commenters on the issue hit.

The workaround people converge on is subclassing `JobStoreCMT` and overriding `GetNonManagedTXConnection()` to hand back the EF Core `DbContext`'s connection. It works, but it needs a custom job store type, fights the singleton lifetime of `IJobStore`, and leaks Quartz internals into application code.

## The change

Opt in with `quartz.jobStore.acceptEnlistedTransactions`, or `AcceptEnlistedTransactions()` when configuring through `SchedulerBuilder`:

```csharp
q.UsePersistentStore(s =>
{
    s.UsePostgres(connectionString);
    s.AcceptEnlistedTransactions();
});
```

Then hand the job store a connection for the duration of a scope:

```csharp
await using var tx = await dbContext.Database.BeginTransactionAsync();

dbContext.Add(entity);
await dbContext.SaveChangesAsync();

using (scheduler.EnlistTransaction(tx.GetDbTransaction()))
{
    await scheduler.ScheduleJob(job, trigger);
    await tx.CommitAsync();
}
```

The application owns the commit, so the job store neither commits nor rolls back. The enlistment flows with the current asynchronous context, the same way `Transaction.Current` itself does, so nothing has to be resolved from the container — which is what made this intractable while `IJobStore` is a singleton and a `DbContext` is scoped. Nothing here is EF Core specific: any `DbConnection` and `DbTransaction` will do.

**Taking part always means handing over a connection.** An ambient `TransactionScope` on its own is not enough — for `JobStoreTX` a connection the job store opens for itself is deliberately kept *out* of one, since joining a scope whose outcome it does not control would also put a second connection in that transaction. Inside a `TransactionScope`, open the connection there and enlist it; sharing the one connection is what keeps the transaction local:

```csharp
using var scope = new TransactionScope(TransactionScopeOption.Required, options, TransactionScopeAsyncFlowOption.Enabled);

using var connection = new NpgsqlConnection(connectionString);
await connection.OpenAsync();

using (scheduler.EnlistConnection(connection))
{
    await scheduler.ScheduleJob(job, trigger);
}

scope.Complete();
```

`JobStoreCMT` is left alone — running inside a transaction its container manages is that store's whole contract.

The switch is opt-in because joining the application's transaction changes when, and whether, scheduling commits.

## Supporting changes

- `ConnectionAndTransactionHolder` can hold borrowed resources, in which case commit, rollback, close and dispose are left to the owner. The new constructor and `OwnsResources` are internal.
- Locking moves to database locks unless a lock handler was configured explicitly — `SimpleSemaphore` releases its in-process lock before the application commits, which would let a concurrent caller act on scheduling data it cannot see yet. SQLite cannot be upgraded this way and logs what that means.
- Scheduler-owned work — column probing, cluster check-in, misfire recovery, recovery at start, and completion bookkeeping after a job runs — never borrows the enlisted connection. A probe is *expected* to fail when a column is absent, and on PostgreSQL that aborts the whole transaction.
- Transient retries are skipped inside an application-owned transaction; on most providers the first failure has already doomed it.
- Write operations arrange a scheduling change signal for after the commit — accumulated on the enlistment so the earliest candidate across the whole scope wins, and hooked once per transaction. `QuartzScheduler` otherwise notifies the scheduler thread only *before* the rows are visible, so the trigger would sit until the idle interval elapsed. Reads do not signal, since a null candidate time bounces acquired triggers back to waiting. When an ambient transaction is present it owns the signal, so a rollback raises nothing.
- Misuse is refused rather than left to fail obscurely: a job store that cannot take part (including `RAMJobStore`), a remote scheduler, a connection whose provider does not match the configured one, a transaction begun on a different connection, the feature switched off, a connection with no transaction to join, a transaction that has since completed, an ambient scope that is no longer current, concurrent calls on one enlisted connection, and starting the scheduler from inside an enlistment scope — which deadlocks against the locks that scope holds. The guard resolves the real scheduler by name, so it still applies behind an `IScheduler` decorator.
- `QuartzScheduler.Start` releases its initial-start marker when — and only when — the job store declines to start before creating anything, so a corrected retry runs the full start-up sequence instead of the resume path. Any later failure keeps the marker latched, since re-running would orphan a misfire handler whose foreground thread outlives `Shutdown`.
- `System.Transactions` reference added for the full-framework targets; netstandard2.0 and net8.0+ need none.

Everything is additive: no existing signature changed, and with the switch off behaviour is what it was.

## Trade-offs and known limits

- The job store takes its locks in the caller's transaction, so they are released only when that transaction completes. Long application transactions block trigger acquisition, the misfire handler and cluster check-in. Inherent to container-managed transactions; `lockOnInsert=false` mitigates it for insert-only workloads.
- No savepoint: an operation that fails halfway leaves its statements in the caller's transaction.
- A connection opened *before* the ambient scope it is enlisted under is not actually part of that scope, and ADO.NET offers no portable way to detect it. Open the connection inside the scope.
- The enlistment rides on `AsyncLocal`, so establishing it inside an `async` helper does not carry it back out to the caller — the same constraint `TransactionScope` has.
- `txIsolationLevelSerializable` applies to the job store's own connections; an enlisted operation runs at the caller's isolation level. `Initialize` says so when both are configured.
- The "this transaction already completed" refusal relies on `DbTransaction.Connection` becoming null, which Npgsql only does on dispose rather than on commit. Dispose the enlistment scope right after committing rather than scheduling more inside it.
- `StartDelayed` logs the enlistment-scope refusal rather than surfacing it, as it does for any start-up failure.

## Testing

Unit tests cover holder ownership, the enlistment flowing/nesting/expiring, isolation per scheduler and per async flow, forking inside a scope being refused rather than corrupting the connection, the completed-transaction and concurrent-use refusals, the fail-fast guard against a non-persistent store, suppression of scheduler-owned work, and that a job store connection stays out of an ambient scope.

Integration tests on PostgreSQL and SQL Server cover rollback discarding the schedule — asserting first that it *is* visible inside the transaction, so the write really went through it — commit keeping it, an incomplete `TransactionScope` discarding it, the enlist-refused guard, and, with a two-minute idle wait and a 30-second assertion, that a running scheduler fires the job promptly after the commit, which only passes if the post-commit signal works.

Solution builds warning-free across all target frameworks; 1740 unit tests, 53 `db-postgres` and 49 `db-sqlserver` integration tests pass.

Documentation lands on `main`, together with the 4.x port, since the site is published from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
