### PR TITLE
Watch the options of the scheduler you belong to, not the default one

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -303,6 +303,12 @@ Take what you need — `ISchedulerSignaler`, `ITypeLoadHelper`, `TimeProvider`,
 that has to happen before the scheduler runs and cannot be done while constructing, such as verifying
 a database schema.
 
+Options arrive as the scheduler's own, whichever of the three interfaces you ask for.
+`IOptionsMonitor<QuartzSchedulerOptions>` and `IOptionsSnapshot<QuartzSchedulerOptions>` work as well
+as `IOptions<>`: `CurrentValue` and `Value` are the options of the scheduler your component belongs
+to, `Get(name)` answers for the name you pass, and `OnChange` reports your scheduler's changes and
+not another's.
+
 Plugin configuration extension methods now extend `IQuartzBuilder` and register the plugin as a
 service, rather than deriving from `PropertiesSetter` to write string keys.
 

--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -182,6 +182,11 @@ plugin sees its own configuration. They are named options under the scheduler's 
 `services.AddQuartz("reporting", …)` is configured by `services.Configure<MyPluginOptions>("reporting", …)`
 as well — a plain `services.Configure<MyPluginOptions>(…)` configures the default scheduler's.
 
+Take them as `IOptions<MyPluginOptions>` for a fixed value, or as `IOptionsMonitor<MyPluginOptions>`
+to follow a reloading configuration source. `CurrentValue` is your scheduler's instance, `Get(name)`
+is whichever instance you name, and `OnChange` fires for your scheduler's options only — so a plugin
+watching for changes is never handed a sibling scheduler's configuration as though it were its own.
+
 ## Authoring plugin configuration extensions
 
 When you write your own `ISchedulerPlugin`, offer the same experience as the built-in plugins with an

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerScopedOptionsMonitorTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerScopedOptionsMonitorTest.cs
@@ -1,0 +1,310 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Guards that a scheduler-scoped component asking for a <em>reloadable</em> view of its options —
+/// <see cref="IOptionsMonitor{TOptions}"/> or <see cref="IOptionsSnapshot{TOptions}"/> — is answered with
+/// its own scheduler's configuration.
+/// </summary>
+/// <remarks>
+/// A scheduler's options are named options, keyed by the scheduler's name, and the unnamed members of
+/// both interfaces resolve the unnamed instance. A component on a named scheduler therefore used to read
+/// the default scheduler's configuration, silently. <c>IOptions&lt;T&gt;</c> is covered by
+/// <see cref="PluginOptionsRegistrationTest"/>; these are the two interfaces it left behind.
+/// </remarks>
+public class SchedulerScopedOptionsMonitorTest
+{
+    [Test]
+    public void AMonitorInjectedIntoANamedSchedulersComponentReportsThatSchedulersOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz("reporting", q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<WatchingPlugin>();
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Plugin<WatchingPlugin>(provider, "reporting").Monitor.CurrentValue.MaxBatchSize.Should().Be(7,
+            "CurrentValue is the unnamed member, so for a scheduler's component it has to mean that scheduler");
+    }
+
+    [Test]
+    public void AMonitorInjectedIntoTheDefaultSchedulersComponentReportsItsOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<WatchingPlugin>();
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Plugin<WatchingPlugin>(provider, key: null).Monitor.CurrentValue.MaxBatchSize.Should().Be(7);
+    }
+
+    [Test]
+    public void NamedSchedulersDoNotShareWhatTheirMonitorsReport()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.MaxBatchSize = 1));
+        services.AddQuartz("reporting", q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<WatchingPlugin>();
+        });
+        services.AddQuartz("ingest", q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 11);
+            q.AddPlugin<WatchingPlugin>();
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Plugin<WatchingPlugin>(provider, "reporting").Monitor.CurrentValue.MaxBatchSize.Should().Be(7);
+        Plugin<WatchingPlugin>(provider, "ingest").Monitor.CurrentValue.MaxBatchSize.Should().Be(11,
+            "two schedulers watching the same options type must still each watch their own");
+    }
+
+    [Test]
+    public void AMonitorAnsweringAnExplicitNameGivesThatNamesOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.MaxBatchSize = 1));
+        services.AddQuartz("reporting", q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<WatchingPlugin>();
+        });
+        services.AddQuartz("ingest", q => q.ConfigureScheduler(options => options.MaxBatchSize = 11));
+
+        using var provider = services.BuildServiceProvider();
+        var monitor = Plugin<WatchingPlugin>(provider, "reporting").Monitor;
+
+        monitor.Get("ingest").MaxBatchSize.Should().Be(11,
+            "Get names the instance it wants, so it must not be rewritten to the scheduler's own name");
+        monitor.Get(Options.DefaultName).MaxBatchSize.Should().Be(1);
+        monitor.Get(null).MaxBatchSize.Should().Be(1, "a null name is the default one, as it is everywhere else");
+    }
+
+    [Test]
+    public void ASnapshotResolvedInANamedSchedulersScopeReportsThatSchedulersOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.MaxBatchSize = 1));
+        services.AddQuartz("reporting", q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<CapturingPlugin>(p => new CapturingPlugin(p));
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        // The provider a job is built from: the scheduler's own, scoped the way the job factory scopes it.
+        using IServiceScope scope = Scheduler(provider, "reporting").GetRequiredService<IServiceScopeFactory>().CreateScope();
+        var snapshot = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<QuartzSchedulerOptions>>();
+
+        snapshot.Value.MaxBatchSize.Should().Be(7,
+            "IOptionsSnapshot derives from IOptions, so Value has to mean the same scheduler IOptions means");
+        snapshot.Get("reporting").MaxBatchSize.Should().Be(7);
+        snapshot.Get(Options.DefaultName).MaxBatchSize.Should().Be(1, "an explicit name is honoured as asked");
+    }
+
+    [Test]
+    public void ASnapshotResolvedInTheDefaultSchedulersScopeReportsItsOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<CapturingPlugin>(p => new CapturingPlugin(p));
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        using IServiceScope scope = Scheduler(provider, key: null).GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+        scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<QuartzSchedulerOptions>>()
+            .Value.MaxBatchSize.Should().Be(7);
+    }
+
+    [Test]
+    public void AMonitorOverAPluginsOwnOptionsReportsThatSchedulersOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.AddPlugin<WatchingPlugin, WatchedOptions>(options => options.Setting = "default"));
+        services.AddQuartz("reporting", q => q.AddPlugin<WatchingPlugin, WatchedOptions>(
+            options => options.Setting = "reporting"));
+
+        using var provider = services.BuildServiceProvider();
+
+        Plugin<WatchingPlugin>(provider, "reporting").Plugin.CurrentValue.Setting.Should().Be("reporting",
+            "AddPlugin declares the options type as a scheduler's own, and that has to hold for a monitor too");
+        Plugin<WatchingPlugin>(provider, key: null).Plugin.CurrentValue.Setting.Should().Be("default");
+    }
+
+    [Test]
+    public void OnChangeFiresWhenThisSchedulersOptionsChange()
+    {
+        var changes = new ManualChangeTokenSource<QuartzSchedulerOptions>("reporting");
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptionsChangeTokenSource<QuartzSchedulerOptions>>(changes);
+        services.AddQuartz("reporting", q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<WatchingPlugin>();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var monitor = Plugin<WatchingPlugin>(provider, "reporting").Monitor;
+
+        List<(QuartzSchedulerOptions Options, string? Name)> seen = [];
+        using IDisposable? registration = monitor.OnChange((options, name) => seen.Add((options, name)));
+
+        changes.Trigger();
+
+        seen.Should().ContainSingle("the scheduler's own options changed, so its listener has to hear about it");
+        seen[0].Options.MaxBatchSize.Should().Be(7);
+        seen[0].Name.Should().Be("reporting");
+    }
+
+    [Test]
+    public void OnChangeStaysSilentWhenAnotherSchedulersOptionsChange()
+    {
+        var changes = new ManualChangeTokenSource<QuartzSchedulerOptions>("ingest");
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptionsChangeTokenSource<QuartzSchedulerOptions>>(changes);
+        services.AddQuartz("reporting", q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<WatchingPlugin>();
+        });
+        services.AddQuartz("ingest", q => q.ConfigureScheduler(options => options.MaxBatchSize = 11));
+
+        using var provider = services.BuildServiceProvider();
+        var monitor = Plugin<WatchingPlugin>(provider, "reporting").Monitor;
+
+        List<QuartzSchedulerOptions> seen = [];
+        using IDisposable? registration = monitor.OnChange(options => seen.Add(options));
+
+        changes.Trigger();
+
+        seen.Should().BeEmpty(
+            "the single-argument listener is handed the changed value as if it were its own, so another " +
+            "scheduler's change must not reach it at all");
+    }
+
+    [Test]
+    public void OnChangeStopsFiringOnceTheRegistrationIsDisposed()
+    {
+        var changes = new ManualChangeTokenSource<QuartzSchedulerOptions>("reporting");
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptionsChangeTokenSource<QuartzSchedulerOptions>>(changes);
+        services.AddQuartz("reporting", q =>
+        {
+            q.ConfigureScheduler(options => options.MaxBatchSize = 7);
+            q.AddPlugin<WatchingPlugin>();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var monitor = Plugin<WatchingPlugin>(provider, "reporting").Monitor;
+
+        int fired = 0;
+        IDisposable? registration = monitor.OnChange((_, _) => fired++);
+        registration.Should().NotBeNull("a wrapper that swallowed the registration could never be unhooked");
+
+        changes.Trigger();
+        registration!.Dispose();
+        changes.Trigger();
+
+        fired.Should().Be(1, "disposing the registration has to unhook the listener from the underlying monitor");
+    }
+
+    private static T Plugin<T>(IServiceProvider provider, string? key) where T : ISchedulerPlugin
+    {
+        IEnumerable<ISchedulerPlugin> plugins = key is null
+            ? provider.GetServices<ISchedulerPlugin>()
+            : provider.GetKeyedServices<ISchedulerPlugin>(key);
+
+        return plugins.OfType<T>().Single();
+    }
+
+    /// <summary>
+    /// The provider a scheduler's own components are built from.
+    /// </summary>
+    private static IServiceProvider Scheduler(IServiceProvider provider, string? key)
+    {
+        return Plugin<CapturingPlugin>(provider, key).Provider;
+    }
+
+    public sealed class WatchedOptions
+    {
+        public string Setting { get; set; } = "default-setting";
+    }
+
+    public sealed class WatchingPlugin : ISchedulerPlugin
+    {
+        public WatchingPlugin(IOptionsMonitor<QuartzSchedulerOptions> monitor, IOptionsMonitor<WatchedOptions> plugin)
+        {
+            Monitor = monitor;
+            Plugin = plugin;
+        }
+
+        public IOptionsMonitor<QuartzSchedulerOptions> Monitor { get; }
+
+        public IOptionsMonitor<WatchedOptions> Plugin { get; }
+
+        public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask Start(CancellationToken cancellationToken = default) => default;
+
+        public ValueTask Shutdown(CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// Hands the test the provider a scheduler's components are constructed from.
+    /// </summary>
+    public sealed class CapturingPlugin : ISchedulerPlugin
+    {
+        public CapturingPlugin(IServiceProvider provider) => Provider = provider;
+
+        public IServiceProvider Provider { get; }
+
+        public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask Start(CancellationToken cancellationToken = default) => default;
+
+        public ValueTask Shutdown(CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// Reports a change to one named options instance on demand, which is what a reloading configuration
+    /// source amounts to.
+    /// </summary>
+    private sealed class ManualChangeTokenSource<TOptions> : IOptionsChangeTokenSource<TOptions>
+    {
+        private CancellationTokenSource source = new();
+
+        public ManualChangeTokenSource(string name) => Name = name;
+
+        public string Name { get; }
+
+        public IChangeToken GetChangeToken() => new CancellationChangeToken(source.Token);
+
+        public void Trigger()
+        {
+            CancellationTokenSource previous = Interlocked.Exchange(ref source, new CancellationTokenSource());
+            previous.Cancel();
+            previous.Dispose();
+        }
+    }
+}

--- a/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
+++ b/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
@@ -56,14 +56,17 @@ internal sealed class SchedulerScopedServiceProvider
     ];
 
     /// <summary>
-    /// The options a scheduler's components ask for as <see cref="IOptions{TOptions}"/>.
+    /// The options a scheduler's components ask for, in each of the shapes the options framework offers
+    /// them: <see cref="IOptions{TOptions}"/>, <see cref="IOptionsMonitor{TOptions}"/> and
+    /// <see cref="IOptionsSnapshot{TOptions}"/>.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// A scheduler's options are <em>named</em> options, but <see cref="IOptions{TOptions}"/> always
-    /// resolves the unnamed instance. A named scheduler's job store would therefore be configured from
-    /// the default scheduler's settings, which is the same cross-wiring this class exists to prevent —
-    /// so the request is answered from the monitor, under this scheduler's name.
+    /// A scheduler's options are <em>named</em> options, but the unnamed members of all three interfaces
+    /// — <c>Value</c> and <c>CurrentValue</c> — resolve the unnamed instance. A named scheduler's job
+    /// store would therefore be configured from the default scheduler's settings, which is the same
+    /// cross-wiring this class exists to prevent, so those members are answered under this scheduler's
+    /// name. <c>Get(name)</c> asks for an instance by name and is passed through as asked.
     /// </para>
     /// <para>
     /// The map is explicit rather than generic because closing <c>OptionsWrapper&lt;&gt;</c> over a
@@ -72,26 +75,23 @@ internal sealed class SchedulerScopedServiceProvider
     /// where that type is still known at compile time.
     /// </para>
     /// </remarks>
-    private static readonly Dictionary<Type, Func<IServiceProvider, string, object>> namedOptions = new()
-    {
-        [typeof(IOptions<QuartzSchedulerOptions>)] = static (p, name) => Named<QuartzSchedulerOptions>(p, name),
-        [typeof(IOptions<ThreadPoolOptions>)] = static (p, name) => Named<ThreadPoolOptions>(p, name),
-        [typeof(IOptions<InMemoryJobStoreOptions>)] = static (p, name) => Named<InMemoryJobStoreOptions>(p, name),
-        [typeof(IOptions<AdoJobStoreOptions>)] = static (p, name) => Named<AdoJobStoreOptions>(p, name),
-        [typeof(IOptions<ClusteringOptions>)] = static (p, name) => Named<ClusteringOptions>(p, name),
-        [typeof(IOptions<QuartzOptions>)] = static (p, name) => Named<QuartzOptions>(p, name),
-    };
+    private static readonly Dictionary<Type, Func<IServiceProvider, string, object>> namedOptions = DeclareQuartzOptions();
 
-    private static OptionsWrapper<T> Named<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(
-        IServiceProvider provider,
-        string name) where T : class
+    private static Dictionary<Type, Func<IServiceProvider, string, object>> DeclareQuartzOptions()
     {
-        return new OptionsWrapper<T>(provider.GetRequiredService<IOptionsMonitor<T>>().Get(name));
+        Dictionary<Type, Func<IServiceProvider, string, object>> map = [];
+        SchedulerNamedOptions<QuartzSchedulerOptions>.Declare(map);
+        SchedulerNamedOptions<ThreadPoolOptions>.Declare(map);
+        SchedulerNamedOptions<InMemoryJobStoreOptions>.Declare(map);
+        SchedulerNamedOptions<AdoJobStoreOptions>.Declare(map);
+        SchedulerNamedOptions<ClusteringOptions>.Declare(map);
+        SchedulerNamedOptions<QuartzOptions>.Declare(map);
+        return map;
     }
 
     private readonly IServiceProvider inner;
     private readonly object? key;
-    private Dictionary<Type, SchedulerNamedOptions>? declared;
+    private Dictionary<Type, Func<IServiceProvider, string, object>>? declared;
 
     private SchedulerScopedServiceProvider(IServiceProvider inner, object? key)
     {
@@ -102,17 +102,35 @@ internal sealed class SchedulerScopedServiceProvider
     private string Name => key as string ?? Options.DefaultName;
 
     /// <summary>
-    /// Finds the resolver for an options type a plugin brought with it, or <see langword="null"/> when
-    /// the request is for something else.
+    /// Finds the resolver for an options type this scheduler owns, whether Quartz declared it or a plugin
+    /// brought it, or <see langword="null"/> when the request is for something else.
     /// </summary>
     /// <remarks>
-    /// The static map above cannot list these: the type comes from the caller's plugin, not from Quartz.
-    /// <c>AddPlugin&lt;T, TOptions&gt;</c> registers a resolver instead, closed over <c>TOptions</c> where
-    /// it is still a compile-time type, so nothing here has to close a generic over a runtime one.
+    /// The static map above cannot list a plugin's: the type comes from the caller, not from Quartz.
+    /// <c>AddPlugin&lt;T, TOptions&gt;</c> registers a declaration instead, closed over <c>TOptions</c>
+    /// where it is still a compile-time type, so nothing here has to close a generic over a runtime one.
     /// </remarks>
-    private SchedulerNamedOptions? Declared(Type serviceType)
+    private Func<IServiceProvider, string, object>? NamedOptions(Type serviceType)
     {
-        if (!serviceType.IsConstructedGenericType || serviceType.GetGenericTypeDefinition() != typeof(IOptions<>))
+        return namedOptions.GetValueOrDefault(serviceType) ?? Declared(serviceType);
+    }
+
+    /// <summary>
+    /// Finds the resolver for an options type a plugin brought with it.
+    /// </summary>
+    private Func<IServiceProvider, string, object>? Declared(Type serviceType)
+    {
+        // Asking the container for every declaration is not free, so the requests that cannot be one are
+        // turned away first. Every options service is a closed generic over one of these three.
+        if (!serviceType.IsConstructedGenericType)
+        {
+            return null;
+        }
+
+        Type definition = serviceType.GetGenericTypeDefinition();
+        if (definition != typeof(IOptions<>)
+            && definition != typeof(IOptionsMonitor<>)
+            && definition != typeof(IOptionsSnapshot<>))
         {
             return null;
         }
@@ -120,13 +138,13 @@ internal sealed class SchedulerScopedServiceProvider
         // Built into a local and then published, because this provider outlives the construction it was
         // made for — a component handed it as IServiceProvider keeps resolving through it — so two
         // threads can arrive here at once, and a half-filled dictionary must never be one of them.
-        Dictionary<Type, SchedulerNamedOptions>? known = declared;
+        Dictionary<Type, Func<IServiceProvider, string, object>>? known = declared;
         if (known is null)
         {
             known = [];
             foreach (var options in inner.GetServices<SchedulerNamedOptions>())
             {
-                known[options.ServiceType] = options;
+                options.DeclareInto(known);
             }
 
             declared = known;
@@ -151,14 +169,9 @@ internal sealed class SchedulerScopedServiceProvider
             return inner.GetKeyedService(serviceType, key);
         }
 
-        if (namedOptions.TryGetValue(serviceType, out var options))
+        if (NamedOptions(serviceType) is { } options)
         {
             return options(inner, Name);
-        }
-
-        if (Declared(serviceType) is { } pluginOptions)
-        {
-            return pluginOptions.Resolve(inner, Name);
         }
 
         // A component handed "the container" so it can resolve things later must keep resolving this
@@ -249,8 +262,7 @@ internal sealed class SchedulerScopedServiceProvider
             return IsKeyedService(serviceType, key);
         }
 
-        if (namedOptions.ContainsKey(serviceType)
-            || Declared(serviceType) is not null
+        if (NamedOptions(serviceType) is not null
             || serviceType == typeof(IServiceProvider)
             || serviceType == typeof(IServiceProviderIsService)
             || serviceType == typeof(IServiceProviderIsKeyedService)
@@ -278,11 +290,11 @@ internal sealed class SchedulerScopedServiceProvider
 /// </remarks>
 internal abstract class SchedulerNamedOptions
 {
-    /// <summary>The service a component asks for when it wants these options.</summary>
-    public abstract Type ServiceType { get; }
-
-    /// <summary>Resolves the options belonging to one scheduler.</summary>
-    public abstract object Resolve(IServiceProvider provider, string schedulerName);
+    /// <summary>
+    /// Adds the services a component asks for when it wants these options, each resolving the instance
+    /// configured for one scheduler.
+    /// </summary>
+    public abstract void DeclareInto(Dictionary<Type, Func<IServiceProvider, string, object>> map);
 }
 
 /// <inheritdoc />
@@ -296,10 +308,107 @@ internal sealed class SchedulerNamedOptions<
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>
     : SchedulerNamedOptions where TOptions : class
 {
-    public override Type ServiceType => typeof(IOptions<TOptions>);
-
-    public override object Resolve(IServiceProvider provider, string schedulerName)
+    /// <inheritdoc />
+    public override void DeclareInto(Dictionary<Type, Func<IServiceProvider, string, object>> map)
     {
-        return new OptionsWrapper<TOptions>(provider.GetRequiredService<IOptionsMonitor<TOptions>>().Get(schedulerName));
+        Declare(map);
     }
+
+    /// <summary>
+    /// Declares all three shapes of one options type. Also how <see cref="SchedulerScopedServiceProvider"/>
+    /// builds its own list, so Quartz's options types and a plugin's are answered by the same code.
+    /// </summary>
+    internal static void Declare(Dictionary<Type, Func<IServiceProvider, string, object>> map)
+    {
+        // A fixed value, so there is nothing to keep watching: read the scheduler's instance once and hand
+        // it over.
+        map[typeof(IOptions<TOptions>)] = static (provider, name) =>
+            new OptionsWrapper<TOptions>(provider.GetRequiredService<IOptionsMonitor<TOptions>>().Get(name));
+
+        map[typeof(IOptionsMonitor<TOptions>)] = static (provider, name) =>
+            new SchedulerOptionsMonitor<TOptions>(provider.GetRequiredService<IOptionsMonitor<TOptions>>(), name);
+
+        // Resolved from whatever provider is asking, so a snapshot taken in a job's scope still lives and
+        // caches for that scope rather than for the container.
+        map[typeof(IOptionsSnapshot<TOptions>)] = static (provider, name) =>
+            new SchedulerOptionsSnapshot<TOptions>(provider.GetRequiredService<IOptionsSnapshot<TOptions>>(), name);
+    }
+}
+
+/// <summary>
+/// An <see cref="IOptionsMonitor{TOptions}"/> whose unnamed members mean one scheduler's options.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rule is the same one <see cref="SchedulerScopedServiceProvider"/> applies throughout: a member
+/// that does not name an instance means <em>this</em> scheduler, and a member that names one is left
+/// alone. So <see cref="CurrentValue"/> is the scheduler's instance, while <see cref="Get"/> answers for
+/// whatever name it was handed.
+/// </para>
+/// <para>
+/// <see cref="OnChange"/> follows <see cref="CurrentValue"/> and reports only this scheduler's changes.
+/// The listener has an overload that discards the name — <c>monitor.OnChange(options =&gt; …)</c> — and
+/// forwarding every name to it would hand a component another scheduler's options as though they were
+/// its own, which is the very confusion this class exists to prevent. A component that wants to watch a
+/// different scheduler's configuration can still read it, by name, through <see cref="Get"/>.
+/// </para>
+/// </remarks>
+internal sealed class SchedulerOptionsMonitor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>
+    : IOptionsMonitor<TOptions>
+{
+    private readonly IOptionsMonitor<TOptions> inner;
+    private readonly string name;
+
+    public SchedulerOptionsMonitor(IOptionsMonitor<TOptions> inner, string name)
+    {
+        this.inner = inner;
+        this.name = name;
+    }
+
+    public TOptions CurrentValue => inner.Get(name);
+
+    public TOptions Get(string? name) => inner.Get(name);
+
+    public IDisposable? OnChange(Action<TOptions, string?> listener)
+    {
+        // The name rather than this wrapper is what the filter closes over, so a live registration does not
+        // keep the component's copy of the monitor alive.
+        string scheduler = name;
+
+        // The registration the inner monitor hands back is returned as it is, so disposing it unhooks the
+        // filter along with the listener it wraps.
+        return inner.OnChange((options, changed) =>
+        {
+            if (string.Equals(changed ?? Options.DefaultName, scheduler, StringComparison.Ordinal))
+            {
+                listener(options, changed);
+            }
+        });
+    }
+}
+
+/// <summary>
+/// An <see cref="IOptionsSnapshot{TOptions}"/> whose unnamed member means one scheduler's options.
+/// </summary>
+/// <remarks>
+/// <see cref="IOptionsSnapshot{TOptions}"/> derives from <see cref="IOptions{TOptions}"/>, so
+/// <see cref="Value"/> has to mean what <c>IOptions&lt;TOptions&gt;.Value</c> means here: this
+/// scheduler's instance. The snapshot itself comes from the container, so the per-scope caching a
+/// snapshot exists for is unchanged.
+/// </remarks>
+internal sealed class SchedulerOptionsSnapshot<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>
+    : IOptionsSnapshot<TOptions> where TOptions : class
+{
+    private readonly IOptionsSnapshot<TOptions> inner;
+    private readonly string name;
+
+    public SchedulerOptionsSnapshot(IOptionsSnapshot<TOptions> inner, string name)
+    {
+        this.inner = inner;
+        this.name = name;
+    }
+
+    public TOptions Value => inner.Get(name);
+
+    public TOptions Get(string? name) => inner.Get(name);
 }


### PR DESCRIPTION
**Stacked on #3239** (base `fix-plugin-named-options`) — it extends the mechanism that PR introduces, so it genuinely depends on it rather than merely touching the same file.

## What is wrong

`SchedulerScopedServiceProvider` exists so a scheduler-scoped component gets the options configured for *its* scheduler. It intercepts `IOptions<X>` and redirects to the named instance — but only `IOptions<X>`. A component whose constructor takes **`IOptionsMonitor<X>` or `IOptionsSnapshot<X>`**, which is what you take when you want reload-on-change, fell through to the container and received the **unnamed** instance. On a named scheduler, `CurrentValue` reported the *default* scheduler's configuration.

This applies to **Quartz's own option types**, not just plugin options: `QuartzSchedulerOptions`, `AdoJobStoreOptions`, `ThreadPoolOptions` and the rest all sat in the same static map with the same gap. #3239 fixed the `IOptions<X>` half for plugins; this is the remaining, wider half.

**Framed honestly: this is a latent trap, not a bug anyone is hitting today.** Every scheduler-scoped component currently takes `IOptions<X>`. The one in-repo constructor taking a monitor over a Quartz option type is `QuartzHostedService`, which is container-wide rather than scheduler-scoped and calls `.Get(name)` itself, correctly. The gap would have bitten the first person to write the reloadable version of a job store, thread pool or plugin — silently, exactly as the `IOptions<X>` half did.

## The `OnChange` decision

The wrapper's rule is: *a member that does not name an instance means this scheduler; a member that names one is left alone.* `CurrentValue` → `Get(schedulerName)`; `Get(name)` → passed through verbatim; `OnChange` follows `CurrentValue` and fires only for this scheduler's name.

The deciding argument is `OptionsMonitorExtensions.OnChange(monitor, Action<TOptions>)` — the common overload that **discards the name**. Forwarding unfiltered would hand a component a sibling scheduler's options object as though it were its own, which is worse than the bug being fixed. A component that genuinely wants another scheduler's configuration can still ask for it by name. The inner registration is returned as-is, so disposing it unhooks the filter with the listener.

`IOptionsSnapshot<X>` is wrapped rather than rebuilt and is resolved from whichever provider is asking, so per-scope caching is unchanged; `Value` already meant the scheduler's instance via `IOptions<T>`.

Quartz's own option types and plugin types are now declared through the same code path, so the three shapes cannot drift apart again.

## Tests

Ten tests in `SchedulerScopedOptionsMonitorTest`, written against the unfixed code first — **five failed**: a named scheduler's monitor reporting the default's values, two named schedulers sharing, a snapshot in a job scope, a monitor over a plugin's own options, and `OnChange` delivering another scheduler's change as this one's. The other five passed before and after and are regression guards on the wrapper (default-scheduler paths, `Get(name)` pass-through, subscribe/unsubscribe). `OnChange` is driven by a real `IOptionsChangeTokenSource`, the minimal form of a reloading configuration source.

No public API moved; the wrappers are internal.

## Verification

`build.cmd` green; unit 2064 passed; AspNetCore 203. Postgres integration skipped deliberately: nothing on a persistence path changed behaviour — the `IOptions<X>` resolver produces the identical wrapper it did before, now from shared code, and the new entries are service types no in-repo component requests.

No migration-guide section: `SchedulerScopedServiceProvider` is new in unreleased 4.x and 3.x injected no options into these components at all, so there is nothing to un-learn. The two places that enumerate what a component may inject were amended instead, since that is where a reader decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)