### PR TITLE
Give job instantiation failures a trigger to point at

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1231,8 +1231,19 @@
     scheduler can still be resolved to the real one. See
     [Joining an existing transaction](https://www.quartz-scheduler.net/documentation/quartz-4.x/tutorial/job-stores.html#joining-an-existing-transaction).
 
+### NEW FEATURES
+
+  * **JobInstantiationException** — when `IJobFactory` cannot produce a job, the trigger has already fired but
+    there is no `IJobExecutionContext` yet, so no `ITriggerListener` or `IJobListener` callback can be raised and
+    `ISchedulerListener.SchedulerError` is the only notification. It now receives a `JobInstantiationException`
+    carrying `Trigger`, `JobDetail` and `FireInstanceId`, so a listener can identify the firing that died without
+    parsing the message text. Additive — `SchedulerError` already took a `SchedulerException`. Mirrors what
+    `JobExecutionProcessException` does for execution-time failures (#3213)
+
 ### FIXES
 
+  * The "Problem instantiating type/class" messages closed their quote after the inner exception's message
+    rather than after the type name; they read `'TypeName': message` now
   * Fix for deserializing CronExpression using Json Serializer throwing error calling `GetNextValidTimeAfter`.  (#1996)
     `IDeserializationCallback` interface was removed from class `CronExpression` and the deserialization logic
     added to the constructor `CronExpression(SerializationInfo info, StreamingContext context)`.

--- a/src/Quartz.Tests.Unit/Core/JobInstantiationExceptionTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobInstantiationExceptionTest.cs
@@ -1,0 +1,152 @@
+using Quartz.Core;
+using Quartz.Extensibility;
+using Quartz.Listener;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// When a job cannot be instantiated there is no <see cref="IJobExecutionContext"/> yet, so
+/// <see cref="ISchedulerListener.SchedulerError"/> is the only notification the scheduler makes.
+/// These tests pin down that it carries enough to identify what failed (#3213).
+/// </summary>
+[NonParallelizable]
+public class JobInstantiationExceptionTest
+{
+    [Test]
+    public async Task FactoryThrowingPlainException_ReportsTriggerAndJobIdentity()
+    {
+        // The DI path: MicrosoftDependencyInjectionJobFactory lets ActivatorUtilities' own
+        // InvalidOperationException out unwrapped, so it lands in JobRunShell's generic catch.
+        InvalidOperationException cause = new InvalidOperationException("Unable to resolve service for type 'ITaskTracker'");
+
+        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(cause);
+
+        try
+        {
+            JobInstantiationException failure = reported.Should().BeOfType<JobInstantiationException>().Subject;
+
+            failure.Trigger.Key.Should().Be(new TriggerKey("trigger1", "instantiation"));
+            failure.JobDetail.Key.Should().Be(new JobKey("job1", "instantiation"));
+            failure.FireInstanceId.Should().NotBeNullOrEmpty();
+            failure.InnerException.Should().BeSameAs(cause);
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    [Test]
+    public async Task FactoryThrowingSchedulerException_KeepsOriginalAsInnerException()
+    {
+        // The non-DI path: SimpleJobFactory wraps whatever went wrong in a SchedulerException,
+        // so enriching only the generic catch would leave these users where they were.
+        SchedulerException cause = new SchedulerException("Problem instantiating class 'MyJob'", new MissingMethodException());
+
+        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(cause);
+
+        try
+        {
+            JobInstantiationException failure = reported.Should().BeOfType<JobInstantiationException>().Subject;
+
+            failure.Trigger.Key.Should().Be(new TriggerKey("trigger1", "instantiation"));
+            failure.InnerException.Should().BeSameAs(cause,
+                "the factory's own exception has to stay reachable, it says what actually went wrong");
+            failure.Message.Should().Be(cause.Message, "the reported message text is unchanged from before");
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    [Test]
+    public async Task FactoryThrowingOperationCanceled_LeavesTriggerOutOfErrorState()
+    {
+        // Shutdown races must not poison the schedule; only real failures set Error.
+        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(new OperationCanceledException());
+
+        try
+        {
+            reported.Should().BeOfType<JobInstantiationException>();
+
+            TriggerState state = await scheduler.GetTriggerState(new TriggerKey("trigger1", "instantiation"));
+            state.Should().NotBe(TriggerState.Error,
+                "a cancelled instantiation is not a configuration problem and must not require manual reset");
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    /// <summary>
+    /// Schedules a single job whose instantiation fails with <paramref name="cause"/> and returns the
+    /// exception handed to <see cref="ISchedulerListener.SchedulerError"/>. The scheduler is returned
+    /// still running so that trigger state can be inspected before shutdown.
+    /// </summary>
+    private static async Task<(SchedulerException Reported, IScheduler Scheduler)> RunFailingJob(Exception cause)
+    {
+        ErrorCapturingListener listener = new ErrorCapturingListener();
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .UseJobFactory(new ThrowingJobFactory(cause))
+            .BuildScheduler();
+
+        scheduler.ListenerManager.AddSchedulerListener(listener);
+
+        IJobDetail job = JobBuilder.Create<NeverRunsJob>()
+            .WithIdentity("job1", "instantiation")
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "instantiation")
+            .ForJob(job)
+            .StartNow()
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+        await scheduler.Start();
+
+        SchedulerException reported = await listener.Reported.WaitAsync(TimeSpan.FromSeconds(30));
+        return (reported, scheduler);
+    }
+
+    private sealed class ThrowingJobFactory : IJobFactory
+    {
+        private readonly Exception cause;
+
+        public ThrowingJobFactory(Exception cause) => this.cause = cause;
+
+        public ValueTask<JobScope> CreateJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
+        {
+            throw cause;
+        }
+
+        public ValueTask ReturnJob(JobScope scope, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class ErrorCapturingListener : SchedulerListenerSupport
+    {
+        private readonly TaskCompletionSource<SchedulerException> reported = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<SchedulerException> Reported => reported.Task;
+
+        public override ValueTask SchedulerError(
+            string message,
+            SchedulerException exception,
+            CancellationToken cancellationToken = default)
+        {
+            reported.TrySetResult(exception);
+            return default;
+        }
+    }
+
+    public sealed class NeverRunsJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("must never be constructed");
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1219,6 +1219,12 @@ namespace Quartz.Core
     {
         public Quartz.IJobExecutionContext JobExecutionContext { get; }
     }
+    public sealed class JobInstantiationException : Quartz.SchedulerException
+    {
+        public string FireInstanceId { get; }
+        public Quartz.IJobDetail JobDetail { get; }
+        public Quartz.ITrigger Trigger { get; }
+    }
 }
 namespace Quartz.Diagnostics
 {

--- a/src/Quartz/Core/JobInstantiationException.cs
+++ b/src/Quartz/Core/JobInstantiationException.cs
@@ -1,0 +1,45 @@
+using Quartz.Extensibility;
+
+namespace Quartz.Core;
+
+/// <summary>
+/// Thrown when the <see cref="IJobFactory" /> cannot produce a job instance for a trigger that has
+/// already fired.
+/// </summary>
+/// <remarks>
+/// The failure happens before there is an <see cref="IJobExecutionContext" />, so no
+/// <see cref="ITriggerListener" /> or <see cref="IJobListener" /> callback can be raised for it and
+/// <see cref="ISchedulerListener.SchedulerError" /> is the only notification the scheduler makes.
+/// This exception carries the identity of what failed, so that a listener can act on it without
+/// parsing the message text.
+/// </remarks>
+public sealed class JobInstantiationException : SchedulerException
+{
+    internal JobInstantiationException(string message, TriggerFiredBundle bundle, Exception cause)
+        : base(message, cause)
+    {
+        Trigger = bundle.Trigger;
+        JobDetail = bundle.JobDetail;
+        FireInstanceId = bundle.Trigger.FireInstanceId;
+    }
+
+    /// <summary>
+    /// The trigger whose firing could not be served.
+    /// </summary>
+    /// <remarks>
+    /// Typed as <see cref="ITrigger" /> rather than <see cref="IOperableTrigger" />: this is here to
+    /// be read, and mutating the scheduler's trigger from an error handler is not supported.
+    /// </remarks>
+    public ITrigger Trigger { get; }
+
+    /// <summary>
+    /// The job that could not be instantiated.
+    /// </summary>
+    public IJobDetail JobDetail { get; }
+
+    /// <summary>
+    /// Identifies this particular firing, matching <see cref="IJobExecutionContext.FireInstanceId" />
+    /// of the execution that never started.
+    /// </summary>
+    public string FireInstanceId { get; }
+}

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -117,7 +117,10 @@ internal sealed class JobRunShell
         }
         catch (SchedulerException se)
         {
-            await qs!.NotifySchedulerListenersError($"An error occurred instantiating job to be executed. job='{jobDetail.Key}'", se, cancellationToken).ConfigureAwait(false);
+            // The factory said what went wrong; the exception handed to listeners adds which trigger
+            // and which firing it went wrong for, which the message text alone never carried.
+            JobInstantiationException failure = new JobInstantiationException(se.Message, firedTriggerBundle, se);
+            await qs!.NotifySchedulerListenersError($"An error occurred instantiating job to be executed. job='{jobDetail.Key}'", failure, cancellationToken).ConfigureAwait(false);
 
             IOperableTrigger errorTrigger = (IOperableTrigger) firedTriggerBundle.Trigger;
             SchedulerInstruction instruction = se.InnerException is ObjectDisposedException or OperationCanceledException
@@ -316,7 +319,7 @@ internal sealed class JobRunShell
 
         async ValueTask NotifyInstantiationFailed(Exception e)
         {
-            SchedulerException se = new SchedulerException($"Problem instantiating type '{jobDetail.JobType.FullName}: {e.Message}'", e);
+            SchedulerException se = new JobInstantiationException($"Problem instantiating type '{jobDetail.JobType.FullName}': {e.Message}", firedTriggerBundle, e);
             await qs!.NotifySchedulerListenersError($"An error occurred instantiating job to be executed. job='{jobDetail.Key}', message='{e.Message}'", se, cancellationToken).ConfigureAwait(false);
 
             IOperableTrigger errorTrigger = (IOperableTrigger) firedTriggerBundle.Trigger;

--- a/src/Quartz/Impl/SimpleJobFactory.cs
+++ b/src/Quartz/Impl/SimpleJobFactory.cs
@@ -87,7 +87,7 @@ public class SimpleJobFactory : IJobFactory
         }
         catch (Exception e)
         {
-            SchedulerException se = new SchedulerException($"Problem instantiating class '{jobDetail.JobType.FullName}: {e.Message}'", e);
+            SchedulerException se = new SchedulerException($"Problem instantiating class '{jobDetail.JobType.FullName}': {e.Message}", e);
             throw se;
         }
     }


### PR DESCRIPTION
Closes #3213 for 4.x. Port of #3215. Reported in #3211.

When `IJobFactory` cannot produce a job, the trigger has already fired and been committed to the job store, but there is no `IJobExecutionContext` yet — so no `ITriggerListener` or `IJobListener` callback can be raised. `ISchedulerListener.SchedulerError` is the only notification, and it carried the job key only as interpolated message text, leaving callers to parse a string to find out which firing died.

### What changed

A new `Quartz.Core.JobInstantiationException : SchedulerException` carrying `Trigger`, `JobDetail` and `FireInstanceId` — the same shape as `JobExecutionProcessException`, which does the equivalent job for execution-time failures.

```csharp
public override ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken ct = default)
{
    if (exception is JobInstantiationException failure)
    {
        tracker.MarkFailed(failure.Trigger.Key, failure.JobDetail.Key, failure.FireInstanceId);
    }

    return default;
}
```

`SchedulerError` already takes a `SchedulerException`, so this is additive. Both catch blocks around the factory call raise it — the generic one is the DI path, where `ActivatorUtilities`' `InvalidOperationException` arrives unwrapped, and the `SchedulerException` one is the non-DI path, where `SimpleJobFactory` has already wrapped the failure.

### Divergence from the 3.x port

The `Problem instantiating type '{FullName}: {message}'` messages in `JobRunShell` and `SimpleJobFactory` both close their quote after the *inner exception's message* rather than after the type name. #3215 keeps them byte-identical because someone on 3.x is parsing them right now; here they read `'TypeName': message`. One changelog line under FIXES.

### Public API

`PublicApiTest_Quartz.verified.txt` gains exactly the new type and nothing else:

```
+    public sealed class JobInstantiationException : Quartz.SchedulerException
+    {
+        public string FireInstanceId { get; }
+        public Quartz.IJobDetail JobDetail { get; }
+        public Quartz.ITrigger Trigger { get; }
+    }
```

The 4.0.0 changelog had no `### NEW FEATURES` section; this adds one, since the entry is an addition rather than a break or a fix.

### Tests

`JobInstantiationExceptionTest` covers the plain-exception path, the `SchedulerException` path including inner-exception preservation and unchanged message text, and that an `OperationCanceledException` still leaves the trigger out of the `Error` state. Full unit suite green: 2003 passed.

The companion gap — nothing observes a trigger entering `TriggerState.Error`, from any path — is #3214 and comes next, on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
