### PR TITLE
Give job instantiation failures a trigger to point at

### DIFF
--- a/src/Quartz.Tests.Unit/Core/JobInstantiationExceptionTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobInstantiationExceptionTest.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Specialized;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Quartz.Core;
+using Quartz.Impl;
+using Quartz.Listener;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// When a job cannot be instantiated there is no <see cref="IJobExecutionContext"/> yet, so
+/// <see cref="ISchedulerListener.SchedulerError"/> is the only notification the scheduler makes.
+/// These tests pin down that it carries enough to identify what failed (#3213).
+/// </summary>
+[NonParallelizable]
+public class JobInstantiationExceptionTest
+{
+    [Test]
+    public async Task FactoryThrowingPlainException_ReportsTriggerAndJobIdentity()
+    {
+        // The DI path: MicrosoftDependencyInjectionJobFactory lets ActivatorUtilities' own
+        // InvalidOperationException out unwrapped, so it lands in JobRunShell's generic catch.
+        InvalidOperationException cause = new InvalidOperationException("Unable to resolve service for type 'ITaskTracker'");
+
+        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(cause);
+
+        try
+        {
+            JobInstantiationException failure = reported.Should().BeOfType<JobInstantiationException>().Subject;
+
+            failure.Trigger.Key.Should().Be(new TriggerKey("trigger1", "instantiation"));
+            failure.JobDetail.Key.Should().Be(new JobKey("job1", "instantiation"));
+            failure.FireInstanceId.Should().NotBeNullOrEmpty();
+            failure.InnerException.Should().BeSameAs(cause);
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    [Test]
+    public async Task FactoryThrowingSchedulerException_KeepsOriginalAsInnerException()
+    {
+        // The non-DI path: SimpleJobFactory wraps whatever went wrong in a SchedulerException,
+        // so enriching only the generic catch would leave these users where they were.
+        SchedulerException cause = new SchedulerException("Problem instantiating class 'MyJob'", new MissingMethodException());
+
+        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(cause);
+
+        try
+        {
+            JobInstantiationException failure = reported.Should().BeOfType<JobInstantiationException>().Subject;
+
+            failure.Trigger.Key.Should().Be(new TriggerKey("trigger1", "instantiation"));
+            failure.InnerException.Should().BeSameAs(cause,
+                "the factory's own exception has to stay reachable, it says what actually went wrong");
+            failure.Message.Should().Be(cause.Message, "the reported message text is unchanged from before");
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    [Test]
+    public async Task FactoryThrowingOperationCanceled_LeavesTriggerOutOfErrorState()
+    {
+        // Shutdown races must not poison the schedule; only real failures set Error.
+        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(new OperationCanceledException());
+
+        try
+        {
+            reported.Should().BeOfType<JobInstantiationException>();
+
+            TriggerState state = await scheduler.GetTriggerState(new TriggerKey("trigger1", "instantiation"));
+            state.Should().NotBe(TriggerState.Error,
+                "a cancelled instantiation is not a configuration problem and must not require manual reset");
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    /// <summary>
+    /// Schedules a single job whose instantiation fails with <paramref name="cause"/> and returns the
+    /// exception handed to <see cref="ISchedulerListener.SchedulerError"/>. The scheduler is returned
+    /// still running so that trigger state can be inspected before shutdown.
+    /// </summary>
+    private static async Task<(SchedulerException Reported, IScheduler Scheduler)> RunFailingJob(Exception cause)
+    {
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+            ["quartz.scheduler.instanceName"] = "JobInstantiationExceptionTest",
+        };
+
+        IScheduler scheduler = await new StdSchedulerFactory(properties).GetScheduler();
+        scheduler.JobFactory = new ThrowingJobFactory(cause);
+
+        ErrorCapturingListener listener = new ErrorCapturingListener();
+        scheduler.ListenerManager.AddSchedulerListener(listener);
+
+        IJobDetail job = JobBuilder.Create<NeverRunsJob>()
+            .WithIdentity("job1", "instantiation")
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "instantiation")
+            .ForJob(job)
+            .StartNow()
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+        await scheduler.Start();
+
+        SchedulerException reported = await listener.WaitForError();
+        return (reported, scheduler);
+    }
+
+    private sealed class ThrowingJobFactory : IJobFactory
+    {
+        private readonly Exception cause;
+
+        public ThrowingJobFactory(Exception cause) => this.cause = cause;
+
+        public IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler) => throw cause;
+
+        public void ReturnJob(IJob job)
+        {
+        }
+    }
+
+    private sealed class ErrorCapturingListener : SchedulerListenerSupport
+    {
+        private readonly TaskCompletionSource<SchedulerException> reported =
+            new TaskCompletionSource<SchedulerException>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <remarks>
+        /// Task.WaitAsync would say this in one line, but the test project also targets net472.
+        /// </remarks>
+        public async Task<SchedulerException> WaitForError()
+        {
+            Task completed = await Task.WhenAny(reported.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+            completed.Should().BeSameAs(reported.Task, "the scheduler never reported an error");
+            return await reported.Task;
+        }
+
+        public override Task SchedulerError(string msg, SchedulerException cause, CancellationToken cancellationToken = default)
+        {
+            reported.TrySetResult(cause);
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class NeverRunsJob : IJob
+    {
+        public Task Execute(IJobExecutionContext context) => throw new InvalidOperationException("must never be constructed");
+    }
+}

--- a/src/Quartz/Core/JobInstantiationException.cs
+++ b/src/Quartz/Core/JobInstantiationException.cs
@@ -1,0 +1,47 @@
+using System;
+
+using Quartz.Spi;
+
+namespace Quartz.Core;
+
+/// <summary>
+/// Thrown when the <see cref="IJobFactory" /> cannot produce a job instance for a trigger that has
+/// already fired.
+/// </summary>
+/// <remarks>
+/// The failure happens before there is an <see cref="IJobExecutionContext" />, so no
+/// <see cref="ITriggerListener" /> or <see cref="IJobListener" /> callback can be raised for it and
+/// <see cref="ISchedulerListener.SchedulerError" /> is the only notification the scheduler makes.
+/// This exception carries the identity of what failed, so that a listener can act on it without
+/// parsing the message text.
+/// </remarks>
+public sealed class JobInstantiationException : SchedulerException
+{
+    internal JobInstantiationException(string message, TriggerFiredBundle bundle, Exception cause)
+        : base(message, cause)
+    {
+        Trigger = bundle.Trigger;
+        JobDetail = bundle.JobDetail;
+        FireInstanceId = bundle.Trigger.FireInstanceId;
+    }
+
+    /// <summary>
+    /// The trigger whose firing could not be served.
+    /// </summary>
+    /// <remarks>
+    /// Typed as <see cref="ITrigger" /> rather than <see cref="IOperableTrigger" />: this is here to
+    /// be read, and mutating the scheduler's trigger from an error handler is not supported.
+    /// </remarks>
+    public ITrigger Trigger { get; }
+
+    /// <summary>
+    /// The job that could not be instantiated.
+    /// </summary>
+    public IJobDetail JobDetail { get; }
+
+    /// <summary>
+    /// Identifies this particular firing, matching <see cref="IJobExecutionContext.FireInstanceId" />
+    /// of the execution that never started.
+    /// </summary>
+    public string FireInstanceId { get; }
+}

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -123,7 +123,10 @@ public class JobRunShell : SchedulerListenerSupport
         }
         catch (SchedulerException se)
         {
-            await qs!.NotifySchedulerListenersError($"An error occurred instantiating job to be executed. job='{jobDetail.Key}'", se, cancellationToken).ConfigureAwait(false);
+            // The factory said what went wrong; the exception handed to listeners adds which trigger
+            // and which firing it went wrong for, which the message text alone never carried.
+            JobInstantiationException failure = new JobInstantiationException(se.Message, firedTriggerBundle, se);
+            await qs!.NotifySchedulerListenersError($"An error occurred instantiating job to be executed. job='{jobDetail.Key}'", failure, cancellationToken).ConfigureAwait(false);
 
             IOperableTrigger errorTrigger = (IOperableTrigger) firedTriggerBundle.Trigger;
             SchedulerInstruction instruction = se.InnerException is ObjectDisposedException or OperationCanceledException
@@ -134,7 +137,7 @@ public class JobRunShell : SchedulerListenerSupport
         }
         catch (Exception e)
         {
-            SchedulerException se = new SchedulerException($"Problem instantiating type '{jobDetail.JobType.FullName}: {e.Message}'", e);
+            SchedulerException se = new JobInstantiationException($"Problem instantiating type '{jobDetail.JobType.FullName}: {e.Message}'", firedTriggerBundle, e);
             await qs!.NotifySchedulerListenersError($"An error occurred instantiating job to be executed. job='{jobDetail.Key}', message='{e.Message}'", se, cancellationToken).ConfigureAwait(false);
 
             IOperableTrigger errorTrigger = (IOperableTrigger) firedTriggerBundle.Trigger;


### PR DESCRIPTION
Closes #3213 for the 3.x line. Reported in #3211.

When `IJobFactory` cannot produce a job, the trigger has already fired and been committed to the job store, but there is no `IJobExecutionContext` yet — so no `ITriggerListener` or `IJobListener` callback can be raised. `ISchedulerListener.SchedulerError` is the only notification, and it carried the job key only as interpolated message text. The trigger key and fire instance id were nowhere at all, leaving callers to parse a string to find out which firing died.

That was a reasonable design when instantiation meant `Activator.CreateInstance` on a parameterless constructor and essentially could not fail. With container-built jobs it fails for ordinary application reasons.

### What changed

A new `Quartz.Core.JobInstantiationException : SchedulerException` carrying `Trigger`, `JobDetail` and `FireInstanceId` — the same shape as `JobExecutionProcessException` (#2762), which does the equivalent job for execution-time failures.

```csharp
public override Task SchedulerError(string msg, SchedulerException cause, CancellationToken ct = default)
{
    if (cause is JobInstantiationException failure)
    {
        tracker.MarkFailed(failure.Trigger.Key, failure.JobDetail.Key, failure.FireInstanceId);
    }

    return Task.CompletedTask;
}
```

`SchedulerError` already takes a `SchedulerException`, so this is additive.

Both catch blocks in `JobRunShell.Run` raise it:

* the generic `catch (Exception)` is the DI path — `MicrosoftDependencyInjectionJobFactory` overrides `InstantiateJob` and does not route through `SimpleJobFactory.InstantiateJobCore`, so `ActivatorUtilities`' `InvalidOperationException` arrives unwrapped;
* the `catch (SchedulerException)` is the non-DI path — `SimpleJobFactory` wraps its own failures. Enriching only the first would have left every non-DI user exactly where they were.

### Compatibility

Message text is byte-identical in both paths, including the long-standing misplaced quote in `Problem instantiating type 'X: msg'` — anything parsing it today keeps working while it migrates to the typed exception. `main` fixes that quote separately.

The one observable change: in the `SchedulerException` path the exception handed to listeners is now a `JobInstantiationException` wrapping the factory's exception rather than being it, so the original is reachable as `InnerException`. The choice between `NoInstruction` and `SetAllJobTriggersError` still tests the *original* exception, so cancellation and disposal races behave exactly as before.

### Tests

`JobInstantiationExceptionTest` covers the plain-exception path, the `SchedulerException` path including inner-exception preservation and unchanged message text, and that an `OperationCanceledException` still leaves the trigger out of the `Error` state.

Full unit suite green on net10.0 (1743 passed); test project also builds for net472.

New public type, so this wants a minor release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
