### PR TITLE
Run unit tests on every framework, not just one

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -125,21 +125,34 @@ partial class Build : FalloutBuild, ICompile, IPack
         {
             var solution = ((IHasSolution) this).Solution;
             var configuration = ((ICompile) this).Configuration;
-            var framework = "";
-            if (!IsRunningOnWindows)
+            var testProjects = new[] { "Quartz.Tests.Unit", "Quartz.Tests.AspNetCore" };
+
+            // Run each project once per target framework it declares, rather than forcing one
+            // framework on all of them. `dotnet test --framework X` against a project that does not
+            // target X exits 0 having run nothing, so the hardcoded net8.0 meant the non-Windows
+            // legs ran no unit tests at all once everything moved to net10.0. net4x needs the .NET
+            // Framework runtime, so it is the one framework that cannot run off Windows.
+            var testRuns = testProjects
+                .Select(x => solution.GetAllProjects(x).First())
+                .SelectMany(project => project.GetTargetFrameworks()
+                    .Where(framework => IsRunningOnWindows || !framework.StartsWith("net4", StringComparison.Ordinal))
+                    .Select(framework => (Project: project, Framework: framework)))
+                .OrderBy(x => x.Project.Name).ThenBy(x => x.Framework)
+                .ToArray();
+
+            foreach (var (project, framework) in testRuns)
             {
-                framework = "net8.0";
+                Log.Information("Unit tests: {Project} ({Framework})", project.Name, framework);
             }
 
-            var testProjects = new[] { "Quartz.Tests.Unit", "Quartz.Tests.AspNetCore" };
             DotNetTest(s => s
                 .EnableNoRestore()
                 .EnableNoBuild()
                 .SetConfiguration(configuration)
-                .SetFramework(framework)
                 .SetLoggers(GitHubActions.Instance is not null ? ["GitHubActions"] : [])
-                .CombineWith(testProjects, (_, testProject) => _
-                    .SetProjectFile(solution.GetAllProjects(testProject).First())
+                .CombineWith(testRuns, (_, run) => _
+                    .SetProjectFile(run.Project)
+                    .SetFramework(run.Framework)
                 )
             );
         });


### PR DESCRIPTION
Companion to quartznet/quartznet#3228 on `3.x`. The bug is the same; the damage here is larger.

`UnitTest` picked one framework for all test projects and hardcoded `net8.0` off Windows. Everything on this branch is `net10.0`, so that value matches nothing — and `dotnet test --framework X` against a project that does not target X **exits 0 having run nothing**:

```
> dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj --framework net8.0 --no-build
(no output)
EXIT CODE: 0
```

So the Ubuntu and macOS legs of `pr-tests-unit` have been running **no unit tests at all**, and reporting green while doing it. Only `windows-latest` has been testing anything.

## The fix

Ask each project which frameworks it declares and run it once per framework, dropping `net4x` off Windows because it needs the .NET Framework runtime. Nothing else is filtered, so this stays correct when a project changes its TFMs instead of needing another hardcoded string — which is how the old value went stale in the first place. It also means the same code is correct on both branches, where the TFM sets differ.

Each run is logged before the tests start, so a framework quietly dropping out is visible rather than silent:

```
[INF] Unit tests: Quartz.Tests.AspNetCore (net10.0)
[INF] Unit tests: Quartz.Tests.Unit (net10.0)
```

## Verification

**Linux, in a `mcr.microsoft.com/dotnet/sdk:10.0` container: the full `Quartz.Tests.Unit` suite passes — 2020 tests, 0 failures.** Worth doing before asking CI, given these legs have never run.

One note for anyone reproducing that: mounting a Windows working tree into a Linux container fails `CronExpressionTest.CanGetExpressionSummary`, because the expected value is a source literal whose line endings come from checkout while `GetExpressionSummary` builds its output with `AppendLine`/`Environment.NewLine`. That is an artifact of CRLF-on-disk, not a bug — with LF sources, as `* text=auto` gives real CI, it passes. Nothing was changed for it.

Expect the Ubuntu and macOS legs on this PR to go from ~0s of testing to a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
