### PR TITLE
Upgrade Fallout to 10.4.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fallout.cli": {
-      "version": "11.0.18",
+    "fallout.globaltool": {
+      "version": "10.4.0",
       "commands": [
         "fallout"
       ]

--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -130,7 +130,7 @@
         },
         "FeedzApiKey": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+          "default": "Secrets must be entered via 'fallout :secrets [profile]'"
         },
         "IgnoreFailedSources": {
           "type": "boolean",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # Fallout's 11.x packages were published by the pre-community maintainership and the line is
+      # abandoned; releases continue from 10.4.0, which is semver-lower but newer. Without this,
+      # every run would propose "upgrading" back to the dead 11.0.18.
+      - dependency-name: "Fallout.*"
+        versions: ["11.*"]
     # Dependencies are matched against groups in the order they are declared here,
     # and each dependency ends up in the first group it matches.
     groups:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -49,7 +49,7 @@ jobs:
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
       - name: 'Publish: packages'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ runner.os == 'Windows' }}
         with:
           name: packages
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -71,7 +71,7 @@ jobs:
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
       - name: 'Publish: packages'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ runner.os == 'Windows' }}
         with:
           name: packages
@@ -81,9 +81,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -93,7 +93,7 @@ jobs:
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
       - name: 'Publish: packages'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ runner.os == 'Windows' }}
         with:
           name: packages

--- a/.github/workflows/pr-integration-basic.yml
+++ b/.github/workflows/pr-integration-basic.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-firebird.yml
+++ b/.github/workflows/pr-integration-firebird.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-mysql.yml
+++ b/.github/workflows/pr-integration-mysql.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-oracle.yml
+++ b/.github/workflows/pr-integration-oracle.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-postgres.yml
+++ b/.github/workflows/pr-integration-postgres.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-redis.yml
+++ b/.github/workflows/pr-integration-redis.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-sqlite.yml
+++ b/.github/workflows/pr-integration-sqlite.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-sqlserver.yml
+++ b/.github/workflows/pr-integration-sqlserver.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-tests-unit.yml
+++ b/.github/workflows/pr-tests-unit.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -69,9 +69,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 20
     environment: nuget
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -42,7 +42,7 @@ jobs:
       - name: 'Run: Compile, UnitTest, Pack, Publish'
         run: dotnet fallout Compile UnitTest Pack Publish
       - name: 'Publish: packages'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: packages
           path: artifacts/packages

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,16 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fallout.Components" Version="11.0.18" />
-  </ItemGroup>
-
-  <!--
-    Override a vulnerable transitive dependency pulled in by Fallout.Components (GHSA-23rf-6693-g89p,
-    GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q, GHSA-g8r8-53c2-pm3f, GHSA-mmjf-rqrv-855v).
-    Remove this when Fallout ships a release that bumps it itself.
-  -->
-  <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+    <PackageReference Include="Fallout.Components" Version="10.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrades the Fallout build orchestrator from 11.0.18 to [v10.4.0](https://github.com/Fallout-build/Fallout/releases/tag/v10.4.0), the first stable release since the project moved to community maintenance.

### Why the version goes *down*

The 11.0.x NuGet line we pinned when migrating off NUKE (#3162) was published by the previous maintainership and is abandoned — releases continue from the repo's own 10.3.x versioning. 10.4.0 is semver-lower but chronologically and functionally newer (verified against the tag: everything our build uses exists there, plus APIs 11.0.18 never had).

### Changes

- **Tool manifest swaps package ID**: the CLI now ships as `Fallout.GlobalTool` (`fallout.cli` has no 10.4.0); the command is still `fallout`, so `build.ps1`/`build.sh`/`build.cmd` and CI run steps are untouched.
- **`System.Security.Cryptography.Xml` override removed** — 10.4.0 depends on the patched 10.0.10 itself, which is exactly what the pin's comment said to wait for. Restore audit is clean without it.
- **Regenerated workflows** pick up Fallout's new generated-action defaults: `checkout` v6→v7, `setup-dotnet` v4→v6, `upload-artifact` v5→v7. All three majors verified to exist upstream. No other YAML shape changes.
- **Dependabot `ignore` for `Fallout.*` 11.*** — without it, every run would propose "upgrading" back to the dead 11.0.18 line, which is semver-higher.
- `.fallout/build.schema.json` regeneration also picks up the fixed `fallout :secrets` hint text.

### Verified

- `dotnet tool restore`, build-project restore (no NU1901–NU1904) and compile
- `./build.ps1 Compile` — including from a **git worktree**, which 11.0.18's `[GitRepository]` could not resolve (one of the release's fixes); versioning resolved correctly
- `./build.ps1 -Target Clean`, `dotnet fallout VerifyMigrations`
- env→parameter binding (`Configuration=Release` reached the inner `dotnet build`), the mechanism the per-database integration workflows use for `Database`

Publish/Pack-to-feed targets were not run; they change by version bump only.

A companion PR ports the same change to `3.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
