### PR TITLE
Report a first-class Executing trigger state

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -581,6 +581,7 @@ The cron expression parser now supports additional syntax:
 * **HTTP API** — optional REST API for managing the scheduler remotely (see [HTTP API](packages/http-api.md))
 * **Paged, projected job store queries** — list and count jobs, triggers, groups and calendars a page at a time, with the metadata a listing needs already in the row (see [Job store listings became queries](#job-store-listings-became-queries))
 * **Job data by property name** — bind job data to the job property it is meant for instead of spelling its key (see [Job data can name the property](#job-data-can-name-the-property))
+* **`TriggerState.Executing`** — tell whether a trigger's job is running, across the whole cluster (see [Executing is a trigger state](#executing-is-a-trigger-state))
 
 ## Job data can name the property
 
@@ -690,6 +691,85 @@ needs the same annotation:
 + public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] TJob>(IQuartzBuilder q) where TJob : IJob
       => q.ScheduleJob<TJob>(t => t.StartNow());
 ```
+
+## Executing is a trigger state
+
+There was no way to ask whether a trigger's job is running right now.
+`IScheduler.GetCurrentlyExecutingJobs` only ever sees the node it is called on, so a process that schedules
+and observes triggers but does not execute them — a dashboard, an admin UI, a separate control
+application — could not answer the question at all.
+
+`TriggerState` now has an `Executing` member, reported by both `IScheduler.GetTriggerState` and trigger
+listings. With a persistent job store it is visible from every node, because it is established from the
+fired-triggers table rather than from process-local state.
+
+### What changed in what you get back
+
+A trigger with an execution in flight previously reported `Normal`, `Complete`, or `Blocked` depending on
+its schedule; it now reports `Executing`. States are resolved in this order:
+
+```
+None > Error > Paused > Executing > Blocked > Complete > Normal
+```
+
+So a trigger that is paused, or in the error state, still reports that even while its job runs — those are
+the facts an operator has to act on. Two consequences worth calling out:
+
+* `Blocked` now means a **different** trigger of the same `[DisallowConcurrentExecution]` job is running,
+  so this one cannot fire. The trigger that is actually running reports `Executing`. Previously both
+  reported `Blocked` and nothing could tell them apart.
+* A trigger with no fire times left whose final execution is still running reports `Executing` rather than
+  `Complete`. In 3.x this case reported `Blocked`, which was a stand-in for a state that did not exist yet.
+
+Note that executing is not exclusive with being scheduled: a trigger whose job allows concurrent execution
+can be running several jobs and still be due to fire again. It reports `Executing` until the last of them
+finishes.
+
+### What to check in your own code
+
+* **Health checks and guards of the form `if (state == TriggerState.Normal)`** will now see `Executing` for
+  a trigger that is simply busy. Treat `Executing` as healthy.
+* **Watchdogs of the form `if (state != TriggerState.Normal) await ResumeTrigger(key)`** deserve a closer
+  look. `ResumeTrigger` applies the trigger's misfire policy to any trigger whose next fire time has
+  passed, regardless of the state it is currently in — and for a long-running job on a short interval, the
+  next fire time is in the past for the whole execution. Such a watchdog can therefore alter the schedule
+  of a perfectly healthy trigger. This is not new in 4.x, but `Executing` routes more triggers into it, so
+  gate the watchdog on the states you actually mean to repair (`Error`, `Paused`).
+* **Alerting that treats `Blocked` as "a job is running"** should move to `Executing`.
+
+### Filtering a listing by state
+
+`TriggerQuery.State` accepts `Executing` like any other state. Because the filter and the reported state
+are derived together, a listing filtered by `Normal` no longer returns triggers it would then report as
+`Executing`.
+
+### A note on stale executions
+
+Executing is established from the fired-triggers table, which is the only durable record that a job is
+running. If a node dies mid-execution, its rows stay behind until another node's cluster recovery clears
+them, so during that window a trigger reports `Executing` although nothing is running — and, because the
+filter and the reported state agree by construction, it is also absent from a listing filtered by
+`Normal`. The same window already existed for `Blocked`; it is now visible for more states.
+
+How long that lasts depends on the job. For an ordinary job the rows are cleared as soon as another node
+detects the failure, roughly `clusterCheckinInterval` + `clusterCheckinMisfireThreshold`. For a
+`[DisallowConcurrentExecution]` job, cluster recovery deliberately *preserves* the executing rows on first
+detection — the node may still be alive and running the job, and reviving it elsewhere would break the
+concurrency guarantee — and only cleans them up on a later pass, once the elapsed time exceeds
+`2 × clusterCheckinInterval + clusterCheckinMisfireThreshold`. So with a 15-second interval and a
+60-second threshold, expect up to about 90 seconds plus one more check-in cycle before such a trigger
+stops reporting `Executing`.
+
+### If you implement IDriverDelegate
+
+`IsTriggerCurrentlyExecuting` was replaced by `SelectTriggerStateWithExecuting`, which returns the stored
+state and whether an execution is in flight from a single statement, so reporting a trigger's state stays
+one round trip. Subclasses of `StdAdoDelegate` get it for free. There is no schema change.
+
+Note that `GetTriggerState` now calls this method instead of `SelectTriggerState`. If you override
+`SelectTriggerState` to handle a vendor quirk or a legacy state value, override
+`SelectTriggerStateWithExecuting` as well — the compiler cannot tell you, because the old method is still
+on the interface and still used elsewhere.
 
 ## Batched Misfire Recovery
 
@@ -1106,3 +1186,7 @@ called out.
 | `TimeSpanParseRuleAttribute` is public | It says how a bare number in configuration is read as a `TimeSpan`, which a component configured by the same keys needs to be able to say |
 | `TimeZoneUtil.CustomResolver` is a property | It was a public mutable field |
 | Setter-only members gained getters | `DbMetadata.DbBinaryTypeName` (now nullable) and `.ParameterDbTypePropertyName`, `HttpSchedulerProxyFactory.Address` |
+| `TriggerState.Executing` added | Reported where `Normal`, `Complete` or `Blocked` used to be, and `Blocked` narrowed to mean a sibling trigger is running (see [Executing is a trigger state](#executing-is-a-trigger-state)) |
+| `IDriverDelegate.IsTriggerCurrentlyExecuting` removed | Replaced by `SelectTriggerStateWithExecuting`, which reads the state and the execution in one statement and returns `TriggerExecutionState` |
+| `StdAdoConstants.SqlSelectCountExecutingFiredTriggersOfTrigger` removed | Removed with the method that used it; the per-job `SqlSelectCountExecutingFiredTriggersOfJob` remains |
+| `InternalTriggerState.Executing` removed | It was never assigned or read; RAMJobStore counts executions separately from the state that drives scheduling |

--- a/src/Quartz.Dashboard/Components/Pages/Triggers.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Triggers.razor
@@ -15,8 +15,9 @@
 
     <SearchFilter Placeholder="Filter by group" OnFilterChanged="OnFilterChangedAsync" />
     <div class="qz-actions qz-group-actions">
-        <button type="button" class="qz-button @GetStateFilterButtonClass(false)" @onclick="ShowAllStates">All states</button>
-        <button type="button" class="qz-button @GetStateFilterButtonClass(true)" @onclick="ShowErrorStateOnly">Error only</button>
+        <button type="button" class="qz-button @GetStateFilterButtonClass(null)" @onclick="ShowAllStates">All states</button>
+        <button type="button" class="qz-button @GetStateFilterButtonClass(TriggerState.Error)" @onclick="ShowErrorStateOnly">Error only</button>
+        <button type="button" class="qz-button @GetStateFilterButtonClass(TriggerState.Executing)" @onclick="ShowExecutingStateOnly">Executing only</button>
     </div>
 
     @if (_isLoading)
@@ -128,7 +129,7 @@
     private string? _pendingGroup;
     private string? _pendingName;
     private string _pendingTriggerKey = string.Empty;
-    private bool _showErrorOnly;
+    private TriggerState? _stateFilter;
 
     private bool IsReadOnly => Options.Value.ReadOnly;
 
@@ -163,7 +164,7 @@
             }
 
             string? groupFilter = string.IsNullOrWhiteSpace(_filter) ? null : _filter;
-            TriggerState? state = _showErrorOnly ? TriggerState.Error : null;
+            TriggerState? state = _stateFilter;
             TriggerPageDto page = await Api.GetTriggers(schedulerName, groupFilter, state, _currentPage, _pageSize);
 
             int totalPages = Math.Max(1, (int) Math.Ceiling((double) page.TotalCount / _pageSize));
@@ -253,23 +254,22 @@
             "Resumed");
     }
 
-    private Task ShowAllStates()
+    private Task ShowAllStates() => ApplyStateFilter(null);
+
+    private Task ShowErrorStateOnly() => ApplyStateFilter(TriggerState.Error);
+
+    private Task ShowExecutingStateOnly() => ApplyStateFilter(TriggerState.Executing);
+
+    private Task ApplyStateFilter(TriggerState? state)
     {
-        _showErrorOnly = false;
+        _stateFilter = state;
         _currentPage = 1;
         return LoadDataAsync();
     }
 
-    private Task ShowErrorStateOnly()
+    private string GetStateFilterButtonClass(TriggerState? state)
     {
-        _showErrorOnly = true;
-        _currentPage = 1;
-        return LoadDataAsync();
-    }
-
-    private string GetStateFilterButtonClass(bool errorOnly)
-    {
-        return _showErrorOnly == errorOnly ? "qz-button-primary" : string.Empty;
+        return _stateFilter == state ? "qz-button-primary" : string.Empty;
     }
 
     private void PromptUnschedule(string group, string name)

--- a/src/Quartz.Dashboard/Components/Shared/StateIndicator.razor
+++ b/src/Quartz.Dashboard/Components/Shared/StateIndicator.razor
@@ -30,6 +30,12 @@
                 return "paused";
             }
 
+            // Checked before "running", which is a scheduler status and has to keep reading as success.
+            if (normalized.Contains("executing"))
+            {
+                return "executing";
+            }
+
             if (normalized.Contains("normal") || normalized.Contains("running") || normalized.Contains("complete"))
             {
                 return "success";

--- a/src/Quartz.Dashboard/wwwroot/css/quartz-dashboard.css
+++ b/src/Quartz.Dashboard/wwwroot/css/quartz-dashboard.css
@@ -38,6 +38,8 @@
     --qz-color-danger-hover: #b91c1c;
     --qz-color-info: #2563eb;
     --qz-color-info-bg: #dbeafe;
+    --qz-color-executing: #7c3aed;
+    --qz-color-executing-bg: #ede9fe;
 
     /* --- Spacing (4px increments) --- */
     --qz-space-xs: 4px;
@@ -118,6 +120,8 @@
         --qz-color-danger-hover: #f87171;
         --qz-color-info: #3b82f6;
         --qz-color-info-bg: #1e3a5f;
+        --qz-color-executing: #a78bfa;
+        --qz-color-executing-bg: #3b0764;
 
         --qz-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
         --qz-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4),
@@ -156,6 +160,8 @@
     --qz-color-danger-hover: #b91c1c;
     --qz-color-info: #2563eb;
     --qz-color-info-bg: #dbeafe;
+    --qz-color-executing: #7c3aed;
+    --qz-color-executing-bg: #ede9fe;
 
     --qz-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
     --qz-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
@@ -192,6 +198,8 @@
     --qz-color-danger-hover: #f87171;
     --qz-color-info: #3b82f6;
     --qz-color-info-bg: #1e3a5f;
+    --qz-color-executing: #a78bfa;
+    --qz-color-executing-bg: #3b0764;
 
     --qz-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
     --qz-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4),
@@ -770,6 +778,15 @@
 .qz-state-dot.qz-state-normal {
     background-color: var(--qz-color-success);
     box-shadow: 0 0 0 3px var(--qz-color-success-bg);
+}
+
+/*
+ * Violet rather than the info blue: blue is the fallback for a state the dashboard cannot classify, and
+ * executing has to stay distinguishable from "unrecognised" as well as from normal, paused and error.
+ */
+.qz-state-indicator.qz-state-executing .qz-state-dot {
+    background-color: var(--qz-color-executing);
+    box-shadow: 0 0 0 3px var(--qz-color-executing-bg);
 }
 
 .qz-state-label {

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
@@ -166,6 +166,42 @@ public class TriggerEndpointsTest : WebApiTest
     }
 
     [Test]
+    public async Task GetTriggerStateShouldWorkForExecuting()
+    {
+        A.CallTo(() => FakeScheduler.GetTriggerState(triggerKeyOne, A<CancellationToken>._)).Returns(TriggerState.Executing);
+
+        var state = await HttpScheduler.GetTriggerState(triggerKeyOne);
+        state.Should().Be(TriggerState.Executing);
+    }
+
+    /// <summary>
+    /// The enum crosses the wire as its numeric value, so the ordinals are a contract with clients built
+    /// against a different version. Both ends of the round trip above share the same enum, so only the
+    /// literal values can catch a renumbering.
+    /// </summary>
+    [Test]
+    public void TriggerStateOrdinalsAreTheWireContract()
+    {
+        ((int) TriggerState.Normal).Should().Be(0);
+        ((int) TriggerState.Paused).Should().Be(1);
+        ((int) TriggerState.Complete).Should().Be(2);
+        ((int) TriggerState.Error).Should().Be(3);
+        ((int) TriggerState.Blocked).Should().Be(4);
+        ((int) TriggerState.None).Should().Be(5);
+        ((int) TriggerState.Executing).Should().Be(6);
+    }
+
+    /// <summary>
+    /// The state filter is sent by member name, so the names are a contract too.
+    /// </summary>
+    [Test]
+    public void TriggerStateNamesAreTheWireContract()
+    {
+        Enum.GetNames<TriggerState>().Should().Equal(
+            "Normal", "Paused", "Complete", "Error", "Blocked", "None", "Executing");
+    }
+
+    [Test]
     public async Task PauseTriggerShouldWork()
     {
         await HttpScheduler.PauseTrigger(triggerKeyOne);

--- a/src/Quartz.Tests.Integration/ExecutingTriggerStateRamTest.cs
+++ b/src/Quartz.Tests.Integration/ExecutingTriggerStateRamTest.cs
@@ -1,0 +1,119 @@
+namespace Quartz.Tests.Integration;
+
+/// <summary>
+/// Drives a real scheduler over <c>RAMJobStore</c> through a whole execution, so the executing state is
+/// proven on the paths <c>QuartzSchedulerThread</c> and <c>JobRunShell</c> actually use rather than on a
+/// job store poked directly. The store keys executions by fire instance id, and only a real run proves the
+/// trigger instance handed to <c>TriggeredJobComplete</c> still carries the id that recorded them.
+/// </summary>
+[NonParallelizable]
+public class ExecutingTriggerStateRamTest
+{
+    private static SemaphoreSlim jobStarted = new(0);
+    private static SemaphoreSlim jobCanFinish = new(0);
+    private static volatile bool finishedOnRelease;
+
+    [SetUp]
+    public void ResetSignals()
+    {
+        jobStarted = new SemaphoreSlim(0);
+        jobCanFinish = new SemaphoreSlim(0);
+        finishedOnRelease = false;
+    }
+
+    [TearDown]
+    public void DisposeSignals()
+    {
+        jobStarted.Dispose();
+        jobCanFinish.Dispose();
+    }
+
+    [Test]
+    public async Task GetTriggerState_ReportsExecuting_ForTheWholeRunAndNormalAfterwards()
+    {
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(o =>
+            {
+                o.InstanceId = "AUTO";
+                o.InstanceName = "ExecutingStateRamTest";
+            })
+            .BuildScheduler();
+
+        var triggerKey = new TriggerKey("executingStateTrigger", "executingStateGroup");
+
+        try
+        {
+            await scheduler.Start();
+
+            IJobDetail job = JobBuilder.Create<BlockingJob>()
+                .WithIdentity("executingStateJob", "executingStateGroup")
+                .Build();
+
+            // Repeating, so the trigger stays schedulable while it runs — without consulting the
+            // execution records there would be nothing to distinguish it from an idle trigger.
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .WithSimpleSchedule(x => x.WithIntervalInHours(1).RepeatForever())
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+
+            (await jobStarted.WaitAsync(TimeSpan.FromSeconds(30)))
+                .Should().BeTrue("the job should have started");
+
+            (await scheduler.GetTriggerState(triggerKey)).Should().Be(TriggerState.Executing);
+
+            PagedResult<TriggerHeader> executing = await scheduler.QueryTriggers(new TriggerQuery { State = TriggerState.Executing });
+            executing.Items.Select(x => x.Key).Should().Contain(triggerKey,
+                "a listing filtered by Executing should return the running trigger");
+
+            PagedResult<TriggerHeader> normal = await scheduler.QueryTriggers(new TriggerQuery { State = TriggerState.Normal });
+            normal.Items.Select(x => x.Key).Should().NotContain(triggerKey,
+                "filtering by Normal must not return a trigger the same listing reports as Executing");
+
+            jobCanFinish.Release();
+
+            // The completion travels back through JobRunShell; if the trigger it hands over no longer
+            // carried the fire instance id that recorded the execution, this would never become Normal.
+            DateTimeOffset deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+            TriggerState finalState = TriggerState.Executing;
+            while (DateTimeOffset.UtcNow < deadline)
+            {
+                finalState = await scheduler.GetTriggerState(triggerKey);
+                if (finalState == TriggerState.Normal)
+                {
+                    break;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+            }
+
+            finalState.Should().Be(TriggerState.Normal,
+                "completing the job must release the execution it recorded");
+            finishedOnRelease.Should().BeTrue(
+                "the job must have finished because the test released it, not because its wait timed out");
+        }
+        finally
+        {
+            jobCanFinish.Release();
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// Allows concurrent execution, and blocks until the test releases it.
+    /// </summary>
+    private sealed class BlockingJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            jobStarted.Release();
+
+            // Recorded rather than asserted: an exception thrown here would be caught by JobRunShell and
+            // never reach the test runner.
+            finishedOnRelease = await jobCanFinish.WaitAsync(TimeSpan.FromSeconds(60), cancellationToken);
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ExecutingTriggerStateClusteredPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ExecutingTriggerStateClusteredPostgresTest.cs
@@ -1,0 +1,211 @@
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Covers the scenario behind #1416: one process schedules and observes triggers but never executes
+/// jobs, while another process executes them, the two sharing only the database. The observing process
+/// has to be able to tell that a trigger's job is running, which <see cref="IScheduler.GetCurrentlyExecutingJobs" />
+/// cannot answer because it only ever sees its own node.
+/// Runs against the assembly-wide PostgreSQL database (see ClusteredPostgresTestBase).
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class ExecutingTriggerStateClusteredPostgresTest : ClusteredPostgresTestBase
+{
+    protected override string SchedulerName => "ExecutingStateClusterTest";
+
+    private static SemaphoreSlim jobStarted = new(0);
+    private static SemaphoreSlim jobCanFinish = new(0);
+    private static volatile bool finishedOnRelease;
+
+    [SetUp]
+    public void ResetSignals()
+    {
+        jobStarted = new SemaphoreSlim(0);
+        jobCanFinish = new SemaphoreSlim(0);
+        finishedOnRelease = false;
+    }
+
+    [TearDown]
+    public void DisposeSignals()
+    {
+        jobStarted.Dispose();
+        jobCanFinish.Dispose();
+    }
+
+    /// <summary>
+    /// A repeating trigger, so that while the job runs the trigger row is WAITING or ACQUIRED rather
+    /// than COMPLETE — the path the single-fire smoke test does not exercise. The job allows concurrent
+    /// execution, so the trigger is never BLOCKED either: without consulting FIRED_TRIGGERS there would
+    /// be nothing at all to distinguish it from an idle trigger.
+    /// </summary>
+    [Test]
+    public async Task GetTriggerState_ReportsExecuting_OnNodeThatIsNotRunningTheJob()
+    {
+        IScheduler executingNode = await CreateScheduler("executing-node");
+        IScheduler observingNode = await CreateScheduler("observing-node");
+
+        var triggerKey = new TriggerKey("executingStateTrigger", "clusteredTest");
+
+        try
+        {
+            // Only this node is started, so only it can acquire and fire triggers.
+            await executingNode.Start();
+
+            IJobDetail job = JobBuilder.Create<BlockingJob>()
+                .WithIdentity("executingStateJob", "clusteredTest")
+                .StoreDurably()
+                .Build();
+            await executingNode.AddJob(job, true);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                // Comfortably longer than every timeout below, so a slow run cannot start a second
+                // execution while the first is still parked waiting for its one permit.
+                .WithSimpleSchedule(s => s.WithIntervalInHours(1).RepeatForever())
+                .StartNow()
+                .Build();
+            await executingNode.ScheduleJob(trigger);
+
+            (await jobStarted.WaitAsync(TimeSpan.FromSeconds(30)))
+                .Should().BeTrue("the job should have started on the executing node");
+
+            // The observing node was never started and never ran anything, so this answer can only have
+            // come from the shared database.
+            TriggerState observed = await observingNode.GetTriggerState(triggerKey);
+
+            // Captured only when it is about to be needed, and before anything else can move the state on.
+            string diagnostics = observed == TriggerState.Executing ? "" : await DumpDatabaseState();
+
+            observed.Should().Be(TriggerState.Executing,
+                "the observing node should see the trigger as executing. State:\n{0}", diagnostics);
+
+            (await observingNode.GetCurrentlyExecutingJobs())
+                .Should().BeEmpty("GetCurrentlyExecutingJobs stays node-local, which is why the trigger state is needed");
+
+            // The listing is the scenario the dashboard actually uses, and it is the only place the
+            // per-row executing projection and the EXISTS filter run against a real database with a
+            // fired-trigger row present.
+            PagedResult<TriggerHeader> executing = await observingNode.QueryTriggers(new TriggerQuery { State = TriggerState.Executing });
+            executing.Items.Select(x => x.Key).Should().Contain(triggerKey,
+                "a listing filtered by Executing should return the running trigger");
+            executing.Items.Single(x => x.Key.Equals(triggerKey)).State.Should().Be(TriggerState.Executing,
+                "the listing should report the same state GetTriggerState does");
+
+            PagedResult<TriggerHeader> normal = await observingNode.QueryTriggers(new TriggerQuery { State = TriggerState.Normal });
+            normal.Items.Select(x => x.Key).Should().NotContain(triggerKey,
+                "filtering by Normal must not return a trigger the same listing reports as Executing");
+
+            jobCanFinish.Release();
+
+            await WaitForCondition(
+                async () => await observingNode.GetTriggerState(triggerKey) == TriggerState.Normal,
+                timeoutMs: 30000,
+                "observing node should see the trigger return to normal once the job finishes");
+
+            finishedOnRelease.Should().BeTrue(
+                "the job must have finished because the test released it, not because its wait timed out");
+        }
+        finally
+        {
+            // Release first, so a failed assertion cannot leave the job thread parked on shutdown.
+            jobCanFinish.Release();
+            await executingNode.Shutdown(waitForJobsToComplete: true);
+            await observingNode.Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// The self/sibling split, against a real database. The ADO store writes BLOCKED to TRIGGER_STATE for
+    /// <em>every</em> trigger of a non-concurrent job, including the one that fired, so the only thing
+    /// telling them apart is the fired-trigger row — which makes this the case the whole `Blocked`
+    /// narrowing rests on, and the one a faked delegate cannot exercise.
+    /// </summary>
+    [Test]
+    public async Task GetTriggerState_ReportsExecutingForTheFiringTrigger_AndBlockedForItsSibling()
+    {
+        IScheduler scheduler = await CreateScheduler("nonconcurrent-node");
+
+        var firstKey = new TriggerKey("nonConcurrentTriggerOne", "clusteredTest");
+        var secondKey = new TriggerKey("nonConcurrentTriggerTwo", "clusteredTest");
+
+        try
+        {
+            await scheduler.Start();
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentBlockingJob>()
+                .WithIdentity("nonConcurrentJob", "clusteredTest")
+                .StoreDurably()
+                .Build();
+            await scheduler.AddJob(job, true);
+
+            foreach (TriggerKey key in (TriggerKey[]) [firstKey, secondKey])
+            {
+                await scheduler.ScheduleJob(TriggerBuilder.Create()
+                    .WithIdentity(key)
+                    .ForJob(job)
+                    .WithSimpleSchedule(x => x.WithIntervalInHours(1).RepeatForever())
+                    .StartNow()
+                    .Build());
+            }
+
+            (await jobStarted.WaitAsync(TimeSpan.FromSeconds(30)))
+                .Should().BeTrue("the job should have started");
+
+            TriggerState firstState = await scheduler.GetTriggerState(firstKey);
+            TriggerState secondState = await scheduler.GetTriggerState(secondKey);
+
+            string diagnostics = await DumpDatabaseState();
+
+            // Whichever won the race is the one running; the other is gated behind it.
+            TriggerState[] states = [firstState, secondState];
+            states.Should().BeEquivalentTo([TriggerState.Executing, TriggerState.Blocked],
+                "exactly one trigger is running the job and the other is blocked by it. State:\n{0}", diagnostics);
+
+            // Two permits: completing the first execution unblocks the sibling, which is itself overdue
+            // and fires straight away, so both have to be let through before either trigger settles.
+            jobCanFinish.Release(2);
+
+            await WaitForCondition(
+                async () => await scheduler.GetTriggerState(firstKey) == TriggerState.Normal
+                            && await scheduler.GetTriggerState(secondKey) == TriggerState.Normal,
+                timeoutMs: 30000,
+                "both triggers should return to normal once the job finishes");
+        }
+        finally
+        {
+            jobCanFinish.Release();
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// Allows concurrent execution, and blocks until the test releases it.
+    /// </summary>
+    private sealed class BlockingJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            jobStarted.Release();
+
+            // Recorded rather than asserted: an exception thrown here is caught by JobRunShell and never
+            // reaches the test runner. The test body checks it, so a job that finished on the timeout
+            // instead of on the test's release cannot make the return-to-normal assertion pass for the
+            // wrong reason.
+            finishedOnRelease = await jobCanFinish.WaitAsync(TimeSpan.FromSeconds(60), cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// The same, but disallowing concurrent execution, so its triggers gate each other.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    private sealed class NonConcurrentBlockingJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            jobStarted.Release();
+            finishedOnRelease = await jobCanFinish.WaitAsync(TimeSpan.FromSeconds(60), cancellationToken);
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -372,7 +372,7 @@ public class SmokeTestPerformer
 
                 await TestExecutionGroups(scheduler);
                 await TestMatchers(scheduler);
-                await TestGetTriggerStateBlockedWhileExecuting(scheduler);
+                await TestGetTriggerStateExecutingWhileJobRuns(scheduler);
             }
         }
         finally
@@ -514,10 +514,14 @@ public class SmokeTestPerformer
     }
 
     /// <summary>
-    /// Regression test for #2255: GetTriggerState should return Blocked (not Complete)
-    /// when a trigger's last fire is currently executing.
+    /// Regression test for #2255 and #1416: GetTriggerState should report Executing (not Complete)
+    /// while a trigger's last fire is still running.
     /// </summary>
-    private async Task TestGetTriggerStateBlockedWhileExecuting(IScheduler scheduler)
+    /// <remarks>
+    /// #2255 was originally fixed by reporting Blocked here, because there was no state for "still
+    /// executing". #1416 gave that case its own state, so the answer is now Executing.
+    /// </remarks>
+    private async Task TestGetTriggerStateExecutingWhileJobRuns(IScheduler scheduler)
     {
         await scheduler.Clear();
         await scheduler.Start();
@@ -544,18 +548,18 @@ public class SmokeTestPerformer
         try
         {
             // Wait for the job to start executing
-            Assert.That(await jobStarted.WaitAsync(TimeSpan.FromSeconds(10)), Is.True, "Job should have started within 10 seconds");
+            (await jobStarted.WaitAsync(TimeSpan.FromSeconds(10))).Should().BeTrue("the job should have started within 10 seconds");
 
-            // While the job is executing, GetTriggerState should return Blocked, not Complete
+            // While the job is executing, GetTriggerState should return Executing, not Complete
             var state = await scheduler.GetTriggerState(trigger.Key);
-            Assert.That(state, Is.EqualTo(TriggerState.Blocked),
-                "GetTriggerState should return Blocked while the trigger's job is executing, not Complete (#2255)");
+            state.Should().Be(TriggerState.Executing,
+                "GetTriggerState should return Executing while the trigger's job is running, not Complete (#2255, #1416)");
 
             // Let the job finish
             jobCanFinish.Release();
 
             // Wait for the scheduler to process completion by polling deterministically
-            TriggerState finalState = TriggerState.Blocked;
+            TriggerState finalState = TriggerState.Executing;
             DateTimeOffset deadline = DateTimeOffset.UtcNow.AddSeconds(30);
             while (DateTimeOffset.UtcNow < deadline)
             {
@@ -569,7 +573,7 @@ public class SmokeTestPerformer
             }
 
             // After job completes, single-fire trigger is removed (DeleteTrigger instruction)
-            Assert.That(finalState, Is.EqualTo(TriggerState.None),
+            finalState.Should().Be(TriggerState.None,
                 "Single-fire trigger should be removed after the job finishes executing (#2255)");
         }
         finally

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -953,6 +953,49 @@ public class JobStoreSupportTest
         }
     }
 
+    #region GetTriggerState precedence
+
+    /// <summary>
+    /// Pins the whole stored-state/executing matrix, including the cases that only differ once a trigger
+    /// is executing. The reported precedence is None &gt; Error &gt; Paused &gt; Executing &gt; Blocked &gt;
+    /// Complete &gt; Normal.
+    /// </summary>
+    [TestCase(AdoConstants.StateWaiting, false, TriggerState.Normal)]
+    [TestCase(AdoConstants.StateWaiting, true, TriggerState.Executing)]
+    [TestCase(AdoConstants.StateAcquired, false, TriggerState.Normal)]
+    [TestCase(AdoConstants.StateAcquired, true, TriggerState.Executing)]
+    [TestCase(AdoConstants.StateComplete, false, TriggerState.Complete)]
+    [TestCase(AdoConstants.StateComplete, true, TriggerState.Executing)]
+    [TestCase(AdoConstants.StateBlocked, false, TriggerState.Blocked)]
+    [TestCase(AdoConstants.StateBlocked, true, TriggerState.Executing)]
+    [TestCase(AdoConstants.StatePaused, false, TriggerState.Paused)]
+    [TestCase(AdoConstants.StatePaused, true, TriggerState.Paused)]
+    [TestCase(AdoConstants.StatePausedBlocked, false, TriggerState.Paused)]
+    [TestCase(AdoConstants.StatePausedBlocked, true, TriggerState.Paused)]
+    [TestCase(AdoConstants.StateError, false, TriggerState.Error)]
+    [TestCase(AdoConstants.StateError, true, TriggerState.Error)]
+    [TestCase(AdoConstants.StateDeleted, false, TriggerState.None)]
+    [TestCase(AdoConstants.StateDeleted, true, TriggerState.None)]
+    public async Task GetTriggerState_MapsStoredStateAndExecutionToReportedState(
+        string storedState,
+        bool isExecuting,
+        TriggerState expected)
+    {
+        TransientTriggersFiredTestStore store = CreateTransientTriggersFiredTestStore();
+        IDriverDelegate del = A.Fake<IDriverDelegate>();
+        store.DirectDelegate = del;
+
+        var triggerKey = new TriggerKey("trigger1", "group1");
+        A.CallTo(() => del.SelectTriggerStateWithExecuting(A<ConnectionAndTransactionHolder>.Ignored, triggerKey, A<CancellationToken>.Ignored))
+            .Returns(new TriggerExecutionState(storedState, isExecuting));
+
+        TriggerState state = await store.GetTriggerState(triggerKey);
+
+        state.Should().Be(expected);
+    }
+
+    #endregion
+
     #region TriggersFired transient retry tests
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateGroupMatcherTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateGroupMatcherTest.cs
@@ -34,9 +34,9 @@ using Quartz.Impl.Matchers;
 namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 
 /// <summary>
-/// How <see cref="StdAdoDelegate" /> translates a <see cref="GroupMatcher{TKey}" /> into SQL: an
-/// equality matcher must compare with '=', and anything that does become a LIKE has to have the
-/// matcher's own text escaped, so a group literally named "50%" is not a wildcard.
+/// The SQL <see cref="StdAdoDelegate" /> generates, asserted against the command text rather than a
+/// database: how a <see cref="GroupMatcher{TKey}" /> becomes an '=' or an escaped LIKE, so a group
+/// literally named "50%" is not a wildcard, and how a trigger state becomes a filter.
 /// </summary>
 public class StdAdoDelegateGroupMatcherTest
 {
@@ -48,15 +48,6 @@ public class StdAdoDelegateGroupMatcherTest
     [SetUp]
     public void SetUp()
     {
-        IDbProvider dbProvider = A.Fake<IDbProvider>();
-        DbMetadata metadata = new()
-        {
-            BindByName = true,
-            ParameterNamePrefix = "@"
-        };
-        metadata.Initialize();
-        A.CallTo(() => dbProvider.Metadata).Returns(metadata);
-
         parameters = new RecordingParameterCollection();
         command = A.Fake<StubCommand>();
 
@@ -75,10 +66,29 @@ public class StdAdoDelegateGroupMatcherTest
             .WithReturnType<Task<DbDataReader>>()
             .Returns(Task.FromResult(reader));
 
+        adoDelegate = CreateDelegate(bindByName: true, parameterNamePrefix: "@");
+
+        conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+    }
+
+    /// <summary>
+    /// Builds a delegate whose commands are this fixture's stub, so the generated SQL can be inspected.
+    /// Providers differ in how they name parameters, which changes how the statement is rewritten.
+    /// </summary>
+    private StdAdoDelegate CreateDelegate(bool bindByName, string parameterNamePrefix)
+    {
+        IDbProvider dbProvider = A.Fake<IDbProvider>();
+        DbMetadata metadata = new()
+        {
+            BindByName = bindByName,
+            ParameterNamePrefix = parameterNamePrefix
+        };
+        metadata.Initialize();
+        A.CallTo(() => dbProvider.Metadata).Returns(metadata);
         A.CallTo(() => dbProvider.CreateCommand()).Returns(command);
 
-        adoDelegate = new StdAdoDelegate();
-        adoDelegate.Initialize(new DelegateInitializationArgs
+        StdAdoDelegate result = new();
+        result.Initialize(new DelegateInitializationArgs
         {
             TablePrefix = "QRTZ_",
             InstanceName = "TESTSCHED",
@@ -87,7 +97,7 @@ public class StdAdoDelegateGroupMatcherTest
             DbProvider = dbProvider
         });
 
-        conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+        return result;
     }
 
     [TearDown]
@@ -241,6 +251,172 @@ public class StdAdoDelegateGroupMatcherTest
 
         command.CommandText.Should().Contain("TRIGGER_GROUP LIKE @triggerGroup ESCAPE '!'");
         parameters.Value("@triggerGroup").Should().Be("50!%%");
+    }
+
+    [Test]
+    public async Task SelectTriggerStateWithExecuting_BuildsExpectedSql()
+    {
+        await adoDelegate.SelectTriggerStateWithExecuting(conn, new TriggerKey("trigger1", "group1"));
+
+        string expectedCommandText = "SELECT TRIGGER_STATE, "
+                                     + "CASE WHEN EXISTS ("
+                                     + "SELECT 1 FROM QRTZ_FIRED_TRIGGERS FT "
+                                     + "WHERE FT.SCHED_NAME = QRTZ_TRIGGERS.SCHED_NAME "
+                                     + "AND FT.TRIGGER_NAME = QRTZ_TRIGGERS.TRIGGER_NAME "
+                                     + "AND FT.TRIGGER_GROUP = QRTZ_TRIGGERS.TRIGGER_GROUP "
+                                     + "AND FT.STATE = 'EXECUTING') "
+                                     + "THEN 1 ELSE 0 END "
+                                     + "FROM QRTZ_TRIGGERS "
+                                     + "WHERE SCHED_NAME = @schedulerName "
+                                     + "AND TRIGGER_NAME = @triggerName "
+                                     + "AND TRIGGER_GROUP = @triggerGroup";
+        command.CommandText.Should().Be(expectedCommandText);
+    }
+
+    /// <summary>
+    /// Providers that bind positionally have their parameter names rewritten by a plain substring
+    /// replace, so a statement mentioning one name twice would end up with more placeholders than bound
+    /// parameters. The executing state is embedded as a literal precisely to avoid that.
+    /// </summary>
+    [Test]
+    public async Task SelectTriggerStateWithExecuting_BindsPositionallyWithoutDuplicateParameters()
+    {
+        StdAdoDelegate positional = CreateDelegate(bindByName: false, parameterNamePrefix: "?");
+
+        await positional.SelectTriggerStateWithExecuting(conn, new TriggerKey("trigger1", "group1"));
+
+        command.CommandText.Should().NotContain("@", "every named parameter must have been rewritten");
+        command.CommandText.Count(c => c == '?')
+            .Should().Be(3, "exactly the scheduler name, trigger name and trigger group are bound");
+        command.CommandText.Should().Contain("'EXECUTING'", "the state is a literal, not a parameter");
+    }
+
+    [Test]
+    public async Task SelectTriggerHeaders_FilteringByExecuting_RequiresAFiredTriggerRow()
+    {
+        await adoDelegate.SelectTriggerHeaders(conn, new TriggerQuery { State = TriggerState.Executing });
+
+        // Executing is not a stored state, so the filter has to reach into FIRED_TRIGGERS.
+        command.CommandText.Should().Contain("AND EXISTS (SELECT 1 FROM QRTZ_FIRED_TRIGGERS FT");
+        command.CommandText.Should().NotContain("AND NOT EXISTS");
+
+        // Executing is also what an unrecognised stored state reports as while it is running, and those
+        // values cannot be listed, so the filter excludes the states that outrank executing instead.
+        command.CommandText.Should().Contain("AND TRIGGER_STATE NOT IN (");
+        BoundStates().Should().BeEquivalentTo([
+            AdoConstants.StatePaused,
+            AdoConstants.StatePausedBlocked,
+            AdoConstants.StateError,
+            AdoConstants.StateDeleted
+        ]);
+    }
+
+    [Test]
+    public async Task SelectTriggerHeaders_FilteringByNormal_ExcludesExecutingTriggers()
+    {
+        await adoDelegate.SelectTriggerHeaders(conn, new TriggerQuery { State = TriggerState.Normal });
+
+        // Otherwise the listing would return a row here and then report it as executing.
+        command.CommandText.Should().Contain("AND NOT EXISTS (SELECT 1 FROM QRTZ_FIRED_TRIGGERS FT");
+
+        // Normal is what an unrecognised stored state reports as, and those values cannot be listed, so
+        // the filter excludes the states that report as something else instead of listing its own.
+        command.CommandText.Should().Contain("AND TRIGGER_STATE NOT IN (");
+        BoundStates().Should().BeEquivalentTo([
+            AdoConstants.StateComplete,
+            AdoConstants.StateBlocked,
+            AdoConstants.StatePaused,
+            AdoConstants.StatePausedBlocked,
+            AdoConstants.StateError,
+            AdoConstants.StateDeleted
+        ]);
+    }
+
+    [Test]
+    public async Task SelectTriggerHeaders_FilteringByPaused_IgnoresExecution()
+    {
+        await adoDelegate.SelectTriggerHeaders(conn, new TriggerQuery { State = TriggerState.Paused });
+
+        // Paused outranks executing, so execution cannot change the answer and needs no predicate.
+        command.CommandText.Should().NotContain("AND EXISTS");
+        command.CommandText.Should().NotContain("AND NOT EXISTS");
+        BoundStates().Should().BeEquivalentTo([AdoConstants.StatePaused, AdoConstants.StatePausedBlocked]);
+    }
+
+    /// <summary>
+    /// The listing projection and <c>ReadTriggerHeader</c> agree on where the executing flag is: the
+    /// reader takes it from a fixed ordinal, so a column added to the SELECT list ahead of it would make
+    /// every listing read the wrong value. Only exercised here — the paging tests need a database.
+    /// </summary>
+    [TestCase(0, TriggerState.Normal)]
+    [TestCase(1, TriggerState.Executing)]
+    public async Task SelectTriggerHeaders_ReadsTheExecutingFlagFromTheProjection(int executingFlag, TriggerState expected)
+    {
+        InstallSingleRowReader(AdoConstants.StateWaiting, executingFlag);
+
+        PagedResult<TriggerHeader> result = await adoDelegate.SelectTriggerHeaders(conn, new TriggerQuery());
+
+        TriggerHeader header = result.Items.Should().ContainSingle().Subject;
+        header.Key.Should().Be(new TriggerKey("trigger1", "group1"));
+        header.State.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Fakes one listing row. The values are positional on purpose: this is what pins the projection's
+    /// column order to the reader's ordinals.
+    /// </summary>
+    private void InstallSingleRowReader(string triggerState, int executingFlag)
+    {
+        var strings = new Dictionary<int, string>
+        {
+            [0] = "trigger1",
+            [1] = "group1",
+            [2] = "job1",
+            [3] = "jobGroup1",
+            [4] = "description",
+            [5] = "SIMPLE",
+            [6] = triggerState,
+            [11] = "calendar",
+            [13] = "executionGroup"
+        };
+
+        DbDataReader reader = A.Fake<DbDataReader>();
+        bool read = false;
+        A.CallTo(() => reader.ReadAsync(A<CancellationToken>._)).ReturnsLazily(() =>
+        {
+            bool first = !read;
+            read = true;
+            return first;
+        });
+
+        A.CallTo(() => reader.GetString(A<int>._)).ReturnsLazily((int i) => strings[i]);
+        A.CallTo(() => reader.IsDBNull(A<int>._)).ReturnsLazily((int i) => !strings.ContainsKey(i));
+
+        // Date columns come back as DBNull so the reader's own null handling applies; priority and the
+        // executing flag are the two the reader converts.
+        A.CallTo(() => reader.GetValue(A<int>._)).ReturnsLazily((int i) => i switch
+        {
+            12 => 5,
+            14 => executingFlag,
+            _ => DBNull.Value
+        });
+
+        A.CallTo(command)
+            .Where(x => x.Method.Name == "ExecuteDbDataReaderAsync")
+            .WithReturnType<Task<DbDataReader>>()
+            .Returns(Task.FromResult(reader));
+    }
+
+    /// <summary>
+    /// The stored states the trigger-state filter bound, in no particular order.
+    /// </summary>
+    private List<object> BoundStates()
+    {
+        return parameters
+            .Cast<DbParameter>()
+            .Where(x => x.ParameterName.StartsWith("@state", StringComparison.Ordinal))
+            .Select(x => x.Value)
+            .ToList();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/TriggerExecutionStateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/TriggerExecutionStateTest.cs
@@ -1,0 +1,73 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The value-type contract of <see cref="TriggerExecutionState" />: a struct can always be
+/// default-constructed, and the type promises that doing so means "no such trigger" rather than null.
+/// </summary>
+public class TriggerExecutionStateTest
+{
+    [Test]
+    public void DefaultValueReadsAsAMissingTrigger()
+    {
+        TriggerExecutionState state = default;
+
+        state.State.Should().Be(AdoConstants.StateDeleted,
+            "the declared non-nullable State must not surface as null for a default struct");
+        state.IsExecuting.Should().BeFalse();
+        state.Should().Be(TriggerExecutionState.NotFound);
+    }
+
+    [Test]
+    public void SpellingOutDeletedEqualsNotFound()
+    {
+        // The constructor doc offers these as alternatives, so they have to compare equal.
+        TriggerExecutionState spelledOut = new(AdoConstants.StateDeleted, isExecuting: false);
+
+        spelledOut.Should().Be(TriggerExecutionState.NotFound);
+        (spelledOut == TriggerExecutionState.NotFound).Should().BeTrue();
+        spelledOut.GetHashCode().Should().Be(TriggerExecutionState.NotFound.GetHashCode());
+    }
+
+    [Test]
+    public void CarriesTheStateAndExecutionItWasGiven()
+    {
+        TriggerExecutionState state = new(AdoConstants.StateWaiting, isExecuting: true);
+
+        state.State.Should().Be(AdoConstants.StateWaiting);
+        state.IsExecuting.Should().BeTrue();
+        state.Should().NotBe(TriggerExecutionState.NotFound);
+    }
+
+    [Test]
+    public void ValuesWithTheSameStateAndExecutionAreEqual()
+    {
+        new TriggerExecutionState(AdoConstants.StateBlocked, isExecuting: true)
+            .Should().Be(new TriggerExecutionState(AdoConstants.StateBlocked, isExecuting: true));
+
+        new TriggerExecutionState(AdoConstants.StateBlocked, isExecuting: true)
+            .Should().NotBe(new TriggerExecutionState(AdoConstants.StateBlocked, isExecuting: false));
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/TriggerStateMappingTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/TriggerStateMappingTest.cs
@@ -1,0 +1,120 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Reflection;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The property the trigger-state design rests on: a listing's state filter selects exactly the rows that
+/// same listing reports as that state. Asserted over the whole matrix rather than per case, so a change to
+/// the precedence cannot satisfy one direction and quietly break the other.
+/// </summary>
+public class TriggerStateMappingTest
+{
+    /// <summary>
+    /// Every state constant the store defines, discovered rather than listed, plus one entirely foreign
+    /// value standing in for whatever a third-party delegate, a migration or a hand-repaired row may have
+    /// left in the column.
+    /// </summary>
+    /// <remarks>
+    /// Read off <see cref="AdoConstants" /> so that adding a state constant automatically brings it into
+    /// this property — a hand-maintained copy would silently stop covering it, which is the same drift the
+    /// production mapping derives its filters to avoid.
+    /// </remarks>
+    private static readonly string[] storedStates =
+    [
+        .. typeof(AdoConstants)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(x => x.IsLiteral && x.FieldType == typeof(string) && x.Name.StartsWith("State", StringComparison.Ordinal))
+            .Select(x => (string) x.GetRawConstantValue()!),
+        "SOME_FOREIGN_STATE"
+    ];
+
+    [Test]
+    public void TheStateConstantsWereActuallyDiscovered()
+    {
+        // Guards the reflection above: if it silently matched nothing, every property below would pass
+        // vacuously over a single foreign value.
+        storedStates.Should().Contain(AdoConstants.StateWaiting).And.Contain(AdoConstants.StateExecuting)
+            .And.Contain(AdoConstants.StateDeleted).And.HaveCountGreaterThan(8);
+    }
+
+    [Test]
+    public void EveryFilterSelectsExactlyWhatTheListingReports()
+    {
+        foreach (TriggerState reported in Enum.GetValues<TriggerState>())
+        {
+            TriggerStateFilter filter = TriggerStateMapping.ToFilter(reported);
+
+            foreach (string stored in storedStates)
+            {
+                foreach (bool isExecuting in (bool[]) [false, true])
+                {
+                    bool selected = Selects(filter, stored, isExecuting);
+                    bool reportedAsThis = TriggerStateMapping.ToTriggerState(stored, isExecuting) == reported;
+
+                    selected.Should().Be(reportedAsThis,
+                        "a listing filtered by {0} must select TRIGGER_STATE '{1}' (executing: {2}) exactly when it reports it as {0}",
+                        reported, stored, isExecuting);
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void NoneFilterSelectsOnlyTheDeletedSentinel()
+    {
+        TriggerStateFilter filter = TriggerStateMapping.ToFilter(TriggerState.None);
+
+        // The store never writes DELETED to the column, so in practice this matches no row — but if one
+        // carries the value it reports as None, and the filter has to agree rather than leak it into the
+        // Normal listing.
+        Selects(filter, AdoConstants.StateDeleted, isExecuting: false).Should().BeTrue();
+        Selects(filter, AdoConstants.StateWaiting, isExecuting: false).Should().BeFalse();
+        Selects(filter, "SOME_FOREIGN_STATE", isExecuting: false).Should().BeFalse();
+    }
+
+    [Test]
+    public void ToFilterRejectsAnUndefinedState()
+    {
+        Action act = () => TriggerStateMapping.ToFilter((TriggerState) 99);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// Evaluates a filter the way the generated SQL does: the state list, negated or not, and then the
+    /// optional requirement on whether an execution is in flight.
+    /// </summary>
+    private static bool Selects(TriggerStateFilter filter, string storedState, bool isExecuting)
+    {
+        bool inList = filter.States.Contains(storedState);
+        if (filter.Negated ? inList : !inList)
+        {
+            return false;
+        }
+
+        return filter.Executing is null || filter.Executing.Value == isExecuting;
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/RAMJobStoreQueryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/RAMJobStoreQueryTest.cs
@@ -224,6 +224,38 @@ public class RAMJobStoreQueryTest
     }
 
     [Test]
+    public async Task QueryTriggers_ReportsAndFiltersExecutingConsistently()
+    {
+        IJobDetail job = await StoreJob("job", "g");
+
+        // Has to be firable now, unlike the far-future triggers the other listing tests use.
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("running", "g")
+            .ForJob(job)
+            .StartAt(d.AddSeconds(1))
+            .WithSimpleSchedule(x => x.WithIntervalInSeconds(5).RepeatForever())
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        await store.StoreTrigger(trigger, replaceExisting: false);
+
+        var acquired = await store.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        acquired.Should().HaveCount(1);
+        (await store.TriggersFired(acquired)).Should().HaveCount(1);
+
+        PagedResult<TriggerHeader> all = await store.QueryTriggers(new TriggerQuery());
+        all.Items.Single().State.Should().Be(TriggerState.Executing,
+            "a listing reports the same state GetTriggerState would");
+
+        PagedResult<TriggerHeader> executing = await store.QueryTriggers(new TriggerQuery { State = TriggerState.Executing });
+        executing.Items.Select(x => x.Key).Should().Equal([trigger.Key]);
+
+        PagedResult<TriggerHeader> normal = await store.QueryTriggers(new TriggerQuery { State = TriggerState.Normal });
+        normal.Items.Should().BeEmpty(
+            "filtering by normal must not return a trigger the same listing reports as executing");
+    }
+
+    [Test]
     public async Task QueryTriggers_HeaderCarriesTheStoredTriggerMetadata()
     {
         IJobDetail job = await StoreJob("job", "g");

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -629,20 +629,24 @@ public class RAMJobStoreTest
         var firedResults = await fJobStore.TriggersFired(acquiredTriggers);
         Assert.That(firedResults, Has.Count.EqualTo(1));
 
-        // Both triggers should be blocked now (DisallowConcurrentExecution)
-        Assert.That(await fJobStore.GetTriggerState(trigger1.Key), Is.EqualTo(TriggerState.Blocked));
-        Assert.That(await fJobStore.GetTriggerState(trigger2.Key), Is.EqualTo(TriggerState.Blocked));
+        // The trigger that fired is running the job, so it reports Executing. Its sibling is merely
+        // gated behind the DisallowConcurrentExecution job, which is what Blocked means.
+        var firedResult = firedResults.First();
+        TriggerKey firedKey = firedResult.TriggerFiredBundle.Trigger.Key;
+        TriggerKey siblingKey = firedKey.Equals(trigger1.Key) ? trigger2.Key : trigger1.Key;
+
+        (await fJobStore.GetTriggerState(firedKey)).Should().Be(TriggerState.Executing);
+        (await fJobStore.GetTriggerState(siblingKey)).Should().Be(TriggerState.Blocked);
 
         // Simulate job completion with NoInstruction (graceful shutdown scenario)
-        var firedResult = firedResults.First();
         await fJobStore.TriggeredJobComplete(
             firedResult.TriggerFiredBundle.Trigger,
             firedResult.TriggerFiredBundle.JobDetail,
             SchedulerInstruction.NoInstruction);
 
         // Both triggers should be unblocked (Normal = Waiting)
-        Assert.That(await fJobStore.GetTriggerState(trigger1.Key), Is.EqualTo(TriggerState.Normal));
-        Assert.That(await fJobStore.GetTriggerState(trigger2.Key), Is.EqualTo(TriggerState.Normal));
+        (await fJobStore.GetTriggerState(trigger1.Key)).Should().Be(TriggerState.Normal);
+        (await fJobStore.GetTriggerState(trigger2.Key)).Should().Be(TriggerState.Normal);
     }
 
     [Test]
@@ -676,25 +680,332 @@ public class RAMJobStoreTest
         var firedResults = await fJobStore.TriggersFired(acquiredTriggers);
         Assert.That(firedResults, Has.Count.EqualTo(1));
 
-        // Both triggers should be blocked
-        Assert.That(await fJobStore.GetTriggerState(trigger1.Key), Is.EqualTo(TriggerState.Blocked));
-        Assert.That(await fJobStore.GetTriggerState(trigger2.Key), Is.EqualTo(TriggerState.Blocked));
+        // The trigger that fired is running the job; its sibling is gated behind it.
+        TriggerKey siblingKey = firedTrigger.Key.Equals(trigger1.Key) ? trigger2.Key : trigger1.Key;
+
+        (await fJobStore.GetTriggerState(firedTrigger.Key)).Should().Be(TriggerState.Executing);
+        (await fJobStore.GetTriggerState(siblingKey)).Should().Be(TriggerState.Blocked);
 
         // ReleaseAcquiredTrigger only handles the specific trigger's Acquired state,
         // it does NOT unblock other triggers since it doesn't know about job concurrency
         await fJobStore.ReleaseAcquiredTrigger(firedTrigger);
 
-        // The other trigger remains blocked - this is the bug scenario
-        // that was fixed by using TriggeredJobComplete instead
-        var trigger1State = await fJobStore.GetTriggerState(trigger1.Key);
-        var trigger2State = await fJobStore.GetTriggerState(trigger2.Key);
-
-        // At least one trigger should still be blocked since ReleaseAcquiredTrigger
-        // does not handle the unblocking of all triggers for the job
-        Assert.That(
-            trigger1State == TriggerState.Blocked || trigger2State == TriggerState.Blocked,
-            Is.True,
+        // Releasing means the fire is not going to run after all, so the execution is dropped and the
+        // trigger is no longer executing - but it stays blocked, along with its sibling, because
+        // ReleaseAcquiredTrigger knows nothing about job concurrency. That is the bug scenario this
+        // documents: only TriggeredJobComplete unblocks the job's triggers.
+        (await fJobStore.GetTriggerState(firedTrigger.Key)).Should().Be(TriggerState.Blocked,
+            "releasing drops the execution but does not unblock the job");
+        (await fJobStore.GetTriggerState(siblingKey)).Should().Be(TriggerState.Blocked,
             "ReleaseAcquiredTrigger should not unblock all triggers for DisallowConcurrentExecution jobs");
+    }
+
+    /// <summary>
+    /// Builds a repeating trigger for the concurrency-allowed job the fixture stores.
+    /// </summary>
+    private static SimpleTriggerImpl ExecutingTestTrigger(string name, DateTimeOffset d)
+    {
+        var trigger = new SimpleTriggerImpl(name, "triggerGroup1", "job1", "jobGroup1",
+            d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    [Test]
+    public async Task GetTriggerState_ReturnsExecuting_WhileConcurrencyAllowedJobRuns()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("executingTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        acquired.Should().HaveCount(1);
+
+        // Nothing is running yet, so an acquired trigger still reads as normal.
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
+
+        var fired = await fJobStore.TriggersFired(acquired);
+        fired.Should().HaveCount(1);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing);
+
+        var bundle = fired[0].TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
+    }
+
+    [Test]
+    public async Task GetTriggerState_ReturnsExecuting_UntilLastOfSeveralConcurrentFiresCompletes()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("concurrentTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        // The job allows concurrent execution, so the trigger is re-armed as soon as it fires and can be
+        // acquired again while the first execution is still in flight.
+        var firstAcquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        firstAcquired.Should().HaveCount(1);
+        var firstFired = await fJobStore.TriggersFired(firstAcquired);
+        firstFired.Should().HaveCount(1);
+
+        var secondAcquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        secondAcquired.Should().HaveCount(1);
+        var secondFired = await fJobStore.TriggersFired(secondAcquired);
+        secondFired.Should().HaveCount(1);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing);
+
+        var firstBundle = firstFired[0].TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(firstBundle.Trigger, firstBundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing,
+            "one of the two executions is still running");
+
+        var secondBundle = secondFired[0].TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(secondBundle.Trigger, secondBundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
+    }
+
+    [Test]
+    public async Task GetTriggerState_ReturnsPaused_WhenTriggerPausedWhileJobExecuting()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("pausedWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        var fired = await fJobStore.TriggersFired(acquired);
+        fired.Should().HaveCount(1);
+
+        await fJobStore.PauseTrigger(trigger.Key);
+
+        // The pause is the actionable fact, so it outranks the execution still in flight.
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Paused);
+
+        var bundle = fired[0].TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Paused);
+    }
+
+    [Test]
+    public async Task GetTriggerState_ReturnsNone_WhenTriggerRemovedWhileExecuting()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("removedWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        var fired = await fJobStore.TriggersFired(acquired);
+        fired.Should().HaveCount(1);
+
+        (await fJobStore.RemoveTrigger(trigger.Key)).Should().BeTrue();
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.None);
+
+        // The completion arrives for a trigger that no longer exists and must not throw.
+        var bundle = fired[0].TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        // Once the execution has been accounted for, a trigger re-stored under the same key is idle.
+        var replacement = ExecutingTestTrigger("removedWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(replacement, false);
+
+        (await fJobStore.GetTriggerState(replacement.Key)).Should().Be(TriggerState.Normal);
+    }
+
+    /// <summary>
+    /// The other half of the rule the reschedule test pins: deleting a trigger takes its executions with
+    /// it, so a trigger later created under the same key is a different trigger and starts idle. Asserted
+    /// while the original execution is still in flight — after its completion the entry would have been
+    /// released anyway, and the test would pass whether or not removal forgets it.
+    /// </summary>
+    [Test]
+    public async Task GetTriggerState_ForgetsExecutions_WhenTriggerIsRemovedAndRecreatedMidExecution()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("recreatedWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        var fired = await fJobStore.TriggersFired(acquired);
+        fired.Should().HaveCount(1);
+
+        (await fJobStore.RemoveTrigger(trigger.Key)).Should().BeTrue();
+
+        var replacement = ExecutingTestTrigger("recreatedWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(replacement, false);
+
+        (await fJobStore.GetTriggerState(replacement.Key)).Should().Be(TriggerState.Normal,
+            "the new trigger never fired, so it cannot inherit the deleted trigger's execution");
+
+        // The orphaned completion still arrives and must not disturb the new trigger.
+        var bundle = fired[0].TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.GetTriggerState(replacement.Key)).Should().Be(TriggerState.Normal);
+    }
+
+    /// <summary>
+    /// ReplaceTrigger deletes rather than updates, so unlike StoreTrigger(replaceExisting: true) it does
+    /// not carry the executions over — matching the ADO store, where ReplaceTrigger removes the
+    /// fired-trigger rows and an in-place update leaves them.
+    /// </summary>
+    [Test]
+    public async Task GetTriggerState_ForgetsExecutions_WhenTriggerIsReplacedMidExecution()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("replacedWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        var fired = await fJobStore.TriggersFired(acquired);
+        fired.Should().HaveCount(1);
+
+        var replacement = ExecutingTestTrigger("replacedWhileExecutingTrigger", d);
+        (await fJobStore.ReplaceTrigger(trigger.Key, replacement)).Should().BeTrue();
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal,
+            "the replaced trigger was deleted, so its execution went with it");
+    }
+
+    /// <summary>
+    /// Clearing the store forgets everything, executions included.
+    /// </summary>
+    [Test]
+    public async Task GetTriggerState_ForgetsExecutions_WhenSchedulingDataIsClearedMidExecution()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("clearedWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        (await fJobStore.TriggersFired(acquired)).Should().HaveCount(1);
+
+        await fJobStore.ClearAllSchedulingData();
+
+        await fJobStore.StoreJob(fJobDetail, true);
+        var replacement = ExecutingTestTrigger("clearedWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(replacement, false);
+
+        (await fJobStore.GetTriggerState(replacement.Key)).Should().Be(TriggerState.Normal);
+    }
+
+    /// <summary>
+    /// A rejected replacement must leave the store exactly as it was, rather than half-deleting the
+    /// trigger it refused to replace.
+    /// </summary>
+    [Test]
+    public async Task ReplaceTrigger_LeavesTriggerIntact_WhenReplacementNamesADifferentJob()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("mismatchedReplacementTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var otherJob = JobBuilder.Create<NoOpJob>().WithIdentity("otherJob", "jobGroup1").StoreDurably().Build();
+        await fJobStore.StoreJob(otherJob, true);
+
+        var replacement = new SimpleTriggerImpl("mismatchedReplacementTrigger", "triggerGroup1",
+            otherJob.Key.Name, otherJob.Key.Group, d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        replacement.ComputeFirstFireTimeUtc(null);
+
+        Func<Task> act = async () => await fJobStore.ReplaceTrigger(trigger.Key, replacement);
+        await act.Should().ThrowAsync<JobPersistenceException>();
+
+        (await fJobStore.CheckExists(trigger.Key)).Should().BeTrue("a rejected replacement must not remove the trigger");
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
+        (await fJobStore.RetrieveTrigger(trigger.Key)).Should().NotBeNull();
+        (await fJobStore.RemoveTrigger(trigger.Key)).Should().BeTrue("the trigger must still be removable");
+    }
+
+    [Test]
+    public async Task GetTriggerState_KeepsReportingExecuting_WhenTriggerIsRescheduledMidExecution()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("rescheduledWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        var fired = await fJobStore.TriggersFired(acquired);
+        fired.Should().HaveCount(1);
+
+        // Replacing the trigger builds a new wrapper; the execution it already started is unaffected and
+        // has to stay visible, which is also what the ADO store reports since its fired-trigger row
+        // survives the update.
+        var replacement = ExecutingTestTrigger("rescheduledWhileExecutingTrigger", d);
+        await fJobStore.StoreTrigger(replacement, replaceExisting: true);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing);
+
+        var bundle = fired[0].TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
+    }
+
+    /// <summary>
+    /// A fire that bails out records nothing, so the trigger must not be left looking like it is running
+    /// with no completion coming to clear it.
+    /// </summary>
+    [Test]
+    public async Task GetTriggerState_RecordsNoExecution_WhenFiringBailsOut()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("missingCalendarTrigger", d);
+        trigger.CalendarName = "noSuchCalendar";
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        acquired.Should().HaveCount(1);
+
+        // The calendar the trigger names does not exist, so no bundle is produced.
+        var fired = await fJobStore.TriggersFired(acquired);
+        fired.Should().HaveCount(1);
+        fired[0].TriggerFiredBundle.Should().BeNull();
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().NotBe(TriggerState.Executing,
+            "nothing started, so nothing may be recorded as running");
+    }
+
+    /// <summary>
+    /// Releasing after the fire was recorded has to drop the record: the scheduler releases the whole
+    /// batch when <c>TriggersFired</c> fails part-way, and no completion will arrive for the fires it had
+    /// already recorded. Uses a concurrency-allowed job so the answer is not masked by the blocking
+    /// fan-out.
+    /// </summary>
+    [Test]
+    public async Task GetTriggerState_DropsExecution_WhenTriggerIsReleasedAfterFiring()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("releasedAfterFiringTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        var fired = await fJobStore.TriggersFired(acquired);
+        fired.Should().HaveCount(1);
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing);
+
+        await fJobStore.ReleaseAcquiredTrigger(fired[0].TriggerFiredBundle.Trigger);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal,
+            "releasing means the fire is not going to run, so nothing may still be recorded for it");
+    }
+
+    [Test]
+    public async Task GetTriggerState_ReturnsNormal_WhenAcquiredTriggerReleasedWithoutFiring()
+    {
+        DateTimeOffset d = DateBuilder.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("releasedTrigger", d);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(d.AddSeconds(10), 1, TimeSpan.Zero);
+        acquired.Should().HaveCount(1);
+
+        // Released before it ever fired, so no execution was ever counted.
+        await fJobStore.ReleaseAcquiredTrigger(acquired[0]);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1276,6 +1276,7 @@ namespace Quartz
         Error = 3,
         Blocked = 4,
         None = 5,
+        Executing = 6,
     }
     public static class TriggerUtils
     {
@@ -1867,7 +1868,6 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask<int> InsertSchedulerState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string instanceId, System.DateTimeOffset checkInTime, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> InsertTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, string state, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> IsJobCurrentlyExecuting(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string jobName, string jobGroup, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<bool> IsTriggerCurrentlyExecuting(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string triggerName, string triggerGroup, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> IsTriggerGroupPaused(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string groupName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> JobExists(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> RepinTriggersFromDeadNode(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string oldPreferredNode, string newPreferredNode, System.Threading.CancellationToken cancellationToken = default);
@@ -1891,6 +1891,7 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask<Quartz.JobDataMap> SelectTriggerJobDataMap(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> SelectTriggerNamesForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<string> SelectTriggerState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.TriggerExecutionState> SelectTriggerStateWithExecuting(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.TriggerStatus?> SelectTriggerStatus(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> SelectTriggers(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> SelectTriggersForCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default);
@@ -2332,7 +2333,6 @@ namespace Quartz.Impl.AdoJobStore
         public static readonly string SqlSelectCalendarExistence;
         public static readonly string SqlSelectCalendarNamesOrdered;
         public static readonly string SqlSelectCountExecutingFiredTriggersOfJob;
-        public static readonly string SqlSelectCountExecutingFiredTriggersOfTrigger;
         public static readonly string SqlSelectCronTriggers;
         public static readonly string SqlSelectCronTriggersByKeysPrefix;
         public static readonly string SqlSelectFiredTriggerInstanceNames;
@@ -2365,6 +2365,7 @@ namespace Quartz.Impl.AdoJobStore
         public static readonly string SqlSelectTriggerGroupsWithPausedFlag;
         public static readonly string SqlSelectTriggerHeaders;
         public static readonly string SqlSelectTriggerState;
+        public static readonly string SqlSelectTriggerStateWithExecuting;
         public static readonly string SqlSelectTriggerStatus;
         public static readonly string SqlSelectTriggerType;
         public static readonly string SqlSelectTriggersByKeysPrefix;
@@ -2375,10 +2376,13 @@ namespace Quartz.Impl.AdoJobStore
         public static readonly string SqlSelectTriggersInState;
         public static readonly string SqlSelectUnpausedTriggerGroupsOrdered;
         public static readonly string SqlTriggerCalendarPredicate;
+        public static readonly string SqlTriggerExecutingPredicate;
         public static readonly string SqlTriggerGroupEqualsPredicate;
         public static readonly string SqlTriggerGroupLikePredicate;
         public static readonly string SqlTriggerJobPredicate;
+        public static readonly string SqlTriggerNotExecutingPredicate;
         public static readonly string SqlTriggerStateInPredicateStart;
+        public static readonly string SqlTriggerStateNotInPredicateStart;
         public static readonly string SqlUpdateBlobTrigger;
         public static readonly string SqlUpdateCalendar;
         public static readonly string SqlUpdateCronTrigger;
@@ -2460,7 +2464,6 @@ namespace Quartz.Impl.AdoJobStore
         public virtual System.Threading.Tasks.ValueTask<int> InsertSchedulerState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string instanceName, System.DateTimeOffset checkInTime, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> InsertTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, string state, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> IsJobCurrentlyExecuting(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string jobName, string jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask<bool> IsTriggerCurrentlyExecuting(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string triggerName, string triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> IsTriggerGroupPaused(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string groupName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> JobExists(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
@@ -2492,6 +2495,7 @@ namespace Quartz.Impl.AdoJobStore
         public virtual System.Threading.Tasks.ValueTask<Quartz.JobDataMap> SelectTriggerJobDataMap(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> SelectTriggerNamesForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<string> SelectTriggerState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.TriggerExecutionState> SelectTriggerStateWithExecuting(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.TriggerStatus?> SelectTriggerStatus(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> SelectTriggers(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> SelectTriggersForCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2560,6 +2564,13 @@ namespace Quartz.Impl.AdoJobStore
         public required int MaxCount { get; init; }
         public required System.DateTimeOffset NoEarlierThan { get; init; }
         public required System.DateTimeOffset NoLaterThan { get; init; }
+    }
+    public readonly struct TriggerExecutionState : System.IEquatable<Quartz.Impl.AdoJobStore.TriggerExecutionState>
+    {
+        public TriggerExecutionState(string state, bool isExecuting) { }
+        public bool IsExecuting { get; }
+        public string State { get; }
+        public static Quartz.Impl.AdoJobStore.TriggerExecutionState NotFound { get; }
     }
     public sealed class TriggerPropertyBundle
     {

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -695,6 +695,7 @@ public interface IScheduler
     /// <seealso cref="TriggerState.Blocked" />
     /// <seealso cref="TriggerState.Error" />
     /// <seealso cref="TriggerState.None" />
+    /// <seealso cref="TriggerState.Executing" />
     ValueTask<TriggerState> GetTriggerState(
         TriggerKey triggerKey,
         CancellationToken cancellationToken = default);

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -709,13 +709,15 @@ public interface IDriverDelegate
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Checks whether a trigger currently has a fired trigger in EXECUTING state.
-    /// Used to return correct trigger state when trigger is COMPLETE but still executing.
+    /// Selects a trigger's stored state together with whether it currently has an execution in flight.
     /// </summary>
-    ValueTask<bool> IsTriggerCurrentlyExecuting(
+    /// <returns>
+    /// The trigger's state and execution, or <see cref="TriggerExecutionState.NotFound" /> when no such
+    /// trigger exists.
+    /// </returns>
+    ValueTask<TriggerExecutionState> SelectTriggerStateWithExecuting(
         ConnectionAndTransactionHolder conn,
-        string triggerName,
-        string triggerGroup,
+        TriggerKey triggerKey,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -1898,6 +1898,8 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
     /// <seealso cref="TriggerState.Complete" />
     /// <seealso cref="TriggerState.Error" />
     /// <seealso cref="TriggerState.None" />
+    /// <seealso cref="TriggerState.Blocked" />
+    /// <seealso cref="TriggerState.Executing" />
     public ValueTask<TriggerState> GetTriggerState(
         TriggerKey triggerKey,
         CancellationToken cancellationToken = default)
@@ -1920,19 +1922,10 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
     {
         try
         {
-            string ts = await Delegate.SelectTriggerState(conn, triggerKey, cancellationToken).ConfigureAwait(false);
-            TriggerState state = TriggerStateMapping.ToTriggerState(ts);
+            TriggerExecutionState stored = await Delegate
+                .SelectTriggerStateWithExecuting(conn, triggerKey, cancellationToken).ConfigureAwait(false);
 
-            // A trigger that has completed but is still executing reports as blocked. Establishing that
-            // costs a FIRED_TRIGGERS query, which is why the mapping does not do it and listings, which
-            // would pay it per row, do not either.
-            if (state == TriggerState.Complete
-                && await IsTriggerCurrentlyExecuting(conn, triggerKey, cancellationToken).ConfigureAwait(false))
-            {
-                return TriggerState.Blocked;
-            }
-
-            return state;
+            return TriggerStateMapping.ToTriggerState(stored.State, stored.IsExecuting);
         }
         catch (Exception e)
         {
@@ -2625,17 +2618,6 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         CancellationToken cancellationToken = default)
     {
         return Delegate.IsJobCurrentlyExecuting(conn, jobKey.Name, jobKey.Group, cancellationToken);
-    }
-
-    /// <summary>
-    /// Checks whether the given trigger currently has a fired trigger in EXECUTING state.
-    /// </summary>
-    private ValueTask<bool> IsTriggerCurrentlyExecuting(
-        ConnectionAndTransactionHolder conn,
-        TriggerKey triggerKey,
-        CancellationToken cancellationToken = default)
-    {
-        return Delegate.IsTriggerCurrentlyExecuting(conn, triggerKey.Name, triggerKey.Group, cancellationToken);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -191,9 +191,6 @@ public class StdAdoConstants : AdoConstants
     public static readonly string SqlSelectCountExecutingFiredTriggersOfJob =
         Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup AND {ColumnEntryState} = @executingState");
 
-    public static readonly string SqlSelectCountExecutingFiredTriggersOfTrigger =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnEntryState} = @executingState");
-
     public static readonly string SqlSelectInstancesRecoverableFiredTriggers =
         Invariant($"SELECT * FROM {TablePrefixSubst}{TableFiredTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnInstanceName} = @instanceName AND {ColumnRequestsRecovery} = @requestsRecovery");
 
@@ -403,6 +400,24 @@ public class StdAdoConstants : AdoConstants
     public static readonly string SqlSelectTriggerState =
         Invariant($"SELECT {ColumnTriggerState} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");
 
+    /// <summary>
+    /// Whether the trigger of the surrounding TRIGGERS row has an execution in flight. EXECUTING is only
+    /// ever a FIRED_TRIGGERS state, never a TRIGGER_STATE, so this is the only way to establish it.
+    /// </summary>
+    /// <remarks>
+    /// Correlates on the trigger table's full name rather than an alias, so that statements embedding it
+    /// keep the shape callers append their own predicates to. The state value is embedded rather than
+    /// passed as a parameter because a listing mentions this fragment twice in one statement — once in
+    /// the projection, once in the state filter — and <see cref="AdoUtil" /> rewrites parameters by plain
+    /// substring replace, which cannot cope with the same name occurring twice. The embedded value is a
+    /// compile-time constant, not input.
+    /// </remarks>
+    internal static readonly string SqlExecutingFiredTriggerExists =
+        Invariant($"EXISTS (SELECT 1 FROM {TablePrefixSubst}{TableFiredTriggers} FT WHERE FT.{ColumnSchedulerName} = {TablePrefixSubst}{TableTriggers}.{ColumnSchedulerName} AND FT.{ColumnTriggerName} = {TablePrefixSubst}{TableTriggers}.{ColumnTriggerName} AND FT.{ColumnTriggerGroup} = {TablePrefixSubst}{TableTriggers}.{ColumnTriggerGroup} AND FT.{ColumnEntryState} = '{StateExecuting}')");
+
+    public static readonly string SqlSelectTriggerStateWithExecuting =
+        Invariant($"SELECT {ColumnTriggerState}, CASE WHEN {SqlExecutingFiredTriggerExists} THEN 1 ELSE 0 END FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");
+
     public static readonly string SqlSelectTriggerStatus =
         Invariant($"SELECT {ColumnTriggerState}, {ColumnNextFireTime}, {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");
 
@@ -444,7 +459,7 @@ public class StdAdoConstants : AdoConstants
     public static readonly string SqlOrderByJobGroupAndName = Invariant($" ORDER BY {ColumnJobGroup}, {ColumnJobName}");
 
     public static readonly string SqlSelectTriggerHeaders =
-        Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnJobName}, {ColumnJobGroup}, {ColumnDescription}, {ColumnTriggerType}, {ColumnTriggerState}, {ColumnStartTime}, {ColumnEndTime}, {ColumnNextFireTime}, {ColumnPreviousFireTime}, {ColumnCalendarName}, {ColumnPriority}, {ColumnExecutionGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup}, {ColumnJobName}, {ColumnJobGroup}, {ColumnDescription}, {ColumnTriggerType}, {ColumnTriggerState}, {ColumnStartTime}, {ColumnEndTime}, {ColumnNextFireTime}, {ColumnPreviousFireTime}, {ColumnCalendarName}, {ColumnPriority}, {ColumnExecutionGroup}, CASE WHEN {SqlExecutingFiredTriggerExists} THEN 1 ELSE 0 END FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
 
     public static readonly string SqlCountTriggerHeaders =
         Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
@@ -462,6 +477,23 @@ public class StdAdoConstants : AdoConstants
     /// internal states the requested <see cref="TriggerState" /> maps to.
     /// </summary>
     public static readonly string SqlTriggerStateInPredicateStart = Invariant($" AND {ColumnTriggerState} IN (");
+
+    /// <summary>
+    /// Opening of the negated trigger state filter, for the state an unrecognised stored value reports
+    /// as: the values it has to cover cannot be listed, so the others are excluded instead.
+    /// </summary>
+    public static readonly string SqlTriggerStateNotInPredicateStart = Invariant($" AND {ColumnTriggerState} NOT IN (");
+
+    /// <summary>
+    /// Narrows a state filter to triggers that are currently executing.
+    /// </summary>
+    public static readonly string SqlTriggerExecutingPredicate = Invariant($" AND {SqlExecutingFiredTriggerExists}");
+
+    /// <summary>
+    /// Narrows a state filter to triggers that are not currently executing, so that a listing filtered by
+    /// a state which executing outranks does not return rows it would then report as executing.
+    /// </summary>
+    public static readonly string SqlTriggerNotExecutingPredicate = Invariant($" AND NOT {SqlExecutingFiredTriggerExists}");
 
     public static readonly string SqlOrderByTriggerGroupAndName = Invariant($" ORDER BY {ColumnTriggerGroup}, {ColumnTriggerName}");
 

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Queries.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Queries.cs
@@ -269,9 +269,9 @@ public partial class StdAdoDelegate
 
         if (query.State is not null)
         {
-            string[] states = TriggerStateMapping.ToStoredStates(query.State.Value);
-            predicateBuilder.Append(SqlTriggerStateInPredicateStart);
-            for (int i = 0; i < states.Length; i++)
+            TriggerStateFilter filter = TriggerStateMapping.ToFilter(query.State.Value);
+            predicateBuilder.Append(filter.Negated ? SqlTriggerStateNotInPredicateStart : SqlTriggerStateInPredicateStart);
+            for (int i = 0; i < filter.States.Length; i++)
             {
                 if (i > 0)
                 {
@@ -281,10 +281,18 @@ public partial class StdAdoDelegate
                 // Single digit, so no state parameter name is a prefix of another one.
                 string parameterName = "state" + i.ToString(CultureInfo.InvariantCulture);
                 predicateBuilder.Append('@').Append(parameterName);
-                parameters.Add(new KeyValuePair<string, object?>(parameterName, states[i]));
+                parameters.Add(new KeyValuePair<string, object?>(parameterName, filter.States[i]));
             }
 
             predicateBuilder.Append(')');
+
+            // Executing is not a stored state, so it cannot be part of the list above; it has to be
+            // established against FIRED_TRIGGERS. Requiring its absence for the states executing outranks
+            // is what keeps this filter in step with what ReadTriggerHeader will report.
+            if (filter.Executing is not null)
+            {
+                predicateBuilder.Append(filter.Executing.Value ? SqlTriggerExecutingPredicate : SqlTriggerNotExecutingPredicate);
+            }
         }
 
         string predicate = predicateBuilder.ToString();
@@ -325,10 +333,9 @@ public partial class StdAdoDelegate
     /// Reads one trigger listing row.
     /// </summary>
     /// <remarks>
-    /// The state comes straight from TRIGGER_STATE. <c>JobStoreSupport.GetTriggerState</c> refines a
-    /// COMPLETE trigger to <see cref="TriggerState.Blocked" /> when it is currently executing, at the
-    /// cost of a FIRED_TRIGGERS query per trigger; a listing does not pay that per row, so a trigger
-    /// in that (pre-existing, narrow) window is listed as <see cref="TriggerState.Complete" />.
+    /// The last column is the executing flag the statement computes per row, so a listing reports the
+    /// same state <c>JobStoreSupport.GetTriggerState</c> would for the same trigger. It costs one
+    /// correlated subquery per row within the single listing statement rather than a query per trigger.
     /// </remarks>
     private TriggerHeader ReadTriggerHeader(DbDataReader rs)
     {
@@ -337,7 +344,7 @@ public partial class StdAdoDelegate
             new JobKey(rs.GetString(2), rs.GetString(3)),
             rs.IsDBNull(4) ? null : rs.GetString(4),
             rs.GetString(5),
-            TriggerStateMapping.ToTriggerState(rs.GetString(6)),
+            TriggerStateMapping.ToTriggerState(rs.GetString(6), Convert.ToInt32(rs.GetValue(14), CultureInfo.InvariantCulture) != 0),
             GetDateTimeFromDbValue(rs.GetValue(7)) ?? DateTimeOffset.MinValue,
             GetDateTimeFromDbValue(rs.GetValue(8)),
             GetDateTimeFromDbValue(rs.GetValue(9)),

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -213,23 +213,6 @@ public partial class StdAdoDelegate
     }
 
     /// <inheritdoc />
-    public virtual async ValueTask<bool> IsTriggerCurrentlyExecuting(
-        ConnectionAndTransactionHolder conn,
-        string triggerName,
-        string triggerGroup,
-        CancellationToken cancellationToken = default)
-    {
-        using DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectCountExecutingFiredTriggersOfTrigger));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerName);
-        AddCommandParameter(cmd, "triggerGroup", triggerGroup);
-        AddCommandParameter(cmd, "executingState", AdoConstants.StateExecuting);
-
-        object? result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-        return Convert.ToInt32(result) > 0;
-    }
-
-    /// <inheritdoc />
     public virtual async ValueTask<int> InsertTrigger(
         ConnectionAndTransactionHolder conn,
         IOperableTrigger trigger,
@@ -919,6 +902,28 @@ public partial class StdAdoDelegate
         var state = (string?) await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
 
         return state ?? StateDeleted;
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask<TriggerExecutionState> SelectTriggerStateWithExecuting(
+        ConnectionAndTransactionHolder conn,
+        TriggerKey triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectTriggerStateWithExecuting));
+
+        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
+        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+
+        using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return TriggerExecutionState.NotFound;
+        }
+
+        // Providers disagree on the CLR type of a CASE expression, so go through Convert.
+        return new TriggerExecutionState(rs.GetString(0), Convert.ToInt32(rs.GetValue(1), CultureInfo.InvariantCulture) != 0);
     }
 
     /// <inheritdoc />

--- a/src/Quartz/Impl/AdoJobStore/TriggerExecutionState.cs
+++ b/src/Quartz/Impl/AdoJobStore/TriggerExecutionState.cs
@@ -1,0 +1,42 @@
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// A trigger's stored state together with whether it currently has an execution in flight.
+/// </summary>
+/// <remarks>
+/// The two facts live in different tables — the state in TRIGGERS, the execution in FIRED_TRIGGERS — and
+/// are read together so that reporting a trigger's state stays a single round trip.
+/// </remarks>
+public readonly record struct TriggerExecutionState
+{
+    private readonly string? state;
+
+    /// <param name="state">The stored state. Pass <see cref="AdoConstants.StateDeleted" /> when no such trigger exists, or use <see cref="NotFound" />.</param>
+    /// <param name="isExecuting">Whether a FIRED_TRIGGERS row for the trigger is in the executing state.</param>
+    public TriggerExecutionState(string state, bool isExecuting)
+    {
+        // Normalized so that spelling "no such trigger" out is equal to NotFound rather than merely
+        // equivalent — this is a value type, and two values meaning the same thing should compare equal.
+        this.state = state == AdoConstants.StateDeleted ? null : state;
+        IsExecuting = isExecuting;
+    }
+
+    /// <summary>
+    /// The stored state, or <see cref="AdoConstants.StateDeleted" /> when no such trigger exists.
+    /// </summary>
+    /// <remarks>
+    /// A struct can always be default-constructed, which would otherwise leave this null despite being
+    /// declared non-nullable; the default reads as a trigger that does not exist rather than as null.
+    /// </remarks>
+    public string State => state ?? AdoConstants.StateDeleted;
+
+    /// <summary>
+    /// Whether a FIRED_TRIGGERS row for the trigger is in the executing state.
+    /// </summary>
+    public bool IsExecuting { get; }
+
+    /// <summary>
+    /// The result for a trigger that does not exist.
+    /// </summary>
+    public static TriggerExecutionState NotFound => default;
+}

--- a/src/Quartz/Impl/AdoJobStore/TriggerStateMapping.cs
+++ b/src/Quartz/Impl/AdoJobStore/TriggerStateMapping.cs
@@ -19,86 +19,158 @@
 
 #endregion
 
+using System.Diagnostics;
+
 namespace Quartz.Impl.AdoJobStore;
 
 /// <summary>
 /// Translates between the state strings the ADO job store persists in TRIGGER_STATE and the public
-/// <see cref="TriggerState" />. Both directions live here so that a listing's state filter and the
-/// state it reports back cannot disagree.
+/// <see cref="TriggerState" />. Both directions live here, and the filter direction is derived from the
+/// reporting one, so a listing's state filter and the state it reports back cannot disagree.
 /// </summary>
+/// <remarks>
+/// The precedence itself belongs to <see cref="TriggerStateResolver" />, which the in-memory store shares.
+/// </remarks>
 internal static class TriggerStateMapping
 {
-    private static readonly string[] normalStates = [AdoConstants.StateWaiting, AdoConstants.StateAcquired, AdoConstants.StateExecuting];
-    private static readonly string[] pausedStates = [AdoConstants.StatePaused, AdoConstants.StatePausedBlocked];
-    private static readonly string[] completeStates = [AdoConstants.StateComplete];
-    private static readonly string[] errorStates = [AdoConstants.StateError];
-    private static readonly string[] blockedStates = [AdoConstants.StateBlocked];
+    // Every state string the column can hold, including the ones this store never writes there: EXECUTING
+    // is only a FIRED_TRIGGERS state and DELETED is only what a read of a missing row reports, but a
+    // third-party delegate, migrated data or a hand-repaired row can leave either in the column, and each
+    // has to filter as whatever it reports as. Anything not listed here is covered by the negated filters.
+    private static readonly string[] storedStates =
+    [
+        AdoConstants.StateWaiting, AdoConstants.StateAcquired, AdoConstants.StateExecuting,
+        AdoConstants.StateComplete, AdoConstants.StateBlocked, AdoConstants.StatePaused,
+        AdoConstants.StatePausedBlocked, AdoConstants.StateError, AdoConstants.StateDeleted
+    ];
 
-    // DELETED is never written to TRIGGER_STATE — it is what a read of a missing row reports — so a
-    // filter on it matches no row, which is exactly what "None" means for a stored trigger.
-    private static readonly string[] noneStates = [AdoConstants.StateDeleted];
+    private static readonly Dictionary<TriggerState, TriggerStateFilter> filters = BuildFilters();
 
     /// <summary>
-    /// Maps a stored state string to the state callers see.
+    /// Maps a stored state string, plus whether the trigger has an execution in flight, to the state
+    /// callers see.
     /// </summary>
-    /// <remarks>
-    /// <see cref="AdoConstants.StateComplete" /> maps to <see cref="TriggerState.Complete" /> here.
-    /// <c>JobStoreSupport.GetTriggerState</c> refines that one case to <see cref="TriggerState.Blocked" />
-    /// when the trigger is currently executing, which costs an extra query per trigger; a listing takes
-    /// the unrefined answer rather than paying that per row.
-    /// </remarks>
-    internal static TriggerState ToTriggerState(string? state)
+    internal static TriggerState ToTriggerState(string? state, bool isExecuting)
     {
-        if (state is null || state == AdoConstants.StateDeleted)
-        {
-            return TriggerState.None;
-        }
-
-        if (state == AdoConstants.StateComplete)
-        {
-            return TriggerState.Complete;
-        }
-
-        if (state == AdoConstants.StatePaused || state == AdoConstants.StatePausedBlocked)
-        {
-            return TriggerState.Paused;
-        }
-
-        if (state == AdoConstants.StateError)
-        {
-            return TriggerState.Error;
-        }
-
-        if (state == AdoConstants.StateBlocked)
-        {
-            return TriggerState.Blocked;
-        }
-
-        return TriggerState.Normal;
+        InternalTriggerState? stored = ToInternalState(state);
+        return stored is null ? TriggerState.None : TriggerStateResolver.Resolve(stored.Value, isExecuting);
     }
 
     /// <summary>
-    /// The stored state strings a public state covers, for a <c>TRIGGER_STATE IN (...)</c> filter.
+    /// The predicate that selects exactly the rows a listing would report as the given state.
     /// </summary>
-    internal static string[] ToStoredStates(TriggerState state)
+    internal static TriggerStateFilter ToFilter(TriggerState state)
     {
-        switch (state)
+        if (!filters.TryGetValue(state, out TriggerStateFilter filter))
         {
-            case TriggerState.Normal:
-                return normalStates;
-            case TriggerState.Paused:
-                return pausedStates;
-            case TriggerState.Complete:
-                return completeStates;
-            case TriggerState.Error:
-                return errorStates;
-            case TriggerState.Blocked:
-                return blockedStates;
-            case TriggerState.None:
-                return noneStates;
-            default:
-                Throw.ArgumentOutOfRangeException(nameof(state), "Unknown trigger state: " + state);
-                return default;
+            Throw.ArgumentOutOfRangeException(nameof(state), "Unknown trigger state: " + state);
         }
+
+        return filter;
+    }
+
+    /// <summary>
+    /// Normalizes a stored state string to the state shared with the in-memory store.
+    /// </summary>
+    /// <returns><see langword="null" /> when the row does not exist.</returns>
+    private static InternalTriggerState? ToInternalState(string? state)
+    {
+        return state switch
+        {
+            null => null,
+            AdoConstants.StateDeleted => null,
+            AdoConstants.StateComplete => InternalTriggerState.Complete,
+            AdoConstants.StateBlocked => InternalTriggerState.Blocked,
+            AdoConstants.StatePaused => InternalTriggerState.Paused,
+            AdoConstants.StatePausedBlocked => InternalTriggerState.PausedAndBlocked,
+            AdoConstants.StateError => InternalTriggerState.Error,
+            AdoConstants.StateAcquired => InternalTriggerState.Acquired,
+
+            // WAITING, the EXECUTING value this store never writes to TRIGGER_STATE, and anything a
+            // foreign delegate may have put there: all schedulable, all report as normal.
+            _ => InternalTriggerState.Waiting
+        };
+    }
+
+    /// <summary>
+    /// Derives every listing filter from <see cref="TriggerStateResolver" />, so that a filter cannot
+    /// select rows the listing would then report as some other state. Changing the precedence changes
+    /// both directions at once.
+    /// </summary>
+    private static Dictionary<TriggerState, TriggerStateFilter> BuildFilters()
+    {
+        // The values an unrecognised state string can take cannot be enumerated, so whatever it reports as
+        // has to match by exclusion instead. It reports one thing while idle and another while executing,
+        // so both sides need their own catch-all; everything else matches by inclusion.
+        InternalTriggerState unrecognised = ToInternalState("~unrecognised~")!.Value;
+        TriggerState catchAllIdle = TriggerStateResolver.Resolve(unrecognised, isExecuting: false);
+        TriggerState catchAllExecuting = TriggerStateResolver.Resolve(unrecognised, isExecuting: true);
+
+        var result = new Dictionary<TriggerState, TriggerStateFilter>();
+
+        foreach (TriggerState reported in Enum.GetValues<TriggerState>())
+        {
+            string[] whenIdle = Matching(reported, isExecuting: false);
+            string[] whenExecuting = Matching(reported, isExecuting: true);
+
+            // A state executing outranks is only reported while nothing is running, and vice versa; a
+            // state that outranks executing reports the same either way and needs no extra predicate. A
+            // state no stored value reports as gets no entry at all, so asking to filter by it fails
+            // loudly rather than quietly matching the wrong rows.
+            if (whenIdle.Length == 0 && whenExecuting.Length == 0)
+            {
+                continue;
+            }
+
+            result[reported] = (whenIdle.Length, whenExecuting.Length) switch
+            {
+                (0, _) => Build(whenExecuting, reported == catchAllExecuting, executing: true),
+                (_, 0) => Build(whenIdle, reported == catchAllIdle, executing: false),
+                _ => BuildUnconditional(whenIdle, whenExecuting, reported == catchAllIdle)
+            };
+        }
+
+        return result;
+
+        static TriggerStateFilter Build(string[] states, bool isCatchAll, bool? executing)
+        {
+            // Excluding what reports as something else also covers the values that cannot be listed.
+            return isCatchAll
+                ? new TriggerStateFilter(Array.FindAll(storedStates, x => !states.Contains(x)), Negated: true, executing)
+                : new TriggerStateFilter(states, Negated: false, executing);
+        }
+
+        static TriggerStateFilter BuildUnconditional(string[] whenIdle, string[] whenExecuting, bool isCatchAll)
+        {
+            // Reported either way, so no executing predicate — which is only expressible because the two
+            // sides agree. A precedence change that broke that would need a different predicate shape.
+            Debug.Assert(
+                whenIdle.SequenceEqual(whenExecuting),
+                "a state reported both while idle and while executing must cover the same stored states");
+
+            return Build(whenIdle, isCatchAll, executing: null);
+        }
+    }
+
+    /// <summary>
+    /// The stored states that report as <paramref name="reported" /> under the given execution.
+    /// </summary>
+    private static string[] Matching(TriggerState reported, bool isExecuting)
+    {
+        return Array.FindAll(storedStates, stored => ToTriggerState(stored, isExecuting) == reported);
     }
 }
+
+/// <summary>
+/// The predicate that selects the rows a listing reports as one particular <see cref="TriggerState" />.
+/// </summary>
+/// <param name="States">The stored state strings to match.</param>
+/// <param name="Negated">
+/// Whether <paramref name="States" /> is the set to exclude rather than the set to match. Needed for the
+/// state an unrecognised stored value reports as, since those values cannot be listed.
+/// </param>
+/// <param name="Executing">
+/// <see langword="true" /> when the rows must also have an execution in flight, <see langword="false" />
+/// when they must not, and <see langword="null" /> when execution cannot change the reported state.
+/// </param>
+internal readonly record struct TriggerStateFilter(string[] States, bool Negated, bool? Executing);

--- a/src/Quartz/Impl/InternalTriggerState.cs
+++ b/src/Quartz/Impl/InternalTriggerState.cs
@@ -1,9 +1,14 @@
 namespace Quartz.Impl;
 
 /// <summary>
-/// Possible internal trigger states 
-/// in RAMJobStore
+/// The stored trigger states, normalized across job stores. The in-memory store holds one of these
+/// directly; the ADO store maps its persisted state strings onto them, so that both can resolve a
+/// reported <see cref="TriggerState" /> through <see cref="TriggerStateResolver" />.
 /// </summary>
+/// <remarks>
+/// There is deliberately no "executing" state: this drives scheduling decisions, and a trigger stays
+/// schedulable while its job runs. Executions are tracked separately by each store.
+/// </remarks>
 internal enum InternalTriggerState
 {
     /// <summary>
@@ -15,11 +20,6 @@ internal enum InternalTriggerState
     /// Acquired
     /// </summary>
     Acquired,
-
-    /// <summary>
-    /// Executing
-    /// </summary>
-    Executing,
 
     /// <summary>
     /// Complete

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -59,6 +59,17 @@ public class RAMJobStore : IJobStore
     private readonly HashSet<string> pausedJobGroups = [];
     private readonly HashSet<JobKey> blockedJobs = [];
     private readonly HashSet<JobKey> resumedJobsInPausedGroups = new HashSet<JobKey>();
+
+    /// <summary>
+    /// Fire instance ids of the executions each trigger has started that are still running.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately keyed by <see cref="TriggerKey" /> rather than held on the wrapper: rescheduling a
+    /// trigger replaces its wrapper, and an execution already in flight has to survive that. Keying by
+    /// fire instance makes a late or duplicated completion a no-op instead of a miscount. This mirrors the
+    /// ADO store, where the answer comes from FIRED_TRIGGERS rows that likewise outlive a trigger update.
+    /// </remarks>
+    private readonly Dictionary<TriggerKey, HashSet<string>> executingFireInstances = [];
     private TimeSpan misfireThreshold = TimeSpan.FromSeconds(5);
     private readonly ISchedulerSignaler signaler;
     private readonly TimeProvider timeProvider;
@@ -188,7 +199,7 @@ public class RAMJobStore : IJobStore
                 var keys = GetTriggerKeysNoLock(GroupMatcher<TriggerKey>.GroupEquals(group));
                 foreach (TriggerKey key in keys)
                 {
-                    await RemoveTriggerNoLock(key, removeOrphanedJob: true, cancellationToken).ConfigureAwait(false);
+                    await RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -209,6 +220,7 @@ public class RAMJobStore : IJobStore
             }
 
             resumedJobsInPausedGroups.Clear();
+            executingFireInstances.Clear();
         }
         finally
         {
@@ -309,7 +321,7 @@ public class RAMJobStore : IJobStore
         var triggersForJob = GetTriggerKeysForJobNoLock(jobKey);
         foreach (var key in triggersForJob)
         {
-            await RemoveTriggerNoLock(key, removeOrphanedJob: true, cancellationToken).ConfigureAwait(false);
+            await RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
             found = true;
         }
 
@@ -357,7 +369,7 @@ public class RAMJobStore : IJobStore
             bool allFound = true;
             foreach (TriggerKey key in triggerKeys)
             {
-                allFound = await RemoveTriggerNoLock(key, removeOrphanedJob: true, cancellationToken).ConfigureAwait(false) && allFound;
+                allFound = await RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false) && allFound;
             }
 
             return allFound;
@@ -456,7 +468,7 @@ public class RAMJobStore : IJobStore
             }
 
             // don't delete orphaned job, this trigger has the job anyways
-            await RemoveTriggerNoLock(tw.TriggerKey, removeOrphanedJob: false, cancellationToken).ConfigureAwait(false);
+            await RemoveTriggerNoLock(tw.TriggerKey, removeOrphanedJob: false, keepExecutions: true, cancellationToken).ConfigureAwait(false);
         }
 
         if (!jobsByKey.ContainsKey(tw.JobKey))
@@ -520,7 +532,7 @@ public class RAMJobStore : IJobStore
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return await RemoveTriggerNoLock(key, removeOrphanedJob, cancellationToken).ConfigureAwait(false);
+            return await RemoveTriggerNoLock(key, removeOrphanedJob, keepExecutions: false, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -528,8 +540,16 @@ public class RAMJobStore : IJobStore
         }
     }
 
-    private async Task<bool> RemoveTriggerNoLock(TriggerKey key, bool removeOrphanedJob, CancellationToken cancellationToken)
+    // keepExecutions: whether executions already started under this key survive. Only a trigger being
+    // replaced in place keeps them, matching the ADO store, where updating a trigger leaves its
+    // fired-trigger rows alone but deleting one removes them. There is no default: every caller says which.
+    private async Task<bool> RemoveTriggerNoLock(TriggerKey key, bool removeOrphanedJob, bool keepExecutions, CancellationToken cancellationToken)
     {
+        if (!keepExecutions)
+        {
+            executingFireInstances.Remove(key);
+        }
+
         // remove from triggers by FQN map
         var found = triggersByKey.TryRemove(key, out var tw);
         if (tw is not null)
@@ -581,36 +601,25 @@ public class RAMJobStore : IJobStore
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // remove from triggers by FQN map
-            triggersByKey.TryRemove(triggerKey, out var tw);
-            found = tw is not null;
+            found = triggersByKey.TryGetValue(triggerKey, out var tw);
 
             if (found)
             {
+                // Validated before anything is removed, so a rejected replacement leaves the store exactly
+                // as it was rather than half-deleting the trigger it refused to replace.
                 if (!tw!.JobKey.Equals(trigger.JobKey))
                 {
                     Throw.JobPersistenceException("New trigger is not related to the same job as the old trigger.");
                 }
 
-                // remove from triggers by group
-                if (triggersByGroup.TryGetValue(triggerKey.Group, out var grpMap))
-                {
-                    if (grpMap.Remove(triggerKey) && grpMap.Count == 0)
-                    {
-                        triggersByGroup.Remove(triggerKey.Group);
-                    }
-                }
+                // Kept so the rollback below can put them back: the old trigger is still the one running
+                // them until the replacement actually succeeds.
+                executingFireInstances.TryGetValue(triggerKey, out var fireInstances);
 
-                // remove from triggers by job
-                if (triggersByJob.TryGetValue(tw.JobKey, out var jobList))
-                {
-                    if (jobList.Remove(tw) && jobList.Count == 0)
-                    {
-                        triggersByJob.Remove(tw.JobKey);
-                    }
-                }
-
-                timeTriggers.Remove(tw);
+                // The old trigger is deleted rather than updated, so its executions go with it, as they do
+                // in the ADO store where ReplaceTrigger deletes the fired-trigger rows. Removing through
+                // the shared path means anything kept per trigger is cleaned up here too.
+                await RemoveTriggerNoLock(triggerKey, removeOrphanedJob: false, keepExecutions: false, cancellationToken).ConfigureAwait(false);
 
                 try
                 {
@@ -620,6 +629,13 @@ public class RAMJobStore : IJobStore
                 {
                     // put previous trigger back...
                     await StoreTriggerNoLock(tw.Trigger, replaceExisting: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    // ...along with the executions it never stopped running.
+                    if (fireInstances is not null)
+                    {
+                        executingFireInstances[triggerKey] = fireInstances;
+                    }
+
                     throw;
                 }
             }
@@ -791,38 +807,43 @@ public class RAMJobStore : IJobStore
     /// <seealso cref="TriggerState.Error" />
     /// <seealso cref="TriggerState.Blocked" />
     /// <seealso cref="TriggerState.None"/>
+    /// <seealso cref="TriggerState.Executing" />
     public virtual async ValueTask<TriggerState> GetTriggerState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        TriggerWrapper? tw;
         try
         {
-            triggersByKey.TryGetValue(triggerKey, out tw);
+            // Both facts have to be read under the same lock, or a fire landing between the two reads
+            // would produce a state that was never actually true.
+            return triggersByKey.TryGetValue(triggerKey, out var tw) ? ToTriggerStateNoLock(tw) : TriggerState.None;
         }
         finally
         {
             lockObject.Release();
         }
-
-        if (tw is null)
-        {
-            return TriggerState.None;
-        }
-
-        return ToTriggerState(tw.state);
     }
 
-    private static TriggerState ToTriggerState(InternalTriggerState state)
+    /// <summary>
+    /// Maps a wrapper to the state callers see. The precedence lives in <see cref="TriggerStateResolver" />,
+    /// shared with the ADO store.
+    /// </summary>
+    private TriggerState ToTriggerStateNoLock(TriggerWrapper tw)
     {
-        return state switch
+        return TriggerStateResolver.Resolve(tw.state, executingFireInstances.ContainsKey(tw.TriggerKey));
+    }
+
+    /// <summary>
+    /// Records that an execution of the trigger has finished, forgetting the trigger entirely once its
+    /// last one has. An unknown fire instance is a no-op, so a repeated completion cannot miscount.
+    /// </summary>
+    private void ReleaseExecutionNoLock(TriggerKey triggerKey, string fireInstanceId)
+    {
+        if (executingFireInstances.TryGetValue(triggerKey, out var fireInstances)
+            && fireInstances.Remove(fireInstanceId)
+            && fireInstances.Count == 0)
         {
-            InternalTriggerState.Complete => TriggerState.Complete,
-            InternalTriggerState.Paused => TriggerState.Paused,
-            InternalTriggerState.PausedAndBlocked => TriggerState.Paused,
-            InternalTriggerState.Blocked => TriggerState.Blocked,
-            InternalTriggerState.Error => TriggerState.Error,
-            _ => TriggerState.Normal
-        };
+            executingFireInstances.Remove(triggerKey);
+        }
     }
 
     public async ValueTask ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
@@ -1171,7 +1192,7 @@ public class RAMJobStore : IJobStore
             match.Trigger.ExecutionGroup));
     }
 
-    private static void CollectMatchingTriggersNoLock(
+    private void CollectMatchingTriggersNoLock(
         Dictionary<TriggerKey, TriggerWrapper> groupMap,
         TriggerQuery query,
         List<TriggerMatch> matches)
@@ -1189,7 +1210,7 @@ public class RAMJobStore : IJobStore
                 continue;
             }
 
-            TriggerState state = ToTriggerState(triggerWrapper.state);
+            TriggerState state = ToTriggerStateNoLock(triggerWrapper);
             if (query.State is not null && state != query.State.Value)
             {
                 continue;
@@ -2077,7 +2098,17 @@ public class RAMJobStore : IJobStore
                 }
 
                 JobKey jobKey = tw.JobKey;
-                IJobDetail job = jobsByKey[jobKey].JobDetail;
+
+                // A trigger whose job is gone cannot be fired. Skipping it leaves it out of timeTriggers,
+                // where it stays until something stores or resumes it again; throwing here would instead
+                // take down the acquisition loop and stop every other trigger from firing.
+                if (!jobsByKey.TryGetValue(jobKey, out var jobWrapper))
+                {
+                    logger.LogWarning("Skipping trigger {TriggerKey}: its job {JobKey} no longer exists", tw.TriggerKey, jobKey);
+                    continue;
+                }
+
+                IJobDetail job = jobWrapper.JobDetail;
 
                 // If trigger's job disallows concurrent execution and the job was already added to the result,
                 // then we'll add the trigger to the list of excluded triggers (which we'll add back to the set
@@ -2153,6 +2184,14 @@ public class RAMJobStore : IJobStore
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            // Releasing means the scheduler is not going to run this fire after all, so anything recorded
+            // for it has to go: the scheduler releases the whole batch when TriggersFired fails part-way,
+            // and no completion will ever arrive for the fires it had already recorded. Note this does not
+            // undo the blocking fan-out TriggersFired applies for a non-concurrent job — only
+            // TriggeredJobComplete does that, which is why the scheduler uses it on every path where a job
+            // actually started.
+            ReleaseExecutionNoLock(trigger.Key, trigger.FireInstanceId);
+
             if (triggersByKey.TryGetValue(trigger.Key, out var tw) && tw.state == InternalTriggerState.Acquired)
             {
                 tw.state = InternalTriggerState.Waiting;
@@ -2204,6 +2243,16 @@ public class RAMJobStore : IJobStore
                     }
                 }
 
+                // Was the job deleted since the trigger was acquired? Checked here, with the other
+                // bail-outs, because everything below mutates the trigger: once it has left timeTriggers
+                // and been moved off Acquired, ReleaseAcquiredTrigger can no longer re-arm it and the
+                // trigger would stop firing altogether.
+                if (!jobsByKey.TryGetValue(trigger.JobKey, out var jobWrapper))
+                {
+                    results.Add(new TriggerFiredResult((TriggerFiredBundle?) null));
+                    continue;
+                }
+
                 DateTimeOffset? prevFireTime = trigger.PreviousFireTimeUtc;
 
                 // Read saved original fire time (set during ApplyMisfireNoLock if a misfire occurred)
@@ -2223,10 +2272,13 @@ public class RAMJobStore : IJobStore
                 // call triggered on our copy, and the scheduler's copy
                 tw.Trigger.Triggered(calendar);
                 trigger.Triggered(calendar);
-                //tw.state = TriggerWrapper.STATE_EXECUTING;
+                // Deliberately not an "executing" state: this field decides whether the trigger can be
+                // acquired and fired again, and TriggersFired/ReleaseAcquiredTrigger/the blocking fan-out
+                // below all depend on it being Waiting or Blocked here. Executions are tracked separately,
+                // in executingFireInstances.
                 tw.state = InternalTriggerState.Waiting;
 
-                var jobDetail = jobsByKey[trigger.JobKey].JobDetail.Clone();
+                var jobDetail = jobWrapper.JobDetail.Clone();
                 TriggerFiredBundle bndle = new TriggerFiredBundle(
                     jobDetail,
                     trigger,
@@ -2266,6 +2318,16 @@ public class RAMJobStore : IJobStore
                 {
                     timeTriggers.Add(tw);
                 }
+
+                // Recorded only once the bundle is guaranteed, so nothing above can leave an execution
+                // behind that no completion will ever clear. Released in TriggeredJobComplete.
+                if (!executingFireInstances.TryGetValue(tw.TriggerKey, out var fireInstances))
+                {
+                    fireInstances = [];
+                    executingFireInstances[tw.TriggerKey] = fireInstances;
+                }
+
+                fireInstances.Add(trigger.FireInstanceId);
 
                 results.Add(new TriggerFiredResult(bndle));
             }
@@ -2339,6 +2401,10 @@ public class RAMJobStore : IJobStore
                 blockedJobs.Remove(jobDetail.Key);
             }
 
+            // Releases what TriggersFired recorded. Done before the trigger-deleted check below, and
+            // unconditionally, so that an execution outliving its trigger still clears its entry.
+            ReleaseExecutionNoLock(trigger.Key, trigger.FireInstanceId);
+
             // check for trigger deleted during execution...
             if (triggersByKey.TryGetValue(trigger.Key, out var tw))
             {
@@ -2353,7 +2419,7 @@ public class RAMJobStore : IJobStore
                         d = tw.Trigger.NextFireTimeUtc;
                         if (!d.HasValue)
                         {
-                            await RemoveTriggerNoLock(trigger.Key, removeOrphanedJob: true, cancellationToken).ConfigureAwait(false);
+                            await RemoveTriggerNoLock(trigger.Key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
@@ -2362,7 +2428,7 @@ public class RAMJobStore : IJobStore
                     }
                     else
                     {
-                        await RemoveTriggerNoLock(trigger.Key, removeOrphanedJob: true, cancellationToken).ConfigureAwait(false);
+                        await RemoveTriggerNoLock(trigger.Key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
                         await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
                     }
                 }

--- a/src/Quartz/Impl/TriggerStateResolver.cs
+++ b/src/Quartz/Impl/TriggerStateResolver.cs
@@ -1,0 +1,46 @@
+namespace Quartz.Impl;
+
+/// <summary>
+/// The single definition of how a stored trigger state plus "is it executing" becomes the
+/// <see cref="TriggerState" /> callers see. Every job store resolves through this, so the stores cannot
+/// report different states for the same situation.
+/// </summary>
+internal static class TriggerStateResolver
+{
+    /// <summary>
+    /// Resolves the reported state, applying the precedence
+    /// <c>None &gt; Error &gt; Paused &gt; Executing &gt; Blocked &gt; Complete &gt; Normal</c>.
+    /// </summary>
+    /// <remarks>
+    /// Paused and error outrank executing because they are the facts an operator has to act on, and both
+    /// remain true while a previously started execution finishes. Executing outranks blocked so that the
+    /// trigger which actually started the running job stays distinguishable from the siblings that are
+    /// merely gated behind it.
+    /// </remarks>
+    /// <param name="stored">The trigger's stored state. A trigger that does not exist is not a case here — callers report <see cref="TriggerState.None" /> before asking.</param>
+    /// <param name="isExecuting">Whether at least one execution started by the trigger is still running.</param>
+    internal static TriggerState Resolve(InternalTriggerState stored, bool isExecuting)
+    {
+        if (stored == InternalTriggerState.Error)
+        {
+            return TriggerState.Error;
+        }
+
+        if (stored is InternalTriggerState.Paused or InternalTriggerState.PausedAndBlocked)
+        {
+            return TriggerState.Paused;
+        }
+
+        if (isExecuting)
+        {
+            return TriggerState.Executing;
+        }
+
+        return stored switch
+        {
+            InternalTriggerState.Blocked => TriggerState.Blocked,
+            InternalTriggerState.Complete => TriggerState.Complete,
+            _ => TriggerState.Normal
+        };
+    }
+}

--- a/src/Quartz/TriggerState.cs
+++ b/src/Quartz/TriggerState.cs
@@ -22,27 +22,37 @@ namespace Quartz;
 /// <summary>
 /// All trigger states known to Scheduler.
 /// </summary>
+/// <remarks>
+/// Both the numeric values and the member names are a wire contract. The HTTP API returns this enum as an
+/// integer, so members must never be renumbered or reordered; it accepts a state filter by name, so
+/// members must never be renamed either. New members are appended.
+/// </remarks>
 /// <author>Marko Lahma (.NET)</author>
 public enum TriggerState
 {
     /// <summary>
     /// Indicates that the <see cref="ITrigger" /> is in the "normal" state.
     /// </summary>
-    Normal,
+    Normal = 0,
 
     /// <summary>
     /// Indicates that the <see cref="ITrigger" /> is in the "paused" state.
     /// </summary>
-    Paused,
+    /// <remarks>
+    /// A paused trigger reports "paused" even while a previously started execution of its job is still
+    /// running; the pause is the actionable fact, so it takes precedence over <see cref="Executing" />.
+    /// </remarks>
+    Paused = 1,
 
     /// <summary>
     /// Indicates that the <see cref="ITrigger" /> is in the "complete" state.
     /// </summary>
     /// <remarks>
     /// "Complete" indicates that the trigger has not remaining fire-times in
-    /// its schedule.
+    /// its schedule. A trigger whose final execution is still in progress reports
+    /// <see cref="Executing" /> until that execution finishes.
     /// </remarks>
-    Complete,
+    Complete = 2,
 
     /// <summary>
     /// Indicates that the <see cref="ITrigger" /> is in the "error" state.
@@ -60,21 +70,41 @@ public enum TriggerState
     /// attempts to fire it.
     /// </para>
     /// </remarks>
-    Error,
+    Error = 3,
 
     /// <summary>
     /// Indicates that the <see cref="ITrigger" /> is in the "blocked" state.
     /// </summary>
     /// <remarks>
-    /// A <see cref="ITrigger" /> arrives at the blocked state when the job that
-    /// it is associated with has a <see cref="DisallowConcurrentExecutionAttribute" /> and it is 
-    /// currently executing.
+    /// A <see cref="ITrigger" /> arrives at the blocked state when a <b>different</b> trigger of the same
+    /// job is currently executing and that job has a <see cref="DisallowConcurrentExecutionAttribute" />,
+    /// so this trigger cannot fire. The trigger that is itself running reports
+    /// <see cref="Executing" /> instead.
     /// </remarks>
     /// <seealso cref="DisallowConcurrentExecutionAttribute" />
-    Blocked,
+    Blocked = 4,
 
     /// <summary>
     /// Indicates that the <see cref="ITrigger" /> does not exist.
     /// </summary>
-    None
+    None = 5,
+
+    /// <summary>
+    /// Indicates that at least one execution started by this <see cref="ITrigger" /> is currently running.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Unlike <see cref="IScheduler.GetCurrentlyExecutingJobs" />, which only sees the node it is called
+    /// on, this state is observable across every node of a cluster when a persistent job store is used.
+    /// </para>
+    ///
+    /// <para>
+    /// Execution is not mutually exclusive with being scheduled: a trigger that allows concurrent
+    /// execution can be running one or more jobs and still be due to fire again. It reports "executing"
+    /// until the last of those executions finishes. A paused trigger reports <see cref="Paused" />
+    /// and a trigger in the error state reports <see cref="Error" /> even while an execution is
+    /// still running.
+    /// </para>
+    /// </remarks>
+    Executing = 6
 }


### PR DESCRIPTION
Fixes #1416.

## Why

There was no way to ask whether a trigger's job is running right now.
`IScheduler.GetCurrentlyExecutingJobs()` is documented as not cluster aware — it only sees the node it is
called on — so the topology in #1416 (one process doing trigger CRUD, another executing jobs, sharing only
the database) could not answer the question at all.

The stronger argument is that "executing" was already leaking into `TriggerState`, three times:

* `TriggerState.Blocked`'s own XML doc described it: *"the job that it is associated with has a
  `DisallowConcurrentExecutionAttribute` and it is currently executing"*.
* The #2255 fix returned **`Blocked`** when `TRIGGER_STATE` was `COMPLETE` but a fired-trigger row was
  `EXECUTING` — and `RAMJobStore` had no such branch, so **the two stores disagreed**.
* `InternalTriggerState.Executing` existed, public, never assigned and never read, with a commented-out
  relic in `TriggersFired`. Someone had started this exact feature and abandoned it.

## What

`TriggerState` gains `Executing`, reported by both `GetTriggerState` and trigger listings, and visible
across a cluster because it is established from the fired-triggers table rather than process-local state.

States resolve by the precedence:

```
None > Error > Paused > Executing > Blocked > Complete > Normal
```

Paused and error outrank executing because they are the facts an operator has to act on, and both stay
true while a previously started execution finishes. Executing outranks blocked so the trigger that
actually started the running job stays distinguishable from the siblings merely gated behind it —
`Blocked` now means only the latter, which is what its docs always claimed.

### One definition of the rule

`TriggerStateResolver` holds the precedence and both stores resolve through it; `InternalTriggerState`
became the normalized stored state the ADO strings map onto.

The ADO listing filters are **derived** from that resolver rather than restated: `BuildFilters()`
enumerates every `(stored state, executing)` pair and groups them by what the resolver reports, so a
filter cannot select rows the same listing would then report as another state. Two of the filters come
out negated (`NOT IN`) rather than inclusive, because `Normal` (when idle) and `Executing` (when running)
are what an *unrecognised* `TRIGGER_STATE` value reports as — and those values cannot be enumerated, so
they have to be matched by exclusion.

### Store parity

`RAMJobStore` tracks executions by fire-instance id, keyed by trigger. That survives an in-place trigger
update and is dropped when the trigger is deleted, replaced or cleared — matching the ADO store, where
`StoreTrigger` leaves fired-trigger rows alone but `ReplaceTrigger`/delete remove them. Keying by fire
instance makes a late or duplicated completion a no-op instead of a miscount.

### ADO cost

Reading the state and the execution happens in one statement, so reporting a trigger's state stays a
single round trip — and the `COMPLETE` path drops from two queries to one, making this *cheaper* than
before. Listings pay one correlated subquery per row inside the single listing statement, not a query per
row. **No schema change**; the existing `IDX_QRTZ_FT_T_G` index covers it.

## Breaking changes

| Change | Details |
|---|---|
| `TriggerState.Executing` added | Reported where `Normal`, `Complete` or `Blocked` used to be |
| `TriggerState.Blocked` narrowed | Now means a *sibling* trigger of the same `[DisallowConcurrentExecution]` job is running |
| `IDriverDelegate.IsTriggerCurrentlyExecuting` removed | Replaced by `SelectTriggerStateWithExecuting`, returning the new `TriggerExecutionState`; `StdAdoConstants.SqlSelectCountExecutingFiredTriggersOfTrigger` went with it |
| `InternalTriggerState.Executing` removed | Never assigned or read |

Documented in the 4.x migration guide, including two things worth calling out for upgraders:

* `if (state == TriggerState.Normal)` health checks now see `Executing` for a busy trigger.
* `if (state != Normal) → ResumeTrigger` watchdogs route into a **pre-existing** sharp edge:
  `ResumeTrigger` applies the misfire policy to any overdue trigger regardless of its current state, so
  such a watchdog can alter a healthy long-running trigger's schedule. Not new, but `Executing` sends more
  traffic into it.

Also documented: executing is derived from fired-trigger rows, so a node dying mid-execution leaves a
trigger reporting `Executing` until cluster recovery clears the row — bounded by
`clusterCheckinInterval` + `clusterCheckinMisfireThreshold`.

## Pre-existing bugs fixed along the way

Both were found by review of this change and are worth noting separately from the feature:

* **`RAMJobStore.ReplaceTrigger` validated the job key *after* removing the trigger**, so a rejected
  reschedule (`RescheduleJob` with a trigger naming a different job) left the trigger half-deleted and
  unrecoverable — invisible to `GetTriggerState`/`RetrieveTrigger`, un-removable, yet still listed and
  still in `timeTriggers`. It now validates first and removes through the shared `RemoveTriggerNoLock`
  path.
* **`AcquireNextTriggers` used an unguarded `jobsByKey[jobKey]` indexer**, so a trigger whose job no
  longer exists threw `KeyNotFoundException` inside the acquisition loop — which the scheduler thread
  retries forever, stopping *every* trigger from firing. It now skips and logs the orphan.

## Dashboard

Triggers show a distinct violet **Executing** indicator (deliberately not the info blue, which is the
fallback for a state the dashboard cannot classify), and the state filter became a `TriggerState?` with
an "Executing only" button so the new filter is reachable.

## Testing

| Suite | Result |
|---|---|
| Unit | 1927 passed, 4 skipped |
| AspNetCore | 200 passed |
| Integration | 153 passed |

The load-bearing test is a **property test over the whole matrix**
(`TriggerStateMappingTest.EveryFilterSelectsExactlyWhatTheListingReports`): for every `TriggerState` ×
every stored state × executing/idle, it asserts a filter selects a row *exactly* when the listing reports
it as that state. Its state list deliberately includes the two values the store never writes to the
column (`EXECUTING`, `DELETED`) plus a wholly foreign one, which is what makes the negated filters
falsifiable — it fails against an inclusive-only derivation.

Other new coverage:

* RAMJobStore: concurrent fires, paused-outranks-executing, self/sibling split, removed-while-executing,
  rescheduled-while-executing, released-without-firing.
* A 16-case ADO precedence matrix driven through a faked `IDriverDelegate` — **no database needed**.
* Listing report/filter consistency for both stores.
* Generated-SQL tests including a `BindByName = false` case asserting exactly three positional
  placeholders — the regression guard for `AdoUtil`'s substring-replace parameter rewriting, which is why
  the `'EXECUTING'` literal is embedded rather than parameterised.
* Wire-contract tests pinning the enum's numeric values *and* member names as literals, since the HTTP API
  returns the ordinal and accepts the state filter by name — a round-trip test cannot catch a renumbering
  because both ends share the enum.
* A clustered Postgres test reproducing the issue's topology: an unstarted observing node sees `Executing`
  for a job running on another node, while its own `GetCurrentlyExecutingJobs` is empty.

The ADO paging tests exercise the new projection and filters against **all six providers** via
Testcontainers, including Oracle.

## Follow-up

#3205 tracks the richer, non-lossy answer: a cluster-aware query returning the fire instances themselves.
A scalar enum cannot express "3 executions running on node-2 since 14:02", and precedence necessarily
discards whichever fact loses. That query would also fix the dashboard's currently-executing tile, which
is node-local and already wrong in a cluster. The two are complementary: `TriggerState` answers "what will
the scheduler do next", the query answers "what is running right now".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZmHvijCv475hKeLLR3J7v
