### PR TITLE
Carry a trigger's preferred node through both JSON serializers

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1195,6 +1195,30 @@ services.AddSingleton(new SystemTextJsonSerializerRegistry()
 
 See [Serialization (System.Text.Json)](packages/system-text-json) for the full picture.
 
+### A serialized trigger carries its preferred node
+
+Both JSON trigger serializers write a trigger's [node affinity](tutorial/node-affinity.md) pin, as the same
+pair the `QRTZ_TRIGGERS` row stores:
+
+```json
+"PreferredNode": "node-1",
+"PreferredNodeAuto": false
+```
+
+`PreferredNode` is the node name — `null` when the trigger is unpinned, `*` for an auto pin no node has
+claimed yet — and `PreferredNodeAuto` says whether the node holding the pin claimed it automatically. It
+takes both halves: a claimed auto pin and one the caller named look identical from the node name alone, yet
+only the automatic one is released when its node stops checking in.
+
+Payloads written before the fields existed, 3.x's included, have neither and read back as
+`PreferredNode.None` — an unpinned trigger, which is what they always were.
+
+This matters wherever a whole trigger travels as JSON. The HTTP API, `Quartz.HttpClient` and the dashboard
+dropped the pin in both directions, so scheduling or rescheduling a pinned trigger over HTTP quietly
+unpinned it, and the same held for a custom `IJobStore` that persists serialized triggers. The ADO.NET job
+store was never affected: it keeps the pin in the `PREFERRED_NODE` and `PREFERRED_NODE_AUTO` columns and
+reapplies them to every trigger it reads, blob triggers included.
+
 ### Newtonsoft types moved out of the core namespaces
 
 The `Quartz.Serialization.Newtonsoft` package used to put types in namespaces that read as if they came from the

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
@@ -57,6 +57,17 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
                 writer.WriteValue(abstractTrigger.ExecutionGroup);
             }
 
+            // The pin travels as the pair the triggers table holds - the node name (or the auto-pin
+            // sentinel) plus the auto-claim flag - so an automatic pin stays automatic across the
+            // round trip instead of hardening into one the user named.
+            PreferredNode preferredNode = trigger.PreferredNode;
+
+            writer.WritePropertyName("PreferredNode");
+            writer.WriteValue(preferredNode.StoredNode);
+
+            writer.WritePropertyName("PreferredNodeAuto");
+            writer.WriteValue(preferredNode.StoredAutomatic);
+
             triggerSerializer.SerializeFields(writer, trigger);
             writer.WriteEndObject();
         }
@@ -107,6 +118,13 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
             if (trigger is IMutableTrigger mutableTrigger)
             {
                 mutableTrigger.MisfireInstruction = misfireInstruction;
+
+                // Written as the pair the triggers table stores, and absent altogether from payloads
+                // written before triggers could be pinned - a missing pair reads back as
+                // PreferredNode.None, which is exactly an unpinned trigger.
+                string? preferredNode = source.Value<string>("PreferredNode");
+                bool preferredNodeAuto = source.Value<bool?>("PreferredNodeAuto") ?? false;
+                mutableTrigger.PreferredNode = PreferredNode.FromStored(preferredNode, preferredNodeAuto);
             }
 
             if (trigger is IOperableTrigger operableTrigger)

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -499,6 +499,44 @@ public class JsonObjectSerializerTest
         await VerifyCreatedJson(trigger);
     }
 
+    [Test]
+    public void PinnedTriggerKeepsItsPin()
+    {
+        // Every shape the pin has, including the two that a single node-name field could not tell
+        // apart: an auto pin nobody has claimed yet, and one a node already claimed.
+        PreferredNode[] pins =
+        [
+            PreferredNode.None,
+            PreferredNode.Auto,
+            PreferredNode.For("node-a"),
+            PreferredNode.ClaimedBy("node-b")
+        ];
+
+        foreach (PreferredNode pin in pins)
+        {
+            FakeTimeProvider timeProvider = CreateFakeTimeProvider();
+
+            IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(timeProvider)
+                .WithSimpleSchedule(builder => builder
+                    .WithInterval(TimeSpan.FromMinutes(5))
+                    .WithRepeatCount(3)
+                )
+                .WithIdentity("PinnedTriggerKey", "PinnedTriggerGroup")
+                .ForJob("PinnedJobKey", "PinnedJobGroup")
+                .WithPreferredNode(pin)
+                .StartAt(timeProvider.GetUtcNow())
+                .Build();
+
+            SetTimeProvider(timeProvider, trigger);
+
+            CompareSerialization(
+                trigger,
+                (deserialized, original) => deserialized.PreferredNode.Should().Be(
+                    original.PreferredNode,
+                    $"a trigger pinned '{pin}' has to come back pinned exactly that way, auto-claim flag included"));
+        }
+    }
+
     private void CompareSerialization<T>(
         T original,
         Action<T, T> asserter = null,

--- a/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
@@ -417,6 +417,27 @@ public class LegacyJsonPayloadTest
         daily.TimesTriggered.Should().Be(4);
     }
 
+    [Test]
+    public void TriggerPayloadsWrittenBeforePinningReadBackUnpinned()
+    {
+        string[] payloads =
+        [
+            LegacySimpleTrigger,
+            LegacyCronTrigger,
+            LegacyCalendarIntervalTrigger,
+            LegacyDailyTimeIntervalTrigger
+        ];
+
+        foreach (string payload in payloads)
+        {
+            IOperableTrigger trigger = Deserialize<IOperableTrigger>(payload);
+
+            trigger.PreferredNode.Should().Be(
+                PreferredNode.None,
+                "a payload written before triggers could be pinned carries neither half of the pin, and a reader must not invent one");
+        }
+    }
+
     private T Deserialize<T>(string json) where T : class
     {
         return serializer.Deserialize<T>(Encoding.UTF8.GetBytes(json))!;

--- a/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeCalendarIntervalTrigger.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeCalendarIntervalTrigger.verified.txt
@@ -20,6 +20,8 @@
   "NextFireTimeUtc": "2024-07-01T00:02:48.5+00:00",
   "PreviousFireTimeUtc": "2024-07-01T00:02:06.5+00:00",
   "ExecutionGroup": null,
+  "PreferredNode": null,
+  "PreferredNodeAuto": false,
   "RepeatInterval": 42,
   "RepeatIntervalUnit": "Second",
   "TimeZone": "UTC",

--- a/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeCronTrigger.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeCronTrigger.verified.txt
@@ -18,6 +18,8 @@
   "NextFireTimeUtc": "2024-07-01T00:00:20+00:00",
   "PreviousFireTimeUtc": "2024-07-01T00:00:15+00:00",
   "ExecutionGroup": null,
+  "PreferredNode": null,
+  "PreferredNodeAuto": false,
   "CronExpressionString": "0/5 * * * * ?",
   "TimeZone": "Tokyo Standard Time"
 }

--- a/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeCustomTriggers.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeCustomTriggers.verified.txt
@@ -20,6 +20,8 @@
   "NextFireTimeUtc": "2024-07-05T00:00:00+00:00",
   "PreviousFireTimeUtc": "2024-07-04T00:00:00+00:00",
   "ExecutionGroup": null,
+  "PreferredNode": null,
+  "PreferredNodeAuto": false,
   "RepeatCount": 10,
   "RepeatIntervalTimeSpan": "1.00:00:00",
   "TimesTriggered": 4,

--- a/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeDailyTimeIntervalTrigger.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeDailyTimeIntervalTrigger.verified.txt
@@ -15,6 +15,8 @@
   "NextFireTimeUtc": "2024-07-01T03:32:06+00:00",
   "PreviousFireTimeUtc": "2024-07-01T03:31:24+00:00",
   "ExecutionGroup": null,
+  "PreferredNode": null,
+  "PreferredNodeAuto": false,
   "RepeatCount": 1000,
   "RepeatInterval": 42,
   "RepeatIntervalUnit": "Second",

--- a/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeSimpleTrigger.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeSimpleTrigger.verified.txt
@@ -20,6 +20,8 @@
   "NextFireTimeUtc": "2025-10-24T10:04:00.496+00:00",
   "PreviousFireTimeUtc": "2025-06-26T07:33:00.497+00:00",
   "ExecutionGroup": null,
+  "PreferredNode": null,
+  "PreferredNodeAuto": false,
   "RepeatCount": 10,
   "RepeatIntervalTimeSpan": "120.02:30:59.9990000",
   "TimesTriggered": 4

--- a/src/Quartz/Serialization/Json/Converters/TriggerConverter.cs
+++ b/src/Quartz/Serialization/Json/Converters/TriggerConverter.cs
@@ -51,6 +51,13 @@ internal sealed class TriggerConverter(SystemTextJsonSerializerRegistry registry
             if (trigger is IMutableTrigger mutableTrigger)
             {
                 mutableTrigger.MisfireInstruction = misfireInstruction;
+
+                // Written as the pair the triggers table stores, and absent altogether from payloads
+                // written before triggers could be pinned - a missing pair reads back as
+                // PreferredNode.None, which is exactly an unpinned trigger.
+                string? preferredNode = rootElement.GetPropertyOrNull(options.GetPropertyName("PreferredNode"))?.GetString();
+                bool preferredNodeAuto = rootElement.GetPropertyOrNull(options.GetPropertyName("PreferredNodeAuto"))?.ValueKind == JsonValueKind.True;
+                mutableTrigger.PreferredNode = PreferredNode.FromStored(preferredNode, preferredNodeAuto);
             }
 
             if (trigger is IOperableTrigger operableTrigger)
@@ -104,6 +111,13 @@ internal sealed class TriggerConverter(SystemTextJsonSerializerRegistry registry
             {
                 writer.WriteString(options.GetPropertyName("ExecutionGroup"), abstractTrigger.ExecutionGroup);
             }
+
+            // The pin travels as the pair the triggers table holds - the node name (or the auto-pin
+            // sentinel) plus the auto-claim flag - so an automatic pin stays automatic across the
+            // round trip instead of hardening into one the user named.
+            PreferredNode preferredNode = value.PreferredNode;
+            writer.WriteString(options.GetPropertyName("PreferredNode"), preferredNode.StoredNode);
+            writer.WriteBoolean(options.GetPropertyName("PreferredNodeAuto"), preferredNode.StoredAutomatic);
 
             triggerSerializer.SerializeFields(writer, value, options);
             writer.WriteEndObject();


### PR DESCRIPTION
Neither JSON trigger serializer wrote a trigger's node pin, so any path that round-trips a whole trigger through JSON silently unpinned it. This was raised as a hazard for custom job stores; triage showed it is a live bug over HTTP and in the dashboard.

## What was actually broken

`AbstractTrigger.GetTriggerBuilder()` carries both `.WithExecutionGroup(...)` and `.WithPreferredNode(...)`. Both converters copied only the first half — they wrote `ExecutionGroup` and stopped.

| Path | Verdict |
|---|---|
| ADO store, persistence-delegate triggers | Safe — the pin lives in `PREFERRED_NODE` / `PREFERRED_NODE_AUTO` |
| ADO store, `BLOB_TRIGGERS` (custom trigger types) | Safe in practice — the whole trigger is serialized, but `ApplyTriggerRoutingState` reapplies the row columns after every read |
| **HTTP API** | **Lost, both directions** — it transfers whole `ITrigger`s, not DTOs |
| **`Quartz.HttpClient`** | **Lost** — and `UpdateTriggerDetails` throws `NotSupportedException`, so there was no workaround |
| **Dashboard** | **Lost** — it JSON round-trips even in-process, so rescheduling from the dashboard silently cleared the pin |
| `RAMJobStore`, clustering | Safe — `MemberwiseClone` and SQL columns only |

A pinned trigger rescheduled through the dashboard came back unpinned, and nothing said so.

## The fix

Both serializers now write the pin as the same **pair** the triggers table stores: `PreferredNode` (node name, `null`, or the auto sentinel) and `PreferredNodeAuto` (the auto-claim flag), via `PreferredNode.StoredNode`/`StoredAutomatic` and `PreferredNode.FromStored` on read.

Two fields rather than one, deliberately: a *claimed* auto pin and a caller-named pin are indistinguishable from the node name alone, yet only the automatic one is released when its node stops checking in. Collapsing them would turn an auto-claim into a permanent manual pin on the first round trip.

Old payloads are tolerated by absence — a missing field yields `PreferredNode.None`, which is what an unpinned trigger has always been.

## Tests

`TriggerPayloadsWrittenBeforePinningReadBackUnpinned` covers all four legacy trigger payloads on both serializers; `PinnedTriggerKeepsItsPin` covers all four pin shapes (`None`/`Auto`/`For`/`ClaimedBy`) across all four serializer×deserializer combinations, so the two implementations are held to the same wire format rather than each to itself.

## Left alone, on purpose

- The OpenAPI shadow interface documenting the trigger contract already omits `ExecutionGroup`, `NextFireTimeUtc` and `PreviousFireTimeUtc`. Adding only `PreferredNode` would trade one inconsistency for another; fixing all four is a documentation PR of its own.
- With Newtonsoft's default `RegisterTriggerConverters = false`, whole triggers serialize reflectively and `PreferredNode`'s private constructor makes that path lossy too. It is reachable only via the ADO blob path, which the row columns rescue, so it is harmless today — but it is the same shape of latent gap.

## Verification

`build.cmd` green; unit 2051 passed; AspNetCore 203; Postgres integration 59 passed — including all eight node-affinity tests (auto-pin, failover re-pinning, explicit-pin survival, three-node settling), confirming the ADO store's own pin handling did not regress. Five Verify snapshots regenerated; each diff was exactly the two new lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)