### PR TITLE
Run unit tests on every framework, not just one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ The only documentation kept on this branch is the per-package NuGet README at `s
 - **This is a maintenance branch.** A removed member or a changed signature in one of these files is a breaking change for 3.x users, and needs an explicit justification — not a quiet re-baseline.
 - **Every packable project gets a baseline.** That is the 13 projects in `packTargetProjects` in `build/Build.cs`; add a test case when a package is added. The one deliberate exception is `Quartz.OpenTelemetry.Instrumentation`, whose `OpenTelemetry 0.6.0-beta.1` dependency cannot be referenced under warnings-as-errors (NU1608 ×2 and the NU1902 advisory GHSA-g94r-2vxg-569j).
 - **Baselines are taken on `net10.0` only** — the file is behind `#if NETCORE`. The `net472` build has a different surface (`REMOTING` adds `RemoteScheduler` and friends) and is deliberately not snapshotted.
-- Because `build/Build.cs` passes `--framework net8.0` on non-Windows, these tests effectively run on the **Windows CI leg only**. The output is platform-independent, so the guard still holds.
+- They run on every CI leg. `UnitTest` runs each test project once per target framework it declares, skipping `net4x` off Windows — so the baselines are taken on `net10.0` on Windows, Ubuntu and macOS alike, and the generated output is identical on all three.
 
 ### Comparing 3.x against main
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -129,21 +129,34 @@ partial class Build : FalloutBuild
         .After(Compile)
         .Executes(() =>
         {
-            var framework = "";
-            if (!IsRunningOnWindows)
+            var testProjects = new[] { "Quartz.Tests.Unit", "Quartz.Tests.AspNetCore" };
+
+            // Run each project once per target framework it declares, rather than forcing one
+            // framework on all of them. `dotnet test --framework X` against a project that does not
+            // target X exits 0 having run nothing, so a single shared value silently skipped whole
+            // projects instead of failing loudly. net4x needs the .NET Framework runtime, so it is
+            // the one framework that cannot run off Windows.
+            var testRuns = testProjects
+                .Select(x => Solution.GetAllProjects(x).First())
+                .SelectMany(project => project.GetTargetFrameworks()
+                    .Where(framework => IsRunningOnWindows || !framework.StartsWith("net4", StringComparison.Ordinal))
+                    .Select(framework => (Project: project, Framework: framework)))
+                .OrderBy(x => x.Project.Name).ThenBy(x => x.Framework)
+                .ToArray();
+
+            foreach (var (project, framework) in testRuns)
             {
-                framework = "net8.0";
+                Log.Information("Unit tests: {Project} ({Framework})", project.Name, framework);
             }
 
-            var testProjects = new[] { "Quartz.Tests.Unit", "Quartz.Tests.AspNetCore" };
             DotNetTest(s => s
                 .EnableNoRestore()
                 .EnableNoBuild()
                 .SetConfiguration(Configuration)
-                .SetFramework(framework)
                 .SetLoggers(GitHubActions.Instance is not null ? ["GitHubActions"] : [])
-                .CombineWith(testProjects, (_, testProject) => _
-                    .SetProjectFile(Solution.GetAllProjects(testProject).First())
+                .CombineWith(testRuns, (_, run) => _
+                    .SetProjectFile(run.Project)
+                    .SetFramework(run.Framework)
                 )
             );
         });


### PR DESCRIPTION
`UnitTest` picked one framework for all test projects and hardcoded `net8.0` off Windows. `Quartz.Tests.Unit` targets `net10.0;net472`, so it matched neither — and `dotnet test --framework X` against a project that does not target X **exits 0 having run nothing**:

```
> dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj --framework net8.0 --no-build
(no output)
EXIT CODE: 0
```

So the Ubuntu and macOS legs have been running only `Quartz.Tests.AspNetCore` — 116 tests. The 1753 in `Quartz.Tests.Unit`, including the public API baselines from #3226, were silently skipped on two of the three legs, and the green check said otherwise.

## The fix

Ask each project which frameworks it declares and run it once per framework, dropping `net4x` off Windows because it needs the .NET Framework runtime. Nothing else is filtered, so this stays correct when a project changes its TFMs instead of needing another hardcoded string — which is how the old value went stale in the first place.

Each run is logged before the tests start, so a framework quietly dropping out is visible rather than silent:

```
[INF] Unit tests: Quartz.Tests.AspNetCore (net8.0)
[INF] Unit tests: Quartz.Tests.Unit (net10.0)
[INF] Unit tests: Quartz.Tests.Unit (net472)
```

Also drops the now-wrong line in `AGENTS.md` saying the baselines effectively run on Windows only.

## Verification

- Windows, `.\build.cmd UnitTest`: all three runs execute and pass — `Quartz.Tests.Unit` net10.0 1753, net472 1742, `Quartz.Tests.AspNetCore` net8.0 116. Same coverage as before, now itemised.
- **Linux, in a `mcr.microsoft.com/dotnet/sdk:10.0` container: the full `Quartz.Tests.Unit` suite passes — 1750 tests, 0 failures.** This is the leg that has never actually run, so it seemed worth checking before asking CI.

Expect the Ubuntu and macOS legs on this PR to take roughly 30s longer, and to be meaningfully more useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
