### PR TITLE
Document the preferred node in the trigger schema

### DIFF
--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/OpenApi/Types.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/OpenApi/Types.cs
@@ -102,6 +102,19 @@ internal interface Trigger
     string? ExecutionGroup { get; }
 
     /// <summary>
+    /// The node this trigger is pinned to, null when it is not pinned, or the auto sentinel when it is
+    /// pinned automatically and has not yet been claimed. Read together with PreferredNodeAuto: a claimed
+    /// automatic pin carries a node name too, and only an automatic pin is released when its node stops
+    /// checking in.
+    /// </summary>
+    string? PreferredNode { get; }
+
+    /// <summary>
+    /// Whether this trigger's pin was requested automatically rather than naming a node
+    /// </summary>
+    bool PreferredNodeAuto { get; }
+
+    /// <summary>
     /// Should be present when TriggerType is CalendarIntervalTrigger, CronTrigger, DailyTimeIntervalTrigger or RecurrenceTrigger
     /// </summary>
     string? TimeZone { get; }


### PR DESCRIPTION
**main is currently red** — `OpenApiTriggerSchemaTest.ShadowInterfaceMatchesWhatATriggerSerializesTo` fails. This fixes it.

## What happened

Two PRs that were independent when written became coupled when both merged:

- **#3240** taught both JSON serializers to carry a trigger's preferred node, as the pair `PreferredNode` + `PreferredNodeAuto`.
- **#3242** published the trigger schema the HTTP API actually sends, and deliberately **left that pair out** — on the branch it was written against, the property genuinely was not serialized, and documenting a property the server does not send is the same bug in the opposite direction.

#3242's description called this out: *"the new test will fail the moment #3240 lands… whichever of the two merges second must add `PreferredNode` and `PreferredNodeAuto` to `OpenApi.Trigger`, and the failing test is what will say so."* That is what happened. The drift test is not broken; it is doing precisely the job it was added to do, on its first real occasion.

## The fix

Adds both properties to the shadow interface, positioned in wire order after `ExecutionGroup`.

They are documented as a **pair** rather than folded into one, because a *claimed* automatic pin carries a node name just like a caller-named one, and only the automatic pin is released when its node stops checking in — the node name alone cannot distinguish them. A generated client that saw only `PreferredNode` could not tell a sticky manual pin from an auto-claim that will be released.

## Verification

`build.cmd` green; `Quartz.Tests.AspNetCore` **207 passed / 0 failed** — including the two drift tests, which fail on main before this change and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)