### PR TITLE
Stop resolving CLR types from HTTP wire input

### DIFF
--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -569,14 +569,18 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
 
     private IJobDetail BuildJobDetail(JobDetailDto source)
     {
-        Type? jobType = Type.GetType(source.JobType, throwOnError: false);
-        if (jobType is null)
+        if (string.IsNullOrWhiteSpace(source.JobType))
         {
-            throw new InvalidOperationException("Unknown job type: " + source.JobType);
+            throw new InvalidOperationException("Job type is required.");
         }
 
         JobDataMap jobDataMap = DeserializeJobDataMap(source.JobDataMap);
-        IJobDetail jobDetail = JobBuilder.Create(jobType)
+
+        // The type name is stored unresolved on purpose: resolving a name that arrived with the request
+        // would have this process probe its assemblies for whatever the caller named. The scheduler
+        // resolves it through the type load path when the job runs.
+        IJobDetail jobDetail = JobBuilder.Create()
+            .OfType(source.JobType)
             .WithIdentity(source.Name, source.Group)
             .WithDescription(source.Description)
             .StoreDurably(source.Durable)

--- a/src/Quartz.HttpClient/HttpApiContract/JobDetailDto.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/JobDetailDto.cs
@@ -15,6 +15,12 @@ internal record JobDetailDto(
     JobDataMap JobDataMap
 ) : IValidatable
 {
+    /// <summary>
+    /// A job type name longer than this is a payload rather than a name, and is rejected before anything
+    /// has to parse it.
+    /// </summary>
+    private const int MaxJobTypeNameLength = 1024;
+
     public IEnumerable<string> Validate()
     {
         if (Name is null)
@@ -31,25 +37,24 @@ internal record JobDetailDto(
         {
             yield return "Job detail is missing job type";
         }
-        else
+        else if (!IsWellFormedTypeName(JobType))
         {
-            var jobType = Type.GetType(JobType, throwOnError: false);
-            if (jobType is null)
-            {
-                yield return "Job detail has unknown job type " + JobType;
-            }
+            yield return "Job detail has malformed job type " + JobType;
         }
     }
 
     public (IJobDetail? JobDetail, string? ErrorReason) AsIJobDetail()
     {
-        var jobType = Type.GetType(JobType, throwOnError: false);
-        if (jobType is null)
+        if (JobType is null || !IsWellFormedTypeName(JobType))
         {
-            return (null, "Unknown job type");
+            return (null, "Missing or malformed job type");
         }
 
-        var jobDetail = JobBuilder.Create(jobType)
+        // The name is carried as a name. OfType(string) stores it unresolved, so building the detail
+        // neither loads nor probes for an assembly - the side the job actually runs on resolves it
+        // through the type load path, when it needs the type.
+        IJobDetail jobDetail = JobBuilder.Create()
+            .OfType(JobType)
             .WithIdentity(Name, Group)
             .WithDescription(Description)
             .StoreDurably(Durable)
@@ -60,6 +65,46 @@ internal record JobDetailDto(
             .Build();
 
         return (jobDetail, null);
+    }
+
+    /// <summary>
+    /// Checks that a job type name has the shape of one, without resolving it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These contract types are shared with the server, so a name this type resolved would be resolved by
+    /// the scheduler host on behalf of whoever sent the request. Add-job and schedule-job requests would
+    /// then let a caller have the host walk its assembly probing paths for any name it likes and read the
+    /// answer off the response - a type disclosure side channel, and one that does real work per request.
+    /// </para>
+    /// <para>
+    /// Resolving here also breaks readers that have every right not to have the job's assembly loaded: a
+    /// dashboard or ops process listing jobs only wants to show the name.
+    /// </para>
+    /// </remarks>
+    private static bool IsWellFormedTypeName(string typeName)
+    {
+        ReadOnlySpan<char> name = typeName.AsSpan().Trim();
+        if (name.IsEmpty || name.Length > MaxJobTypeNameLength)
+        {
+            return false;
+        }
+
+        // A name that leads with the assembly separator has no type part at all.
+        if (name[0] == ',')
+        {
+            return false;
+        }
+
+        foreach (char character in name)
+        {
+            if (char.IsControl(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public static JobDetailDto Create(IJobDetail jobDetail)

--- a/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
@@ -381,12 +381,37 @@ public class JobEndpointsTest : WebApiTest
             })
             .MustHaveHappened(1, Times.Exactly);
 
-        var jobDetailsForUnknownJob = TestData.JobDetail.GetJobBuilder()
-            .OfType("Quartz.Tests.AspNetCore.Support.DummyJob2, Quartz.Tests.AspNetCore")
+        // A job type the server cannot resolve is not rejected at request time - the server never resolves
+        // a name that arrived with the request. The name reaches the scheduler as given, and only whatever
+        // has to run the job resolves it.
+        Fake.ClearRecordedCalls(FakeScheduler);
+        IJobDetail jobDetailWithUnresolvableType = TestData.JobDetail.GetJobBuilder()
+            .OfType(TestData.UnresolvableJobTypeName)
             .Build();
 
-        Assert.ThrowsAsync<HttpClientException>(() => HttpScheduler.AddJob(jobDetailsForUnknownJob).AsTask())!
-            .Message.Should().ContainEquivalentOf("unknown job type");
+        await HttpScheduler.AddJob(jobDetailWithUnresolvableType);
+
+        A.CallTo(() => FakeScheduler.AddJob(A<IJobDetail>._, A<AddJobOptions>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((IJobDetail jobDetail, AddJobOptions? options, CancellationToken _) =>
+            {
+                jobDetail.JobType.FullName.Should().Be(TestData.UnresolvableJobTypeName);
+                return true;
+            })
+            .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public void AddJobShouldRejectMalformedJobType()
+    {
+        // Shape is still checked, it is only resolution that is not done. An empty name has no shape.
+        IJobDetail jobDetailWithEmptyType = TestData.JobDetail.GetJobBuilder()
+            .OfType(" ")
+            .Build();
+
+        Assert.ThrowsAsync<HttpClientException>(() => HttpScheduler.AddJob(jobDetailWithEmptyType).AsTask())!
+            .Message.Should().ContainEquivalentOf("malformed job type");
+
+        A.CallTo(() => FakeScheduler.AddJob(A<IJobDetail>._, A<AddJobOptions>._, A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
@@ -356,12 +356,36 @@ public class TriggerEndpointsTest : WebApiTest
             })
             .MustHaveHappened(1, Times.Exactly);
 
-        var jobDetailsForUnknownJob = TestData.JobDetail.GetJobBuilder()
-            .OfType("Quartz.Tests.AspNetCore.Support.DummyJob2, Quartz.Tests.AspNetCore")
+        // A job type the server cannot resolve is not rejected at request time - the server never resolves
+        // a name that arrived with the request.
+        Fake.ClearRecordedCalls(FakeScheduler);
+        IJobDetail jobDetailWithUnresolvableType = TestData.JobDetail.GetJobBuilder()
+            .OfType(TestData.UnresolvableJobTypeName)
             .Build();
 
-        Assert.ThrowsAsync<HttpClientException>(() => HttpScheduler.ScheduleJob(jobDetailsForUnknownJob, TestData.SimpleTrigger).AsTask())!
-            .Message.Should().ContainEquivalentOf("unknown job type");
+        await HttpScheduler.ScheduleJob(jobDetailWithUnresolvableType, TestData.SimpleTrigger);
+
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((IJobDetail jobDetail, ITrigger trigger, CancellationToken _) =>
+            {
+                jobDetail.JobType.FullName.Should().Be(TestData.UnresolvableJobTypeName);
+                return true;
+            })
+            .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public void ScheduleJobShouldRejectMalformedJobType()
+    {
+        // Shape is still checked, it is only resolution that is not done. An empty name has no shape.
+        IJobDetail jobDetailWithEmptyType = TestData.JobDetail.GetJobBuilder()
+            .OfType(" ")
+            .Build();
+
+        Assert.ThrowsAsync<HttpClientException>(() => HttpScheduler.ScheduleJob(jobDetailWithEmptyType, TestData.SimpleTrigger).AsTask())!
+            .Message.Should().ContainEquivalentOf("malformed job type");
+
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Test]
@@ -411,15 +435,38 @@ public class TriggerEndpointsTest : WebApiTest
             })
             .MustHaveHappened(1, Times.Exactly);
 
-        var jobDetailsForUnknownJob = TestData.JobDetail.GetJobBuilder()
-            .OfType("Quartz.Tests.AspNetCore.Support.DummyJob2, Quartz.Tests.AspNetCore")
+        // A job type the server cannot resolve is not rejected at request time - the server never resolves
+        // a name that arrived with the request.
+        Fake.ClearRecordedCalls(FakeScheduler);
+        IJobDetail jobDetailWithUnresolvableType = TestData.JobDetail.GetJobBuilder()
+            .OfType(TestData.UnresolvableJobTypeName)
             .Build();
 
-        Assert.ThrowsAsync<HttpClientException>(() => HttpScheduler.ScheduleJob(jobDetailsForUnknownJob, [TestData.CronTrigger, TestData.SimpleTrigger], replace: true).AsTask())!
-            .Message.Should().ContainEquivalentOf("unknown job type");
+        Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> requestWithUnresolvableType = new() { { jobDetailWithUnresolvableType, [TestData.CronTrigger] } };
+        await HttpScheduler.ScheduleJobs(requestWithUnresolvableType, replace: true);
 
-        var request = new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> { { jobDetailsForUnknownJob, [TestData.CronTrigger] } };
-        Assert.ThrowsAsync<HttpClientException>(() => HttpScheduler.ScheduleJobs(request, replace: true).AsTask())!.Message.Should().ContainEquivalentOf("unknown job type");
+        A.CallTo(() => FakeScheduler.ScheduleJobs(A<IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<ITrigger>>>._, A<bool>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<ITrigger>> triggersAndJobs, bool replace, CancellationToken _) =>
+            {
+                triggersAndJobs.Single().Key.JobType.FullName.Should().Be(TestData.UnresolvableJobTypeName);
+                return true;
+            })
+            .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public void ScheduleJobsShouldRejectMalformedJobType()
+    {
+        // Shape is still checked, it is only resolution that is not done. An empty name has no shape.
+        IJobDetail jobDetailWithEmptyType = TestData.JobDetail.GetJobBuilder()
+            .OfType(" ")
+            .Build();
+
+        Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> request = new() { { jobDetailWithEmptyType, [TestData.CronTrigger] } };
+        Assert.ThrowsAsync<HttpClientException>(() => HttpScheduler.ScheduleJobs(request, replace: true).AsTask())!
+            .Message.Should().ContainEquivalentOf("malformed job type");
+
+        A.CallTo(() => FakeScheduler.ScheduleJobs(A<IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<ITrigger>>>._, A<bool>._, A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/Support/TestData.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestData.cs
@@ -11,6 +11,12 @@ public static class TestData
     public const string SchedulerName = "TestScheduler";
     public const string SchedulerInstanceId = "TEST_NON_CLUSTERED";
 
+    /// <summary>
+    /// A job type name that nothing in the test process resolves. The API carries job types as names, so
+    /// a request naming this one is accepted and only fails when something has to run the job.
+    /// </summary>
+    public const string UnresolvableJobTypeName = "Quartz.Tests.AspNetCore.Support.DummyJob2, Quartz.Tests.AspNetCore";
+
     public static readonly SchedulerMetadata Metadata;
 
     public static readonly BaseCalendar BaseCalendar;

--- a/src/Quartz.Tests.Unit/HttpApi/JobDetailDtoTest.cs
+++ b/src/Quartz.Tests.Unit/HttpApi/JobDetailDtoTest.cs
@@ -1,0 +1,116 @@
+using Quartz.HttpApiContract;
+
+namespace Quartz.Tests.Unit.HttpApi;
+
+/// <summary>
+/// The HTTP contract carries a job type as a name, and never resolves one that arrived over the wire.
+/// </summary>
+public class JobDetailDtoTest
+{
+    private const string UnresolvableJobTypeName = "Quartz.Tests.Unit.HttpApi.NoSuchJob, No.Such.Assembly";
+
+    [Test]
+    public void UnresolvableJobTypeNameIsGenuinelyUnresolvable()
+    {
+        // Everything below is vacuous if this name happens to resolve.
+        Type.GetType(UnresolvableJobTypeName, throwOnError: false).Should().BeNull();
+    }
+
+    [Test]
+    public void ValidateShouldAcceptJobTypeNameThatDoesNotResolve()
+    {
+        JobDetailDto dto = CreateDto(UnresolvableJobTypeName);
+
+        dto.Validate().Should().BeEmpty("a job type name is validated for shape only, never by resolving it");
+    }
+
+    [Test]
+    public void AsIJobDetailShouldKeepJobTypeNameThatDoesNotResolve()
+    {
+        JobDetailDto dto = CreateDto(UnresolvableJobTypeName);
+
+        (IJobDetail jobDetail, string errorReason) = dto.AsIJobDetail();
+
+        errorReason.Should().BeNull();
+        jobDetail.Should().NotBeNull();
+        jobDetail.JobType.FullName.Should().Be(UnresolvableJobTypeName,
+            "the name has to survive for a reader that does not have the job's assembly, such as a dashboard");
+        jobDetail.Key.Should().Be(new JobKey("job-name", "job-group"));
+        jobDetail.Description.Should().Be("job description");
+        jobDetail.Durable.Should().BeTrue();
+        jobDetail.RequestsRecovery.Should().BeTrue();
+        jobDetail.ConcurrentExecutionDisallowed.Should().BeTrue();
+        jobDetail.PersistJobDataAfterExecution.Should().BeTrue();
+        jobDetail.JobDataMap.Should().ContainKey("key").WhoseValue.Should().Be("value");
+    }
+
+    [Test]
+    public void JobDetailShouldRoundTripThroughDtoWithoutResolvingJobType()
+    {
+        JobDetailDto dto = CreateDto(UnresolvableJobTypeName);
+
+        (IJobDetail jobDetail, string _) = dto.AsIJobDetail();
+        JobDetailDto roundTripped = JobDetailDto.Create(jobDetail);
+
+        roundTripped.Should().Be(dto);
+    }
+
+    [Test]
+    public void AsIJobDetailShouldNotTouchTheJobTypeOfADetailItBuilt()
+    {
+        // Reading these must not force the name to resolve: they were carried explicitly for exactly that
+        // reason, and deducing them from the type would defeat the point.
+        JobDetailDto dto = CreateDto(UnresolvableJobTypeName) with { ConcurrentExecutionDisallowed = false, PersistJobDataAfterExecution = false };
+
+        (IJobDetail jobDetail, string _) = dto.AsIJobDetail();
+
+        jobDetail.ConcurrentExecutionDisallowed.Should().BeFalse();
+        jobDetail.PersistJobDataAfterExecution.Should().BeFalse();
+    }
+
+    [TestCase(null, "Job detail is missing job type")]
+    [TestCase("", "Job detail has malformed job type")]
+    [TestCase("   ", "Job detail has malformed job type")]
+    [TestCase(", Some.Assembly", "Job detail has malformed job type")]
+    [TestCase("Some.Job\r\n, Some.Assembly", "Job detail has malformed job type")]
+    public void ValidateShouldRejectMalformedJobTypeName(string jobTypeName, string expectedMessage)
+    {
+        JobDetailDto dto = CreateDto(jobTypeName);
+
+        dto.Validate().Should().ContainSingle().Which.Should().StartWith(expectedMessage);
+    }
+
+    [Test]
+    public void ValidateShouldRejectAnAbsurdlyLongJobTypeName()
+    {
+        JobDetailDto dto = CreateDto(new string('a', 1025));
+
+        dto.Validate().Should().ContainSingle().Which.Should().StartWith("Job detail has malformed job type");
+    }
+
+    [Test]
+    public void AsIJobDetailShouldRefuseMalformedJobTypeName()
+    {
+        JobDetailDto dto = CreateDto("   ");
+
+        (IJobDetail jobDetail, string errorReason) = dto.AsIJobDetail();
+
+        jobDetail.Should().BeNull();
+        errorReason.Should().Be("Missing or malformed job type");
+    }
+
+    private static JobDetailDto CreateDto(string jobTypeName)
+    {
+        return new JobDetailDto(
+            Name: "job-name",
+            Group: "job-group",
+            JobType: jobTypeName,
+            Description: "job description",
+            Durable: true,
+            RequestsRecovery: true,
+            ConcurrentExecutionDisallowed: true,
+            PersistJobDataAfterExecution: true,
+            JobDataMap: new JobDataMap { { "key", "value" } }
+        );
+    }
+}


### PR DESCRIPTION
The HTTP API contract resolved CLR types from strings that arrived over the wire. `JobDetailDto.Validate()` ran `Type.GetType` on the request body's job type name and `AsIJobDetail()` materialized the resolved `Type` — and since these contract types are shared with the server, an add-job or schedule-job request let any caller have the scheduler host walk its assembly-probing paths for whatever name they liked and read the answer off the response: a type-disclosure side channel that does real work per request. The dashboard's in-process client had the identical primitive in `BuildJobDetail`. Eager resolution also broke legitimate readers — an ops process without the job assembly loaded got failures where it only wanted to display a name.

The fix keeps type names as names: validation checks shape only (non-empty, bounded length, no leading assembly separator, no control characters), and the detail is built via `OfType(string)`, which stores the name unresolved — the side the job actually runs on resolves it through the type-load path (which, after #3258, includes the legacy-name fallback). Behavioral note: a bogus type name is now rejected at scheduling/first-fire on the scheduler side rather than at request time.

Two related sites were found and deliberately left for their scheduled 4.0 work rather than smuggled into a security fix: `HttpScheduler.GetMetadata` resolving server-supplied type names client-side (fixed properly by the planned `SchedulerMetadata` change from `Type` members to type-name strings), and `JobDetailImpl.GetJobBuilder()` resolving through `JobType`'s implicit conversion (covered by the planned JobType operator work).

Tests: endpoint tests now assert an unresolvable-but-well-formed name flows through verbatim and that malformed names get a 400 without reaching the scheduler; a new DTO test suite covers round-tripping, non-resolution, and the malformed-name matrix. No public API change; all `PublicApiTest_*` baselines untouched. `build.cmd Compile` clean; unit suite 2159 passed, AspNetCore suite 210 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)