### PR TITLE
Upgrade Fallout to 10.4.0 (3.x)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fallout.cli": {
-      "version": "11.0.18",
+    "fallout.globaltool": {
+      "version": "10.4.0",
       "commands": [
         "fallout"
       ]

--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -128,7 +128,7 @@
         },
         "FeedzApiKey": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+          "default": "Secrets must be entered via 'fallout :secrets [profile]'"
         },
         "Solution": {
           "type": "string",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -47,7 +47,7 @@ jobs:
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
       - name: 'Publish: artifacts'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: runner.os == 'Windows'
         with:
           name: artifacts
@@ -56,9 +56,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -68,7 +68,7 @@ jobs:
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
       - name: 'Publish: artifacts'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: runner.os == 'Windows'
         with:
           name: artifacts
@@ -77,9 +77,9 @@ jobs:
     name: macos-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -89,7 +89,7 @@ jobs:
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
       - name: 'Publish: artifacts'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: runner.os == 'Windows'
         with:
           name: artifacts

--- a/.github/workflows/pr-integration-basic.yml
+++ b/.github/workflows/pr-integration-basic.yml
@@ -41,9 +41,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-firebird.yml
+++ b/.github/workflows/pr-integration-firebird.yml
@@ -41,9 +41,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-mysql.yml
+++ b/.github/workflows/pr-integration-mysql.yml
@@ -41,9 +41,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-oracle.yml
+++ b/.github/workflows/pr-integration-oracle.yml
@@ -41,9 +41,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-postgres.yml
+++ b/.github/workflows/pr-integration-postgres.yml
@@ -41,9 +41,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-redis.yml
+++ b/.github/workflows/pr-integration-redis.yml
@@ -41,9 +41,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-sqlite.yml
+++ b/.github/workflows/pr-integration-sqlite.yml
@@ -41,9 +41,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-integration-sqlserver.yml
+++ b/.github/workflows/pr-integration-sqlserver.yml
@@ -41,9 +41,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/pr-tests-unit.yml
+++ b/.github/workflows/pr-tests-unit.yml
@@ -40,9 +40,9 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -53,9 +53,9 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -66,9 +66,9 @@ jobs:
     name: macos-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 20
     environment: nuget
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Setup: .NET SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
@@ -42,7 +42,7 @@ jobs:
       - name: 'Run: Compile, UnitTest, Pack, Publish'
         run: dotnet fallout Compile UnitTest Pack Publish
       - name: 'Publish: artifacts'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts
           path: artifacts

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -16,16 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fallout.Common" Version="11.0.18" />
-  </ItemGroup>
-
-  <!--
-    Override a vulnerable transitive dependency pulled in by Fallout.Common (GHSA-23rf-6693-g89p,
-    GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q, GHSA-g8r8-53c2-pm3f, GHSA-mmjf-rqrv-855v).
-    Remove this when Fallout ships a release that bumps it itself.
-  -->
-  <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+    <PackageReference Include="Fallout.Common" Version="10.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
3.x companion to #3251 — upgrades the Fallout build orchestrator from 11.0.18 to [v10.4.0](https://github.com/Fallout-build/Fallout/releases/tag/v10.4.0), the first stable release since the project moved to community maintenance. The 11.0.x NuGet line is abandoned (published by the previous maintainership); releases continue from the repo's own 10.3.x versioning, so the bump is semver-down but functionally forward.

Differences from the main PR: this branch references `Fallout.Common` rather than `Fallout.Components`, and it has no `dependabot.yml`, so the 11.x ignore rule only exists on main.

- **Tool manifest swaps package ID**: the CLI now ships as `Fallout.GlobalTool` (`fallout.cli` has no 10.4.0); the command is still `fallout`, so the shims and CI run steps are untouched.
- **`System.Security.Cryptography.Xml` override removed** — 10.4.0 depends on the patched 10.0.10 itself; restore audit is clean without it.
- **Regenerated workflows**: `checkout` v6→v7, `setup-dotnet` v4→v6, `upload-artifact` v5→v7 (Fallout's new defaults; majors verified to exist). No other YAML shape changes.

Verified: tool restore, build-project restore (no NU1901–NU1904) and compile, `./build.ps1 Compile` from a git worktree (11.0.18's `[GitRepository]` couldn't do that), `./build.ps1 -Target Clean`, `dotnet fallout VerifyMigrations`. Publish/Pack-to-feed targets were not run; they change by version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
