### PR TITLE
Keep [Serializable] only where a database blob needs it

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3255,8 +3255,8 @@ read back the way every other primitive can.
 
 `BinaryFormatter` is obsolete on .NET 8 (SYSLIB0051) and throws on .NET 9 and later, and Quartz 4 ships no
 binary serializer. The attributes that only `BinaryFormatter` ever read were still on 49 types — every
-exception, every matcher, the job execution context, the job detail. Sixteen of them keep the attributes;
-the other 33 lost them.
+exception, every matcher, the job execution context, the job detail. Nineteen of them keep the attributes;
+the other 30 lost them.
 
 The line is drawn at the database. A type keeps `[Serializable]`, `ISerializable` and `GetObjectData` when a
 job store blob can be made of it, so that a 3.x database whose blobs were written by `BinaryFormatter` stays
@@ -3265,7 +3265,7 @@ readable while you migrate it to JSON — see
 
 | Blob column | Types that keep the attributes |
 |---|---|
-| `JOB_DETAILS.JOB_DATA`, `TRIGGERS.JOB_DATA` | `JobDataMap`, `StringKeyDirtyFlagMap`, `DirtyFlagMap<TKey, TValue>` |
+| `JOB_DETAILS.JOB_DATA`, `TRIGGERS.JOB_DATA` | `JobDataMap`, `StringKeyDirtyFlagMap`, `DirtyFlagMap<TKey, TValue>`, `Key<T>`, `JobKey`, `TriggerKey` |
 | `CALENDARS.CALENDAR` | `BaseCalendar`, `AnnualCalendar`, `CronCalendar`, `DailyCalendar`, `HolidayCalendar`, `MonthlyCalendar`, `WeeklyCalendar`, `CronExpression` |
 | `BLOB_TRIGGERS.BLOB_DATA` | `AbstractTrigger`, `SimpleTriggerImpl`, `CronTriggerImpl`, `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` |
 
@@ -3279,7 +3279,6 @@ Everything else lost `[Serializable]`:
 |---|---|
 | Exceptions | `SchedulerException`, `JobExecutionException`, `JobPersistenceException`, `ObjectAlreadyExistsException`, `SchedulerConfigException`, `UnableToInterruptJobException`, `JsonSerializationException`, `LockException`, `NoSuchDelegateException`, `ValidationException` |
 | Matchers | `AndMatcher<TKey>`, `GroupMatcher<TKey>`, `KeyMatcher<TKey>`, `NameMatcher<TKey>`, `NotMatcher<TKey>`, `OrMatcher<TKey>`, `StringMatcher<TKey>`, `StringOperator` |
-| Keys | `Key<T>`, `JobKey`, `TriggerKey` |
 | Everything else | `JobType`, `SchedulerContext`, `JobExecutionContextImpl` |
 
 The `protected` / `public` `(SerializationInfo, StreamingContext)` constructors went with them, on
@@ -3288,11 +3287,14 @@ and `HttpClientException`. If you derive from one of those and forward a `Serial
 delete your constructor — the base class library's `Exception(SerializationInfo, StreamingContext)` is
 obsolete too, and nothing calls yours.
 
-`Key<T>` and its two subclasses are on the removed side even though a key can be a *value* inside a job data
-map. Quartz never puts one there itself: the recovery entries it writes are strings, and both `AbstractTrigger`
-and `JobDetailImpl` deliberately mark their key fields `[NonSerialized]` and serialize the name and group as
-separate strings. If your own job data holds a `JobKey` in a legacy binary blob, migrate that database to JSON
-on 3.x before upgrading.
+`Key<T>` and its two subclasses are on the keep side because a key can be a *value* inside a job data map. Quartz
+never puts one there itself — the recovery entries it writes are strings, and both `AbstractTrigger` and
+`JobDetailImpl` deliberately mark their key fields `[NonSerialized]` and serialize the name and group as separate
+strings — but a job data map holds arbitrary `object` values and serializes them all, so an application that did
+`jobDataMap.Put("parent", jobKey)` on 3.x has a `JobKey` sitting in its `JOB_DATA`. `BinaryFormatter` refuses to
+deserialize an instance whose type is not marked serializable, so removing the attribute would make that blob
+unreadable even through the compatibility package. Blob-reachable means what the graph *can* contain, not only
+what Quartz itself puts there.
 
 ## Other Breaking Changes
 
@@ -3403,7 +3405,6 @@ on 3.x before upgrading.
 | `JobBuilder<TJob>.Key` is public | Reports the identity the builder was given, or `null` when none was set, so a trigger registered alongside a job can agree with it |
 | `ISchedulerProxyFactory` and `HttpSchedulerProxyFactory` removed | Nothing read them — see [Remoting a scheduler is not a Quartz concern](#remoting-a-scheduler-is-not-a-quartz-concern) |
 | `quartz.scheduler.proxy*` and `quartz.scheduler.exporter*` are rejected | They were whitelisted but read by nobody; the exception names the replacement |
-| `[Serializable]` removed from 33 types | It stays only on the types a job store blob is made of — see [`[Serializable]` survives only where a database blob needs it](#serializable-survives-only-where-a-database-blob-needs-it) |
+| `[Serializable]` removed from 30 types | It stays only on the types a job store blob can be made of — see [`[Serializable]` survives only where a database blob needs it](#serializable-survives-only-where-a-database-blob-needs-it) |
 | The `(SerializationInfo, StreamingContext)` constructors removed | On `SchedulerException`, `JobPersistenceException`, `SchedulerConfigException`, `UnableToInterruptJobException` and `HttpClientException`. `BinaryFormatter` was their only caller, and the base class library's equivalent is obsolete |
-| `[Serializable]` removed from `Key<T>`, `JobKey` and `TriggerKey` | Quartz never writes a key into a blob: `AbstractTrigger` and `JobDetailImpl` mark their key fields `[NonSerialized]` and store the name and group as strings |
 | `[Serializable]` removed from `JobExecutionContextImpl` and `SchedulerContext` | Neither is persisted; `SchedulerContext` also lost its private deserialization constructor |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3251,6 +3251,49 @@ with a `QRTZ_FORCE_JOB_DATAMAP_DIRTY` entry: the entry is not copied, and the ne
 `StringKeyDirtyFlagMap` gained `GetDecimal` and `TryGetDecimal`, so a `decimal` in a job data map can now be
 read back the way every other primitive can.
 
+## `[Serializable]` survives only where a database blob needs it
+
+`BinaryFormatter` is obsolete on .NET 8 (SYSLIB0051) and throws on .NET 9 and later, and Quartz 4 ships no
+binary serializer. The attributes that only `BinaryFormatter` ever read were still on 49 types — every
+exception, every matcher, the job execution context, the job detail. Sixteen of them keep the attributes;
+the other 33 lost them.
+
+The line is drawn at the database. A type keeps `[Serializable]`, `ISerializable` and `GetObjectData` when a
+job store blob can be made of it, so that a 3.x database whose blobs were written by `BinaryFormatter` stays
+readable while you migrate it to JSON — see
+[Migrating from binary serialization](packages/json-serialization.md#migrating-from-binary-serialization).
+
+| Blob column | Types that keep the attributes |
+|---|---|
+| `JOB_DETAILS.JOB_DATA`, `TRIGGERS.JOB_DATA` | `JobDataMap`, `StringKeyDirtyFlagMap`, `DirtyFlagMap<TKey, TValue>` |
+| `CALENDARS.CALENDAR` | `BaseCalendar`, `AnnualCalendar`, `CronCalendar`, `DailyCalendar`, `HolidayCalendar`, `MonthlyCalendar`, `WeeklyCalendar`, `CronExpression` |
+| `BLOB_TRIGGERS.BLOB_DATA` | `AbstractTrigger`, `SimpleTriggerImpl`, `CronTriggerImpl`, `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` |
+
+A trigger reaches that third row when no trigger persistence delegate handles it — a type of your own, or one
+deriving from a built-in trigger with `HasAdditionalProperties` returning `true`. The store writes the whole
+object into `BLOB_TRIGGERS`, so the trigger class hierarchy is part of the blob graph.
+
+Everything else lost `[Serializable]`:
+
+| Where | Types |
+|---|---|
+| Exceptions | `SchedulerException`, `JobExecutionException`, `JobPersistenceException`, `ObjectAlreadyExistsException`, `SchedulerConfigException`, `UnableToInterruptJobException`, `JsonSerializationException`, `LockException`, `NoSuchDelegateException`, `ValidationException` |
+| Matchers | `AndMatcher<TKey>`, `GroupMatcher<TKey>`, `KeyMatcher<TKey>`, `NameMatcher<TKey>`, `NotMatcher<TKey>`, `OrMatcher<TKey>`, `StringMatcher<TKey>`, `StringOperator` |
+| Keys | `Key<T>`, `JobKey`, `TriggerKey` |
+| Everything else | `JobType`, `SchedulerContext`, `JobExecutionContextImpl` |
+
+The `protected` / `public` `(SerializationInfo, StreamingContext)` constructors went with them, on
+`SchedulerException`, `JobPersistenceException`, `SchedulerConfigException`, `UnableToInterruptJobException`
+and `HttpClientException`. If you derive from one of those and forward a `SerializationInfo` to the base,
+delete your constructor — the base class library's `Exception(SerializationInfo, StreamingContext)` is
+obsolete too, and nothing calls yours.
+
+`Key<T>` and its two subclasses are on the removed side even though a key can be a *value* inside a job data
+map. Quartz never puts one there itself: the recovery entries it writes are strings, and both `AbstractTrigger`
+and `JobDetailImpl` deliberately mark their key fields `[NonSerialized]` and serialize the name and group as
+separate strings. If your own job data holds a `JobKey` in a legacy binary blob, migrate that database to JSON
+on 3.x before upgrading.
+
 ## Other Breaking Changes
 
 | Change | Details |
@@ -3360,3 +3403,7 @@ read back the way every other primitive can.
 | `JobBuilder<TJob>.Key` is public | Reports the identity the builder was given, or `null` when none was set, so a trigger registered alongside a job can agree with it |
 | `ISchedulerProxyFactory` and `HttpSchedulerProxyFactory` removed | Nothing read them — see [Remoting a scheduler is not a Quartz concern](#remoting-a-scheduler-is-not-a-quartz-concern) |
 | `quartz.scheduler.proxy*` and `quartz.scheduler.exporter*` are rejected | They were whitelisted but read by nobody; the exception names the replacement |
+| `[Serializable]` removed from 33 types | It stays only on the types a job store blob is made of — see [`[Serializable]` survives only where a database blob needs it](#serializable-survives-only-where-a-database-blob-needs-it) |
+| The `(SerializationInfo, StreamingContext)` constructors removed | On `SchedulerException`, `JobPersistenceException`, `SchedulerConfigException`, `UnableToInterruptJobException` and `HttpClientException`. `BinaryFormatter` was their only caller, and the base class library's equivalent is obsolete |
+| `[Serializable]` removed from `Key<T>`, `JobKey` and `TriggerKey` | Quartz never writes a key into a blob: `AbstractTrigger` and `JobDetailImpl` mark their key fields `[NonSerialized]` and store the name and group as strings |
+| `[Serializable]` removed from `JobExecutionContextImpl` and `SchedulerContext` | Neither is persisted; `SchedulerContext` also lost its private deserialization constructor |

--- a/docs/documentation/quartz-4.x/packages/json-serialization.md
+++ b/docs/documentation/quartz-4.x/packages/json-serialization.md
@@ -94,10 +94,10 @@ Because the package does not change `BinaryFormatter`'s type identity, only your
 
 The package restores a working - but still unsafe - `BinaryFormatter`, so read the Microsoft
 guidance before relying on it and remove it once the migration is complete. The Quartz types a
-blob is made of - the job data maps, the calendars and the trigger classes - keep their
-`[Serializable]` / `ISerializable` support, so the hybrid serializer below can read the old
-binary payloads and write everything back as JSON. Types that were never part of a blob lost
-those attributes in 4.0; see
+blob can be made of - the job data maps, the keys that can sit in them as values, the calendars
+and the trigger classes - keep their `[Serializable]` / `ISerializable` support, so the hybrid
+serializer below can read the old binary payloads and write everything back as JSON. Types that
+could never be part of a blob lost those attributes in 4.0; see
 [the migration guide](../migration-guide.md#serializable-survives-only-where-a-database-blob-needs-it)
 for the full list.
 

--- a/docs/documentation/quartz-4.x/packages/json-serialization.md
+++ b/docs/documentation/quartz-4.x/packages/json-serialization.md
@@ -93,9 +93,13 @@ Because the package does not change `BinaryFormatter`'s type identity, only your
 ```
 
 The package restores a working - but still unsafe - `BinaryFormatter`, so read the Microsoft
-guidance before relying on it and remove it once the migration is complete. The Quartz types
-keep their `[Serializable]` / `ISerializable` support, so the hybrid serializer below can read
-the old binary payloads and write everything back as JSON.
+guidance before relying on it and remove it once the migration is complete. The Quartz types a
+blob is made of - the job data maps, the calendars and the trigger classes - keep their
+`[Serializable]` / `ISerializable` support, so the hybrid serializer below can read the old
+binary payloads and write everything back as JSON. Types that were never part of a blob lost
+those attributes in 4.0; see
+[the migration guide](../migration-guide.md#serializable-survives-only-where-a-database-blob-needs-it)
+for the full list.
 
 **Example hybrid serializer**
 

--- a/src/Quartz.HttpClient/HttpClient/HttpClientException.cs
+++ b/src/Quartz.HttpClient/HttpClient/HttpClientException.cs
@@ -1,5 +1,3 @@
-using System.Runtime.Serialization;
-
 namespace Quartz.HttpClient;
 
 public sealed class HttpClientException : SchedulerException
@@ -9,10 +7,6 @@ public sealed class HttpClientException : SchedulerException
     }
 
     public HttpClientException(string message, Exception? innerException) : base(message, innerException)
-    {
-    }
-
-    public HttpClientException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 }

--- a/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
@@ -151,6 +151,98 @@ public class LegacyJsonPayloadTest
         }
         """;
 
+    private const string LegacyJobDataMap =
+        """
+        {
+          "environment": "staging",
+          "retryCount": 3,
+          "threshold": 2.5,
+          "enabled": true,
+          "lastRunNote": null
+        }
+        """;
+
+    private const string LegacySimpleTrigger =
+        """
+        {
+          "TriggerType": "SimpleTrigger",
+          "Key": {
+            "Name": "SimpleTriggerKey",
+            "Group": "SimpleTriggerGroup"
+          },
+          "JobKey": {
+            "Name": "SimpleJob",
+            "Group": "SimpleJobGroup"
+          },
+          "Description": "SimpleTrigger description",
+          "CalendarName": "HolidayCalendar",
+          "JobDataMap": {
+            "environment": "staging",
+            "retryCount": 3,
+            "enabled": true
+          },
+          "MisfireInstruction": 1,
+          "StartTimeUtc": "2024-07-01T00:00:00.5+00:00",
+          "EndTimeUtc": "2024-07-02T00:00:01+00:00",
+          "Priority": 5,
+          "NextFireTimeUtc": "2024-07-01T03:32:06+00:00",
+          "PreviousFireTimeUtc": "2024-07-01T03:31:24+00:00",
+          "RepeatCount": 10,
+          "RepeatIntervalTimeSpan": "00:00:42",
+          "TimesTriggered": 3
+        }
+        """;
+
+    private const string LegacyCronTrigger =
+        """
+        {
+          "TriggerType": "CronTrigger",
+          "Key": {
+            "Name": "CronTriggerKey",
+            "Group": "CronTriggerGroup"
+          },
+          "JobKey": null,
+          "Description": "CronTrigger description",
+          "CalendarName": null,
+          "JobDataMap": {},
+          "MisfireInstruction": 2,
+          "StartTimeUtc": "2024-07-01T00:00:00+00:00",
+          "EndTimeUtc": null,
+          "Priority": 7,
+          "NextFireTimeUtc": "2024-07-01T03:35:00+00:00",
+          "PreviousFireTimeUtc": null,
+          "CronExpressionString": "0 0/5 * * * ?",
+          "TimeZone": "UTC"
+        }
+        """;
+
+    private const string LegacyCalendarIntervalTrigger =
+        """
+        {
+          "TriggerType": "CalendarIntervalTrigger",
+          "Key": {
+            "Name": "CalendarIntervalTriggerKey",
+            "Group": "CalendarIntervalTriggerGroup"
+          },
+          "JobKey": null,
+          "Description": "CalendarIntervalTrigger description",
+          "CalendarName": null,
+          "JobDataMap": {},
+          "MisfireInstruction": 0,
+          "StartTimeUtc": "2024-07-01T00:00:00+00:00",
+          "EndTimeUtc": null,
+          "Priority": 5,
+          "NextFireTimeUtc": "2024-09-01T00:00:00+00:00",
+          "PreviousFireTimeUtc": "2024-07-01T00:00:00+00:00",
+          "RepeatInterval": 2,
+          "RepeatIntervalUnit": "Month",
+          "TimeZone": "UTC",
+          "PreserveHourOfDayAcrossDaylightSavings": true,
+          "SkipDayIfHourDoesNotExist": false,
+          "TimesTriggered": 6
+        }
+        """;
+
     private const string LegacyDailyTimeIntervalTrigger =
         """
         {
@@ -248,6 +340,66 @@ public class LegacyJsonPayloadTest
         var calendar = Deserialize<CronCalendar>(LegacyCronCalendar);
 
         calendar.CronExpression.CronExpressionString.Should().Be("0/5 * * * * ?");
+    }
+
+    [Test]
+    public void JobDataMapStillReadsTheBlobTheJobDataColumnHolds()
+    {
+        var map = Deserialize<JobDataMap>(LegacyJobDataMap);
+
+        map.GetString("environment").Should().Be("staging");
+        map.GetInt("retryCount").Should().Be(3);
+        map.GetDouble("threshold").Should().Be(2.5);
+        map.GetBoolean("enabled").Should().BeTrue();
+        map["lastRunNote"].Should().BeNull();
+        map.Dirty.Should().BeFalse("a map loaded from the store has not been modified since it was written");
+    }
+
+    [Test]
+    public void SimpleTriggerStillReadsItsUnchangedPayload()
+    {
+        var trigger = Deserialize<IOperableTrigger>(LegacySimpleTrigger);
+
+        var simple = trigger.Should().BeOfType<SimpleTriggerImpl>().Subject;
+        simple.Key.Should().Be(new TriggerKey("SimpleTriggerKey", "SimpleTriggerGroup"));
+        simple.JobKey.Should().Be(new JobKey("SimpleJob", "SimpleJobGroup"));
+        simple.CalendarName.Should().Be("HolidayCalendar");
+        simple.RepeatCount.Should().Be(10);
+        simple.RepeatInterval.Should().Be(TimeSpan.FromSeconds(42));
+        simple.TimesTriggered.Should().Be(3);
+        simple.MisfireInstruction.Should().Be(MisfireInstruction.SimpleTrigger.FireNow);
+        simple.NextFireTimeUtc.Should().Be(new DateTimeOffset(2024, 7, 1, 3, 32, 6, TimeSpan.Zero));
+
+        simple.JobDataMap.GetString("environment").Should().Be("staging");
+        simple.JobDataMap.GetInt("retryCount").Should().Be(3);
+        simple.JobDataMap.GetBoolean("enabled").Should().BeTrue();
+    }
+
+    [Test]
+    public void CronTriggerStillReadsItsUnchangedPayload()
+    {
+        var trigger = Deserialize<IOperableTrigger>(LegacyCronTrigger);
+
+        var cron = trigger.Should().BeOfType<CronTriggerImpl>().Subject;
+        cron.Key.Should().Be(new TriggerKey("CronTriggerKey", "CronTriggerGroup"));
+        cron.CronExpressionString.Should().Be("0 0/5 * * * ?");
+        cron.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        cron.Priority.Should().Be(7);
+        cron.MisfireInstruction.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
+        cron.EndTimeUtc.Should().BeNull();
+    }
+
+    [Test]
+    public void CalendarIntervalTriggerStillReadsItsUnchangedPayload()
+    {
+        var trigger = Deserialize<IOperableTrigger>(LegacyCalendarIntervalTrigger);
+
+        var calendarInterval = trigger.Should().BeOfType<CalendarIntervalTriggerImpl>().Subject;
+        calendarInterval.RepeatInterval.Should().Be(2);
+        calendarInterval.RepeatIntervalUnit.Should().Be(IntervalUnit.Month);
+        calendarInterval.PreserveHourOfDayAcrossDaylightSavings.Should().BeTrue();
+        calendarInterval.SkipDayIfHourDoesNotExist.Should().BeFalse();
+        calendarInterval.TimesTriggered.Should().Be(6);
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
@@ -4,7 +4,6 @@ namespace Quartz.HttpClient
     public sealed class HttpClientException : Quartz.SchedulerException
     {
         public HttpClientException(string message) { }
-        public HttpClientException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public HttpClientException(string message, System.Exception? innerException) { }
     }
     public class HttpScheduler : Quartz.IScheduler

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -632,7 +632,6 @@ namespace Quartz
         public void PutAsString<T>(string key, T value)
             where T : System.IConvertible { }
     }
-    [System.Serializable]
     public sealed class JobExecutionException : Quartz.SchedulerException
     {
         public JobExecutionException() { }
@@ -671,17 +670,14 @@ namespace Quartz
         public bool PersistJobDataAfterExecution { get; init; }
         public bool RequestsRecovery { get; init; }
     }
-    [System.Serializable]
     public sealed class JobKey : Quartz.Key<Quartz.JobKey>
     {
         public JobKey(string name) { }
         public JobKey(string name, string group) { }
     }
-    [System.Serializable]
     public class JobPersistenceException : Quartz.SchedulerException
     {
         public JobPersistenceException(string message) { }
-        protected JobPersistenceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public JobPersistenceException(string message, System.Exception? innerException) { }
     }
     public sealed class JobQuery : Quartz.PagedQuery, System.IEquatable<Quartz.JobQuery>
@@ -690,7 +686,6 @@ namespace Quartz
         public Quartz.Matchers.GroupMatcher<Quartz.JobKey>? Group { get; init; }
         public Quartz.Matchers.NameMatcher<Quartz.JobKey>? Name { get; init; }
     }
-    [System.Serializable]
     public sealed class JobType
     {
         public JobType(System.Type type) { }
@@ -707,13 +702,11 @@ namespace Quartz
     {
         public static Quartz.IPersistentStoreBuilder UseSystemTextJsonSerializer(this Quartz.IPersistentStoreBuilder builder, System.Action<Quartz.SystemTextJsonSerializerOptions>? configure = null) { }
     }
-    [System.Serializable]
     public sealed class JsonSerializationException : Quartz.SchedulerException
     {
         public JsonSerializationException(string message) { }
         public JsonSerializationException(string message, System.Exception? innerException) { }
     }
-    [System.Serializable]
     public class Key<T> : System.IComparable<Quartz.Key<T>>
     {
         public const string DefaultGroup = "DEFAULT";
@@ -766,7 +759,6 @@ namespace Quartz
             public const int RescheduleNowWithRemainingRepeatCount = 3;
         }
     }
-    [System.Serializable]
     public sealed class ObjectAlreadyExistsException : Quartz.JobPersistenceException
     {
         public ObjectAlreadyExistsException(Quartz.IJobDetail offendingJob) { }
@@ -939,11 +931,9 @@ namespace Quartz
         FireAndProceed = 1,
         DoNothing = 2,
     }
-    [System.Serializable]
     public sealed class SchedulerConfigException : Quartz.SchedulerException
     {
         public SchedulerConfigException(string message) { }
-        public SchedulerConfigException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public SchedulerConfigException(string message, System.Exception? innerException) { }
     }
     public static class SchedulerConstants
@@ -957,7 +947,6 @@ namespace Quartz
         public const string FailedJobOriginalTriggerScheduledFireTime = "QRTZ_FAILED_JOB_ORIG_TRIGGER_SCHEDULED_FIRETIME_AS_STRING";
         public const string ForceJobDataMapDirty = "QRTZ_FORCE_JOB_DATAMAP_DIRTY";
     }
-    [System.Serializable]
     public sealed class SchedulerContext : Quartz.Util.StringKeyDirtyFlagMap
     {
         public SchedulerContext() { }
@@ -968,13 +957,11 @@ namespace Quartz
         public static System.IDisposable EnlistConnection(this Quartz.IScheduler scheduler, System.Data.Common.DbConnection connection, System.Data.Common.DbTransaction? transaction = null) { }
         public static System.IDisposable EnlistTransaction(this Quartz.IScheduler scheduler, System.Data.Common.DbTransaction transaction) { }
     }
-    [System.Serializable]
     public class SchedulerException : System.Exception
     {
         public SchedulerException() { }
         public SchedulerException(System.Exception innerException) { }
         public SchedulerException(string message) { }
-        protected SchedulerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public SchedulerException(string message, System.Exception? innerException) { }
         public override string ToString() { }
     }
@@ -1205,7 +1192,6 @@ namespace Quartz
         public Quartz.TriggerState State { get; init; }
         public string TriggerType { get; init; }
     }
-    [System.Serializable]
     public sealed class TriggerKey : Quartz.Key<Quartz.TriggerKey>
     {
         public TriggerKey(string name) { }
@@ -1236,12 +1222,10 @@ namespace Quartz
         public static System.Collections.Generic.List<System.DateTimeOffset> ComputeFireTimes(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numTimes) { }
         public static System.Collections.Generic.List<System.DateTimeOffset> ComputeFireTimesBetween(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, System.DateTimeOffset from, System.DateTimeOffset to) { }
     }
-    [System.Serializable]
     public sealed class UnableToInterruptJobException : Quartz.SchedulerException
     {
         public UnableToInterruptJobException(System.Exception innerException) { }
         public UnableToInterruptJobException(string message) { }
-        public UnableToInterruptJobException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
 }
 namespace Quartz.Configuration
@@ -1966,7 +1950,6 @@ namespace Quartz.Impl.AdoJobStore
         protected override System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder> GetLocalTransactionConnection(System.Threading.CancellationToken cancellationToken = default) { }
         public override System.Threading.Tasks.ValueTask Initialize(System.Threading.CancellationToken cancellationToken = default) { }
     }
-    [System.Serializable]
     public sealed class LockException : Quartz.JobPersistenceException
     {
         public LockException(string message) { }
@@ -1994,7 +1977,6 @@ namespace Quartz.Impl.AdoJobStore
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
         protected override string GetSelectNextTriggerToAcquireSql(int maxCount) { }
     }
-    [System.Serializable]
     public sealed class NoSuchDelegateException : Quartz.JobPersistenceException
     {
         public NoSuchDelegateException(string message) { }
@@ -2665,7 +2647,6 @@ namespace Quartz.Impl
         protected virtual System.Threading.Tasks.ValueTask<System.Net.IPHostEntry> GetHostAddress(System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<string> GetHostName(int maxLength, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    [System.Serializable]
     public sealed class JobExecutionContextImpl : Quartz.ICancellableJobExecutionContext, Quartz.IJobExecutionContext, System.IDisposable
     {
         public JobExecutionContextImpl(Quartz.IScheduler scheduler, Quartz.Extensibility.TriggerFiredBundle firedBundle, Quartz.IJob job) { }
@@ -3141,7 +3122,6 @@ namespace Quartz.Listener
 }
 namespace Quartz.Matchers
 {
-    [System.Serializable]
     public sealed class AndMatcher<TKey> : Quartz.IMatcher<TKey>
         where TKey : Quartz.Key<TKey>
     {
@@ -3162,7 +3142,6 @@ namespace Quartz.Matchers
         public static Quartz.Matchers.EverythingMatcher<Quartz.JobKey> AllJobs() { }
         public static Quartz.Matchers.EverythingMatcher<Quartz.TriggerKey> AllTriggers() { }
     }
-    [System.Serializable]
     public sealed class GroupMatcher<TKey> : Quartz.Matchers.StringMatcher<TKey>
         where TKey : Quartz.Key<TKey>
     {
@@ -3173,7 +3152,6 @@ namespace Quartz.Matchers
         public static Quartz.Matchers.GroupMatcher<TKey> GroupEquals(string compareTo) { }
         public static Quartz.Matchers.GroupMatcher<TKey> GroupStartsWith(string compareTo) { }
     }
-    [System.Serializable]
     public sealed class KeyMatcher<TKey> : Quartz.IMatcher<TKey>
         where TKey : Quartz.Key<TKey>
     {
@@ -3184,7 +3162,6 @@ namespace Quartz.Matchers
         public static Quartz.Matchers.KeyMatcher<T> KeyEquals<T>(T compareTo)
             where T : Quartz.Key<T> { }
     }
-    [System.Serializable]
     public sealed class NameMatcher<TKey> : Quartz.Matchers.StringMatcher<TKey>
         where TKey : Quartz.Key<TKey>
     {
@@ -3195,7 +3172,6 @@ namespace Quartz.Matchers
         public static Quartz.Matchers.NameMatcher<TKey> NameEquals(string compareTo) { }
         public static Quartz.Matchers.NameMatcher<TKey> NameStartsWith(string compareTo) { }
     }
-    [System.Serializable]
     public sealed class NotMatcher<TKey> : Quartz.IMatcher<TKey>
         where TKey : Quartz.Key<TKey>
     {
@@ -3206,7 +3182,6 @@ namespace Quartz.Matchers
         public static Quartz.Matchers.NotMatcher<T> Not<T>(Quartz.IMatcher<T> operand)
             where T : Quartz.Key<T> { }
     }
-    [System.Serializable]
     public sealed class OrMatcher<TKey> : Quartz.IMatcher<TKey>
         where TKey : Quartz.Key<TKey>
     {
@@ -3218,7 +3193,6 @@ namespace Quartz.Matchers
         public static Quartz.Matchers.OrMatcher<T> Or<T>(Quartz.IMatcher<T> leftOperand, Quartz.IMatcher<T> rightOperand)
             where T : Quartz.Key<T> { }
     }
-    [System.Serializable]
     public abstract class StringMatcher<TKey> : Quartz.IMatcher<TKey>
         where TKey : Quartz.Key<TKey>
     {
@@ -3231,7 +3205,6 @@ namespace Quartz.Matchers
         public bool IsMatch(TKey key) { }
         public override string ToString() { }
     }
-    [System.Serializable]
     public abstract class StringOperator : System.IEquatable<Quartz.Matchers.StringOperator>
     {
         public static readonly Quartz.Matchers.StringOperator Anything;
@@ -3588,7 +3561,6 @@ namespace Quartz.Xml.JobSchedulingData20
 }
 namespace Quartz.Xml
 {
-    [System.Serializable]
     public sealed class ValidationException : System.Exception
     {
         public ValidationException() { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -670,6 +670,7 @@ namespace Quartz
         public bool PersistJobDataAfterExecution { get; init; }
         public bool RequestsRecovery { get; init; }
     }
+    [System.Serializable]
     public sealed class JobKey : Quartz.Key<Quartz.JobKey>
     {
         public JobKey(string name) { }
@@ -707,6 +708,7 @@ namespace Quartz
         public JsonSerializationException(string message) { }
         public JsonSerializationException(string message, System.Exception? innerException) { }
     }
+    [System.Serializable]
     public class Key<T> : System.IComparable<Quartz.Key<T>>
     {
         public const string DefaultGroup = "DEFAULT";
@@ -1192,6 +1194,7 @@ namespace Quartz
         public Quartz.TriggerState State { get; init; }
         public string TriggerType { get; init; }
     }
+    [System.Serializable]
     public sealed class TriggerKey : Quartz.Key<Quartz.TriggerKey>
     {
         public TriggerKey(string name) { }

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -460,7 +460,6 @@ internal sealed class JobRunShell
         }
     }
 
-    [Serializable]
     internal sealed class VetoedException : Exception
     {
         public VetoedException(JobRunShell shell)

--- a/src/Quartz/Diagnostics/JobDiagnosticData.cs
+++ b/src/Quartz/Diagnostics/JobDiagnosticData.cs
@@ -1,6 +1,5 @@
 namespace Quartz.Diagnostics;
 
-[Serializable]
 internal sealed class JobDiagnosticData : IJobDiagnosticData
 {
     public JobDiagnosticData(IJobExecutionContext context)

--- a/src/Quartz/Impl/AdoJobStore/LockException.cs
+++ b/src/Quartz/Impl/AdoJobStore/LockException.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
-
 namespace Quartz.Impl.AdoJobStore;
 
 /// <summary>
@@ -28,7 +26,6 @@ namespace Quartz.Impl.AdoJobStore;
 /// <seealso cref="ISemaphore" />
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class LockException : JobPersistenceException
 {
     public LockException(string message) : base(message)
@@ -36,17 +33,6 @@ public sealed class LockException : JobPersistenceException
     }
 
     public LockException(string message, Exception? innerException) : base(message, innerException)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="LockException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    private LockException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/NoSuchDelegateException.cs
+++ b/src/Quartz/Impl/AdoJobStore/NoSuchDelegateException.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
-
 namespace Quartz.Impl.AdoJobStore;
 
 /// <summary>
@@ -27,7 +25,6 @@ namespace Quartz.Impl.AdoJobStore;
 /// </summary>
 /// <author><a href="mailto:jeff@binaryfeed.org">Jeffrey Wescott</a></author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class NoSuchDelegateException : JobPersistenceException
 {
     public NoSuchDelegateException(string message, Exception? innerException) : base(message, innerException)
@@ -35,17 +32,6 @@ public sealed class NoSuchDelegateException : JobPersistenceException
     }
 
     public NoSuchDelegateException(string message) : base(message)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NoSuchDelegateException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    private NoSuchDelegateException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 }

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -89,7 +89,6 @@ internal sealed class JobTypeInformation
 /// <seealso cref="ITrigger"/>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 internal sealed class JobDetailImpl : IJobDetail
 {
     private string name = null!;
@@ -100,7 +99,7 @@ internal sealed class JobDetailImpl : IJobDetail
     private bool? disallowConcurrentExecution;
     private bool? persistJobDataAfterExecution;
 
-    [NonSerialized] // we have the key in string fields
+    // built on demand from the name and group fields, which are the authoritative pair
     private JobKey key = null!;
 
     /// <summary>

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -64,7 +64,6 @@ namespace Quartz.Impl;
 /// <seealso cref="JobDataMap" />
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 #pragma warning disable CA1708
 public sealed class JobExecutionContextImpl : ICancellableJobExecutionContext, IDisposable
 #pragma warning restore CA1708
@@ -72,21 +71,17 @@ public sealed class JobExecutionContextImpl : ICancellableJobExecutionContext, I
     private readonly ITrigger trigger;
     private readonly IJobDetail jobDetail;
     private JobDataMap? jobDataMap;
-    [NonSerialized]
     private readonly IScheduler scheduler;
 
     private int numRefires;
     private TimeSpan? jobRunTime;
 
-    [NonSerialized]
     private Dictionary<object, object>? data;
 
-    [NonSerialized]
     private CancellationTokenSource? cancellationTokenSource;
 
-    [NonSerialized] internal readonly IJob jobInstance;
+    internal readonly IJob jobInstance;
 
-    [NonSerialized]
     private readonly Lock lazyInitLock = new();
 
     /// <summary>

--- a/src/Quartz/JobExecutionException.cs
+++ b/src/Quartz/JobExecutionException.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
-
 namespace Quartz;
 
 /// <summary>
@@ -37,7 +35,6 @@ namespace Quartz;
 /// <seealso cref="SchedulerException" />
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class JobExecutionException : SchedulerException
 {
     /// <summary>
@@ -97,17 +94,6 @@ public sealed class JobExecutionException : SchedulerException
     public JobExecutionException(string message, Exception innerException, bool refireImmediately) : base(message, innerException)
     {
         RefireImmediately = refireImmediately;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="JobExecutionException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    private JobExecutionException(SerializationInfo info, StreamingContext context) : base(info, context)
-    {
     }
 
     /// <summary>

--- a/src/Quartz/JobKey.cs
+++ b/src/Quartz/JobKey.cs
@@ -53,6 +53,7 @@ namespace Quartz;
 /// </remarks>
 /// <seealso cref="IJob"/>
 /// <seealso cref="Key{T}.DefaultGroup" />
+[Serializable]
 public sealed class JobKey : Key<JobKey>
 {
     public JobKey(string name) : base(name)

--- a/src/Quartz/JobKey.cs
+++ b/src/Quartz/JobKey.cs
@@ -53,7 +53,6 @@ namespace Quartz;
 /// </remarks>
 /// <seealso cref="IJob"/>
 /// <seealso cref="Key{T}.DefaultGroup" />
-[Serializable]
 public sealed class JobKey : Key<JobKey>
 {
     public JobKey(string name) : base(name)

--- a/src/Quartz/JobPersistenceException.cs
+++ b/src/Quartz/JobPersistenceException.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
-
 namespace Quartz;
 
 /// <summary>
@@ -27,7 +25,6 @@ namespace Quartz;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public class JobPersistenceException : SchedulerException
 {
     /// <summary> <para>
@@ -35,17 +32,6 @@ public class JobPersistenceException : SchedulerException
     /// </para>
     /// </summary>
     public JobPersistenceException(string message) : base(message)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="JobPersistenceException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    protected JobPersistenceException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 

--- a/src/Quartz/JobType.cs
+++ b/src/Quartz/JobType.cs
@@ -8,7 +8,6 @@ namespace Quartz;
 /// <summary>
 /// Store the Job Type and FullName for serialization
 /// </summary>
-[Serializable]
 public sealed class JobType
 {
     private readonly Lazy<Type> type;

--- a/src/Quartz/JsonSerializationException.cs
+++ b/src/Quartz/JsonSerializationException.cs
@@ -1,8 +1,5 @@
-using System.Runtime.Serialization;
-
 namespace Quartz;
 
-[Serializable]
 public sealed class JsonSerializationException : SchedulerException
 {
     public JsonSerializationException(string message) : base(message)
@@ -10,10 +7,6 @@ public sealed class JsonSerializationException : SchedulerException
     }
 
     public JsonSerializationException(string message, Exception? innerException) : base(message, innerException)
-    {
-    }
-
-    private JsonSerializationException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 }

--- a/src/Quartz/Key.cs
+++ b/src/Quartz/Key.cs
@@ -26,7 +26,6 @@ namespace Quartz;
 /// </summary>
 /// <author>  <a href="mailto:jeff@binaryfeed.org">Jeffrey Wescott</a></author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public class Key<T> : IComparable<Key<T>>
 {
     /// <summary>

--- a/src/Quartz/Key.cs
+++ b/src/Quartz/Key.cs
@@ -26,6 +26,7 @@ namespace Quartz;
 /// </summary>
 /// <author>  <a href="mailto:jeff@binaryfeed.org">Jeffrey Wescott</a></author>
 /// <author>Marko Lahma (.NET)</author>
+[Serializable]
 public class Key<T> : IComparable<Key<T>>
 {
     /// <summary>

--- a/src/Quartz/Matchers/AndMatcher.cs
+++ b/src/Quartz/Matchers/AndMatcher.cs
@@ -28,7 +28,6 @@ namespace Quartz.Matchers;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class AndMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 {
     // ReSharper disable once UnusedMember.Local

--- a/src/Quartz/Matchers/GroupMatcher.cs
+++ b/src/Quartz/Matchers/GroupMatcher.cs
@@ -28,7 +28,6 @@ namespace Quartz.Matchers;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class GroupMatcher<TKey> : StringMatcher<TKey> where TKey : Key<TKey>
 {
     private GroupMatcher(string compareTo, StringOperator compareWith) : base(compareTo, compareWith)

--- a/src/Quartz/Matchers/KeyMatcher.cs
+++ b/src/Quartz/Matchers/KeyMatcher.cs
@@ -28,7 +28,6 @@ namespace Quartz.Matchers;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class KeyMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 {
     // ReSharper disable once UnusedMember.Local

--- a/src/Quartz/Matchers/NameMatcher.cs
+++ b/src/Quartz/Matchers/NameMatcher.cs
@@ -28,7 +28,6 @@ namespace Quartz.Matchers;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class NameMatcher<TKey> : StringMatcher<TKey> where TKey : Key<TKey>
 {
     private NameMatcher(string compareTo, StringOperator compareWith) : base(compareTo, compareWith)

--- a/src/Quartz/Matchers/NotMatcher.cs
+++ b/src/Quartz/Matchers/NotMatcher.cs
@@ -28,7 +28,6 @@ namespace Quartz.Matchers;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class NotMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 {
     // ReSharper disable once UnusedMember.Local

--- a/src/Quartz/Matchers/OrMatcher.cs
+++ b/src/Quartz/Matchers/OrMatcher.cs
@@ -28,7 +28,6 @@ namespace Quartz.Matchers;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class OrMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 {
     // ReSharper disable once UnusedMember.Local

--- a/src/Quartz/Matchers/StringMatcher.cs
+++ b/src/Quartz/Matchers/StringMatcher.cs
@@ -28,7 +28,6 @@ namespace Quartz.Matchers;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public abstract class StringMatcher<TKey> : IMatcher<TKey> where TKey : Key<TKey>
 {
     protected StringMatcher(string compareTo, StringOperator compareWith)

--- a/src/Quartz/Matchers/StringOperator.cs
+++ b/src/Quartz/Matchers/StringOperator.cs
@@ -24,7 +24,6 @@ namespace Quartz.Matchers;
 /// <summary>
 /// Operators available for comparing string values.
 /// </summary>
-[Serializable]
 public abstract class StringOperator : IEquatable<StringOperator>
 {
     public static readonly StringOperator Equality = new EqualityOperator();
@@ -35,7 +34,6 @@ public abstract class StringOperator : IEquatable<StringOperator>
 
     public abstract bool Evaluate(string value, string compareTo);
 
-    [Serializable]
     private sealed class EqualityOperator : StringOperator
     {
         public override bool Evaluate(string value, string compareTo)
@@ -44,7 +42,6 @@ public abstract class StringOperator : IEquatable<StringOperator>
         }
     }
 
-    [Serializable]
     private sealed class StartsWithOperator : StringOperator
     {
         public override bool Evaluate(string value, string compareTo)
@@ -53,7 +50,6 @@ public abstract class StringOperator : IEquatable<StringOperator>
         }
     }
 
-    [Serializable]
     private sealed class EndsWithOperator : StringOperator
     {
         public override bool Evaluate(string value, string compareTo)
@@ -62,7 +58,6 @@ public abstract class StringOperator : IEquatable<StringOperator>
         }
     }
 
-    [Serializable]
     private sealed class ContainsOperator : StringOperator
     {
         public override bool Evaluate(string value, string compareTo)
@@ -71,7 +66,6 @@ public abstract class StringOperator : IEquatable<StringOperator>
         }
     }
 
-    [Serializable]
     private sealed class AnythingOperator : StringOperator
     {
         public override bool Evaluate(string value, string compareTo)

--- a/src/Quartz/ObjectAlreadyExistsException.cs
+++ b/src/Quartz/ObjectAlreadyExistsException.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
-
 namespace Quartz;
 
 /// <summary>
@@ -29,7 +27,6 @@ namespace Quartz;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class ObjectAlreadyExistsException : JobPersistenceException
 {
     /// <summary> <para>
@@ -38,17 +35,6 @@ public sealed class ObjectAlreadyExistsException : JobPersistenceException
     /// </para>
     /// </summary>
     public ObjectAlreadyExistsException(string message) : base(message)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ObjectAlreadyExistsException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    private ObjectAlreadyExistsException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 

--- a/src/Quartz/SchedulerConfigException.cs
+++ b/src/Quartz/SchedulerConfigException.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
-
 namespace Quartz;
 
 /// <summary>
@@ -28,7 +26,6 @@ namespace Quartz;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class SchedulerConfigException : SchedulerException
 {
     /// <summary>
@@ -43,17 +40,6 @@ public sealed class SchedulerConfigException : SchedulerException
     /// and cause.
     /// </summary>
     public SchedulerConfigException(string message, Exception? innerException) : base(message, innerException)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SchedulerConfigException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    public SchedulerConfigException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 }

--- a/src/Quartz/SchedulerContext.cs
+++ b/src/Quartz/SchedulerContext.cs
@@ -19,8 +19,6 @@
 
 #endregion
 
-using System.Runtime.Serialization;
-
 using Quartz.Util;
 
 namespace Quartz;
@@ -37,7 +35,6 @@ namespace Quartz;
 /// <seealso cref="IScheduler.Context" />
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class SchedulerContext : StringKeyDirtyFlagMap
 {
     /// <summary>
@@ -56,14 +53,5 @@ public sealed class SchedulerContext : StringKeyDirtyFlagMap
         {
             this[pair.Key] = pair.Value;
         }
-    }
-
-    /// <summary>
-    /// Serialization constructor.
-    /// </summary>
-    /// <param name="info"></param>
-    /// <param name="context"></param>
-    private SchedulerContext(SerializationInfo info, StreamingContext context) : base(info, context)
-    {
     }
 }

--- a/src/Quartz/SchedulerException.cs
+++ b/src/Quartz/SchedulerException.cs
@@ -1,5 +1,3 @@
-#pragma warning disable SYSLIB0051 // 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete
-
 #region License
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -19,8 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
-
 namespace Quartz;
 
 /// <summary>
@@ -32,7 +28,6 @@ namespace Quartz;
 /// </remarks>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public class SchedulerException : Exception
 {
     /// <summary>
@@ -46,17 +41,6 @@ public class SchedulerException : Exception
     /// Initializes a new instance of the <see cref="SchedulerException"/> class.
     /// </summary>
     public SchedulerException(string message) : base(message)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SchedulerException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    protected SchedulerException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 

--- a/src/Quartz/TriggerKey.cs
+++ b/src/Quartz/TriggerKey.cs
@@ -35,7 +35,6 @@ namespace Quartz;
 /// </remarks>
 /// <seealso cref="ITrigger" />
 /// <seealso cref="Key{T}.DefaultGroup" />
-[Serializable]
 public sealed class TriggerKey : Key<TriggerKey>
 {
     public TriggerKey(string name) : base(name)

--- a/src/Quartz/TriggerKey.cs
+++ b/src/Quartz/TriggerKey.cs
@@ -35,6 +35,7 @@ namespace Quartz;
 /// </remarks>
 /// <seealso cref="ITrigger" />
 /// <seealso cref="Key{T}.DefaultGroup" />
+[Serializable]
 public sealed class TriggerKey : Key<TriggerKey>
 {
     public TriggerKey(string name) : base(name)

--- a/src/Quartz/TriggerTimeComparator.cs
+++ b/src/Quartz/TriggerTimeComparator.cs
@@ -7,7 +7,6 @@ namespace Quartz;
 /// value first), if the priorities are the same, then they are sorted
 /// by key.
 /// </summary>
-[Serializable]
 internal sealed class TriggerTimeComparator : IComparer<ITrigger>
 {
     public int Compare(ITrigger? trig1, ITrigger? trig2)

--- a/src/Quartz/UnableToInterruptJobException.cs
+++ b/src/Quartz/UnableToInterruptJobException.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
-
 namespace Quartz;
 
 /// <summary>
@@ -26,7 +24,6 @@ namespace Quartz;
 /// </summary>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class UnableToInterruptJobException : SchedulerException
 {
     /// <summary>
@@ -40,17 +37,6 @@ public sealed class UnableToInterruptJobException : SchedulerException
     /// Create a <see cref="UnableToInterruptJobException" /> with the given cause.
     /// </summary>
     public UnableToInterruptJobException(Exception innerException) : base(innerException)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UnableToInterruptJobException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    public UnableToInterruptJobException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 }

--- a/src/Quartz/Xml/ValidationException.cs
+++ b/src/Quartz/Xml/ValidationException.cs
@@ -1,5 +1,3 @@
-#pragma warning disable SYSLIB0051 // 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete
-
 #region License
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -19,7 +17,6 @@
  */
 #endregion
 
-using System.Runtime.Serialization;
 using System.Text;
 
 namespace Quartz.Xml;
@@ -29,7 +26,6 @@ namespace Quartz.Xml;
 /// </summary>
 /// <author> <a href="mailto:bonhamcm@thirdeyeconsulting.com">Chris Bonham</a></author>
 /// <author>Marko Lahma (.NET)</author>
-[Serializable]
 public sealed class ValidationException : Exception
 {
     /// <summary>
@@ -83,16 +79,5 @@ public sealed class ValidationException : Exception
     public ValidationException(IEnumerable<Exception> errors) : this()
     {
         ValidationExceptions = new List<Exception>(errors);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SchedulerException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-    /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="System.Exception.HResult"></see> is zero (0). </exception>
-    /// <exception cref="System.ArgumentNullException">The info parameter is null. </exception>
-    private ValidationException(SerializationInfo info, StreamingContext context) : base(info, context)
-    {
     }
 }


### PR DESCRIPTION
**Stack layer 1 of 3** (Phase 6 of the 4.0 API coherence campaign). Base: `api-coherence-phase5` (#3230) → `main`.

Applies the project's serialization policy: keep `[Serializable]`/`ISerializable` on types reachable from a persisted database blob, so a legacy binary payload stays readable through Microsoft's unsupported BinaryFormatter package; remove it everywhere else, where it has meant nothing since binary serialization left the runtime.

## The audit came first

`StdAdoDelegate` is the only `IObjectSerializer.Serialize` call site, with three entry points, which makes the keep-list determinable rather than a matter of taste:

| Blob column | Reachable types |
|---|---|
| `JOB_DETAILS.JOB_DATA`, `TRIGGERS.JOB_DATA` | `JobDataMap` → `StringKeyDirtyFlagMap` → `DirtyFlagMap`, **and the keys** (see below) |
| `CALENDARS.CALENDAR` | `BaseCalendar` + the six calendars, and `CronExpression` |
| `BLOB_TRIGGERS.BLOB_DATA` | `AbstractTrigger` and the four trigger implementations |

Two corrections to the plan came out of the audit:

- **The trigger classes belong on the keep-list.** `FindTriggerPersistenceDelegate` returns null for any trigger no delegate handles — a custom type, or one deriving from a built-in with `HasAdditionalProperties => true` — and the store then serializes the whole object into `BLOB_TRIGGERS`.
- **The keys stay, for a subtler reason.** Quartz marks `key`/`jobKey` `[NonSerialized]` in its own graph, which argues for removal — but `DirtyFlagMap` serializes its `Dictionary<string, object>` wholesale, so an application that did `jobDataMap.Put("parent", jobKey)` on 3.x has a `JobKey` sitting in its `JOB_DATA`, and BinaryFormatter refuses to deserialize a type that is not marked serializable. Blob-reachable means what the graph *can* contain, not only what Quartz itself puts there.

## Removed

30 `[Serializable]` attributes (10 exceptions, 13 matcher sites, and `JobType`, `SchedulerContext`, `JobExecutionContextImpl`, `JobDetailImpl`, `JobDiagnosticData`, `TriggerTimeComparator`, `JobRunShell.VetoedException`) and 12 `(SerializationInfo, StreamingContext)` constructors — the obsolete SYSLIB0051 pattern — along with the two `#pragma warning disable SYSLIB0051` it needed.

`LegacyJsonPayloadTest` was extended to cover the keep-list types it missed (a populated `JobDataMap`, and legacy simple/cron/calendar-interval trigger payloads). The fixture literals were derived from the **3.x writers**, not from 4.x output — a fixture generated from current code only proves the code round-trips with itself.

## Verification

`build.cmd` green; unit 2045 passed; AspNetCore 203; Postgres integration 59. Baseline diff against the layer below is 26 lines, all deletions, nothing outside scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)