### PR TITLE
Let AdoJobStore take part in the application's transaction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -607,6 +607,34 @@
     If the calculated day would cross a month boundary it will be reset to the 1st of the month. (e.g. LW-30 in Feb will be 1st Feb)
   * Add cron parser support for day-of-month and day-of-week together. (#1543)
 
+#### Transactional scheduling
+
+  * AdoJobStore can now take part in a transaction the application owns, so saving your own data and scheduling
+    the job that acts on it commit together or not at all (#2038). Turn it on with
+    `AcceptEnlistedTransactions()` on the persistent store builder, `JobStore:AcceptEnlistedTransactions`, or
+    `quartz.jobStore.acceptEnlistedTransactions`, then hand the store a connection for the duration of a scope:
+
+    ```csharp
+    await using var tx = await dbContext.Database.BeginTransactionAsync();
+    await dbContext.SaveChangesAsync();
+
+    using (scheduler.EnlistTransaction(tx.GetDbTransaction()))
+    {
+        await scheduler.ScheduleJob(job, trigger);
+        await tx.CommitAsync();
+    }
+    ```
+
+    Handing over a connection is the only way to take part: a connection the job store opens for itself is
+    deliberately kept out of any ambient `TransactionScope`, since a second connection in that transaction would
+    require promoting it to a distributed one. New public API: the `SchedulerEnlistmentExtensions` static class with
+    `EnlistTransaction` and `EnlistConnection` extension methods on `IScheduler`,
+    `AdoJobStoreOptions.AcceptEnlistedTransactions`,
+    `IPersistentStoreBuilder.AcceptEnlistedTransactions()` — the last of which is a breaking addition for anyone
+    implementing `IPersistentStoreBuilder` themselves — and `DelegatingScheduler.InnerScheduler`, so a decorated
+    scheduler can still be resolved to the real one. See
+    [Joining an existing transaction](https://www.quartz-scheduler.net/documentation/quartz-4.x/tutorial/job-stores.html#joining-an-existing-transaction).
+
 ### FIXES
 
   * Fix for deserializing CronExpression using Json Serializer throwing error calling `GetNextValidTimeAfter`.  (#1996)

--- a/docs/documentation/quartz-3.x/configuration/reference.md
+++ b/docs/documentation/quartz-3.x/configuration/reference.md
@@ -363,6 +363,7 @@ JobStoreTX can be tuned with the following properties:
 | quartz.jobStore.maxMisfiresToHandleAtATime   | no       | int     | 20                                                                           |
 | quartz.jobStore.selectWithLockSQL            | no       | string  | "SELECT * FROM {0}LOCKS WHERE SCHED_NAME = {1} AND LOCK_NAME = ? FOR UPDATE" |
 | quartz.jobStore.txIsolationLevelSerializable | no       | boolean | false                                                                        |
+| quartz.jobStore.acceptEnlistedTransactions        | no       | boolean | false                                                                        |
 | quartz.jobStore.acquireTriggersWithinLock    | no       | boolean | false (or true - see doc below)                                              |
 | quartz.jobStore.lockHandler.type             | no       | string  | null                                                                         |
 | quartz.jobStore.driverDelegateInitString     | no       | string  | null                                                                         |
@@ -432,6 +433,23 @@ The "{1}" is replaced with the scheduler’s name.
 
 A value of "true" tells Quartz (when using JobStoreTX or CMT) to set transaction level to serialize on ADO.NET connections.
 This can be helpful to prevent lock timeouts with some databases under high load, and "long-lasting" transactions.
+
+### `quartz.jobStore.acceptEnlistedTransactions`
+
+A value of "true" lets the job store take part in a transaction your application already owns, rather than always managing
+an ADO.NET transaction of its own. It then uses the connection you enlisted with `IScheduler.EnlistTransaction` or
+`IScheduler.EnlistConnection` for operations on that asynchronous flow, so your application owns the commit and scheduling
+happens together with the rest of its work or not at all.
+
+Handing over a connection is the only way to take part. Operations with nothing enlisted keep using a connection of the
+job store's own, and while this setting is on that connection is deliberately kept out of any ambient
+`System.Transactions.TransactionScope`.
+
+Because locks are then held until your transaction completes, enabling this also switches locking to database locks unless
+`quartz.jobStore.lockHandler.type` was set explicitly.
+
+See [Joining an existing transaction](../tutorial/job-stores.md#joining-an-existing-transaction) for what this means in
+practice and what to watch out for.
 
 ### `quartz.jobStore.acquireTriggersWithinLock`
 

--- a/docs/documentation/quartz-3.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-3.x/tutorial/job-stores.md
@@ -49,9 +49,9 @@ One thing to note is that in these scripts, all the the tables start with the pr
 what the prefix is (in your Quartz.NET properties). Using different prefixes may be useful for creating multiple sets of tables,
 for multiple scheduler instances, within the same database.
 
-Currently the only option for the internal implementation of job store is `JobStoreTX`which creates transactions by itself.
-This is different from Java version of Quartz where there is also option to choose `JobStoreCMT` which uses J2EE container
-managed transactions.
+`JobStoreTX` creates transactions by itself and is the implementation you normally want. If you need scheduling to
+commit together with your application's own database work, `JobStoreTX` can also be told to join a transaction you
+own - see [Joining an existing transaction](#joining-an-existing-transaction) below.
 
 The last piece of the puzzle is setting up a data source from which AdoJobStore can get connections to your database.
 Data sources are defined in your Quartz.NET properties. Data source information contains the connection string
@@ -189,3 +189,94 @@ ISchedulerFactory schedulerFactory = config.Build();
     // "newtonsoft" and "json" are aliases for "Quartz.Simpl.JsonObjectSerializer, Quartz.Serialization.Json"
     quartz.serializer.type = stj
 ```
+
+### Joining an existing transaction
+
+Normally AdoJobStore opens a connection of its own and commits as soon as the scheduling operation is done. That means
+saving your own data and scheduling the job that acts on it are two separate transactions, and one can succeed while the
+other fails.
+
+Setting `quartz.jobStore.acceptEnlistedTransactions` to `true` lets the job store join a transaction your application already
+owns instead, so scheduling commits with the rest of your work or not at all.
+
+```csharp
+var config = SchedulerBuilder.Create();
+config.UsePersistentStore(store =>
+{
+    store.UsePostgres(connectionString);
+    store.AcceptEnlistedTransactions();
+});
+```
+
+You then hand your connection and transaction to the scheduler for the duration of a scope:
+
+```csharp
+await using var tx = await dbContext.Database.BeginTransactionAsync();
+
+dbContext.Add(entity);
+await dbContext.SaveChangesAsync();
+
+using (scheduler.EnlistTransaction(tx.GetDbTransaction()))
+{
+    await scheduler.ScheduleJob(job, trigger);
+    await tx.CommitAsync();
+}
+```
+
+Nothing about this is specific to Entity Framework Core - any `DbConnection` and `DbTransaction` will do, whether they
+come from EF Core, Dapper or plain ADO.NET.
+
+::: warning
+Handing over a connection is the only way to take part. An ambient `TransactionScope` on its own is **not** enough: a
+connection the job store opens for itself is deliberately kept out of it, so that scheduling would commit separately.
+Open the connection inside the scope and enlist that one.
+:::
+
+Inside a `TransactionScope` the shape is the same, except that the connection carries the transaction for you:
+
+```csharp
+var options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+using var scope = new TransactionScope(TransactionScopeOption.Required, options, TransactionScopeAsyncFlowOption.Enabled);
+
+using var connection = new NpgsqlConnection(connectionString);
+await connection.OpenAsync();
+
+// ... your own work on this connection ...
+
+using (scheduler.EnlistConnection(connection))
+{
+    await scheduler.ScheduleJob(job, trigger);
+}
+
+scope.Complete();
+```
+
+Sharing the one connection is also what keeps the transaction from having to be promoted to a distributed one, which is
+unavailable outside Windows and unsupported by providers such as Npgsql.
+
+Things worth knowing before you enable this:
+
+* The enlistment flows with the current asynchronous context, so establish it in the same scope as the scheduler calls it
+  should cover. This is the same rule that makes `TransactionScope` need `TransactionScopeAsyncFlowOption.Enabled`. In
+  particular, enlisting inside an `async` helper does not carry the enlistment back out to the caller.
+* The job store takes its locks in your transaction, so they are only released once you commit or roll back. Keep enlisted
+  transactions short - a long running one blocks trigger acquisition, the misfire handler and cluster check-in. For the
+  same reason starting a scheduler for the first time from inside an enlistment scope is refused, and says so; resuming
+  one that was in standby is not, so avoid that too.
+* With a `DbTransaction` of your own, dispose the enlistment scope after committing: that is when a pending scheduling
+  change is signalled to the scheduler, and doing it earlier would point it at rows it cannot see yet. Under a
+  `TransactionScope` the scope itself reports the outcome, so the enlistment can close first - as in the sample above -
+  and nothing is signalled if the transaction rolls back.
+* Await scheduler calls one at a time inside a scope. A connection carries a single transaction and cannot serve two
+  operations at once.
+* Automatic retries of transient database errors are skipped inside your transaction. On most providers the first failure
+  has already doomed it, so the error is yours to handle - including any of your own work in that transaction.
+* An operation that fails halfway leaves its statements in your transaction; there is no savepoint to roll back to.
+* Because your transaction outlives the scheduling operation, this mode uses database locks even when the scheduler is not
+  clustered - an in-process lock would be released before you commit. SQLite is the exception: it always locks in
+  process, so a concurrent scheduler operation there can fail with "database is locked" until your transaction
+  completes. Quartz logs a warning about it at startup.
+* Work the scheduler does on its own - acquiring triggers, handling misfires, cluster check-in - always uses its own
+  connections and is unaffected.
+* `JobStoreCMT` is the exception to the previous point: running inside a transaction its container manages is that
+  store's whole contract, so its own connections enlist in an ambient transaction as they always have.

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -121,6 +121,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
 | `LockOnInsert` | bool | `true` | Takes a lock when inserting rows. |
 | `AcquireTriggersWithinLock` | bool | `false` | Acquires triggers inside the database lock. |
 | `TxIsolationLevelSerializable` | bool | `false` | Uses the serializable isolation level. |
+| `AcceptEnlistedTransactions` | bool | `false` | Lets the job store use a connection the application enlisted with `SchedulerEnlistmentExtensions.EnlistTransaction`, so scheduling commits with the application's own work. See [Joining an existing transaction](../tutorial/job-stores.md#joining-an-existing-transaction). |
 | `DoubleCheckLockMisfireHandler` | bool | `true` | Re-checks the lock before handling misfires. |
 | `MakeThreadsDaemons` | bool | `false` | Runs the store's background threads as background threads. |
 | `PerformSchemaValidation` | bool | `true` | Verifies the expected tables exist at startup. |
@@ -392,6 +393,7 @@ Two differences are worth knowing:
 | `quartz.jobStore.tablePrefix` | `JobStore:TablePrefix` |
 | `quartz.jobStore.useProperties` | `JobStore:UseProperties` |
 | `quartz.jobStore.clustered` | `JobStore:Clustered`, or `UseClustering()` |
+| `quartz.jobStore.acceptEnlistedTransactions` | `JobStore:AcceptEnlistedTransactions`, or `AcceptEnlistedTransactions()` |
 | `quartz.jobStore.clusterCheckinInterval` | `JobStore:ClusterCheckinInterval` |
 | `quartz.jobStore.dataSource` | set for you by the database methods |
 | `quartz.dataSource.NAME.provider` | `DataSource:NAME:Provider` |

--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -49,9 +49,9 @@ One thing to note is that in these scripts, all the the tables start with the pr
 what the prefix is (in your Quartz.NET properties). Using different prefixes may be useful for creating multiple sets of tables,
 for multiple scheduler instances, within the same database.
 
-Currently the only option for the internal implementation of job store is `JobStoreTX`which creates transactions by itself.
-This is different from Java version of Quartz where there is also option to choose `JobStoreCMT` which uses J2EE container
-managed transactions.
+`JobStoreTX` creates transactions by itself and is the implementation you normally want. If you need scheduling to
+commit together with your application's own database work, `JobStoreTX` can also be told to use a connection you
+own - see [Joining an existing transaction](#joining-an-existing-transaction) below.
 
 The last piece of the puzzle is setting up a data source from which AdoJobStore can get connections to your database.
 Data sources are defined in your Quartz.NET properties. Data source information contains the connection string
@@ -189,3 +189,97 @@ ISchedulerFactory schedulerFactory = config.Build();
     // "newtonsoft" is alias for "Quartz.Impl.NewtonsoftJsonObjectSerializer, Quartz.Serialization.Newtonsoft"
     quartz.serializer.type = stj
 ```
+
+### Joining an existing transaction
+
+Normally AdoJobStore opens a connection of its own and commits as soon as the scheduling operation is done. That means
+saving your own data and scheduling the job that acts on it are two separate transactions, and one can succeed while the
+other fails.
+
+Telling the store to accept enlisted transactions lets it use a connection your application already owns instead, so
+scheduling commits with the rest of your work or not at all.
+
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    q.UsePersistentStore(store =>
+    {
+        store.UsePostgres(connectionString);
+        store.AcceptEnlistedTransactions();
+    });
+});
+```
+
+You then hand your connection and transaction to the scheduler for the duration of a scope:
+
+```csharp
+await using var tx = await dbContext.Database.BeginTransactionAsync();
+
+dbContext.Add(entity);
+await dbContext.SaveChangesAsync();
+
+using (scheduler.EnlistTransaction(tx.GetDbTransaction()))
+{
+    await scheduler.ScheduleJob(job, trigger);
+    await tx.CommitAsync();
+}
+```
+
+Nothing about this is specific to Entity Framework Core - any `DbConnection` and `DbTransaction` will do, whether they
+come from EF Core, Dapper or plain ADO.NET.
+
+::: warning
+Handing over a connection is the only way to take part. An ambient `TransactionScope` on its own is **not** enough: a
+connection the job store opens for itself is deliberately kept out of it, so that scheduling would commit separately.
+Open the connection inside the scope and enlist that one.
+:::
+
+Inside a `TransactionScope` the shape is the same, except that the connection carries the transaction for you:
+
+```csharp
+var options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+using var scope = new TransactionScope(TransactionScopeOption.Required, options, TransactionScopeAsyncFlowOption.Enabled);
+
+using var connection = new NpgsqlConnection(connectionString);
+await connection.OpenAsync();
+
+// ... your own work on this connection ...
+
+using (scheduler.EnlistConnection(connection))
+{
+    await scheduler.ScheduleJob(job, trigger);
+}
+
+scope.Complete();
+```
+
+Sharing the one connection is also what keeps the transaction from having to be promoted to a distributed one, which is
+unavailable outside Windows and unsupported by providers such as Npgsql.
+
+Things worth knowing before you enable this:
+
+* The enlistment flows with the current asynchronous context, so establish it in the same scope as the scheduler calls it
+  should cover. This is the same rule that makes `TransactionScope` need `TransactionScopeAsyncFlowOption.Enabled`. In
+  particular, enlisting inside an `async` helper does not carry the enlistment back out to the caller.
+* The job store takes its locks in your transaction, so they are only released once you commit or roll back. Keep enlisted
+  transactions short - a long running one blocks trigger acquisition, the misfire handler and cluster check-in. For the
+  same reason starting a scheduler for the first time from inside an enlistment scope is refused, and says so; resuming
+  one that was in standby is not, so avoid that too.
+* With a `DbTransaction` of your own, dispose the enlistment scope after committing: that is when a pending scheduling
+  change is signalled to the scheduler, and doing it earlier would point it at rows it cannot see yet. Under a
+  `TransactionScope` the scope itself reports the outcome, so the enlistment can close first - as in the sample above -
+  and nothing is signalled if the transaction rolls back.
+* Await scheduler calls one at a time inside a scope. A connection carries a single transaction and cannot serve two
+  operations at once.
+* Automatic retries of transient database errors are skipped inside your transaction. On most providers the first failure
+  has already doomed it, so the error is yours to handle - including any of your own work in that transaction.
+* Because your transaction outlives the scheduling operation, this mode uses database locks even when the scheduler is not
+  clustered - an in-process lock would be released before you commit. SQLite is the exception: it always locks in
+  process, so a concurrent scheduler operation there can fail with "database is locked" until your transaction
+  completes. Quartz logs a warning about it at startup.
+* An operation that fails halfway leaves its statements in your transaction; there is no savepoint to roll back to.
+* Work the scheduler does on its own - acquiring triggers, handling misfires, cluster check-in - always uses its own
+  connections and is unaffected.
+* `JobStoreCMT` is the exception to the previous point: running inside a transaction its container manages is that
+  store's whole contract, so its own connections enlist in an ambient transaction as they always have.
+

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistedTransactionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistedTransactionTest.cs
@@ -1,0 +1,468 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Specialized;
+using System.Data.Common;
+using System.Transactions;
+
+using Microsoft.Data.SqlClient;
+
+using Npgsql;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Job;
+using Quartz.Util;
+
+using IsolationLevel = System.Transactions.IsolationLevel;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Verifies that scheduling can take part in a transaction the application owns: the schedule is
+/// committed together with the application's own work, and is discarded together with it when that
+/// work is rolled back. Reported as https://github.com/quartznet/quartznet/issues/2038.
+/// </summary>
+[NonParallelizable]
+public class EnlistedTransactionTest
+{
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresRollingBackTheApplicationTransactionDiscardsTheSchedule()
+    {
+        return RollingBackTheApplicationTransactionDiscardsTheSchedule(Postgres(), "EnlistedRollbackPg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresCommittingTheApplicationTransactionKeepsTheSchedule()
+    {
+        return CommittingTheApplicationTransactionKeepsTheSchedule(Postgres(), "EnlistedCommitPg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresIncompleteAmbientScopeDiscardsTheSchedule()
+    {
+        return IncompleteAmbientScopeDiscardsTheSchedule(Postgres(), "AmbientScopePg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresRunningSchedulerFiresTheJobRightAfterTheApplicationCommits()
+    {
+        return RunningSchedulerFiresTheJobRightAfterTheApplicationCommits(Postgres(), "EnlistedRunningPg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresRunningSchedulerFiresTheJobAfterAnAmbientScopeCompletes()
+    {
+        return RunningSchedulerFiresTheJobAfterAnAmbientScopeCompletes(Postgres(), "AmbientRunningPg");
+    }
+
+    [Test]
+    [Category("db-postgres")]
+    public Task PostgresEnlistingIsRefusedWhenTheStoreDoesNotAcceptIt()
+    {
+        return EnlistingIsRefusedWhenTheStoreDoesNotAcceptIt(Postgres(), "EnlistedRefusedPg");
+    }
+
+    [Test]
+    [Category("db-sqlserver")]
+    public Task SqlServerRollingBackTheApplicationTransactionDiscardsTheSchedule()
+    {
+        return RollingBackTheApplicationTransactionDiscardsTheSchedule(SqlServer(), "EnlistedRollbackMssql");
+    }
+
+    [Test]
+    [Category("db-sqlserver")]
+    public Task SqlServerCommittingTheApplicationTransactionKeepsTheSchedule()
+    {
+        return CommittingTheApplicationTransactionKeepsTheSchedule(SqlServer(), "EnlistedCommitMssql");
+    }
+
+    [Test]
+    [Category("db-sqlserver")]
+    public Task SqlServerIncompleteAmbientScopeDiscardsTheSchedule()
+    {
+        return IncompleteAmbientScopeDiscardsTheSchedule(SqlServer(), "AmbientScopeMssql");
+    }
+
+    private static async Task RollingBackTheApplicationTransactionDiscardsTheSchedule(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName);
+        JobKey jobKey = new JobKey("enlisted", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+
+            using (DbConnection connection = provider.CreateConnection())
+            {
+                await connection.OpenAsync();
+                using (DbTransaction transaction = connection.BeginTransaction())
+                {
+                    using (scheduler.EnlistTransaction(transaction))
+                    {
+                        await scheduler.ScheduleJob(CreateJob(jobKey), CreateTrigger(jobKey));
+
+                        bool visibleInsideTheTransaction = await scheduler.CheckExists(jobKey);
+                        visibleInsideTheTransaction.Should().BeTrue("the job store wrote through the enlisted transaction");
+                    }
+
+                    transaction.Rollback();
+                }
+            }
+
+            bool survivedTheRollback = await scheduler.CheckExists(jobKey);
+            survivedTheRollback.Should().BeFalse("the schedule belongs to the transaction the application rolled back");
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    private static async Task CommittingTheApplicationTransactionKeepsTheSchedule(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName);
+        JobKey jobKey = new JobKey("enlisted", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+
+            using (DbConnection connection = provider.CreateConnection())
+            {
+                await connection.OpenAsync();
+                using (DbTransaction transaction = connection.BeginTransaction())
+                {
+                    using (scheduler.EnlistTransaction(transaction))
+                    {
+                        await scheduler.ScheduleJob(CreateJob(jobKey), CreateTrigger(jobKey));
+                        transaction.Commit();
+                    }
+                }
+            }
+
+            IJobDetail persisted = await scheduler.GetJobDetail(jobKey);
+            persisted.Should().NotBeNull("the application committed the transaction the schedule was written in");
+            (await scheduler.GetTriggersOfJob(jobKey)).Should().HaveCount(1);
+
+            await scheduler.Clear();
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    private static async Task IncompleteAmbientScopeDiscardsTheSchedule(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName);
+        JobKey jobKey = new JobKey("ambient", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+
+            TransactionOptions options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+            using (new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled))
+            {
+                // Sharing the one connection is what keeps the scope from being promoted to a
+                // distributed transaction, which Npgsql does not support at all.
+                using (DbConnection connection = provider.CreateConnection())
+                {
+                    await connection.OpenAsync();
+
+                    using (scheduler.EnlistConnection(connection))
+                    {
+                        await scheduler.ScheduleJob(CreateJob(jobKey), CreateTrigger(jobKey));
+                    }
+                }
+
+                // scope is disposed without Complete, so the ambient transaction rolls back
+            }
+
+            bool survivedTheRollback = await scheduler.CheckExists(jobKey);
+            survivedTheRollback.Should().BeFalse("the ambient transaction was never completed");
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    /// <summary>
+    /// The scheduler runs for real here, which is what exercises the parts the other tests cannot:
+    /// the scheduler thread contending for the locks the application transaction holds, and the
+    /// scheduling change signal that has to wait for the commit. A job scheduled to fire immediately
+    /// must run promptly after the application commits - not an idle interval later.
+    /// </summary>
+    private static async Task RunningSchedulerFiresTheJobRightAfterTheApplicationCommits(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName, idleWaitTime: TimeSpan.FromMinutes(2));
+        JobKey jobKey = new JobKey("running", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+            SignallingJob.Reset();
+            await scheduler.Start();
+
+            using (DbConnection connection = provider.CreateConnection())
+            {
+                await connection.OpenAsync();
+                using (DbTransaction transaction = connection.BeginTransaction())
+                {
+                    IJobDetail job = JobBuilder.Create<SignallingJob>()
+                        .WithIdentity(jobKey)
+                        .StoreDurably()
+                        .Build();
+
+                    ITrigger trigger = TriggerBuilder.Create()
+                        .WithIdentity(jobKey.Name, jobKey.Group)
+                        .ForJob(jobKey)
+                        .StartNow()
+                        .Build();
+
+                    using (scheduler.EnlistTransaction(transaction))
+                    {
+                        await scheduler.ScheduleJob(job, trigger);
+                        transaction.Commit();
+                    }
+                }
+            }
+
+            // Comfortably below the two minute idle wait, so passing means the post-commit signal
+            // woke the scheduler rather than the idle timer expiring.
+            bool fired = SignallingJob.Fired.Wait(TimeSpan.FromSeconds(30));
+            fired.Should().BeTrue("the scheduler must be signalled once the application's commit makes the trigger visible");
+
+            await scheduler.Clear();
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    /// <summary>
+    /// The ambient half of the deferred signal: with a <see cref="TransactionScope" /> in play the
+    /// enlistment scope closes first and the transaction itself reports the outcome, so the signal has
+    /// to come from its completion rather than from disposing the enlistment.
+    /// </summary>
+    private static async Task RunningSchedulerFiresTheJobAfterAnAmbientScopeCompletes(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName, idleWaitTime: TimeSpan.FromMinutes(2));
+        JobKey jobKey = new JobKey("ambient-running", schedulerName);
+
+        try
+        {
+            await scheduler.Clear();
+            SignallingJob.Reset();
+            await scheduler.Start();
+
+            TransactionOptions options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+            using (TransactionScope scope = new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled))
+            {
+                using (DbConnection connection = provider.CreateConnection())
+                {
+                    await connection.OpenAsync();
+
+                    IJobDetail job = JobBuilder.Create<SignallingJob>()
+                        .WithIdentity(jobKey)
+                        .StoreDurably()
+                        .Build();
+
+                    ITrigger trigger = TriggerBuilder.Create()
+                        .WithIdentity(jobKey.Name, jobKey.Group)
+                        .ForJob(jobKey)
+                        .StartNow()
+                        .Build();
+
+                    using (scheduler.EnlistConnection(connection))
+                    {
+                        await scheduler.ScheduleJob(job, trigger);
+                    }
+
+                    // The enlistment is already gone here, so only the scope completing can raise the signal.
+                    SignallingJob.Fired.IsSet.Should().BeFalse("nothing is committed until the scope completes");
+                }
+
+                scope.Complete();
+            }
+
+            bool fired = SignallingJob.Fired.Wait(TimeSpan.FromSeconds(30));
+            fired.Should().BeTrue("completing the ambient transaction must signal the scheduler");
+
+            await scheduler.Clear();
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    private static async Task EnlistingIsRefusedWhenTheStoreDoesNotAcceptIt(
+        TestProvider provider,
+        string schedulerName)
+    {
+        IScheduler scheduler = await CreateScheduler(provider, schedulerName, acceptEnlistedTransactions: false);
+
+        try
+        {
+            using (DbConnection connection = provider.CreateConnection())
+            {
+                await connection.OpenAsync();
+                using DbTransaction transaction = connection.BeginTransaction();
+
+                Action enlist = () => scheduler.EnlistTransaction(transaction);
+
+                enlist.Should().Throw<InvalidOperationException>()
+                    .WithMessage("*acceptEnlistedTransactions*",
+                        "silently ignoring the enlistment would let scheduling commit outside the application transaction");
+            }
+        }
+        finally
+        {
+            await scheduler.Shutdown(false);
+        }
+    }
+
+    private static IJobDetail CreateJob(JobKey jobKey)
+    {
+        return JobBuilder.Create<NoOpJob>()
+            .WithIdentity(jobKey)
+            .StoreDurably()
+            .Build();
+    }
+
+    private static ITrigger CreateTrigger(JobKey jobKey)
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity(jobKey.Name, jobKey.Group)
+            .ForJob(jobKey)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+            .Build();
+    }
+
+    private static async Task<IScheduler> CreateScheduler(
+        TestProvider provider,
+        string schedulerName,
+        bool acceptEnlistedTransactions = true,
+        TimeSpan? idleWaitTime = null)
+    {
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = schedulerName,
+            ["quartz.scheduler.instanceId"] = "AUTO",
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+            ["quartz.jobStore.type"] = typeof(JobStoreTX).AssemblyQualifiedNameWithoutVersion(),
+            ["quartz.jobStore.useProperties"] = "true",
+            ["quartz.jobStore.dataSource"] = "default",
+            ["quartz.jobStore.tablePrefix"] = "QRTZ_",
+            ["quartz.jobStore.acceptEnlistedTransactions"] = acceptEnlistedTransactions.ToString().ToLowerInvariant(),
+            ["quartz.jobStore.driverDelegateType"] = provider.DriverDelegateType.AssemblyQualifiedNameWithoutVersion(),
+            ["quartz.dataSource.default.connectionString"] = provider.ConnectionString,
+            ["quartz.dataSource.default.provider"] = provider.ProviderName,
+            ["quartz.threadPool.maxConcurrency"] = "2"
+        };
+
+        if (idleWaitTime != null)
+        {
+            properties["quartz.scheduler.idleWaitTime"] = ((int) idleWaitTime.Value.TotalMilliseconds).ToString();
+        }
+
+        // Most of these tests never start the scheduler - they are about what reaches the database,
+        // and a running scheduler thread would contend for the locks the application transaction
+        // holds. RunningSchedulerFiresTheJobRightAfterTheApplicationCommits is the one that does.
+        return await new StdSchedulerFactory(properties).GetScheduler();
+    }
+
+    private static TestProvider Postgres()
+    {
+        return new TestProvider(
+            TestConstants.PostgresProvider,
+            TestConstants.PostgresConnectionString,
+            typeof(PostgreSQLDelegate),
+            () => new NpgsqlConnection(TestConstants.PostgresConnectionString));
+    }
+
+    private static TestProvider SqlServer()
+    {
+        return new TestProvider(
+            TestConstants.DefaultSqlServerProvider,
+            TestConstants.SqlServerConnectionString,
+            typeof(SqlServerDelegate),
+            () => new SqlConnection(TestConstants.SqlServerConnectionString));
+    }
+
+    [DisallowConcurrentExecution]
+    public sealed class SignallingJob : IJob
+    {
+        internal static readonly ManualResetEventSlim Fired = new ManualResetEventSlim(false);
+
+        internal static void Reset() => Fired.Reset();
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Fired.Set();
+            return default;
+        }
+    }
+
+    private sealed class TestProvider
+    {
+        private readonly Func<DbConnection> connectionFactory;
+
+        internal TestProvider(
+            string providerName,
+            string connectionString,
+            Type driverDelegateType,
+            Func<DbConnection> connectionFactory)
+        {
+            ProviderName = providerName;
+            ConnectionString = connectionString;
+            DriverDelegateType = driverDelegateType;
+            this.connectionFactory = connectionFactory;
+        }
+
+        internal string ProviderName { get; }
+
+        internal string ConnectionString { get; }
+
+        internal Type DriverDelegateType { get; }
+
+        internal DbConnection CreateConnection() => connectionFactory();
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AmbientConnectionTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AmbientConnectionTest.cs
@@ -1,0 +1,543 @@
+#nullable enable
+
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Data;
+using System.Data.Common;
+using System.Transactions;
+
+using FakeItEasy;
+
+using Quartz.Core;
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+
+using IsolationLevel = System.Data.IsolationLevel;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// Covers the job store using a connection the application enlisted, and staying out of an ambient
+/// <see cref="TransactionScope" /> when nothing was enlisted.
+/// </summary>
+public sealed class AmbientConnectionTest
+{
+    private const string SchedulerName = "AmbientConnectionTestScheduler";
+
+    [Test]
+    public async Task EnlistTransaction_MakesTheJobStoreUseTheApplicationsConnection()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        applicationConnection.Open();
+        DbTransaction applicationTransaction = applicationConnection.BeginTransaction();
+
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out var ownConnection);
+
+        using (CreateScheduler().EnlistTransaction(applicationTransaction))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection);
+            holder.Transaction.Should().BeSameAs(applicationTransaction);
+            holder.OwnsResources.Should().BeFalse("the application owns what it enlisted");
+        }
+
+        ownConnection.OpenCount.Should().Be(0, "the job store should not have opened a connection of its own");
+        applicationConnection.BeginTransactionCount.Should().Be(1, "only the application's own transaction was started");
+    }
+
+    [Test]
+    public async Task EnlistConnection_OpensTheConnectionWhenItIsClosed()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistConnection(applicationConnection))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection);
+            holder.Transaction.Should().BeNull("the ambient scope owns the transaction");
+        }
+
+        applicationConnection.OpenCount.Should().Be(1);
+        applicationConnection.BeginTransactionCount.Should().Be(0, "an enlisted connection joins the transaction the application already has");
+    }
+
+    [Test]
+    public void EnlistConnection_WithNothingToJoin_IsRefused()
+    {
+        var applicationConnection = new RecordingDbConnection();
+
+        Action enlist = () => CreateScheduler().EnlistConnection(applicationConnection);
+
+        enlist.Should().Throw<ArgumentException>()
+            .WithParameterName("connection")
+            .WithMessage("*no transaction to join*",
+                "without one every statement would commit on the spot while looking like a working enlistment");
+    }
+
+    [Test]
+    public void EnlistConnection_WithATransactionFromAnotherConnection_IsRefused()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        var otherConnection = new RecordingDbConnection();
+        otherConnection.Open();
+        DbTransaction foreign = otherConnection.BeginTransaction();
+
+        Action enlist = () => CreateScheduler().EnlistConnection(applicationConnection, foreign);
+
+        enlist.Should().Throw<ArgumentException>()
+            .WithParameterName("transaction")
+            .WithMessage("*belongs to a different connection*");
+    }
+
+    [Test]
+    public async Task Enlistment_EndsWhenTheScopeIsDisposed()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out var ownConnection);
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+        }
+
+        var holder = await jobStore.CallGetConnection();
+
+        holder.Connection.Should().BeSameAs(ownConnection);
+        holder.OwnsResources.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Enlistment_IsScopedToTheScheduler()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out var ownConnection);
+
+        using (Enlist(CreateScheduler("SomeOtherScheduler"), applicationConnection))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(ownConnection, "the enlistment belongs to a different scheduler");
+        }
+    }
+
+    [Test]
+    public async Task Enlistment_Nests()
+    {
+        var outerConnection = new RecordingDbConnection();
+        var innerConnection = new RecordingDbConnection();
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (Enlist(CreateScheduler(), outerConnection))
+        {
+            using (Enlist(CreateScheduler(), innerConnection))
+            {
+                (await jobStore.CallGetConnection()).Connection.Should().BeSameAs(innerConnection);
+            }
+
+            (await jobStore.CallGetConnection()).Connection.Should().BeSameAs(outerConnection, "disposing the inner scope restores the outer one");
+        }
+    }
+
+    [Test]
+    public async Task Enlistment_DoesNotLeakIntoFlowsStartedOutsideIt()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out var ownConnection);
+
+        // Started outside the scope, so it must never see the enlistment however long it runs. The gate
+        // makes the enlistment exist before the flow does any work, which a plain static field would fail.
+        var enlisted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var unrelatedFlow = Task.Run(async () =>
+        {
+            await enlisted.Task;
+            return (await jobStore.CallGetConnection()).Connection;
+        });
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+            enlisted.SetResult(true);
+
+            (await unrelatedFlow).Should().BeSameAs(ownConnection);
+        }
+    }
+
+    [Test]
+    public async Task ForkingInsideAnEnlistment_RefusesTheSecondConcurrentUse()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+            // Both children inherit the enlistment - that is the point of AsyncLocal - and one connection
+            // cannot serve two operations, so the loser is told why rather than left to hit
+            // "a command is already in progress" from the provider.
+            var held = await jobStore.CallGetConnection();
+
+            Func<Task> forked = () => Task.Run(async () => await jobStore.CallGetConnection());
+
+            await forked.Should().ThrowAsync<JobPersistenceException>()
+                .WithMessage("*cannot be used concurrently*");
+
+            await jobStore.CallCleanupConnection(held);
+        }
+    }
+
+    [Test]
+    public async Task Enlistment_IsRefusedWhenTheStoreDoesNotAcceptIt()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: false, out _);
+
+        using (Enlist(CreateScheduler(), applicationConnection))
+        {
+            Func<Task> operate = async () => await jobStore.CallGetConnection();
+
+            // Ignoring it would commit the scheduling separately while the caller believes it is part of
+            // their transaction. This is also what covers a scheduler the call site could not inspect.
+            await operate.Should().ThrowAsync<JobPersistenceException>()
+                .WithMessage("*not configured to take part in transactions the application owns*");
+        }
+    }
+
+    [Test]
+    public async Task UsingAnEnlistmentAfterItsTransactionCompleted_IsRefused()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        applicationConnection.Open();
+        DbTransaction applicationTransaction = applicationConnection.BeginTransaction();
+
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (CreateScheduler().EnlistTransaction(applicationTransaction))
+        {
+            applicationTransaction.Commit();
+
+            Func<Task> afterCommit = async () => await jobStore.CallGetConnection();
+
+            // Carrying on would attach a completed transaction, or - worse - run in autocommit where a
+            // half-finished write can no longer be rolled back.
+            await afterCommit.Should().ThrowAsync<JobPersistenceException>()
+                .WithMessage("*already been committed or rolled back*");
+        }
+    }
+
+    [Test]
+    public async Task SchedulerOwnedWorkInsideAnAmbientScope_StaysOutOfIt()
+    {
+        var applicationConnection = new RecordingDbConnection();
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out var ownConnection);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistConnection(applicationConnection))
+        using (AmbientConnection.Suppress())
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(ownConnection, "suppressed work must not borrow the application's connection");
+            holder.Transaction.Should().NotBeNull("suppressed work runs in a transaction of its own");
+            ownConnection.EnlistedIn.Should().BeNull("and that transaction must not be the application's");
+        }
+    }
+
+    [Test]
+    public async Task AmbientTransactionScopeAlone_DoesNotMakeTheJobStoreJoinIt()
+    {
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out var ownConnection);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            // Taking part means handing over a connection. Joining the scope with a connection of our own
+            // would put a second connection in it - a distributed transaction, which not every provider
+            // supports - and leave the commit outside our control.
+            holder.Connection.Should().BeSameAs(ownConnection);
+            holder.Transaction.Should().NotBeNull("the job store manages its own connection's transaction");
+            holder.OwnsResources.Should().BeTrue();
+            ownConnection.EnlistedIn.Should().BeNull("the job store's own connection stays out of the ambient transaction");
+        }
+    }
+
+    [Test]
+    public async Task AmbientTransactionScope_IsLeftAloneWhenTheFeatureIsOff()
+    {
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: false, out var ownConnection);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Transaction.Should().NotBeNull("behaviour must not change unless the feature is switched on");
+            ownConnection.EnlistedIn.Should().NotBeNull(
+                "with the feature off the connection enlists as it always did - suppressing it would be a behaviour change of its own");
+        }
+    }
+
+    [Test]
+    public void EnlistTransaction_RejectsATransactionThatLostItsConnection()
+    {
+        DbTransaction orphaned = new OrphanedDbTransaction();
+
+        Action enlist = () => CreateScheduler().EnlistTransaction(orphaned);
+
+        enlist.Should().Throw<ArgumentException>().WithParameterName("transaction");
+    }
+
+    [Test]
+    public async Task WithoutAnApplicationTransaction_TheJobStoreStartsItsOwn()
+    {
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out var ownConnection);
+
+        var holder = await jobStore.CallGetConnection();
+
+        holder.Connection.Should().BeSameAs(ownConnection);
+        holder.Transaction.Should().NotBeNull();
+        holder.OwnsResources.Should().BeTrue();
+        ownConnection.BeginTransactionCount.Should().Be(1);
+    }
+
+    [Test]
+    public void EnlistingOnASchedulerWithoutAPersistentStore_IsRefused()
+    {
+        // The fakes used elsewhere in this fixture are not StdScheduler, so the call-site guard
+        // short-circuits for them; this drives it through a real one.
+        var scheduler = new StdScheduler(BuildRamScheduler());
+
+        var connection = new RecordingDbConnection();
+        connection.Open();
+
+        Action enlist = () => scheduler.EnlistTransaction(connection.BeginTransaction());
+
+        enlist.Should().Throw<InvalidOperationException>()
+            .WithMessage("*does not store anything in the application's database*",
+                "an in-memory store would let the scheduling survive the application's rollback");
+    }
+
+    [Test]
+    public async Task EnlistingThroughADecorator_ReachesTheSameJobStore()
+    {
+        // The guard unwraps decorators, and the enlistment is keyed by the name the job store resolves
+        // rather than by whatever the outermost wrapper reports.
+        var applicationConnection = new RecordingDbConnection();
+        applicationConnection.Open();
+
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+        var scheduler = new DelegatingScheduler(CreateScheduler());
+
+        using (scheduler.EnlistTransaction(applicationConnection.BeginTransaction()))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection);
+        }
+    }
+
+    /// <summary>
+    /// Enlists a connection together with a transaction of its own, the shape most callers use.
+    /// </summary>
+    private static IDisposable Enlist(IScheduler scheduler, RecordingDbConnection connection)
+    {
+        if (connection.State == ConnectionState.Closed)
+        {
+            connection.Open();
+        }
+
+        return scheduler.EnlistTransaction(connection.BeginTransaction());
+    }
+
+    private static QuartzScheduler BuildRamScheduler()
+    {
+        var resources = new QuartzSchedulerResources
+        {
+            Name = "AmbientConnectionGuardScheduler",
+            InstanceId = "NON_CLUSTERED",
+            ThreadPool = new DefaultThreadPool(),
+            JobStore = TestJobStores.Ram(),
+            JobRunShellFactory = new StdJobRunShellFactory(TestJobStores.Logger<Quartz.Core.JobRunShell>()),
+            TimeProvider = TimeProvider.System,
+        };
+
+        return new QuartzScheduler(resources);
+    }
+
+    private static IScheduler CreateScheduler(string name = SchedulerName)
+    {
+        var scheduler = A.Fake<IScheduler>();
+        A.CallTo(() => scheduler.SchedulerName).Returns(name);
+        return scheduler;
+    }
+
+    private static TestJobStore CreateJobStore(bool acceptEnlistedTransactions, out RecordingDbConnection ownConnection)
+    {
+        var connection = new RecordingDbConnection();
+        ownConnection = connection;
+
+        return new TestJobStore(
+            new RecordingDbProvider(connection),
+            TestJobStores.StoreOptions(configure: options =>
+            {
+                options.AcceptEnlistedTransactions = acceptEnlistedTransactions;
+            }),
+            SchedulerName);
+    }
+
+    private sealed class TestJobStore : JobStoreTX
+    {
+        internal TestJobStore(
+            IDbProvider dbProvider,
+            Microsoft.Extensions.Options.IOptions<AdoJobStoreOptions> storeOptions,
+            string instanceName)
+            : base(
+                TestJobStores.Signaler(),
+                TestJobStores.TypeLoader(),
+                TimeProvider.System,
+                TestJobStores.SchedulerOptions(instanceName),
+                storeOptions,
+                TestJobStores.Serializer(),
+                TestJobStores.ConnectionManager(),
+                dbProvider,
+                TestJobStores.DriverDelegate(),
+                TestJobStores.LockHandler())
+        {
+        }
+
+        internal ValueTask<ConnectionAndTransactionHolder> CallGetConnection() => GetConnection();
+
+        internal ValueTask CallCleanupConnection(ConnectionAndTransactionHolder conn) => CleanupConnection(conn);
+    }
+
+    private sealed class RecordingDbProvider : IDbProvider
+    {
+        private readonly DbConnection connection;
+
+        internal RecordingDbProvider(DbConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public string ConnectionString { get; set; } = "";
+
+        public DbMetadata Metadata { get; } = new();
+
+        public void Initialize()
+        {
+        }
+
+        public DbCommand CreateCommand() => throw new NotSupportedException();
+
+        public DbConnection CreateConnection() => connection;
+
+        public void Shutdown()
+        {
+        }
+    }
+
+    private sealed class RecordingDbConnection : DbConnection
+    {
+        private ConnectionState state = ConnectionState.Closed;
+
+        internal int OpenCount { get; private set; }
+
+        internal int BeginTransactionCount { get; private set; }
+
+        /// <summary>
+        /// The ambient transaction this connection would have auto-enlisted in when it was opened,
+        /// which is how ADO.NET providers behave unless enlistment is suppressed or switched off.
+        /// </summary>
+        internal Transaction? EnlistedIn { get; private set; }
+
+        [System.Diagnostics.CodeAnalysis.AllowNull]
+        public override string ConnectionString { get; set; } = "";
+
+        public override string Database => "";
+
+        public override string DataSource => "";
+
+        public override string ServerVersion => "";
+
+        public override ConnectionState State => state;
+
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
+
+        public override void Close() => state = ConnectionState.Closed;
+
+        public override void Open()
+        {
+            OpenCount++;
+            state = ConnectionState.Open;
+            EnlistedIn = Transaction.Current;
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            BeginTransactionCount++;
+            return new RecordingDbTransaction(this, isolationLevel);
+        }
+
+        protected override DbCommand CreateDbCommand() => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingDbTransaction : DbTransaction
+    {
+        private readonly IsolationLevel isolationLevel;
+        private DbConnection? connection;
+
+        internal RecordingDbTransaction(DbConnection connection, IsolationLevel isolationLevel)
+        {
+            this.connection = connection;
+            this.isolationLevel = isolationLevel;
+        }
+
+        // ADO.NET providers drop the connection reference once the transaction completes, which is how
+        // a completed transaction is recognised.
+        protected override DbConnection? DbConnection => connection;
+
+        public override IsolationLevel IsolationLevel => isolationLevel;
+
+        public override void Commit() => connection = null;
+
+        public override void Rollback() => connection = null;
+    }
+
+    private sealed class OrphanedDbTransaction : DbTransaction
+    {
+        protected override DbConnection? DbConnection => null;
+
+        public override IsolationLevel IsolationLevel => IsolationLevel.ReadCommitted;
+
+        public override void Commit()
+        {
+        }
+
+        public override void Rollback()
+        {
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/ConnectionAndTransactionHolderTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/ConnectionAndTransactionHolderTest.cs
@@ -45,6 +45,89 @@ public sealed class ConnectionAndTransactionHolderTest
         await holder.Rollback(transientError: false);
     }
 
+    [Test]
+    public async Task BorrowedHolder_LeavesTheApplicationsTransactionAlone()
+    {
+        var connection = new TestDbConnection();
+        var transaction = new TestDbTransaction(dbConnection: connection);
+
+        var holder = new ConnectionAndTransactionHolder(connection, transaction, ownsResources: false);
+
+        await holder.Commit(openNewTransaction: false);
+        await holder.Rollback(transientError: false);
+
+        holder.OwnsResources.Should().BeFalse();
+        transaction.CommitCalled.Should().BeFalse("the application decides when its transaction commits");
+        transaction.RollbackCalled.Should().BeFalse("rolling back here would discard the application's own work too");
+    }
+
+    [Test]
+    public async Task BorrowedHolder_LeavesTheApplicationsConnectionOpen()
+    {
+        var connection = new TestDbConnection();
+        var transaction = new TestDbTransaction(dbConnection: connection);
+
+        var holder = new ConnectionAndTransactionHolder(connection, transaction, ownsResources: false);
+
+        await holder.Close();
+        holder.Dispose();
+
+        connection.CloseCalled.Should().BeFalse("the application keeps using its connection after we are done");
+        connection.DisposeCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task OwnedHolder_ClosesItsConnection()
+    {
+        var connection = new TestDbConnection();
+
+        var holder = new ConnectionAndTransactionHolder(connection, transaction: null);
+
+        holder.OwnsResources.Should().BeTrue("a holder that opened its own connection is responsible for it");
+
+        await holder.Close();
+
+        connection.CloseCalled.Should().BeTrue();
+    }
+
+    private sealed class TestDbConnection : DbConnection
+    {
+        public bool CloseCalled { get; private set; }
+
+        public bool DisposeCalled { get; private set; }
+
+        [System.Diagnostics.CodeAnalysis.AllowNull]
+        public override string ConnectionString { get; set; } = "";
+
+        public override string Database => "";
+
+        public override string DataSource => "";
+
+        public override string ServerVersion => "";
+
+        public override ConnectionState State => ConnectionState.Open;
+
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
+
+        public override void Close() => CloseCalled = true;
+
+        public override void Open()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalled = true;
+            base.Dispose(disposing);
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+
+        protected override DbCommand CreateDbCommand() => throw new NotSupportedException();
+    }
+
     private sealed class TestDbTransaction : DbTransaction
     {
         private readonly DbConnection dbConnection;
@@ -56,12 +139,15 @@ public sealed class ConnectionAndTransactionHolderTest
 
         public bool RollbackCalled { get; private set; }
 
+        public bool CommitCalled { get; private set; }
+
         protected override DbConnection DbConnection => dbConnection;
 
         public override IsolationLevel IsolationLevel => IsolationLevel.ReadCommitted;
 
         public override void Commit()
         {
+            CommitCalled = true;
         }
 
         public override void Rollback()

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -5,6 +5,7 @@ namespace Quartz
     {
         public const string DefaultTablePrefix = "QRTZ_";
         public AdoJobStoreOptions() { }
+        public bool AcceptEnlistedTransactions { get; set; }
         public bool AcquireTriggersWithinLock { get; set; }
         public System.TimeSpan ClusterCheckinInterval { get; set; }
         public System.TimeSpan ClusterCheckinMisfireThreshold { get; set; }
@@ -404,6 +405,7 @@ namespace Quartz
     {
         string SchedulerName { get; }
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+        Quartz.IPersistentStoreBuilder AcceptEnlistedTransactions();
         Quartz.IPersistentStoreBuilder Configure(System.Action<Quartz.AdoJobStoreOptions> configure);
         Quartz.IPersistentStoreBuilder UseClustering(System.Action<Quartz.ClusteringOptions>? configure = null);
         Quartz.IPersistentStoreBuilder UseDataSource(System.Action<Quartz.DataSourceOptions> configure);
@@ -972,6 +974,11 @@ namespace Quartz
     {
         public SchedulerContext() { }
         public SchedulerContext(System.Collections.Generic.IDictionary<string, object?> map) { }
+    }
+    public static class SchedulerEnlistmentExtensions
+    {
+        public static System.IDisposable EnlistConnection(this Quartz.IScheduler scheduler, System.Data.Common.DbConnection connection, System.Data.Common.DbTransaction? transaction = null) { }
+        public static System.IDisposable EnlistTransaction(this Quartz.IScheduler scheduler, System.Data.Common.DbTransaction transaction) { }
     }
     [System.Serializable]
     public class SchedulerException : System.Exception
@@ -1963,6 +1970,7 @@ namespace Quartz.Impl.AdoJobStore
         protected const string LockStateAccess = "STATE_ACCESS";
         protected const string LockTriggerAccess = "TRIGGER_ACCESS";
         protected JobStoreSupport(Quartz.Extensibility.ISchedulerSignaler schedulerSignaler, Quartz.Extensibility.ITypeLoadHelper typeLoadHelper, System.TimeProvider timeProvider, Microsoft.Extensions.Options.IOptions<Quartz.QuartzSchedulerOptions> schedulerOptions, Microsoft.Extensions.Options.IOptions<Quartz.AdoJobStoreOptions> storeOptions, Quartz.Extensibility.IObjectSerializer objectSerializer, Quartz.Util.IDbConnectionManager connectionManager, Quartz.Impl.AdoJobStore.Common.IDbProvider dbProvider, Quartz.Impl.AdoJobStore.IDriverDelegate driverDelegate, Quartz.Impl.AdoJobStore.ISemaphore? lockHandler = null) { }
+        public bool AcceptEnlistedTransactions { get; set; }
         public bool AcquireTriggersWithinLock { get; set; }
         public virtual bool CanUseProperties { get; }
         [Quartz.TimeSpanParseRule(Quartz.TimeSpanParseRule.Milliseconds)]
@@ -2811,6 +2819,7 @@ namespace Quartz.Impl
         public DelegatingScheduler(Quartz.IScheduler scheduler) { }
         public Quartz.SchedulerContext Context { get; }
         public bool InStandbyMode { get; }
+        protected Quartz.IScheduler InnerScheduler { get; }
         public bool IsShutdown { get; }
         public bool IsStarted { get; }
         public Quartz.IListenerManager ListenerManager { get; }

--- a/src/Quartz/Configuration/AdoJobStoreOptions.cs
+++ b/src/Quartz/Configuration/AdoJobStoreOptions.cs
@@ -103,6 +103,28 @@ public sealed class AdoJobStoreOptions
     public bool TxIsolationLevelSerializable { get; set; }
 
     /// <summary>
+    /// Whether the job store may take part in a transaction the application owns, rather than
+    /// always managing an ADO.NET transaction of its own.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, the job store uses the connection the application enlisted with
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistTransaction" /> or
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistConnection" /> for operations on that
+    /// asynchronous flow, so scheduling either commits with the rest of the application's work or
+    /// not at all.
+    /// </para>
+    /// <para>
+    /// Taking part always means handing over a connection. Operations with nothing enlisted keep
+    /// using a connection of the job store's own, and for <see cref="Quartz.Impl.AdoJobStore.JobStoreTX" />
+    /// that connection is deliberately kept out of any ambient
+    /// <see cref="System.Transactions.Transaction" />. <see cref="Quartz.Impl.AdoJobStore.JobStoreCMT" />
+    /// is the exception, since running inside a container-managed transaction is that store's contract.
+    /// </para>
+    /// </remarks>
+    public bool AcceptEnlistedTransactions { get; set; }
+
+    /// <summary>
     /// Whether the job store leaves auto-commit alone rather than disabling it.
     /// </summary>
     public bool DontSetAutoCommitFalse { get; set; }

--- a/src/Quartz/Configuration/IPersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/IPersistentStoreBuilder.cs
@@ -43,6 +43,30 @@ public interface IPersistentStoreBuilder
     IPersistentStoreBuilder Configure(Action<AdoJobStoreOptions> configure);
 
     /// <summary>
+    /// Lets the job store take part in a transaction the application owns, instead of always managing
+    /// an ADO.NET transaction of its own, so that scheduling commits together with the rest of the
+    /// application's work.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The job store then uses a connection enlisted with
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistTransaction" /> or
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistConnection" />. Handing over a connection is the
+    /// only way to take part, and the one that works on every provider: with the default
+    /// <see cref="Quartz.Impl.AdoJobStore.JobStoreTX" />, a connection the job store opens for itself
+    /// stays out of any ambient <see cref="System.Transactions.TransactionScope" />, since a second
+    /// connection in that transaction would require it to be promoted to a distributed one.
+    /// <see cref="Quartz.Impl.AdoJobStore.JobStoreCMT" /> is the exception, since running inside a
+    /// container-managed transaction is that store's contract.
+    /// </para>
+    /// <para>
+    /// Locks are held until the application commits, so keep such transactions short. This also
+    /// switches locking to database locks unless an explicit lock handler was configured.
+    /// </para>
+    /// </remarks>
+    IPersistentStoreBuilder AcceptEnlistedTransactions();
+
+    /// <summary>
     /// Names this store's data source, which is how its connection provider is registered.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/Configuration/PersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilder.cs
@@ -39,6 +39,11 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
         return this;
     }
 
+    public IPersistentStoreBuilder AcceptEnlistedTransactions()
+    {
+        return Configure(options => options.AcceptEnlistedTransactions = true);
+    }
+
     public IPersistentStoreBuilder UseDataSource(Action<DataSourceOptions> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);

--- a/src/Quartz/Configuration/QuartzPropertyBridge.cs
+++ b/src/Quartz/Configuration/QuartzPropertyBridge.cs
@@ -511,6 +511,7 @@ internal static class QuartzPropertyBridge
         parser.Bool("quartz.jobStore.useDBLocks", value => options.UseDbLocks = value);
         parser.Bool("quartz.jobStore.lockOnInsert", value => options.LockOnInsert = value);
         parser.Bool("quartz.jobStore.acquireTriggersWithinLock", value => options.AcquireTriggersWithinLock = value);
+        parser.Bool("quartz.jobStore.acceptEnlistedTransactions", value => options.AcceptEnlistedTransactions = value);
         parser.Bool("quartz.jobStore.txIsolationLevelSerializable", value => options.TxIsolationLevelSerializable = value);
         parser.Bool("quartz.jobStore.doubleCheckLockMisfireHandler", value => options.DoubleCheckLockMisfireHandler = value);
         parser.Bool("quartz.jobStore.performSchemaValidation", value => options.PerformSchemaValidation = value);

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -307,8 +307,21 @@ public sealed class QuartzScheduler
         if (!initialStart.HasValue)
         {
             initialStart = this.resources.TimeProvider.GetUtcNow();
-            await resources.JobStore.SchedulerStarted(cancellationToken).ConfigureAwait(false);
-            await StartPlugins(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await resources.JobStore.SchedulerStarted(cancellationToken).ConfigureAwait(false);
+                await StartPlugins(cancellationToken).ConfigureAwait(false);
+            }
+            catch (SchedulerStartRefusedException)
+            {
+                // Refused before the job store set anything up, so starting again is safe once the
+                // caller has fixed the cause. Leaving the marker latched would send the retry down the
+                // "already started" path, skipping job recovery, the misfire handler and cluster
+                // check-in while still starting the acquire loop. Only this one exception un-latches: a
+                // failure further in may already have created those, and re-running would orphan them.
+                initialStart = null;
+                throw;
+            }
         }
         else
         {

--- a/src/Quartz/Core/SchedulerStartRefusedException.cs
+++ b/src/Quartz/Core/SchedulerStartRefusedException.cs
@@ -1,0 +1,35 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Core;
+
+/// <summary>
+/// Thrown by a job store that declines to start at all, before it has created anything. It is a
+/// <see cref="SchedulerException" /> to the caller; the distinct type only tells
+/// <see cref="QuartzScheduler.Start" /> that nothing was set up, so the start marker can be released
+/// and a corrected retry can run the full start-up sequence rather than the resume path.
+/// </summary>
+internal sealed class SchedulerStartRefusedException : SchedulerException
+{
+    internal SchedulerStartRefusedException(string message) : base(message)
+    {
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/AmbientConnection.cs
+++ b/src/Quartz/Impl/AdoJobStore/AmbientConnection.cs
@@ -1,0 +1,312 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Data.Common;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// Keeps track of the connection and transaction that the current asynchronous flow has enlisted
+/// for a given scheduler, so that <see cref="JobStoreSupport" /> can use the unit of work the
+/// application already owns instead of opening a connection of its own.
+/// </summary>
+/// <remarks>
+/// The state flows with <see cref="AsyncLocal{T}" />, the same mechanism that carries
+/// <see cref="System.Transactions.Transaction.Current" />. Entries form an immutable chain so that
+/// nested enlistments - possibly for different schedulers - restore the previous value when disposed.
+/// </remarks>
+/// <seealso cref="SchedulerEnlistmentExtensions" />
+internal static class AmbientConnection
+{
+    private static readonly AsyncLocal<EnlistedConnection?> current = new();
+
+    /// <summary>
+    /// Returns the connection enlisted for the given scheduler in the current asynchronous flow,
+    /// or <see langword="null" /> when there is none.
+    /// </summary>
+    internal static EnlistedConnection? Get(string schedulerName)
+    {
+        var entry = current.Value;
+        while (entry is not null)
+        {
+            if (!entry.Disposed && string.Equals(entry.SchedulerName, schedulerName, StringComparison.Ordinal))
+            {
+                return entry;
+            }
+
+            entry = entry.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Enlists the given connection and transaction for the given scheduler until the returned
+    /// scope is disposed.
+    /// </summary>
+    internal static IDisposable Enlist(
+        string schedulerName,
+        DbConnection connection,
+        DbTransaction? transaction,
+        System.Transactions.Transaction? ambient = null)
+    {
+        var entry = new EnlistedConnection(schedulerName, connection, transaction, current.Value, ambient);
+        current.Value = entry;
+        return new EnlistmentScope(entry);
+    }
+
+    /// <summary>
+    /// Hides every enlistment from the current asynchronous flow until the returned scope is
+    /// disposed. Used for work that belongs to the scheduler rather than to the caller - optional
+    /// column probing, cluster check-in, misfire recovery - which must run on a connection of its
+    /// own whatever the caller enlisted.
+    /// </summary>
+    /// <remarks>
+    /// Only the enlistment is hidden; keeping the connection the job store then opens out of an
+    /// ambient transaction is handled where that connection is opened, so it applies to every job
+    /// store connection and not just to suppressed work.
+    /// </remarks>
+    internal static IDisposable Suppress()
+    {
+        var previous = current.Value;
+        if (previous is null)
+        {
+            return NullScope.Instance;
+        }
+
+        current.Value = null;
+        return new SuppressionScope(previous);
+    }
+
+    private sealed class SuppressionScope : IDisposable
+    {
+        private readonly EnlistedConnection previous;
+        private bool disposed;
+
+        internal SuppressionScope(EnlistedConnection previous)
+        {
+            this.previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            current.Value = previous;
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        internal static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class EnlistmentScope : IDisposable
+    {
+        private readonly EnlistedConnection entry;
+
+        internal EnlistmentScope(EnlistedConnection entry)
+        {
+            this.entry = entry;
+        }
+
+        public void Dispose()
+        {
+            if (entry.Disposed)
+            {
+                return;
+            }
+
+            entry.Disposed = true;
+
+            // Only unwind when we are the innermost entry; out-of-order disposal leaves the chain alone
+            // and relies on the disposed flag to hide the entry from lookups.
+            if (ReferenceEquals(current.Value, entry))
+            {
+                current.Value = entry.Parent;
+            }
+
+            var flush = !entry.SignalOwnedByAmbient;
+
+            // Drop the references either way. A chain left in place by out-of-order disposal stays
+            // rooted in the execution context for the rest of the flow, and holding the application
+            // connection and transaction there would keep them alive with it.
+            entry.Detach();
+
+            if (flush)
+            {
+                try
+                {
+                    entry.FlushSignal();
+                }
+                catch (Exception)
+                {
+                    // Raising the signal is best effort. Letting it out of Dispose would replace
+                    // whatever exception the block was already unwinding with - typically the database
+                    // error the caller actually needs to see.
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+/// A connection and transaction that application code has enlisted for a scheduler, together with
+/// the scheduling change signal that is deferred until the enlistment ends.
+/// </summary>
+internal sealed class EnlistedConnection
+{
+    private readonly Lock signalLock = new();
+    private DateTimeOffset? pendingSignalTime;
+    private bool signalPending;
+    private Action<DateTimeOffset?>? signaler;
+    private int inUse;
+
+    private DbConnection? connection;
+    private DbTransaction? transaction;
+
+    internal EnlistedConnection(
+        string schedulerName,
+        DbConnection connection,
+        DbTransaction? transaction,
+        EnlistedConnection? parent,
+        System.Transactions.Transaction? ambient)
+    {
+        SchedulerName = schedulerName;
+        this.connection = connection;
+        this.transaction = transaction;
+        Parent = parent;
+        Ambient = ambient;
+    }
+
+    /// <summary>
+    /// Lets go of the connection and transaction once the enlistment ends, so they are not kept alive
+    /// by an entry that stays in the chain because the scopes were disposed out of order.
+    /// </summary>
+    internal void Detach()
+    {
+        connection = null;
+        transaction = null;
+    }
+
+    internal string SchedulerName { get; }
+
+    internal DbConnection Connection => connection!;
+
+    internal DbTransaction? Transaction => transaction;
+
+    /// <summary>
+    /// The ambient transaction the connection was enlisted under, when the caller supplied no
+    /// <see cref="DbTransaction" /> of its own. Kept so that a scope which has since ended can be
+    /// recognised instead of letting the operation quietly autocommit.
+    /// </summary>
+    internal System.Transactions.Transaction? Ambient { get; }
+
+    internal EnlistedConnection? Parent { get; }
+
+    internal bool Disposed { get; set; }
+
+    /// <summary>
+    /// Whether a post-commit signal has already been hooked onto the ambient transaction, so that a
+    /// scope containing many scheduling calls ends up with one handler rather than one per call.
+    /// </summary>
+    internal bool AmbientSignalHooked { get; set; }
+
+    /// <summary>
+    /// Whether an ambient transaction has taken over raising the deferred signal. It reports whether
+    /// the work actually committed, which disposing this scope cannot, so the scope stays quiet and
+    /// a rollback raises nothing.
+    /// </summary>
+    internal bool SignalOwnedByAmbient { get; set; }
+
+    /// <summary>
+    /// Claims the enlisted connection for one job store operation. A single connection cannot serve
+    /// two operations at once, so a second concurrent claim is refused with an explanation rather
+    /// than left to surface as a provider-specific "a command is already in progress".
+    /// </summary>
+    internal bool TryClaim() => Interlocked.CompareExchange(ref inUse, 1, 0) == 0;
+
+    internal void Release() => Interlocked.Exchange(ref inUse, 0);
+
+    /// <summary>
+    /// Remembers that the scheduler should be told about a scheduling change, but only once the
+    /// application has committed. Signalling while the rows are still uncommitted would send the
+    /// scheduler thread looking for a trigger it cannot see yet.
+    /// </summary>
+    internal void DeferSignal(DateTimeOffset? signalTime, Action<DateTimeOffset?> signalAction)
+    {
+        lock (signalLock)
+        {
+            signaler = signalAction;
+
+            if (!signalPending)
+            {
+                signalPending = true;
+                pendingSignalTime = signalTime;
+                return;
+            }
+
+            // Keep the earliest candidate. A null candidate means "recompute from scratch" and wins
+            // over any concrete time, since it makes the scheduler re-evaluate unconditionally.
+            if (signalTime is null || pendingSignalTime is null)
+            {
+                pendingSignalTime = null;
+            }
+            else if (signalTime < pendingSignalTime)
+            {
+                pendingSignalTime = signalTime;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fires the deferred scheduling change signal, if any. Called when the enlistment scope is
+    /// disposed, or by the ambient transaction once it reports that it committed.
+    /// </summary>
+    internal void FlushSignal()
+    {
+        Action<DateTimeOffset?>? signalAction;
+        DateTimeOffset? signalTime;
+        bool pending;
+        lock (signalLock)
+        {
+            signalAction = signaler;
+            signalTime = pendingSignalTime;
+            pending = signalPending;
+            signaler = null;
+            pendingSignalTime = null;
+            signalPending = false;
+        }
+
+        if (pending && signalAction is not null)
+        {
+            signalAction(signalTime);
+        }
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/ConnectionAndTransactionHolder.cs
+++ b/src/Quartz/Impl/AdoJobStore/ConnectionAndTransactionHolder.cs
@@ -38,6 +38,7 @@ public sealed class ConnectionAndTransactionHolder : IDisposable
 
     private readonly DbConnection connection;
     private DbTransaction? transaction;
+    private readonly bool ownsResources;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConnectionAndTransactionHolder"/> class.
@@ -45,10 +46,48 @@ public sealed class ConnectionAndTransactionHolder : IDisposable
     /// <param name="connection">The connection.</param>
     /// <param name="transaction">The transaction.</param>
     public ConnectionAndTransactionHolder(DbConnection connection, DbTransaction? transaction)
+        : this(connection, transaction, ownsResources: true)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionAndTransactionHolder"/> class.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="transaction">The transaction.</param>
+    /// <param name="ownsResources">
+    /// Whether this unit of work owns the connection and transaction. When <see langword="false" />
+    /// they belong to the caller, who enlisted them via
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistTransaction" />, and this holder will neither
+    /// commit, roll back, close nor dispose them.
+    /// </param>
+    /// <param name="borrowedFrom">
+    /// The enlistment the connection was borrowed from, so its single-use claim can be returned to
+    /// that exact entry when this unit of work is cleaned up.
+    /// </param>
+    internal ConnectionAndTransactionHolder(
+        DbConnection connection,
+        DbTransaction? transaction,
+        bool ownsResources,
+        EnlistedConnection? borrowedFrom = null)
     {
         this.connection = connection;
         this.transaction = transaction;
+        this.ownsResources = ownsResources;
+        BorrowedFrom = borrowedFrom;
     }
+
+    /// <summary>
+    /// Whether this unit of work owns the connection and the transaction. When it does not, the
+    /// application enlisted them and is responsible for committing, rolling back and disposing them.
+    /// </summary>
+    internal bool OwnsResources => ownsResources;
+
+    /// <summary>
+    /// The enlistment this unit of work borrowed its connection from, so that the claim is returned
+    /// to that exact entry rather than to whatever is enlisted by the time cleanup runs.
+    /// </summary>
+    internal EnlistedConnection? BorrowedFrom { get; }
 
     public DbConnection Connection => connection;
 
@@ -82,6 +121,12 @@ public sealed class ConnectionAndTransactionHolder : IDisposable
 
     public async ValueTask Commit(bool openNewTransaction, CancellationToken cancellationToken = default)
     {
+        if (!ownsResources)
+        {
+            // The application owns the transaction and decides when it commits.
+            return;
+        }
+
         if (transaction is not null)
         {
             try
@@ -104,6 +149,12 @@ public sealed class ConnectionAndTransactionHolder : IDisposable
 
     public async ValueTask Close(CancellationToken cancellationToken = default)
     {
+        if (!ownsResources)
+        {
+            // Borrowed connection, the application keeps using it after we are done.
+            return;
+        }
+
         try
         {
             await connection.CloseAsync().ConfigureAwait(false);
@@ -120,6 +171,14 @@ public sealed class ConnectionAndTransactionHolder : IDisposable
 
     public void Dispose()
     {
+        if (!ownsResources)
+        {
+            // Hand the enlistment back even when disposed directly rather than through
+            // CleanupConnection, or its single-use claim would stay held for the rest of the scope.
+            BorrowedFrom?.Release();
+            return;
+        }
+
         try
         {
             connection?.Dispose();
@@ -160,6 +219,13 @@ public sealed class ConnectionAndTransactionHolder : IDisposable
 
     public async ValueTask Rollback(bool transientError, CancellationToken cancellationToken = default)
     {
+        if (!ownsResources)
+        {
+            // The application owns the transaction; the failure propagates to it and it decides
+            // whether to roll back. Rolling back here would silently discard its work as well.
+            return;
+        }
+
         if (transaction is not null)
         {
             if (transaction.Connection is null)

--- a/src/Quartz/Impl/AdoJobStore/JobStoreCMT.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreCMT.cs
@@ -110,9 +110,18 @@ public class JobStoreCMT : JobStoreSupport
     /// <returns></returns>
     protected override async ValueTask<ConnectionAndTransactionHolder> GetNonManagedTXConnection(CancellationToken cancellationToken = default)
     {
+        var enlisted = await GetEnlistedConnection(cancellationToken).ConfigureAwait(false);
+        if (enlisted is not null)
+        {
+            return enlisted;
+        }
+
         DbConnection conn;
         try
         {
+            // Deliberately not kept out of an ambient transaction the way JobStoreSupport does it: this
+            // store exists precisely to run inside a transaction its container manages, so the
+            // connection auto-enlisting is the contract rather than an accident.
             conn = DbProvider.CreateConnection();
             if (OpenConnection)
             {
@@ -172,7 +181,24 @@ public class JobStoreCMT : JobStoreSupport
                 conn = await GetNonManagedTXConnection(cancellationToken).ConfigureAwait(false);
             }
 
-            return await txCallback(conn).ConfigureAwait(false);
+            var result = await txCallback(conn).ConfigureAwait(false);
+
+            // Only for a connection the application enlisted, and only for operations that took the
+            // lock - those are the ones that can have changed the schedule. There the change becomes
+            // visible when its owner commits, and the scheduler is otherwise notified solely before
+            // that - by QuartzScheduler, as soon as the store call returns - finds nothing, and waits
+            // out a whole idle interval. Signalling for reads as well would announce an unknown earlier
+            // time on every query and keep bouncing acquired triggers back to waiting, and deployments
+            // that never opted in must keep the behaviour they had, which for this store is no signal
+            // from here at all.
+            var sigTime = conn.SignalSchedulingChangeOnTxCompletion;
+            if (conn.BorrowedFrom is not null
+                && (sigTime is not null || lockName is not null && !LockAllOperations))
+            {
+                SignalSchedulingChangeOnApplicationCommit(conn, sigTime, cancellationToken);
+            }
+
+            return result;
         }
         finally
         {

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -108,6 +108,7 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         LockOnInsert = options.LockOnInsert;
         AcquireTriggersWithinLock = options.AcquireTriggersWithinLock;
         TxIsolationLevelSerializable = options.TxIsolationLevelSerializable;
+        AcceptEnlistedTransactions = options.AcceptEnlistedTransactions;
         DoubleCheckLockMisfireHandler = options.DoubleCheckLockMisfireHandler;
         MakeThreadsDaemons = options.MakeThreadsDaemons;
         PerformSchemaValidation = options.PerformSchemaValidation;
@@ -249,6 +250,35 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
     public bool UseDbLocks { get; set; }
 
     /// <summary>
+    /// Whether this instance may take part in a transaction the application owns, rather than always
+    /// managing an ADO.NET transaction of its own. Defaults to <see langword="false" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, the job store uses the connection the application enlisted with
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistTransaction" /> or
+    /// <see cref="SchedulerEnlistmentExtensions.EnlistConnection" /> for operations on that
+    /// asynchronous flow. The application owns the commit, so the job store neither commits nor rolls
+    /// back, and scheduling either happens together with the rest of the work or not at all.
+    /// </para>
+    /// <para>
+    /// Taking part always means handing over a connection. Operations with nothing enlisted keep using
+    /// a connection of the job store own, and for <see cref="JobStoreTX" /> that connection is
+    /// deliberately kept out of any ambient <see cref="System.Transactions.Transaction" />: joining a
+    /// scope whose outcome the job store does not control would also put a second connection in that
+    /// transaction, which needs a distributed transaction and is not available on every provider.
+    /// <see cref="JobStoreCMT" /> is the exception - running inside a transaction its container manages
+    /// is that store contract, so its connections enlist as they always have.
+    /// </para>
+    /// <para>
+    /// Because locks taken during an application-owned transaction are only released when that
+    /// transaction completes, enabling this switches locking to database locks
+    /// (<see cref="UseDbLocks" />) unless an explicit lock handler was configured.
+    /// </para>
+    /// </remarks>
+    public bool AcceptEnlistedTransactions { get; set; }
+
+    /// <summary>
     /// Whether or not to obtain locks when inserting new jobs/triggers.
     /// </summary>
     /// <remarks>
@@ -386,17 +416,148 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
     protected abstract ValueTask<ConnectionAndTransactionHolder> GetNonManagedTXConnection(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the connection the application enlisted for this scheduler on the current
+    /// asynchronous flow, or <see langword="null" /> when enlisted transactions are not accepted or
+    /// nothing is enlisted. The returned holder does not own the connection or the transaction.
+    /// </summary>
+    private protected async ValueTask<ConnectionAndTransactionHolder?> GetEnlistedConnection(CancellationToken cancellationToken = default)
+    {
+        var enlisted = AmbientConnection.Get(InstanceName);
+        if (enlisted is null)
+        {
+            return null;
+        }
+
+        // Refused rather than ignored. Ignoring it would commit the scheduling in a transaction of the
+        // store own while the caller believes it is part of theirs, and that only shows up later as a
+        // job firing for an entity the caller rolled back. This is also what covers schedulers the
+        // enlistment call site could not inspect, such as a decorator around the real one.
+        if (!AcceptEnlistedTransactions)
+        {
+            Throw.JobPersistenceException(
+                $"A connection is enlisted for scheduler '{InstanceName}', but it is not configured to take part in "
+                + "transactions the application owns, so this operation would commit on its own. Call "
+                + "AcceptEnlistedTransactions() when configuring the persistent store, or set "
+                + "'quartz.jobStore.acceptEnlistedTransactions' to true.");
+        }
+
+        // The enlisted transaction may have finished while its scope was still open - the application
+        // committed or rolled back, or its TransactionScope ended. Carrying on would run this
+        // operation in autocommit, where a half-finished write can no longer be rolled back, so refuse
+        // rather than quietly drop the transactional guarantee the caller asked for.
+        if (enlisted.Transaction is not null && enlisted.Transaction.Connection is null)
+        {
+            Throw.JobPersistenceException(
+                $"The transaction enlisted for scheduler '{InstanceName}' has already been committed or rolled back, "
+                + "so this operation would run with no transaction at all. Dispose the enlistment scope once the "
+                + "transaction completes, and enlist a new one for any further scheduling.");
+        }
+
+        // Compared with == rather than by reference: a dependent clone is a different object standing
+        // for the same transaction, and refusing those would break legitimate fan-out.
+        if (enlisted.Ambient is not null && enlisted.Ambient != System.Transactions.Transaction.Current)
+        {
+            Throw.JobPersistenceException(
+                $"The transaction the connection enlisted for scheduler '{InstanceName}' belongs to is no longer the "
+                + "current one, so this operation would run with no transaction at all. Keep the enlistment scope inside "
+                + "the transaction scope it was created in, and dispose it before that scope ends.");
+        }
+
+        var expected = DbProvider.Metadata.ConnectionType;
+        if (expected is not null && !expected.IsInstanceOfType(enlisted.Connection))
+        {
+            Throw.JobPersistenceException(
+                $"The connection enlisted for scheduler '{InstanceName}' is {enlisted.Connection.GetType().FullName}, but "
+                + $"this job store is configured for {expected.FullName}. A connection from a different provider cannot "
+                + "carry its commands - configure both against the same one.");
+        }
+
+        if (!enlisted.TryClaim())
+        {
+            Throw.JobPersistenceException(
+                $"The connection enlisted for scheduler '{InstanceName}' is already serving another job store operation. "
+                + "An enlisted connection carries a single transaction and cannot be used concurrently, so scheduler calls "
+                + "made inside an enlistment scope must be awaited one at a time.");
+        }
+
+        try
+        {
+            // Anything that is not open needs opening - Broken and Connecting are their own states, and
+            // handing a broken connection to the delegate produces a provider error instead of any of
+            // the diagnostics above.
+            if (enlisted.Connection.State != ConnectionState.Open)
+            {
+                if (enlisted.Connection.State != ConnectionState.Closed)
+                {
+                    await enlisted.Connection.CloseAsync().ConfigureAwait(false);
+                }
+
+                await enlisted.Connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is not a persistence failure, and callers match on it.
+            enlisted.Release();
+            throw;
+        }
+        catch (Exception e)
+        {
+            enlisted.Release();
+            Throw.JobPersistenceException($"Failed to open the connection enlisted for scheduler '{InstanceName}': {e}", e);
+        }
+
+        return new ConnectionAndTransactionHolder(enlisted.Connection, enlisted.Transaction, ownsResources: false, borrowedFrom: enlisted);
+    }
+
+    /// <summary>
+    /// Whether the current operation runs inside a transaction the application owns. That is the case
+    /// only when the application enlisted a connection: a connection the job store opens for itself
+    /// deliberately stays outside whatever the caller has in flight.
+    /// </summary>
+    private bool InApplicationOwnedTransaction =>
+        AcceptEnlistedTransactions && AmbientConnection.Get(InstanceName) is not null;
+
+    /// <summary>
+    /// Opens a connection that belongs to the job store.
+    /// </summary>
+    /// <remarks>
+    /// While <see cref="AcceptEnlistedTransactions" /> is on, such a connection is kept out of any
+    /// ambient <see cref="System.Transactions.Transaction" />. The application takes part by enlisting
+    /// a connection, not by the job store quietly joining a scope whose outcome it does not control;
+    /// letting it enlist would also put a second connection in that transaction, which needs a
+    /// distributed transaction and is not available on every provider.
+    /// </remarks>
+    private async ValueTask<DbConnection> OpenOwnConnection(CancellationToken cancellationToken)
+    {
+        using var ambientSuppression = AcceptEnlistedTransactions && System.Transactions.Transaction.Current is not null
+            ? new System.Transactions.TransactionScope(
+                System.Transactions.TransactionScopeOption.Suppress,
+                System.Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            : null;
+
+        var conn = DbProvider.CreateConnection();
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+    /// <summary>
     /// Gets the connection and starts a new transaction.
     /// </summary>
     /// <returns></returns>
     protected virtual async ValueTask<ConnectionAndTransactionHolder> GetConnection(CancellationToken cancellationToken = default)
     {
+        var enlisted = await GetEnlistedConnection(cancellationToken).ConfigureAwait(false);
+        if (enlisted is not null)
+        {
+            return enlisted;
+        }
+
         DbConnection conn;
         DbTransaction tx;
         try
         {
-            conn = DbProvider.CreateConnection();
-            await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+            conn = await OpenOwnConnection(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -542,6 +703,13 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
             }
         }
 
+        // The job store own connections still honour this; a connection the application enlisted was
+        // begun at whatever level the application chose, and cannot be changed after the fact.
+        if (AcceptEnlistedTransactions && TxIsolationLevelSerializable && Delegate is not SQLiteDelegate)
+        {
+            Logger.LogWarning("'quartz.jobStore.txIsolationLevelSerializable' applies only to connections the job store opens itself: an operation running on a connection enlisted by the application uses that transaction isolation level instead.");
+        }
+
         // If the user hasn't specified an explicit lock handler, then
         // choose one based on CMT/Clustered/UseDbLocks.
         if (LockHandler is null)
@@ -549,6 +717,14 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
             // If the user hasn't specified an explicit lock handler,
             // then we *must* use DB locks with clustering
             if (Clustered)
+            {
+                UseDbLocks = true;
+            }
+
+            // The same applies when the application owns the transaction: SimpleSemaphore releases its
+            // in-process lock as soon as our work is done, which is before the application has
+            // committed, so another caller could act on scheduling data that is not visible yet.
+            if (AcceptEnlistedTransactions)
             {
                 UseDbLocks = true;
             }
@@ -584,6 +760,22 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         }
         else
         {
+            // be ready to give a friendly warning if locks would be released before the application commits
+            if (AcceptEnlistedTransactions && !LockHandler.RequiresConnection)
+            {
+                if (LockHandler is SQLiteSemaphore)
+                {
+                    // SQLite gets this handler unconditionally, before the upgrade to database locks
+                    // can be applied, and it cannot be swapped for one - so this is a property of the
+                    // combination rather than something to reconfigure away.
+                    Logger.LogWarning("Accepting enlisted transactions with SQLite keeps in-process locking: SQLiteSemaphore releases the lock when the scheduling call returns, while the application transaction still holds the SQLite writer lock, so a concurrent scheduler operation can fail with 'database is locked' until that transaction completes. Keep enlisted transactions short, or use a database that supports row locking.");
+                }
+                else
+                {
+                    Logger.LogWarning("Accepting enlisted transactions with lock handler {LockHandlerType}, which does not lock in the database. Its locks are released before the application commits its transaction, so concurrent callers can act on scheduling data that is not visible to them yet.", LockHandler.GetType().Name);
+                }
+            }
+
             // A lock handler built by the container knows nothing about the store it locks for, so it
             // has to be told which tables to look in and whose rows they are. Without this it queries
             // QRTZ_LOCKS with a null scheduler name, whatever the store is actually configured with.
@@ -668,6 +860,24 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
     public virtual async ValueTask SchedulerStarted(
         CancellationToken cancellationToken = default)
     {
+        // Recovery below competes for the same TRIGGER_ACCESS lock that a scheduling call made earlier
+        // in this scope is still holding on the caller uncommitted transaction, and the caller cannot
+        // commit while awaiting Start(). That deadlock has no diagnostic of its own, so refuse the call
+        // instead of hanging. Nothing has been created yet, so the scheduler stays startable.
+        if (AcceptEnlistedTransactions && AmbientConnection.Get(InstanceName) is not null)
+        {
+            throw new Core.SchedulerStartRefusedException(
+                $"The scheduler '{InstanceName}' cannot be started from inside an enlistment scope: startup work waits for "
+                + "locks the enlisted transaction holds until the application commits, which it cannot do while starting. "
+                + "Start the scheduler outside the scope.");
+        }
+
+        // Everything below belongs to the scheduler, not to whoever called Start(). Suppressing here
+        // keeps job recovery and the first cluster check-in off an enlisted connection, and - because
+        // the misfire handler and cluster manager loops capture the execution context when they are
+        // started - keeps those loops from ever seeing an enlistment either.
+        using var suppression = AmbientConnection.Suppress();
+
         if (Clustered)
         {
             clusterManager = new ClusterManager(this);
@@ -3492,6 +3702,12 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
     /// </summary>
     public virtual async ValueTask TriggeredJobComplete(IOperableTrigger trigger, IJobDetail jobDetail, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default)
     {
+        // Completion bookkeeping belongs to the scheduler, not to the job, and it retries a failing
+        // JobPersistenceException until it succeeds. If a job body left an enlistment behind, this
+        // would borrow a connection whose transaction is long gone and retry against it forever,
+        // leaving the fired trigger uncleaned and its DisallowConcurrentExecution siblings blocked.
+        using var suppression = AmbientConnection.Suppress();
+
         await activityTracer.Trace(
             OperationName.JobStore.TriggeredJobComplete,
             () => RetryExecuteInNonManagedTXLock(
@@ -3633,6 +3849,10 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         Guid requestorId,
         CancellationToken cancellationToken = default)
     {
+        // Misfire recovery is the scheduler own work and commits on its own schedule, so it must not
+        // run inside a transaction the application owns.
+        using var suppression = AmbientConnection.Suppress();
+
         bool transOwner = false;
         ConnectionAndTransactionHolder? conn = null;
         try
@@ -3726,6 +3946,70 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         return schedSignaler.SignalSchedulingChange(candidateNewNextFireTime, cancellationToken);
     }
 
+    /// <summary>
+    /// Holds back a scheduling change signal until the transaction the application owns has completed.
+    /// Signalling while our rows are still uncommitted would send the scheduler thread looking for a
+    /// trigger it cannot see yet, and it would then wait out the idle interval before looking again.
+    /// </summary>
+    internal void SignalSchedulingChangeOnApplicationCommit(
+        ConnectionAndTransactionHolder conn,
+        DateTimeOffset? candidateNewNextFireTime,
+        CancellationToken cancellationToken)
+    {
+        void Signal(DateTimeOffset? signalTime)
+        {
+            // Fire and forget: the signaler only wakes the scheduler thread, and this runs from a
+            // transaction completion callback that has nothing to await it.
+            _ = SignalSchedulingChangeImmediately(signalTime, cancellationToken).AsTask();
+        }
+
+        var enlisted = conn.BorrowedFrom;
+        if (enlisted is null)
+        {
+            Signal(candidateNewNextFireTime);
+            return;
+        }
+
+        // Accumulate on the enlistment rather than in the handler, so every operation in the scope
+        // contributes and the earliest candidate wins. Capturing one operation time in a closure would
+        // let a later, sooner trigger go unannounced until the idle wait expired.
+        enlisted.DeferSignal(candidateNewNextFireTime, Signal);
+
+        // The transaction the enlistment was made under, not whatever is ambient now: an unrelated outer
+        // scope governs nothing here, and handing it the signal would drop it when that scope aborts.
+        var ambient = enlisted.Ambient;
+        if (ambient is null)
+        {
+            // A bare DbTransaction reports no outcome, so the enlistment scope disposal is the only
+            // moment we have; the caller is documented to dispose it after committing.
+            return;
+        }
+
+        // An ambient transaction does report its outcome, and reports it after the enlistment scope is
+        // disposed, so let it own the signal: nothing is raised when the application rolls back. Hooked
+        // once per enlistment - a scope that schedules hundreds of jobs would otherwise accumulate that
+        // many handlers and fire them all back to back, each able to knock the scheduler off its
+        // acquired triggers.
+        if (enlisted.AmbientSignalHooked)
+        {
+            return;
+        }
+
+        // Subscribe first: the add accessor throws once the transaction has been disposed, and latching
+        // the flags before that would leave neither the ambient flush nor the scope fallback able to
+        // raise the signal at all.
+        ambient.TransactionCompleted += (_, e) =>
+        {
+            if (e.Transaction?.TransactionInformation.Status == System.Transactions.TransactionStatus.Committed)
+            {
+                enlisted.FlushSignal();
+            }
+        };
+
+        enlisted.AmbientSignalHooked = true;
+        enlisted.SignalOwnedByAmbient = true;
+    }
+
     //---------------------------------------------------------------------------
     // Cluster management methods
     //---------------------------------------------------------------------------
@@ -3738,6 +4022,10 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
         Guid requestorId,
         CancellationToken cancellationToken = default)
     {
+        // Cluster check-in has to run in a transaction of its own to avoid deadlocking under recovery,
+        // so it must never borrow a connection the application enlisted.
+        using var suppression = AmbientConnection.Suppress();
+
         int maxRetries = MaxTransientRetries;
         int totalAttempts = maxRetries + 1;
         for (int attempt = 1; attempt <= totalAttempts; attempt++)
@@ -4205,6 +4493,11 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
     {
         if (conn is not null)
         {
+            // Hand the enlisted connection back so the next operation on this flow can claim it.
+            // Released through the holder rather than by looking the enlistment up again, which with
+            // nested scopes can resolve to a different entry than the one that was claimed.
+            conn.BorrowedFrom?.Release();
+
             await CloseConnection(conn, cancellationToken).ConfigureAwait(false);
         }
     }
@@ -4624,7 +4917,11 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
             }
         }
 
-        int maxRetries = MaxTransientRetries;
+        // Retrying inside a transaction the application owns is pointless and harmful: the first failure
+        // has already doomed that transaction on most providers, so a second attempt would only pile
+        // another error on top of it. Let the caller decide what to do instead.
+        bool applicationOwnedTransaction = InApplicationOwnedTransaction;
+        int maxRetries = applicationOwnedTransaction ? 0 : MaxTransientRetries;
         int totalAttempts = maxRetries + 1;
         for (int attempt = 1; attempt <= totalAttempts; attempt++)
         {
@@ -4672,7 +4969,23 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore
                 }
 
                 DateTimeOffset? sigTime = conn.SignalSchedulingChangeOnTxCompletion;
-                if (sigTime is not null)
+
+                // Arrange a signal for after the commit even when the job store did not ask for one:
+                // QuartzScheduler notifies the scheduler thread as soon as the store call returns, which
+                // here is still before the application commits, so that notification finds nothing and
+                // the thread settles down for a whole idle interval. Taking the lock stands in for "this
+                // may have changed the schedule" - doing it for reads as well would signal an unknown
+                // earlier time on every query and keep bouncing acquired triggers back to waiting. That
+                // proxy does not hold once LockAllOperations routes reads through the lock too, so there
+                // we fall back to an explicit request only.
+                // Asked of the holder rather than the registry: a subclass overriding GetConnection can
+                // return one it opened itself even while an enlistment exists on this flow.
+                if (conn.BorrowedFrom is not null
+                    && (sigTime is not null || lockName is not null && !LockAllOperations))
+                {
+                    SignalSchedulingChangeOnApplicationCommit(conn, sigTime, cancellationToken);
+                }
+                else if (sigTime is not null)
                 {
                     await SignalSchedulingChangeImmediately(sigTime, cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -12,6 +12,12 @@ public class DelegatingScheduler : IScheduler
         this.scheduler = scheduler;
     }
 
+    /// <summary>
+    /// The scheduler this one forwards to, so that code which needs the real scheduler - rather than
+    /// the behaviour a decorator adds - can reach it through however many layers are in the way.
+    /// </summary>
+    protected internal IScheduler InnerScheduler => scheduler;
+
     public string SchedulerName => scheduler.SchedulerName;
     public string SchedulerInstanceId => scheduler.SchedulerInstanceId;
     public SchedulerContext Context => scheduler.Context;

--- a/src/Quartz/SchedulerEnlistmentExtensions.cs
+++ b/src/Quartz/SchedulerEnlistmentExtensions.cs
@@ -1,0 +1,221 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Data.Common;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz;
+
+/// <summary>
+/// Lets application code hand its own ADO.NET connection and transaction to the persistent job
+/// store, so that scheduling operations take part in a unit of work the application already owns.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Requires the job store to be configured to accept enlisted transactions -
+/// <c>AcceptEnlistedTransactions</c> on the persistent store builder, or
+/// <c>quartz.jobStore.acceptEnlistedTransactions</c>. Without it the job store keeps opening its own
+/// connection and managing its own transaction, and enlisting throws rather than being ignored.
+/// </para>
+/// <para>
+/// Enlisting is the only way to take part: an ambient
+/// <see cref="System.Transactions.TransactionScope" /> on its own is not enough, because a
+/// connection the job store opens for itself is deliberately kept out of it. Open the connection
+/// inside the scope and enlist that, which also keeps the transaction from having to be promoted to
+/// a distributed one.
+/// </para>
+/// <para>
+/// The enlistment flows with the current asynchronous context, so it must be established in the
+/// same scope as the scheduler calls it should cover - the same rule that applies to
+/// <see cref="System.Transactions.TransactionScope" />, and for the same reason. In particular,
+/// establishing it inside an <c>async</c> helper does not carry it back out to the caller.
+/// </para>
+/// <para>
+/// While the enlistment is in effect the job store holds its locks in the caller's transaction, so
+/// they are only released once that transaction completes. Keep enlisted transactions short: a long
+/// running one blocks trigger acquisition, the misfire handler and cluster check-in.
+/// </para>
+/// <example>
+/// <code>
+/// await using var tx = await dbContext.Database.BeginTransactionAsync();
+/// dbContext.Add(entity);
+/// await dbContext.SaveChangesAsync();
+///
+/// using (scheduler.EnlistTransaction(tx.GetDbTransaction()))
+/// {
+///     await scheduler.ScheduleJob(job, trigger);
+///     await tx.CommitAsync();
+/// }
+/// </code>
+/// </example>
+/// </remarks>
+public static class SchedulerEnlistmentExtensions
+{
+    /// <summary>
+    /// Makes the persistent job store use the given transaction, and the connection it belongs to,
+    /// for every operation performed on the current asynchronous flow until the returned scope is
+    /// disposed.
+    /// </summary>
+    /// <param name="scheduler">The scheduler whose job store should join the transaction.</param>
+    /// <param name="transaction">The transaction to join. Must still be associated with a connection.</param>
+    /// <returns>
+    /// A scope that ends the enlistment when disposed. Dispose it after committing, so that any
+    /// scheduling change the job store recorded is signalled to the scheduler once it is visible.
+    /// </returns>
+    public static IDisposable EnlistTransaction(this IScheduler scheduler, DbTransaction transaction)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+        ArgumentNullException.ThrowIfNull(transaction);
+
+        var connection = transaction.Connection
+                         ?? throw new ArgumentException(
+                             "The transaction is not associated with a connection, it has already been committed, rolled back or disposed.",
+                             nameof(transaction));
+
+        var schedulerName = ResolveSchedulerName(scheduler, connection);
+
+        return AmbientConnection.Enlist(schedulerName, connection, transaction);
+    }
+
+    /// <summary>
+    /// Makes the persistent job store use the given connection, and optionally the given
+    /// transaction, for every operation performed on the current asynchronous flow until the
+    /// returned scope is disposed.
+    /// </summary>
+    /// <remarks>
+    /// Pass only a connection when the transaction is an ambient
+    /// <see cref="System.Transactions.TransactionScope" /> the connection is already enlisted in.
+    /// Sharing the one connection is what keeps such a scope from being promoted to a distributed
+    /// transaction, which providers like Npgsql do not support at all.
+    /// </remarks>
+    /// <param name="scheduler">The scheduler whose job store should use the connection.</param>
+    /// <param name="connection">The connection to use. Opened if it is not open already.</param>
+    /// <param name="transaction">The transaction to enlist in, if any.</param>
+    /// <returns>
+    /// A scope that ends the enlistment when disposed. Dispose it after committing, so that any
+    /// scheduling change the job store recorded is signalled to the scheduler once it is visible.
+    /// </returns>
+    public static IDisposable EnlistConnection(
+        this IScheduler scheduler,
+        DbConnection connection,
+        DbTransaction? transaction = null)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+        ArgumentNullException.ThrowIfNull(connection);
+
+        // A transaction from some other connection governs nothing here: providers take the
+        // connection's own transaction and ignore the one on the command, so every statement would
+        // commit on the spot while the caller believes rolling that transaction back undoes them.
+        if (transaction is not null && !ReferenceEquals(transaction.Connection, connection))
+        {
+            throw new ArgumentException(
+                "The transaction belongs to a different connection, so it would not govern anything the job store does on "
+                + "this one. Pass the transaction that was begun on this connection.",
+                nameof(transaction));
+        }
+
+        // With neither a transaction of its own nor an ambient one to enlist in, every statement the
+        // job store issues on this connection commits on the spot. That looks exactly like a working
+        // enlistment right up to the point where the caller rolls back and the job fires anyway.
+        if (transaction is null && System.Transactions.Transaction.Current is null)
+        {
+            throw new ArgumentException(
+                "The connection has no transaction to join: pass the DbTransaction, or call this from inside a "
+                + "TransactionScope created with TransactionScopeAsyncFlowOption.Enabled. Enlisting a connection with "
+                + "neither would let scheduling commit on its own.",
+                nameof(connection));
+        }
+
+        var schedulerName = ResolveSchedulerName(scheduler, connection);
+
+        // Remembered so a later operation can tell that the scope has since ended, instead of
+        // quietly running with no transaction at all.
+        return AmbientConnection.Enlist(
+            schedulerName,
+            connection,
+            transaction,
+            transaction is null ? System.Transactions.Transaction.Current : null);
+    }
+
+    /// <summary>
+    /// Fails fast when the job store would ignore the enlistment, and returns the name to register it
+    /// under. Without this the scheduling would quietly commit in a transaction of its own while the
+    /// caller believes it is part of theirs - the exact split unit of work these methods exist to
+    /// prevent, and one that only shows up as a job firing for an entity that was rolled back.
+    /// </summary>
+    private static string ResolveSchedulerName(IScheduler scheduler, DbConnection connection)
+    {
+        // Unwrap decorators - logging, tenant routing, metrics - so the checks below still apply behind
+        // one, and so the enlistment is keyed by the name the job store actually looks it up by rather
+        // than whatever the outermost wrapper calls itself.
+        var unwrapped = scheduler;
+        while (unwrapped is DelegatingScheduler delegating)
+        {
+            unwrapped = delegating.InnerScheduler;
+        }
+
+        // A scheduler this assembly did not build cannot be inspected here. A persistent ADO.NET store
+        // refuses an enlistment it cannot honour when it reaches one, so the mistake is still caught -
+        // just later, and only for that kind of store.
+        if (unwrapped is not StdScheduler local)
+        {
+            return unwrapped.SchedulerName;
+        }
+
+        IJobStore jobStore = local.scheduler.resources.JobStore;
+
+        if (jobStore is not JobStoreSupport adoJobStore)
+        {
+            throw new InvalidOperationException(
+                $"Scheduler '{scheduler.SchedulerName}' uses {jobStore.GetType().Name}, which does not store anything in the "
+                + "application's database, so the enlistment would be ignored and scheduling would survive a rollback. "
+                + "Taking part in the application's transaction requires a persistent ADO.NET job store.");
+        }
+
+        if (!adoJobStore.AcceptEnlistedTransactions)
+        {
+            throw new InvalidOperationException(
+                $"Scheduler '{scheduler.SchedulerName}' is not configured to take part in transactions the application owns, "
+                + "so the enlistment would be ignored and scheduling would commit on its own. Call "
+                + "AcceptEnlistedTransactions() when configuring the persistent store, or set "
+                + "'quartz.jobStore.acceptEnlistedTransactions' to true.");
+        }
+
+        // The job store builds its commands from its own configured provider, and assigning a
+        // connection of a different provider's type to one of those commands throws a cast error deep
+        // in the first statement, naming two identically-named connection types and nothing else.
+        var expected = adoJobStore.DbProvider.Metadata.ConnectionType;
+        if (expected is not null && !expected.IsInstanceOfType(connection))
+        {
+            throw new ArgumentException(
+                $"Scheduler '{scheduler.SchedulerName}' is configured with a data source that produces {expected.FullName} "
+                + $"({expected.Assembly.GetName().Name}), but the enlisted connection is {connection.GetType().FullName} "
+                + $"({connection.GetType().Assembly.GetName().Name}). The job store cannot use a connection from a "
+                + "different provider - configure both against the same one.",
+                nameof(connection));
+        }
+
+        return adoJobStore.InstanceName;
+    }
+}


### PR DESCRIPTION
Fixes #2038.

Ports the 3.x feature (#3204, merged) to 4.x, and adds the documentation for **both** lines — 3.x and 4.x — since the site is published from this branch. Merging #3204 into `3.x` did not close the issue, so this PR claims it.

## The problem

Scheduling cannot be made atomic with the application's own database work. `JobStoreSupport.GetConnection()` always opens a connection of its own and begins a transaction on it. Inside an ambient `TransactionScope` the freshly opened connection auto-enlists, and the `BeginTransaction` that follows is either rejected outright — Npgsql: *"A transaction is already in progress; nested/concurrent transactions aren't supported"* — or produces a local transaction that commits regardless of the scope's outcome. Even past that, a second connection forces promotion to a distributed transaction: MSDTC-only, Windows-only, and impossible with Npgsql.

## The change

Opt in with `AcceptEnlistedTransactions()` on the persistent store builder, `JobStore:AcceptEnlistedTransactions`, or `quartz.jobStore.acceptEnlistedTransactions`:

```csharp
builder.Services.AddQuartz(q =>
{
    q.UsePersistentStore(store =>
    {
        store.UsePostgres(connectionString);
        store.AcceptEnlistedTransactions();
    });
});
```

Then hand the job store a connection for the duration of a scope:

```csharp
await using var tx = await dbContext.Database.BeginTransactionAsync();

dbContext.Add(entity);
await dbContext.SaveChangesAsync();

using (scheduler.EnlistTransaction(tx.GetDbTransaction()))
{
    await scheduler.ScheduleJob(job, trigger);
    await tx.CommitAsync();
}
```

The application owns the commit, so the job store neither commits nor rolls back. The enlistment flows with the current asynchronous context, the same way `Transaction.Current` itself does, so nothing has to be resolved from the container — which is what made this intractable while `IJobStore` is a singleton and a `DbContext` is scoped. Nothing here is EF Core specific: any `DbConnection` and `DbTransaction` will do.

**Taking part always means handing over a connection.** An ambient `TransactionScope` on its own is not enough — for `JobStoreTX` a connection the job store opens for itself is deliberately kept *out* of one, since joining a scope whose outcome it does not control would also put a second connection in that transaction. Inside a `TransactionScope`, open the connection there and enlist it; sharing the one connection is what keeps the transaction local. `JobStoreCMT` is left alone — running inside a transaction its container manages is that store's whole contract.

## What differs from the 3.x version

Mostly mechanical adaptation — `ValueTask` and `CancellationToken` throughout, the sealed `ConnectionAndTransactionHolder`, `Quartz.Extensibility` rather than `Quartz.Spi`, and no optional-column probing or `RemoteScheduler` on this branch. Two things are genuinely different:

- **Configuration is DI-native.** `AdoJobStoreOptions.AcceptEnlistedTransactions`, a `QuartzPropertyBridge` mapping for the legacy property key, and `IPersistentStoreBuilder.AcceptEnlistedTransactions()` — main has no `SchedulerBuilder.PersistentStoreOptions`.
- **The job store itself refuses an enlistment it was not configured to accept**, rather than ignoring it. 3.x resolves a decorated scheduler through the process-wide `SchedulerRepository`; main has none, so the guarantee moved to where it cannot be bypassed. This is stricter than 3.x and worth backporting there.

`DelegatingScheduler` gained a `protected internal InnerScheduler`, so the call-site checks still apply behind a decorator.

## Supporting changes

- `ConnectionAndTransactionHolder` can hold borrowed resources, in which case commit, rollback, close and dispose are left to the owner. The new constructor and `OwnsResources` are internal.
- Locking moves to database locks unless a lock handler was configured explicitly — `SimpleSemaphore` releases its in-process lock before the application commits. SQLite cannot be upgraded this way and logs what that means.
- Scheduler-owned work — cluster check-in, misfire recovery, recovery at start, and completion bookkeeping after a job runs — never borrows the enlisted connection.
- Transient retries are skipped inside an application-owned transaction; on most providers the first failure has already doomed it.
- Write operations arrange a scheduling change signal for after the commit, accumulated on the enlistment so the earliest candidate across the scope wins, and hooked once per transaction. Reads do not signal. When the enlistment was made under an ambient transaction, that transaction owns the signal, so a rollback raises nothing.
- Misuse is refused rather than left to fail obscurely: a job store that cannot take part, a connection whose provider does not match the configured one, a transaction begun on a different connection, a connection with no transaction to join, a transaction that has since completed, an ambient scope that is no longer current, concurrent calls on one enlisted connection, and starting the scheduler from inside an enlistment scope — which deadlocks against the locks that scope holds.
- `QuartzScheduler.Start` releases its initial-start marker when, and only when, the job store declines to start before creating anything, so a corrected retry runs the full start-up sequence rather than the resume path.

## Trade-offs and known limits

- The job store takes its locks in the caller's transaction, so they are released only when that transaction completes. Long application transactions block trigger acquisition, the misfire handler and cluster check-in. Inherent to container-managed transactions; `LockOnInsert = false` mitigates it for insert-only workloads.
- No savepoint: an operation that fails halfway leaves its statements in the caller's transaction.
- A connection opened *before* the ambient scope it is enlisted under is not actually part of that scope, and ADO.NET offers no portable way to detect it. Open the connection inside the scope.
- The enlistment rides on `AsyncLocal`, so establishing it inside an `async` helper does not carry it back out to the caller — the same constraint `TransactionScope` has.
- Disposing an enlistment scope after a rollback still raises one scheduling-change signal, which costs the scheduler a look and nothing more.
- `StartDelayed` logs the start refusal rather than surfacing it, as it does for any start-up failure.
- Only the *first* `Start()` is refused inside an enlistment scope; resuming from standby is not, and the docs say so.
- A decorator that implements `IScheduler` directly rather than deriving from `DelegatingScheduler` bypasses the call-site checks. A persistent ADO.NET store still refuses the enlistment when it reaches one, so only a non-persistent store behind such a decorator goes unreported.
- Two schedulers enlisted on the *same* connection each hold their own claim, so the concurrency guard does not catch that combination.
- `CloseConnection` overrides in another assembly cannot tell a borrowed connection apart, since `OwnsResources` is internal.

## Testing

Unit tests cover borrowed-holder ownership, the enlistment flowing/nesting/expiring, isolation per scheduler and per async flow, forking inside a scope being refused, the completed-transaction and concurrent-use refusals, the store-does-not-accept refusal, suppression of scheduler-owned work, and that a job store connection stays out of an ambient scope.

Integration tests on PostgreSQL cover rollback discarding the schedule — asserting first that it *is* visible inside the transaction — commit keeping it, an incomplete `TransactionScope` discarding it, the refusal when the store is not configured for it, and two started-scheduler tests that assert the job fires promptly after the commit: one for a bare `DbTransaction` and one for an ambient `TransactionScope`, each with a two-minute idle wait and a 30-second assertion, so they only pass if the post-commit signal actually works.

Solution builds warning-free; 2000 unit tests and 58 `db-postgres` integration tests pass. The public API baseline and `changelog.md` are updated together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
