### PR TITLE
Interrupt only the monitored fire instance in JobInterruptMonitorPlugin (main)

### DIFF
--- a/docs/documentation/quartz-3.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-3.x/packages/quartz-plugins.md
@@ -114,6 +114,10 @@ var job = JobBuilder.Create<SlowJob>()
     .Build();
 ```
 
+Both `AutoInterruptable` and `MaxRunTime` are read from the merged job data map, so a trigger's data map can also enable interruption or override the timeout for its own fires.
+
+Only the execution that exceeded its allowed run time is interrupted — the plugin monitors each fire instance separately, so concurrent executions of the same job are unaffected. Executions vetoed by a trigger listener do not arm the interrupt timer.
+
 ## Authoring plugin configuration extensions
 
 ::: tip

--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -139,6 +139,10 @@ var job = JobBuilder.Create<SlowJob>()
     .Build();
 ```
 
+Both `AutoInterruptable` and `MaxRunTime` are read from the merged job data map, so a trigger's data map can also enable interruption or override the timeout for its own fires.
+
+Only the execution that exceeded its allowed run time is interrupted — the plugin monitors each fire instance separately, so concurrent executions of the same job are unaffected. Executions vetoed by a trigger listener do not arm the interrupt timer.
+
 ## Adding a plugin
 
 `AddPlugin` comes in the same three shapes as the listener registrations: the container builds the

--- a/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
@@ -11,7 +11,7 @@ namespace Quartz.Plugin.Interrupt;
 /// This plugin catches the event of job running for a long time (more than the
 /// configured max time) and tells the scheduler to "try" interrupting it if enabled.
 /// </summary>
-/// <seealso cref="IScheduler.Interrupt(Quartz.JobKey,System.Threading.CancellationToken)"/>
+/// <seealso cref="IScheduler.InterruptFireInstance(string,System.Threading.CancellationToken)"/>
 /// <author>Rama Chavali</author>
 /// <author>Marko Lahma (.NET)</author>
 public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugin
@@ -44,14 +44,19 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
 
     private void ScheduleJobInterruptMonitor(string fireInstanceId, JobKey jobkey, TimeSpan delay)
     {
-        var monitor = new InterruptMonitor(fireInstanceId, jobkey, scheduler, delay);
+        var monitor = new InterruptMonitor(this, fireInstanceId, jobkey, scheduler, delay);
+        if (!interruptMonitors.TryAdd(fireInstanceId, monitor))
+        {
+            // a re-executed job (SchedulerInstruction.ReExecuteJob) fires trigger listeners again
+            // with the same fire instance id - the existing monitor keeps watching it
+            return;
+        }
+
         _ = Task.Factory.StartNew(
             monitor.Run,
             monitor.cancellationTokenSource.Token,
             TaskCreationOptions.HideScheduler,
             taskScheduler).Unwrap();
-
-        interruptMonitors.TryAdd(fireInstanceId, monitor);
     }
 
     /// <summary>
@@ -72,7 +77,7 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
         try
         {
             // Schedule Monitor only if the job wants AutoInterruptable functionality
-            if (context.JobDetail.JobDataMap.TryGetBoolean(JobDataMapKeyAutoInterruptable, out bool value) && value)
+            if (context.MergedJobDataMap.TryGetBoolean(JobDataMapKeyAutoInterruptable, out bool value) && value)
             {
                 var monitorPlugin = (JobInterruptMonitorPlugin) context.Scheduler.Context[JobInterruptMonitorKey]!;
 
@@ -123,21 +128,48 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
         // Set the trigger Listener as this class to the ListenerManager here
         this.scheduler.ListenerManager.AddTriggerListener(this);
 
+        // a vetoed execution never reaches TriggerComplete, so its monitor must be cancelled from a job listener
+        this.scheduler.ListenerManager.AddJobListener(new JobExecutionVetoedListener(this));
+
         return default;
+    }
+
+    private sealed class JobExecutionVetoedListener : JobListenerSupport
+    {
+        private readonly JobInterruptMonitorPlugin plugin;
+
+        public JobExecutionVetoedListener(JobInterruptMonitorPlugin plugin)
+        {
+            this.plugin = plugin;
+        }
+
+        public override string Name => plugin.name + "-VetoedJobListener";
+
+        public override ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            if (plugin.interruptMonitors.TryRemove(context.FireInstanceId, out var monitor))
+            {
+                monitor.Cancel();
+            }
+
+            return default;
+        }
     }
 
     private sealed class InterruptMonitor
     {
         private readonly ILogger<InterruptMonitor> logger = LogProvider.CreateLogger<InterruptMonitor>();
 
+        private readonly JobInterruptMonitorPlugin plugin;
         private readonly JobKey jobKey;
         private readonly IScheduler scheduler;
         private readonly TimeSpan delay;
 
         internal readonly CancellationTokenSource cancellationTokenSource;
 
-        public InterruptMonitor(string fireInstanceId, JobKey jobKey, IScheduler scheduler, TimeSpan delay)
+        public InterruptMonitor(JobInterruptMonitorPlugin plugin, string fireInstanceId, JobKey jobKey, IScheduler scheduler, TimeSpan delay)
         {
+            this.plugin = plugin;
             FireInstanceId = fireInstanceId;
             this.jobKey = jobKey;
             this.scheduler = scheduler;
@@ -154,9 +186,18 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
             {
                 await Task.Delay(delay, cancellationTokenSource.Token).ConfigureAwait(false);
 
-                // Interrupt the job here - using Scheduler API that gets propagated to Job's interrupt
-                logger.LogInformation("Interrupting Job as it ran more than the configured max time. Job Details [{JobName}:{JobGroup}]", jobKey.Name, jobKey.Group);
-                await scheduler.Interrupt(jobKey, cancellationTokenSource.Token).ConfigureAwait(false);
+                // Interrupt the job here - using Scheduler API that gets propagated to Job's interrupt.
+                // Interrupting by fire instance id makes sure only the monitored execution is signaled
+                // and not every currently running execution of the same job.
+                bool interrupted = await scheduler.InterruptFireInstance(FireInstanceId, cancellationTokenSource.Token).ConfigureAwait(false);
+                if (interrupted)
+                {
+                    logger.LogInformation("Interrupted Job as it ran more than the configured max time. Job Details [{JobName}:{JobGroup}], fire instance id {FireInstanceId}", jobKey.Name, jobKey.Group, FireInstanceId);
+                }
+                else
+                {
+                    logger.LogDebug("Job execution was no longer running, nothing to interrupt. Job Details [{JobName}:{JobGroup}], fire instance id {FireInstanceId}", jobKey.Name, jobKey.Group, FireInstanceId);
+                }
             }
             catch (TaskCanceledException)
             {
@@ -165,6 +206,12 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
             catch (SchedulerException ex)
             {
                 logger.LogError(ex, "Error interrupting Job: {ExceptionMessage}", ex.Message);
+            }
+            finally
+            {
+                // TriggerComplete and JobExecutionVetoed already remove the entry; this bounds the
+                // dictionary when neither notification arrives, e.g. a listener earlier in the chain threw
+                plugin.interruptMonitors.TryRemove(FireInstanceId, out _);
             }
         }
 

--- a/src/Quartz.Tests.Unit/InterrubtableJobTest.cs
+++ b/src/Quartz.Tests.Unit/InterrubtableJobTest.cs
@@ -19,6 +19,8 @@
 
 using System.Collections.Specialized;
 
+using Quartz.Listener;
+
 namespace Quartz.Tests.Unit;
 
 /// <summary>
@@ -101,6 +103,9 @@ public class InterruptableJobTest
             .StartNow()
             .Build();
 
+        var interruptionListener = new JobInterruptedCaptureListener();
+        scheduler.ListenerManager.AddSchedulerListener(interruptionListener);
+
         await scheduler.ScheduleJob(job, trigger);
 
         started.WaitOne(); // make sure the job starts running...
@@ -121,7 +126,23 @@ public class InterruptableJobTest
             Assert.That(TestInterruptableJob.interrupted, Is.True, "Expected interrupted flag to be set on job class ");
         });
 
+        // the notification is awaited inside InterruptFireInstance before it returns, so no waiting is needed here
+        interruptionListener.Interrupted.Task.IsCompleted.Should().BeTrue(
+            "interrupting by fire instance id should notify scheduler listeners of the interruption");
+        (await interruptionListener.Interrupted.Task).Should().Be(job.Key);
+
         await scheduler.Clear();
         await scheduler.Shutdown();
+    }
+
+    private sealed class JobInterruptedCaptureListener : SchedulerListenerSupport
+    {
+        public TaskCompletionSource<JobKey> Interrupted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            Interrupted.TrySetResult(jobKey);
+            return default;
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/Plugin/Interrupt/JobInterruptMonitorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/Interrupt/JobInterruptMonitorPluginTest.cs
@@ -1,0 +1,211 @@
+using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Globalization;
+
+using Quartz.Listener;
+using Quartz.Plugin.Interrupt;
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit.Plugin.Interrupt;
+
+/// <summary>
+/// Regression tests for https://github.com/quartznet/quartznet/issues/3248 - the interrupt monitor
+/// must only ever cancel the execution it was created for.
+/// </summary>
+[NonParallelizable]
+public class JobInterruptMonitorPluginTest
+{
+    private static readonly TimeSpan waitTimeout = TimeSpan.FromSeconds(10);
+
+    private static readonly ConcurrentDictionary<string, bool> interruptedByTrigger = new();
+    private static SemaphoreSlim started;
+    private static SemaphoreSlim done;
+    private static SemaphoreSlim gate;
+    private static int executionCount;
+
+    [SetUp]
+    public void SetUp()
+    {
+        interruptedByTrigger.Clear();
+        started = new SemaphoreSlim(0);
+        done = new SemaphoreSlim(0);
+        gate = new SemaphoreSlim(0);
+        executionCount = 0;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        started.Dispose();
+        done.Dispose();
+        gate.Dispose();
+    }
+
+    [Test]
+    public async Task ShouldOnlyInterruptTheExecutionThatExceededItsMaxRunTime()
+    {
+        IScheduler scheduler = await CreateScheduler("PerInstance", defaultMaxRunTimeMilliseconds: 60_000);
+        try
+        {
+            IJobDetail job = CreateAutoInterruptableJob();
+
+            ITrigger shortTrigger = TriggerBuilder.Create()
+                .WithIdentity("t-short")
+                .ForJob(job)
+                .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "500")
+                .StartNow()
+                .Build();
+
+            ITrigger longTrigger = TriggerBuilder.Create()
+                .WithIdentity("t-long")
+                .ForJob(job)
+                .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "60000")
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, new[] { shortTrigger, longTrigger }, replace: false);
+
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("first execution should start");
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("second execution should start");
+
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue("the short-limit execution should be interrupted by its monitor");
+            interruptedByTrigger.Should().ContainKey("t-short",
+                "the execution that exceeded its max run time is the one that should have been interrupted");
+            interruptedByTrigger["t-short"].Should().BeTrue("t-short exceeded its 500 ms max run time");
+            interruptedByTrigger.Should().NotContainKey("t-long",
+                "t-short's monitor must not cancel a concurrent execution that has not exceeded its own limit");
+
+            gate.Release();
+
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue("the long-limit execution should complete once the gate opens");
+            interruptedByTrigger["t-long"].Should().BeFalse("t-long had a 60 second limit and must complete uninterrupted");
+        }
+        finally
+        {
+            gate.Release(10); // unblock any execution still gated so shutdown does not wait on it
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    [Test]
+    public async Task ShouldCancelMonitorOfVetoedExecution()
+    {
+        IScheduler scheduler = await CreateScheduler("Veto", defaultMaxRunTimeMilliseconds: 500);
+        try
+        {
+            VetoingTriggerListener vetoListener = new VetoingTriggerListener("t-veto");
+            scheduler.ListenerManager.AddTriggerListener(vetoListener);
+
+            IJobDetail job = CreateAutoInterruptableJob();
+
+            // vetoed fire uses the plugin default of 500 ms; the healthy fire allows 60 seconds
+            ITrigger vetoedTrigger = TriggerBuilder.Create()
+                .WithIdentity("t-veto")
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            ITrigger healthyTrigger = TriggerBuilder.Create()
+                .WithIdentity("t-run")
+                .ForJob(job)
+                .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "60000")
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, new[] { vetoedTrigger, healthyTrigger }, replace: false);
+
+            Task vetoTask = vetoListener.Vetoed.Task;
+            (await Task.WhenAny(vetoTask, Task.Delay(waitTimeout))).Should().Be(vetoTask, "the t-veto fire should be vetoed");
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("the healthy execution should start");
+
+            // keep the healthy execution running well past the vetoed fire's would-be 500 ms deadline;
+            // before the fix the vetoed fire's leaked monitor would cancel it here
+            await Task.Delay(2000);
+
+            gate.Release();
+
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue("the healthy execution should complete once the gate opens");
+            executionCount.Should().Be(1, "the vetoed fire must never execute");
+            interruptedByTrigger["t-run"].Should().BeFalse("a vetoed fire's monitor must not interrupt a later healthy execution");
+        }
+        finally
+        {
+            gate.Release(10); // unblock any execution still gated so shutdown does not wait on it
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    private static async Task<IScheduler> CreateScheduler(string name, int defaultMaxRunTimeMilliseconds)
+    {
+        NameValueCollection config = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = "JobInterruptMonitorPluginTest_" + name,
+            ["quartz.scheduler.instanceId"] = "AUTO",
+            ["quartz.threadPool.threadCount"] = "3",
+            ["quartz.plugin.jobInterruptor.type"] = typeof(JobInterruptMonitorPlugin).AssemblyQualifiedNameWithoutVersion(),
+            ["quartz.plugin.jobInterruptor.defaultMaxRunTime"] = defaultMaxRunTimeMilliseconds.ToString(CultureInfo.InvariantCulture)
+        };
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create().UseProperties(config).BuildScheduler();
+        await scheduler.Start();
+        return scheduler;
+    }
+
+    private static IJobDetail CreateAutoInterruptableJob()
+    {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.PutAsString(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true);
+
+        return JobBuilder.Create<GatedJob>()
+            .WithIdentity("gated-job")
+            .UsingJobData(jobDataMap)
+            .Build();
+    }
+
+    private sealed class GatedJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref executionCount);
+            bool wasInterrupted = false;
+            started.Release();
+
+            try
+            {
+                await gate.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                wasInterrupted = true;
+            }
+
+            interruptedByTrigger[context.Trigger.Key.Name] = wasInterrupted;
+            done.Release();
+        }
+    }
+
+    private sealed class VetoingTriggerListener : TriggerListenerSupport
+    {
+        private readonly string triggerNameToVeto;
+
+        public VetoingTriggerListener(string triggerNameToVeto)
+        {
+            this.triggerNameToVeto = triggerNameToVeto;
+        }
+
+        public TaskCompletionSource<bool> Vetoed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override string Name => "veto-listener";
+
+        public override ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            if (trigger.Key.Name == triggerNameToVeto)
+            {
+                Vetoed.TrySetResult(true);
+                return new ValueTask<bool>(true);
+            }
+
+            return new ValueTask<bool>(false);
+        }
+    }
+}

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -2196,13 +2196,11 @@ internal sealed class QuartzScheduler
     /// <param name="fireInstanceId"></param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns></returns>
-    public ValueTask<bool> InterruptFireInstance(
+    public async ValueTask<bool> InterruptFireInstance(
         string fireInstanceId,
         CancellationToken cancellationToken = default)
     {
         var interruptableJobs = GetCurrentlyExecutingJobs().OfType<IInterruptableJobExecutionContext>();
-
-        bool interrupted = false;
 
         foreach (var interruptableContext in interruptableJobs)
         {
@@ -2211,12 +2209,13 @@ internal sealed class QuartzScheduler
             if (interruptableContext.FireInstanceId == fireInstanceId)
             {
                 interruptableContext.Interrupt();
-                interrupted = true;
-                break;
+                var jobKey = interruptableContext.JobDetail.Key;
+                await NotifySchedulerListeners(l => l.JobInterrupted(jobKey, cancellationToken), "job interruption").ConfigureAwait(false);
+                return true;
             }
         }
 
-        return new ValueTask<bool>(interrupted);
+        return false;
     }
 
     private async Task ShutdownPlugins(


### PR DESCRIPTION
Fixes #3248 on main — companion to #3249, same fix ported to 4.x idioms.

`JobInterruptMonitorPlugin` interrupted by job key (cancelling every running execution of the job,
not the monitored one) and never cancelled the monitor of a vetoed fire, letting the leaked monitor
later interrupt an unrelated healthy execution. See #3248 and the 3.x PR for the full analysis.

### Changes (mirroring the 3.x PR)

- `InterruptMonitor.Run` interrupts via `IScheduler.InterruptFireInstance(fireInstanceId)` instead of
  `Interrupt(jobKey)`, and logs based on whether an execution was actually interrupted.
- A job listener registered by the plugin cancels the monitor from `JobExecutionVetoed`, the only
  notification a vetoed fire receives.
- `QuartzScheduler.InterruptFireInstance` now raises `ISchedulerListener.JobInterrupted`, matching
  the `Interrupt(JobKey)` overload.
- `AutoInterruptable` is read from the merged job data map, consistent with `MaxRunTime` — a
  trigger's data map can now opt a fire in or out of auto-interruption.
- Refire hardening: no duplicate monitor when `ReExecuteJob` re-raises `TriggerFired` with the same
  fire instance id; monitors clean up their own bookkeeping entry when they elapse.

### Tests and docs

Same regression tests as the 3.x PR (per-instance interrupt, vetoed-monitor cancellation,
`JobInterrupted` notification). The `JobInterruptMonitorPlugin` sections of the quartz-3.x and
quartz-4.x plugin documentation pages gained a paragraph on the per-fire-instance behavior and the
merged-map read.

Public API surface unchanged; API baselines have no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
