### PR TITLE
Close the campaign: name the stragglers, then check the guide against 3.x

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -261,7 +261,7 @@ scheduler registered with `AddQuartz` and another built by a `QuartzSchedulerBui
 process:
 
 * `ISchedulerFactory.GetAllSchedulers()` on either one lists only its own schedulers.
-* `ISchedulerFactory.GetScheduler(name)` returns `null` for the other one's name.
+* `ISchedulerFactory.LookupScheduler(name)` returns `null` for the other one's name.
 * `ISchedulerRepository.Lookup(name)` likewise sees only its own container's schedulers.
 
 If you were relying on that reach — typically to find a scheduler from code that had no reference to the
@@ -402,7 +402,7 @@ reaching for one of them. Each had a reason that the container now covers direct
 | `StdSchedulerFactory(NameValueCollection)` | `QuartzSchedulerBuilder.Create().UseProperties(properties)` |
 | `Initialize(NameValueCollection)` | `UseProperties(properties)` |
 | `Initialize()` | nothing; there is no file and no environment overlay left to read |
-| `GetScheduler()`, `GetScheduler(name)`, `GetAllSchedulers()` | unchanged — they are `ISchedulerFactory`, which `Build()` returns |
+| `GetScheduler()`, `LookupScheduler(name)`, `GetAllSchedulers()` | unchanged apart from the by-name rename — they are `ISchedulerFactory`, which `Build()` returns |
 | `static GetDefaultScheduler()` | build a scheduler where the application starts and hold it, or inject `IScheduler` |
 | `Dispose()`, `Dispose(bool)` | the factory `Build()` returns owns its container and implements `IDisposable` and `IAsyncDisposable`; cast to dispose it |
 | `GetSchedulerRepository()` | `ISchedulerRepository`, resolved from the container |
@@ -1133,7 +1133,7 @@ on `QuartzSchedulerResources` are `QuartzSchedulerOptions`.
 
 **`StdAdoConstants` and `IAdoUtil` are internal, and constants are no longer inherited.** `AdoConstants` stays
 public — table, column and state names are a real contract for delegate authors — but it is a `static class`
-now, and `JobStoreSupport`, `StdAdoDelegate` and `DBSemaphore` no longer derive from it or from
+now, and `JobStoreSupport`, `StdAdoDelegate` and `DbSemaphore` no longer derive from it or from
 `StdAdoConstants`:
 
 ```diff
@@ -1148,8 +1148,8 @@ The `Sql*` statement templates on `StdAdoConstants` are not visible at all any m
 statement is not a contract. Build the statement your dialect needs, or override the `GetSelect*Sql` hooks,
 which are unchanged.
 
-`DBSemaphore.AdoUtil` is `private protected` for the same reason, so a semaphore written outside Quartz no
-longer sees it — derive from `DBSemaphore` and use `IDbProvider`, or implement `ISemaphore` directly.
+`DbSemaphore.AdoUtil` is `private protected` for the same reason, so a semaphore written outside Quartz no
+longer sees it — derive from `DbSemaphore` and use `IDbProvider`, or implement `ISemaphore` directly.
 
 **Three trigger persistence delegates became public**, so a custom delegate list can name all five built-ins:
 `CronTriggerPersistenceDelegate`, `SimpleTriggerPersistenceDelegate` and
@@ -1994,7 +1994,7 @@ changes in the database**: the `LOCK_NAME` column still holds `TRIGGER_ACCESS` a
 conversion happens where the row is written, and a 4.0 node contends for the same rows as a 3.x one. The
 same applies to `Quartz.Extensions.Redis`, whose keys keep their `…:TRIGGER_ACCESS` spelling.
 
-`DBSemaphore.ExecuteSql` still receives the stored name as a `string` — that parameter really is the value
+`DbSemaphore.ExecuteSql` still receives the stored name as a `string` — that parameter really is the value
 bound into the statement.
 
 ## The job store configuration is read-only
@@ -2040,7 +2040,7 @@ this store they no longer do.
   the class hierarchy that owns them ever read them: `StdRowLockSemaphore.SelectForLock` /
   `.InsertLock` keep their names, and `UpdateLockRowSemaphore.SqlUpdateForLock` / `.SqlInsertLock` are
   `UpdateForLock` / `InsertLock`.
-* `DBSemaphore.Sql` and `.InsertSql` are get-only and arrive through the constructor. They were
+* `DbSemaphore.Sql` and `.InsertSql` are get-only and arrive through the constructor. They were
   `protected` settable, which let a subclass swap a statement after the table prefix had already been
   folded into it — the select and the insert backing the same lock could end up naming different tables.
   A subclass that needs its own insert statement passes it up:
@@ -3418,6 +3418,179 @@ instead:
 `IScheduler.GetCurrentlyExecutingJobs()` returns `List<IJobExecutionContext>` as before — the element type never
 was the cancellable interface, only the documentation said so.
 
+## `JobDataMap`'s typed accessors are the ones it inherits
+
+`JobDataMap` declared sixty typed accessors of its own — `GetIntValue`, `TryGetIntValue`,
+`GetIntValueFromString`, `TryGetIntValueFromString`, and the same four for `bool`, `char`, `double`,
+`float`, `long`, `Guid`, `TimeSpan`, `DateTime` and `DateTimeOffset` — while the
+`StringKeyDirtyFlagMap` it derives from declared a second, shorter set doing the same job. Two names
+for one lookup, differing only in a suffix. The `…Value` set is gone; the inherited one stays:
+
+```diff
+- int retries = context.JobDetail.JobDataMap.GetIntValue("retries");
++ int retries = context.JobDetail.JobDataMap.GetInt("retries");
+
+- if (map.TryGetTimeSpanValue("timeout", out TimeSpan timeout)) { }
++ if (map.TryGetTimeSpan("timeout", out TimeSpan timeout)) { }
+```
+
+| 3.x `JobDataMap` | 4.x, inherited from `StringKeyDirtyFlagMap` |
+|---|---|
+| `GetBooleanValue`, `GetBooleanValueFromString` | `GetBoolean` |
+| `GetCharFromString` | `GetChar` |
+| `GetDateTimeValue`, `GetDateTimeValueFromString` | `GetDateTime` |
+| `GetDateTimeOffsetValue`, `GetDateTimeOffsetValueFromString` | `GetDateTimeOffset` |
+| `GetDoubleValue`, `GetDoubleValueFromString` | `GetDouble` |
+| `GetFloatValue`, `GetFloatValueFromString` | `GetFloat` |
+| `GetGuidValue`, `GetGuidValueFromString` | `GetGuid` |
+| `GetIntValue`, `GetIntValueFromString` | `GetInt` |
+| `GetLongValue`, `GetLongValueFromString` | `GetLong` |
+| `GetTimeSpanValue`, `GetTimeSpanValueFromString` | `GetTimeSpan` |
+| every `TryGet…Value` / `TryGet…ValueFromString` | the matching `TryGet…` |
+| `GetNullableGuidValue` | `TryGetGuid`, or read the entry and test it yourself |
+| (none) | `GetString`, `TryGetString`, `GetDecimal`, `TryGetDecimal` |
+
+The `…FromString` half collapses because the retained accessors already convert: a value written as a
+string — which is what `UseProperties` forces, and what `PutAsString` writes — is parsed on the way
+out, so one accessor covers both. `GetNullableGuidValue` is the only one without a direct
+replacement; it returned `null` both for "absent" and for "present but not a `Guid`", which
+`TryGetGuid` distinguishes.
+
+`PutAsString`'s eleven overloads are one generic `PutAsString<T>(string key, T value) where T :
+IConvertible`, plus the four the constraint cannot express (`DateTimeOffset`, `Guid`, `Guid?`,
+`TimeSpan`). Call sites are unchanged.
+
+## `AddQuartzServer` is `AddQuartzHostedService`
+
+`Quartz.AspNetCore.AddQuartzServer` did two unrelated things behind one name: it registered the
+hosted service that starts the scheduler, and — on frameworks that had them — an ASP.NET Core health
+check. Both are separately available, and the hosted service was never specific to ASP.NET Core, so
+the combined method is gone and each half is called by its own name:
+
+```diff
+  services.AddQuartz(q => { /* ... */ });
+
+- services.AddQuartzServer(options => options.WaitForJobsToComplete = true);
++ services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
++ services.AddQuartzHealthChecks();
+```
+
+`AddQuartzHostedService` lives in the core `Quartz` package, so an application that only wants the
+scheduler started with the host no longer needs `Quartz.AspNetCore` at all — see
+[The hosted service starts every scheduler](#the-hosted-service-starts-every-scheduler) for what it
+now starts, and [The ASP.NET Core methods say Quartz once](#the-asp-net-core-methods-say-quartz-once)
+for the rest of that package.
+
+The health-check overload that took `IEnumerable<string> healthCheckTags` is gone with it; tags are
+`QuartzHealthCheckOptions.Tags`, which is assigned rather than added to:
+
+```diff
+- services.AddQuartzServer(configure, healthCheckTags: ["ready", "live"]);
++ services.AddQuartzHealthChecks(options => options.Tags = ["ready", "live"]);
+```
+
+## The ambient logger factory stays ambient
+
+`LogProvider.SetLogProvider(ILoggerFactory)` is the one piece of mutable process-wide state left in
+Quartz, and it is deliberate rather than overlooked.
+
+Almost everything the scheduler is made of is built by a container and is injected an `ILogger` the
+ordinary way. What is left over cannot be: static helpers such as `TimeZoneUtil`, types a caller
+constructs directly — triggers, calendars, plugins, the jobs in `Quartz.Jobs` — and anything that
+runs while the container is still being built. A type cannot be handed a logger by a container that
+does not exist yet, so those sites read the ambient factory instead of going unlogged.
+
+Nor is it seeded from the container, which would be the obvious convenience. The slot outlives any
+one container: a process that builds a host, disposes it and builds another — every integration test
+suite, and every application that reloads configuration — would be left holding a disposed
+`ILoggerFactory`, and the next logger created anywhere in Quartz would throw
+`ObjectDisposedException` from somewhere unrelated to logging. Whoever sets the factory owns its
+lifetime, and only the application can make that call. The same applies to a hand-written
+`LogProvider.SetLogProvider(host.Services.GetRequiredService<ILoggerFactory>())`: it is correct as
+long as the host outlives the schedulers.
+
+`TimeZoneUtil.CustomResolver` is ambient for the same reason and is now nullable, `null` meaning
+"no custom resolver", so a resolver can be removed again rather than replaced with a lambda that
+returns `null`. `FindTimeZoneById` is reached from parsing a `CronExpression` and from deserializing
+a trigger out of a job store blob, neither of which has a scheduler in scope — which is why
+installing `Quartz.Plugins.TimeZoneConverter` in one scheduler changes id resolution for the whole
+process.
+
+## `TriggerUtils` moved to `Quartz.Extensibility`
+
+It computes fire times by advancing a copy of a trigger through its schedule, applying the calendar
+at each step, which is exactly what `IOperableTrigger` adds over `ITrigger` — so it belongs with that
+contract rather than in the root namespace next to `IScheduler`. The methods are unchanged:
+
+```diff
++ using Quartz.Extensibility;
+
+  var times = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, calendar, 10);
+```
+
+## The road from 3.x, phase by phase
+
+The 4.0 API is the result of six passes over the public surface, each with its own theme. The guide
+above is organised by topic rather than by pass, so this is the map: what changed, in the order it is
+worth working through when migrating.
+
+**1. The extensibility contracts.** The interfaces you implement rather than call. `Quartz.Spi` is
+[`Quartz.Extensibility` and `Quartz.Simpl` is `Quartz.Impl`](#quartz-spi-and-quartz-simpl-were-renamed);
+every asynchronous member returns [`ValueTask`](#tasks-changed-to-valuetask) and ends with a
+`CancellationToken`; [jobs take that token as a parameter](#jobs-take-a-cancellationtoken); the
+[job factory hands out a scope](#the-job-factory-hands-out-a-scope) instead of an instance; the
+[thread pool is asynchronous](#the-thread-pool-is-asynchronous); and
+[trigger fire times are properties](#trigger-fire-times-are-properties) rather than getter/setter
+pairs. Start here: everything else assumes these signatures.
+
+**2. The vocabulary and the surface.** One word per concept, and nothing public that was never a
+contract. [Names that were normalized](#names-that-were-normalized),
+[the scheduler and the job store speak the same verbs](#the-scheduler-and-the-job-store-speak-the-same-verbs),
+[matchers moved to `Quartz.Matchers`](#matchers-moved-to-quartz-matchers),
+[`Key<T>` moved to `Quartz` and is immutable](#key-t-moved-to-quartz-and-is-immutable),
+[`SchedulerMetadata` replaces `SchedulerMetaData`](#schedulermetadata-replaces-schedulermetadata),
+[the listener API](#listener-api-changes), and
+[sealed and internalized types](#sealed-and-internalized-types).
+
+**3. Listings, schedules and dates.** [Job store listings became queries](#job-store-listings-became-queries)
+returning `PagedResult<T>` of headers; [misfire instructions are enums](#misfire-instructions-are-enums);
+[intervals are said once per builder](#intervals-are-said-once-per-builder);
+[`TimeOfDay` became `TimeOnly`](#timeofday-became-timeonly) and
+[`DateBuilder`'s static factories are gone](#datebuilders-static-factories-are-gone);
+[`Executing` is a trigger state](#executing-is-a-trigger-state); and
+[the preferred node is a value](#the-preferred-node-is-a-value).
+
+**4. The ADO.NET job store.** [Trigger states are typed on the driver delegate](#trigger-states-are-typed-on-the-driver-delegate);
+[the stores are named for whose transaction they use](#the-ado-net-job-stores-are-named-for-whose-transaction-they-use);
+[nine `Execute…Lock` overloads became four](#nine-execute-lock-overloads-became-four-members);
+[locks are a `SchedulerLock`](#locks-are-a-schedulerlock-not-a-string);
+[the job store configuration is read-only](#the-job-store-configuration-is-read-only);
+[the driver delegate speaks in records](#the-driver-delegate-speaks-in-records);
+[`RAMJobStore` is sealed](#ramjobstore-is-sealed); and
+[a job store of your own can join your transaction](#a-job-store-of-your-own-can-join-your-transaction).
+
+**5. Configuration and hosting.** The container builds the scheduler:
+[`StdSchedulerFactory` is gone](#stdschedulerfactory-is-gone),
+[the standalone builder is the same builder](#the-standalone-builder-is-the-same-builder),
+[there is no process-global scheduler state](#no-process-global-scheduler-or-connection-state),
+[`AddJob` registers the job with the container](#addjob-registers-the-job-with-the-container),
+[one shape per registration method](#one-shape-per-registration-method),
+[clustering is configured in one place](#clustering-is-configured-in-one-place),
+[the hosted service starts every scheduler](#the-hosted-service-starts-every-scheduler), and
+[job execution metrics](#job-execution-metrics) are published by every scheduler.
+
+**6. Serialization policy and the last edges.**
+[`[Serializable]` survives only where a database blob needs it](#serializable-survives-only-where-a-database-blob-needs-it);
+[the two exceptions moved out of `Quartz.Core`](#the-two-exceptions-moved-out-of-quartz-core);
+[execution limits are built once, then frozen](#execution-limits-are-built-once-then-frozen);
+[interruption has two names, not three](#interruption-has-two-names-not-three); and the naming and
+visibility odds and ends in this section and in the table below.
+
+Two differences run through all six and are not called out case by case, because they are almost
+universal: `Task` became `ValueTask` on nearly every member, and the namespaces moved as described in
+pass 1. If a type you used does not appear in this guide at all, check
+[Package Changes](#package-changes) first — it may have moved packages rather than changed.
+
 ## Other Breaking Changes
 
 | Change | Details |
@@ -3495,7 +3668,7 @@ was the cancellable interface, only the documentation said so.
 | `AdoJobStoreOptions.DontSetAutoCommitFalse` removed | The option the deleted store property mirrored. No code path read it and no `quartz.*` key set it, so setting it configured nothing |
 | `JobStoreSupport.LastCheckin` is internal, `LogWarnIfNonZero` is private | Cluster check-in bookkeeping and a logging helper, neither of them an extension point |
 | `JobStoreSupport.RecoverJobs(CancellationToken)` returns `ValueTask` | The `bool` it returned was the constant `true` |
-| `DBSemaphore.Sql` and `.InsertSql` are get-only, fed by the constructor | Assigning one after construction left it un-prefixed relative to its pair — see [The semaphores were tidied](#the-semaphores-were-tidied) |
+| `DbSemaphore.Sql` and `.InsertSql` are get-only, fed by the constructor | Assigning one after construction left it un-prefixed relative to its pair — see [The semaphores were tidied](#the-semaphores-were-tidied) |
 | Row-lock semaphore SQL fields are `protected` and consistently named | `UpdateLockRowSemaphore.SqlUpdateForLock` / `.SqlInsertLock` are `UpdateForLock` / `InsertLock`; `StdRowLockSemaphore.SelectForLock` / `.InsertLock` keep their names |
 | `JobStoreSupport.GetEnlistedConnection` is `protected` | So a job store outside the core assembly can honour an enlisted transaction rather than silently opening its own connection |
 | `ConnectionAndTransactionHolder` gained an ownership-aware constructor and `OwnsResources` | `(connection, transaction, ownsResources)` for a store running on a connection it did not open |
@@ -3539,3 +3712,17 @@ was the cancellable interface, only the documentation said so.
 | `Quartz.Diagnostics.IJobDiagnosticData` removed | It was the payload contract of the `DiagnosticSource` events `Quartz.OpenTracing` consumed. Both the package and the events are gone; job execution is on `Activity` through `QuartzActivitySource`, and `IJobExecutionContext` is what a listener reads |
 | `CronExpression.Clone()` returns `CronExpression` | It returned `object`, unlike `ITrigger.Clone`, `IJobDetail.Clone` and `ICalendar.Clone`; the casts at the call sites can go |
 | `IJobExecutionContext.Put` / `.Get` take a `string` key | They took `object`. The volatile per-execution map keys by name, like `JobDataMap`, and `Put`'s value is `object?` and its parameter is `value` rather than `objectValue` |
+| `JobDataMap`'s sixty typed accessors removed | The inherited `StringKeyDirtyFlagMap` set does the same job — see [`JobDataMap`'s typed accessors are the ones it inherits](#jobdatamaps-typed-accessors-are-the-ones-it-inherits) |
+| `Quartz.AspNetCore.AddQuartzServer` removed | `AddQuartzHostedService` starts the scheduler and `AddQuartzHealthChecks` registers the check — see [`AddQuartzServer` is `AddQuartzHostedService`](#addquartzserver-is-addquartzhostedservice) |
+| `ISchedulerFactory.GetScheduler(name)` is `LookupScheduler(name)` | Two members named `GetScheduler` differed only in nullability. `GetScheduler()` builds this factory's scheduler and cannot return null; `LookupScheduler(name)` looks one up in the container's repository and can, which is what the verb now says. `Lookup` matches `ISchedulerRepository.Lookup` |
+| `TriggerUtils` moved to `Quartz.Extensibility` | It is a helper over `IOperableTrigger`, not part of the scheduling API — see [`TriggerUtils` moved to `Quartz.Extensibility`](#triggerutils-moved-to-quartz-extensibility) |
+| `Quartz.Util.ObjectExtensions` is internal | `AssemblyQualifiedNameWithoutVersion()` is how Quartz spells a type name into a blob or onto the wire, not a general-purpose helper |
+| `TimeZoneUtil.CustomResolver` is nullable | `null` means there is no custom resolver, which is how one is removed; it defaulted to a lambda returning `null` — see [The ambient logger factory stays ambient](#the-ambient-logger-factory-stays-ambient) |
+| `Quartz.Diagnostics.ActivityOptions` is `ActivityTags` | It holds `Activity` tag names, not options, and `*Options` names an options type everywhere else. It replaced 3.x's `DiagnosticHeaders`; the tag names and values are unchanged |
+| `DBSemaphore` is `DbSemaphore` | The last `DB` spelling, with `DBConnectionManager` → `DbConnectionManager`. The type is abstract and is never named in configuration |
+| `StartingDailyAt` / `EndingDailyAt` take a `timeOfDay` | The parameter was `timeOfDayUtc`, and the value is wall-clock in the trigger's time zone rather than UTC — the property it sets, `StartTimeOfDay`, never claimed otherwise. `DailyTimeIntervalTriggerImpl`'s five constructors say `startTimeOfDay` / `endTimeOfDay` for the same reason |
+| `ITriggerSerializer.TriggerTypeForJson` is `TriggerTypeName` | `ICalendarSerializer.CalendarTypeName` names the same concept; both JSON serializers changed |
+| `IDriverDelegate.SelectNumTriggersForJob` is `CountTriggersForJob` | Matching `CountMisfiredTriggersInState`, and spelling out the last `Num` |
+| `SimpleTriggerImpl.ComputeNumTimesFiredBetween` is `ComputeNumberOfTimesFiredBetween` | As above |
+| `TriggerAcquireResult.JobType` is `JobTypeName` | It holds `JOB_CLASS_NAME` — a type name, the same thing `JobHeader.JobTypeName` carries — and was documented as a discriminator, which it is not. `TriggerHeader.TriggerType` really is a discriminator and keeps its name |
+| Parameter names spelled out on the ADO.NET surface | `IDriverDelegate.SelectJobDetail`'s `classLoadHelper` is `loadHelper` (the implementation already called it that, so named arguments disagreed with the interface); `ts` is `misfireTime`; `JobStoreSupport.ReleaseLock`'s `doIt` is `shouldRelease`; `StdAdoDelegate.AddTriggerPersistenceDelegate`'s `del` is `persistenceDelegate`; `TriggerPropertyBundle`'s `sb` is `scheduleBuilder`; `CronTriggerImpl.WillFireOn`'s `test` is `timeUtc`; `TriggerUtils.ComputeFireTimes`'s `numTimes` is `numberOfTimes` |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -9,6 +9,72 @@ title: Migration Guide
 If you are a new user starting with the latest version, you don't need to follow this guide. Just jump right to [the tutorial](tutorial/index.html)
 :::
 
+## The road from 3.x, phase by phase
+
+The 4.0 API is the result of six passes over the public surface, each with its own theme. The guide
+below is organised by topic rather than by pass, so this is the map: what changed, in the order it is
+worth working through when migrating.
+
+**1. The extensibility contracts.** The interfaces you implement rather than call. `Quartz.Spi` is
+[`Quartz.Extensibility` and `Quartz.Simpl` is `Quartz.Impl`](#quartz-spi-and-quartz-simpl-were-renamed);
+every asynchronous member returns [`ValueTask`](#tasks-changed-to-valuetask) and ends with a
+`CancellationToken`; [jobs take that token as a parameter](#jobs-take-a-cancellationtoken); the
+[job factory hands out a scope](#the-job-factory-hands-out-a-scope) instead of an instance; the
+[thread pool is asynchronous](#the-thread-pool-is-asynchronous); and
+[trigger fire times are properties](#trigger-fire-times-are-properties) rather than getter/setter
+pairs. Start here: everything else assumes these signatures.
+
+**2. The vocabulary and the surface.** One word per concept, and nothing public that was never a
+contract. [Names that were normalized](#names-that-were-normalized),
+[the scheduler and the job store speak the same verbs](#the-scheduler-and-the-job-store-speak-the-same-verbs),
+[matchers moved to `Quartz.Matchers`](#matchers-moved-to-quartz-matchers),
+[`Key<T>` moved to `Quartz` and is immutable](#key-t-moved-to-quartz-and-is-immutable),
+[`SchedulerMetadata` replaces `SchedulerMetaData`](#schedulermetadata-replaces-schedulermetadata),
+[the listener API](#listener-api-changes), and
+[sealed and internalized types](#sealed-and-internalized-types).
+
+**3. Listings, schedules and dates.** [Job store listings became queries](#job-store-listings-became-queries)
+returning `PagedResult<T>` of headers; [misfire instructions are enums](#misfire-instructions-are-enums);
+[intervals are said once per builder](#intervals-are-said-once-per-builder);
+[`TimeOfDay` became `TimeOnly`](#timeofday-became-timeonly) and
+[`DateBuilder`'s static factories are gone](#datebuilder-s-static-factories-are-gone);
+[`Executing` is a trigger state](#executing-is-a-trigger-state); and
+[the preferred node is a value](#the-preferred-node-is-a-value).
+
+**4. The ADO.NET job store.** [Trigger states are typed on the driver delegate](#trigger-states-are-typed-on-the-driver-delegate);
+[the stores are named for whose transaction they use](#the-ado-net-job-stores-are-named-for-whose-transaction-they-use);
+[nine `Execute…Lock` overloads became four](#nine-execute-lock-overloads-became-four-members);
+[locks are a `SchedulerLock`](#locks-are-a-schedulerlock-not-a-string);
+[the job store configuration is read-only](#the-job-store-configuration-is-read-only);
+[the driver delegate speaks in records](#the-driver-delegate-speaks-in-records);
+[the optional columns are required, so the probes are gone](#the-optional-columns-are-required-so-the-probes-are-gone)
+and the [schema migration](#database-schema-migration) that goes with that is mandatory;
+[`RAMJobStore` is sealed](#ramjobstore-is-sealed); and
+[a job store of your own can join your transaction](#a-job-store-of-your-own-can-join-your-transaction).
+
+**5. Configuration and hosting.** The container builds the scheduler:
+[`StdSchedulerFactory` is gone](#stdschedulerfactory-is-gone),
+[the standalone builder is the same builder](#the-standalone-builder-is-the-same-builder),
+[there is no process-global scheduler state](#no-process-global-scheduler-or-connection-state),
+[`AddJob` registers the job with the container](#addjob-registers-the-job-with-the-container),
+[one shape per registration method](#one-shape-per-registration-method),
+[clustering is configured in one place](#clustering-is-configured-in-one-place),
+[the hosted service starts every scheduler](#the-hosted-service-starts-every-scheduler), and
+[job execution metrics](#job-execution-metrics) are published by every scheduler.
+
+**6. Serialization policy and the last edges.**
+[`[Serializable]` survives only where a database blob needs it](#serializable-survives-only-where-a-database-blob-needs-it);
+[the two exceptions moved out of `Quartz.Core`](#the-two-exceptions-moved-out-of-quartz-core);
+[execution limits are built once, then frozen](#execution-limits-are-built-once-then-frozen);
+[interruption has two names, not three](#interruption-has-two-names-not-three); and the naming and
+visibility odds and ends gathered in [Other Breaking Changes](#other-breaking-changes) at the end of
+this guide.
+
+Two differences run through all six and are not called out case by case, because they are almost
+universal: `Task` became `ValueTask` on nearly every member, and the namespaces moved as described in
+pass 1. If a type you used does not appear in this guide at all, check
+[Package Changes](#package-changes) first — it may have moved packages rather than changed.
+
 ## Target Framework
 
 Quartz.NET 4.x targets `net10.0`. There is no `netstandard2.0` build and no support for Full Framework
@@ -584,6 +650,31 @@ What is left says three different things:
 
 Where connections come from is a property of the data source, so it is said in `DataSourceOptions`
 alongside `ConnectionString` and `ConnectionStringName`, and it wins over both.
+
+### `AddDataSourceProvider()` went with it
+
+The two always travelled together. `AddDataSourceProvider()`, on the configurator, registered
+`DataSourceDbProvider` in the container as the `IDbProvider` to use; `UseDataSourceConnectionProvider()`,
+on the store, then named it as that data source's connection provider. Two calls, in two different
+places, that had to agree with each other to do anything. Both are gone, and
+`UseRegisteredDataSource` does the whole job — the data source builds its own `DataSourceDbProvider`
+around the `DbDataSource` it resolves from the container:
+
+```diff
+  services.AddQuartz(q =>
+  {
+-     q.AddDataSourceProvider();
+      q.UsePersistentStore(store =>
+      {
+-         store.UsePostgres(db => db.Provider = "Npgsql");
+-         store.UseDataSourceConnectionProvider();
++         store.UsePostgres(db => db.UseRegisteredDataSource = true);
+      });
+  });
+```
+
+Registering the `DbDataSource` itself is still yours to do — `services.AddNpgsqlDataSource(…)`, or
+whatever your provider offers. What is no longer yours to do is wiring it up to Quartz.
 
 ## `QuartzOptions` lost its three typed settings
 
@@ -2145,6 +2236,63 @@ A delegate of your own that derives from `StdAdoDelegate` inherits the implement
 cover tables of its own. One written against the interface directly has to implement it; returning `0`
 without checking anything restores the old skip.
 
+## The optional columns are required, so the probes are gone
+
+3.x asked the database at startup whether `MISFIRE_ORIG_FIRE_TIME`, `EXECUTION_GROUP` and
+`PREFERRED_NODE` were present, and switched the matching feature off when they were not. **4.x
+requires all of them**, so there is no question left to ask, and the members that asked it are gone
+from `StdAdoDelegate`:
+
+| Removed | What it did |
+|---|---|
+| `HasMisfireOriginalFireTimeColumn`, `HasExecutionGroupColumn`, `HasPreferredNodeColumn` | Reported the result of the matching probe |
+| `SupportsMisfireOriginalFireTimeColumn`, `SupportsExecutionGroupColumn`, `SupportsPreferredNodeColumn` | Ran the probe, swallowing the provider error that meant "no such column" |
+| `VerifyTriggersTableReachable` | Told a genuinely missing column apart from a database that was momentarily unreachable, so a transient failure did not disable a feature for the life of the process |
+
+**The upgrade path is the schema migration, and it is mandatory.** Run
+`schema_30_to_40_upgrade_<dialect>.sql` from
+[database/migrations/4.0/](https://github.com/quartznet/quartznet/tree/main/database/migrations/4.0)
+before pointing 4.x at a 3.x database — [Database Schema Migration](#database-schema-migration) lists
+the columns and what each script does. Skipping it no longer degrades gracefully, and it does not
+fail tidily either: [`ValidateSchema`](#validateschema-is-part-of-idriverdelegate) only checks that
+each table can be queried, not which columns it has, so what you reach instead is a provider-level
+missing-column error from the first statement that names one. That happens almost immediately —
+loading a trigger projects all four columns, and storing one names three of them.
+
+A delegate of your own has nothing to override here any more. If it derived from `StdAdoDelegate` and
+overrode a probe — to hard-code `true` against a schema you knew was current, say — delete the
+override; the base class no longer declares it.
+
+### The three extra acquisition SQL hooks went with them
+
+Because the columns were optional, 3.x carried four versions of the trigger acquisition statement and
+chose between them at run time from the probe results: plain, with `EXECUTION_GROUP`, with
+`PREFERRED_NODE`, and with both. Each had its own `protected virtual` hook, and all six dialect
+delegates overrode all four to hang their own row-limiting clause off the end. Three of the four are
+gone from `StdAdoDelegate` and from `FirebirdDelegate`, `MySQLDelegate`, `OracleDelegate`,
+`PostgreSQLDelegate`, `SQLiteDelegate` and `SqlServerDelegate`:
+
+* `GetSelectNextTriggerToAcquireWithExecutionGroupSql(int maxCount)`
+* `GetSelectNextTriggerToAcquireWithPreferredNodeSql(int maxCount)`
+* `GetSelectNextTriggerToAcquireWithPreferredNodeOnlySql(int maxCount)`
+
+With the columns required there is one statement — `StdAdoConstants.SqlSelectNextTriggerToAcquire`,
+which always projects `EXECUTION_GROUP` and always carries the preferred-node filter — and one hook,
+which is the one that was already there:
+
+```csharp
+protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount)
+```
+
+It is unchanged, and it is still the only thing the dialects differed in: `FirebirdDelegate` appends
+`ROWS n`, `SqlServerDelegate` splices in `SELECT TOP n`, `OracleDelegate` wraps the statement in a
+`rownum` filter, and the rest append `LIMIT n`. **A dialect delegate of your own should keep its
+`GetSelectNextTriggerToAcquireSql` override and delete the other three.**
+
+The node-affinity parameters the statement now always carries are bound for you by the protected
+`AddPreferredNodeParameters(cmd, liveNodeCutoff)`, so an override that rewrites the statement text
+still does not have to know their names or the order they are bound in.
+
 ## The connection manager lives with the other ADO.NET types
 
 `IDbConnectionManager` and `DbConnectionManager` were in `Quartz.Util`, two namespaces away from the
@@ -3528,69 +3676,6 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
   var times = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, calendar, 10);
 ```
 
-## The road from 3.x, phase by phase
-
-The 4.0 API is the result of six passes over the public surface, each with its own theme. The guide
-above is organised by topic rather than by pass, so this is the map: what changed, in the order it is
-worth working through when migrating.
-
-**1. The extensibility contracts.** The interfaces you implement rather than call. `Quartz.Spi` is
-[`Quartz.Extensibility` and `Quartz.Simpl` is `Quartz.Impl`](#quartz-spi-and-quartz-simpl-were-renamed);
-every asynchronous member returns [`ValueTask`](#tasks-changed-to-valuetask) and ends with a
-`CancellationToken`; [jobs take that token as a parameter](#jobs-take-a-cancellationtoken); the
-[job factory hands out a scope](#the-job-factory-hands-out-a-scope) instead of an instance; the
-[thread pool is asynchronous](#the-thread-pool-is-asynchronous); and
-[trigger fire times are properties](#trigger-fire-times-are-properties) rather than getter/setter
-pairs. Start here: everything else assumes these signatures.
-
-**2. The vocabulary and the surface.** One word per concept, and nothing public that was never a
-contract. [Names that were normalized](#names-that-were-normalized),
-[the scheduler and the job store speak the same verbs](#the-scheduler-and-the-job-store-speak-the-same-verbs),
-[matchers moved to `Quartz.Matchers`](#matchers-moved-to-quartz-matchers),
-[`Key<T>` moved to `Quartz` and is immutable](#key-t-moved-to-quartz-and-is-immutable),
-[`SchedulerMetadata` replaces `SchedulerMetaData`](#schedulermetadata-replaces-schedulermetadata),
-[the listener API](#listener-api-changes), and
-[sealed and internalized types](#sealed-and-internalized-types).
-
-**3. Listings, schedules and dates.** [Job store listings became queries](#job-store-listings-became-queries)
-returning `PagedResult<T>` of headers; [misfire instructions are enums](#misfire-instructions-are-enums);
-[intervals are said once per builder](#intervals-are-said-once-per-builder);
-[`TimeOfDay` became `TimeOnly`](#timeofday-became-timeonly) and
-[`DateBuilder`'s static factories are gone](#datebuilders-static-factories-are-gone);
-[`Executing` is a trigger state](#executing-is-a-trigger-state); and
-[the preferred node is a value](#the-preferred-node-is-a-value).
-
-**4. The ADO.NET job store.** [Trigger states are typed on the driver delegate](#trigger-states-are-typed-on-the-driver-delegate);
-[the stores are named for whose transaction they use](#the-ado-net-job-stores-are-named-for-whose-transaction-they-use);
-[nine `Execute…Lock` overloads became four](#nine-execute-lock-overloads-became-four-members);
-[locks are a `SchedulerLock`](#locks-are-a-schedulerlock-not-a-string);
-[the job store configuration is read-only](#the-job-store-configuration-is-read-only);
-[the driver delegate speaks in records](#the-driver-delegate-speaks-in-records);
-[`RAMJobStore` is sealed](#ramjobstore-is-sealed); and
-[a job store of your own can join your transaction](#a-job-store-of-your-own-can-join-your-transaction).
-
-**5. Configuration and hosting.** The container builds the scheduler:
-[`StdSchedulerFactory` is gone](#stdschedulerfactory-is-gone),
-[the standalone builder is the same builder](#the-standalone-builder-is-the-same-builder),
-[there is no process-global scheduler state](#no-process-global-scheduler-or-connection-state),
-[`AddJob` registers the job with the container](#addjob-registers-the-job-with-the-container),
-[one shape per registration method](#one-shape-per-registration-method),
-[clustering is configured in one place](#clustering-is-configured-in-one-place),
-[the hosted service starts every scheduler](#the-hosted-service-starts-every-scheduler), and
-[job execution metrics](#job-execution-metrics) are published by every scheduler.
-
-**6. Serialization policy and the last edges.**
-[`[Serializable]` survives only where a database blob needs it](#serializable-survives-only-where-a-database-blob-needs-it);
-[the two exceptions moved out of `Quartz.Core`](#the-two-exceptions-moved-out-of-quartz-core);
-[execution limits are built once, then frozen](#execution-limits-are-built-once-then-frozen);
-[interruption has two names, not three](#interruption-has-two-names-not-three); and the naming and
-visibility odds and ends in this section and in the table below.
-
-Two differences run through all six and are not called out case by case, because they are almost
-universal: `Task` became `ValueTask` on nearly every member, and the namespaces moved as described in
-pass 1. If a type you used does not appear in this guide at all, check
-[Package Changes](#package-changes) first — it may have moved packages rather than changed.
-
 ## Other Breaking Changes
 
 | Change | Details |
@@ -3639,6 +3724,7 @@ pass 1. If a type you used does not appear in this guide at all, check
 | `JobStoreSupport`'s constructor takes `IOptions<ClusteringOptions>` | Between `storeOptions` and `objectSerializer`; a job store deriving from it has to pass one on |
 | `UseSQLite` is `UseSystemDataSqlite`, `UseMicrosoftSQLite` is `UseSqlite` | **The short name changed meaning** — see [The SQLite extension methods swapped names](#the-sqlite-extension-methods-swapped-names) |
 | `UseDataSourceConnectionProvider()` removed | `DataSourceOptions.UseRegisteredDataSource`, which is what it set |
+| `AddDataSourceProvider()` removed | Its other half. It registered `DataSourceDbProvider` in the container for `UseDataSourceConnectionProvider()` to name; `UseRegisteredDataSource` builds the provider itself from the registered `DbDataSource` — see [`AddDataSourceProvider()` went with it](#adddatasourceprovider-went-with-it) |
 | `QuartzOptions.SchedulerName`, `.SchedulerId`, `.MisfireThreshold` removed | Each duplicated a typed option — see [`QuartzOptions` lost its three typed settings](#quartzoptions-lost-its-three-typed-settings) |
 | Job execution metrics are published by every scheduler | The meters were configured only by `StdSchedulerFactory`, so a scheduler registered with `AddQuartz` published none |
 | `scheduling.quartz.execute.active` is an `UpDownCounter<long>` | It was a `Counter<long>` receiving the `-1` that ends an execution, which an exporter aggregating a monotonic sum may drop — see [Job execution metrics](#job-execution-metrics) |
@@ -3678,6 +3764,8 @@ pass 1. If a type you used does not appear in this guide at all, check
 | `TriggerAcquireResult` carries a `TriggerKey` | It carried `TriggerName` and `TriggerGroup`, which every caller immediately paired back up |
 | `TriggerStatus` removed, `IDriverDelegate.SelectTriggerStatus` is `SelectTriggerHeader` | It returns `StoredTriggerHeader`, an immutable record whose state is a `StoredTriggerState` — see [The driver delegate speaks in records](#the-driver-delegate-speaks-in-records) |
 | `IDriverDelegate.ValidateSchema` added | Schema validation was a `StdAdoDelegate` method reached by type test, so a delegate of your own silently skipped it — see [`ValidateSchema` is part of `IDriverDelegate`](#validateschema-is-part-of-idriverdelegate) |
+| `StdAdoDelegate`'s column probes removed | The three `Has*Column` properties, the three `Supports*Column` probes and `VerifyTriggersTableReachable`. The columns they probed for are required on 4.x, so the schema migration replaces them — see [The optional columns are required, so the probes are gone](#the-optional-columns-are-required-so-the-probes-are-gone) |
+| `GetSelectNextTriggerToAcquireWith*Sql` removed | The `…WithExecutionGroupSql`, `…WithPreferredNodeSql` and `…WithPreferredNodeOnlySql` hooks, on `StdAdoDelegate` and all six dialect delegates. One statement covers every case now, so a dialect delegate keeps only its `GetSelectNextTriggerToAcquireSql` override — see [The three extra acquisition SQL hooks went with them](#the-three-extra-acquisition-sql-hooks-went-with-them) |
 | `IDbConnectionManager` / `DbConnectionManager` moved to `Quartz.Impl.AdoJobStore.Common` | And `AddConnectionProvider` / `GetConnectionProvider` are `AddDbProvider` / `GetDbProvider` — see [The connection manager lives with the other ADO.NET types](#the-connection-manager-lives-with-the-other-ado-net-types) |
 | `DbMetadataFactory` is internal | Every implementation was already internal and no public member accepted one; describe a driver through `UseGenericDatabase`'s metadata callback |
 | `DbProvider.PropertyDbProvider` and `.DbProviderResourceName` removed | Two `protected const`s nothing read, left over from the process-wide provider registry |
@@ -3712,7 +3800,7 @@ pass 1. If a type you used does not appear in this guide at all, check
 | `Quartz.Diagnostics.IJobDiagnosticData` removed | It was the payload contract of the `DiagnosticSource` events `Quartz.OpenTracing` consumed. Both the package and the events are gone; job execution is on `Activity` through `QuartzActivitySource`, and `IJobExecutionContext` is what a listener reads |
 | `CronExpression.Clone()` returns `CronExpression` | It returned `object`, unlike `ITrigger.Clone`, `IJobDetail.Clone` and `ICalendar.Clone`; the casts at the call sites can go |
 | `IJobExecutionContext.Put` / `.Get` take a `string` key | They took `object`. The volatile per-execution map keys by name, like `JobDataMap`, and `Put`'s value is `object?` and its parameter is `value` rather than `objectValue` |
-| `JobDataMap`'s sixty typed accessors removed | The inherited `StringKeyDirtyFlagMap` set does the same job — see [`JobDataMap`'s typed accessors are the ones it inherits](#jobdatamaps-typed-accessors-are-the-ones-it-inherits) |
+| `JobDataMap`'s sixty typed accessors removed | The inherited `StringKeyDirtyFlagMap` set does the same job — see [`JobDataMap`'s typed accessors are the ones it inherits](#jobdatamap-s-typed-accessors-are-the-ones-it-inherits) |
 | `Quartz.AspNetCore.AddQuartzServer` removed | `AddQuartzHostedService` starts the scheduler and `AddQuartzHealthChecks` registers the check — see [`AddQuartzServer` is `AddQuartzHostedService`](#addquartzserver-is-addquartzhostedservice) |
 | `ISchedulerFactory.GetScheduler(name)` is `LookupScheduler(name)` | Two members named `GetScheduler` differed only in nullability. `GetScheduler()` builds this factory's scheduler and cannot return null; `LookupScheduler(name)` looks one up in the container's repository and can, which is what the verb now says. `Lookup` matches `ISchedulerRepository.Lookup` |
 | `TriggerUtils` moved to `Quartz.Extensibility` | It is a helper over `IOperableTrigger`, not part of the scheduling API — see [`TriggerUtils` moved to `Quartz.Extensibility`](#triggerutils-moved-to-quartz-extensibility) |

--- a/docs/documentation/quartz-4.x/packages/aspnet-core-integration.md
+++ b/docs/documentation/quartz-4.x/packages/aspnet-core-integration.md
@@ -20,8 +20,13 @@ Install-Package Quartz.AspNetCore
 
 ## Using
 
-You can add Quartz configuration by invoking an extension method `AddQuartzServer` on `IServiceCollection`.
-This will add a hosted Quartz server into ASP.NET Core process that will be started and stopped based on applications lifetime.
+You can host the scheduler by invoking `AddQuartzHostedService` on `IServiceCollection`.
+This adds a hosted Quartz server into the ASP.NET Core process that is started and stopped based on the application's lifetime.
+
+::: tip
+`AddQuartzHostedService` lives in the core `Quartz` package. Quartz 3's `AddQuartzServer`, which registered the
+hosted service and a health check together, is gone — call `AddQuartzHealthChecks` for the health check.
+:::
 
 ::: tip
 See [Quartz documentation](microsoft-di-integration) to learn more about configuring Quartz scheduler, jobs and triggers.
@@ -38,7 +43,7 @@ public void ConfigureServices(IServiceCollection services)
     });
 
     // ASP.NET Core hosting
-    services.AddQuartzServer(options =>
+    services.AddQuartzHostedService(options =>
     {
         // when shutting down we want jobs to complete gracefully
         options.WaitForJobsToComplete = true;
@@ -112,8 +117,7 @@ tags so the check can be filtered into separate liveness and readiness probes:
 services.AddQuartzHealthChecks(options =>
 {
     options.Name = "quartz-scheduler";   // defaults to "quartz-scheduler"
-    options.Tags.Add("ready");
-    options.Tags.Add("live");
+    options.Tags = ["ready", "live"];
     options.FailureStatus = HealthStatus.Unhealthy;
 });
 ```

--- a/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
+++ b/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
@@ -112,7 +112,7 @@ public class MyService
 }
 ```
 
-If you also have a default scheduler (registered via unnamed `AddQuartz()`), you can inject `ISchedulerFactory` and use `GetScheduler(name)`:
+If you also have a default scheduler (registered via unnamed `AddQuartz()`), you can inject `ISchedulerFactory` and use `LookupScheduler(name)`:
 
 ```csharp
 public class MyService
@@ -126,7 +126,7 @@ public class MyService
 
     public async Task DoWork()
     {
-        var scheduler = await schedulerFactory.GetScheduler("FastScheduler");
+        var scheduler = await schedulerFactory.LookupScheduler("FastScheduler");
     }
 }
 ```

--- a/docs/documentation/quartz-4.x/packages/quartz-jobs.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-jobs.md
@@ -32,10 +32,16 @@ Built in job for executing native executables in a separate process.
 **Example**
 
 ```csharp
-var job = new JobDetail("dumbJob", null, typeof(Quartz.Jobs.NativeJob));
-job.JobDataMap.Put(Quartz.Jobs.NativeJob.PropertyCommand, "echo \"hi\" >> foobar.txt");
-var trigger = TriggerUtils.MakeSecondlyTrigger(5);
-trigger.Name = "dumbTrigger";
+var job = JobBuilder.Create<NativeJob>()
+    .WithIdentity("dumbJob")
+    .UsingJobData(NativeJob.PropertyCommand, "echo \"hi\" >> foobar.txt")
+    .Build();
+
+var trigger = TriggerBuilder.Create()
+    .WithIdentity("dumbTrigger")
+    .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(5)).RepeatForever())
+    .Build();
+
 await scheduler.ScheduleJob(job, trigger);
 ```
 

--- a/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
+++ b/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
@@ -706,7 +706,7 @@ public class SimpleTriggerImplBenchmark
 
                 if (newFireTime.HasValue)
                 {
-                    int timesMissed = ComputeNumTimesFiredBetween(NextFireTimeUtc!.Value, newFireTime!.Value);
+                    int timesMissed = ComputeNumberOfTimesFiredBetween(NextFireTimeUtc!.Value, newFireTime!.Value);
                     TimesTriggered = TimesTriggered + timesMissed;
                 }
 
@@ -734,7 +734,7 @@ public class SimpleTriggerImplBenchmark
             else if (instr == Quartz.MisfireInstruction.SimpleTrigger.RescheduleNowWithRemainingRepeatCount)
             {
                 DateTimeOffset newFireTime = TimeProvider.System.GetUtcNow();
-                int timesMissed = ComputeNumTimesFiredBetween(NextFireTimeUtc!.Value, newFireTime);
+                int timesMissed = ComputeNumberOfTimesFiredBetween(NextFireTimeUtc!.Value, newFireTime);
 
                 if (repeatCount != 0 && repeatCount != RepeatIndefinitely)
                 {
@@ -953,7 +953,7 @@ public class SimpleTriggerImplBenchmark
                 return null;
             }
 
-            int numFires = ComputeNumTimesFiredBetween(StartTimeUtc, endUtc!.Value);
+            int numFires = ComputeNumberOfTimesFiredBetween(StartTimeUtc, endUtc!.Value);
             return StartTimeUtc.AddTicks(numFires * repeatInterval.Ticks);
         }
 
@@ -963,7 +963,7 @@ public class SimpleTriggerImplBenchmark
         /// <param name="startTimeUtc">The UTC start date and time.</param>
         /// <param name="endTimeUtc">The UTC end date and time.</param>
         /// <returns></returns>
-        public virtual int ComputeNumTimesFiredBetween(DateTimeOffset startTimeUtc, DateTimeOffset endTimeUtc)
+        public virtual int ComputeNumberOfTimesFiredBetween(DateTimeOffset startTimeUtc, DateTimeOffset endTimeUtc)
         {
             long time = (endTimeUtc - startTimeUtc).Ticks;
             return (int) (time / repeatInterval.Ticks);

--- a/src/Quartz.Jobs/Job/NativeJob.cs
+++ b/src/Quartz.Jobs/Job/NativeJob.cs
@@ -33,11 +33,17 @@ namespace Quartz.Job;
 /// </summary>
 /// <remarks>
 /// <example>
-///     JobDetail job = new JobDetail("dumbJob", null, typeof(Quartz.Jobs.NativeJob));
-///     job.JobDataMap[Quartz.Jobs.NativeJob.PropertyCommand] = "echo \"hi\" >> foobar.txt";
-///     Trigger trigger = TriggerUtils.MakeSecondlyTrigger(5);
-///     trigger.Name = "dumbTrigger";
-///     scheduler.ScheduleJob(job, trigger);
+///     IJobDetail job = JobBuilder.Create&lt;NativeJob&gt;()
+///         .WithIdentity("dumbJob")
+///         .UsingJobData(NativeJob.PropertyCommand, "echo \"hi\" >> foobar.txt")
+///         .Build();
+///
+///     ITrigger trigger = TriggerBuilder.Create()
+///         .WithIdentity("dumbTrigger")
+///         .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(5)).RepeatForever())
+///         .Build();
+///
+///     await scheduler.ScheduleJob(job, trigger);
 /// </example>
 /// If PropertyWaitForProcess is true, then the integer exit value of the process
 /// will be saved as the job execution result in the JobExecutionContext.

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
@@ -19,7 +19,7 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
             var triggerSerializer = registry.GetTriggerSerializer(type);
 
             writer.WritePropertyName("TriggerType");
-            writer.WriteValue(triggerSerializer.TriggerTypeForJson);
+            writer.WriteValue(triggerSerializer.TriggerTypeName);
 
             writer.WriteKey("Key", trigger.Key);
             writer.WriteKey("JobKey", trigger.JobKey);

--- a/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonSerializerRegistry.cs
+++ b/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonSerializerRegistry.cs
@@ -62,7 +62,7 @@ public sealed class NewtonsoftJsonSerializerRegistry
         ArgumentNullException.ThrowIfNull(serializer);
 
         // Found by its JSON discriminator, and also by its type name.
-        triggerSerializers.Add(serializer, serializer.TriggerTypeForJson, typeof(TTrigger).AssemblyQualifiedNameWithoutVersion());
+        triggerSerializers.Add(serializer, serializer.TriggerTypeName, typeof(TTrigger).AssemblyQualifiedNameWithoutVersion());
         return this;
     }
 

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CalendarIntervalTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CalendarIntervalTriggerSerializer.cs
@@ -9,7 +9,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers;
 
 public class CalendarIntervalTriggerSerializer : TriggerSerializer<CalendarIntervalTriggerImpl>
 {
-    public override string TriggerTypeForJson => "CalendarIntervalTrigger";
+    public override string TriggerTypeName => "CalendarIntervalTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
@@ -7,7 +7,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers;
 
 public class CronTriggerSerializer : TriggerSerializer<ICronTrigger>
 {
-    public override string TriggerTypeForJson => "CronTrigger";
+    public override string TriggerTypeName => "CronTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/DailyTimeIntervalTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/DailyTimeIntervalTriggerSerializer.cs
@@ -9,7 +9,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers;
 
 public class DailyTimeIntervalTriggerSerializer : TriggerSerializer<DailyTimeIntervalTriggerImpl>
 {
-    public override string TriggerTypeForJson => "DailyTimeIntervalTrigger";
+    public override string TriggerTypeName => "DailyTimeIntervalTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/RecurrenceTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/RecurrenceTriggerSerializer.cs
@@ -9,7 +9,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers;
 
 public sealed class RecurrenceTriggerSerializer : TriggerSerializer<RecurrenceTriggerImpl>
 {
-    public override string TriggerTypeForJson => "RecurrenceTrigger";
+    public override string TriggerTypeName => "RecurrenceTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/SimpleTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/SimpleTriggerSerializer.cs
@@ -9,7 +9,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers;
 
 public class SimpleTriggerSerializer : TriggerSerializer<SimpleTriggerImpl>
 {
-    public override string TriggerTypeForJson => "SimpleTrigger";
+    public override string TriggerTypeName => "SimpleTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/TriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/TriggerSerializer.cs
@@ -5,7 +5,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers;
 
 public interface ITriggerSerializer
 {
-    string TriggerTypeForJson { get; }
+    string TriggerTypeName { get; }
 
     IScheduleBuilder CreateScheduleBuilder(JObject source);
 
@@ -16,7 +16,7 @@ public interface ITriggerSerializer
 
 public abstract class TriggerSerializer<TTrigger> : ITriggerSerializer where TTrigger : ITrigger
 {
-    public abstract string TriggerTypeForJson { get; }
+    public abstract string TriggerTypeName { get; }
 
     public abstract IScheduleBuilder CreateScheduleBuilder(JObject source);
 

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -718,7 +718,7 @@ internal sealed class CustomTrigger : CronTriggerImpl
 
 internal sealed class CustomNewtonsoftTriggerSerializer : CronTriggerSerializer
 {
-    public override string TriggerTypeForJson => "CustomTrigger";
+    public override string TriggerTypeName => "CustomTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {
@@ -751,7 +751,7 @@ internal sealed class CustomNewtonsoftTriggerSerializer : CronTriggerSerializer
 
 internal sealed class CustomSystemTextJsonTriggerSerializer : Serialization.Json.Triggers.CronTriggerSerializer
 {
-    public override string TriggerTypeForJson => "CustomTrigger";
+    public override string TriggerTypeName => "CustomTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
     {

--- a/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
@@ -585,7 +585,7 @@ public abstract class AbstractSchedulerTest
 
         public sealed class SystemTextJsonSerializer : TriggerSerializer<TestBlobCronTriggerImpl>
         {
-            public override string TriggerTypeForJson => "TestBlobCronTrigger";
+            public override string TriggerTypeName => "TestBlobCronTrigger";
 
             public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
             {

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
@@ -865,7 +865,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
 
     private sealed class TriggerKnownToASerializer : TriggerSerializer<TriggerKnownToA>
     {
-        public override string TriggerTypeForJson => "KnownToA";
+        public override string TriggerTypeName => "KnownToA";
 
         public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
             => SimpleScheduleBuilder.Create();
@@ -881,7 +881,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
 
     private sealed class TriggerKnownToBSerializer : TriggerSerializer<TriggerKnownToB>
     {
-        public override string TriggerTypeForJson => "KnownToB";
+        public override string TriggerTypeName => "KnownToB";
 
         public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
             => SimpleScheduleBuilder.Create();

--- a/src/Quartz.Tests.Unit/Configuration/QuartzSchedulerBuilderPropertiesTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/QuartzSchedulerBuilderPropertiesTest.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -160,7 +160,7 @@ public class QuartzSchedulerBuilderPropertiesTest
         using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create().UseProperties(PropertiesForScheduler(SchedulerName)).Build();
 
         // no GetScheduler() call first, which used to be the only way to get a non-null result here
-        IScheduler scheduler = await factory.GetScheduler(SchedulerName);
+        IScheduler scheduler = await factory.LookupScheduler(SchedulerName);
 
         try
         {
@@ -183,7 +183,7 @@ public class QuartzSchedulerBuilderPropertiesTest
 
         try
         {
-            IScheduler namedScheduler = await factory.GetScheduler(SchedulerName);
+            IScheduler namedScheduler = await factory.LookupScheduler(SchedulerName);
             namedScheduler.Should().BeSameAs(defaultScheduler);
         }
         finally
@@ -198,7 +198,7 @@ public class QuartzSchedulerBuilderPropertiesTest
         const string SchedulerName = "NamedLookupIgnoresCase";
         using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create().UseProperties(PropertiesForScheduler(SchedulerName)).Build();
 
-        IScheduler scheduler = await factory.GetScheduler(SchedulerName.ToLowerInvariant());
+        IScheduler scheduler = await factory.LookupScheduler(SchedulerName.ToLowerInvariant());
 
         try
         {
@@ -217,7 +217,7 @@ public class QuartzSchedulerBuilderPropertiesTest
         const string SchedulerName = "NamedLookupOtherName";
         using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create().UseProperties(PropertiesForScheduler(SchedulerName)).Build();
 
-        IScheduler scheduler = await factory.GetScheduler("SchedulerThisFactoryDoesNotProduce");
+        IScheduler scheduler = await factory.LookupScheduler("SchedulerThisFactoryDoesNotProduce");
 
         scheduler.Should().BeNull();
         (await factory.GetAllSchedulers()).Should().BeEmpty("asking for another name must not create this factory's own scheduler");

--- a/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
@@ -94,7 +94,7 @@ public sealed class JobExecutionObservabilityTest
 
         activityListener = new ActivityListener
         {
-            ShouldListenTo = static source => source.Name == ActivityOptions.DefaultListenerName,
+            ShouldListenTo = static source => source.Name == ActivityTags.DefaultListenerName,
             Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             ActivityStopped = activity =>
             {
@@ -152,10 +152,10 @@ public sealed class JobExecutionObservabilityTest
 
         foreach (RecordedMeasurement measurement in published)
         {
-            measurement.Tags.Should().Contain(new KeyValuePair<string, object>(ActivityOptions.TriggerGroup, execution.TriggerKey.Group))
-                .And.Contain(new KeyValuePair<string, object>(ActivityOptions.TriggerName, execution.TriggerKey.Name))
-                .And.Contain(new KeyValuePair<string, object>(ActivityOptions.JobGroup, execution.JobKey.Group))
-                .And.Contain(new KeyValuePair<string, object>(ActivityOptions.JobName, execution.JobKey.Name));
+            measurement.Tags.Should().Contain(new KeyValuePair<string, object>(ActivityTags.TriggerGroup, execution.TriggerKey.Group))
+                .And.Contain(new KeyValuePair<string, object>(ActivityTags.TriggerName, execution.TriggerKey.Name))
+                .And.Contain(new KeyValuePair<string, object>(ActivityTags.JobGroup, execution.JobKey.Group))
+                .And.Contain(new KeyValuePair<string, object>(ActivityTags.JobName, execution.JobKey.Name));
 
             measurement.Tags.Should().HaveCount(4,
                 "an execution is identified by its trigger and its job, and nothing else is added to it");
@@ -222,20 +222,20 @@ public sealed class JobExecutionObservabilityTest
         Activity activity = ActivityFor(execution.JobKey);
 
         activity.OperationName.Should().Be(OperationName.Job.Execute);
-        activity.Source.Name.Should().Be(ActivityOptions.DefaultListenerName,
+        activity.Source.Name.Should().Be(ActivityTags.DefaultListenerName,
             "the source name is what a tracer is told to subscribe to");
         activity.Kind.Should().Be(ActivityKind.Internal);
         activity.Status.Should().Be(ActivityStatusCode.Unset, "the job succeeded");
 
-        activity.GetTagItem(ActivityOptions.SchedulerName).Should().Be(execution.SchedulerName);
-        activity.GetTagItem(ActivityOptions.SchedulerId).Should().Be(execution.SchedulerInstanceId);
-        activity.GetTagItem(ActivityOptions.JobType).Should().Be(new JobType(typeof(SucceedingJob)).FullName,
+        activity.GetTagItem(ActivityTags.SchedulerName).Should().Be(execution.SchedulerName);
+        activity.GetTagItem(ActivityTags.SchedulerId).Should().Be(execution.SchedulerInstanceId);
+        activity.GetTagItem(ActivityTags.JobType).Should().Be(new JobType(typeof(SucceedingJob)).FullName,
             "the job type is reported the way the scheduler names it — assembly-qualified, without a version");
-        activity.GetTagItem(ActivityOptions.FireInstanceId).Should().Be(execution.FireInstanceId);
-        activity.GetTagItem(ActivityOptions.TriggerGroup).Should().Be(execution.TriggerKey.Group);
-        activity.GetTagItem(ActivityOptions.TriggerName).Should().Be(execution.TriggerKey.Name);
-        activity.GetTagItem(ActivityOptions.JobGroup).Should().Be(execution.JobKey.Group);
-        activity.GetTagItem(ActivityOptions.JobName).Should().Be(execution.JobKey.Name);
+        activity.GetTagItem(ActivityTags.FireInstanceId).Should().Be(execution.FireInstanceId);
+        activity.GetTagItem(ActivityTags.TriggerGroup).Should().Be(execution.TriggerKey.Group);
+        activity.GetTagItem(ActivityTags.TriggerName).Should().Be(execution.TriggerKey.Name);
+        activity.GetTagItem(ActivityTags.JobGroup).Should().Be(execution.JobKey.Group);
+        activity.GetTagItem(ActivityTags.JobName).Should().Be(execution.JobKey.Name);
     }
 
     [Test]
@@ -322,7 +322,7 @@ public sealed class JobExecutionObservabilityTest
         lock (measurements)
         {
             return measurements
-                .Where(m => Equals(m.Tags.GetValueOrDefault(ActivityOptions.JobName), jobKey.Name))
+                .Where(m => Equals(m.Tags.GetValueOrDefault(ActivityTags.JobName), jobKey.Name))
                 .ToList();
         }
     }
@@ -333,7 +333,7 @@ public sealed class JobExecutionObservabilityTest
         {
             return stoppedActivities.Should().ContainSingle(a =>
                     a.OperationName == OperationName.Job.Execute
-                    && Equals(a.GetTagItem(ActivityOptions.JobName), jobKey.Name))
+                    && Equals(a.GetTagItem(ActivityTags.JobName), jobKey.Name))
                 .Subject;
         }
     }

--- a/src/Quartz.Tests.Unit/Diagnostics/JobStoreActivityTracerTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobStoreActivityTracerTest.cs
@@ -36,7 +36,7 @@ public sealed class JobStoreActivityTracerTest : IDisposable
     {
         activityListener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name == ActivityOptions.DefaultListenerName,
+            ShouldListenTo = source => source.Name == ActivityTags.DefaultListenerName,
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             ActivityStarted = activity => startedActivities.Add(activity),
             ActivityStopped = activity => stoppedActivities.Add(activity),
@@ -65,7 +65,7 @@ public sealed class JobStoreActivityTracerTest : IDisposable
         int result = await tracer.Trace(
             OperationName.JobStore.AcquireNextTriggers,
             () => new ValueTask<int>(42),
-            activity => activity.SetTag(ActivityOptions.BatchSize, 10));
+            activity => activity.SetTag(ActivityTags.BatchSize, 10));
 
         result.Should().Be(42);
 
@@ -89,8 +89,8 @@ public sealed class JobStoreActivityTracerTest : IDisposable
             });
 
         capturedActivity.Should().NotBeNull();
-        capturedActivity.GetTagItem(ActivityOptions.SchedulerName).Should().Be("MyScheduler");
-        capturedActivity.GetTagItem(ActivityOptions.SchedulerId).Should().Be("sched-42");
+        capturedActivity.GetTagItem(ActivityTags.SchedulerName).Should().Be("MyScheduler");
+        capturedActivity.GetTagItem(ActivityTags.SchedulerId).Should().Be("sched-42");
     }
 
     [Test]
@@ -107,10 +107,10 @@ public sealed class JobStoreActivityTracerTest : IDisposable
                 capturedActivity = Activity.Current;
                 return new ValueTask<bool>(true);
             },
-            activity => activity.SetTag(ActivityOptions.TriggerCount, 5));
+            activity => activity.SetTag(ActivityTags.TriggerCount, 5));
 
         capturedActivity.Should().NotBeNull();
-        capturedActivity.GetTagItem(ActivityOptions.TriggerCount).Should().Be(5);
+        capturedActivity.GetTagItem(ActivityTags.TriggerCount).Should().Be(5);
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Quartz.Configuration;
@@ -516,9 +516,9 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Test]
-    public async Task GetScheduler_ByName_ShouldReturnSchedulerWithoutRequiringDefaultSchedulerCall()
+    public async Task LookupScheduler_ByName_ShouldReturnSchedulerWithoutRequiringDefaultSchedulerCall()
     {
-        // This tests the fix for the issue where GetScheduler(name) returned null
+        // This tests the fix for the issue where the by-name lookup returned null
         // unless GetScheduler() was called first
         const string schedulerName = "TestScheduler";
 
@@ -534,7 +534,7 @@ public class ServiceCollectionExtensionsTests
         var factory = serviceProvider.GetRequiredService<ISchedulerFactory>();
 
         // Call GetScheduler with the name directly, without calling GetScheduler() first
-        var scheduler = await factory.GetScheduler(schedulerName);
+        var scheduler = await factory.LookupScheduler(schedulerName);
 
         // Should not be null
         Assert.That(scheduler, Is.Not.Null);
@@ -544,7 +544,7 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Test]
-    public async Task GetScheduler_ByName_AfterDefaultCall_ShouldReturnSameScheduler()
+    public async Task LookupScheduler_ByName_AfterDefaultCall_ShouldReturnSameScheduler()
     {
         // This tests that both methods return the same scheduler instance
         const string schedulerName = "TestScheduler2";
@@ -562,7 +562,7 @@ public class ServiceCollectionExtensionsTests
 
         // Call both methods
         var defaultScheduler = await factory.GetScheduler();
-        var namedScheduler = await factory.GetScheduler(schedulerName);
+        var namedScheduler = await factory.LookupScheduler(schedulerName);
 
         // Should return the same instance
         Assert.That(namedScheduler, Is.Not.Null);

--- a/src/Quartz.Tests.Unit/Impl/SchedulerRepositoryIsolationTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/SchedulerRepositoryIsolationTest.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,9 +72,9 @@ public sealed class SchedulerRepositoryIsolationTest
                 .Which.Should().BeSameAs(propertiesScheduler,
                     "a standalone builder reports the schedulers of its own container, not every scheduler in the process");
 
-            (await containerFactory.GetScheduler("PropertiesScheduler")).Should().BeNull(
+            (await containerFactory.LookupScheduler("PropertiesScheduler")).Should().BeNull(
                 "a scheduler built by a standalone builder is no longer reachable from an AddQuartz container");
-            (await propertiesFactory.GetScheduler("ContainerScheduler")).Should().BeNull(
+            (await propertiesFactory.LookupScheduler("ContainerScheduler")).Should().BeNull(
                 "and the other way round");
         }
         finally

--- a/src/Quartz.Tests.Unit/Plugin/TimeZoneConverter/TimeZoneConverterTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/TimeZoneConverter/TimeZoneConverterTest.cs
@@ -17,7 +17,7 @@ public class TimeZoneConverterTest
         }
         finally
         {
-            TimeZoneUtil.CustomResolver = _ => null;
+            TimeZoneUtil.CustomResolver = null;
         }
     }
 }

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -47,7 +47,7 @@ public class QuartzHostedServiceTests
             return scheduler;
         }
 
-        public ValueTask<IScheduler> GetScheduler(string schedulerName, CancellationToken cancellationToken = default)
+        public ValueTask<IScheduler> LookupScheduler(string schedulerName, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -627,7 +627,7 @@ public class JsonSerializationTestTrigger : SimpleTriggerImpl
 
     public sealed class SystemTextJsonSerializer : Serialization.Json.Triggers.TriggerSerializer<JsonSerializationTestTrigger>
     {
-        public override string TriggerTypeForJson => "TestTrigger";
+        public override string TriggerTypeName => "TestTrigger";
 
         public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, StjJsonSerializerOptions options)
         {
@@ -666,7 +666,7 @@ public class JsonSerializationTestTrigger : SimpleTriggerImpl
 
     public sealed class NewtonsoftSerializer : Serialization.Newtonsoft.Triggers.TriggerSerializer<JsonSerializationTestTrigger>
     {
-        public override string TriggerTypeForJson => "TestTrigger";
+        public override string TriggerTypeName => "TestTrigger";
 
         public override IScheduleBuilder CreateScheduleBuilder(JObject jsonElement)
         {

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Serialization.Newtonsoft.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Serialization.Newtonsoft.verified.txt
@@ -67,7 +67,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers
     public class CalendarIntervalTriggerSerializer : Quartz.Serialization.Newtonsoft.Triggers.TriggerSerializer<Quartz.Impl.Triggers.CalendarIntervalTriggerImpl>
     {
         public CalendarIntervalTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(Newtonsoft.Json.Linq.JObject source) { }
         protected override void DeserializeFields(Quartz.Impl.Triggers.CalendarIntervalTriggerImpl trigger, Newtonsoft.Json.Linq.JObject source) { }
         protected override void SerializeFields(Newtonsoft.Json.JsonWriter writer, Quartz.Impl.Triggers.CalendarIntervalTriggerImpl trigger) { }
@@ -75,21 +75,21 @@ namespace Quartz.Serialization.Newtonsoft.Triggers
     public class CronTriggerSerializer : Quartz.Serialization.Newtonsoft.Triggers.TriggerSerializer<Quartz.ICronTrigger>
     {
         public CronTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(Newtonsoft.Json.Linq.JObject source) { }
         protected override void SerializeFields(Newtonsoft.Json.JsonWriter writer, Quartz.ICronTrigger trigger) { }
     }
     public class DailyTimeIntervalTriggerSerializer : Quartz.Serialization.Newtonsoft.Triggers.TriggerSerializer<Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl>
     {
         public DailyTimeIntervalTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(Newtonsoft.Json.Linq.JObject source) { }
         protected override void DeserializeFields(Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl trigger, Newtonsoft.Json.Linq.JObject source) { }
         protected override void SerializeFields(Newtonsoft.Json.JsonWriter writer, Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl trigger) { }
     }
     public interface ITriggerSerializer
     {
-        string TriggerTypeForJson { get; }
+        string TriggerTypeName { get; }
         Quartz.IScheduleBuilder CreateScheduleBuilder(Newtonsoft.Json.Linq.JObject source);
         void DeserializeFields(Quartz.ITrigger trigger, Newtonsoft.Json.Linq.JObject source);
         void SerializeFields(Newtonsoft.Json.JsonWriter writer, Quartz.ITrigger trigger);
@@ -97,7 +97,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers
     public sealed class RecurrenceTriggerSerializer : Quartz.Serialization.Newtonsoft.Triggers.TriggerSerializer<Quartz.Impl.Triggers.RecurrenceTriggerImpl>
     {
         public RecurrenceTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(Newtonsoft.Json.Linq.JObject source) { }
         protected override void DeserializeFields(Quartz.Impl.Triggers.RecurrenceTriggerImpl trigger, Newtonsoft.Json.Linq.JObject source) { }
         protected override void SerializeFields(Newtonsoft.Json.JsonWriter writer, Quartz.Impl.Triggers.RecurrenceTriggerImpl trigger) { }
@@ -105,7 +105,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers
     public class SimpleTriggerSerializer : Quartz.Serialization.Newtonsoft.Triggers.TriggerSerializer<Quartz.Impl.Triggers.SimpleTriggerImpl>
     {
         public SimpleTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(Newtonsoft.Json.Linq.JObject source) { }
         protected override void DeserializeFields(Quartz.Impl.Triggers.SimpleTriggerImpl trigger, Newtonsoft.Json.Linq.JObject source) { }
         protected override void SerializeFields(Newtonsoft.Json.JsonWriter writer, Quartz.Impl.Triggers.SimpleTriggerImpl trigger) { }
@@ -114,7 +114,7 @@ namespace Quartz.Serialization.Newtonsoft.Triggers
         where TTrigger : Quartz.ITrigger
     {
         protected TriggerSerializer() { }
-        public abstract string TriggerTypeForJson { get; }
+        public abstract string TriggerTypeName { get; }
         public abstract Quartz.IScheduleBuilder CreateScheduleBuilder(Newtonsoft.Json.Linq.JObject source);
         protected virtual void DeserializeFields(TTrigger trigger, Newtonsoft.Json.Linq.JObject source) { }
         protected abstract void SerializeFields(Newtonsoft.Json.JsonWriter writer, TTrigger trigger);

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -153,13 +153,13 @@ namespace Quartz
     {
         public Quartz.Extensibility.IMutableTrigger Build() { }
         public Quartz.DailyTimeIntervalScheduleBuilder EndingDailyAfterCount(int count) { }
-        public Quartz.DailyTimeIntervalScheduleBuilder EndingDailyAt(System.TimeOnly timeOfDayUtc) { }
+        public Quartz.DailyTimeIntervalScheduleBuilder EndingDailyAt(System.TimeOnly timeOfDay) { }
         public Quartz.DailyTimeIntervalScheduleBuilder InTimeZone(System.TimeZoneInfo? timeZone) { }
         public Quartz.DailyTimeIntervalScheduleBuilder OnDaysOfTheWeek([System.Runtime.CompilerServices.ParamCollection] System.Collections.Generic.IReadOnlyCollection<System.DayOfWeek> onDaysOfWeek) { }
         public Quartz.DailyTimeIntervalScheduleBuilder OnEveryDay() { }
         public Quartz.DailyTimeIntervalScheduleBuilder OnMondayThroughFriday() { }
         public Quartz.DailyTimeIntervalScheduleBuilder OnSaturdayAndSunday() { }
-        public Quartz.DailyTimeIntervalScheduleBuilder StartingDailyAt(System.TimeOnly timeOfDayUtc) { }
+        public Quartz.DailyTimeIntervalScheduleBuilder StartingDailyAt(System.TimeOnly timeOfDay) { }
         public Quartz.DailyTimeIntervalScheduleBuilder WithInterval(int interval, Quartz.IntervalUnit unit) { }
         public Quartz.DailyTimeIntervalScheduleBuilder WithMisfireHandlingInstruction(Quartz.DailyTimeIntervalTriggerMisfireInstruction instruction) { }
         public Quartz.DailyTimeIntervalScheduleBuilder WithRepeatCount(int repeatCount) { }
@@ -490,7 +490,7 @@ namespace Quartz
     {
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IScheduler>> GetAllSchedulers(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.IScheduler> GetScheduler(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.IScheduler?> GetScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.IScheduler?> LookupScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface ISchedulerListener
     {
@@ -1088,7 +1088,7 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IScheduler>> GetAllSchedulers(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.IScheduler> GetScheduler(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask<Quartz.IScheduler?> GetScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<Quartz.IScheduler?> LookupScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class SystemTextJsonSerializerOptions
     {
@@ -1237,12 +1237,6 @@ namespace Quartz
         None = 5,
         Executing = 6,
     }
-    public static class TriggerUtils
-    {
-        public static System.DateTimeOffset? ComputeEndTimeToAllowParticularNumberOfFirings(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numberOfTimes) { }
-        public static System.Collections.Generic.List<System.DateTimeOffset> ComputeFireTimes(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numTimes) { }
-        public static System.Collections.Generic.List<System.DateTimeOffset> ComputeFireTimesBetween(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, System.DateTimeOffset from, System.DateTimeOffset to) { }
-    }
     public sealed class UnableToInterruptJobException : Quartz.SchedulerException
     {
         public UnableToInterruptJobException(System.Exception innerException) { }
@@ -1258,7 +1252,7 @@ namespace Quartz.Configuration
 }
 namespace Quartz.Diagnostics
 {
-    public static class ActivityOptions
+    public static class ActivityTags
     {
         public const string BatchSize = "jobstore.batch.size";
         public const string FireInstanceId = "fire.instance.id";
@@ -1484,6 +1478,12 @@ namespace Quartz.Extensibility
         public System.Exception? Exception { get; }
         public Quartz.Extensibility.TriggerFiredBundle? TriggerFiredBundle { get; }
     }
+    public static class TriggerUtils
+    {
+        public static System.DateTimeOffset? ComputeEndTimeToAllowParticularNumberOfFirings(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numberOfTimes) { }
+        public static System.Collections.Generic.List<System.DateTimeOffset> ComputeFireTimes(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numberOfTimes) { }
+        public static System.Collections.Generic.List<System.DateTimeOffset> ComputeFireTimesBetween(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, System.DateTimeOffset from, System.DateTimeOffset to) { }
+    }
 }
 namespace Quartz.Impl.AdoJobStore
 {
@@ -1592,9 +1592,17 @@ namespace Quartz.Impl.AdoJobStore
         public Quartz.Impl.AdoJobStore.TriggerPropertyBundle ReadTriggerPropertyBundle(System.Data.Common.DbDataReader rs) { }
         public System.Threading.Tasks.ValueTask<int> UpdateExtendedTriggerProperties(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, Quartz.Impl.AdoJobStore.StoredTriggerState state, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    public abstract class DBSemaphore : Quartz.Impl.AdoJobStore.ISemaphore, Quartz.Impl.AdoJobStore.ITablePrefixAware
+    public sealed class DailyTimeIntervalTriggerPersistenceDelegate : Quartz.Impl.AdoJobStore.SimplePropertiesTriggerPersistenceDelegateSupport
     {
-        protected DBSemaphore(string tablePrefix, string? schedulerName, string sql, string insertSql, Quartz.Impl.AdoJobStore.Common.IDbProvider dbProvider) { }
+        public DailyTimeIntervalTriggerPersistenceDelegate() { }
+        public override bool CanHandleTriggerType(Quartz.Extensibility.IOperableTrigger trigger) { }
+        public override string GetHandledTriggerTypeDiscriminator() { }
+        protected override Quartz.Impl.AdoJobStore.SimplePropertiesTriggerProperties GetTriggerProperties(Quartz.Extensibility.IOperableTrigger trigger) { }
+        protected override Quartz.Impl.AdoJobStore.TriggerPropertyBundle GetTriggerPropertyBundle(Quartz.Impl.AdoJobStore.SimplePropertiesTriggerProperties props) { }
+    }
+    public abstract class DbSemaphore : Quartz.Impl.AdoJobStore.ISemaphore, Quartz.Impl.AdoJobStore.ITablePrefixAware
+    {
+        protected DbSemaphore(string tablePrefix, string? schedulerName, string sql, string insertSql, Quartz.Impl.AdoJobStore.Common.IDbProvider dbProvider) { }
         protected string InsertSql { get; }
         public bool RequiresConnection { get; }
         public string? SchedulerName { get; set; }
@@ -1603,14 +1611,6 @@ namespace Quartz.Impl.AdoJobStore
         protected abstract System.Threading.Tasks.ValueTask ExecuteSql(System.Guid requestorId, Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string lockName, string expandedSql, string expandedInsertSql, System.Threading.CancellationToken cancellationToken = default);
         public System.Threading.Tasks.ValueTask<bool> ObtainLock(System.Guid requestorId, Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder? conn, Quartz.Impl.AdoJobStore.SchedulerLock lockKind, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask ReleaseLock(System.Guid requestorId, Quartz.Impl.AdoJobStore.SchedulerLock lockKind, System.Threading.CancellationToken cancellationToken = default) { }
-    }
-    public sealed class DailyTimeIntervalTriggerPersistenceDelegate : Quartz.Impl.AdoJobStore.SimplePropertiesTriggerPersistenceDelegateSupport
-    {
-        public DailyTimeIntervalTriggerPersistenceDelegate() { }
-        public override bool CanHandleTriggerType(Quartz.Extensibility.IOperableTrigger trigger) { }
-        public override string GetHandledTriggerTypeDiscriminator() { }
-        protected override Quartz.Impl.AdoJobStore.SimplePropertiesTriggerProperties GetTriggerProperties(Quartz.Extensibility.IOperableTrigger trigger) { }
-        protected override Quartz.Impl.AdoJobStore.TriggerPropertyBundle GetTriggerPropertyBundle(Quartz.Impl.AdoJobStore.SimplePropertiesTriggerProperties props) { }
     }
     public sealed class DelegateInitializationArgs : System.IEquatable<Quartz.Impl.AdoJobStore.DelegateInitializationArgs>
     {
@@ -1678,7 +1678,8 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask<bool> CalendarIsReferenced(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ClearData(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ClearMisfireOriginalFireTime(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<int> CountMisfiredTriggersInState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.StoredTriggerState state, System.DateTimeOffset ts, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<int> CountMisfiredTriggersInState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.StoredTriggerState state, System.DateTimeOffset misfireTime, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<int> CountTriggersForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> DeleteBlobTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> DeleteCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> DeleteFiredTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string entryId, System.Threading.CancellationToken cancellationToken = default);
@@ -1703,14 +1704,13 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> SelectCalendarNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> SelectFiredTriggerInstanceNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.FiredTriggerRecord>> SelectFiredTriggerRecords(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.FiredTriggerQuery query, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> SelectJobDetail(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, Quartz.Extensibility.ITypeLoadHelper classLoadHelper, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> SelectJobDetail(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, Quartz.Extensibility.ITypeLoadHelper loadHelper, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> SelectJobDetails(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, Quartz.Extensibility.ITypeLoadHelper loadHelper, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> SelectJobForTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, Quartz.Extensibility.ITypeLoadHelper loadHelper, bool loadJobType, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> SelectJobGroups(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> SelectJobHeaders(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> SelectJobsInGroup(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Matchers.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.StoredTriggerState state, System.DateTimeOffset ts, int count, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<int> SelectNumTriggersForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.StoredTriggerState state, System.DateTimeOffset misfireTime, int count, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.SchedulerStateRecord>> SelectSchedulerStateRecords(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string? instanceId, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Extensibility.IOperableTrigger?> SelectTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> SelectTriggerGroups(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Matchers.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default);
@@ -1904,7 +1904,7 @@ namespace Quartz.Impl.AdoJobStore
         protected virtual System.Threading.Tasks.ValueTask<int> RecoverStaleAcquiredTriggers(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask ReleaseAcquiredTrigger(Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual System.Threading.Tasks.ValueTask ReleaseAcquiredTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
-        protected virtual System.Threading.Tasks.ValueTask ReleaseLock(System.Guid requestorId, Quartz.Impl.AdoJobStore.SchedulerLock? lockKind, bool doIt, System.Threading.CancellationToken cancellationToken = default) { }
+        protected virtual System.Threading.Tasks.ValueTask ReleaseLock(System.Guid requestorId, Quartz.Impl.AdoJobStore.SchedulerLock? lockKind, bool shouldRelease, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> ReplaceTrigger(Quartz.TriggerKey triggerKey, Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual System.Threading.Tasks.ValueTask<bool> ReplaceTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, Quartz.Extensibility.IOperableTrigger newTrigger, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask ResetTriggerFromErrorState(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2110,7 +2110,7 @@ namespace Quartz.Impl.AdoJobStore
         protected virtual void AddDefaultTriggerPersistenceDelegates() { }
         protected virtual void AddPagingParameters(System.Data.Common.DbCommand cmd, long skip, long take, bool takeLimited) { }
         protected void AddPreferredNodeParameters(System.Data.Common.DbCommand cmd, long liveNodeCutoff) { }
-        public virtual void AddTriggerPersistenceDelegate(Quartz.Impl.AdoJobStore.ITriggerPersistenceDelegate del) { }
+        public virtual void AddTriggerPersistenceDelegate(Quartz.Impl.AdoJobStore.ITriggerPersistenceDelegate persistenceDelegate) { }
         protected virtual string ApplyPaging(string sql, bool takeLimited) { }
         public virtual System.Threading.Tasks.ValueTask<bool> CalendarExists(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> CalendarIsReferenced(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2118,7 +2118,8 @@ namespace Quartz.Impl.AdoJobStore
         public virtual System.Threading.Tasks.ValueTask ClearMisfireOriginalFireTime(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual System.Collections.IDictionary ConvertFromProperty(System.Collections.Specialized.NameValueCollection properties) { }
         protected virtual System.Collections.Specialized.NameValueCollection ConvertToProperty(System.Collections.Generic.IDictionary<string, object?> data) { }
-        public virtual System.Threading.Tasks.ValueTask<int> CountMisfiredTriggersInState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.StoredTriggerState state, System.DateTimeOffset ts, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<int> CountMisfiredTriggersInState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.StoredTriggerState state, System.DateTimeOffset misfireTime, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<int> CountTriggersForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> DeleteBlobTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> DeleteCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> DeleteFiredTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string entryId, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2174,8 +2175,7 @@ namespace Quartz.Impl.AdoJobStore
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> SelectJobGroups(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> SelectJobHeaders(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> SelectJobsInGroup(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Matchers.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.StoredTriggerState state, System.DateTimeOffset ts, int count, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask<int> SelectNumTriggersForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.StoredTriggerState state, System.DateTimeOffset misfireTime, int count, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.SchedulerStateRecord>> SelectSchedulerStateRecords(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string? instanceId, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.Extensibility.IOperableTrigger?> SelectTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> SelectTriggerGroups(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Matchers.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2225,7 +2225,7 @@ namespace Quartz.Impl.AdoJobStore
         protected static string ToSqlEqualsClause<T>(Quartz.Matchers.StringMatcher<T> matcher)
             where T : Quartz.Key<T> { }
     }
-    public class StdRowLockSemaphore : Quartz.Impl.AdoJobStore.DBSemaphore
+    public class StdRowLockSemaphore : Quartz.Impl.AdoJobStore.DbSemaphore
     {
         protected static readonly string InsertLock;
         protected static readonly string SelectForLock;
@@ -2265,9 +2265,9 @@ namespace Quartz.Impl.AdoJobStore
     }
     public readonly struct TriggerAcquireResult : System.IEquatable<Quartz.Impl.AdoJobStore.TriggerAcquireResult>
     {
-        public TriggerAcquireResult(Quartz.TriggerKey TriggerKey, string JobType, string? ExecutionGroup) { }
+        public TriggerAcquireResult(Quartz.TriggerKey TriggerKey, string JobTypeName, string? ExecutionGroup) { }
         public string? ExecutionGroup { get; init; }
-        public string JobType { get; init; }
+        public string JobTypeName { get; init; }
         public Quartz.TriggerKey TriggerKey { get; init; }
     }
     public sealed class TriggerAcquisitionCriteria : System.IEquatable<Quartz.Impl.AdoJobStore.TriggerAcquisitionCriteria>
@@ -2288,13 +2288,13 @@ namespace Quartz.Impl.AdoJobStore
     }
     public sealed class TriggerPropertyBundle
     {
-        public TriggerPropertyBundle(Quartz.IScheduleBuilder sb) { }
-        public TriggerPropertyBundle(Quartz.IScheduleBuilder sb, string[]? statePropertyNames, object[]? statePropertyValues) { }
+        public TriggerPropertyBundle(Quartz.IScheduleBuilder scheduleBuilder) { }
+        public TriggerPropertyBundle(Quartz.IScheduleBuilder scheduleBuilder, string[]? statePropertyNames, object[]? statePropertyValues) { }
         public Quartz.IScheduleBuilder ScheduleBuilder { get; }
         public string[] StatePropertyNames { get; }
         public object[] StatePropertyValues { get; }
     }
-    public class UpdateLockRowSemaphore : Quartz.Impl.AdoJobStore.DBSemaphore
+    public class UpdateLockRowSemaphore : Quartz.Impl.AdoJobStore.DbSemaphore
     {
         protected static readonly string InsertLock;
         protected static readonly string UpdateForLock;
@@ -2901,19 +2901,19 @@ namespace Quartz.Impl.Triggers
         public override void UpdateAfterMisfire(Quartz.ICalendar? calendar) { }
         public override void UpdateWithNewCalendar(Quartz.ICalendar calendar, System.TimeSpan misfireThreshold) { }
         protected override bool ValidateMisfireInstruction(int misfireInstruction) { }
-        public bool WillFireOn(System.DateTimeOffset test) { }
-        public bool WillFireOn(System.DateTimeOffset test, bool dayOnly) { }
+        public bool WillFireOn(System.DateTimeOffset timeUtc) { }
+        public bool WillFireOn(System.DateTimeOffset timeUtc, bool dayOnly) { }
     }
     [System.Serializable]
     public sealed class DailyTimeIntervalTriggerImpl : Quartz.Impl.Triggers.AbstractTrigger, Quartz.IDailyTimeIntervalTrigger, Quartz.ITrigger
     {
         public const int RepeatIndefinitely = -1;
         public DailyTimeIntervalTriggerImpl(System.TimeProvider? timeProvider = null) { }
-        public DailyTimeIntervalTriggerImpl(string name, System.TimeOnly startTimeOfDayUtc, System.TimeOnly endTimeOfDayUtc, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
-        public DailyTimeIntervalTriggerImpl(string name, string group, System.TimeOnly startTimeOfDayUtc, System.TimeOnly endTimeOfDayUtc, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
-        public DailyTimeIntervalTriggerImpl(string name, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, System.TimeOnly startTimeOfDayUtc, System.TimeOnly endTimeOfDayUtc, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
-        public DailyTimeIntervalTriggerImpl(string name, string group, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, System.TimeOnly startTimeOfDayUtc, System.TimeOnly endTimeOfDayUtc, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
-        public DailyTimeIntervalTriggerImpl(string name, string group, string jobName, string jobGroup, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, System.TimeOnly startTimeOfDayUtc, System.TimeOnly endTimeOfDayUtc, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
+        public DailyTimeIntervalTriggerImpl(string name, System.TimeOnly startTimeOfDay, System.TimeOnly endTimeOfDay, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
+        public DailyTimeIntervalTriggerImpl(string name, string group, System.TimeOnly startTimeOfDay, System.TimeOnly endTimeOfDay, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
+        public DailyTimeIntervalTriggerImpl(string name, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, System.TimeOnly startTimeOfDay, System.TimeOnly endTimeOfDay, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
+        public DailyTimeIntervalTriggerImpl(string name, string group, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, System.TimeOnly startTimeOfDay, System.TimeOnly endTimeOfDay, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
+        public DailyTimeIntervalTriggerImpl(string name, string group, string jobName, string jobGroup, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, System.TimeOnly startTimeOfDay, System.TimeOnly endTimeOfDay, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
         public System.Collections.Generic.IReadOnlyCollection<System.DayOfWeek> DaysOfWeek { get; set; }
         public System.TimeOnly EndTimeOfDay { get; set; }
         public override System.DateTimeOffset? EndTimeUtc { get; set; }
@@ -2985,7 +2985,7 @@ namespace Quartz.Impl.Triggers
         public System.TimeSpan RepeatInterval { get; set; }
         public int TimesTriggered { get; set; }
         public override System.DateTimeOffset? ComputeFirstFireTimeUtc(Quartz.ICalendar? calendar) { }
-        public int ComputeNumTimesFiredBetween(System.DateTimeOffset startTimeUtc, System.DateTimeOffset endTimeUtc) { }
+        public int ComputeNumberOfTimesFiredBetween(System.DateTimeOffset startTimeUtc, System.DateTimeOffset endTimeUtc) { }
         public override System.DateTimeOffset? GetFireTimeAfter(System.DateTimeOffset? afterTimeUtc) { }
         public System.DateTimeOffset? GetFireTimeBefore(System.DateTimeOffset endUtc) { }
         public override Quartz.IScheduleBuilder GetScheduleBuilder() { }
@@ -3245,7 +3245,7 @@ namespace Quartz.Serialization.Json.Triggers
     public class CalendarIntervalTriggerSerializer : Quartz.Serialization.Json.Triggers.TriggerSerializer<Quartz.Impl.Triggers.CalendarIntervalTriggerImpl>
     {
         public CalendarIntervalTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void DeserializeFields(Quartz.Impl.Triggers.CalendarIntervalTriggerImpl trigger, System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void SerializeFields(System.Text.Json.Utf8JsonWriter writer, Quartz.Impl.Triggers.CalendarIntervalTriggerImpl trigger, System.Text.Json.JsonSerializerOptions options) { }
@@ -3253,21 +3253,21 @@ namespace Quartz.Serialization.Json.Triggers
     public class CronTriggerSerializer : Quartz.Serialization.Json.Triggers.TriggerSerializer<Quartz.ICronTrigger>
     {
         public CronTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void SerializeFields(System.Text.Json.Utf8JsonWriter writer, Quartz.ICronTrigger trigger, System.Text.Json.JsonSerializerOptions options) { }
     }
     public class DailyTimeIntervalTriggerSerializer : Quartz.Serialization.Json.Triggers.TriggerSerializer<Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl>
     {
         public DailyTimeIntervalTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void DeserializeFields(Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl trigger, System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void SerializeFields(System.Text.Json.Utf8JsonWriter writer, Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl trigger, System.Text.Json.JsonSerializerOptions options) { }
     }
     public interface ITriggerSerializer
     {
-        string TriggerTypeForJson { get; }
+        string TriggerTypeName { get; }
         Quartz.IScheduleBuilder CreateScheduleBuilder(System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options);
         void DeserializeFields(Quartz.ITrigger trigger, System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options);
         void SerializeFields(System.Text.Json.Utf8JsonWriter writer, Quartz.ITrigger trigger, System.Text.Json.JsonSerializerOptions options);
@@ -3275,7 +3275,7 @@ namespace Quartz.Serialization.Json.Triggers
     public sealed class RecurrenceTriggerSerializer : Quartz.Serialization.Json.Triggers.TriggerSerializer<Quartz.Impl.Triggers.RecurrenceTriggerImpl>
     {
         public RecurrenceTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void DeserializeFields(Quartz.Impl.Triggers.RecurrenceTriggerImpl trigger, System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void SerializeFields(System.Text.Json.Utf8JsonWriter writer, Quartz.Impl.Triggers.RecurrenceTriggerImpl trigger, System.Text.Json.JsonSerializerOptions options) { }
@@ -3283,7 +3283,7 @@ namespace Quartz.Serialization.Json.Triggers
     public class SimpleTriggerSerializer : Quartz.Serialization.Json.Triggers.TriggerSerializer<Quartz.Impl.Triggers.SimpleTriggerImpl>
     {
         public SimpleTriggerSerializer() { }
-        public override string TriggerTypeForJson { get; }
+        public override string TriggerTypeName { get; }
         public override Quartz.IScheduleBuilder CreateScheduleBuilder(System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void DeserializeFields(Quartz.Impl.Triggers.SimpleTriggerImpl trigger, System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected override void SerializeFields(System.Text.Json.Utf8JsonWriter writer, Quartz.Impl.Triggers.SimpleTriggerImpl trigger, System.Text.Json.JsonSerializerOptions options) { }
@@ -3292,7 +3292,7 @@ namespace Quartz.Serialization.Json.Triggers
         where TTrigger : Quartz.ITrigger
     {
         protected TriggerSerializer() { }
-        public abstract string TriggerTypeForJson { get; }
+        public abstract string TriggerTypeName { get; }
         public abstract Quartz.IScheduleBuilder CreateScheduleBuilder(System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options);
         protected virtual void DeserializeFields(TTrigger trigger, System.Text.Json.JsonElement jsonElement, System.Text.Json.JsonSerializerOptions options) { }
         protected abstract void SerializeFields(System.Text.Json.Utf8JsonWriter writer, TTrigger trigger, System.Text.Json.JsonSerializerOptions options);
@@ -3327,10 +3327,6 @@ namespace Quartz.Util
         public bool Remove(TKey key) { }
         public bool TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out TValue value) { }
     }
-    public static class ObjectExtensions
-    {
-        public static string AssemblyQualifiedNameWithoutVersion(this System.Type type) { }
-    }
     [System.Serializable]
     public class StringKeyDirtyFlagMap : Quartz.Util.DirtyFlagMap<string, object>
     {
@@ -3364,7 +3360,7 @@ namespace Quartz.Util
     }
     public static class TimeZoneUtil
     {
-        public static System.Func<string, System.TimeZoneInfo?> CustomResolver { get; set; }
+        public static System.Func<string, System.TimeZoneInfo?>? CustomResolver { get; set; }
         public static System.DateTimeOffset ConvertTime(System.DateTimeOffset dateTimeOffset, System.TimeZoneInfo timeZoneInfo) { }
         public static System.TimeZoneInfo FindTimeZoneById(string id) { }
         public static System.TimeSpan GetUtcOffset(System.DateTime dateTime, System.TimeZoneInfo timeZoneInfo) { }

--- a/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
+++ b/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -74,8 +74,8 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
     private int interval = 1;
     private IntervalUnit intervalUnit = IntervalUnit.Minute;
     private HashSet<DayOfWeek>? daysOfWeek;
-    private TimeOnly? startTimeOfDayUtc;
-    private TimeOnly? endTimeOfDayUtc;
+    private TimeOnly? startTimeOfDay;
+    private TimeOnly? endTimeOfDay;
     private int repeatCount = DailyTimeIntervalTriggerImpl.RepeatIndefinitely;
     private TimeZoneInfo? timeZone;
 
@@ -157,8 +157,8 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
             st.DaysOfWeek = new HashSet<DayOfWeek>(AllDaysOfTheWeek);
         }
 
-        st.EndTimeOfDay = endTimeOfDayUtc ?? DailyTimeIntervalTriggerImpl.DefaultEndTimeOfDay;
-        st.StartTimeOfDay = startTimeOfDayUtc ?? DailyTimeIntervalTriggerImpl.DefaultStartTimeOfDay;
+        st.EndTimeOfDay = endTimeOfDay ?? DailyTimeIntervalTriggerImpl.DefaultEndTimeOfDay;
+        st.StartTimeOfDay = startTimeOfDay ?? DailyTimeIntervalTriggerImpl.DefaultStartTimeOfDay;
 
         return st;
     }
@@ -245,30 +245,30 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
     /// <summary>
     /// The time of day for this trigger to start firing each day. Defaults to <c>00:00:00</c>.
     /// </summary>
-    /// <param name="timeOfDayUtc">the time of day, with one-second resolution.</param>
+    /// <param name="timeOfDay">the time of day, with one-second resolution.</param>
     /// <returns>the updated DailyTimeIntervalScheduleBuilder</returns>
     /// <exception cref="ArgumentException">
-    /// <paramref name="timeOfDayUtc" /> carries precision finer than a whole second.
+    /// <paramref name="timeOfDay" /> carries precision finer than a whole second.
     /// </exception>
-    public DailyTimeIntervalScheduleBuilder StartingDailyAt(TimeOnly timeOfDayUtc)
+    public DailyTimeIntervalScheduleBuilder StartingDailyAt(TimeOnly timeOfDay)
     {
-        TimeOnlyExtensions.ValidateWholeSeconds(timeOfDayUtc, nameof(timeOfDayUtc));
-        startTimeOfDayUtc = timeOfDayUtc;
+        TimeOnlyExtensions.ValidateWholeSeconds(timeOfDay, nameof(timeOfDay));
+        startTimeOfDay = timeOfDay;
         return this;
     }
 
     /// <summary>
     /// The time of day for this trigger to end firing each day. Defaults to <c>23:59:59</c>.
     /// </summary>
-    /// <param name="timeOfDayUtc">the time of day, with one-second resolution.</param>
+    /// <param name="timeOfDay">the time of day, with one-second resolution.</param>
     /// <returns>the updated DailyTimeIntervalScheduleBuilder</returns>
     /// <exception cref="ArgumentException">
-    /// <paramref name="timeOfDayUtc" /> carries precision finer than a whole second.
+    /// <paramref name="timeOfDay" /> carries precision finer than a whole second.
     /// </exception>
-    public DailyTimeIntervalScheduleBuilder EndingDailyAt(TimeOnly timeOfDayUtc)
+    public DailyTimeIntervalScheduleBuilder EndingDailyAt(TimeOnly timeOfDay)
     {
-        TimeOnlyExtensions.ValidateWholeSeconds(timeOfDayUtc, nameof(timeOfDayUtc));
-        endTimeOfDayUtc = timeOfDayUtc;
+        TimeOnlyExtensions.ValidateWholeSeconds(timeOfDay, nameof(timeOfDay));
+        endTimeOfDay = timeOfDay;
         return this;
     }
 
@@ -285,13 +285,13 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
             Throw.ArgumentException("Ending daily after count must be a positive number!");
         }
 
-        if (startTimeOfDayUtc is null)
+        if (startTimeOfDay is null)
         {
             Throw.ArgumentException("You must set the StartDailyAt() before calling this EndingDailyAfterCount()!");
         }
 
         DateTimeOffset today = timeProvider.GetUtcNow();
-        DateTimeOffset startTimeOfDayDate = startTimeOfDayUtc.Value.OnDate(today);
+        DateTimeOffset startTimeOfDayDate = startTimeOfDay.Value.OnDate(today);
         DateTimeOffset tomorrow = startTimeOfDayDate.AddDays(1).UtcDateTime.Date;
 
         //apply proper offsets according to timezone
@@ -340,7 +340,7 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
 
         DateTime date = timeProvider.GetUtcNow().Date;
         date = date.Add(endTimeOfDayDate.TimeOfDay);
-        endTimeOfDayUtc = new TimeOnly(date.Hour, date.Minute, date.Second);
+        endTimeOfDay = new TimeOnly(date.Hour, date.Minute, date.Second);
         return this;
     }
 

--- a/src/Quartz/Diagnostics/ActivityTags.cs
+++ b/src/Quartz/Diagnostics/ActivityTags.cs
@@ -1,9 +1,9 @@
 namespace Quartz.Diagnostics;
 
-public static class ActivityOptions
+public static class ActivityTags
 {
     internal const string DefaultListenerName = "Quartz";
-    internal static readonly string? Version = typeof(ActivityOptions).Assembly.GetName().Version?.ToString();
+    internal static readonly string? Version = typeof(ActivityTags).Assembly.GetName().Version?.ToString();
 
     public const string SchedulerName = "scheduler.name";
     public const string SchedulerId = "scheduler.id";

--- a/src/Quartz/Diagnostics/JobStoreActivityTracer.cs
+++ b/src/Quartz/Diagnostics/JobStoreActivityTracer.cs
@@ -56,8 +56,8 @@ internal sealed class JobStoreActivityTracer
         Func<ValueTask<T>> operation,
         Action<Activity>? enrichActivity)
     {
-        activity.SetTag(ActivityOptions.SchedulerName, schedulerName);
-        activity.SetTag(ActivityOptions.SchedulerId, schedulerId);
+        activity.SetTag(ActivityTags.SchedulerName, schedulerName);
+        activity.SetTag(ActivityTags.SchedulerId, schedulerId);
         if (activity.IsAllDataRequested)
         {
             enrichActivity?.Invoke(activity);
@@ -84,8 +84,8 @@ internal sealed class JobStoreActivityTracer
         Func<ValueTask> operation,
         Action<Activity>? enrichActivity)
     {
-        activity.SetTag(ActivityOptions.SchedulerName, schedulerName);
-        activity.SetTag(ActivityOptions.SchedulerId, schedulerId);
+        activity.SetTag(ActivityTags.SchedulerName, schedulerName);
+        activity.SetTag(ActivityTags.SchedulerId, schedulerId);
         if (activity.IsAllDataRequested)
         {
             enrichActivity?.Invoke(activity);

--- a/src/Quartz/Diagnostics/LogProvider.cs
+++ b/src/Quartz/Diagnostics/LogProvider.cs
@@ -3,19 +3,50 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Quartz.Diagnostics;
 
+/// <summary>
+/// The logger factory Quartz logs to from the places that cannot be handed one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is ambient, mutable, process-wide state, and it stays that way on purpose. Nearly everything the
+/// scheduler is made of is built by a container and is injected an <see cref="ILogger" /> the ordinary
+/// way. What is left over cannot be: static helpers such as <see cref="Quartz.Util.TimeZoneUtil" />,
+/// types a caller constructs directly — triggers, calendars, plugins, the jobs in <c>Quartz.Jobs</c> —
+/// and anything that runs while the container is still being built. A type cannot be handed a logger by
+/// a container that does not exist yet, so those sites read this instead of going unlogged.
+/// </para>
+/// <para>
+/// It is deliberately <em>not</em> seeded from the container either, which would otherwise be the obvious
+/// convenience. This slot outlives any one container: a process that builds a host, disposes it and
+/// builds another — every integration test suite, and every application that reloads configuration —
+/// would be left holding a disposed <see cref="ILoggerFactory" />, and the next
+/// <see cref="CreateLogger{T}" /> would throw <see cref="ObjectDisposedException" /> from somewhere
+/// unrelated to logging. Whoever sets this has to own the lifetime of what they set, which is a decision
+/// only the application can make.
+/// </para>
+/// <para>
+/// A logger is usually resolved once, when the type that logs is constructed, so setting the factory
+/// after a scheduler has been running affects only what is created from then on.
+/// </para>
+/// </remarks>
 public static class LogProvider
 {
-    private static ILoggerFactory? _loggerFactory;
+    private static ILoggerFactory? loggerFactory;
 
     /// <summary>
-    /// Sets the current log provider based on logger factory.
+    /// Sets the logger factory Quartz logs to where no logger can be injected. Until this is called,
+    /// those sites log to <see cref="NullLogger" />.
     /// </summary>
+    /// <remarks>
+    /// Pass a factory that lives at least as long as the schedulers in the process. Handing over a
+    /// factory owned by a host and then disposing that host leaves this pointing at a disposed object.
+    /// </remarks>
     /// <param name="loggerFactory">The logger factory.</param>
     public static void SetLogProvider(ILoggerFactory loggerFactory)
     {
-        _loggerFactory = loggerFactory;
+        LogProvider.loggerFactory = loggerFactory;
     }
 
-    public static ILogger CreateLogger(string category) => _loggerFactory != null ? _loggerFactory.CreateLogger(category) : NullLogger.Instance;
-    public static ILogger<T> CreateLogger<T>() => _loggerFactory != null ? _loggerFactory.CreateLogger<T>() : NullLogger<T>.Instance;
+    public static ILogger CreateLogger(string category) => loggerFactory != null ? loggerFactory.CreateLogger(category) : NullLogger.Instance;
+    public static ILogger<T> CreateLogger<T>() => loggerFactory != null ? loggerFactory.CreateLogger<T>() : NullLogger<T>.Instance;
 }

--- a/src/Quartz/Diagnostics/Meters.cs
+++ b/src/Quartz/Diagnostics/Meters.cs
@@ -43,10 +43,10 @@ internal static class Meters
 
         TagList tagList = new()
         {
-            { ActivityOptions.TriggerGroup, context.Trigger.Key.Group },
-            { ActivityOptions.TriggerName, context.Trigger.Key.Name },
-            { ActivityOptions.JobGroup, context.JobDetail.Key.Group },
-            { ActivityOptions.JobName, context.JobDetail.Key.Name },
+            { ActivityTags.TriggerGroup, context.Trigger.Key.Group },
+            { ActivityTags.TriggerName, context.Trigger.Key.Name },
+            { ActivityTags.JobGroup, context.JobDetail.Key.Group },
+            { ActivityTags.JobName, context.JobDetail.Key.Name },
         };
 
         _jobExecuteTotal.Add(1, tagList);

--- a/src/Quartz/Diagnostics/QuartzActivitySource.cs
+++ b/src/Quartz/Diagnostics/QuartzActivitySource.cs
@@ -6,7 +6,7 @@ namespace Quartz.Diagnostics;
 
 internal static class QuartzActivitySource
 {
-    internal static readonly ActivitySource Instance = new(ActivityOptions.DefaultListenerName, ActivityOptions.Version);
+    internal static readonly ActivitySource Instance = new(ActivityTags.DefaultListenerName, ActivityTags.Version);
 
     public static StartedActivity StartJobExecute(JobExecutionContextImpl context, DateTimeOffset startTime)
     {
@@ -32,16 +32,16 @@ internal static class QuartzActivitySource
 
         if (activity.IsAllDataRequested)
         {
-            activity.AddTag(ActivityOptions.SchedulerName, context.Scheduler.SchedulerName);
-            activity.AddTag(ActivityOptions.SchedulerId, context.Scheduler.SchedulerInstanceId);
-            activity.AddTag(ActivityOptions.JobType, context.JobDetail.JobType.ToString());
-            activity.AddTag(ActivityOptions.FireInstanceId, context.FireInstanceId);
+            activity.AddTag(ActivityTags.SchedulerName, context.Scheduler.SchedulerName);
+            activity.AddTag(ActivityTags.SchedulerId, context.Scheduler.SchedulerInstanceId);
+            activity.AddTag(ActivityTags.JobType, context.JobDetail.JobType.ToString());
+            activity.AddTag(ActivityTags.FireInstanceId, context.FireInstanceId);
         }
 
-        activity.AddTag(ActivityOptions.TriggerGroup, context.Trigger.Key.Group);
-        activity.AddTag(ActivityOptions.TriggerName, context.Trigger.Key.Name);
-        activity.AddTag(ActivityOptions.JobGroup, context.JobDetail.Key.Group);
-        activity.AddTag(ActivityOptions.JobName, context.JobDetail.Key.Name);
+        activity.AddTag(ActivityTags.TriggerGroup, context.Trigger.Key.Group);
+        activity.AddTag(ActivityTags.TriggerName, context.Trigger.Key.Name);
+        activity.AddTag(ActivityTags.JobGroup, context.JobDetail.Key.Group);
+        activity.AddTag(ActivityTags.JobName, context.JobDetail.Key.Name);
     }
 }
 

--- a/src/Quartz/Extensibility/TriggerUtils.cs
+++ b/src/Quartz/Extensibility/TriggerUtils.cs
@@ -19,14 +19,19 @@
 
 #endregion
 
-using Quartz.Extensibility;
-
-namespace Quartz;
+namespace Quartz.Extensibility;
 
 /// <summary>
-/// Convenience and utility methods for simplifying the construction and
-/// configuration of <see cref="ITrigger" />s and DateTimeOffsetOffsets.
+/// Answers what a trigger would fire, without scheduling it.
 /// </summary>
+/// <remarks>
+/// These take an <see cref="IOperableTrigger" /> rather than an <see cref="ITrigger" /> because
+/// answering the question means advancing a copy of the trigger through its schedule, applying the
+/// calendar at each step — which is precisely what <see cref="IOperableTrigger" /> adds over
+/// <see cref="ITrigger" />. That is why this lives here rather than in the <c>Quartz</c> namespace: it
+/// is a helper over the operable-trigger contract, not part of the scheduling API. Cast a trigger you
+/// hold, or use the one a schedule builder handed you.
+/// </remarks>
 /// <seealso cref="ICronTrigger" />
 /// <seealso cref="ISimpleTrigger" />
 /// <author>James House</author>
@@ -41,8 +46,8 @@ public static class TriggerUtils
     /// </summary>
     /// <param name="trigger">The trigger upon which to do the work</param>
     /// <param name="calendar">The calendar to apply to the trigger's schedule</param>
-    /// <param name="numTimes">The number of next fire times to produce</param>
-    public static List<DateTimeOffset> ComputeFireTimes(IOperableTrigger trigger, ICalendar? calendar, int numTimes)
+    /// <param name="numberOfTimes">The number of next fire times to produce</param>
+    public static List<DateTimeOffset> ComputeFireTimes(IOperableTrigger trigger, ICalendar? calendar, int numberOfTimes)
     {
         List<DateTimeOffset> lst = new List<DateTimeOffset>();
 
@@ -53,7 +58,7 @@ public static class TriggerUtils
             t.ComputeFirstFireTimeUtc(calendar);
         }
 
-        for (int i = 0; i < numTimes; i++)
+        for (int i = 0; i < numberOfTimes; i++)
         {
             DateTimeOffset? d = t.NextFireTimeUtc;
             if (d.HasValue)

--- a/src/Quartz/ISchedulerFactory.cs
+++ b/src/Quartz/ISchedulerFactory.cs
@@ -29,19 +29,40 @@ namespace Quartz;
 public interface ISchedulerFactory
 {
     /// <summary>
-    /// Returns handles to all known Schedulers (made by any SchedulerFactory
-    /// within this app domain.).
+    /// Returns handles to every scheduler in the container this factory belongs to.
     /// </summary>
+    /// <remarks>
+    /// A scheduler is only in the repository of the container that built it, so a factory lists its own
+    /// container's schedulers and nobody else's.
+    /// </remarks>
     ValueTask<List<IScheduler>> GetAllSchedulers(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns a client-usable handle to a <see cref="IScheduler" />.
+    /// Returns a client-usable handle to the <see cref="IScheduler" /> this factory produces, building
+    /// it if it has not been built yet.
     /// </summary>
+    /// <remarks>
+    /// Never returns <see langword="null" />: a factory is configured to produce exactly one scheduler,
+    /// so either it can be built or the attempt throws.
+    /// </remarks>
     ValueTask<IScheduler> GetScheduler(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns a handle to the Scheduler with the given name. A factory can create the scheduler it is
-    /// configured to produce; any other name is returned only if that scheduler already exists.
+    /// Finds the scheduler with the given name, or <see langword="null" /> when this container has none.
     /// </summary>
-    ValueTask<IScheduler?> GetScheduler(string schedulerName, CancellationToken cancellationToken = default);
+    /// <remarks>
+    /// <para>
+    /// This is a lookup, which is why it is named for one and why it is nullable while
+    /// <see cref="GetScheduler(CancellationToken)" /> is not: any name other than this factory's own
+    /// belongs to a scheduler somebody else registered, and it may not exist. Asking for this factory's
+    /// own scheduler by name builds it on demand, exactly as <see cref="GetScheduler(CancellationToken)" />
+    /// would; the comparison ignores case, because that is how the repository indexes names.
+    /// </para>
+    /// <para>
+    /// Only schedulers from the same container are visible. A scheduler built by a
+    /// <see cref="QuartzSchedulerBuilder" /> of its own is not in this container's repository and is
+    /// reported as absent.
+    /// </para>
+    /// </remarks>
+    ValueTask<IScheduler?> LookupScheduler(string schedulerName, CancellationToken cancellationToken = default);
 }

--- a/src/Quartz/Impl/AdoJobStore/DbSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/DbSemaphore.cs
@@ -33,7 +33,7 @@ namespace Quartz.Impl.AdoJobStore;
 /// same time.
 /// </summary>
 /// <author>Marko Lahma (.NET)</author>
-public abstract class DBSemaphore : ISemaphore, ITablePrefixAware
+public abstract class DbSemaphore : ISemaphore, ITablePrefixAware
 {
     private readonly ConcurrentDictionary<ThreadLockKey, object?> locks = new();
 
@@ -48,7 +48,7 @@ public abstract class DBSemaphore : ISemaphore, ITablePrefixAware
     private string expandedInsertSql = null!;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DBSemaphore"/> class.
+    /// Initializes a new instance of the <see cref="DbSemaphore"/> class.
     /// </summary>
     /// <remarks>
     /// The two statements are fixed at construction. They were settable, which meant a subclass could
@@ -60,14 +60,14 @@ public abstract class DBSemaphore : ISemaphore, ITablePrefixAware
     /// <param name="insertSql">The statement that inserts the lock row when it does not exist yet.</param>
     /// <param name="sql">The statement that takes the lock.</param>
     /// <param name="dbProvider">The db provider.</param>
-    protected DBSemaphore(
+    protected DbSemaphore(
         string tablePrefix,
         string? schedulerName,
         string sql,
         string insertSql,
         IDbProvider dbProvider)
     {
-        logger = LogProvider.CreateLogger<DBSemaphore>();
+        logger = LogProvider.CreateLogger<DbSemaphore>();
         this.schedulerName = schedulerName;
         this.tablePrefix = tablePrefix;
         this.sql = sql.Trim();
@@ -80,7 +80,7 @@ public abstract class DBSemaphore : ISemaphore, ITablePrefixAware
     /// Gets the log.
     /// </summary>
     /// <value>The log.</value>
-    internal ILogger<DBSemaphore> logger { get; }
+    internal ILogger<DbSemaphore> logger { get; }
 
     /// <summary>
     /// Execute the SQL that will lock the proper database row.

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -178,13 +178,13 @@ public interface IDriverDelegate
     /// </summary>
     /// <param name="conn">The DB Connection</param>
     /// <param name="jobKey">The key identifying the job.</param>
-    /// <param name="classLoadHelper">The class load helper.</param>
+    /// <param name="loadHelper">The type load helper.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns>The populated JobDetail object</returns>
     ValueTask<IJobDetail?> SelectJobDetail(
         ConnectionAndTransactionHolder conn,
         JobKey jobKey,
-        ITypeLoadHelper classLoadHelper,
+        ITypeLoadHelper loadHelper,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -445,7 +445,7 @@ public interface IDriverDelegate
     /// <param name="jobKey">The key identifying the job.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns> the number of triggers for the given job </returns>
-    ValueTask<int> SelectNumTriggersForJob(
+    ValueTask<int> CountTriggersForJob(
         ConnectionAndTransactionHolder conn,
         JobKey jobKey,
         CancellationToken cancellationToken = default);
@@ -845,13 +845,13 @@ public interface IDriverDelegate
     /// </summary>
     /// <param name="conn">The DB connection.</param>
     /// <param name="state">The trigger state to scan.</param>
-    /// <param name="ts">Triggers whose next fire time is before this are misfired.</param>
+    /// <param name="misfireTime">Triggers whose next fire time is before this are misfired.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns></returns>
     ValueTask<int> CountMisfiredTriggersInState(
         ConnectionAndTransactionHolder conn,
         StoredTriggerState state,
-        DateTimeOffset ts,
+        DateTimeOffset misfireTime,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -926,13 +926,13 @@ public interface IDriverDelegate
     /// </summary>
     /// <param name="conn">The DB connection.</param>
     /// <param name="state">The trigger state to scan (<see cref="StoredTriggerState.Waiting" />).</param>
-    /// <param name="ts">Triggers whose next fire time is before this are misfired.</param>
+    /// <param name="misfireTime">Triggers whose next fire time is before this are misfired.</param>
     /// <param name="count">Maximum number of triggers to return, or -1 for all of them.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     ValueTask<MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(
         ConnectionAndTransactionHolder conn,
         StoredTriggerState state,
-        DateTimeOffset ts,
+        DateTimeOffset misfireTime,
         int count,
         CancellationToken cancellationToken = default);
 

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -960,10 +960,10 @@ public abstract class JobStoreSupport : IJobStore
     protected virtual async ValueTask ReleaseLock(
         Guid requestorId,
         SchedulerLock? lockKind,
-        bool doIt,
+        bool shouldRelease,
         CancellationToken cancellationToken = default)
     {
-        if (doIt && lockKind is not null)
+        if (shouldRelease && lockKind is not null)
         {
             try
             {
@@ -1389,10 +1389,10 @@ public abstract class JobStoreSupport : IJobStore
             }, cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.JobGroup, job.Key.Group);
-                activity.SetTag(ActivityOptions.JobName, job.Key.Name);
-                activity.SetTag(ActivityOptions.TriggerGroup, trigger.Key.Group);
-                activity.SetTag(ActivityOptions.TriggerName, trigger.Key.Name);
+                activity.SetTag(ActivityTags.JobGroup, job.Key.Group);
+                activity.SetTag(ActivityTags.JobName, job.Key.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, trigger.Key.Group);
+                activity.SetTag(ActivityTags.TriggerName, trigger.Key.Name);
             }).ConfigureAwait(false);
     }
 
@@ -1415,8 +1415,8 @@ public abstract class JobStoreSupport : IJobStore
                 cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.JobGroup, job.Key.Group);
-                activity.SetTag(ActivityOptions.JobName, job.Key.Name);
+                activity.SetTag(ActivityTags.JobGroup, job.Key.Group);
+                activity.SetTag(ActivityTags.JobName, job.Key.Name);
             }).ConfigureAwait(false);
     }
 
@@ -1502,8 +1502,8 @@ public abstract class JobStoreSupport : IJobStore
                 cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, trigger.Key.Group);
-                activity.SetTag(ActivityOptions.TriggerName, trigger.Key.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, trigger.Key.Group);
+                activity.SetTag(ActivityTags.TriggerName, trigger.Key.Name);
             }).ConfigureAwait(false);
     }
 
@@ -1630,8 +1630,8 @@ public abstract class JobStoreSupport : IJobStore
             () => ExecuteInLock(SchedulerLock.TriggerAccess, conn => DeleteJob(conn, jobKey, true, cancellationToken), cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.JobGroup, jobKey.Group);
-                activity.SetTag(ActivityOptions.JobName, jobKey.Name);
+                activity.SetTag(ActivityTags.JobGroup, jobKey.Group);
+                activity.SetTag(ActivityTags.JobName, jobKey.Name);
             });
     }
 
@@ -1840,8 +1840,8 @@ public abstract class JobStoreSupport : IJobStore
                 cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, triggerKey.Group);
-                activity.SetTag(ActivityOptions.TriggerName, triggerKey.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, triggerKey.Group);
+                activity.SetTag(ActivityTags.TriggerName, triggerKey.Name);
             });
     }
 
@@ -1873,7 +1873,7 @@ public abstract class JobStoreSupport : IJobStore
 
             if (null != job && !job.Durable)
             {
-                int numTriggers = await Delegate.SelectNumTriggersForJob(conn, job.Key, cancellationToken).ConfigureAwait(false);
+                int numTriggers = await Delegate.CountTriggersForJob(conn, job.Key, cancellationToken).ConfigureAwait(false);
                 if (numTriggers == 0)
                 {
                     // Don't call DeleteJob() because we don't want to check for
@@ -1915,8 +1915,8 @@ public abstract class JobStoreSupport : IJobStore
                 cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, triggerKey.Group);
-                activity.SetTag(ActivityOptions.TriggerName, triggerKey.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, triggerKey.Group);
+                activity.SetTag(ActivityTags.TriggerName, triggerKey.Name);
             });
     }
 
@@ -1968,8 +1968,8 @@ public abstract class JobStoreSupport : IJobStore
                 cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, triggerKey.Group);
-                activity.SetTag(ActivityOptions.TriggerName, triggerKey.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, triggerKey.Group);
+                activity.SetTag(ActivityTags.TriggerName, triggerKey.Name);
             });
     }
 
@@ -2146,8 +2146,8 @@ public abstract class JobStoreSupport : IJobStore
                 cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, triggerKey.Group);
-                activity.SetTag(ActivityOptions.TriggerName, triggerKey.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, triggerKey.Group);
+                activity.SetTag(ActivityTags.TriggerName, triggerKey.Name);
             }).ConfigureAwait(false);
     }
 
@@ -2723,8 +2723,8 @@ public abstract class JobStoreSupport : IJobStore
             () => ExecuteInLock(SchedulerLock.TriggerAccess, conn => PauseTrigger(conn, triggerKey, cancellationToken), cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, triggerKey.Group);
-                activity.SetTag(ActivityOptions.TriggerName, triggerKey.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, triggerKey.Group);
+                activity.SetTag(ActivityTags.TriggerName, triggerKey.Name);
             }).ConfigureAwait(false);
     }
 
@@ -2774,8 +2774,8 @@ public abstract class JobStoreSupport : IJobStore
             }, cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.JobGroup, jobKey.Group);
-                activity.SetTag(ActivityOptions.JobName, jobKey.Name);
+                activity.SetTag(ActivityTags.JobGroup, jobKey.Group);
+                activity.SetTag(ActivityTags.JobName, jobKey.Name);
             }).ConfigureAwait(false);
     }
 
@@ -2854,8 +2854,8 @@ public abstract class JobStoreSupport : IJobStore
             () => ExecuteInLock(SchedulerLock.TriggerAccess, conn => ResumeTrigger(conn, triggerKey, cancellationToken), cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, triggerKey.Group);
-                activity.SetTag(ActivityOptions.TriggerName, triggerKey.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, triggerKey.Group);
+                activity.SetTag(ActivityTags.TriggerName, triggerKey.Name);
             }).ConfigureAwait(false);
     }
 
@@ -2934,8 +2934,8 @@ public abstract class JobStoreSupport : IJobStore
             }, cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.JobGroup, jobKey.Group);
-                activity.SetTag(ActivityOptions.JobName, jobKey.Name);
+                activity.SetTag(ActivityTags.JobGroup, jobKey.Group);
+                activity.SetTag(ActivityTags.JobName, jobKey.Name);
             }).ConfigureAwait(false);
     }
 
@@ -3213,7 +3213,7 @@ public abstract class JobStoreSupport : IJobStore
                     }
                 },
                 cancellationToken: cancellationToken),
-            activity => activity.SetTag(ActivityOptions.BatchSize, request.MaxCount));
+            activity => activity.SetTag(ActivityTags.BatchSize, request.MaxCount));
     }
 
     // TODO: this really ought to return something like a FiredTriggerBundle,
@@ -3279,7 +3279,7 @@ public abstract class JobStoreSupport : IJobStore
                     Type jobType;
                     try
                     {
-                        jobType = typeLoadHelper.LoadType(result.JobType)!;
+                        jobType = typeLoadHelper.LoadType(result.JobTypeName)!;
                     }
                     catch (Exception e)
                     {
@@ -3390,8 +3390,8 @@ public abstract class JobStoreSupport : IJobStore
                 cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, trigger.Key.Group);
-                activity.SetTag(ActivityOptions.TriggerName, trigger.Key.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, trigger.Key.Group);
+                activity.SetTag(ActivityTags.TriggerName, trigger.Key.Name);
             }).ConfigureAwait(false);
     }
 
@@ -3491,7 +3491,7 @@ public abstract class JobStoreSupport : IJobStore
                     }
                 },
                 cancellationToken: cancellationToken),
-            activity => activity.SetTag(ActivityOptions.TriggerCount, triggers.Count));
+            activity => activity.SetTag(ActivityTags.TriggerCount, triggers.Count));
     }
 
     protected virtual async ValueTask<TriggerFiredBundle?> TriggerFired(
@@ -3696,10 +3696,10 @@ public abstract class JobStoreSupport : IJobStore
                 cancellationToken),
             activity =>
             {
-                activity.SetTag(ActivityOptions.TriggerGroup, trigger.Key.Group);
-                activity.SetTag(ActivityOptions.TriggerName, trigger.Key.Name);
-                activity.SetTag(ActivityOptions.JobGroup, jobDetail.Key.Group);
-                activity.SetTag(ActivityOptions.JobName, jobDetail.Key.Name);
+                activity.SetTag(ActivityTags.TriggerGroup, trigger.Key.Group);
+                activity.SetTag(ActivityTags.TriggerName, trigger.Key.Name);
+                activity.SetTag(ActivityTags.JobGroup, jobDetail.Key.Group);
+                activity.SetTag(ActivityTags.JobName, jobDetail.Key.Name);
             }).ConfigureAwait(false);
 
         // Deliberately after the transaction, and only if it committed: these run listener code, which

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -94,12 +94,12 @@ public partial class StdAdoDelegate
     public virtual async ValueTask<int> CountMisfiredTriggersInState(
         ConnectionAndTransactionHolder conn,
         StoredTriggerState state,
-        DateTimeOffset ts,
+        DateTimeOffset misfireTime,
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(GetCountMisfiredTriggersInStateSql()));
         AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
+        AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(misfireTime));
         AddCommandParameter(cmd, "state", state.ToStoredValue());
 
         return Convert.ToInt32(await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false));
@@ -1347,20 +1347,20 @@ public partial class StdAdoDelegate
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual void AddTriggerPersistenceDelegate(ITriggerPersistenceDelegate del)
+    public virtual void AddTriggerPersistenceDelegate(ITriggerPersistenceDelegate persistenceDelegate)
     {
-        logger.LogDebug("Adding TriggerPersistenceDelegate of type: {Type}", del.GetType());
-        del.Initialize(tablePrefix, schedulerName, this);
-        triggerPersistenceDelegates.Add(del);
+        logger.LogDebug("Adding TriggerPersistenceDelegate of type: {Type}", persistenceDelegate.GetType());
+        persistenceDelegate.Initialize(tablePrefix, schedulerName, this);
+        triggerPersistenceDelegates.Add(persistenceDelegate);
     }
 
     protected virtual ITriggerPersistenceDelegate? FindTriggerPersistenceDelegate(IOperableTrigger trigger)
     {
-        foreach (var del in triggerPersistenceDelegates)
+        foreach (var persistenceDelegate in triggerPersistenceDelegates)
         {
-            if (del.CanHandleTriggerType(trigger))
+            if (persistenceDelegate.CanHandleTriggerType(trigger))
             {
-                return del;
+                return persistenceDelegate;
             }
         }
 
@@ -1369,11 +1369,11 @@ public partial class StdAdoDelegate
 
     protected virtual ITriggerPersistenceDelegate? FindTriggerPersistenceDelegate(string discriminator)
     {
-        foreach (var del in triggerPersistenceDelegates)
+        foreach (var persistenceDelegate in triggerPersistenceDelegates)
         {
-            if (del.GetHandledTriggerTypeDiscriminator() == discriminator)
+            if (persistenceDelegate.GetHandledTriggerTypeDiscriminator() == discriminator)
             {
-                return del;
+                return persistenceDelegate;
             }
         }
 
@@ -1400,7 +1400,7 @@ public partial class StdAdoDelegate
     }
 
     /// <inheritdoc />
-    public virtual async ValueTask<int> SelectNumTriggersForJob(
+    public virtual async ValueTask<int> CountTriggersForJob(
         ConnectionAndTransactionHolder conn,
         JobKey jobKey,
         CancellationToken cancellationToken = default)
@@ -1532,7 +1532,7 @@ public partial class StdAdoDelegate
     public virtual async ValueTask<MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(
         ConnectionAndTransactionHolder conn,
         StoredTriggerState state,
-        DateTimeOffset ts,
+        DateTimeOffset misfireTime,
         int count,
         CancellationToken cancellationToken = default)
     {
@@ -1546,7 +1546,7 @@ public partial class StdAdoDelegate
         using (var cmd = PrepareCommand(conn, sql))
         {
             AddCommandParameter(cmd, "schedulerName", schedulerName);
-            AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(ts));
+            AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(misfireTime));
             AddCommandParameter(cmd, "state", state.ToStoredValue());
 
             using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Impl/AdoJobStore/StdRowLockSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdRowLockSemaphore.cs
@@ -33,7 +33,7 @@ namespace Quartz.Impl.AdoJobStore;
 /// in order to protect resources from being altered by multiple threads at the
 /// same time.
 /// </summary>
-public class StdRowLockSemaphore : DBSemaphore
+public class StdRowLockSemaphore : DbSemaphore
 {
     /// <summary>
     /// The statement that takes the lock by selecting its row for update.

--- a/src/Quartz/Impl/AdoJobStore/TriggerAcquireResult.cs
+++ b/src/Quartz/Impl/AdoJobStore/TriggerAcquireResult.cs
@@ -30,6 +30,9 @@ namespace Quartz.Impl.AdoJobStore;
 /// execution group to count against its limit.
 /// </remarks>
 /// <param name="TriggerKey">The key of the trigger that could be fired.</param>
-/// <param name="JobType">The job type discriminator, as the trigger's job row stores it.</param>
+/// <param name="JobTypeName">The name of the job's type, as the trigger's job row stores it — the same
+/// thing <see cref="JobHeader.JobTypeName" /> carries, and what the type load helper is handed to load
+/// the job. Not to be confused with <see cref="TriggerHeader.TriggerType" />, which is a store
+/// discriminator rather than a type name.</param>
 /// <param name="ExecutionGroup">The trigger's execution group, if it has one.</param>
-public readonly record struct TriggerAcquireResult(TriggerKey TriggerKey, string JobType, string? ExecutionGroup);
+public readonly record struct TriggerAcquireResult(TriggerKey TriggerKey, string JobTypeName, string? ExecutionGroup);

--- a/src/Quartz/Impl/AdoJobStore/TriggerPropertyBundle.cs
+++ b/src/Quartz/Impl/AdoJobStore/TriggerPropertyBundle.cs
@@ -5,14 +5,14 @@
 /// </summary>
 public sealed class TriggerPropertyBundle
 {
-    public TriggerPropertyBundle(IScheduleBuilder sb)
-        : this(sb, [], [])
+    public TriggerPropertyBundle(IScheduleBuilder scheduleBuilder)
+        : this(scheduleBuilder, [], [])
     {
     }
 
-    public TriggerPropertyBundle(IScheduleBuilder sb, string[]? statePropertyNames, object[]? statePropertyValues)
+    public TriggerPropertyBundle(IScheduleBuilder scheduleBuilder, string[]? statePropertyNames, object[]? statePropertyValues)
     {
-        ScheduleBuilder = sb;
+        ScheduleBuilder = scheduleBuilder;
         StatePropertyNames = statePropertyNames ?? [];
         StatePropertyValues = statePropertyValues ?? [];
 

--- a/src/Quartz/Impl/AdoJobStore/UpdateLockRowSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/UpdateLockRowSemaphore.cs
@@ -43,7 +43,7 @@ namespace Quartz.Impl.AdoJobStore;
 /// </para>
 /// </remarks>
 /// <author>Marko Lahma (.NET)</author>
-public class UpdateLockRowSemaphore : DBSemaphore
+public class UpdateLockRowSemaphore : DbSemaphore
 {
     /// <summary>
     /// The statement that takes the lock by updating its row.

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -52,7 +52,7 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
         return new ValueTask<List<IScheduler>>(schedulerRepository.LookupAll());
     }
 
-    public async ValueTask<IScheduler?> GetScheduler(string schedulerName, CancellationToken cancellationToken = default)
+    public async ValueTask<IScheduler?> LookupScheduler(string schedulerName, CancellationToken cancellationToken = default)
     {
         // Asking for this factory's scheduler by name has to be able to create it. Looking straight in
         // the repository would only ever find a scheduler somebody else had already asked for. The

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -749,11 +749,11 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     /// Equivalent to calling <see cref="WillFireOn(DateTimeOffset, bool)" />.
     /// </para>
     /// </summary>
-    /// <param name="test">The date to compare.</param>
+    /// <param name="timeUtc">The time to compare.</param>
     /// <returns></returns>
-    public bool WillFireOn(DateTimeOffset test)
+    public bool WillFireOn(DateTimeOffset timeUtc)
     {
-        return WillFireOn(test, false);
+        return WillFireOn(timeUtc, false);
     }
 
     /// <summary>
@@ -764,19 +764,19 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     /// ICalendar (if any).
     /// </para>
     /// </summary>
-    /// <param name="test">The date to compare</param>
+    /// <param name="timeUtc">The time to compare.</param>
     /// <param name="dayOnly">If set to true, the method will only determine if the
     /// trigger will fire during the day represented by the given Calendar
     /// (hours, minutes and seconds will be ignored).</param>
     /// <returns></returns>
-    public bool WillFireOn(DateTimeOffset test, bool dayOnly)
+    public bool WillFireOn(DateTimeOffset timeUtc, bool dayOnly)
     {
         if (dayOnly)
         {
-            test = new DateTimeOffset(test.Year, test.Month, test.Day, 0, 0, 0, TimeProvider.LocalTimeZone.BaseUtcOffset);
+            timeUtc = new DateTimeOffset(timeUtc.Year, timeUtc.Month, timeUtc.Day, 0, 0, 0, TimeProvider.LocalTimeZone.BaseUtcOffset);
         }
 
-        DateTimeOffset? fta = GetFireTimeAfter(test.AddMilliseconds(-1 * 1000));
+        DateTimeOffset? fta = GetFireTimeAfter(timeUtc.AddMilliseconds(-1 * 1000));
 
         if (fta is null)
         {
@@ -787,17 +787,17 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
 
         if (dayOnly)
         {
-            return p.Year == test.Year
-                   && p.Month == test.Month
-                   && p.Day == test.Day;
+            return p.Year == timeUtc.Year
+                   && p.Month == timeUtc.Month
+                   && p.Day == timeUtc.Day;
         }
 
-        while (fta is not null && fta.Value < test)
+        while (fta is not null && fta.Value < timeUtc)
         {
             fta = GetFireTimeAfter(fta);
         }
 
-        if (fta.Equals(test))
+        if (fta.Equals(timeUtc))
         {
             return true;
         }

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -127,20 +127,20 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// repeat at the given interval.
     /// </summary>
     /// <param name="name"></param>
-    /// <param name="startTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
-    /// <param name="endTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
+    /// <param name="startTimeOfDay">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
+    /// <param name="endTimeOfDay">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
     /// <param name="intervalUnit">The repeat interval unit. The only intervals that are valid for this type of trigger are <see cref="IntervalUnit.Second"/>, <see cref="IntervalUnit.Minute"/>, and <see cref="IntervalUnit.Hour"/>.</param>
     /// <param name="repeatInterval"></param>
     /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
     /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
     public DailyTimeIntervalTriggerImpl(
         string name,
-        TimeOnly startTimeOfDayUtc,
-        TimeOnly endTimeOfDayUtc,
+        TimeOnly startTimeOfDay,
+        TimeOnly endTimeOfDay,
         IntervalUnit intervalUnit,
         int repeatInterval,
         TimeProvider? timeProvider = null)
-        : this(name, SchedulerConstants.DefaultGroup, startTimeOfDayUtc, endTimeOfDayUtc, intervalUnit, repeatInterval, timeProvider)
+        : this(name, SchedulerConstants.DefaultGroup, startTimeOfDay, endTimeOfDay, intervalUnit, repeatInterval, timeProvider)
     {
     }
 
@@ -150,8 +150,8 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// </summary>
     /// <param name="name"></param>
     /// <param name="group"></param>
-    /// <param name="startTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
-    /// <param name="endTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
+    /// <param name="startTimeOfDay">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
+    /// <param name="endTimeOfDay">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
     /// <param name="intervalUnit">The repeat interval unit. The only intervals that are valid for this type of trigger are <see cref="IntervalUnit.Second"/>, <see cref="IntervalUnit.Minute"/>, and <see cref="IntervalUnit.Hour"/>.</param>
     /// <param name="repeatInterval"></param>
     /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
@@ -159,12 +159,12 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     public DailyTimeIntervalTriggerImpl(
         string name,
         string group,
-        TimeOnly startTimeOfDayUtc,
-        TimeOnly endTimeOfDayUtc,
+        TimeOnly startTimeOfDay,
+        TimeOnly endTimeOfDay,
         IntervalUnit intervalUnit,
         int repeatInterval,
         TimeProvider? timeProvider = null)
-        : this(name, group, (timeProvider ?? TimeProvider.System).GetUtcNow(), null, startTimeOfDayUtc, endTimeOfDayUtc, intervalUnit, repeatInterval, timeProvider)
+        : this(name, group, (timeProvider ?? TimeProvider.System).GetUtcNow(), null, startTimeOfDay, endTimeOfDay, intervalUnit, repeatInterval, timeProvider)
     {
     }
 
@@ -175,8 +175,8 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// <param name="name"></param>
     /// <param name="startTimeUtc">A <see cref="DateTimeOffset" /> set to the time for the <see cref="ITrigger" />to fire.</param>
     /// <param name="endTimeUtc">A <see cref="DateTimeOffset" /> set to the time for the <see cref="ITrigger" />to quit repeat firing.</param>
-    /// <param name="startTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
-    /// <param name="endTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
+    /// <param name="startTimeOfDay">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
+    /// <param name="endTimeOfDay">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
     /// <param name="intervalUnit">The repeat interval unit. The only intervals that are valid for this type of trigger are <see cref="IntervalUnit.Second"/>, <see cref="IntervalUnit.Minute"/>, and <see cref="IntervalUnit.Hour"/>.</param>
     /// <param name="repeatInterval">The number of milliseconds to pause between the repeat firing.</param>
     /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
@@ -185,12 +185,12 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         string name,
         DateTimeOffset startTimeUtc,
         DateTimeOffset? endTimeUtc,
-        TimeOnly startTimeOfDayUtc,
-        TimeOnly endTimeOfDayUtc,
+        TimeOnly startTimeOfDay,
+        TimeOnly endTimeOfDay,
         IntervalUnit intervalUnit,
         int repeatInterval,
         TimeProvider? timeProvider = null)
-        : this(name, SchedulerConstants.DefaultGroup, startTimeUtc, endTimeUtc, startTimeOfDayUtc, endTimeOfDayUtc, intervalUnit, repeatInterval, timeProvider)
+        : this(name, SchedulerConstants.DefaultGroup, startTimeUtc, endTimeUtc, startTimeOfDay, endTimeOfDay, intervalUnit, repeatInterval, timeProvider)
     {
     }
 
@@ -202,8 +202,8 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// <param name="group"></param>
     /// <param name="startTimeUtc">A <see cref="DateTimeOffset" /> set to the time for the <see cref="ITrigger" />to fire.</param>
     /// <param name="endTimeUtc">A <see cref="DateTimeOffset" /> set to the time for the <see cref="ITrigger" />to quit repeat firing.</param>
-    /// <param name="startTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
-    /// <param name="endTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
+    /// <param name="startTimeOfDay">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
+    /// <param name="endTimeOfDay">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
     /// <param name="intervalUnit">The repeat interval unit. The only intervals that are valid for this type of trigger are <see cref="IntervalUnit.Second"/>, <see cref="IntervalUnit.Minute"/>, and <see cref="IntervalUnit.Hour"/>.</param>
     /// <param name="repeatInterval">The number of milliseconds to pause between the repeat firing.</param>
     /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
@@ -213,8 +213,8 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         string group,
         DateTimeOffset startTimeUtc,
         DateTimeOffset? endTimeUtc,
-        TimeOnly startTimeOfDayUtc,
-        TimeOnly endTimeOfDayUtc,
+        TimeOnly startTimeOfDay,
+        TimeOnly endTimeOfDay,
         IntervalUnit intervalUnit,
         int repeatInterval,
         TimeProvider? timeProvider = null)
@@ -224,8 +224,8 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         EndTimeUtc = endTimeUtc;
         RepeatIntervalUnit = intervalUnit;
         RepeatInterval = repeatInterval;
-        StartTimeOfDay = startTimeOfDayUtc;
-        EndTimeOfDay = endTimeOfDayUtc;
+        StartTimeOfDay = startTimeOfDay;
+        EndTimeOfDay = endTimeOfDay;
     }
 
     /// <summary>
@@ -239,8 +239,8 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// <param name="jobGroup"></param>
     /// <param name="startTimeUtc">A <see cref="DateTimeOffset" /> set to the time for the <see cref="ITrigger" />to fire.</param>
     /// <param name="endTimeUtc">A <see cref="DateTimeOffset" /> set to the time for the <see cref="ITrigger" />to quit repeat firing.</param>
-    /// <param name="startTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
-    /// <param name="endTimeOfDayUtc">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
+    /// <param name="startTimeOfDay">The <see cref="TimeOnly" /> that the repeating should begin occurring.</param>
+    /// <param name="endTimeOfDay">The <see cref="TimeOnly" /> that the repeating should stop occurring.</param>
     /// <param name="intervalUnit">The repeat interval unit. The only intervals that are valid for this type of trigger are <see cref="IntervalUnit.Second"/>, <see cref="IntervalUnit.Minute"/>, and <see cref="IntervalUnit.Hour"/>.</param>
     /// <param name="repeatInterval">The number of milliseconds to pause between the repeat firing.</param>
     /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
@@ -252,8 +252,8 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         string jobGroup,
         DateTimeOffset startTimeUtc,
         DateTimeOffset? endTimeUtc,
-        TimeOnly startTimeOfDayUtc,
-        TimeOnly endTimeOfDayUtc,
+        TimeOnly startTimeOfDay,
+        TimeOnly endTimeOfDay,
         IntervalUnit intervalUnit,
         int repeatInterval,
         TimeProvider? timeProvider = null)
@@ -263,8 +263,8 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         EndTimeUtc = endTimeUtc;
         RepeatIntervalUnit = intervalUnit;
         RepeatInterval = repeatInterval;
-        StartTimeOfDay = startTimeOfDayUtc;
-        EndTimeOfDay = endTimeOfDayUtc;
+        StartTimeOfDay = startTimeOfDay;
+        EndTimeOfDay = endTimeOfDay;
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -437,7 +437,7 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
 
             if (newFireTime.HasValue)
             {
-                int timesMissed = ComputeNumTimesFiredBetween(NextFireTimeUtc.GetValueOrDefault(), newFireTime.GetValueOrDefault());
+                int timesMissed = ComputeNumberOfTimesFiredBetween(NextFireTimeUtc.GetValueOrDefault(), newFireTime.GetValueOrDefault());
                 TimesTriggered = TimesTriggered + timesMissed;
             }
 
@@ -469,7 +469,7 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
 
             if (repeatCount != 0 && repeatCount != RepeatIndefinitely)
             {
-                int timesMissed = ComputeNumTimesFiredBetween(NextFireTimeUtc.GetValueOrDefault(), newFireTime);
+                int timesMissed = ComputeNumberOfTimesFiredBetween(NextFireTimeUtc.GetValueOrDefault(), newFireTime);
                 int remainingCount = RepeatCount - (TimesTriggered + timesMissed);
                 if (remainingCount <= 0)
                 {
@@ -691,7 +691,7 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
             return null;
         }
 
-        int numFires = ComputeNumTimesFiredBetween(StartTimeUtc, endUtc);
+        int numFires = ComputeNumberOfTimesFiredBetween(StartTimeUtc, endUtc);
         return StartTimeUtc.AddTicks(numFires * repeatInterval.Ticks);
     }
 
@@ -701,7 +701,7 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
     /// <param name="startTimeUtc">The UTC start date and time.</param>
     /// <param name="endTimeUtc">The UTC end date and time.</param>
     /// <returns></returns>
-    public int ComputeNumTimesFiredBetween(DateTimeOffset startTimeUtc, DateTimeOffset endTimeUtc)
+    public int ComputeNumberOfTimesFiredBetween(DateTimeOffset startTimeUtc, DateTimeOffset endTimeUtc)
     {
         long time = (endTimeUtc - startTimeUtc).Ticks;
         return (int) (time / repeatInterval.Ticks);

--- a/src/Quartz/Queries/TriggerHeader.cs
+++ b/src/Quartz/Queries/TriggerHeader.cs
@@ -27,8 +27,13 @@ namespace Quartz;
 /// <param name="Key">The trigger's key.</param>
 /// <param name="JobKey">The key of the job the trigger fires.</param>
 /// <param name="Description">The trigger's description, if one was given.</param>
-/// <param name="TriggerType">The store's trigger type discriminator, for example
-/// <c>"CRON"</c> or <c>"SIMPLE"</c>.</param>
+/// <param name="TriggerType">The store's trigger type discriminator, for example <c>"CRON"</c> or
+/// <c>"SIMPLE"</c> — the value of the <c>TRIGGER_TYPE</c> column, which is what
+/// <see cref="Quartz.Impl.AdoJobStore.ITriggerPersistenceDelegate.GetHandledTriggerTypeDiscriminator" />
+/// returns. It is a discriminator, <em>not</em> a type name, and so is deliberately not called one:
+/// contrast <see cref="JobHeader.JobTypeName" /> and
+/// <see cref="Quartz.Impl.AdoJobStore.TriggerAcquireResult.JobTypeName" />, both of which carry a CLR
+/// type name that a type load helper can resolve.</param>
 /// <param name="State">The trigger's current state.</param>
 /// <param name="StartTimeUtc">The time the trigger's schedule comes into effect.</param>
 /// <param name="EndTimeUtc">The time the trigger's schedule ends, if bounded.</param>

--- a/src/Quartz/Serialization/Json/Converters/TriggerConverter.cs
+++ b/src/Quartz/Serialization/Json/Converters/TriggerConverter.cs
@@ -85,7 +85,7 @@ internal sealed class TriggerConverter(SystemTextJsonSerializerRegistry registry
             var type = value.GetType().AssemblyQualifiedNameWithoutVersion();
             var triggerSerializer = registry.GetTriggerSerializer(type);
 
-            writer.WriteString(options.GetPropertyName("TriggerType"), triggerSerializer.TriggerTypeForJson);
+            writer.WriteString(options.GetPropertyName("TriggerType"), triggerSerializer.TriggerTypeName);
 
             writer.WriteKey(options.GetPropertyName("Key"), value.Key, options);
             writer.WriteKey(options.GetPropertyName("JobKey"), value.JobKey, options);

--- a/src/Quartz/Serialization/Json/SystemTextJsonSerializerRegistry.cs
+++ b/src/Quartz/Serialization/Json/SystemTextJsonSerializerRegistry.cs
@@ -56,7 +56,7 @@ public sealed class SystemTextJsonSerializerRegistry
         ArgumentNullException.ThrowIfNull(serializer);
 
         // Found by its JSON discriminator, and also by its type name.
-        triggerSerializers.Add(serializer, serializer.TriggerTypeForJson, typeof(TTrigger).AssemblyQualifiedNameWithoutVersion());
+        triggerSerializers.Add(serializer, serializer.TriggerTypeName, typeof(TTrigger).AssemblyQualifiedNameWithoutVersion());
         return this;
     }
 

--- a/src/Quartz/Serialization/Json/Triggers/CalendarIntervalTriggerSerializer.cs
+++ b/src/Quartz/Serialization/Json/Triggers/CalendarIntervalTriggerSerializer.cs
@@ -6,7 +6,7 @@ namespace Quartz.Serialization.Json.Triggers;
 
 public class CalendarIntervalTriggerSerializer : TriggerSerializer<CalendarIntervalTriggerImpl>
 {
-    public override string TriggerTypeForJson => "CalendarIntervalTrigger";
+    public override string TriggerTypeName => "CalendarIntervalTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
     {

--- a/src/Quartz/Serialization/Json/Triggers/CronTriggerSerializer.cs
+++ b/src/Quartz/Serialization/Json/Triggers/CronTriggerSerializer.cs
@@ -4,7 +4,7 @@ namespace Quartz.Serialization.Json.Triggers;
 
 public class CronTriggerSerializer : TriggerSerializer<ICronTrigger>
 {
-    public override string TriggerTypeForJson => "CronTrigger";
+    public override string TriggerTypeName => "CronTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
     {

--- a/src/Quartz/Serialization/Json/Triggers/DailyTimeIntervalTriggerSerializer.cs
+++ b/src/Quartz/Serialization/Json/Triggers/DailyTimeIntervalTriggerSerializer.cs
@@ -6,7 +6,7 @@ namespace Quartz.Serialization.Json.Triggers;
 
 public class DailyTimeIntervalTriggerSerializer : TriggerSerializer<DailyTimeIntervalTriggerImpl>
 {
-    public override string TriggerTypeForJson => "DailyTimeIntervalTrigger";
+    public override string TriggerTypeName => "DailyTimeIntervalTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
     {

--- a/src/Quartz/Serialization/Json/Triggers/RecurrenceTriggerSerializer.cs
+++ b/src/Quartz/Serialization/Json/Triggers/RecurrenceTriggerSerializer.cs
@@ -6,7 +6,7 @@ namespace Quartz.Serialization.Json.Triggers;
 
 public sealed class RecurrenceTriggerSerializer : TriggerSerializer<RecurrenceTriggerImpl>
 {
-    public override string TriggerTypeForJson => "RecurrenceTrigger";
+    public override string TriggerTypeName => "RecurrenceTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
     {

--- a/src/Quartz/Serialization/Json/Triggers/SimpleTriggerSerializer.cs
+++ b/src/Quartz/Serialization/Json/Triggers/SimpleTriggerSerializer.cs
@@ -6,7 +6,7 @@ namespace Quartz.Serialization.Json.Triggers;
 
 public class SimpleTriggerSerializer : TriggerSerializer<SimpleTriggerImpl>
 {
-    public override string TriggerTypeForJson => "SimpleTrigger";
+    public override string TriggerTypeName => "SimpleTrigger";
 
     public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
     {

--- a/src/Quartz/Serialization/Json/Triggers/TriggerSerializer.cs
+++ b/src/Quartz/Serialization/Json/Triggers/TriggerSerializer.cs
@@ -4,7 +4,7 @@ namespace Quartz.Serialization.Json.Triggers;
 
 public interface ITriggerSerializer
 {
-    string TriggerTypeForJson { get; }
+    string TriggerTypeName { get; }
 
     IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options);
 
@@ -15,7 +15,7 @@ public interface ITriggerSerializer
 
 public abstract class TriggerSerializer<TTrigger> : ITriggerSerializer where TTrigger : ITrigger
 {
-    public abstract string TriggerTypeForJson { get; }
+    public abstract string TriggerTypeName { get; }
 
     public abstract IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options);
 

--- a/src/Quartz/StandaloneSchedulerFactory.cs
+++ b/src/Quartz/StandaloneSchedulerFactory.cs
@@ -46,9 +46,9 @@ public sealed class StandaloneSchedulerFactory : ISchedulerFactory, IDisposable,
     }
 
     /// <inheritdoc />
-    public ValueTask<IScheduler?> GetScheduler(string schedulerName, CancellationToken cancellationToken = default)
+    public ValueTask<IScheduler?> LookupScheduler(string schedulerName, CancellationToken cancellationToken = default)
     {
-        return inner.GetScheduler(schedulerName, cancellationToken);
+        return inner.LookupScheduler(schedulerName, cancellationToken);
     }
 
     /// <summary>

--- a/src/Quartz/Util/ObjectExtensions.cs
+++ b/src/Quartz/Util/ObjectExtensions.cs
@@ -4,9 +4,11 @@ using System.Text.RegularExpressions;
 namespace Quartz.Util;
 
 /// <summary>
-/// Generic extension methods for objects.
+/// Produces the type name Quartz stores and sends over the wire: assembly-qualified, but without the
+/// version, culture and public key token, so a payload written by one build still binds after an
+/// assembly version bump.
 /// </summary>
-public static class ObjectExtensions
+internal static class ObjectExtensions
 {
     private static readonly ConcurrentDictionary<Type, string> assemblyQualifiedNameCache = new();
     private static readonly Regex cleanup = new(", (Version|Culture|PublicKeyToken)=[0-9.\\w]+", RegexOptions.Compiled | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(5));

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -49,7 +49,24 @@ public static class TimeZoneUtil
         timeZoneIdAliases["Asia/Karachi"] = "Pakistan Standard Time";
     }
 
-    public static Func<string, TimeZoneInfo?> CustomResolver { get; set; } = id => null;
+    /// <summary>
+    /// A last-resort resolver consulted when a time zone id is neither a system id nor one of the
+    /// aliases above. <see langword="null" /> — the default — means there is none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is process-wide, and deliberately so: <see cref="FindTimeZoneById" /> is reached from
+    /// places that have no scheduler in scope — parsing a <see cref="CronExpression" />, deserializing
+    /// a trigger or calendar out of a job store blob — so there is nothing scheduler-scoped to hang a
+    /// resolver on. Setting it from one scheduler changes id resolution for every scheduler in the
+    /// process, which is what installing <c>Quartz.Plugins.TimeZoneConverter</c> does.
+    /// </para>
+    /// <para>
+    /// Assign <see langword="null" /> to remove a resolver again; a resolver returning
+    /// <see langword="null" /> for an id it does not know is how it declines a single id.
+    /// </para>
+    /// </remarks>
+    public static Func<string, TimeZoneInfo?>? CustomResolver { get; set; }
 
     /// <summary>
     /// TimeZoneInfo.ConvertTime is not supported under mono
@@ -212,10 +229,7 @@ public static class TimeZoneUtil
                 }
             }
 
-            if (info is null)
-            {
-                info = CustomResolver(id);
-            }
+            info ??= CustomResolver?.Invoke(id);
 
             if (info is null)
             {


### PR DESCRIPTION
**Stack layer 3 of 3, and the last piece of the 4.0 API coherence campaign.** Base: `api-coherence-phase6b` (#3232) → `api-coherence-phase6a` (#3231) → `api-coherence-phase5` (#3230) → `main`.

## The acceptance test, and what it caught

The campaign's own measure of doneness: **every non-systematic removal or rename in the 3.x→4.0 public API diff should be findable in the migration guide.** That diff is now mechanical to produce — 3.x carries the same `PublicApiTest_*.verified.txt` baselines (#3227) — so this ran as a machine-checked audit of every removed and renamed name, not an eyeball pass. It found two things review-by-phase had missed, both affecting ordinary users rather than extenders:

- **`JobDataMap`'s sixty typed accessors** (`GetIntValue`, `TryGetIntValue`, `GetIntValueFromString`, … across fifteen types) were replaced by the inherited `GetInt`/`TryGetInt` set, and the guide never said so. This is among the most common lines in 3.x user code. Now a section with a full old→new table; `GetNullableGuidValue` has no direct replacement, and that is stated.
- **`Quartz.AspNetCore.AddQuartzServer` was removed and unmentioned** — while `packages/aspnet-core-integration.md` still instructed readers to call it. Both fixed.

Three narrower gaps are closed too: the `Supports*Column`/`Has*Column` probes and `VerifyTriggersTableReachable` (4.x requires what 3.x probed for, so the schema migration is **mandatory** — and since `ValidateSchema` only checks that each table is queryable, skipping it surfaces as a provider-level missing-column error, not a tidy failure), the three removed acquisition-SQL hooks on the dialect delegates, and `AddDataSourceProvider()`.

The remaining tier is reported rather than hidden: roughly 46 internalized types are covered by the blanket policy paragraph but never by name, so a reader searching for `PropertiesParser` finds nothing. That wants an alphabetical appendix, which is a better standalone change than a rushed addition here.

## Naming sweep

Applied where the name was wrong and nothing external depends on it: `timeOfDayUtc` → `timeOfDay` (the value is wall-clock and the property it sets never claimed otherwise), `TriggerAcquireResult.JobType` → `JobTypeName`, `ActivityOptions` → `ActivityTags`, `DBSemaphore` → `DbSemaphore`, `SelectNumTriggersForJob` → `CountTriggersForJob`, plus a parameter sweep where an interface and its own implementation disagreed and broke named arguments (`classLoadHelper`/`loadHelper`).

Declined, with reasons: the `MySQLDelegate`/`XMLSchedulingDataProcessor` casing — **the line drawn is "rename what no configuration string names"** — and `TriggerHeader.TriggerType`, which was renamed and then reverted, because `TriggerType` is the established word across the HTTP API DTOs, the dashboard and the `TRIGGER_TYPE` column; splitting one vocabulary into three costs more than the inconsistency. Its documentation now says it is a discriminator.

## Two ambient statics stay ambient, and now say why

`LogProvider.SetLogProvider` and `TimeZoneUtil.CustomResolver` were candidates for DI. Seeding the logger from the container was **tried and reverted: 172 unit tests failed with `ObjectDisposedException`**, because the ambient slot outlives any one container — a process that builds a host, disposes it and builds another is left holding a disposed factory, and the next logger created anywhere throws from somewhere unrelated. ~55 call sites can reach no container at all. The finding is now the documentation, including the caveat that the guide's own recipe only holds while the host outlives the schedulers.

Also: `TriggerUtils` moves to `Quartz.Extensibility` (it operates on `IOperableTrigger`), `ObjectExtensions` goes internal, and `ISchedulerFactory.GetScheduler(string)` becomes `LookupScheduler(string)` — the nullability asymmetry was correct and load-bearing, but two members sharing a name while differing in nullability made it look arbitrary.

Finally, the guide gains **"The road from 3.x, phase by phase"** at the top, mapping the six passes to the sections each one wrote. Anchor links were verified against VuePress's actual slugify rule, which turned up two broken links this layer had introduced.

## Verification

`build.cmd` green; unit 2048 passed; AspNetCore 203; Postgres integration 59. Baseline against layer 6b is 4 net removals — `TriggerUtils` changing namespace and `ObjectExtensions` going internal — everything else a 1:1 rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)