### PR TITLE
Report the exception the job threw, as error.type

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1112,9 +1112,9 @@ anything already charting them:
 | Instrument | 4.x type | Tags |
 |---|---|---|
 | `scheduling.quartz.execute` | `Counter<long>` | `trigger.group`, `trigger.name`, `job.group`, `job.name` |
-| `scheduling.quartz.execute.errors` | `Counter<long>` | the four identity tags **+ `scheduling.quartz.exception_type`** |
+| `scheduling.quartz.execute.errors` | `Counter<long>` | the four identity tags **+ `error.type`** |
 | `scheduling.quartz.execute.active` | **`UpDownCounter<long>`** (was `Counter<long>`) | the four identity tags |
-| `scheduling.quartz.execute.duration` | `Histogram<double>` | the four identity tags, **+ `scheduling.quartz.exception_type`** when the execution failed |
+| `scheduling.quartz.execute.duration` | `Histogram<double>` | the four identity tags, **+ `error.type`** when the execution failed |
 
 **`scheduling.quartz.execute.active` is an up-down counter.** The number of jobs running goes down as
 often as it goes up, and Quartz has always measured the decrement — but a `Counter` is monotonic by
@@ -1124,16 +1124,34 @@ meaning are unchanged; the instrument type an exporter sees is not, so a dashboa
 the old series has to be rebuilt on a non-monotonic one — a `Sum` with `IsMonotonic = false` in the
 OpenTelemetry SDK, which Prometheus renders as a gauge rather than a counter.
 
-**`scheduling.quartz.exception_type` reaches the measurements it is meant to.** The tag was added to a
-copy of the tag list and thrown away, so the errors counter carried the four identity tags and nothing
-else: an exporter could see that executions failed, but never what failed. It is now on the errors counter
-and on the duration histogram, so a failed run's duration can be told apart from a successful one's. It is
-deliberately *not* on `scheduling.quartz.execute.active`, whose increment and decrement have to carry
-identical attributes or the series never comes back to zero.
+**`scheduling.quartz.exception_type` is `error.type`, and it names the exception the job threw.** Two
+things were wrong with it. The tag was added to a copy of the tag list and thrown away, so the errors
+counter carried the four identity tags and nothing else: an exporter could see that executions failed, but
+never what failed. And the type it named was the `JobExecutionException` that the job run shell wraps
+anything a job throws in — the same answer for very nearly every failure there is.
 
-The value is the exception type the job run shell reports, which is the `JobExecutionException` that
-anything a job throws is wrapped in. The exception the job itself threw is on the execution's span, which
-records it as an exception event.
+The tag now arrives, and it reports the exception an application would recognise. A job that throws
+`InvalidOperationException` is reported as `System.InvalidOperationException`, not as the
+`JobExecutionException` -> `JobExecutionProcessException` -> cause chain the run shell built around it. A
+job that raises a `JobExecutionException` itself has no such wrapper underneath and is reported as
+`Quartz.JobExecutionException`, which is what it chose to say. The value is a fully-qualified type name
+and nothing else: a message would be unbounded, and an attribute an exporter aggregates on has to have
+bounded cardinality.
+
+The name is OpenTelemetry's. [`error.type`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/error/)
+is the semantic convention's attribute for what an operation failed with, so these series line up with
+every other instrumented failure in the same dashboard; the Quartz-specific spelling is gone rather than
+emitted alongside it, since two names for one attribute doubles the series and settles nothing. **A query
+or an alert matching on `scheduling.quartz.exception_type` has to be rewritten**, and one that expected
+the value `JobExecutionException` now sees the type the job threw.
+
+The tag is on the errors counter and on the duration histogram, so a failed run's duration can be told
+apart from a successful one's. It is deliberately *not* on `scheduling.quartz.execute.active`, whose
+increment and decrement have to carry identical attributes or the series never comes back to zero.
+
+The execution's span carries the same `error.type` with the same value, so one attribute finds a failure
+in a trace and in a metric alike. The span also still records the exception as an event, with the whole
+wrapper chain, because that is where the stack traces are.
 
 ## JSON Serialization
 
@@ -3728,7 +3746,7 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `QuartzOptions.SchedulerName`, `.SchedulerId`, `.MisfireThreshold` removed | Each duplicated a typed option — see [`QuartzOptions` lost its three typed settings](#quartzoptions-lost-its-three-typed-settings) |
 | Job execution metrics are published by every scheduler | The meters were configured only by `StdSchedulerFactory`, so a scheduler registered with `AddQuartz` published none |
 | `scheduling.quartz.execute.active` is an `UpDownCounter<long>` | It was a `Counter<long>` receiving the `-1` that ends an execution, which an exporter aggregating a monotonic sum may drop — see [Job execution metrics](#job-execution-metrics) |
-| `scheduling.quartz.exception_type` reaches the errors counter | The tag was added to a copy of the tag list and discarded, so the counter said only that something failed; it is on the duration histogram too |
+| `scheduling.quartz.exception_type` is `error.type`, naming the exception the job threw | The tag was added to a copy of the tag list and discarded, so the counter said only that something failed — and the type it named was the `JobExecutionException` the run shell wraps everything in. It is OpenTelemetry's conventional name now, it is on the duration histogram and the execution's span too, and a query matching the old name or expecting the old value has to be rewritten — see [Job execution metrics](#job-execution-metrics) |
 | `XmlSchedulingOptions` and `JsonSchedulingOptions` merged | They were byte-for-byte identical and are now one type |
 | Constructing a scheduler no longer starts a thread | `QuartzScheduler` starts its scheduler thread from `Start()` rather than its constructor, so resolving the service graph, running a `ValidateOnBuild` pass or asserting on registrations no longer spins one up. The thread always started paused, so this changes when the thread exists, not when jobs run |
 | `IPersistentStoreBuilder.AcceptEnlistedTransactions()` added | A breaking addition for anyone implementing the interface themselves — see [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction) |

--- a/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
@@ -57,7 +57,10 @@ public sealed class JobExecutionObservabilityTest
     private const string ExecuteErrors = "scheduling.quartz.execute.errors";
     private const string ExecuteActive = "scheduling.quartz.execute.active";
     private const string ExecuteDuration = "scheduling.quartz.execute.duration";
-    private const string ExceptionType = "scheduling.quartz.exception_type";
+    // OpenTelemetry's conventional attribute for what an operation failed with, spelled out here rather
+    // than read from Quartz, because the wire name is the contract an exporter and a dashboard are
+    // written against.
+    private const string ErrorTypeTag = "error.type";
 
     private readonly List<RecordedMeasurement> measurements = [];
     private readonly List<Activity> stoppedActivities = [];
@@ -179,13 +182,13 @@ public sealed class JobExecutionObservabilityTest
 
         active.Sum(m => m.Value).Should().Be(0,
             "a job that throws leaves nothing in progress either — the decrement is not on the happy path only");
-        active.Should().AllSatisfy(m => m.Tags.Should().NotContainKey(ExceptionType,
+        active.Should().AllSatisfy(m => m.Tags.Should().NotContainKey(ErrorTypeTag,
             "an up-down counter is aggregated per attribute set, so the decrement has to carry exactly the "
             + "tags the increment carried or the series never comes back to zero"));
 
         published.Should().ContainSingle(m => m.Instrument == ExecuteDuration,
             "how long a job ran is worth knowing whether or not it failed")
-            .Which.Tags.Should().ContainKey(ExceptionType,
+            .Which.Tags.Should().ContainKey(ErrorTypeTag,
                 "and a failed run's duration is worth telling apart from a successful one's");
     }
 
@@ -195,23 +198,43 @@ public sealed class JobExecutionObservabilityTest
     /// <remarks>
     /// The tag used to be added to <c>_tagList.Value</c>, and <see cref="Nullable{T}.Value"/> hands back a
     /// copy of the struct: it went onto a temporary that was thrown away on the next line, where a second
-    /// copy — still the four identity tags — was what the counter was given. The type reported is the one
-    /// the run shell hands to the instrumentation, which is the <see cref="JobExecutionException"/> it
-    /// wraps anything a job throws in, so the tag separates a job that raised one deliberately from a job
-    /// whose failure the pipeline wrapped. The exception the job itself threw is on the span, as
-    /// <see cref="FailingJobExecution_EmitsActivityWithErrorStatusAndException"/> asserts.
+    /// copy — still the four identity tags — was what the counter was given. Once it did arrive it named
+    /// the <see cref="JobExecutionException"/> the run shell wraps anything a job throws in, which is the
+    /// same answer for nearly every failure there is; what it reports now is the exception the job threw,
+    /// found by unwrapping that pair of wrappers.
     /// </remarks>
     [Test]
-    public async Task FailingJobExecution_TagsTheErrorWithTheExceptionType()
+    public async Task FailingJobExecution_TagsTheErrorWithTheExceptionTheJobThrew()
     {
         Execution execution = await RunJob<ThrowingJob>();
 
         RecordedMeasurement error = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteErrors);
 
-        error.Tags.Should().ContainKey(ExceptionType)
-            .WhoseValue.Should().Be(nameof(JobExecutionException),
-                "an exporter that can see that executions failed but never what failed is missing most of "
-                + "the reason to look");
+        error.Tags.Should().ContainKey(ErrorTypeTag)
+            .WhoseValue.Should().Be(typeof(InvalidOperationException).FullName,
+                "the run shell wraps what a job throws as JobExecutionException -> "
+                + "JobExecutionProcessException -> the cause, and naming either wrapper would tell an "
+                + "exporter only that Quartz caught something, which it already knew from the counter");
+    }
+
+    /// <summary>
+    /// Unwrapping stops at what the job threw, so a job that raises a <see cref="JobExecutionException"/>
+    /// deliberately is reported as having thrown one.
+    /// </summary>
+    [Test]
+    public async Task JobThrowingJobExecutionException_TagsTheErrorWithThatType()
+    {
+        Execution execution = await RunJob<DeliberatelyFailingJob>();
+
+        RecordedMeasurement error = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteErrors);
+
+        error.Tags.Should().ContainKey(ErrorTypeTag)
+            .WhoseValue.Should().Be(typeof(JobExecutionException).FullName,
+                "a JobExecutionException a job raised itself is not a wrapper the run shell added — there "
+                + "is no JobExecutionProcessException under it — and it is what the job chose to say");
+
+        ActivityFor(execution.JobKey).GetTagItem(ErrorTypeTag).Should().Be(typeof(JobExecutionException).FullName,
+            "the span and the errors counter answer the same question the same way");
     }
 
     [Test]
@@ -248,6 +271,15 @@ public sealed class JobExecutionObservabilityTest
         activity.Status.Should().Be(ActivityStatusCode.Error);
         activity.Events.Should().ContainSingle(e => e.Name == "exception",
             "the exception the job threw is recorded on the span that failed");
+
+        activity.GetTagItem(ErrorTypeTag).Should().Be(typeof(InvalidOperationException).FullName,
+            "the span classifies the failure with the attribute the errors counter is tagged with, so one "
+            + "value finds the failed executions in a trace and in a metric alike");
+
+        RecordedMeasurement error = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteErrors);
+        error.Tags[ErrorTypeTag].Should().Be(activity.GetTagItem(ErrorTypeTag),
+            "the two signals are read together, and disagreeing about what failed is worse than either "
+            + "of them being silent");
     }
 
     /// <summary>
@@ -385,6 +417,18 @@ public sealed class JobExecutionObservabilityTest
         public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             throw new InvalidOperationException("this job fails on purpose");
+        }
+    }
+
+    /// <summary>
+    /// A job reporting its own failure the way Quartz asks a job to, rather than letting an exception of
+    /// its own out.
+    /// </summary>
+    public sealed class DeliberatelyFailingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            throw new JobExecutionException("this job reports its own failure");
         }
     }
 }

--- a/src/Quartz/Diagnostics/ActivityTags.cs
+++ b/src/Quartz/Diagnostics/ActivityTags.cs
@@ -18,3 +18,50 @@ public static class ActivityTags
     public const string TriggerCount = "jobstore.trigger.count";
     public const string BatchSize = "jobstore.batch.size";
 }
+
+/// <summary>
+/// OpenTelemetry's <c>error.type</c> attribute: what a failed job execution failed with, named the
+/// same way on the span and on the errors counter.
+/// </summary>
+internal static class ErrorType
+{
+    /// <summary>
+    /// The attribute name. OpenTelemetry's semantic conventions have one attribute for what an
+    /// operation failed with, and every instrumentation that reports a failure spells it this way, so a
+    /// Quartz-specific name would only keep these series from lining up with the rest of a dashboard.
+    /// </summary>
+    internal const string TagName = "error.type";
+
+    /// <summary>
+    /// The value: the fully-qualified name of the type of exception that ended the execution. A type
+    /// name is bounded by the exception types an application can throw, which is what keeps the
+    /// attribute's cardinality low enough to aggregate on; nothing derived from a message belongs here.
+    /// </summary>
+    internal static string Of(Exception exception)
+    {
+        Type type = Unwrap(exception).GetType();
+        return type.FullName ?? type.Name;
+    }
+
+    /// <summary>
+    /// The exception an application would recognise, out of the ones the run shell has wrapped it in.
+    /// </summary>
+    private static Exception Unwrap(Exception exception)
+    {
+        // JobRunShell reports anything a job throws as JobExecutionException -> JobExecutionProcessException
+        // -> what the job threw. Naming the exception it hands the instrumentation would therefore answer
+        // "JobExecutionException" for very nearly every failure there is: both of those layers are Quartz's
+        // own bookkeeping, and neither says anything an application can act on.
+        //
+        // Only that exact pair is peeled off. A job that raises a JobExecutionException itself has no
+        // JobExecutionProcessException underneath it, so it is reported as the type it chose to throw; and
+        // the cause is never unwrapped further, because an AggregateException is what failed, not its
+        // children.
+        if (exception is JobExecutionException { InnerException: JobExecutionProcessException process })
+        {
+            return process.InnerException ?? process;
+        }
+
+        return exception;
+    }
+}

--- a/src/Quartz/Diagnostics/Meters.cs
+++ b/src/Quartz/Diagnostics/Meters.cs
@@ -58,8 +58,6 @@ internal static class Meters
 
 internal readonly struct Instrumentation
 {
-    private const string ExceptionTypeTag = "scheduling.quartz.exception_type";
-
     private readonly TagList? _tagList;
 
     public Instrumentation(TagList? tagList)
@@ -85,7 +83,9 @@ internal readonly struct Instrumentation
 
         if (exception != null)
         {
-            tags.Add(ExceptionTypeTag, exception.GetType().Name);
+            // The exception the job threw, not the JobExecutionException the run shell wrapped it in —
+            // which is also what the execution's span reports, so the two signals name the same failure.
+            tags.Add(ErrorType.TagName, ErrorType.Of(exception));
             Meters._jobExecuteErrorTotal.Add(1, tags);
         }
 

--- a/src/Quartz/Diagnostics/QuartzActivitySource.cs
+++ b/src/Quartz/Diagnostics/QuartzActivitySource.cs
@@ -66,6 +66,10 @@ internal readonly struct StartedActivity
         if (jobExEx != null)
         {
             _activity.SetStatus(ActivityStatusCode.Error, jobExEx.Message);
+            // The same value the errors counter is tagged with, so a failure can be found by the same
+            // attribute in a trace and in a metric. The exception event below keeps the whole chain,
+            // wrappers included, because that is where the stack traces are.
+            _activity.SetTag(ErrorType.TagName, ErrorType.Of(jobExEx));
             _activity.AddException(jobExEx);
         }
         _activity.Stop();


### PR DESCRIPTION
Job-failure telemetry currently reports the wrapper, not the failure. This makes the metric say what the span already knows, under OpenTelemetry's conventional attribute name.

## The problem

`JobRunShell.Run` wraps anything a job throws twice — `JobExecutionProcessException` ("Job threw an unhandled exception"), then `JobExecutionException` — before the metrics see it. The errors counter reported `exception.GetType().Name` of the outermost, so **`scheduling.quartz.exception_type` was `JobExecutionException` on essentially every failure**. It distinguished "the job deliberately threw a `JobExecutionException`" from "Quartz wrapped something," and nothing finer. An operator could see that jobs were failing but not what was failing them — while the span, on the same execution, carried the original exception all along.

## The change

Unwrap exactly the two Quartz bookkeeping layers and report what the job actually threw: `System.InvalidOperationException` rather than `Quartz.JobExecutionException`. A `JobExecutionException` a job raises itself has no `JobExecutionProcessException` beneath it and is reported as itself, so a deliberate signal is still distinguishable from a wrapped crash. Nothing is unwrapped past the job's own exception — an `AggregateException` stays an `AggregateException`.

The tag is renamed **`scheduling.quartz.exception_type` → `error.type`**, OTel's stable registry attribute for exactly this, with the fully-qualified type name as its value. No dual emission: carrying both names would double the series and settle nothing, and 4.0 is unreleased and already re-aligning to modern idiom. Cardinality stays bounded by exception types — no message text.

**The span now sets the same attribute, from the same helper, and a test asserts the two values are equal.** One attribute finds a failure in either signal. The span keeps its exception event on the wrapper, because `exception.stacktrace` is the wrapper's `ToString()` and therefore contains the whole chain including the job's own stack — the trace gains the classification without giving up detail.

## Notes for review

- If you have a dashboard or alert on `scheduling.quartz.exception_type`, it needs rewriting for `error.type` — called out in the migration guide's existing job-execution-metrics section, not in a competing new one.
- No public API moved: the unwrap helper and the tag constant are internal, deliberately, since the name belongs to OpenTelemetry rather than to Quartz.
- The `.active` up-down counter invariants from the tests that found the original bug are untouched: it still nets to zero and still does not carry the error tag, because asymmetric tags on `+1`/`-1` strand two series in an aggregating exporter.

## Verification

`build.cmd` green; unit suite run twice, 2049 passed both times; AspNetCore 203; the observability fixture also run filtered-alone, 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)