### PR TITLE
Resolve stored job type names through ITypeLoadHelper

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2663,6 +2663,15 @@ rename, so a string naming both still resolves:
 + quartz.serializer.type = Quartz.Impl.SystemTextJsonObjectSerializer, Quartz
 ```
 
+Configuration is not the only place a type is named by string. `JOB_CLASS_NAME` holds whatever spelling the
+version that wrote the row used, so a database carried over from 2.x or 3.x names jobs by namespaces and
+assemblies that have since moved. **Those stored names now resolve through the same fallback**, with the same
+warning naming both spellings, rather than through the runtime's lookup alone — a `Quartz.Job.NoOpJob, Quartz`
+written years ago finds the type in `Quartz.Jobs` today. The column itself is left alone: reading a job never
+rewrites what is persisted for it, so the fallback stays visible until you migrate the data. Previously such a
+job started up and listed perfectly well, because a job's type is resolved lazily, and then failed with a
+`TypeLoadException` the first time it fired.
+
 ## The scheduler and the job store speak the same verbs
 
 `IJobStore` had its own vocabulary — Store/Remove/Retrieve — for the operations `IScheduler` calls

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -304,7 +304,7 @@ public class StdAdoDelegateTest
         var jobDetail = await adoDelegate.SelectJobDetail(
             conn,
             jobKey,
-            new SimpleTypeLoadHelper(), // Irrelevant, not used actually by method implementation
+            new SimpleTypeLoadHelper(), // resolves the stored JOB_CLASS_NAME
             CancellationToken.None);
 
         Assert.Multiple(() =>
@@ -334,6 +334,78 @@ public class StdAdoDelegateTest
                                   + "AND JOB_NAME = @jobName "
                                   + "AND JOB_GROUP = @jobGroup";
         Assert.That(command.CommandText, Is.EqualTo(expectedCommandText));
+    }
+
+    /// <summary>
+    /// A table carried over from 2.x or 3.x names job types the way those versions spelled them, and
+    /// only the type load helper knows what such a spelling means today. Resolving the stored name
+    /// without it leaves the job loading and listing perfectly well - the type is resolved lazily -
+    /// and then failing at its first fire.
+    /// </summary>
+    [Test]
+    public async Task SelectJobDetailResolvesAPre40JobClassNameThroughTheTypeLoadHelper()
+    {
+        const string StoredJobClassName = "Quartz.Job.NoOpJob, Quartz";
+
+        var connection = A.Fake<DbConnection>();
+        var transaction = A.Fake<DbTransaction>();
+        var conn = new ConnectionAndTransactionHolder(connection, transaction);
+
+        var dataReader = A.Fake<DbDataReader>();
+        A.CallTo(() => dataReader.ReadAsync(CancellationToken.None))
+            .Returns(true)
+            .Once();
+
+        A.CallTo(() => dataReader[AdoConstants.ColumnJobName]).Returns("job");
+        A.CallTo(() => dataReader[AdoConstants.ColumnJobGroup]).Returns("group");
+        A.CallTo(() => dataReader[AdoConstants.ColumnDescription]).Returns("description");
+        A.CallTo(() => dataReader[AdoConstants.ColumnJobClass]).Returns(StoredJobClassName);
+        A.CallTo(() => dataReader[AdoConstants.ColumnRequestsRecovery]).Returns(false);
+        A.CallTo(() => dataReader[AdoConstants.ColumnIsDurable]).Returns(true);
+        A.CallTo(() => dataReader[AdoConstants.ColumnIsNonConcurrent]).Returns(false);
+        A.CallTo(() => dataReader[AdoConstants.ColumnIsUpdateData]).Returns(false);
+
+        var command = A.Fake<StubCommand>();
+        A.CallTo(command)
+            .Where(x => x.Method.Name == "ExecuteDbDataReaderAsync")
+            .WithReturnType<Task<DbDataReader>>()
+            .Returns(Task.FromResult(dataReader));
+
+        var dbMetadata = new DbMetadata
+        {
+            BindByName = true,
+            ParameterNamePrefix = "@"
+        };
+        dbMetadata.Initialize();
+
+        var dbProvider = A.Fake<IDbProvider>();
+        A.CallTo(() => dbProvider.CreateCommand()).Returns(command);
+        A.CallTo(() => dbProvider.Metadata).Returns(dbMetadata);
+
+        var adoDelegate = new StdAdoDelegate();
+        adoDelegate.Initialize(new DelegateInitializationArgs
+        {
+            TablePrefix = "QRTZ_",
+            InstanceId = "TESTSCHED",
+            InstanceName = "INSTANCE",
+            TypeLoadHelper = new SimpleTypeLoadHelper(),
+            UseProperties = false,
+            InitString = "",
+            DbProvider = dbProvider,
+            ObjectSerializer = serializer
+        });
+
+        IJobDetail jobDetail = await adoDelegate.SelectJobDetail(
+            conn,
+            new JobKey("job", "group"),
+            new SimpleTypeLoadHelper(),
+            CancellationToken.None);
+
+        jobDetail.Should().NotBeNull();
+        jobDetail.JobType.FullName.Should().Be(StoredJobClassName,
+            "reading a job must not rewrite the JOB_CLASS_NAME that is persisted for it");
+        jobDetail.JobType.Type.Should().Be<global::Quartz.Job.NoOpJob>(
+            "a job class name stored before the jobs moved to their own assembly has to resolve through the load helper");
     }
 
     private sealed class TestJob : IJob

--- a/src/Quartz.Tests.Unit/Impl/JobType/JobTypeTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/JobType/JobTypeTests.cs
@@ -1,3 +1,5 @@
+using Quartz.Extensibility;
+using Quartz.Impl;
 
 namespace Quartz.Tests.Unit.Impl.JobType;
 
@@ -36,6 +38,48 @@ public class JobTypeTests
         var typeFullName = typeof(LoggerJob).AssemblyQualifiedName;
         var jobType = new global::Quartz.JobType(typeFullName);
         jobType.Type.FullName.Should().Be(typeof(LoggerJob).FullName);
+    }
+
+    [Test]
+    public void ConstructWithResolverWillResolveThroughIt()
+    {
+        const string StoredName = "Some.Name.The.Runtime.Cannot.Resolve";
+        string asked = null;
+
+        global::Quartz.JobType jobType = new global::Quartz.JobType(StoredName, name =>
+        {
+            asked = name;
+            return typeof(LoggerJob);
+        });
+
+        jobType.Type.Should().Be<LoggerJob>("the resolver, not Type.GetType, decides what the name means");
+        asked.Should().Be(StoredName, "the resolver is asked about the name exactly as it was given");
+        jobType.FullName.Should().Be(StoredName, "resolving a name must never rewrite it");
+    }
+
+    [Test]
+    public void ConstructWithResolverThatFindsNothing_WillThrowOnTypeResolve()
+    {
+        global::Quartz.JobType jobType = new global::Quartz.JobType("Library.UnknownType", static _ => null);
+
+        jobType.Invoking(jt => jt.Type)
+            .Should().Throw<InvalidOperationException>().WithMessage("*Library.UnknownType*",
+                "a resolver that finds nothing has to fail the same way the runtime lookup does");
+    }
+
+    [Test]
+    public void ConstructWithTypeLoadHelperResolverWillResolveAPre40Name()
+    {
+        // What a 2.x or 3.x scheduler wrote into JOB_CLASS_NAME; the type lives in Quartz.Jobs today.
+        const string StoredName = "Quartz.Job.NoOpJob, Quartz";
+        ITypeLoadHelper loadHelper = new SimpleTypeLoadHelper();
+
+        global::Quartz.JobType jobType = new global::Quartz.JobType(StoredName, loadHelper.LoadType);
+
+        jobType.Type.Should().Be<global::Quartz.Job.NoOpJob>(
+            "a job type name stored before the assembly moved has to keep resolving through the load helper's fallback");
+        jobType.FullName.Should().Be(StoredName,
+            "the stored name is reported back unchanged, so nothing rewrites the persisted spelling");
     }
 
     public sealed class LoggerJob : IJob

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -128,7 +128,7 @@ public partial class StdAdoDelegate
 
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            job = await ReadJobDetail(rs).ConfigureAwait(false);
+            job = await ReadJobDetail(rs, loadHelper).ConfigureAwait(false);
         }
 
         return job;
@@ -159,7 +159,7 @@ public partial class StdAdoDelegate
             using DbDataReader rs = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                jobs.Add(await ReadJobDetail(rs).ConfigureAwait(false));
+                jobs.Add(await ReadJobDetail(rs, loadHelper).ConfigureAwait(false));
             }
         }
 
@@ -198,14 +198,14 @@ public partial class StdAdoDelegate
     /// Reads the current row of a job detail select. Shared by the single-job and batch read paths so
     /// the two cannot drift apart.
     /// </summary>
-    private async ValueTask<IJobDetail> ReadJobDetail(DbDataReader rs)
+    private async ValueTask<IJobDetail> ReadJobDetail(DbDataReader rs, ITypeLoadHelper loadHelper)
     {
         // Due to CommandBehavior.SequentialAccess, columns must be read in order.
 
         var jobBuilder = JobBuilder.Create()
             .WithIdentity(new JobKey(rs.GetString(AdoConstants.ColumnJobName)!, rs.GetString(AdoConstants.ColumnJobGroup)!))
             .WithDescription(rs.GetString(AdoConstants.ColumnDescription))
-            .OfType(rs.GetString(AdoConstants.ColumnJobClass)!)
+            .OfType(CreateJobType(rs.GetString(AdoConstants.ColumnJobClass)!, loadHelper))
             .StoreDurably(GetBooleanFromDbValue(rs[AdoConstants.ColumnIsDurable]))
             .RequestRecovery(GetBooleanFromDbValue(rs[AdoConstants.ColumnRequestsRecovery]));
 
@@ -220,6 +220,44 @@ public partial class StdAdoDelegate
             .PersistJobDataAfterExecution(GetBooleanFromDbValue(rs[AdoConstants.ColumnIsUpdateData]));
 
         return jobBuilder.Build();
+    }
+
+    /// <summary>
+    /// Builds the job type for a stored <c>JOB_CLASS_NAME</c>, resolved through the scheduler's
+    /// <see cref="ITypeLoadHelper" /> rather than by <see cref="Type.GetType(string)" /> alone.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The stored name is whatever wrote the row, so a table carried over from 2.x or 3.x names types
+    /// the way those versions spelled them. The helper is the only thing that knows the namespace,
+    /// type and assembly renames, so resolving without it leaves such a job loading and listing
+    /// perfectly well - <see cref="JobType" /> resolves lazily - and then failing at its first fire,
+    /// with nothing logged to say the name had merely moved.
+    /// </para>
+    /// <para>
+    /// Only the resolution is delegated, not the name: <see cref="JobType.FullName" /> keeps reporting
+    /// the stored spelling, so reading a job never rewrites the column behind the user's back.
+    /// </para>
+    /// </remarks>
+    private static JobType CreateJobType(string jobClassName, ITypeLoadHelper loadHelper)
+    {
+        return new JobType(jobClassName, name =>
+        {
+            Type? resolved;
+            try
+            {
+                resolved = loadHelper.LoadType(name);
+            }
+            catch (TypeLoadException)
+            {
+                // A helper that cannot resolve the name is required to throw, and a fault-tolerant one
+                // returns null instead. Either way the name means nothing to it, and falling back leaves
+                // an unresolvable job type failing exactly the way it did before the helper was consulted.
+                resolved = null;
+            }
+
+            return resolved ?? Type.GetType(name);
+        });
     }
 
     /// <inheritdoc />
@@ -237,15 +275,17 @@ public partial class StdAdoDelegate
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
+            string jobClassName = rs.GetString(AdoConstants.ColumnJobClass)!;
+
             var jobBuilder = JobBuilder.Create()
                 .WithIdentity(new JobKey(rs.GetString(AdoConstants.ColumnJobName)!, rs.GetString(AdoConstants.ColumnJobGroup)!))
                 .RequestRecovery(GetBooleanFromDbValue(rs[AdoConstants.ColumnRequestsRecovery]))
-                .OfType(rs.GetString(AdoConstants.ColumnJobClass)!)
+                .OfType(CreateJobType(jobClassName, loadHelper))
                 .StoreDurably(GetBooleanFromDbValue(rs[AdoConstants.ColumnIsDurable]));
 
             if (loadJobType)
             {
-                jobBuilder.OfType(loadHelper.LoadType(rs.GetString(AdoConstants.ColumnJobClass)!)!);
+                jobBuilder.OfType(loadHelper.LoadType(jobClassName)!);
             }
 
             return jobBuilder.Build();

--- a/src/Quartz/JobBuilder.cs
+++ b/src/Quartz/JobBuilder.cs
@@ -304,6 +304,22 @@ public sealed class JobBuilder<TJob> : IJobConfigurator<TJob> where TJob : IJob
     }
 
     /// <summary>
+    /// Set the job type to one that already knows how to resolve the name it carries.
+    /// </summary>
+    /// <remarks>
+    /// A name read back out of a job store may be spelled the way an older Quartz wrote it, and only the
+    /// scheduler's type load helper knows what such a spelling means today. Handing the resolution over
+    /// rather than the resolved type keeps the stored name as it was stored.
+    /// </remarks>
+    /// <param name="jobType">the job type, with whatever resolution it was constructed with</param>
+    /// <returns>the updated JobBuilder</returns>
+    internal JobBuilder<TJob> OfType(JobType jobType)
+    {
+        _jobType = jobType;
+        return this;
+    }
+
+    /// <summary>
     /// Set the class which will be instantiated and executed when a
     /// Trigger fires that is associated with this JobDetail.
     /// </summary>

--- a/src/Quartz/JobType.cs
+++ b/src/Quartz/JobType.cs
@@ -10,7 +10,17 @@ namespace Quartz;
 /// </summary>
 public sealed class JobType
 {
+    /// <summary>
+    /// How a name becomes a type when the caller had nothing better to offer: the runtime's own lookup.
+    /// </summary>
+    private static readonly Func<string, Type?> defaultResolver = static name => Type.GetType(name);
+
     private readonly Lazy<Type> type;
+
+    /// <summary>
+    /// Turns <see cref="FullName" /> into a type. Only consulted for a name-constructed instance.
+    /// </summary>
+    private readonly Func<string, Type?> resolver;
 
     /// <summary>
     /// The type this was constructed from, when it was constructed from one at all.
@@ -23,16 +33,35 @@ public sealed class JobType
     /// </summary>
     /// <param name="fullName">Type full name</param>
     /// <exception cref="ArgumentNullException"><paramref name="fullName"/> is <see langword="null" /></exception>
-    public JobType(string fullName)
+    public JobType(string fullName) : this(fullName, defaultResolver)
+    {
+    }
+
+    /// <summary>
+    /// Construct a Job Type from a name that something other than <see cref="Type.GetType(string)" />
+    /// knows how to resolve.
+    /// </summary>
+    /// <remarks>
+    /// A name read out of a job store was written by whichever version of Quartz stored it, so resolving
+    /// it may need the same rename fallbacks that a configured type name gets - which live in an
+    /// <see cref="Extensibility.ITypeLoadHelper" />, not in the runtime. The name itself is kept exactly
+    /// as given: <see cref="FullName" /> reports the stored spelling however the type was found, so
+    /// reading a job never rewrites what is persisted for it.
+    /// </remarks>
+    /// <param name="fullName">Type full name</param>
+    /// <param name="resolver">Resolves <paramref name="fullName" />, returning <see langword="null" /> when it names nothing.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="fullName"/> is <see langword="null" /></exception>
+    internal JobType(string fullName, Func<string, Type?> resolver)
     {
         if (fullName is null)
         {
             Throw.ArgumentNullException(nameof(fullName));
         }
         FullName = fullName;
+        this.resolver = resolver;
         type = new Lazy<Type>(() =>
         {
-            var loadedType = Type.GetType(fullName);
+            Type? loadedType = resolver(fullName);
             if (loadedType is null)
             {
                 Throw.InvalidOperationException($"Job type {fullName} cannot be resolved.");
@@ -60,6 +89,7 @@ public sealed class JobType
         }
 
         this.type = new Lazy<Type>(() => type);
+        resolver = defaultResolver;
         declaredType = type;
         FullName = GetFullName(type);
     }
@@ -105,7 +135,7 @@ public sealed class JobType
         try
         {
             // Suppressing not-found does not suppress an assembly that is found but cannot be loaded.
-            resolved = Type.GetType(FullName, throwOnError: false);
+            resolved = resolver(FullName);
         }
         catch (Exception e) when (e is ArgumentException or FileLoadException or BadImageFormatException or TypeLoadException or TargetInvocationException)
         {


### PR DESCRIPTION
Stored `JOB_CLASS_NAME` values bypassed `ITypeLoadHelper` on the read/fire path: `ReadJobDetail` and `SelectJobForTrigger` handed the raw column string to `JobType`, whose lazy resolution uses bare `Type.GetType`. `SimpleTypeLoadHelper`'s 2.x/3.x rename fallbacks (`, Quartz` → `, Quartz.Jobs`, `Quartz.Spi` → `Quartz.Extensibility`, …) were therefore unreachable exactly where old databases need them — a `Quartz.Job.NoOpJob, Quartz` row written years ago passed startup and listing (job types resolve lazily) and then died with a bare `TypeLoadException` at its first fire, with no hint the name had merely moved.

The fix is internal-only:

- `JobType` gains an internal constructor taking a resolver; the public constructor chains to it with the old `Type.GetType` behavior, and both the lazy factory and `TryResolve` consult the same resolver.
- The ADO delegate's two raw-string read sites build the `JobType` with a resolver backed by the `ITypeLoadHelper` those methods already receive, falling back to `Type.GetType` so an unresolvable name still fails exactly as before. `JobType.FullName` keeps reporting the stored spelling — reading a job never rewrites the column.
- The eager `loadJobType: true` branch of `SelectJobForTrigger` is deliberately untouched (it already resolves through the helper).

Tests cover the resolver hook and the end-to-end pre-4.0-name read through the delegate; the migration guide's type-name-fallback section now documents that stored job class names resolve through the same fallback, with the same warning.

No public API change; all `PublicApiTest_*` baselines are untouched. `build.cmd Compile` clean; unit suite 2152 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)