### PR TITLE
Notify listeners when a trigger enters the Error state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1231,19 +1231,8 @@
     scheduler can still be resolved to the real one. See
     [Joining an existing transaction](https://www.quartz-scheduler.net/documentation/quartz-4.x/tutorial/job-stores.html#joining-an-existing-transaction).
 
-### NEW FEATURES
-
-  * **JobInstantiationException** — when `IJobFactory` cannot produce a job, the trigger has already fired but
-    there is no `IJobExecutionContext` yet, so no `ITriggerListener` or `IJobListener` callback can be raised and
-    `ISchedulerListener.SchedulerError` is the only notification. It now receives a `JobInstantiationException`
-    carrying `Trigger`, `JobDetail` and `FireInstanceId`, so a listener can identify the firing that died without
-    parsing the message text. Additive — `SchedulerError` already took a `SchedulerException`. Mirrors what
-    `JobExecutionProcessException` does for execution-time failures (#3213)
-
 ### FIXES
 
-  * The "Problem instantiating type/class" messages closed their quote after the inner exception's message
-    rather than after the type name; they read `'TypeName': message` now
   * Fix for deserializing CronExpression using Json Serializer throwing error calling `GetNextValidTimeAfter`.  (#1996)
     `IDeserializationCallback` interface was removed from class `CronExpression` and the deserialization logic
     added to the constructor `CronExpression(SerializationInfo info, StreamingContext context)`.

--- a/docs/documentation/quartz-3.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-3.x/packages/microsoft-di-integration.md
@@ -64,6 +64,53 @@ As of Quartz.NET 3.3.2 all jobs produced by the default job factory are scoped j
 By default Quartz will try to resolve job's type from container and if there's no explicit registration Quartz will use `ActivatorUtilities` to construct job and inject it's dependencies
 via constructor. Job should have only one public constructor.
 
+### Failing fast when job dependencies cannot be resolved
+
+`AddJob<T>()` does **not** register the job type with the container. It only describes the job to the
+scheduler, and the job factory falls back to `ActivatorUtilities` when the container has no
+registration for the type. That means `ValidateOnBuild` — which the host enables by default in the
+Development environment — never sees your job and never checks that its constructor can be satisfied.
+
+An unresolvable dependency therefore surfaces at fire time rather than at startup, as a failure to
+instantiate the job. The trigger has already fired at that point, so the job never runs and every
+trigger of that job is moved to `TriggerState.Error`, where it stays until
+`IScheduler.ResetTriggerFromErrorState` is called.
+
+Register your job types explicitly and startup validation covers them:
+
+```csharp
+services.AddScoped<SendReportsJob>();   // now ValidateOnBuild checks its constructor
+
+services.AddQuartz(q =>
+{
+    q.AddJob<SendReportsJob>(j => j.WithIdentity("send-reports"));
+});
+```
+
+If you need to react to such a failure at fire time rather than prevent it — to fail whatever
+scheduled the work, for instance — `ISchedulerListener.SchedulerError` receives a
+`JobInstantiationException` naming the trigger, the job and the fire instance:
+
+```csharp
+public class InstantiationFailureListener : SchedulerListenerSupport
+{
+    public override Task SchedulerError(string msg, SchedulerException cause, CancellationToken cancellationToken = default)
+    {
+        if (cause is JobInstantiationException failure)
+        {
+            logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}",
+                failure.JobDetail.Key, failure.Trigger.Key, failure.FireInstanceId);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+```
+
+To take part in construction itself — to record the failure, or to add context to it — derive from
+`MicrosoftDependencyInjectionJobFactory` and override `InstantiateJob`. The `TriggerFiredBundle` it
+receives carries the trigger, the job detail and `bundle.Trigger.FireInstanceId`.
+
 ### Persistent job stores
 
 The scheduling configuration will be checked against database and updated accordingly every time your application starts and schedule is being evaluated.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -661,6 +661,65 @@ unscheduled there is no trigger left to hand out.
 + ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default);
 ```
 
+### Instantiation failures name the trigger
+
+When `IJobFactory` cannot produce a job — a constructor dependency the container cannot resolve is the usual
+reason — the trigger has already fired, but there is no `IJobExecutionContext` yet, so no `ITriggerListener` or
+`IJobListener` callback can be raised. `SchedulerError` is the only notification, and it used to carry the job
+key as interpolated message text and the trigger nowhere at all.
+
+It now receives a `JobInstantiationException`:
+
+```csharp
+public override ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+{
+    if (exception is JobInstantiationException failure)
+    {
+        logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}",
+            failure.JobDetail.Key, failure.Trigger.Key, failure.FireInstanceId);
+    }
+
+    return default;
+}
+```
+
+Additive — `SchedulerError` already took a `SchedulerException` — and it mirrors what
+`JobExecutionProcessException` carries for execution-time failures. Both factory paths raise it: the container's,
+where `ActivatorUtilities` throws, and `SimpleJobFactory`'s, where the original failure arrives as the
+`InnerException`.
+
+The two messages reporting this also had their closing quote moved to where it belongs, from after the inner
+exception's message to after the type name: `Problem instantiating type 'MyNamespace.MyJob': message`. Code
+matching on that text should read the exception instead.
+
+To prevent the failure rather than observe it, see [failing fast when job dependencies cannot be
+resolved](packages/microsoft-di-integration.md#failing-fast-when-job-dependencies-cannot-be-resolved).
+
+### Triggers entering the error state are reported
+
+A trigger could be parked in `TriggerState.Error` with nothing observing it. The stores logged a line and moved
+on, so a trigger simply stopped working and the only way to find out was to poll `GetTriggerState` or read the
+log — and two of the ADO store's transitions, a job type that will not load while acquiring and a job that
+cannot be read back in `TriggersFired`, did not reach the scheduler at all.
+
+```csharp
+ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+```
+
+Following the singular/plural pair `ISchedulerListener` already has for pause and resume. Both are
+default-implemented, as are the matching `ISchedulerSignaler.NotifySchedulerListenersTriggerInError` and
+`NotifySchedulerListenersTriggersInError`, so an existing listener or signaler still compiles and behaves
+exactly as it does today — no notification.
+
+The plural is keyed by `JobKey` rather than by the individual triggers because `SetAllJobTriggersError` is one
+bulk statement in the persistent store, and enumerating the affected keys would mean an extra query on a failure
+path. Ask `GetTriggersOfJob` where the keys themselves matter.
+
+Neither carries a cause. The stores raise these and receive only a `SchedulerInstruction`; `SchedulerError` says
+*why* and these say *what changed*, and where both apply they arrive together. Recover a trigger with
+`IScheduler.ResetTriggerFromErrorState`.
+
 ### The broadcast listeners have one shape
 
 `BroadcastSchedulerListener.GetListeners()` is a `Listeners` property, matching `BroadcastJobListener` and
@@ -707,6 +766,8 @@ The cron expression parser now supports additional syntax:
 * **Paged, projected job store queries** — list and count jobs, triggers, groups and calendars a page at a time, with the metadata a listing needs already in the row (see [Job store listings became queries](#job-store-listings-became-queries))
 * **Job data by property name** — bind job data to the job property it is meant for instead of spelling its key (see [Job data can name the property](#job-data-can-name-the-property))
 * **`TriggerState.Executing`** — tell whether a trigger's job is running, across the whole cluster (see [Executing is a trigger state](#executing-is-a-trigger-state))
+* **`JobInstantiationException`** — a job that could not be built names the trigger, the job and the fire instance instead of only interpolating the job key into a message (see [Instantiation failures name the trigger](#instantiation-failures-name-the-trigger))
+* **`ISchedulerListener.TriggerInError` / `TriggersInError`** — observe a trigger being moved to `TriggerState.Error`, including two ADO store transitions that reached nothing at all before (see [Triggers entering the error state are reported](#triggers-entering-the-error-state-are-reported))
 
 ## Job data can name the property
 

--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -48,6 +48,56 @@ Quartz uses Microsoft's DI construction by default and the jobs produced by the 
 By default Quartz will try to resolve job's type from container and if there's no explicit registration Quartz will use `ActivatorUtilities` to construct job and inject it's dependencies
 via constructor. Job should have only one public constructor.
 
+### Failing fast when job dependencies cannot be resolved
+
+`AddJob<T>()` does **not** register the job type with the container. It only describes the job to the
+scheduler, and the job factory falls back to `ActivatorUtilities` when the container has no
+registration for the type. That means `ValidateOnBuild` — which the host enables by default in the
+Development environment — never sees your job and never checks that its constructor can be satisfied.
+
+An unresolvable dependency therefore surfaces at fire time rather than at startup, as a failure to
+instantiate the job. The trigger has already fired at that point, so the job never runs and every
+trigger of that job is moved to `TriggerState.Error`, where it stays until
+`IScheduler.ResetTriggerFromErrorState` is called.
+
+Register your job types explicitly and startup validation covers them:
+
+```csharp
+services.AddScoped<SendReportsJob>();   // now ValidateOnBuild checks its constructor
+
+services.AddQuartz(q =>
+{
+    q.AddJob<SendReportsJob>(j => j.WithIdentity("send-reports"));
+});
+```
+
+If you need to react to such a failure at fire time rather than prevent it — to fail whatever
+scheduled the work, for instance — `ISchedulerListener.SchedulerError` receives a
+`JobInstantiationException` naming the trigger, the job and the fire instance:
+
+```csharp
+public sealed class InstantiationFailureListener : SchedulerListenerSupport
+{
+    public override ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+    {
+        if (exception is JobInstantiationException failure)
+        {
+            logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}",
+                failure.JobDetail.Key, failure.Trigger.Key, failure.FireInstanceId);
+        }
+
+        return default;
+    }
+}
+```
+
+`ISchedulerListener.TriggersInError` is raised alongside it, and reports the same thing from the job
+store's side: every trigger of that job is now in the error state.
+
+To take part in construction itself — to record the failure, or to add context to it — derive from
+`MicrosoftDependencyInjectionJobFactory` and override `CreateJobInstance`. The `TriggerFiredBundle` it
+receives carries the trigger, the job detail and `bundle.Trigger.FireInstanceId`.
+
 ### Persistent job stores
 
 The scheduling configuration will be checked against database and updated accordingly every time your application starts and schedule is being evaluated.

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/TriggerInErrorNotificationAdoTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/TriggerInErrorNotificationAdoTest.cs
@@ -1,0 +1,122 @@
+using Npgsql;
+
+using Quartz.Extensibility;
+using Quartz.Listener;
+using Quartz.Tests.Integration.TestHelpers;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The persistent store's error notification, which the in-memory tests cannot cover: it is raised after
+/// the transaction commits rather than from inside the branch that writes the state, so the only way to
+/// know it survives the commit is to let a real transaction run (#3214).
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class TriggerInErrorNotificationAdoTest
+{
+    private const string SchedulerName = "TriggerInErrorAdoTest";
+
+    [TearDown]
+    public async Task CleanUpDatabaseState()
+    {
+        using NpgsqlConnection connection = new NpgsqlConnection(TestConstants.PostgresConnectionString);
+        await connection.OpenAsync();
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText =
+            "DELETE FROM qrtz_fired_triggers WHERE sched_name = @schedulerName;" +
+            "DELETE FROM qrtz_simple_triggers WHERE sched_name = @schedulerName;" +
+            "DELETE FROM qrtz_triggers WHERE sched_name = @schedulerName;" +
+            "DELETE FROM qrtz_job_details WHERE sched_name = @schedulerName;" +
+            "DELETE FROM qrtz_scheduler_state WHERE sched_name = @schedulerName;";
+        command.Parameters.AddWithValue("schedulerName", SchedulerName);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    [Test]
+    public async Task JobThatCannotBeInstantiated_NotifiesTriggersInError_AndLeavesErrorStateCommitted()
+    {
+        ErrorStateListener listener = new ErrorStateListener();
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .Configure(q =>
+            {
+                q.ConfigureScheduler(options =>
+                {
+                    options.InstanceName = SchedulerName;
+                    options.GenerateInstanceId = true;
+                });
+                q.UseDefaultThreadPool();
+                q.UseJobFactory(new ThrowingJobFactory());
+                q.UsePersistentStore(store =>
+                {
+                    store.UsePostgres(TestConstants.PostgresConnectionString);
+                    store.UseNewtonsoftJsonSerializer();
+                    store.Configure(options => options.TablePrefix = SchedulerHelper.TablePrefix);
+                });
+            })
+            .BuildScheduler();
+
+        TriggerKey triggerKey = new TriggerKey("trigger1", "errorstate");
+
+        try
+        {
+            scheduler.ListenerManager.AddSchedulerListener(listener);
+
+            IJobDetail job = JobBuilder.Create<NeverRunsJob>()
+                .WithIdentity("job1", "errorstate")
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            JobKey reported = await listener.JobTriggers.WaitAsync(TimeSpan.FromSeconds(60));
+            reported.Should().Be(new JobKey("job1", "errorstate"));
+
+            // Read back rather than trusting the notification: the point of raising it outside the
+            // transaction is that what it announces has actually been committed.
+            (await scheduler.GetTriggerState(triggerKey)).Should().Be(TriggerState.Error);
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    private sealed class ThrowingJobFactory : IJobFactory
+    {
+        public ValueTask<JobScope> CreateJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Unable to resolve service for type 'ITaskTracker'");
+        }
+
+        public ValueTask ReturnJob(JobScope scope, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class ErrorStateListener : SchedulerListenerSupport
+    {
+        private readonly TaskCompletionSource<JobKey> jobTriggers = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<JobKey> JobTriggers => jobTriggers.Task;
+
+        public override ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            jobTriggers.TrySetResult(jobKey);
+            return default;
+        }
+    }
+
+    public sealed class NeverRunsJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("must never be constructed");
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/TriggerInErrorNotificationTest.cs
+++ b/src/Quartz.Tests.Unit/Core/TriggerInErrorNotificationTest.cs
@@ -1,0 +1,192 @@
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Listener;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// A trigger can be parked in <see cref="TriggerState.Error"/> without anything observing it, which
+/// leaves it silently dead until someone polls its state or reads the log (#3214).
+/// </summary>
+[NonParallelizable]
+public class TriggerInErrorNotificationTest
+{
+    [Test]
+    public async Task JobThatCannotBeInstantiated_NotifiesTriggersInError()
+    {
+        ErrorStateListener listener = new ErrorStateListener();
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .UseJobFactory(new ThrowingJobFactory())
+            .BuildScheduler();
+
+        try
+        {
+            scheduler.ListenerManager.AddSchedulerListener(listener);
+
+            await ScheduleOneShot(scheduler, "job1", "trigger1");
+            await scheduler.Start();
+
+            JobKey reported = await listener.JobTriggers.WaitAsync(TimeSpan.FromSeconds(30));
+
+            reported.Should().Be(new JobKey("job1", "errorstate"),
+                "instantiation failure moves every trigger of the job to Error, so the notification is keyed by job");
+
+            TriggerState state = await scheduler.GetTriggerState(new TriggerKey("trigger1", "errorstate"));
+            state.Should().Be(TriggerState.Error, "the notification has to describe a state the store actually reached");
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    [Test]
+    public async Task NoFailure_RaisesNoErrorNotification()
+    {
+        ErrorStateListener listener = new ErrorStateListener();
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create().BuildScheduler();
+
+        try
+        {
+            scheduler.ListenerManager.AddSchedulerListener(listener);
+
+            await ScheduleOneShot(scheduler, "job1", "trigger1");
+            await scheduler.Start();
+
+            bool executed = HarmlessJob.Executed.Wait(TimeSpan.FromSeconds(30));
+            executed.Should().BeTrue("the job has to run before we can say nothing was reported");
+
+            listener.JobTriggers.IsCompleted.Should().BeFalse();
+            listener.SingleTrigger.IsCompleted.Should().BeFalse();
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    [Test]
+    public async Task SetTriggerError_NotifiesForThatTriggerAlone()
+    {
+        // SetTriggerError parks one trigger rather than the job's whole set, and the store is the only
+        // thing that knows it happened. Driven against the store directly: no scheduler instruction
+        // reaches this branch without a trigger implementation that asks for it.
+        CapturingSignaler signaler = new CapturingSignaler();
+        RAMJobStore store = TestJobStores.Ram(signaler);
+        await store.Initialize();
+        await store.SchedulerStarted(CancellationToken.None);
+
+        IJobDetail job = JobBuilder.Create<HarmlessJob>()
+            .WithIdentity("job1", "errorstate")
+            .StoreDurably()
+            .Build();
+
+        await store.AddJob(job, replace: false);
+
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("trigger1", "errorstate")
+            .ForJob(job)
+            .StartNow()
+            .Build();
+
+        trigger.ComputeFirstFireTimeUtc(null);
+        await store.AddTrigger(trigger, replace: false);
+
+        await store.TriggeredJobComplete(trigger, job, SchedulerInstruction.SetTriggerError);
+
+        signaler.Triggers.Should().ContainSingle().Which.Should().Be(new TriggerKey("trigger1", "errorstate"));
+        signaler.Jobs.Should().BeEmpty("only the one trigger moved");
+    }
+
+    [SetUp]
+    public void SetUp() => HarmlessJob.Executed.Reset();
+
+    private sealed class CapturingSignaler : ISchedulerSignaler
+    {
+        public List<TriggerKey> Triggers { get; } = [];
+
+        public List<JobKey> Jobs { get; } = [];
+
+        public ValueTask NotifyTriggerListenersMisfired(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask NotifySchedulerListenersFinalized(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask NotifySchedulerListenersJobDeleted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask SignalSchedulingChange(DateTimeOffset? candidateNewNextFireTimeUtc, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask NotifySchedulerListenersError(string message, SchedulerException exception, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask NotifySchedulerListenersTriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        {
+            Triggers.Add(triggerKey);
+            return default;
+        }
+
+        public ValueTask NotifySchedulerListenersTriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            Jobs.Add(jobKey);
+            return default;
+        }
+    }
+
+    private static async Task ScheduleOneShot(IScheduler scheduler, string jobName, string triggerName)
+    {
+        IJobDetail job = JobBuilder.Create<HarmlessJob>()
+            .WithIdentity(jobName, "errorstate")
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity(triggerName, "errorstate")
+            .ForJob(job)
+            .StartNow()
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+    }
+
+    private sealed class ThrowingJobFactory : IJobFactory
+    {
+        public ValueTask<JobScope> CreateJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Unable to resolve service for type 'ITaskTracker'");
+        }
+
+        public ValueTask ReturnJob(JobScope scope, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class ErrorStateListener : SchedulerListenerSupport
+    {
+        private readonly TaskCompletionSource<JobKey> jobTriggers = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<TriggerKey> singleTrigger = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<JobKey> JobTriggers => jobTriggers.Task;
+
+        public Task<TriggerKey> SingleTrigger => singleTrigger.Task;
+
+        public override ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            jobTriggers.TrySetResult(jobKey);
+            return default;
+        }
+
+        public override ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        {
+            singleTrigger.TrySetResult(triggerKey);
+            return default;
+        }
+    }
+
+    public sealed class HarmlessJob : IJob
+    {
+        public static readonly ManualResetEventSlim Executed = new(false);
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Executed.Set();
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -507,8 +507,10 @@ namespace Quartz
         System.Threading.Tasks.ValueTask SchedulerStarting(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask SchedulingDataCleared(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggerInError(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggerPaused(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggerResumed(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggersInError(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggersPaused(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggersResumed(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default);
     }
@@ -1424,6 +1426,8 @@ namespace Quartz.Extensibility
         System.Threading.Tasks.ValueTask NotifySchedulerListenersError(string message, Quartz.SchedulerException exception, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask NotifySchedulerListenersFinalized(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask NotifySchedulerListenersJobDeleted(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask NotifySchedulerListenersTriggerInError(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask NotifySchedulerListenersTriggersInError(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask NotifyTriggerListenersMisfired(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask SignalSchedulingChange(System.DateTimeOffset? candidateNewNextFireTimeUtc, System.Threading.CancellationToken cancellationToken = default);
     }
@@ -3022,8 +3026,10 @@ namespace Quartz.Listener
         public System.Threading.Tasks.ValueTask SchedulerStarting(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask SchedulingDataCleared(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerInError(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerPaused(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerResumed(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggersInError(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggersPaused(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggersResumed(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
     }
@@ -3077,8 +3083,10 @@ namespace Quartz.Listener
         public virtual System.Threading.Tasks.ValueTask SchedulerStarting(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask SchedulingDataCleared(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask TriggerInError(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask TriggerPaused(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask TriggerResumed(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask TriggersInError(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask TriggersPaused(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask TriggersResumed(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
     }

--- a/src/Quartz/Core/LazySchedulerSignaler.cs
+++ b/src/Quartz/Core/LazySchedulerSignaler.cs
@@ -48,6 +48,16 @@ internal sealed class LazySchedulerSignaler : ISchedulerSignaler
         return signaler.Value.NotifySchedulerListenersJobDeleted(jobKey, cancellationToken);
     }
 
+    public ValueTask NotifySchedulerListenersTriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        return signaler.Value.NotifySchedulerListenersTriggerInError(triggerKey, cancellationToken);
+    }
+
+    public ValueTask NotifySchedulerListenersTriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return signaler.Value.NotifySchedulerListenersTriggersInError(jobKey, cancellationToken);
+    }
+
     public ValueTask SignalSchedulingChange(DateTimeOffset? candidateNewNextFireTimeUtc, CancellationToken cancellationToken = default)
     {
         return signaler.Value.SignalSchedulingChange(candidateNewNextFireTimeUtc, cancellationToken);

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1890,6 +1890,50 @@ internal sealed class QuartzScheduler
     }
 
     /// <summary>
+    /// Notifies the scheduler listeners that a trigger has been parked in the error state.
+    /// </summary>
+    public async ValueTask NotifySchedulerListenersTriggerInError(
+        TriggerKey triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        var schedListeners = BuildSchedulerListenerList();
+
+        foreach (var sl in schedListeners)
+        {
+            try
+            {
+                await sl.TriggerInError(triggerKey, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error while notifying SchedulerListener of trigger in error state. Trigger={TriggerKey}", triggerKey);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Notifies the scheduler listeners that every trigger of a job has been parked in the error state.
+    /// </summary>
+    public async ValueTask NotifySchedulerListenersTriggersInError(
+        JobKey jobKey,
+        CancellationToken cancellationToken = default)
+    {
+        var schedListeners = BuildSchedulerListenerList();
+
+        foreach (var sl in schedListeners)
+        {
+            try
+            {
+                await sl.TriggersInError(jobKey, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error while notifying SchedulerListener of job triggers in error state. Job={JobKey}", jobKey);
+            }
+        }
+    }
+
+    /// <summary>
     /// Notifies the scheduler listeners about paused trigger.
     /// </summary>
     public async ValueTask NotifySchedulerListenersPausedTrigger(

--- a/src/Quartz/Core/SchedulerSignalerImpl.cs
+++ b/src/Quartz/Core/SchedulerSignalerImpl.cs
@@ -96,6 +96,20 @@ internal sealed class SchedulerSignalerImpl : ISchedulerSignaler
         return scheduler.NotifySchedulerListenersJobDeleted(jobKey, cancellationToken);
     }
 
+    public ValueTask NotifySchedulerListenersTriggerInError(
+        TriggerKey triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        return scheduler.NotifySchedulerListenersTriggerInError(triggerKey, cancellationToken);
+    }
+
+    public ValueTask NotifySchedulerListenersTriggersInError(
+        JobKey jobKey,
+        CancellationToken cancellationToken = default)
+    {
+        return scheduler.NotifySchedulerListenersTriggersInError(jobKey, cancellationToken);
+    }
+
     public ValueTask NotifySchedulerListenersError(
         string message,
         SchedulerException exception,

--- a/src/Quartz/Extensibility/ISchedulerSignaler.cs
+++ b/src/Quartz/Extensibility/ISchedulerSignaler.cs
@@ -52,6 +52,30 @@ public interface ISchedulerSignaler
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Notifies the scheduler that a trigger has been parked in the <see cref="TriggerState.Error" />
+    /// state and will not fire again until it is reset.
+    /// </summary>
+    /// <remarks>
+    /// Default-implemented as a no-op so that an existing signaler keeps compiling; a job store that
+    /// calls it against one gets today's behaviour, which is no notification at all.
+    /// </remarks>
+    ValueTask NotifySchedulerListenersTriggerInError(
+        TriggerKey triggerKey,
+        CancellationToken cancellationToken = default) => default;
+
+    /// <summary>
+    /// Notifies the scheduler that every trigger of a job has been parked in the
+    /// <see cref="TriggerState.Error" /> state.
+    /// </summary>
+    /// <remarks>
+    /// Default-implemented as a no-op, for the same reason as
+    /// <see cref="NotifySchedulerListenersTriggerInError" />.
+    /// </remarks>
+    ValueTask NotifySchedulerListenersTriggersInError(
+        JobKey jobKey,
+        CancellationToken cancellationToken = default) => default;
+
+    /// <summary>
     /// Signals the scheduling change.
     /// </summary>
     ValueTask SignalSchedulingChange(

--- a/src/Quartz/ISchedulerListener.cs
+++ b/src/Quartz/ISchedulerListener.cs
@@ -165,6 +165,37 @@ public interface ISchedulerListener
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Called by the <see cref="IScheduler" /> when a <see cref="ITrigger" /> has moved into the
+    /// <see cref="TriggerState.Error" /> state and will not fire again until it is reset with
+    /// <see cref="IScheduler.ResetTriggerFromErrorState" />.
+    /// </summary>
+    /// <remarks>
+    /// This says what changed, not why. Where a cause exists it arrives separately through
+    /// <see cref="SchedulerError" /> — as a <see cref="Core.JobInstantiationException" />, for a job
+    /// that could not be built. Some transitions have no scheduler-side cause at all: the job store
+    /// also parks a trigger here when it cannot load the job's type or read the job back.
+    /// <para>
+    /// The default implementation does nothing.
+    /// </para>
+    /// </remarks>
+    ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+
+    /// <summary>
+    /// Called by the <see cref="IScheduler" /> when every <see cref="ITrigger" /> of a job has moved
+    /// into the <see cref="TriggerState.Error" /> state, which is what a failure to instantiate the
+    /// job leads to.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by job rather than by trigger because that is the shape of the underlying operation —
+    /// the persistent store updates the job's triggers in one statement and never enumerates them.
+    /// Call <see cref="SchedulerQueryExtensions.GetTriggersOfJob" /> if the individual keys matter.
+    /// <para>
+    /// The default implementation does nothing.
+    /// </para>
+    /// </remarks>
+    ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+
+    /// <summary>
     /// Called by the <see cref="IScheduler" /> to inform the listener
     /// that it has move to standby mode.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -3307,6 +3307,11 @@ public abstract class JobStoreSupport : IJobStore
                         {
                             Logger.LogError(e, "Error retrieving job, setting trigger state to ERROR.");
                             await Delegate.UpdateTriggerState(conn, triggerKey, AdoConstants.StateError, cancellationToken).ConfigureAwait(false);
+
+                            // A trigger whose job type will not load stops firing here and is reported
+                            // nowhere else - not even through SchedulerError. Inline, as the misfire
+                            // notification in this store already is.
+                            await schedSignaler.NotifySchedulerListenersTriggerInError(triggerKey, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception ex)
                         {
@@ -3546,6 +3551,9 @@ public abstract class JobStoreSupport : IJobStore
             {
                 Logger.LogError(jpe, "Error retrieving job, setting trigger state to ERROR.");
                 await Delegate.UpdateTriggerState(conn, trigger.Key, AdoConstants.StateError, cancellationToken).ConfigureAwait(false);
+
+                // Same as above: the trigger stops here and nothing else says so.
+                await schedSignaler.NotifySchedulerListenersTriggerInError(trigger.Key, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception sqle)
             {
@@ -3710,6 +3718,17 @@ public abstract class JobStoreSupport : IJobStore
                 activity.SetTag(ActivityOptions.JobGroup, jobDetail.Key.Group);
                 activity.SetTag(ActivityOptions.JobName, jobDetail.Key.Name);
             }).ConfigureAwait(false);
+
+        // Deliberately after the transaction, and only if it committed: these run listener code, which
+        // has no business executing inside the store's transaction or seeing a state that may roll back.
+        if (triggerInstructionCode == SchedulerInstruction.SetTriggerError)
+        {
+            await schedSignaler.NotifySchedulerListenersTriggerInError(trigger.Key, cancellationToken).ConfigureAwait(false);
+        }
+        else if (triggerInstructionCode == SchedulerInstruction.SetAllJobTriggersError)
+        {
+            await schedSignaler.NotifySchedulerListenersTriggersInError(trigger.JobKey, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     protected virtual async ValueTask TriggeredJobComplete(

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -2379,6 +2379,11 @@ public class RAMJobStore : IJobStore
     /// </summary>
     public virtual async ValueTask TriggeredJobComplete(IOperableTrigger trigger, IJobDetail jobDetail, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default)
     {
+        // Which error notification the state changes below earned, raised once the lock is gone.
+        // Listener code runs on this thread and may well call back into the store, which would
+        // deadlock on the semaphore we are holding.
+        ErrorNotification errorNotification = ErrorNotification.None;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -2472,12 +2477,14 @@ public class RAMJobStore : IJobStore
                 {
                     logger.LogInformation("Trigger {TriggerKey} set to ERROR state.", trigger.Key);
                     tw.state = InternalTriggerState.Error;
+                    errorNotification = ErrorNotification.Trigger;
                     await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
                 }
                 else if (triggerInstructionCode == SchedulerInstruction.SetAllJobTriggersError)
                 {
                     logger.LogInformation("All triggers of Job {JobKey} set to ERROR state.", trigger.JobKey);
                     SetAllTriggersOfJobToState(trigger.JobKey, InternalTriggerState.Error);
+                    errorNotification = ErrorNotification.JobTriggers;
                     await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
                 }
                 else if (triggerInstructionCode == SchedulerInstruction.SetAllJobTriggersComplete)
@@ -2491,6 +2498,25 @@ public class RAMJobStore : IJobStore
         {
             lockObject.Release();
         }
+
+        if (errorNotification == ErrorNotification.Trigger)
+        {
+            await signaler.NotifySchedulerListenersTriggerInError(trigger.Key, cancellationToken).ConfigureAwait(false);
+        }
+        else if (errorNotification == ErrorNotification.JobTriggers)
+        {
+            await signaler.NotifySchedulerListenersTriggersInError(trigger.JobKey, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Which error notification a completed firing earned, deferred until the store's lock is released.
+    /// </summary>
+    private enum ErrorNotification
+    {
+        None,
+        Trigger,
+        JobTriggers
     }
 
     public TimeSpan EstimatedTimeToReleaseAndAcquireTrigger => TimeSpan.FromMilliseconds(5);

--- a/src/Quartz/Listener/BroadcastSchedulerListener.cs
+++ b/src/Quartz/Listener/BroadcastSchedulerListener.cs
@@ -134,6 +134,16 @@ public sealed class BroadcastSchedulerListener : ISchedulerListener
         return IterateListenersInGuard(l => l.TriggerPaused(triggerKey, cancellationToken), nameof(TriggerPaused));
     }
 
+    public ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        return IterateListenersInGuard(l => l.TriggerInError(triggerKey, cancellationToken), nameof(TriggerInError));
+    }
+
+    public ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+    {
+        return IterateListenersInGuard(l => l.TriggersInError(jobKey, cancellationToken), nameof(TriggersInError));
+    }
+
     public ValueTask TriggersResumed(string? triggerGroup, CancellationToken cancellationToken = default)
     {
         return IterateListenersInGuard(l => l.TriggersResumed(triggerGroup, cancellationToken), nameof(TriggerResumed));

--- a/src/Quartz/Listener/SchedulerListenerSupport.cs
+++ b/src/Quartz/Listener/SchedulerListenerSupport.cs
@@ -142,6 +142,20 @@ public abstract class SchedulerListenerSupport : ISchedulerListener
         return default;
     }
 
+    public virtual ValueTask TriggerInError(
+        TriggerKey triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        return default;
+    }
+
+    public virtual ValueTask TriggersInError(
+        JobKey jobKey,
+        CancellationToken cancellationToken = default)
+    {
+        return default;
+    }
+
     public virtual ValueTask SchedulerInStandbyMode(CancellationToken cancellationToken = default)
     {
         return default;


### PR DESCRIPTION
Closes #3214. Rebased onto `main` now that #3216 has merged; this is a single commit against it.

A trigger could be parked in `TriggerState.Error` with nothing observing it. The stores logged a line and moved on, so a trigger simply stopped working and the only way to find out was to poll `GetTriggerState` or read the log. Two of the ADO store's transitions — a job type that will not load while acquiring, and a job that cannot be read back in `TriggersFired` — never reached the scheduler at all, not even through `SchedulerError`.

### API

```csharp
ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default) => default;
```

Following the singular/plural pair `ISchedulerListener` already has for pause and resume. Both are default-implemented, as are the two matching `ISchedulerSignaler` members.

That last decision was made by the compiler: a plain interface addition broke five hand-written signaler doubles in this repo alone (`RAMJobStoreTest`, `NodeAffinityTest`, `UpdateTriggerDetailsTest`, `TestJobStores`, `RAMJobStoreBenchmark`), which says enough about what it would cost implementers. A signaler that does not implement them behaves exactly as it does today — no notification.

Two deliberate shapes:

* **Plural keyed by `JobKey`**, not by trigger group. `SetAllJobTriggersError` is one bulk `UPDATE ... WHERE job` in the persistent store; enumerating the affected keys would mean an extra `SELECT` on a failure path. Callers who need them can ask `GetTriggersOfJob`.
* **No `cause` parameter.** The stores raise these and only receive a `SchedulerInstruction`; threading an exception through would change `IJobStore.TriggeredJobComplete`. `SchedulerError` says *why* — now as a `JobInstantiationException` from #3216 — and this says *what changed*. Where both apply they arrive together.

### Where each store raises it

| Path | Notification | Raised |
|---|---|---|
| `RAMJobStore` `SetTriggerError` / `SetAllJobTriggersError` | `TriggerInError` / `TriggersInError` | after the semaphore is released |
| `JobStoreSupport` `SetTriggerError` / `SetAllJobTriggersError` | `TriggerInError` / `TriggersInError` | after the transaction commits |
| `JobStoreSupport` — job type fails to load while acquiring | `TriggerInError` | inline |
| `JobStoreSupport` — job cannot be read back in `TriggersFired` | `TriggerInError` | inline |

`RAMJobStore` records which notification the state change earned and raises it once its lock is gone: listener code runs on the calling thread and may well call back into the store, which would deadlock on the semaphore. The ADO store's `TriggeredJobComplete` notifies from the public wrapper after the transaction, so a listener never runs inside the store's transaction or sees state that may roll back.

The two acquisition-time transitions notify inline, because deferring them would mean threading state out through methods whose signatures are part of the extensibility surface — and this store already calls `NotifyTriggerListenersMisfired` inline from misfire handling, inside a transaction, so it is not a new kind of exposure.

### Tests

`TriggerInErrorNotificationTest` (unit) covers the instantiation-failure path end to end, the singular path driven against `RAMJobStore` directly, and that a healthy run reports nothing.

`TriggerInErrorNotificationAdoTest` (integration, `db-postgres`) covers the post-commit notification against a real database and reads the trigger state back rather than trusting the callback — the point of raising it outside the transaction is that what it announces has actually committed. Confirmed non-vacuous: it times out when the notification is removed.

Unit suite green: 2006 passed.

### Docs

Release notes live in the migration guide rather than `changelog.md`, so `docs/documentation/quartz-4.x/migration-guide.md` gets two new subsections under **Listener API Changes** — one for these two members, one for the `JobInstantiationException` of #3216 — and each is linked from the **New Features** list. The changelog entry #3216 added is removed here rather than joined, so 4.0's release notes have one home.

Both doc sets also get the trap behind #3211 written down: `AddJob<T>()` does not register the job type with the container, so `ValidateOnBuild` — on by default in Development — never validates its constructor, and an unresolvable dependency waits until fire time to show up. Register the job type explicitly and startup catches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
