### PR TITLE
Fix four small defects: JSON failure surfacing, preferred-node updates, log hygiene, license headers

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1197,6 +1197,27 @@ q.UseNewtonsoftJsonSerializer();
 
 Remove the old `Quartz.Serialization.Json` package reference.
 
+### Deserialization failures surface as `Quartz.JsonSerializationException`
+
+| 3.x | 4.x |
+|---|---|
+| `IObjectSerializer.DeSerialize` could let `Newtonsoft.Json.JsonSerializationException` and `Newtonsoft.Json.JsonReaderException` escape | Every deserialization failure arrives as `Quartz.JsonSerializationException` — a `SchedulerException` — from **both** serializers, with the payload in the message and the underlying parse failure as `InnerException` |
+
+`Quartz.JsonSerializationException` shadows Newtonsoft's type of the same name inside the
+`Quartz.Serialization.Newtonsoft` package, because every file in it sits under the `Quartz`
+namespace and the enclosing namespace wins over a `using`. The wrapping `catch` therefore never
+matched Newtonsoft's parse failures and they escaped raw. Code that catches
+`Newtonsoft.Json.JsonSerializationException` around `IObjectSerializer.Deserialize` — or around any
+job store read that goes through it — has to catch `Quartz.JsonSerializationException` instead:
+
+```csharp
+// 3.x
+catch (Newtonsoft.Json.JsonSerializationException e)
+
+// 4.x — the same failure, whichever serializer is configured
+catch (Quartz.JsonSerializationException e)
+```
+
 ### Custom trigger and calendar serializers are no longer static
 
 The static registration methods have been removed, because they wrote into process-global dictionaries: two

--- a/src/Quartz.HttpClient/AssemblyInfoExtras.cs
+++ b/src/Quartz.HttpClient/AssemblyInfoExtras.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Quartz.AspNetCore, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b50e2d982a20034afa89fe27c0e690110ca65b8f758bb1b7c8ddac1b5a23426ee206ec904e60679567b8faf329df6671793c8178daca1d2db7e71ee1695b7eeb570c030de77392a86ccc533ce38e892ee97b826ed5bb5d789216d900fc941975688a7709fc967d1cafd39a6952c666ea706e68f7db3f2e43c4991fc148b54b7")]

--- a/src/Quartz.HttpClient/HttpApiContract/CurrentlyExecutingJobDto.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/CurrentlyExecutingJobDto.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using Quartz.Impl;
 using Quartz.Extensibility;
 

--- a/src/Quartz.HttpClient/HttpApiContract/Dtos.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/Dtos.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 // ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract - Can be null when received from Web API
 
 namespace Quartz.HttpApiContract;

--- a/src/Quartz.HttpClient/HttpApiContract/HttpApiConstants.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/HttpApiConstants.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 namespace Quartz.HttpApiContract;
 
 internal static class HttpApiConstants

--- a/src/Quartz.HttpClient/HttpApiContract/IValidatable.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/IValidatable.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 namespace Quartz.HttpApiContract;
 
 internal interface IValidatable

--- a/src/Quartz.HttpClient/HttpApiContract/JobDetailDto.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/JobDetailDto.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 // ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract - Can be null when received from Web API
 // ReSharper disable NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
 

--- a/src/Quartz.HttpClient/HttpApiContract/QueryDtos.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/QueryDtos.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 // ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract - Can be null when received from Web API
 
 namespace Quartz.HttpApiContract;

--- a/src/Quartz.HttpClient/HttpApiContract/RequestAndResponses.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/RequestAndResponses.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 // ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract - Can be null when received from Web API
 // ReSharper disable NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
 

--- a/src/Quartz.HttpClient/HttpApiContract/SchedulerDto.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/SchedulerDto.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using Quartz.Util;
 
 namespace Quartz.HttpApiContract;

--- a/src/Quartz.HttpClient/HttpApiContract/SchedulerHeaderDto.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/SchedulerHeaderDto.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 namespace Quartz.HttpApiContract;
 
 internal record SchedulerHeaderDto(string Name, string SchedulerInstanceId, SchedulerStatus Status)

--- a/src/Quartz.HttpClient/HttpApiContract/SchedulerStatus.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/SchedulerStatus.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 namespace Quartz.HttpApiContract;
 
 internal enum SchedulerStatus

--- a/src/Quartz.HttpClient/HttpClient/Extensions.cs
+++ b/src/Quartz.HttpClient/HttpClient/Extensions.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using Quartz.Matchers;
 using Quartz.Util;
 

--- a/src/Quartz.HttpClient/HttpClient/HttpClientException.cs
+++ b/src/Quartz.HttpClient/HttpClient/HttpClientException.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 namespace Quartz.HttpClient;
 
 public sealed class HttpClientException : SchedulerException

--- a/src/Quartz.HttpClient/HttpClient/HttpClientExtensions.cs
+++ b/src/Quartz.HttpClient/HttpClient/HttpClientExtensions.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;

--- a/src/Quartz.HttpClient/HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpClient/HttpScheduler.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using System.Text.Json;
 
 using Quartz.HttpApiContract;

--- a/src/Quartz.HttpClient/HttpClient/QueryStringBuilder.cs
+++ b/src/Quartz.HttpClient/HttpClient/QueryStringBuilder.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using System.Globalization;
 
 using Quartz.Matchers;

--- a/src/Quartz.HttpClient/HttpClientOptions.cs
+++ b/src/Quartz.HttpClient/HttpClientOptions.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using System.Text.Json;
 
 namespace Quartz;

--- a/src/Quartz.HttpClient/Impl/SchedulerTypeBuilder.cs
+++ b/src/Quartz.HttpClient/Impl/SchedulerTypeBuilder.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;

--- a/src/Quartz.HttpClient/IsExternalInit.cs
+++ b/src/Quartz.HttpClient/IsExternalInit.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 namespace System.Runtime.CompilerServices;
 
 internal static class IsExternalInit

--- a/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
+++ b/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
@@ -1,3 +1,24 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using System.Text.Json;
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
@@ -73,7 +73,10 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
         }
         catch (Exception e)
         {
-            throw new JsonSerializationException("Failed to serialize ITrigger to json", e);
+            // Quartz's exception, deliberately - the qualification is what keeps the choice visible,
+            // because this namespace is nested inside Quartz and the unqualified name would bind here
+            // whether or not anyone meant it to.
+            throw new Quartz.JsonSerializationException("Failed to serialize ITrigger to json", e);
         }
     }
 
@@ -147,7 +150,8 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
         }
         catch (Exception e)
         {
-            throw new JsonSerializationException("Failed to parse ITrigger from json", e);
+            // Quartz's exception, deliberately - see the note on the serialize side above.
+            throw new Quartz.JsonSerializationException("Failed to parse ITrigger from json", e);
         }
     }
 

--- a/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
@@ -136,10 +136,20 @@ public class NewtonsoftJsonObjectSerializer : IObjectSerializer
             using StreamReader sr = new(ms);
             return (T?) Serializer.Deserialize(sr, typeof(T));
         }
-        catch (JsonSerializationException e)
+        // Every name below is qualified on purpose. This file lives in Quartz.Impl, so an unqualified
+        // JsonSerializationException binds to Quartz's type - the enclosing namespace beats the
+        // "using Newtonsoft.Json" above it - and Newtonsoft's parse failures would sail straight past
+        // a catch that only looked like it named them.
+        catch (Exception e) when (e is Newtonsoft.Json.JsonSerializationException
+                                      or Newtonsoft.Json.JsonReaderException
+                                      or Quartz.JsonSerializationException)
         {
             string json = Encoding.UTF8.GetString(data);
-            throw new JsonSerializationException($"Could not deserialize JSON: {json}", e);
+
+            // Quartz's type, not Newtonsoft's: this is the exception callers catch, the HTTP API's
+            // exception handler maps and the dashboard special-cases, and it must not differ between
+            // the two serializers.
+            throw new Quartz.JsonSerializationException($"Could not deserialize JSON: {json}", e);
         }
     }
 }

--- a/src/Quartz.Serialization.Newtonsoft/Util/SerializationExtensions.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Util/SerializationExtensions.cs
@@ -174,7 +174,9 @@ internal static class Utf8JsonWriterExtensions
         string[] parts = value.Split(':');
         if (parts.Length < 2 || parts.Length > 4)
         {
-            throw new JsonSerializationException($"Invalid time string '{value}'");
+            // Quartz's exception, deliberately - this file is in Quartz.Util, so the unqualified name
+            // would bind to Quartz's type regardless of the "using Newtonsoft.Json" above.
+            throw new Quartz.JsonSerializationException($"Invalid time string '{value}'");
         }
 
         int hour = int.Parse(parts[0], CultureInfo.InvariantCulture);

--- a/src/Quartz.Tests.Unit/Simpl/JsonDeserializationFailureTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonDeserializationFailureTest.cs
@@ -1,0 +1,167 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Text;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.Calendar;
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// A job store blob that cannot be read has to fail the same way whichever serializer is reading
+/// it: as <see cref="Quartz.JsonSerializationException" />, carrying the payload that could not be
+/// read and the underlying parse failure. That is the exception callers catch, the HTTP API's
+/// exception handler maps, and the dashboard special-cases.
+/// </summary>
+[TestFixture(typeof(NewtonsoftJsonObjectSerializer))]
+[TestFixture(typeof(SystemTextJsonObjectSerializer))]
+public class JsonDeserializationFailureTest
+{
+    private readonly IObjectSerializer serializer;
+
+    public JsonDeserializationFailureTest(Type serializerType)
+    {
+        serializer = (IObjectSerializer) Activator.CreateInstance(serializerType)!;
+
+        if (serializer is NewtonsoftJsonObjectSerializer newtonsoft)
+        {
+            // Newtonsoft only understands the trigger wire format when its converter is registered.
+            newtonsoft.RegisterTriggerConverters = true;
+        }
+    }
+
+    /// <summary>
+    /// Valid up to the point it stops - the shape a truncated write leaves behind.
+    /// </summary>
+    private const string TruncatedCalendar =
+        """{"$type": "Quartz.Impl.Calendar.AnnualCalendar, Quartz", "Description": "Test AnnualCalendar""";
+
+    /// <summary>
+    /// Parses perfectly and means nothing - the shape a blob written by something else has.
+    /// </summary>
+    private const string WellFormedButNotATrigger =
+        """{"totally": "valid json", "just": ["not", "a", "trigger"]}""";
+
+    [Test]
+    public void SyntacticallyBrokenPayloadFailsAsQuartzJsonSerializationException()
+    {
+        Action act = () => serializer.Deserialize<AnnualCalendar>(Encoding.UTF8.GetBytes(TruncatedCalendar));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>(
+                "a parse failure must not escape as the underlying library's own exception type")
+            .Which;
+
+        thrown.Should().BeAssignableTo<SchedulerException>();
+        thrown.Message.Should().Contain(TruncatedCalendar, "the payload that could not be read is the whole diagnostic");
+        thrown.InnerException.Should().NotBeNull("the underlying parse failure is what says where the payload broke");
+    }
+
+    [Test]
+    public void PayloadThatIsNotJsonAtAllFailsAsQuartzJsonSerializationException()
+    {
+        const string NotJson = "this is not json";
+
+        Action act = () => serializer.Deserialize<AnnualCalendar>(Encoding.UTF8.GetBytes(NotJson));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>(
+                "a payload rejected on its very first token never reaches a converter, and must still fail the same way")
+            .Which;
+
+        thrown.Message.Should().Contain(NotJson);
+        thrown.InnerException.Should().NotBeNull();
+    }
+
+    [Test]
+    public void WellFormedButWrongShapePayloadFailsAsQuartzJsonSerializationException()
+    {
+        Action act = () => serializer.Deserialize<IOperableTrigger>(Encoding.UTF8.GetBytes(WellFormedButNotATrigger));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>().Which;
+
+        thrown.Should().BeAssignableTo<SchedulerException>();
+        thrown.Message.Should().Contain(WellFormedButNotATrigger);
+        thrown.InnerException.Should().NotBeNull();
+    }
+}
+
+/// <summary>
+/// <c>Quartz.JsonSerializationException</c> shadows <c>Newtonsoft.Json.JsonSerializationException</c>
+/// throughout this package - every file in it sits under the <c>Quartz</c> namespace, and the
+/// enclosing namespace beats a <c>using</c> - so an unqualified <c>catch</c> that reads as if it
+/// caught Newtonsoft's parse failures caught nothing of the sort, and they escaped raw.
+/// </summary>
+public class NewtonsoftJsonDeserializationFailureTest
+{
+    [Test]
+    public void ReaderFailureIsWrappedRatherThanEscapingAsNewtonsoftsOwnException()
+    {
+        NewtonsoftJsonObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+
+        // The calendar converter has no catch of its own, so Newtonsoft's reader exception travels
+        // all the way out to the serializer - the exact path the shadowed catch used to miss.
+        const string Truncated = """{"$type": "Quartz.Impl.Calendar.AnnualCalendar, Quartz", "Description": "x""";
+
+        Action act = () => serializer.Deserialize<AnnualCalendar>(Encoding.UTF8.GetBytes(Truncated));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>().Which;
+
+        thrown.Message.Should().Contain(Truncated);
+        thrown.InnerException.Should().BeOfType<global::Newtonsoft.Json.JsonReaderException>();
+    }
+
+    [Test]
+    public void NewtonsoftSerializationFailureIsWrappedRatherThanEscaping()
+    {
+        // No trigger converter registered, so Newtonsoft's own contract handling reads the payload
+        // and rejects the array with its JsonSerializationException.
+        NewtonsoftJsonObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+
+        const string Array = "[1, 2, 3]";
+
+        Action act = () => serializer.Deserialize<SimpleTriggerImpl>(Encoding.UTF8.GetBytes(Array));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>().Which;
+
+        thrown.Message.Should().Contain(Array);
+        thrown.InnerException.Should().BeOfType<global::Newtonsoft.Json.JsonSerializationException>();
+    }
+
+    [Test]
+    public void ConverterFailureStillSurfacesAsQuartzsExceptionWithThePayload()
+    {
+        // The trigger converter already throws Quartz's exception; wrapping it is what attaches the
+        // payload, and that has to keep working now that the catch names three types instead of one.
+        NewtonsoftJsonObjectSerializer serializer = new NewtonsoftJsonObjectSerializer { RegisterTriggerConverters = true };
+
+        const string NotATrigger = """{"totally": "valid json"}""";
+
+        Action act = () => serializer.Deserialize<IOperableTrigger>(Encoding.UTF8.GetBytes(NotATrigger));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>().Which;
+
+        thrown.Message.Should().Contain(NotATrigger);
+        thrown.InnerException.Should().BeOfType<Quartz.JsonSerializationException>()
+            .Which.Message.Should().Be("Failed to parse ITrigger from json");
+    }
+}

--- a/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
+++ b/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
@@ -231,6 +231,77 @@ public class UpdateTriggerDetailsTest
     }
 
     [Test]
+    public async Task PreferredNode_UpdatedOnItsOwn()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
+
+        bool result = await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithPreferredNode(PreferredNode.For("nodeB")));
+
+        result.Should().BeTrue();
+        IOperableTrigger retrieved = (await jobStore.GetTrigger(trigger.Key))!;
+        retrieved.PreferredNode.Should().Be(
+            PreferredNode.For("nodeB"),
+            "an update carrying only a pin must still apply it - reporting success while storing nothing is the worst of both");
+        retrieved.NextFireTimeUtc.Should().Be(nextFireBefore);
+    }
+
+    [Test]
+    public async Task PreferredNode_None_ClearsExistingPin()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.PreferredNode = PreferredNode.For("nodeA");
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        (await jobStore.GetTrigger(trigger.Key))!.PreferredNode.Should().Be(PreferredNode.For("nodeA"));
+
+        bool result = await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithPreferredNode(PreferredNode.None));
+
+        result.Should().BeTrue();
+        (await jobStore.GetTrigger(trigger.Key))!.PreferredNode.Should().Be(PreferredNode.None);
+    }
+
+    [Test]
+    public async Task PreferredNode_AutoPinSurvivesAsAutomatic()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithPreferredNode(PreferredNode.Auto));
+
+        PreferredNode retrieved = (await jobStore.GetTrigger(trigger.Key))!.PreferredNode;
+        retrieved.Should().Be(PreferredNode.Auto);
+        retrieved.IsAutomatic.Should().BeTrue("an auto pin that hardened into a named one would never be released again");
+    }
+
+    [Test]
+    public async Task PreferredNode_UpdatedAlongsideOtherProperties()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        TriggerDetailsUpdate update = new TriggerDetailsUpdate()
+            .WithDescription("pinned")
+            .WithPreferredNode(PreferredNode.For("nodeB"));
+
+        (await jobStore.UpdateTriggerDetails(trigger.Key, update)).Should().BeTrue();
+
+        IOperableTrigger retrieved = (await jobStore.GetTrigger(trigger.Key))!;
+        retrieved.Description.Should().Be("pinned");
+        retrieved.PreferredNode.Should().Be(PreferredNode.For("nodeB"));
+    }
+
+    [Test]
     public async Task SchedulerLevel_UpdateTriggerDetails()
     {
         NameValueCollection config = new NameValueCollection

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -1078,7 +1078,10 @@ public abstract class JobStoreSupport : IJobStore
         }
         else
         {
-            Logger.LogInformation(
+            // A healthy scheduler takes this branch on every misfire scan, forever, so it is Debug -
+            // "nothing happened" is not news. The branches above, where something did misfire, stay
+            // at Information.
+            Logger.LogDebug(
                 "Found 0 triggers that missed their scheduled fire-time.");
             return RecoverMisfiredJobsResult.NoOp;
         }

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -654,7 +654,7 @@ public sealed class RAMJobStore : IJobStore
             }
 
             if (!update.HasDescription && !update.HasPriority && !update.HasJobDataMap
-                && !update.HasCalendarName && !update.HasMisfireInstruction)
+                && !update.HasCalendarName && !update.HasMisfireInstruction && !update.HasPreferredNode)
             {
                 return true;
             }
@@ -702,6 +702,13 @@ public sealed class RAMJobStore : IJobStore
             if (update.HasMisfireInstruction)
             {
                 trigger.MisfireInstruction = update.MisfireInstruction;
+            }
+
+            if (update.HasPreferredNode)
+            {
+                // The stored instance is the one mutated here - reads hand out clones of it - so the
+                // new pin is what every later reader sees, exactly as the ADO.NET store's update does.
+                trigger.PreferredNode = update.PreferredNode;
             }
 
             return true;

--- a/src/Quartz/Impl/SystemTextJsonObjectSerializer.cs
+++ b/src/Quartz/Impl/SystemTextJsonObjectSerializer.cs
@@ -84,10 +84,13 @@ public class SystemTextJsonObjectSerializer : IObjectSerializer
         {
             return JsonSerializer.Deserialize<T?>(data, Options);
         }
-        catch (JsonSerializationException e)
+        // Quartz's exception comes from Quartz's own converters; System.Text.Json's comes from the
+        // reader, which rejects a payload whose very first token is malformed before any converter is
+        // reached. Both are the same failure to a caller, and both have to arrive as Quartz's type.
+        catch (Exception e) when (e is Quartz.JsonSerializationException or System.Text.Json.JsonException)
         {
             string json = Encoding.UTF8.GetString(data);
-            throw new JsonSerializationException($"Could not deserialize JSON: {json}", e);
+            throw new Quartz.JsonSerializationException($"Could not deserialize JSON: {json}", e);
         }
     }
 }


### PR DESCRIPTION
Four independent fixes, one commit each:

**JSON deserialization failures surface as `Quartz.JsonSerializationException` — from both serializers.** Inside the Newtonsoft package an unqualified `JsonSerializationException` binds to Quartz's type (enclosing-namespace lookup beats the `using`), so the catch in `NewtonsoftJsonObjectSerializer.Deserialize` never caught a Newtonsoft parse failure — a truncated blob escaped as a raw Newtonsoft exception with no payload text, invisible to the HTTP exception handler and the dashboard. The catch now names `Newtonsoft.Json.JsonSerializationException`, `JsonReaderException` and Quartz's own type (so converter failures keep their payload-carrying wrap), rethrowing as `Quartz.JsonSerializationException`. Probing the claimed symmetry found the mirror-image hole in `SystemTextJsonObjectSerializer`: a payload malformed at its first token is rejected by the reader before any converter runs and that `System.Text.Json.JsonException` escaped raw — same two-line treatment. A shared test fixture pins both serializers to the same contract, and the migration guide documents the exception type for 3.x code that caught Newtonsoft's.

**`RAMJobStore.UpdateTriggerDetails` now applies `WithPreferredNode`.** The guard omitted `HasPreferredNode` and no apply branch existed, so a preferred-node-only update returned true and did nothing — while the ADO store honors it. The stores now agree; tests cover pin, unpin, auto-pin survival, and combined updates (verified to fail without the fix).

**Empty misfire scans log at Debug.** A healthy scheduler logged "Found 0 triggers that missed their scheduled fire-time" at Information on every scan, forever. The non-zero branches stay at Information.

**`Quartz.HttpClient` gains its missing Apache license headers** — none of the project's 20 source files carried one (all other shipping projects do); pure prepends, verified byte-for-byte.

No public API change; all `PublicApiTest_*` baselines untouched. `build.cmd Compile` clean; `Quartz.Tests.Unit` 2160 passed / 0 failed; `Quartz.Tests.AspNetCore` 207 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)