### PR TITLE
Interrupt only the monitored fire instance in JobInterruptMonitorPlugin

### DIFF
--- a/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
@@ -14,7 +14,7 @@ namespace Quartz.Plugin.Interrupt;
 /// This plugin catches the event of job running for a long time (more than the
 /// configured max time) and tells the scheduler to "try" interrupting it if enabled.
 /// </summary>
-/// <seealso cref="IScheduler.Interrupt(Quartz.JobKey,System.Threading.CancellationToken)"/>
+/// <seealso cref="IScheduler.Interrupt(string,System.Threading.CancellationToken)"/>
 /// <author>Rama Chavali</author>
 /// <author>Marko Lahma (.NET)</author>
 public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugin
@@ -47,14 +47,19 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
 
     private void ScheduleJobInterruptMonitor(string fireInstanceId, JobKey jobkey, TimeSpan delay)
     {
-        var monitor = new InterruptMonitor(fireInstanceId, jobkey, scheduler, delay);
+        var monitor = new InterruptMonitor(this, fireInstanceId, jobkey, scheduler, delay);
+        if (!interruptMonitors.TryAdd(fireInstanceId, monitor))
+        {
+            // a re-executed job (SchedulerInstruction.ReExecuteJob) fires trigger listeners again
+            // with the same fire instance id - the existing monitor keeps watching it
+            return;
+        }
+
         Task.Factory.StartNew(
             monitor.Run,
             monitor.cancellationTokenSource.Token,
             TaskCreationOptions.HideScheduler,
             taskScheduler).Unwrap();
-
-        interruptMonitors.TryAdd(fireInstanceId, monitor);
     }
 
     /// <summary>
@@ -75,7 +80,7 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
         try
         {
             // Schedule Monitor only if the job wants AutoInterruptable functionality
-            if (context.JobDetail.JobDataMap.TryGetBoolean(JobDataMapKeyAutoInterruptable, out var value) && value)
+            if (context.MergedJobDataMap.TryGetBoolean(JobDataMapKeyAutoInterruptable, out var value) && value)
             {
                 JobInterruptMonitorPlugin monitorPlugin = (JobInterruptMonitorPlugin) context.Scheduler.Context.Get(JobInterruptMonitorKey);
                 // Get the MaxRuntime from MergedJobDataMap if NOT available use MaxRunTime from Plugin Configuration
@@ -125,21 +130,48 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
         // Set the trigger Listener as this class to the ListenerManager here
         this.scheduler.ListenerManager.AddTriggerListener(this);
 
+        // a vetoed execution never reaches TriggerComplete, so its monitor must be cancelled from a job listener
+        this.scheduler.ListenerManager.AddJobListener(new JobExecutionVetoedListener(this));
+
         return Task.CompletedTask;
+    }
+
+    private sealed class JobExecutionVetoedListener : JobListenerSupport
+    {
+        private readonly JobInterruptMonitorPlugin plugin;
+
+        public JobExecutionVetoedListener(JobInterruptMonitorPlugin plugin)
+        {
+            this.plugin = plugin;
+        }
+
+        public override string Name => plugin.name + "-VetoedJobListener";
+
+        public override Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            if (plugin.interruptMonitors.TryRemove(context.FireInstanceId, out var monitor))
+            {
+                monitor.Cancel();
+            }
+
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class InterruptMonitor
     {
         private readonly ILog log = LogProvider.GetLogger(typeof(InterruptMonitor));
 
+        private readonly JobInterruptMonitorPlugin plugin;
         private readonly JobKey jobKey;
         private readonly IScheduler scheduler;
         private readonly TimeSpan delay;
 
         internal readonly CancellationTokenSource cancellationTokenSource;
 
-        public InterruptMonitor(string fireInstanceId, JobKey jobKey, IScheduler scheduler, TimeSpan delay)
+        public InterruptMonitor(JobInterruptMonitorPlugin plugin, string fireInstanceId, JobKey jobKey, IScheduler scheduler, TimeSpan delay)
         {
+            this.plugin = plugin;
             FireInstanceId = fireInstanceId;
             this.jobKey = jobKey;
             this.scheduler = scheduler;
@@ -156,9 +188,18 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
             {
                 await Task.Delay(delay, cancellationTokenSource.Token);
 
-                // Interrupt the job here - using Scheduler API that gets propagated to Job's interrupt
-                log.Info($"Interrupting Job as it ran more than the configured max time. Job Details [{jobKey.Name}:{jobKey.Group}]");
-                await scheduler.Interrupt(jobKey, cancellationTokenSource.Token);
+                // Interrupt the job here - using Scheduler API that gets propagated to Job's interrupt.
+                // Interrupting by fire instance id makes sure only the monitored execution is signaled
+                // and not every currently running execution of the same job.
+                var interrupted = await scheduler.Interrupt(FireInstanceId, cancellationTokenSource.Token);
+                if (interrupted)
+                {
+                    log.Info($"Interrupted Job as it ran more than the configured max time. Job Details [{jobKey.Name}:{jobKey.Group}], fire instance id {FireInstanceId}");
+                }
+                else
+                {
+                    log.Debug($"Job execution was no longer running, nothing to interrupt. Job Details [{jobKey.Name}:{jobKey.Group}], fire instance id {FireInstanceId}");
+                }
             }
             catch (TaskCanceledException)
             {
@@ -167,6 +208,12 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
             catch (SchedulerException ex)
             {
                 log.Error($"Error interrupting Job: {ex.Message}", ex);
+            }
+            finally
+            {
+                // TriggerComplete and JobExecutionVetoed already remove the entry; this bounds the
+                // dictionary when neither notification arrives, e.g. a listener earlier in the chain threw
+                plugin.interruptMonitors.TryRemove(FireInstanceId, out _);
             }
         }
 

--- a/src/Quartz.Tests.Unit/InterrubtableJobTest.cs
+++ b/src/Quartz.Tests.Unit/InterrubtableJobTest.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Quartz.Impl;
+using Quartz.Listener;
 
 namespace Quartz.Tests.Unit;
 
@@ -97,6 +98,9 @@ public class InterruptableJobTest
             .StartNow()
             .Build();
 
+        var interruptionListener = new JobInterruptedCaptureListener();
+        sched.ListenerManager.AddSchedulerListener(interruptionListener);
+
         await sched.ScheduleJob(job, trigger);
 
         started.WaitOne(); // make sure the job starts running...
@@ -114,7 +118,23 @@ public class InterruptableJobTest
         Assert.IsTrue(interruptResult, "Expected successful result from interruption of job ");
         Assert.IsTrue(TestInterruptableJob.interrupted, "Expected interrupted flag to be set on job class ");
 
+        // the notification is awaited inside Interrupt before it returns, so no waiting is needed here
+        interruptionListener.Interrupted.Task.IsCompleted.Should().BeTrue(
+            "interrupting by fire instance id should notify scheduler listeners of the interruption");
+        (await interruptionListener.Interrupted.Task).Should().Be(job.Key);
+
         await sched.Clear();
         await sched.Shutdown();
+    }
+
+    private sealed class JobInterruptedCaptureListener : SchedulerListenerSupport
+    {
+        public TaskCompletionSource<JobKey> Interrupted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override Task JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            Interrupted.TrySetResult(jobKey);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/Plugin/Interrupt/JobInterruptMonitorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/Interrupt/JobInterruptMonitorPluginTest.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Quartz.Impl;
+using Quartz.Listener;
+using Quartz.Plugin.Interrupt;
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit.Plugin.Interrupt;
+
+/// <summary>
+/// Regression tests for https://github.com/quartznet/quartznet/issues/3248 - the interrupt monitor
+/// must only ever cancel the execution it was created for.
+/// </summary>
+[NonParallelizable]
+public class JobInterruptMonitorPluginTest
+{
+    private static readonly TimeSpan waitTimeout = TimeSpan.FromSeconds(10);
+
+    private static readonly ConcurrentDictionary<string, bool> interruptedByTrigger = new();
+    private static SemaphoreSlim started;
+    private static SemaphoreSlim done;
+    private static SemaphoreSlim gate;
+    private static int executionCount;
+
+    [SetUp]
+    public void SetUp()
+    {
+        interruptedByTrigger.Clear();
+        started = new SemaphoreSlim(0);
+        done = new SemaphoreSlim(0);
+        gate = new SemaphoreSlim(0);
+        executionCount = 0;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        started.Dispose();
+        done.Dispose();
+        gate.Dispose();
+    }
+
+    [Test]
+    public async Task ShouldOnlyInterruptTheExecutionThatExceededItsMaxRunTime()
+    {
+        IScheduler scheduler = await CreateScheduler("PerInstance", defaultMaxRunTimeMilliseconds: 60_000);
+        try
+        {
+            IJobDetail job = CreateAutoInterruptableJob();
+
+            ITrigger shortTrigger = TriggerBuilder.Create()
+                .WithIdentity("t-short")
+                .ForJob(job)
+                .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "500")
+                .StartNow()
+                .Build();
+
+            ITrigger longTrigger = TriggerBuilder.Create()
+                .WithIdentity("t-long")
+                .ForJob(job)
+                .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "60000")
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, new[] { shortTrigger, longTrigger }, replace: false);
+
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("first execution should start");
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("second execution should start");
+
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue("the short-limit execution should be interrupted by its monitor");
+            interruptedByTrigger.Should().ContainKey("t-short",
+                "the execution that exceeded its max run time is the one that should have been interrupted");
+            interruptedByTrigger["t-short"].Should().BeTrue("t-short exceeded its 500 ms max run time");
+            interruptedByTrigger.Should().NotContainKey("t-long",
+                "t-short's monitor must not cancel a concurrent execution that has not exceeded its own limit");
+
+            gate.Release();
+
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue("the long-limit execution should complete once the gate opens");
+            interruptedByTrigger["t-long"].Should().BeFalse("t-long had a 60 second limit and must complete uninterrupted");
+        }
+        finally
+        {
+            gate.Release(10); // unblock any execution still gated so shutdown does not wait on it
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    [Test]
+    public async Task ShouldCancelMonitorOfVetoedExecution()
+    {
+        IScheduler scheduler = await CreateScheduler("Veto", defaultMaxRunTimeMilliseconds: 500);
+        try
+        {
+            VetoingTriggerListener vetoListener = new VetoingTriggerListener("t-veto");
+            scheduler.ListenerManager.AddTriggerListener(vetoListener);
+
+            IJobDetail job = CreateAutoInterruptableJob();
+
+            // vetoed fire uses the plugin default of 500 ms; the healthy fire allows 60 seconds
+            ITrigger vetoedTrigger = TriggerBuilder.Create()
+                .WithIdentity("t-veto")
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            ITrigger healthyTrigger = TriggerBuilder.Create()
+                .WithIdentity("t-run")
+                .ForJob(job)
+                .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "60000")
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, new[] { vetoedTrigger, healthyTrigger }, replace: false);
+
+            Task vetoTask = vetoListener.Vetoed.Task;
+            (await Task.WhenAny(vetoTask, Task.Delay(waitTimeout))).Should().Be(vetoTask, "the t-veto fire should be vetoed");
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("the healthy execution should start");
+
+            // keep the healthy execution running well past the vetoed fire's would-be 500 ms deadline;
+            // before the fix the vetoed fire's leaked monitor would cancel it here
+            await Task.Delay(2000);
+
+            gate.Release();
+
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue("the healthy execution should complete once the gate opens");
+            executionCount.Should().Be(1, "the vetoed fire must never execute");
+            interruptedByTrigger["t-run"].Should().BeFalse("a vetoed fire's monitor must not interrupt a later healthy execution");
+        }
+        finally
+        {
+            gate.Release(10); // unblock any execution still gated so shutdown does not wait on it
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    private static async Task<IScheduler> CreateScheduler(string name, int defaultMaxRunTimeMilliseconds)
+    {
+        NameValueCollection config = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = "JobInterruptMonitorPluginTest_" + name,
+            ["quartz.scheduler.instanceId"] = "AUTO",
+            ["quartz.threadPool.threadCount"] = "3",
+            ["quartz.plugin.jobInterruptor.type"] = typeof(JobInterruptMonitorPlugin).AssemblyQualifiedNameWithoutVersion(),
+            ["quartz.plugin.jobInterruptor.defaultMaxRunTime"] = defaultMaxRunTimeMilliseconds.ToString(CultureInfo.InvariantCulture)
+        };
+
+        IScheduler scheduler = await new StdSchedulerFactory(config).GetScheduler();
+        await scheduler.Start();
+        return scheduler;
+    }
+
+    private static IJobDetail CreateAutoInterruptableJob()
+    {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.PutAsString(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true);
+
+        return JobBuilder.Create<GatedJob>()
+            .WithIdentity("gated-job")
+            .SetJobData(jobDataMap)
+            .Build();
+    }
+
+    private sealed class GatedJob : IJob
+    {
+        public async Task Execute(IJobExecutionContext context)
+        {
+            Interlocked.Increment(ref executionCount);
+            bool wasInterrupted = false;
+            started.Release();
+
+            try
+            {
+                await gate.WaitAsync(context.CancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                wasInterrupted = true;
+            }
+
+            interruptedByTrigger[context.Trigger.Key.Name] = wasInterrupted;
+            done.Release();
+        }
+    }
+
+    private sealed class VetoingTriggerListener : TriggerListenerSupport
+    {
+        private readonly string triggerNameToVeto;
+
+        public VetoingTriggerListener(string triggerNameToVeto)
+        {
+            this.triggerNameToVeto = triggerNameToVeto;
+        }
+
+        public TaskCompletionSource<bool> Vetoed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override string Name => "veto-listener";
+
+        public override Task<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            if (trigger.Key.Name == triggerNameToVeto)
+            {
+                Vetoed.TrySetResult(true);
+                return Task.FromResult(true);
+            }
+
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -2332,13 +2332,11 @@ public class QuartzScheduler :
     /// <param name="fireInstanceId"></param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns></returns>
-    public Task<bool> Interrupt(
+    public async Task<bool> Interrupt(
         string fireInstanceId,
         CancellationToken cancellationToken = default)
     {
         var cancellableJobs = CurrentlyExecutingJobs.OfType<ICancellableJobExecutionContext>();
-
-        bool interrupted = false;
 
         foreach (var cancellableJobExecutionContext in cancellableJobs)
         {
@@ -2347,12 +2345,13 @@ public class QuartzScheduler :
             if (cancellableJobExecutionContext.FireInstanceId.Equals(fireInstanceId))
             {
                 cancellableJobExecutionContext.Cancel();
-                interrupted = true;
-                break;
+                var jobKey = cancellableJobExecutionContext.JobDetail.Key;
+                await NotifySchedulerListeners(l => l.JobInterrupted(jobKey, cancellationToken), "job interruption").ConfigureAwait(false);
+                return true;
             }
         }
 
-        return Task.FromResult(interrupted);
+        return false;
     }
 
     private async Task ShutdownPlugins(


### PR DESCRIPTION
Fixes #3248.

`JobInterruptMonitorPlugin` interrupted by **job key**, so a monitor that elapsed cancelled every
running execution of that job instead of the one it was created for. A vetoed fire's monitor was
never cancelled at all — the only cleanup point was `TriggerComplete`, which a vetoed fire never
reaches — so every veto leaked a live monitor that would later interrupt an unrelated, healthy
execution of the same job. Both scenarios are exactly as analyzed in the excellent report by
@Break-1T.

### Changes

- **Interrupt by fire instance id.** `InterruptMonitor.Run` now calls
  `IScheduler.Interrupt(fireInstanceId)` instead of `Interrupt(jobKey)`. A monitor can no longer
  touch any execution other than its own, and a stale monitor finds nothing (vetoed fires never
  enter the currently-executing list). The log message is emitted after the call and reflects
  whether anything was actually interrupted.
- **Cancel the monitor on veto.** The plugin now also registers a job listener whose
  `JobExecutionVetoed` removes and cancels the monitor — `JobRunShell` raises that notification on
  the vetoed path right before bailing out, on the same await chain that created the monitor.
- **`Interrupt(fireInstanceId)` now raises `ISchedulerListener.JobInterrupted`**, matching the
  `Interrupt(JobKey)` overload. Without this, switching the plugin over would have silently dropped
  the notification for auto-interruptions. Behavior note for anyone calling the fire-instance
  overload directly: scheduler listeners are now notified.
- **`AutoInterruptable` is read from the merged job data map**, consistent with `MaxRunTime`.
  Behavior note: a trigger's data map can now opt a fire in or out of auto-interruption, not just
  override the timeout.
- **Refire hardening.** A re-executed job (`SchedulerInstruction.ReExecuteJob`) raises
  `TriggerFired` again with the same fire instance id; the plugin no longer starts a second,
  untracked monitor for it. Monitors also remove their own bookkeeping entry when they elapse, so
  the monitor dictionary stays bounded even when a throwing listener earlier in the chain suppresses
  the completion callbacks.

### Tests

- `JobInterruptMonitorPluginTest.ShouldOnlyInterruptTheExecutionThatExceededItsMaxRunTime` — two
  concurrent executions of the same job; only the one past its limit is cancelled. Fails against the
  old code with both executions interrupted (the issue's scenario A).
- `JobInterruptMonitorPluginTest.ShouldCancelMonitorOfVetoedExecution` — a vetoed fire plus a later
  healthy execution that outlives the vetoed fire's would-be deadline. Fails against the old code
  with the healthy execution cancelled (the issue's scenario B).
- `InterruptableJobTest.TestJobInterruption` now also asserts the `JobInterrupted` notification.

Public API surface is unchanged (the new job listener is a private nested class; the
`Interrupt(string)` signature is untouched), so the API baselines have no diff.

Companion PR for main: #3250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
