### PR TITLE
Make the trigger family interfaces read models and the misfire vocabulary family-typed

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3279,74 +3279,88 @@ read back identically, and the JSON trigger payloads never carried the pin.
 Each schedule builder had one no-argument method per misfire policy — eighteen of them across five builders,
 with a slightly different vocabulary each. A method name is a poor place to keep a value: it cannot be read
 from configuration, cannot be switched on, and cannot be defaulted. Every builder now has one
-`WithMisfireHandlingInstruction` taking its family's enum.
+`WithMisfireInstruction` taking its family's enum.
 
 ```diff
   .WithSimpleSchedule(x => x
       .WithInterval(TimeSpan.FromMinutes(5))
       .RepeatForever()
 -     .WithMisfireHandlingInstructionNextWithExistingCount())
-+     .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount))
++     .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount))
 ```
+
+Earlier 4.0 previews spelled that method `WithMisfireHandlingInstruction`. It is `WithMisfireInstruction` now,
+on all five builders, matching `TriggerDetailsUpdate.WithMisfireInstruction` and the XML element name.
 
 ### SimpleScheduleBuilder
 
 | 3.x | 4.x |
 |---|---|
-| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires)` |
-| `WithMisfireHandlingInstructionFireNow()` | `WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.FireNow)` |
-| `WithMisfireHandlingInstructionNowWithExistingCount()` | `WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NowWithExistingCount)` |
-| `WithMisfireHandlingInstructionNowWithRemainingCount()` | `WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NowWithRemainingCount)` |
-| `WithMisfireHandlingInstructionNextWithRemainingCount()` | `WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount)` |
-| `WithMisfireHandlingInstructionNextWithExistingCount()` | `WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount)` |
-| (call nothing) | `WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.SmartPolicy)`, still the default |
+| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires)` |
+| `WithMisfireHandlingInstructionFireNow()` | `WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow)` |
+| `WithMisfireHandlingInstructionNowWithExistingCount()` | `WithMisfireInstruction(SimpleTriggerMisfireInstruction.NowWithExistingCount)` |
+| `WithMisfireHandlingInstructionNowWithRemainingCount()` | `WithMisfireInstruction(SimpleTriggerMisfireInstruction.NowWithRemainingCount)` |
+| `WithMisfireHandlingInstructionNextWithRemainingCount()` | `WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount)` |
+| `WithMisfireHandlingInstructionNextWithExistingCount()` | `WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount)` |
+| (call nothing) | `WithMisfireInstruction(SimpleTriggerMisfireInstruction.SmartPolicy)`, still the default |
 
 ### CronScheduleBuilder
 
 | 3.x | 4.x |
 |---|---|
-| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireHandlingInstruction(CronTriggerMisfireInstruction.IgnoreMisfires)` |
-| `WithMisfireHandlingInstructionFireAndProceed()` | `WithMisfireHandlingInstruction(CronTriggerMisfireInstruction.FireAndProceed)` |
-| `WithMisfireHandlingInstructionDoNothing()` | `WithMisfireHandlingInstruction(CronTriggerMisfireInstruction.DoNothing)` |
+| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireInstruction(CronTriggerMisfireInstruction.IgnoreMisfires)` |
+| `WithMisfireHandlingInstructionFireAndProceed()` | `WithMisfireInstruction(CronTriggerMisfireInstruction.FireAndProceed)` |
+| `WithMisfireHandlingInstructionDoNothing()` | `WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing)` |
 
 ### CalendarIntervalScheduleBuilder
 
 | 3.x | 4.x |
 |---|---|
-| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireHandlingInstruction(CalendarIntervalTriggerMisfireInstruction.IgnoreMisfires)` |
-| `WithMisfireHandlingInstructionFireAndProceed()` | `WithMisfireHandlingInstruction(CalendarIntervalTriggerMisfireInstruction.FireAndProceed)` |
-| `WithMisfireHandlingInstructionDoNothing()` | `WithMisfireHandlingInstruction(CalendarIntervalTriggerMisfireInstruction.DoNothing)` |
+| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction.IgnoreMisfires)` |
+| `WithMisfireHandlingInstructionFireAndProceed()` | `WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction.FireAndProceed)` |
+| `WithMisfireHandlingInstructionDoNothing()` | `WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction.DoNothing)` |
 
 ### DailyTimeIntervalScheduleBuilder
 
 | 3.x | 4.x |
 |---|---|
-| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireHandlingInstruction(DailyTimeIntervalTriggerMisfireInstruction.IgnoreMisfires)` |
-| `WithMisfireHandlingInstructionFireAndProceed()` | `WithMisfireHandlingInstruction(DailyTimeIntervalTriggerMisfireInstruction.FireAndProceed)` |
-| `WithMisfireHandlingInstructionDoNothing()` | `WithMisfireHandlingInstruction(DailyTimeIntervalTriggerMisfireInstruction.DoNothing)` |
+| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireInstruction(DailyTimeIntervalTriggerMisfireInstruction.IgnoreMisfires)` |
+| `WithMisfireHandlingInstructionFireAndProceed()` | `WithMisfireInstruction(DailyTimeIntervalTriggerMisfireInstruction.FireAndProceed)` |
+| `WithMisfireHandlingInstructionDoNothing()` | `WithMisfireInstruction(DailyTimeIntervalTriggerMisfireInstruction.DoNothing)` |
 
 ### RecurrenceScheduleBuilder
 
 | 3.x | 4.x |
 |---|---|
-| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireHandlingInstruction(RecurrenceTriggerMisfireInstruction.IgnoreMisfires)` |
-| `WithMisfireHandlingInstructionFireAndProceed()` | `WithMisfireHandlingInstruction(RecurrenceTriggerMisfireInstruction.FireAndProceed)` |
-| `WithMisfireHandlingInstructionDoNothing()` | `WithMisfireHandlingInstruction(RecurrenceTriggerMisfireInstruction.DoNothing)` |
+| `WithMisfireHandlingInstructionIgnoreMisfires()` | `WithMisfireInstruction(RecurrenceTriggerMisfireInstruction.IgnoreMisfires)` |
+| `WithMisfireHandlingInstructionFireAndProceed()` | `WithMisfireInstruction(RecurrenceTriggerMisfireInstruction.FireAndProceed)` |
+| `WithMisfireHandlingInstructionDoNothing()` | `WithMisfireInstruction(RecurrenceTriggerMisfireInstruction.DoNothing)` |
 
-### The enums and the constants are the same numbers
+### `TriggerDetailsUpdate` takes the same enums
 
-An enum member's underlying value *is* the `MisfireInstruction` constant it replaces, so the two convert
-freely:
+The update object had a single `WithMisfireInstruction(int)`, which let a simple trigger's code be applied to
+a cron trigger: the number is in range for both families and means a different policy in each. It now has one
+overload per family, plus a code form for callers that genuinely have a number and no family — a value read
+off the wire, from configuration, or from a trigger.
+
+| 4.0 preview | 4.x |
+|---|---|
+| `.WithMisfireInstruction(2)` | `.WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing)` |
+| `.WithMisfireInstruction(MisfireInstruction.CronTrigger.DoNothing)` | `.WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing)` |
+| `.WithMisfireInstruction(someInt)` | `.WithMisfireInstructionCode(someInt)` |
+
+The typed overloads are the taught path: the store rejects an update whose family is not the stored trigger's,
+so a cron policy sent to a simple trigger is now an error rather than a silently different policy.
+`WithMisfireInstructionCode` keeps only the range check the trigger itself applies.
+
+### The enums are the vocabulary
+
+An enum member's underlying value *is* the misfire code a trigger stores, so the two convert freely:
 
 ```csharp
 CronTriggerMisfireInstruction policy = (CronTriggerMisfireInstruction) trigger.MisfireInstruction;
-int stored = (int) CronTriggerMisfireInstruction.DoNothing;   // MisfireInstruction.CronTrigger.DoNothing
+int stored = (int) CronTriggerMisfireInstruction.DoNothing;   // 2
 ```
-
-`ITrigger.MisfireInstruction` and `TriggerDetailsUpdate.WithMisfireInstruction(int)` stay `int`, and the
-`MisfireInstruction` static class stays as the storage-level reference. Neither a trigger's own storage nor an
-update object knows which family it belongs to. The enums are the same values offered where the family *is*
-known — on a schedule builder.
 
 ## Intervals are said once per builder
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3064,6 +3064,52 @@ This applies to `SimpleTriggerSerializer`, `CalendarIntervalTriggerSerializer`,
 `Quartz.Serialization.SystemTextJson.Triggers` and `Quartz.Serialization.Newtonsoft.Triggers`. `CronTriggerSerializer`
 is unchanged — it has no fire-count state to restore.
 
+## The trigger family interfaces are read models
+
+The same reasoning removes the rest of the schedule setters from the five family interfaces. Setting one on a
+trigger you got back from the scheduler compiled, ran, and changed nothing: `RAMJobStore.GetTrigger` hands out
+`Trigger.Clone()` and the ADO.NET store materializes a fresh instance per read, so every trigger the scheduler
+gives you is a detached copy.
+
+| 3.x | 4.x |
+|---|---|
+| `int ISimpleTrigger.RepeatCount { get; set; }` | `{ get; }` |
+| `TimeSpan ISimpleTrigger.RepeatInterval { get; set; }` | `{ get; }` |
+| `string? ICronTrigger.CronExpressionString { get; set; }` | `{ get; }` |
+| `TimeZoneInfo ICronTrigger.TimeZone { get; set; }` | `{ get; }` |
+| `IntervalUnit ICalendarIntervalTrigger.RepeatIntervalUnit { get; set; }` | `{ get; }` |
+| `int ICalendarIntervalTrigger.RepeatInterval { get; set; }` | `{ get; }` |
+| `IReadOnlyCollection<DayOfWeek> IDailyTimeIntervalTrigger.DaysOfWeek { get; set; }` | `{ get; }` |
+| `string IRecurrenceTrigger.RecurrenceRule { get; set; }` | `{ get; }` |
+| `TimeZoneInfo IRecurrenceTrigger.TimeZone { get; set; }` | `{ get; }` |
+
+There are two sanctioned ways to change a stored trigger, and both were already public:
+
+```diff
+  ICronTrigger t = (ICronTrigger) await scheduler.GetTrigger(key);
+
+- t.CronExpressionString = "0 0 12 * * ?";                 // compiled, did nothing
++ ITrigger updated = t.GetTriggerBuilder()
++     .WithCronSchedule("0 0 12 * * ?")
++     .Build();
++ await scheduler.RescheduleJob(key, updated);             // reshape the schedule
+
++ await scheduler.UpdateTriggerDetails(key,                // edit metadata in place
++     new TriggerDetailsUpdate().WithDescription("noon"));
+```
+
+Code that owns a concrete `CronTriggerImpl` / `SimpleTriggerImpl` / … is unaffected: `AbstractTrigger` and the
+concrete triggers keep their public setters, and `IMutableTrigger` — the contract job stores and custom
+trigger authors write through — is unchanged.
+
+`ICalendar` deliberately keeps its two setters (`Description`, `CalendarBase`). It is an implementable SPI:
+the built-in calendar serializers assign through the interface while rebuilding a calendar, so they are part
+of its contract in a way the trigger setters never were.
+
+If you author an `ITriggerPersistenceDelegate` of your own, note that `ObjectUtils.SetPropertyValue` falls
+back to writable *interface* properties when the concrete type has none, and that fallback is now narrower.
+No built-in delegate depends on it — all five write only `timesTriggered`, which the concrete triggers expose.
+
 ## Nine `UsingJobData` overloads became one
 
 `JobDataMap`'s indexer takes an `object?`, and every one of the nine primitive `UsingJobData` overloads had

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1375,9 +1375,9 @@ longer sees it — derive from `DbSemaphore` and use `IDbProvider`, or implement
 `RecurrenceTriggerPersistenceDelegate`. All five are `sealed`; write your own against
 `SimplePropertiesTriggerPersistenceDelegateSupport` or `ITriggerPersistenceDelegate`.
 
-**`SchedulerConstants` and `MisfireInstruction` are static classes** rather than structs, and `QuartzOptions`,
-`SchedulingOptions` and `QuartzHostedServiceOptions` are `sealed`. Referring to the constants is unchanged;
-only `new MisfireInstruction()`, which never meant anything, stops compiling.
+**`SchedulerConstants` is a static class** rather than a struct, and `QuartzOptions`, `SchedulingOptions`
+and `QuartzHostedServiceOptions` are `sealed`. **`MisfireInstruction` is internal** — see
+[the enums are the vocabulary](#the-enums-are-the-vocabulary).
 
 **`HttpScheduler` is `sealed`.** It is a wire client — every member turns a call into an HTTP request — so
 deriving from it and overriding half of them produces a scheduler that is partly remote and partly not. Wrap
@@ -3355,12 +3355,55 @@ so a cron policy sent to a simple trigger is now an error rather than a silently
 
 ### The enums are the vocabulary
 
-An enum member's underlying value *is* the misfire code a trigger stores, so the two convert freely:
+A trigger's misfire policy is read from its family interface, typed. The family-agnostic number a trigger
+stores is still on `ITrigger`, renamed so it no longer competes with the typed property for the good name,
+and `IMutableTrigger` still carries the settable one.
 
-```csharp
-CronTriggerMisfireInstruction policy = (CronTriggerMisfireInstruction) trigger.MisfireInstruction;
-int stored = (int) CronTriggerMisfireInstruction.DoNothing;   // 2
+| 3.x | 4.x |
+|---|---|
+| `int ITrigger.MisfireInstruction { get; }` | `int ITrigger.MisfireInstructionCode { get; }` |
+| `int IMutableTrigger.MisfireInstruction { get; set; }` | `int IMutableTrigger.MisfireInstructionCode { get; set; }` |
+| `int AbstractTrigger.MisfireInstruction { get; set; }` | `int AbstractTrigger.MisfireInstructionCode { get; set; }` |
+| `(CronTriggerMisfireInstruction) trigger.MisfireInstruction` | `((ICronTrigger) trigger).MisfireInstruction` |
+| (new) | `SimpleTriggerMisfireInstruction ISimpleTrigger.MisfireInstruction { get; }`, and one per family |
+
+```diff
+- var policy = (CronTriggerMisfireInstruction) trigger.MisfireInstruction;
++ CronTriggerMisfireInstruction policy = ((ICronTrigger) trigger).MisfireInstruction;
+
+  // still there, for code generic over every family - serializers, the wire, logging
+- int stored = trigger.MisfireInstruction;
++ int stored = trigger.MisfireInstructionCode;
 ```
+
+An enum member's underlying value *is* the code, so the two convert freely, and the numbers in
+`QRTZ_TRIGGERS.MISFIRE_INSTR` and in JSON trigger payloads are unchanged.
+
+**The `MisfireInstruction` constant class is internal.** Its members were a third spelling of a vocabulary
+that already had two, and the enums cover all five families where it covered them unevenly. Replace
+`MisfireInstruction.CronTrigger.DoNothing` with `CronTriggerMisfireInstruction.DoNothing`,
+`MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount` with
+`SimpleTriggerMisfireInstruction.NowWithExistingCount`, `MisfireInstruction.IgnoreMisfirePolicy` with the
+family's `IgnoreMisfires`, and `MisfireInstruction.SmartPolicy` with the family's `SmartPolicy`.
+
+### The XML and JSON names are resolved per family
+
+Both scheduling-data readers used to resolve a misfire instruction name by reflecting over the constant class
+and *all* of its nested types at once, so any family's name resolved for any family's trigger. In JSON, which
+has no schema to catch it, a cron trigger configured with `"MisfireInstruction": "RescheduleNowWithExistingRepeatCount"`
+became `DoNothing` — both are 2 — and nothing said so. Explicit per-family maps replace the reflection.
+
+Every name that parses today still parses, and each family additionally accepts its own enum member names, so
+`FireAndProceed` and `NowWithExistingCount` can be written in configuration as well as in code. A name
+belonging to another family is still resolved when the code is legal for this one, but it is logged as a
+warning naming the policy the value actually selects; a name whose code is out of the family's range is
+rejected with a message listing the names that work, where it used to fail later with
+"The misfire instruction code is invalid for this type of trigger".
+
+`XMLSchedulingDataProcessor.ReadMisfireInstructionFromString` was `protected virtual` and is now private: it
+could not tell the families apart, because it was not told which one it was reading. XML itself is unaffected
+either way — `job_scheduling_data_2_0.xsd` restricts `misfire-instruction` per trigger type, so the schema
+rejects a foreign name before the resolver sees it.
 
 ## Intervals are said once per builder
 
@@ -3997,7 +4040,8 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `StdAdoConstants.SqlSelectCountExecutingFiredTriggersOfTrigger` removed | Removed with the method that used it; the per-job `SqlSelectCountExecutingFiredTriggersOfJob` remains — both on what is now an internal type |
 | `StdAdoConstants` and `IAdoUtil` are internal | Statement text is not a contract; the schema names stay public on `AdoConstants`, which is a static class rather than a base class |
 | Trigger persistence delegates are all public and `sealed` | `CronTriggerPersistenceDelegate`, `SimpleTriggerPersistenceDelegate` and `DailyTimeIntervalTriggerPersistenceDelegate` were internal; derive from `SimplePropertiesTriggerPersistenceDelegateSupport` for a delegate of your own |
-| `SchedulerConstants` and `MisfireInstruction` are `static class`es | They were `struct`s holding only `const`s; constant references are unchanged |
+| `SchedulerConstants` is a `static class` | It was a `struct` holding only `const`s; constant references are unchanged |
+| `MisfireInstruction` is internal | The five per-family enums are the vocabulary; every constant has an enum member with the same value |
 | `QuartzOptions`, `SchedulingOptions`, `QuartzHostedServiceOptions` are `sealed` | `QuartzHostedService` itself stays open for `AddQuartzHostedService<T>` |
 | `InternalTriggerState.Executing` removed | It was never assigned or read; RAMJobStore counts executions separately from the state that drives scheduling |
 | `ScheduleBuilder<T>` removed | The five schedule builders implement `IScheduleBuilder` directly — see [`ScheduleBuilder<T>` is gone](#schedulebuilder-t-is-gone) |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1422,6 +1422,11 @@ The following properties have been removed from `AbstractTrigger` as they are re
 | `JobGroup` | `JobKey.Group` |
 | `FullName` | `Key.ToString()` |
 
+`HasMillisecondPrecision` left `ITrigger` and is `protected abstract` on `AbstractTrigger`. It is how a
+trigger describes its own schedule to the base class — which rounds the start time down to the second when it
+is false — and nothing outside the trigger acted on it. A custom trigger changes `public override` to
+`protected override`; to test the behaviour, assert on `StartTimeUtc.Millisecond` instead of on the flag.
+
 ## JobKey and TriggerKey Null Validation
 
 `JobKey` and `TriggerKey` now throw `ArgumentNullException` when you specify `null` for `name` or `group`. Triggers can no longer be constructed with a null group name. If your code was relying on null group names, switch to an explicit group name.
@@ -1698,6 +1703,7 @@ documentation always promised.
 * **`ISchedulerListener.TriggerInError` / `TriggersInError`** — observe a trigger being moved to `TriggerState.Error`, including two ADO store transitions that reached nothing at all before (see [Triggers entering the error state are reported](#triggers-entering-the-error-state-are-reported))
 * **Joining a transaction the application owns** — the ADO job store can take part in a transaction you started, so saving your own data and scheduling the job that acts on it commit together or not at all. Turn it on with `AcceptEnlistedTransactions()` on the persistent store builder, `JobStore:AcceptEnlistedTransactions`, or `quartz.jobStore.acceptEnlistedTransactions`, then hand the store a connection for the duration of a scope with `IScheduler.EnlistTransaction` / `EnlistConnection`. Handing over a connection is the only way to take part: a connection the job store opens for itself is deliberately kept out of any ambient `TransactionScope`, since a second connection in that transaction would require promoting it to a distributed one. See [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction)
 * **Builder methods for three more plugins** — `UseJobHistoryLogging()`, `UseTriggerHistoryLogging()` and `UseShutdownHook()`. Only the structured-logging variants had one, so the classic history plugins and the shutdown hook could previously be reached only through `quartz.plugin.*` property keys
+* **`TriggerDetailsUpdate.WithExecutionGroup`** — move a stored trigger into an execution group, or out of every group, without rescheduling it. `QRTZ_TRIGGERS.EXECUTION_GROUP` was already written by the generic trigger update, and `RAMJobStore` applies it in place the same way it applies a preferred node, so both stores behave alike
 
 ## Job data can name the property
 

--- a/docs/documentation/quartz-4.x/tutorial/crontriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontriggers.md
@@ -150,7 +150,7 @@ When building CronTriggers, you specify the misfire instruction as part of the c
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger3", "group1")
     .WithCronSchedule("0 0/2 8-17 * * ?", x => x
-        .WithMisfireHandlingInstruction(CronTriggerMisfireInstruction.FireAndProceed))
+        .WithMisfireInstruction(CronTriggerMisfireInstruction.FireAndProceed))
     .ForJob("myJob", "group1")
     .Build();
 ```

--- a/docs/documentation/quartz-4.x/tutorial/execution-groups.md
+++ b/docs/documentation/quartz-4.x/tutorial/execution-groups.md
@@ -35,6 +35,22 @@ ITrigger trigger = TriggerBuilder.Create()
 Triggers without an execution group (`null`) use the default behavior. It is expected that all triggers
 for a given job share the same execution group.
 
+A stored trigger can be moved between groups without rescheduling it:
+
+```csharp
+await scheduler.UpdateTriggerDetails(
+    trigger.Key,
+    new TriggerDetailsUpdate().WithExecutionGroup("batch-jobs"));
+
+// pass null to take the trigger out of every group
+await scheduler.UpdateTriggerDetails(
+    trigger.Key,
+    new TriggerDetailsUpdate().WithExecutionGroup(null));
+```
+
+The new group applies from the next acquisition cycle; a job already running keeps counting against the
+group it was acquired under.
+
 The following names are reserved and cannot be used as execution group names:
 - `*` — used for the "other groups" catch-all limit
 - `_` — used as a property-config alias for the default (ungrouped) triggers

--- a/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
@@ -150,7 +150,7 @@ If the 'smart policy' instruction is used (the default), RecurrenceTrigger will 
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger1", "group1")
     .WithRecurrenceSchedule("FREQ=WEEKLY;BYDAY=MO", b => b
-        .WithMisfireHandlingInstruction(RecurrenceTriggerMisfireInstruction.DoNothing))
+        .WithMisfireInstruction(RecurrenceTriggerMisfireInstruction.DoNothing))
     .Build();
 ```
 

--- a/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
@@ -138,13 +138,13 @@ services.AddQuartz(q =>
 ## RecurrenceTrigger Misfire Instructions
 
 RecurrenceTrigger has two trigger-specific misfire instructions (identical semantics to CronTrigger),
-plus the generic `IgnoreMisfirePolicy`:
+plus the generic one every family has. They live on the `RecurrenceTriggerMisfireInstruction` enum:
 
-* `MisfireInstruction.RecurrenceTrigger.FireOnceNow`
-* `MisfireInstruction.RecurrenceTrigger.DoNothing`
-* `MisfireInstruction.IgnoreMisfirePolicy`
+* `RecurrenceTriggerMisfireInstruction.FireAndProceed`
+* `RecurrenceTriggerMisfireInstruction.DoNothing`
+* `RecurrenceTriggerMisfireInstruction.IgnoreMisfires`
 
-If the 'smart policy' instruction is used (the default), RecurrenceTrigger will use `FireOnceNow`.
+If the `SmartPolicy` instruction is used (the default), RecurrenceTrigger will use `FireAndProceed`.
 
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()

--- a/docs/documentation/quartz-4.x/tutorial/simpletriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/simpletriggers.md
@@ -130,6 +130,6 @@ ITrigger trigger = TriggerBuilder.Create()
     .WithSimpleSchedule(x => x
         .WithInterval(TimeSpan.FromMinutes(5))
         .RepeatForever()
-        .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount))
+        .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount))
     .Build();
 ```

--- a/docs/documentation/quartz-4.x/tutorial/simpletriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/simpletriggers.md
@@ -33,13 +33,17 @@ SimpleTrigger instances are built using `TriggerBuilder` (for the trigger's main
 __Build a trigger for a specific moment in time, with no repeats:__
 
 ```csharp
-// trigger builder creates simple trigger by default, actually an ITrigger is returned
-ISimpleTrigger trigger = (ISimpleTrigger) TriggerBuilder.Create()
+// trigger builder creates simple trigger by default
+ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger1", "group1")
     .StartAt(myStartTime) // some Date 
     .ForJob("job1", "group1") // identify job with name, group strings
     .Build();
 ```
+
+The trigger family interfaces (`ISimpleTrigger` and friends) are read models: cast to one to *inspect*
+a trigger's schedule, never to change it. To change a schedule, rebuild the trigger with
+`trigger.GetTriggerBuilder()` and hand it to `IScheduler.RescheduleJob`.
 
 __Build a trigger for a specific moment in time, then repeating every ten seconds ten times:__
 

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -73,7 +73,7 @@ public class JobRunShellBenchmark
             .WithSimpleSchedule(
                 sb => sb.RepeatForever()
                     .WithInterval(repeatInterval)
-                    .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.FireNow))
+                    .WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow))
             .Build();
     }
 

--- a/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
@@ -418,7 +418,7 @@ public class QuartSchedulerBenchmark
         return TriggerBuilder.Create()
             .WithSimpleSchedule(sb => sb.RepeatForever()
                 .WithInterval(repeatInterval)
-                .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.FireNow))
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow))
             .Build();
     }
 

--- a/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
+++ b/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
@@ -379,9 +379,9 @@ public class RAMJobStoreBenchmark
             IOperableTrigger operableTrigger = triggers.First();
             await jobStore.TriggersFired([operableTrigger]);
 
-            if (operableTrigger.MisfireInstruction != MisfireInstruction.IgnoreMisfirePolicy)
+            if (operableTrigger.MisfireInstructionCode != MisfireInstruction.IgnoreMisfirePolicy)
             {
-                throw new Exception($"Expected acquired triggers to have {MisfireInstruction.IgnoreMisfirePolicy} as misfire instruction, but was {operableTrigger.MisfireInstruction} for trigger ${operableTrigger.Key}.");
+                throw new Exception($"Expected acquired triggers to have {MisfireInstruction.IgnoreMisfirePolicy} as misfire instruction, but was {operableTrigger.MisfireInstructionCode} for trigger ${operableTrigger.Key}.");
             }
         }
     }
@@ -454,7 +454,7 @@ public class RAMJobStoreBenchmark
             Key = triggerKey,
             JobKey = job.Key,
             StartTimeUtc = DateTimeOffset.UtcNow,
-            MisfireInstruction = misFirePolicy,
+            MisfireInstructionCode = misFirePolicy,
             RepeatInterval = repeatInterval,
             RepeatCount = SimpleTriggerImpl.RepeatIndefinitely
         };

--- a/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
+++ b/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
@@ -447,7 +447,7 @@ public class RAMJobStoreBenchmark
         TimeSpan repeatInterval,
         int misFirePolicy,
         DateTimeOffset? nextFireTimeUtc = null)
-        where T : class, ISimpleTrigger, IOperableTrigger, new()
+        where T : SimpleTriggerImpl, new()
     {
         var trigger = (IOperableTrigger) new T
         {

--- a/src/Quartz.Benchmark/SchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/SchedulerBenchmark.cs
@@ -588,7 +588,7 @@ public class SchedulerBenchmark
             .WithSimpleSchedule(
                 sb => sb.WithRepeatCount(repeatCount)
                     .WithInterval(repeatInterval)
-                    .WithMisfireHandlingInstruction((SimpleTriggerMisfireInstruction) misfireInstruction))
+                    .WithMisfireInstruction((SimpleTriggerMisfireInstruction) misfireInstruction))
             .Build();
     }
 

--- a/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
+++ b/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
@@ -28,7 +28,7 @@ public class SimpleTriggerImplBenchmark
             null,
             SimpleTriggerImpl.RepeatIndefinitely,
             TimeSpan.FromTicks(1000));
-        _trigger1.MisfireInstruction = MisfireInstruction.SmartPolicy;
+        _trigger1.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
         _trigger1.NextFireTimeUtc = DateTimeOffset.UtcNow;
 
         _trigger1Legacy = new SimpleTriggerImplLegacy("1",
@@ -36,7 +36,7 @@ public class SimpleTriggerImplBenchmark
             null,
             SimpleTriggerImpl.RepeatIndefinitely,
             TimeSpan.FromTicks(1000));
-        _trigger1Legacy.MisfireInstruction = MisfireInstruction.SmartPolicy;
+        _trigger1Legacy.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
         _trigger1Legacy.NextFireTimeUtc = DateTimeOffset.UtcNow;
 
         _trigger2 = new SimpleTriggerImpl("1",
@@ -44,35 +44,35 @@ public class SimpleTriggerImplBenchmark
             DateTimeOffset.MaxValue,
             SimpleTriggerImpl.RepeatIndefinitely,
             TimeSpan.FromTicks(1000));
-        _trigger2.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount;
+        _trigger2.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount;
 
         _trigger2Legacy = new SimpleTriggerImplLegacy("1",
             DateTimeOffset.MinValue,
             DateTimeOffset.MaxValue,
             SimpleTriggerImpl.RepeatIndefinitely,
             TimeSpan.FromTicks(1000));
-        _trigger2Legacy.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount;
+        _trigger2Legacy.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount;
 
         _trigger3 = new SimpleTriggerImpl("1",
             DateTimeOffset.MinValue,
             DateTimeOffset.MaxValue,
             0,
             TimeSpan.FromTicks(1000));
-        _trigger3.MisfireInstruction = MisfireInstruction.SmartPolicy;
+        _trigger3.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
 
         _trigger3Legacy = new SimpleTriggerImplLegacy("1",
             DateTimeOffset.MinValue,
             DateTimeOffset.MaxValue,
             0,
             TimeSpan.FromTicks(1000));
-        _trigger3Legacy.MisfireInstruction = MisfireInstruction.SmartPolicy;
+        _trigger3Legacy.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
 
         _trigger4 = new SimpleTriggerImpl("1",
             DateTimeOffset.MinValue,
             DateTimeOffset.MinValue,
             SimpleTriggerImpl.RepeatIndefinitely,
             TimeSpan.FromTicks(1000));
-        _trigger4.MisfireInstruction = MisfireInstruction.SimpleTrigger.FireNow;
+        _trigger4.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.FireNow;
         _trigger4.NextFireTimeUtc = DateTimeOffset.UtcNow;
 
         _trigger4Legacy = new SimpleTriggerImplLegacy("1",
@@ -80,7 +80,7 @@ public class SimpleTriggerImplBenchmark
             DateTimeOffset.MinValue,
             SimpleTriggerImpl.RepeatIndefinitely,
             TimeSpan.FromTicks(1000));
-        _trigger4Legacy.MisfireInstruction = MisfireInstruction.SimpleTrigger.FireNow;
+        _trigger4Legacy.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.FireNow;
         _trigger4Legacy.NextFireTimeUtc = DateTimeOffset.UtcNow;
 
         _trigger5 = new SimpleTriggerImpl("1",
@@ -88,21 +88,21 @@ public class SimpleTriggerImplBenchmark
             DateTimeOffset.MaxValue,
             5,
             TimeSpan.FromTicks(1000));
-        _trigger5.MisfireInstruction = MisfireInstruction.SmartPolicy;
+        _trigger5.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
 
         _trigger5Legacy = new SimpleTriggerImplLegacy("1",
             DateTimeOffset.MinValue,
             DateTimeOffset.MaxValue,
             5,
             TimeSpan.FromTicks(1000));
-        _trigger5Legacy.MisfireInstruction = MisfireInstruction.SmartPolicy;
+        _trigger5Legacy.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
 
         _trigger6 = new SimpleTriggerImpl("1",
             DateTimeOffset.MinValue,
             DateTimeOffset.MaxValue,
             int.MaxValue,
             TimeSpan.FromDays(1));
-        _trigger6.MisfireInstruction = MisfireInstruction.SimpleTrigger.FireNow;
+        _trigger6.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.FireNow;
         _trigger6.NextFireTimeUtc = DateTimeOffset.UtcNow;
 
         _trigger6Legacy = new SimpleTriggerImplLegacy("1",
@@ -110,7 +110,7 @@ public class SimpleTriggerImplBenchmark
             DateTimeOffset.MaxValue,
             int.MaxValue,
             TimeSpan.FromDays(1));
-        _trigger6Legacy.MisfireInstruction = MisfireInstruction.SimpleTrigger.FireNow;
+        _trigger6Legacy.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.FireNow;
         _trigger6Legacy.NextFireTimeUtc = DateTimeOffset.UtcNow;
 
         _today = new DateTimeOffset(DateTime.Today.ToUniversalTime(), TimeSpan.Zero);
@@ -519,13 +519,16 @@ public class SimpleTriggerImplBenchmark
             set => timesTriggered = value;
         }
 
+        /// <inheritdoc />
+        public SimpleTriggerMisfireInstruction MisfireInstruction => (SimpleTriggerMisfireInstruction) MisfireInstructionCode;
+
         public override IScheduleBuilder GetScheduleBuilder()
         {
             SimpleScheduleBuilder sb = SimpleScheduleBuilder.Create()
                 .WithInterval(RepeatInterval)
                 .WithRepeatCount(RepeatCount);
 
-            switch (MisfireInstruction)
+            switch (MisfireInstructionCode)
             {
                 case Quartz.MisfireInstruction.SimpleTrigger.FireNow:
                     sb.WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow);
@@ -636,7 +639,7 @@ public class SimpleTriggerImplBenchmark
         /// </remarks>
         public override void UpdateAfterMisfire(ICalendar? calendar)
         {
-            int instr = MisfireInstruction;
+            int instr = MisfireInstructionCode;
             if (instr == Quartz.MisfireInstruction.SmartPolicy)
             {
                 if (RepeatCount == 0)

--- a/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
+++ b/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
@@ -592,7 +592,7 @@ public class SimpleTriggerImplBenchmark
         /// in millisecond precision.
         /// </summary>
         /// <value></value>
-        public override bool HasMillisecondPrecision => true;
+        protected override bool HasMillisecondPrecision => true;
 
         /// <summary>
         /// Validates the misfire instruction.

--- a/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
+++ b/src/Quartz.Benchmark/SimpleTriggerImplBenchmark.cs
@@ -528,22 +528,22 @@ public class SimpleTriggerImplBenchmark
             switch (MisfireInstruction)
             {
                 case Quartz.MisfireInstruction.SimpleTrigger.FireNow:
-                    sb.WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.FireNow);
+                    sb.WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow);
                     break;
                 case Quartz.MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount:
-                    sb.WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount);
+                    sb.WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount);
                     break;
                 case Quartz.MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount:
-                    sb.WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount);
+                    sb.WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount);
                     break;
                 case Quartz.MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount:
-                    sb.WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NowWithExistingCount);
+                    sb.WithMisfireInstruction(SimpleTriggerMisfireInstruction.NowWithExistingCount);
                     break;
                 case Quartz.MisfireInstruction.SimpleTrigger.RescheduleNowWithRemainingRepeatCount:
-                    sb.WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NowWithRemainingCount);
+                    sb.WithMisfireInstruction(SimpleTriggerMisfireInstruction.NowWithRemainingCount);
                     break;
                 case Quartz.MisfireInstruction.IgnoreMisfirePolicy:
-                    sb.WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires);
+                    sb.WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires);
                     break;
             }
 

--- a/src/Quartz.Benchmark/TriggerTimeComparatorBenchmark.cs
+++ b/src/Quartz.Benchmark/TriggerTimeComparatorBenchmark.cs
@@ -283,7 +283,7 @@ public class TriggerTimeComparatorBenchmark
         public int Priority { get; set; }
         public DateTimeOffset StartTimeUtc { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DateTimeOffset? EndTimeUtc { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public int MisfireInstruction { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public int MisfireInstructionCode { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DateTimeOffset? FinalFireTimeUtc => throw new NotImplementedException();
         public bool HasMillisecondPrecision => throw new NotImplementedException();
 

--- a/src/Quartz.Examples/05_SchedulingJobsSettingMisfireInstructions/SchedulingJobsSettingMisfireInstructionsExample.cs
+++ b/src/Quartz.Examples/05_SchedulingJobsSettingMisfireInstructions/SchedulingJobsSettingMisfireInstructionsExample.cs
@@ -38,7 +38,7 @@ namespace Quartz.Examples.Example05;
 /// time the jobs complete their execution, the triggers have already "misfired"
 /// (unless the scheduler's "misfire threshold" has been set to more than 7
 /// seconds). You should see that one of the jobs has its misfire instruction
-/// set to <see cref="MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount" />,
+/// set to <see cref="SimpleTriggerMisfireInstruction.NowWithExistingCount" />,
 /// which causes it to fire immediately, when the misfire is detected. The other
 /// trigger uses the default "smart policy" misfire instruction, which causes
 /// the trigger to advance to its next fire time (skipping those that it has

--- a/src/Quartz.Examples/05_SchedulingJobsSettingMisfireInstructions/SchedulingJobsSettingMisfireInstructionsExample.cs
+++ b/src/Quartz.Examples/05_SchedulingJobsSettingMisfireInstructions/SchedulingJobsSettingMisfireInstructionsExample.cs
@@ -96,7 +96,7 @@ public class SchedulingJobsSettingMisfireInstructionsExample : IExample
             .WithSimpleSchedule(x => x
                 .WithInterval(TimeSpan.FromSeconds(3))
                 .RepeatForever()
-                .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NowWithExistingCount)) // set misfire instructions
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NowWithExistingCount)) // set misfire instructions
             .Build();
         ft = await scheduler.ScheduleJob(job, trigger);
 

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
@@ -356,7 +356,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
     {
         var interval = TimeSpan.Parse(simple.Interval, CultureInfo.InvariantCulture);
         var builder = SimpleScheduleBuilder.Create().WithInterval(interval).WithRepeatCount(simple.RepeatCount);
-        if (simple.MisfireInstruction is not null) builder.WithMisfireHandlingInstruction((SimpleTriggerMisfireInstruction) ParseMisfireInstruction(simple.MisfireInstruction));
+        if (simple.MisfireInstruction is not null) builder.WithMisfireInstruction((SimpleTriggerMisfireInstruction) ParseMisfireInstruction(simple.MisfireInstruction));
         return builder;
     }
 
@@ -376,7 +376,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
         }
 
         if (cron.TimeZone is not null) builder.InTimeZone(TimeZoneUtil.FindTimeZoneById(cron.TimeZone));
-        if (cron.MisfireInstruction is not null) builder.WithMisfireHandlingInstruction((CronTriggerMisfireInstruction) ParseMisfireInstruction(cron.MisfireInstruction));
+        if (cron.MisfireInstruction is not null) builder.WithMisfireInstruction((CronTriggerMisfireInstruction) ParseMisfireInstruction(cron.MisfireInstruction));
         return builder;
     }
 
@@ -384,7 +384,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
     {
         var unit = SafeParseEnum<IntervalUnit>(calendar.RepeatIntervalUnit, "CalendarInterval.RepeatIntervalUnit");
         var builder = CalendarIntervalScheduleBuilder.Create().WithInterval(calendar.RepeatInterval, unit);
-        if (calendar.MisfireInstruction is not null) builder.WithMisfireHandlingInstruction((CalendarIntervalTriggerMisfireInstruction) ParseMisfireInstruction(calendar.MisfireInstruction));
+        if (calendar.MisfireInstruction is not null) builder.WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) ParseMisfireInstruction(calendar.MisfireInstruction));
         return builder;
     }
 
@@ -407,7 +407,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
         if (daily.MisfireInstruction is not null)
         {
             var instruction = (DailyTimeIntervalTriggerMisfireInstruction) ParseMisfireInstruction(daily.MisfireInstruction);
-            if (Enum.IsDefined(instruction)) builder.WithMisfireHandlingInstruction(instruction);
+            if (Enum.IsDefined(instruction)) builder.WithMisfireInstruction(instruction);
         }
 
         return builder;

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
@@ -338,7 +338,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
         }
     }
 
-    private static IScheduleBuilder BuildSchedule(JsonFileTriggerDefinition def, string triggerName)
+    private IScheduleBuilder BuildSchedule(JsonFileTriggerDefinition def, string triggerName)
     {
         var count = (def.Simple is not null ? 1 : 0) + (def.Cron is not null ? 1 : 0) +
                     (def.CalendarInterval is not null ? 1 : 0) + (def.DailyTimeInterval is not null ? 1 : 0);
@@ -352,15 +352,15 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
         return BuildDailyTimeIntervalSchedule(def.DailyTimeInterval!);
     }
 
-    private static SimpleScheduleBuilder BuildSimpleSchedule(JsonFileSimpleSchedule simple)
+    private SimpleScheduleBuilder BuildSimpleSchedule(JsonFileSimpleSchedule simple)
     {
         var interval = TimeSpan.Parse(simple.Interval, CultureInfo.InvariantCulture);
         var builder = SimpleScheduleBuilder.Create().WithInterval(interval).WithRepeatCount(simple.RepeatCount);
-        if (simple.MisfireInstruction is not null) builder.WithMisfireInstruction((SimpleTriggerMisfireInstruction) ParseMisfireInstruction(simple.MisfireInstruction));
+        if (simple.MisfireInstruction is not null) builder.WithMisfireInstruction((SimpleTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Simple, simple.MisfireInstruction, logger));
         return builder;
     }
 
-    private static CronScheduleBuilder BuildCronSchedule(JsonFileCronSchedule cron, string triggerName)
+    private CronScheduleBuilder BuildCronSchedule(JsonFileCronSchedule cron, string triggerName)
     {
         if (string.IsNullOrWhiteSpace(cron.Expression))
             throw new SchedulerConfigException($"JSON trigger '{triggerName}': Cron schedule is missing required 'Expression' property.");
@@ -376,19 +376,19 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
         }
 
         if (cron.TimeZone is not null) builder.InTimeZone(TimeZoneUtil.FindTimeZoneById(cron.TimeZone));
-        if (cron.MisfireInstruction is not null) builder.WithMisfireInstruction((CronTriggerMisfireInstruction) ParseMisfireInstruction(cron.MisfireInstruction));
+        if (cron.MisfireInstruction is not null) builder.WithMisfireInstruction((CronTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Cron, cron.MisfireInstruction, logger));
         return builder;
     }
 
-    private static CalendarIntervalScheduleBuilder BuildCalendarIntervalSchedule(JsonFileCalendarIntervalSchedule calendar)
+    private CalendarIntervalScheduleBuilder BuildCalendarIntervalSchedule(JsonFileCalendarIntervalSchedule calendar)
     {
         var unit = SafeParseEnum<IntervalUnit>(calendar.RepeatIntervalUnit, "CalendarInterval.RepeatIntervalUnit");
         var builder = CalendarIntervalScheduleBuilder.Create().WithInterval(calendar.RepeatInterval, unit);
-        if (calendar.MisfireInstruction is not null) builder.WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) ParseMisfireInstruction(calendar.MisfireInstruction));
+        if (calendar.MisfireInstruction is not null) builder.WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.CalendarInterval, calendar.MisfireInstruction, logger));
         return builder;
     }
 
-    private static DailyTimeIntervalScheduleBuilder BuildDailyTimeIntervalSchedule(JsonFileDailyTimeIntervalSchedule daily)
+    private DailyTimeIntervalScheduleBuilder BuildDailyTimeIntervalSchedule(JsonFileDailyTimeIntervalSchedule daily)
     {
         var unit = SafeParseEnum<IntervalUnit>(daily.RepeatIntervalUnit, "DailyTimeInterval.RepeatIntervalUnit");
         var builder = DailyTimeIntervalScheduleBuilder.Create().WithInterval(daily.RepeatInterval, unit).WithRepeatCount(daily.RepeatCount);
@@ -406,7 +406,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
 
         if (daily.MisfireInstruction is not null)
         {
-            var instruction = (DailyTimeIntervalTriggerMisfireInstruction) ParseMisfireInstruction(daily.MisfireInstruction);
+            var instruction = (DailyTimeIntervalTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.DailyTimeInterval, daily.MisfireInstruction, logger);
             if (Enum.IsDefined(instruction)) builder.WithMisfireInstruction(instruction);
         }
 
@@ -429,14 +429,6 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
             throw new SchedulerConfigException($"TimeOfDay value '{value}' must not contain fractional seconds.");
         }
         return new TimeOnly(timeSpan.Hours, timeSpan.Minutes, timeSpan.Seconds);
-    }
-
-    private static int ParseMisfireInstruction(string value)
-    {
-        Constants c = new(typeof(MisfireInstruction), typeof(MisfireInstruction.CronTrigger),
-            typeof(MisfireInstruction.SimpleTrigger), typeof(MisfireInstruction.CalendarIntervalTrigger),
-            typeof(MisfireInstruction.DailyTimeIntervalTrigger));
-        return c.AsNumber(value);
     }
 
     private static T SafeParseEnum<T>(string value, string context) where T : struct, Enum

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
@@ -34,7 +34,7 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
             writer.WriteJobDataMapValue(trigger.JobDataMap);
 
             writer.WritePropertyName("MisfireInstruction");
-            writer.WriteValue(trigger.MisfireInstruction);
+            writer.WriteValue(trigger.MisfireInstructionCode);
 
             writer.WritePropertyName("StartTimeUtc");
             writer.WriteValue(trigger.StartTimeUtc);
@@ -120,7 +120,7 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
 
             if (trigger is IMutableTrigger mutableTrigger)
             {
-                mutableTrigger.MisfireInstruction = misfireInstruction;
+                mutableTrigger.MisfireInstructionCode = misfireInstruction;
 
                 // Written as the pair the triggers table stores, and absent altogether from payloads
                 // written before triggers could be pinned - a missing pair reads back as

--- a/src/Quartz.Tests.Integration/Core/MissSchedulingChangeSignalTest.cs
+++ b/src/Quartz.Tests.Integration/Core/MissSchedulingChangeSignalTest.cs
@@ -34,7 +34,7 @@ public class MissSchedulingChangeSignalTest
             .WithSimpleSchedule(x => x
                 .WithInterval(TimeSpan.FromSeconds(1))
                 .RepeatForever()
-                .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
             .Build();
 
         await scheduler.ScheduleJob(job, trigger);

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
@@ -77,16 +77,16 @@ public class MisfireBatchRecoveryTest
         //  - SIMPLE and CRON arrive complete on the joined row
         //  - DAILY_I and CAL_INT need the SIMPROP_TRIGGERS follow-up query
         await StoreMisfiredTrigger(jobStore, "simple", TriggerBuilder.Create()
-            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever().WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.FireNow)));
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever().WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow)));
 
         await StoreMisfiredTrigger(jobStore, "cron", TriggerBuilder.Create()
-            .WithCronSchedule("0 * * * * ?", x => x.WithMisfireHandlingInstruction(CronTriggerMisfireInstruction.FireAndProceed)));
+            .WithCronSchedule("0 * * * * ?", x => x.WithMisfireInstruction(CronTriggerMisfireInstruction.FireAndProceed)));
 
         await StoreMisfiredTrigger(jobStore, "daily", TriggerBuilder.Create()
-            .WithDailyTimeIntervalSchedule(x => x.WithInterval(1, IntervalUnit.Minute).WithMisfireHandlingInstruction(DailyTimeIntervalTriggerMisfireInstruction.FireAndProceed)));
+            .WithDailyTimeIntervalSchedule(x => x.WithInterval(1, IntervalUnit.Minute).WithMisfireInstruction(DailyTimeIntervalTriggerMisfireInstruction.FireAndProceed)));
 
         await StoreMisfiredTrigger(jobStore, "calint", TriggerBuilder.Create()
-            .WithCalendarIntervalSchedule(x => x.WithInterval(1, IntervalUnit.Minute).WithMisfireHandlingInstruction(CalendarIntervalTriggerMisfireInstruction.FireAndProceed)));
+            .WithCalendarIntervalSchedule(x => x.WithInterval(1, IntervalUnit.Minute).WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction.FireAndProceed)));
 
         //  - a custom trigger with no persistence delegate, which lands in BLOB_TRIGGERS
         await StoreMisfiredBlobTrigger(jobStore, "blob");
@@ -140,7 +140,7 @@ public class MisfireBatchRecoveryTest
         for (var i = 0; i < triggerCount; i++)
         {
             await StoreMisfiredTrigger(jobStore, "simple" + i, TriggerBuilder.Create()
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever().WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.FireNow)));
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever().WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow)));
         }
 
         commandCounter.Reset();
@@ -162,7 +162,7 @@ public class MisfireBatchRecoveryTest
         for (var i = 0; i < 5; i++)
         {
             await StoreMisfiredTrigger(jobStore, "simple" + i, TriggerBuilder.Create()
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever().WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.FireNow)));
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever().WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow)));
         }
 
         RecoverMisfiredJobsResult result = await jobStore.RecoverMisfires();

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
@@ -213,7 +213,7 @@ public class MisfireBatchRecoveryTest
             JobKey = job.Key,
             CronExpressionString = "0 * * * * ?",
             StartTimeUtc = DateTimeOffset.UtcNow.AddHours(-2),
-            MisfireInstruction = MisfireInstruction.CronTrigger.FireOnceNow
+            MisfireInstructionCode = MisfireInstruction.CronTrigger.FireOnceNow
         };
 
         trigger.ComputeFirstFireTimeUtc(null);

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfiredBlockedTriggerTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfiredBlockedTriggerTest.cs
@@ -58,7 +58,7 @@ public class MisfiredBlockedTriggerTest
                 .WithSimpleSchedule(x => x
                     .WithInterval(TimeSpan.FromSeconds(RepeatingTriggerIntervalSeconds))
                     .RepeatForever()
-                    .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount))
+                    .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount))
                 .Build();
 
             await scheduler.ScheduleJob(job, repeatingTrigger);
@@ -78,7 +78,7 @@ public class MisfiredBlockedTriggerTest
                 .StartNow()
                 .WithSimpleSchedule(x => x
                     .WithRepeatCount(0) // Fire once only
-                    .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount))
+                    .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount))
                 .Build();
 
             await scheduler.ScheduleJob(fireAndForgetTrigger);

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -104,6 +104,17 @@ public class SmokeTestPerformer
                 Assert.That(persisted, Is.Not.Null);
                 Assert.That(persisted is SimpleTriggerImpl, Is.True);
 
+                // UpdateTriggerDetails writes the execution group through the generic trigger
+                // update, so the column has to survive a round trip - and clearing it has to
+                // survive one too.
+                (await scheduler.UpdateTriggerDetails(persisted.Key, new TriggerDetailsUpdate().WithExecutionGroup("heavy")))
+                    .Should().BeTrue();
+                (await scheduler.GetTrigger(persisted.Key))!.ExecutionGroup.Should().Be("heavy");
+
+                (await scheduler.UpdateTriggerDetails(persisted.Key, new TriggerDetailsUpdate().WithExecutionGroup(null)))
+                    .Should().BeTrue();
+                (await scheduler.GetTrigger(persisted.Key))!.ExecutionGroup.Should().BeNull();
+
                 count++;
                 job = JobBuilder.Create()
                     .OfType<SimpleRecoveryJob>()

--- a/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Integration/RAMJobStoreTest.cs
@@ -595,7 +595,7 @@ public abstract class AbstractSchedulerTest
                 {
                     CronExpression = new CronExpression(cronExpressionString),
                     TimeZone = timeZone,
-                    MisfireInstruction = Quartz.MisfireInstruction.SmartPolicy
+                    MisfireInstructionCode = Quartz.MisfireInstruction.SmartPolicy
                 };
 
                 return new StaticScheduleBuilder(trigger);

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
@@ -299,10 +299,10 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         try
         {
-            trigger.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
-            trigger.MisfireInstruction = MisfireInstruction.SmartPolicy;
-            trigger.MisfireInstruction = MisfireInstruction.CalendarIntervalTrigger.DoNothing;
-            trigger.MisfireInstruction = MisfireInstruction.CalendarIntervalTrigger.FireOnceNow;
+            trigger.MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy;
+            trigger.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
+            trigger.MisfireInstructionCode = MisfireInstruction.CalendarIntervalTrigger.DoNothing;
+            trigger.MisfireInstructionCode = MisfireInstruction.CalendarIntervalTrigger.FireOnceNow;
         }
         catch (Exception)
         {
@@ -311,7 +311,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         try
         {
-            trigger.MisfireInstruction = MisfireInstruction.CalendarIntervalTrigger.DoNothing + 1;
+            trigger.MisfireInstructionCode = MisfireInstruction.CalendarIntervalTrigger.DoNothing + 1;
 
             Assert.Fail("Expected exception while setting invalid misfire instruction but did not get it.");
         }
@@ -732,7 +732,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         trigger.PreserveHourOfDayAcrossDaylightSavings = true;
         trigger.SkipDayIfHourDoesNotExist = true;
         trigger.TimeZone = TimeZoneInfo.Utc;
-        trigger.MisfireInstruction = MisfireInstruction.CalendarIntervalTrigger.FireOnceNow;
+        trigger.MisfireInstructionCode = MisfireInstruction.CalendarIntervalTrigger.FireOnceNow;
         var scheduleBuilder = trigger.GetScheduleBuilder();
 
         var cloned = (CalendarIntervalTriggerImpl) scheduleBuilder.Build();
@@ -742,7 +742,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             Assert.That(cloned.SkipDayIfHourDoesNotExist, Is.EqualTo(trigger.SkipDayIfHourDoesNotExist));
             Assert.That(cloned.RepeatInterval, Is.EqualTo(trigger.RepeatInterval));
             Assert.That(cloned.RepeatIntervalUnit, Is.EqualTo(trigger.RepeatIntervalUnit));
-            Assert.That(cloned.MisfireInstruction, Is.EqualTo(trigger.MisfireInstruction));
+            Assert.That(cloned.MisfireInstructionCode, Is.EqualTo(trigger.MisfireInstructionCode));
             Assert.That(cloned.TimeZone, Is.EqualTo(trigger.TimeZone));
         });
     }
@@ -776,8 +776,8 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             .Build();
         using (new AssertionScope())
         {
-            trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
-            trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger1.MisfireInstructionCode.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger2.MisfireInstructionCode.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
         }
     }
 
@@ -1177,7 +1177,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             StartTimeUtc = startTime,
             RepeatInterval = 2,
             RepeatIntervalUnit = IntervalUnit.Minute,
-            MisfireInstruction = MisfireInstruction.CalendarIntervalTrigger.DoNothing
+            MisfireInstructionCode = MisfireInstruction.CalendarIntervalTrigger.DoNothing
         };
         trigger.ComputeFirstFireTimeUtc(null);
 

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
@@ -691,7 +691,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         schedBuilder.WithInterval(2, IntervalUnit.Week);
         schedBuilder
             .PreserveHourOfDayAcrossDaylightSavings(true)
-            .WithMisfireHandlingInstruction(CalendarIntervalTriggerMisfireInstruction.FireAndProceed);
+            .WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction.FireAndProceed);
 
         var trigger = tb.StartAt(new DateTimeOffset(new DateTime(2014, 2, 26, 23, 45, 0)))
             .WithSchedule(schedBuilder)
@@ -767,7 +767,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     {
         var trigger1 = TriggerBuilder.Create()
             .WithCalendarIntervalSchedule(x => x
-                .WithMisfireHandlingInstruction(CalendarIntervalTriggerMisfireInstruction.IgnoreMisfires)
+                .WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction.IgnoreMisfires)
             )
             .Build();
 

--- a/src/Quartz.Tests.Unit/Configuration/JsonSchedulingTests.cs
+++ b/src/Quartz.Tests.Unit/Configuration/JsonSchedulingTests.cs
@@ -58,6 +58,61 @@ public class JsonSchedulingTests
         trigger.RepeatInterval.Should().Be(TimeSpan.FromSeconds(10));
     }
 
+    [TestCase("DoNothing", 2)]
+    [TestCase("FireOnceNow", 1)]
+    [TestCase("FireAndProceed", 1)]
+    [TestCase("IgnoreMisfirePolicy", -1)]
+    // A simple trigger's name on a cron trigger. It resolved before the per-family maps existed and
+    // still does - to 2, DoNothing - but the resolver now says so instead of leaving it to be
+    // discovered in production.
+    [TestCase("RescheduleNowWithExistingRepeatCount", 2)]
+    public void AddQuartz_CronTriggerMisfireInstruction_IsReadPerFamily(string name, int expected)
+    {
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "Schedule:Jobs:0:Name", "misfireJob" },
+            { "Schedule:Jobs:0:JobType", "Quartz.Job.NativeJob, Quartz.Jobs" },
+            { "Schedule:Jobs:0:Durable", "true" },
+            { "Schedule:Triggers:0:Name", "misfireTrigger" },
+            { "Schedule:Triggers:0:JobName", "misfireJob" },
+            { "Schedule:Triggers:0:Cron:Expression", "0/30 * * * * ?" },
+            { "Schedule:Triggers:0:Cron:MisfireInstruction", name },
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddQuartz(config);
+
+        var provider = services.BuildServiceProvider();
+
+        provider.ScheduledTriggers()[0].MisfireInstructionCode.Should().Be(expected);
+    }
+
+    [Test]
+    public void AddQuartz_MisfireInstructionOfAnotherFamilyWithNoCounterpart_IsRejected()
+    {
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "Schedule:Jobs:0:Name", "misfireJob" },
+            { "Schedule:Jobs:0:JobType", "Quartz.Job.NativeJob, Quartz.Jobs" },
+            { "Schedule:Jobs:0:Durable", "true" },
+            { "Schedule:Triggers:0:Name", "misfireTrigger" },
+            { "Schedule:Triggers:0:JobName", "misfireJob" },
+            { "Schedule:Triggers:0:Cron:Expression", "0/30 * * * * ?" },
+            { "Schedule:Triggers:0:Cron:MisfireInstruction", "RescheduleNextWithRemainingCount" },
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddQuartz(config);
+
+        var provider = services.BuildServiceProvider();
+
+        Action act = () => provider.ScheduledTriggers();
+
+        act.Should().Throw<SchedulerConfigException>().WithMessage("*RescheduleNextWithRemainingCount*cron*");
+    }
+
     [Test]
     public void AddQuartzSchedulers_SchedulersSection_RegistersNamedSchedulers()
     {

--- a/src/Quartz.Tests.Unit/Core/MissSchedulingChangeSignalTest.cs
+++ b/src/Quartz.Tests.Unit/Core/MissSchedulingChangeSignalTest.cs
@@ -31,7 +31,7 @@ public class MissSchedulingChangeSignalTest
             .WithSimpleSchedule(x => x
                 .WithInterval(TimeSpan.FromSeconds(1))
                 .RepeatForever()
-                .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
             .Build();
 
         await scheduler.ScheduleJob(job, trigger);

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -271,7 +271,7 @@ public class QuartzSchedulerTest
             .WithSimpleSchedule(
                 sb => sb.WithRepeatCount(repeatCount)
                     .WithInterval(repeatInterval)
-                    .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
+                    .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
             .Build();
     }
 

--- a/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
@@ -418,7 +418,7 @@ public class CronExpressionHashTest
             .WithCronSchedule("H H * * * ?", x => x.WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing))
             .Build();
 
-        Assert.AreEqual(MisfireInstruction.CronTrigger.DoNothing, trigger.MisfireInstruction);
+        Assert.AreEqual(MisfireInstruction.CronTrigger.DoNothing, trigger.MisfireInstructionCode);
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
@@ -415,7 +415,7 @@ public class CronExpressionHashTest
     {
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity("misfire-test")
-            .WithCronSchedule("H H * * * ?", x => x.WithMisfireHandlingInstruction(CronTriggerMisfireInstruction.DoNothing))
+            .WithCronSchedule("H H * * * ?", x => x.WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing))
             .Build();
 
         Assert.AreEqual(MisfireInstruction.CronTrigger.DoNothing, trigger.MisfireInstruction);

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -71,7 +71,7 @@ public class CronScheduleBuilderTest
             .WithSchedule(CronScheduleBuilder.CronSchedule("0 20 10 ? * *"))
             .Build();
 
-        trigger.MisfireInstruction.Should().Be(MisfireInstruction.SmartPolicy);
+        trigger.MisfireInstructionCode.Should().Be(MisfireInstruction.SmartPolicy);
     }
 
     [TestCase(CronTriggerMisfireInstruction.IgnoreMisfires, MisfireInstruction.IgnoreMisfirePolicy)]
@@ -84,6 +84,6 @@ public class CronScheduleBuilderTest
             .WithCronSchedule("0 20 10 ? * *", x => x.WithMisfireInstruction(instruction))
             .Build();
 
-        trigger.MisfireInstruction.Should().Be(stored);
+        trigger.MisfireInstructionCode.Should().Be(stored);
     }
 }

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -81,7 +81,7 @@ public class CronScheduleBuilderTest
     {
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity("test")
-            .WithCronSchedule("0 20 10 ? * *", x => x.WithMisfireHandlingInstruction(instruction))
+            .WithCronSchedule("0 20 10 ? * *", x => x.WithMisfireInstruction(instruction))
             .Build();
 
         trigger.MisfireInstruction.Should().Be(stored);

--- a/src/Quartz.Tests.Unit/CronTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CronTriggerTest.cs
@@ -279,7 +279,7 @@ public class CronTriggerTest
         var originalTrigger = (IOperableTrigger) TriggerBuilder.Create()
             .WithIdentity("trigger1", "group1")
             .WithCronSchedule("0 */5 * ? * *",
-                cs => cs.WithMisfireHandlingInstruction(CronTriggerMisfireInstruction.DoNothing))
+                cs => cs.WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing))
             .StartAt(pastStartTime)
             .Build();
 

--- a/src/Quartz.Tests.Unit/CronTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CronTriggerTest.cs
@@ -97,11 +97,8 @@ public class CronTriggerTest
     {
         IOperableTrigger trigger = new CronTriggerImpl();
         trigger.StartTimeUtc = new DateTime(1982, 6, 28, 13, 5, 5, 233);
-        Assert.Multiple(() =>
-        {
-            Assert.That(trigger.HasMillisecondPrecision, Is.False);
-            Assert.That(trigger.StartTimeUtc.Millisecond, Is.EqualTo(0));
-        });
+
+        trigger.StartTimeUtc.Millisecond.Should().Be(0, "a cron trigger has no millisecond precision, so the start time is rounded down to the second");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/CronTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CronTriggerTest.cs
@@ -138,10 +138,10 @@ public class CronTriggerTest
 
         try
         {
-            trigger.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
-            trigger.MisfireInstruction = MisfireInstruction.SmartPolicy;
-            trigger.MisfireInstruction = MisfireInstruction.CronTrigger.DoNothing;
-            trigger.MisfireInstruction = MisfireInstruction.CronTrigger.FireOnceNow;
+            trigger.MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy;
+            trigger.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
+            trigger.MisfireInstructionCode = MisfireInstruction.CronTrigger.DoNothing;
+            trigger.MisfireInstructionCode = MisfireInstruction.CronTrigger.FireOnceNow;
         }
         catch (Exception)
         {
@@ -150,7 +150,7 @@ public class CronTriggerTest
 
         try
         {
-            trigger.MisfireInstruction = MisfireInstruction.CronTrigger.DoNothing + 1;
+            trigger.MisfireInstructionCode = MisfireInstruction.CronTrigger.DoNothing + 1;
 
             Assert.Fail("Expected exception while setting invalid misfire instruction but did not get it.");
         }
@@ -191,13 +191,13 @@ public class CronTriggerTest
         var startTime = DateTimeOffset.UtcNow;
         var endTime = DateTimeOffset.UtcNow.AddDays(1);
         var trigger = new CronTriggerImpl("name", "group", "jobname", "jobgroup", startTime, endTime, "0 0 12 * * ?", TimeZoneInfo.Utc);
-        trigger.MisfireInstruction = MisfireInstruction.CronTrigger.FireOnceNow;
+        trigger.MisfireInstructionCode = MisfireInstruction.CronTrigger.FireOnceNow;
         var scheduleBuilder = trigger.GetScheduleBuilder();
 
         var cloned = (CronTriggerImpl) scheduleBuilder.Build();
         Assert.Multiple(() =>
         {
-            Assert.That(cloned.MisfireInstruction, Is.EqualTo(trigger.MisfireInstruction));
+            Assert.That(cloned.MisfireInstructionCode, Is.EqualTo(trigger.MisfireInstructionCode));
             Assert.That(cloned.TimeZone, Is.EqualTo(trigger.TimeZone));
             Assert.That(cloned.CronExpressionString, Is.EqualTo(trigger.CronExpressionString));
         });
@@ -215,7 +215,7 @@ public class CronTriggerTest
         trigger.CronExpressionString = cronExpression;
         trigger.StartTimeUtc = startDate;
         trigger.EndTimeUtc = endDate;
-        trigger.MisfireInstruction = MisfireInstruction.CronTrigger.FireOnceNow;
+        trigger.MisfireInstructionCode = MisfireInstruction.CronTrigger.FireOnceNow;
 
         DateTimeOffset? firstFireTime = trigger.ComputeFirstFireTimeUtc(null);
 
@@ -327,7 +327,7 @@ public class CronTriggerTest
             Key = new TriggerKey("test", "test"),
             CronExpressionString = "0 0/2 * * * ?",
             StartTimeUtc = startTime,
-            MisfireInstruction = MisfireInstruction.CronTrigger.DoNothing
+            MisfireInstructionCode = MisfireInstruction.CronTrigger.DoNothing
         };
         trigger.ComputeFirstFireTimeUtc(null);
 
@@ -355,7 +355,7 @@ public class CronTriggerTest
             Key = new TriggerKey("test", "test"),
             CronExpressionString = "0 0/2 * * * ?",
             StartTimeUtc = startTime,
-            MisfireInstruction = MisfireInstruction.CronTrigger.DoNothing
+            MisfireInstructionCode = MisfireInstruction.CronTrigger.DoNothing
         };
         trigger.ComputeFirstFireTimeUtc(null);
 

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -459,8 +459,8 @@ public class DailyTimeIntervalScheduleBuilderTest
             .Build();
         using (new AssertionScope())
         {
-            trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
-            trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger1.MisfireInstructionCode.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger2.MisfireInstructionCode.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
         }
     }
 }

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -450,7 +450,7 @@ public class DailyTimeIntervalScheduleBuilderTest
     {
         var trigger1 = TriggerBuilder.Create()
             .WithDailyTimeIntervalSchedule(x => x
-                .WithMisfireHandlingInstruction(DailyTimeIntervalTriggerMisfireInstruction.IgnoreMisfires)
+                .WithMisfireInstruction(DailyTimeIntervalTriggerMisfireInstruction.IgnoreMisfires)
             )
             .Build();
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -552,7 +552,7 @@ public class StdAdoDelegateTest
         {
             Assert.That(trigger.NextFireTimeUtc, Is.EqualTo(nextFireTime));
             Assert.That(trigger.PreviousFireTimeUtc, Is.EqualTo(prevFireTime));
-            Assert.That(trigger.MisfireInstruction, Is.EqualTo(2));
+            Assert.That(trigger.MisfireInstructionCode, Is.EqualTo(2));
         });
     }
 
@@ -629,7 +629,7 @@ public class StdAdoDelegateTest
         Assert.Multiple(() =>
         {
             Assert.That(trigger.NextFireTimeUtc, Is.EqualTo(nextFireTime));
-            Assert.That(trigger.MisfireInstruction, Is.EqualTo(1));
+            Assert.That(trigger.MisfireInstructionCode, Is.EqualTo(1));
             Assert.That(((AbstractTrigger) trigger).MisfiredFromFireTimeUtc, Is.EqualTo(misfireOrigFireTime));
         });
     }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateTriggerTest.cs
@@ -62,7 +62,7 @@ public class UpdateTriggerTest
         //Arrange
         var cronTriggerImpl = new CronTriggerImpl("Trigger", "Trigger.Group", "JobName", "JobGroup", "0 15 23 * * ?");
         cronTriggerImpl.CalendarName = "calName";
-        cronTriggerImpl.MisfireInstruction = 1;
+        cronTriggerImpl.MisfireInstructionCode = 1;
         cronTriggerImpl.Description = "Description";
         cronTriggerImpl.PreviousFireTimeUtc = new DateTimeOffset(new DateTime(2010, 1, 1));
         cronTriggerImpl.NextFireTimeUtc = new DateTimeOffset(new DateTime(2010, 2, 1));
@@ -146,7 +146,7 @@ public class UpdateTriggerTest
         //Arrange
         var cronTriggerImpl = new CronTriggerImpl("Trigger", "Trigger.Group", "JobName", "JobGroup", "0 15 23 * * ?");
         cronTriggerImpl.CalendarName = "calName";
-        cronTriggerImpl.MisfireInstruction = 1;
+        cronTriggerImpl.MisfireInstructionCode = 1;
         cronTriggerImpl.Description = "Description";
         cronTriggerImpl.PreviousFireTimeUtc = new DateTimeOffset(new DateTime(2010, 1, 1));
         cronTriggerImpl.NextFireTimeUtc = new DateTimeOffset(new DateTime(2010, 2, 1));

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -1177,7 +1177,7 @@ public class DailyTimeIntervalTriggerImplTest
                 .StartingDailyAt(new TimeOnly(0, 0, 0))
                 .EndingDailyAt(new TimeOnly(22, 0, 0))
                 .WithInterval(15, IntervalUnit.Minute)
-                .WithMisfireHandlingInstruction(DailyTimeIntervalTriggerMisfireInstruction.DoNothing)
+                .WithMisfireInstruction(DailyTimeIntervalTriggerMisfireInstruction.DoNothing)
             )
             .Build();
 

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -1130,7 +1130,7 @@ public class DailyTimeIntervalTriggerImplTest
         {
             DayOfWeek.Thursday
         };
-        trigger.MisfireInstruction = MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow;
+        trigger.MisfireInstructionCode = MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow;
         trigger.TimeZone = TimeZoneInfo.Utc;
 
         var scheduleBuilder = trigger.GetScheduleBuilder();
@@ -1237,7 +1237,7 @@ public class DailyTimeIntervalTriggerImplTest
             EndTimeOfDay = new TimeOnly(23, 59, 59),
             RepeatInterval = 2,
             RepeatIntervalUnit = IntervalUnit.Minute,
-            MisfireInstruction = MisfireInstruction.DailyTimeIntervalTrigger.DoNothing
+            MisfireInstructionCode = MisfireInstruction.DailyTimeIntervalTrigger.DoNothing
         };
         trigger.ComputeFirstFireTimeUtc(null);
 

--- a/src/Quartz.Tests.Unit/Impl/Triggers/RecurrenceTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/RecurrenceTriggerImplTest.cs
@@ -232,7 +232,7 @@ public class RecurrenceTriggerImplTest
             .WithIdentity("test", "group")
             .WithRecurrenceSchedule("FREQ=MONTHLY;BYDAY=2MO", b => b
                 .InTimeZone(TimeZoneInfo.Utc)
-                .WithMisfireHandlingInstruction(RecurrenceTriggerMisfireInstruction.DoNothing))
+                .WithMisfireInstruction(RecurrenceTriggerMisfireInstruction.DoNothing))
             .StartAt(new DateTimeOffset(2025, 1, 1, 9, 0, 0, TimeSpan.Zero))
             .Build();
 

--- a/src/Quartz.Tests.Unit/Impl/Triggers/RecurrenceTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/RecurrenceTriggerImplTest.cs
@@ -197,10 +197,15 @@ public class RecurrenceTriggerImplTest
     }
 
     [Test]
-    public void TestHasMillisecondPrecisionIsFalse()
+    public void TestStartTimeKeepsItsMilliseconds()
     {
         RecurrenceTriggerImpl trigger = new RecurrenceTriggerImpl();
-        Assert.IsFalse(trigger.HasMillisecondPrecision);
+        trigger.StartTimeUtc = new DateTimeOffset(1982, 6, 28, 13, 5, 5, 233, TimeSpan.Zero);
+
+        // The trigger reports no millisecond precision, but it overrides StartTimeUtc and so never
+        // reaches AbstractTrigger's round-down-to-the-second - unlike CronTriggerImpl, which does.
+        // Recorded as it behaves: rounding here would move the fire times of existing triggers.
+        trigger.StartTimeUtc.Millisecond.Should().Be(233);
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/Triggers/RecurrenceTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/RecurrenceTriggerImplTest.cs
@@ -152,7 +152,7 @@ public class RecurrenceTriggerImplTest
         trigger.RecurrenceRule = "FREQ=MONTHLY;BYDAY=2MO";
         trigger.StartTimeUtc = new DateTimeOffset(2025, 1, 1, 9, 0, 0, TimeSpan.Zero);
         trigger.TimeZone = TimeZoneInfo.Utc;
-        trigger.MisfireInstruction = MisfireInstruction.RecurrenceTrigger.DoNothing;
+        trigger.MisfireInstructionCode = MisfireInstruction.RecurrenceTrigger.DoNothing;
 
         IScheduleBuilder sb = trigger.GetScheduleBuilder();
         ITrigger rebuilt = TriggerBuilder.Create()
@@ -164,7 +164,7 @@ public class RecurrenceTriggerImplTest
         Assert.IsInstanceOf<IRecurrenceTrigger>(rebuilt);
         IRecurrenceTrigger recTrigger = (IRecurrenceTrigger)rebuilt;
         Assert.AreEqual("FREQ=MONTHLY;BYDAY=2MO", recTrigger.RecurrenceRule);
-        Assert.AreEqual(MisfireInstruction.RecurrenceTrigger.DoNothing, rebuilt.MisfireInstruction);
+        Assert.AreEqual(MisfireInstruction.RecurrenceTrigger.DoNothing, rebuilt.MisfireInstructionCode);
     }
 
     [Test]
@@ -175,13 +175,13 @@ public class RecurrenceTriggerImplTest
         trigger.StartTimeUtc = DateTimeOffset.UtcNow;
 
         // Valid values
-        trigger.MisfireInstruction = MisfireInstruction.SmartPolicy;
-        trigger.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
-        trigger.MisfireInstruction = MisfireInstruction.RecurrenceTrigger.FireOnceNow;
-        trigger.MisfireInstruction = MisfireInstruction.RecurrenceTrigger.DoNothing;
+        trigger.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
+        trigger.MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy;
+        trigger.MisfireInstructionCode = MisfireInstruction.RecurrenceTrigger.FireOnceNow;
+        trigger.MisfireInstructionCode = MisfireInstruction.RecurrenceTrigger.DoNothing;
 
         // Invalid value
-        Assert.Throws<ArgumentException>(() => trigger.MisfireInstruction = 99);
+        Assert.Throws<ArgumentException>(() => trigger.MisfireInstructionCode = 99);
     }
 
     [Test]
@@ -240,7 +240,7 @@ public class RecurrenceTriggerImplTest
         IRecurrenceTrigger recTrigger = (IRecurrenceTrigger)trigger;
         Assert.AreEqual("FREQ=MONTHLY;BYDAY=2MO", recTrigger.RecurrenceRule);
         Assert.AreEqual(TimeZoneInfo.Utc, recTrigger.TimeZone);
-        Assert.AreEqual(MisfireInstruction.RecurrenceTrigger.DoNothing, trigger.MisfireInstruction);
+        Assert.AreEqual(MisfireInstruction.RecurrenceTrigger.DoNothing, trigger.MisfireInstructionCode);
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/MisfireInstructionNamesTest.cs
+++ b/src/Quartz.Tests.Unit/MisfireInstructionNamesTest.cs
@@ -1,0 +1,124 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Tests.Unit.Plugin.History;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The XML and JSON misfire instruction names, per family.
+/// </summary>
+/// <remarks>
+/// These used to be resolved by reflecting over <c>MisfireInstruction</c> and all of its nested
+/// types at once, which made every family's names resolve for every family — silently, and with a
+/// different meaning.
+/// </remarks>
+public class MisfireInstructionNamesTest
+{
+    [TestCase("Simple", "SmartPolicy", 0)]
+    [TestCase("Simple", "InstructionNotSet", 0)]
+    [TestCase("Simple", "IgnoreMisfirePolicy", -1)]
+    [TestCase("Simple", "FireNow", 1)]
+    [TestCase("Simple", "RescheduleNowWithExistingRepeatCount", 2)]
+    [TestCase("Simple", "RescheduleNowWithRemainingRepeatCount", 3)]
+    [TestCase("Simple", "RescheduleNextWithRemainingCount", 4)]
+    [TestCase("Simple", "RescheduleNextWithExistingCount", 5)]
+    [TestCase("Cron", "SmartPolicy", 0)]
+    [TestCase("Cron", "IgnoreMisfirePolicy", -1)]
+    [TestCase("Cron", "FireOnceNow", 1)]
+    [TestCase("Cron", "DoNothing", 2)]
+    [TestCase("CalendarInterval", "FireOnceNow", 1)]
+    [TestCase("CalendarInterval", "DoNothing", 2)]
+    [TestCase("DailyTimeInterval", "FireOnceNow", 1)]
+    [TestCase("DailyTimeInterval", "DoNothing", 2)]
+    [TestCase("Recurrence", "FireOnceNow", 1)]
+    [TestCase("Recurrence", "DoNothing", 2)]
+    public void TheDocumentedNamesResolveWithoutComplaint(string familyName, string name, int expected)
+    {
+        RecordingLoggerProvider provider = new RecordingLoggerProvider();
+        TriggerFamily family = Enum.Parse<TriggerFamily>(familyName);
+
+        MisfireInstructionNames.Resolve(family, name, provider.CreateLogger("test")).Should().Be(expected);
+
+        provider.Entries.Should().BeEmpty("a name the family owns is not a legacy spelling");
+    }
+
+    [TestCase("Simple", "smartpolicy", 0)]
+    [TestCase("Simple", "  FireNow  ", 1)]
+    [TestCase("Cron", "donothing", 2)]
+    public void NamesAreCaseInsensitiveAndTrimmed(string familyName, string name, int expected)
+    {
+        TriggerFamily family = Enum.Parse<TriggerFamily>(familyName);
+
+        MisfireInstructionNames.Resolve(family, name).Should().Be(expected);
+    }
+
+    [TestCase("Simple", "IgnoreMisfires", -1)]
+    [TestCase("Simple", "NextWithExistingCount", 5)]
+    [TestCase("Cron", "FireAndProceed", 1)]
+    [TestCase("Recurrence", "IgnoreMisfires", -1)]
+    public void TheEnumSpellingsResolveToo(string familyName, string name, int expected)
+    {
+        TriggerFamily family = Enum.Parse<TriggerFamily>(familyName);
+
+        MisfireInstructionNames.Resolve(family, name).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The live defect this replaces: a cron trigger configured with a simple trigger's name became
+    /// a different policy with nothing said about it. The value is kept - configuration that works
+    /// today keeps working - but it is now said out loud.
+    /// </summary>
+    [Test]
+    public void ANameFromAnotherFamilyStillResolvesButIsWarnedAbout()
+    {
+        RecordingLoggerProvider provider = new RecordingLoggerProvider();
+
+        int value = MisfireInstructionNames.Resolve(TriggerFamily.Cron, "RescheduleNowWithExistingRepeatCount", provider.CreateLogger("test"));
+
+        value.Should().Be((int) CronTriggerMisfireInstruction.DoNothing,
+            "the code is what it always was - 2 in both families - and changing it would break stored configuration");
+
+        LogEntry entry = provider.Entries.Should().ContainSingle().Subject;
+        entry.Level.Should().Be(LogLevel.Warning);
+        entry.Message.Should().Contain("RescheduleNowWithExistingRepeatCount")
+            .And.Contain("DoNothing", "the warning has to name the policy the value actually selects");
+    }
+
+    [Test]
+    public void ANameFromAnotherFamilyWithNoCounterpartIsRejected()
+    {
+        Action act = () => MisfireInstructionNames.Resolve(TriggerFamily.Cron, "RescheduleNowWithRemainingRepeatCount");
+
+        act.Should().Throw<SchedulerConfigException>()
+            .WithMessage("*RescheduleNowWithRemainingRepeatCount*cron*");
+    }
+
+    [Test]
+    public void AnUnknownNameNamesTheValidOnes()
+    {
+        Action act = () => MisfireInstructionNames.Resolve(TriggerFamily.Simple, "FireWhenReady");
+
+        act.Should().Throw<SchedulerConfigException>()
+            .WithMessage("*FireWhenReady*")
+            .WithMessage("*RescheduleNextWithExistingCount*", "an error about a name should list the names that work");
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -297,7 +297,7 @@ public class JsonObjectSerializerTest
                 .InTimeZone(TimeZoneInfo.Utc)
                 .PreserveHourOfDayAcrossDaylightSavings(true)
                 .SkipDayIfHourDoesNotExist(false)
-                .WithMisfireHandlingInstruction(CalendarIntervalTriggerMisfireInstruction.FireAndProceed)
+                .WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction.FireAndProceed)
             )
             .WithIdentity("CalendarIntervalTriggerKey", "CalendarIntervalTriggerGroup")
             .ForJob("CalendarIntervalJobKey", "CalendarIntervalJobGroup")

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -472,7 +472,7 @@ public class JsonObjectSerializerTest
             StartTimeUtc = timeProvider.GetUtcNow(),
             EndTimeUtc = timeProvider.GetUtcNow().AddYears(1),
             Priority = 100,
-            MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy,
+            MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy,
             CustomProperty = 56
         };
 

--- a/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
@@ -367,7 +367,7 @@ public class LegacyJsonPayloadTest
         simple.RepeatCount.Should().Be(10);
         simple.RepeatInterval.Should().Be(TimeSpan.FromSeconds(42));
         simple.TimesTriggered.Should().Be(3);
-        simple.MisfireInstruction.Should().Be(MisfireInstruction.SimpleTrigger.FireNow);
+        simple.MisfireInstructionCode.Should().Be(MisfireInstruction.SimpleTrigger.FireNow);
         simple.NextFireTimeUtc.Should().Be(new DateTimeOffset(2024, 7, 1, 3, 32, 6, TimeSpan.Zero));
 
         simple.JobDataMap.GetString("environment").Should().Be("staging");
@@ -385,7 +385,7 @@ public class LegacyJsonPayloadTest
         cron.CronExpressionString.Should().Be("0 0/5 * * * ?");
         cron.TimeZone.Should().Be(TimeZoneInfo.Utc);
         cron.Priority.Should().Be(7);
-        cron.MisfireInstruction.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
+        cron.MisfireInstructionCode.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
         cron.EndTimeUtc.Should().BeNull();
     }
 

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -101,7 +101,7 @@ public class RAMJobStoreTest
         IOperableTrigger trigger10 = new SimpleTriggerImpl("trigger10", "triggerGroup2", fJobDetail.Key.Name, fJobDetail.Key.Group, d.AddMilliseconds(500000), d.AddMilliseconds(700000), 2, TimeSpan.FromSeconds(2));
 
         early.ComputeFirstFireTimeUtc(null);
-        early.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
+        early.MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy;
 
         trigger1.ComputeFirstFireTimeUtc(null);
         trigger2.ComputeFirstFireTimeUtc(null);
@@ -1028,7 +1028,7 @@ public class RAMJobStoreTest
         var trigger = new CronTriggerImpl("testTrigger", "testGroup", "0 * * * * ?", fakeTime)
         {
             JobKey = job.Key,
-            MisfireInstruction = MisfireInstruction.CronTrigger.FireOnceNow
+            MisfireInstructionCode = MisfireInstruction.CronTrigger.FireOnceNow
         };
         trigger.PreviousFireTimeUtc = previousFireTime;
         trigger.NextFireTimeUtc = originalScheduledTime;
@@ -1077,7 +1077,7 @@ public class RAMJobStoreTest
             StartTimeUtc = startTime,
             RepeatInterval = TimeSpan.FromMinutes(5),
             RepeatCount = SimpleTriggerImpl.RepeatIndefinitely,
-            MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount
+            MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount
         };
         trigger.ComputeFirstFireTimeUtc(null);
         await store.AddTrigger(trigger, false);

--- a/src/Quartz.Tests.Unit/SimpleScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/SimpleScheduleBuilderTest.cs
@@ -9,7 +9,7 @@ public class SimpleScheduleBuilderTest
     {
         var trigger1 = TriggerBuilder.Create()
             .WithSimpleSchedule(x => x
-                .WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires)
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires)
             )
             .Build();
 

--- a/src/Quartz.Tests.Unit/SimpleScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/SimpleScheduleBuilderTest.cs
@@ -18,8 +18,8 @@ public class SimpleScheduleBuilderTest
             .Build();
         using (new AssertionScope())
         {
-            trigger1.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
-            trigger2.MisfireInstruction.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger1.MisfireInstructionCode.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
+            trigger2.MisfireInstructionCode.Should().Be(MisfireInstruction.IgnoreMisfirePolicy);
         }
     }
 }

--- a/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
@@ -71,7 +71,7 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
             CalendarName = "MyCalendar",
             Description = "SimpleTriggerDesc",
             JobDataMap = jobDataMap,
-            MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount
+            MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount
         };
 
         return t;
@@ -91,7 +91,7 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
             Assert.That(deserialized.CalendarName, Is.EqualTo(original.CalendarName));
             Assert.That(deserialized.Description, Is.EqualTo(original.Description));
             Assert.That(deserialized.JobDataMap, Is.EqualTo(original.JobDataMap));
-            Assert.That(deserialized.MisfireInstruction, Is.EqualTo(original.MisfireInstruction));
+            Assert.That(deserialized.MisfireInstructionCode, Is.EqualTo(original.MisfireInstructionCode));
         });
     }
 
@@ -104,7 +104,7 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
 
         SimpleTriggerImpl simpleTrigger = new SimpleTriggerImpl
         {
-            MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount,
+            MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount,
             RepeatCount = 5,
             StartTimeUtc = startTime,
             EndTimeUtc = endTime
@@ -206,13 +206,13 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
 
         try
         {
-            trigger.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
-            trigger.MisfireInstruction = MisfireInstruction.SmartPolicy;
-            trigger.MisfireInstruction = MisfireInstruction.SimpleTrigger.FireNow;
-            trigger.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount;
-            trigger.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount;
-            trigger.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount;
-            trigger.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNowWithRemainingRepeatCount;
+            trigger.MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy;
+            trigger.MisfireInstructionCode = MisfireInstruction.SmartPolicy;
+            trigger.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.FireNow;
+            trigger.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount;
+            trigger.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount;
+            trigger.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount;
+            trigger.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNowWithRemainingRepeatCount;
         }
         catch (Exception)
         {
@@ -221,7 +221,7 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
 
         try
         {
-            trigger.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount + 1;
+            trigger.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount + 1;
 
             Assert.Fail("Expected exception while setting invalid misfire instruction but did not get it.");
         }
@@ -446,7 +446,7 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
             StartTimeUtc = startTime,
             RepeatInterval = TimeSpan.FromMinutes(2),
             RepeatCount = SimpleTriggerImpl.RepeatIndefinitely,
-            MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount
+            MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount
         };
         trigger.ComputeFirstFireTimeUtc(null);
 
@@ -472,7 +472,7 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
             StartTimeUtc = startTime,
             RepeatInterval = TimeSpan.FromMinutes(2),
             RepeatCount = 10,
-            MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount
+            MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount
         };
         trigger.ComputeFirstFireTimeUtc(null);
 

--- a/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/SimpleTriggerTest.cs
@@ -192,11 +192,8 @@ public class SimpleTriggerTest : SerializationTestSupport<SimpleTriggerImpl>
     {
         IOperableTrigger trigger = new SimpleTriggerImpl();
         trigger.StartTimeUtc = new DateTimeOffset(1982, 6, 28, 13, 5, 5, 233, TimeSpan.Zero);
-        Assert.Multiple(() =>
-        {
-            Assert.That(trigger.HasMillisecondPrecision, Is.True);
-            Assert.That(trigger.StartTimeUtc.Millisecond, Is.EqualTo(233));
-        });
+
+        trigger.StartTimeUtc.Millisecond.Should().Be(233, "a simple trigger keeps millisecond precision in its start time");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/TriggerDstMisfireTests.cs
+++ b/src/Quartz.Tests.Unit/TriggerDstMisfireTests.cs
@@ -80,7 +80,7 @@ public class TriggerDstMisfireTests
             CronExpressionString = "0 30 2 * * ?",
             TimeZone = Eastern,
             StartTimeUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            MisfireInstruction = misfireInstruction
+            MisfireInstructionCode = misfireInstruction
         };
         trigger.ComputeFirstFireTimeUtc(null);
         return trigger;
@@ -97,7 +97,7 @@ public class TriggerDstMisfireTests
             RepeatIntervalUnit = IntervalUnit.Day,
             TimeZone = Eastern,
             PreserveHourOfDayAcrossDaylightSavings = true,
-            MisfireInstruction = misfireInstruction
+            MisfireInstructionCode = misfireInstruction
         };
         trigger.ComputeFirstFireTimeUtc(null);
         return trigger;
@@ -114,7 +114,7 @@ public class TriggerDstMisfireTests
             RepeatInterval = 15,
             RepeatIntervalUnit = IntervalUnit.Minute,
             TimeZone = Eastern,
-            MisfireInstruction = misfireInstruction
+            MisfireInstructionCode = misfireInstruction
         };
         trigger.ComputeFirstFireTimeUtc(null);
         return trigger;
@@ -128,7 +128,7 @@ public class TriggerDstMisfireTests
             StartTimeUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
             RepeatInterval = TimeSpan.FromHours(1),
             RepeatCount = SimpleTriggerImpl.RepeatIndefinitely,
-            MisfireInstruction = misfireInstruction
+            MisfireInstructionCode = misfireInstruction
         };
         trigger.ComputeFirstFireTimeUtc(null);
         return trigger;

--- a/src/Quartz.Tests.Unit/TriggerTimeComparatorTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerTimeComparatorTest.cs
@@ -155,7 +155,7 @@ public class TriggerTimeComparatorTest
         public int Priority { get; set; }
         public DateTimeOffset StartTimeUtc { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DateTimeOffset? EndTimeUtc { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public int MisfireInstruction { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public int MisfireInstructionCode { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DateTimeOffset? FinalFireTimeUtc => throw new NotImplementedException();
         public bool HasMillisecondPrecision => throw new NotImplementedException();
 

--- a/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
+++ b/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
@@ -222,12 +222,30 @@ public class UpdateTriggerDetailsTest
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
-        bool result = await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithMisfireInstruction(MisfireInstruction.CronTrigger.DoNothing));
+        bool result = await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing));
 
         result.Should().BeTrue();
         IOperableTrigger retrieved = (await jobStore.GetTrigger(trigger.Key))!;
         retrieved.MisfireInstruction.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
         retrieved.NextFireTimeUtc.Should().Be(nextFireBefore);
+    }
+
+    [Test]
+    public async Task MisfireInstructionCode_TakesTheSameNumberAsTheTypedOverload()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        TriggerDetailsUpdate update = new TriggerDetailsUpdate()
+            .WithMisfireInstructionCode((int) CronTriggerMisfireInstruction.DoNothing);
+
+        (await jobStore.UpdateTriggerDetails(trigger.Key, update)).Should().BeTrue();
+
+        IOperableTrigger retrieved = (await jobStore.GetTrigger(trigger.Key))!;
+        retrieved.MisfireInstruction.Should().Be(MisfireInstruction.CronTrigger.DoNothing,
+            "the code form is the same value the typed overload carries, just without the family");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
+++ b/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
@@ -288,6 +288,42 @@ public class UpdateTriggerDetailsTest
     }
 
     [Test]
+    public async Task ExecutionGroup_UpdatedOnItsOwn()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
+
+        bool result = await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithExecutionGroup("heavy"));
+
+        result.Should().BeTrue();
+        IOperableTrigger retrieved = (await jobStore.GetTrigger(trigger.Key))!;
+        retrieved.ExecutionGroup.Should().Be("heavy",
+            "an update carrying only an execution group must still apply it");
+        retrieved.NextFireTimeUtc.Should().Be(nextFireBefore);
+    }
+
+    [Test]
+    public async Task ExecutionGroup_NullClearsTheGroup()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.ExecutionGroup = "heavy";
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        (await jobStore.GetTrigger(trigger.Key))!.ExecutionGroup.Should().Be("heavy");
+
+        (await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithExecutionGroup(null)))
+            .Should().BeTrue();
+
+        (await jobStore.GetTrigger(trigger.Key))!.ExecutionGroup.Should().BeNull();
+    }
+
+    [Test]
     public async Task PreferredNode_UpdatedOnItsOwn()
     {
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();

--- a/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
+++ b/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
@@ -216,7 +216,7 @@ public class UpdateTriggerDetailsTest
     {
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
-        trigger.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
+        trigger.MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy;
         trigger.ComputeFirstFireTimeUtc(null);
         await jobStore.AddTrigger(trigger, false);
 
@@ -226,7 +226,7 @@ public class UpdateTriggerDetailsTest
 
         result.Should().BeTrue();
         IOperableTrigger retrieved = (await jobStore.GetTrigger(trigger.Key))!;
-        retrieved.MisfireInstruction.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
+        retrieved.MisfireInstructionCode.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
         retrieved.NextFireTimeUtc.Should().Be(nextFireBefore);
     }
 
@@ -244,8 +244,47 @@ public class UpdateTriggerDetailsTest
         (await jobStore.UpdateTriggerDetails(trigger.Key, update)).Should().BeTrue();
 
         IOperableTrigger retrieved = (await jobStore.GetTrigger(trigger.Key))!;
-        retrieved.MisfireInstruction.Should().Be(MisfireInstruction.CronTrigger.DoNothing,
+        retrieved.MisfireInstructionCode.Should().Be(MisfireInstruction.CronTrigger.DoNothing,
             "the code form is the same value the typed overload carries, just without the family");
+    }
+
+    [Test]
+    public async Task MisfireInstruction_FromAnotherFamilyIsRejected()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        // Code 2 is in range for a cron trigger, so AbstractTrigger's own validation passes it and
+        // the trigger silently becomes DoNothing. Only the update object knows a simple trigger's
+        // policy was meant.
+        TriggerDetailsUpdate update = new TriggerDetailsUpdate()
+            .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NowWithExistingCount);
+
+        Func<Task> act = async () => await jobStore.UpdateTriggerDetails(trigger.Key, update);
+
+        await act.Should().ThrowAsync<JobPersistenceException>().WithMessage("*simple*cron*");
+
+        (await jobStore.GetTrigger(trigger.Key))!.MisfireInstructionCode.Should().Be(
+            MisfireInstruction.SmartPolicy,
+            "a rejected update must leave the stored trigger alone");
+    }
+
+    [Test]
+    public async Task MisfireInstruction_IsReadBackFromTheFamilyInterface()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.ComputeFirstFireTimeUtc(null);
+        await jobStore.AddTrigger(trigger, false);
+
+        await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithMisfireInstruction(CronTriggerMisfireInstruction.FireAndProceed));
+
+        ICronTrigger retrieved = (ICronTrigger) (await jobStore.GetTrigger(trigger.Key))!;
+        retrieved.MisfireInstruction.Should().Be(CronTriggerMisfireInstruction.FireAndProceed);
+        retrieved.MisfireInstructionCode.Should().Be((int) CronTriggerMisfireInstruction.FireAndProceed,
+            "the typed property and the raw code are two readings of one value");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -269,21 +269,21 @@ namespace Quartz
     public interface ICalendarIntervalTrigger : Quartz.ITrigger
     {
         bool PreserveHourOfDayAcrossDaylightSavings { get; }
-        int RepeatInterval { get; set; }
-        Quartz.IntervalUnit RepeatIntervalUnit { get; set; }
+        int RepeatInterval { get; }
+        Quartz.IntervalUnit RepeatIntervalUnit { get; }
         bool SkipDayIfHourDoesNotExist { get; }
         System.TimeZoneInfo TimeZone { get; }
         int TimesTriggered { get; }
     }
     public interface ICronTrigger : Quartz.ITrigger
     {
-        string? CronExpressionString { get; set; }
-        System.TimeZoneInfo TimeZone { get; set; }
+        string? CronExpressionString { get; }
+        System.TimeZoneInfo TimeZone { get; }
         string? GetExpressionSummary();
     }
     public interface IDailyTimeIntervalTrigger : Quartz.ITrigger
     {
-        System.Collections.Generic.IReadOnlyCollection<System.DayOfWeek> DaysOfWeek { get; set; }
+        System.Collections.Generic.IReadOnlyCollection<System.DayOfWeek> DaysOfWeek { get; }
         System.TimeOnly EndTimeOfDay { get; }
         int RepeatCount { get; }
         int RepeatInterval { get; }
@@ -449,8 +449,8 @@ namespace Quartz
     }
     public interface IRecurrenceTrigger : Quartz.ITrigger
     {
-        string RecurrenceRule { get; set; }
-        System.TimeZoneInfo TimeZone { get; set; }
+        string RecurrenceRule { get; }
+        System.TimeZoneInfo TimeZone { get; }
         int TimesTriggered { get; }
     }
     public interface IScheduleBuilder
@@ -551,8 +551,8 @@ namespace Quartz
     }
     public interface ISimpleTrigger : Quartz.ITrigger
     {
-        int RepeatCount { get; set; }
-        System.TimeSpan RepeatInterval { get; set; }
+        int RepeatCount { get; }
+        System.TimeSpan RepeatInterval { get; }
         int TimesTriggered { get; }
     }
     public interface ITrigger

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -56,7 +56,7 @@ namespace Quartz
         public Quartz.CalendarIntervalScheduleBuilder PreserveHourOfDayAcrossDaylightSavings(bool preserveHourOfDay = true) { }
         public Quartz.CalendarIntervalScheduleBuilder SkipDayIfHourDoesNotExist(bool skipDay = true) { }
         public Quartz.CalendarIntervalScheduleBuilder WithInterval(int interval, Quartz.IntervalUnit unit) { }
-        public Quartz.CalendarIntervalScheduleBuilder WithMisfireHandlingInstruction(Quartz.CalendarIntervalTriggerMisfireInstruction instruction) { }
+        public Quartz.CalendarIntervalScheduleBuilder WithMisfireInstruction(Quartz.CalendarIntervalTriggerMisfireInstruction instruction) { }
         public static Quartz.CalendarIntervalScheduleBuilder Create() { }
     }
     public enum CalendarIntervalTriggerMisfireInstruction
@@ -149,7 +149,7 @@ namespace Quartz
     {
         public Quartz.Extensibility.IMutableTrigger Build() { }
         public Quartz.CronScheduleBuilder InTimeZone(System.TimeZoneInfo? timeZone) { }
-        public Quartz.CronScheduleBuilder WithMisfireHandlingInstruction(Quartz.CronTriggerMisfireInstruction instruction) { }
+        public Quartz.CronScheduleBuilder WithMisfireInstruction(Quartz.CronTriggerMisfireInstruction instruction) { }
         public static Quartz.CronScheduleBuilder CronSchedule(Quartz.CronExpression cronExpression) { }
         public static Quartz.CronScheduleBuilder CronSchedule(string cronExpression) { }
     }
@@ -172,7 +172,7 @@ namespace Quartz
         public Quartz.DailyTimeIntervalScheduleBuilder OnSaturdayAndSunday() { }
         public Quartz.DailyTimeIntervalScheduleBuilder StartingDailyAt(System.TimeOnly timeOfDay) { }
         public Quartz.DailyTimeIntervalScheduleBuilder WithInterval(int interval, Quartz.IntervalUnit unit) { }
-        public Quartz.DailyTimeIntervalScheduleBuilder WithMisfireHandlingInstruction(Quartz.DailyTimeIntervalTriggerMisfireInstruction instruction) { }
+        public Quartz.DailyTimeIntervalScheduleBuilder WithMisfireInstruction(Quartz.DailyTimeIntervalTriggerMisfireInstruction instruction) { }
         public Quartz.DailyTimeIntervalScheduleBuilder WithRepeatCount(int repeatCount) { }
         public static Quartz.DailyTimeIntervalScheduleBuilder Create(System.TimeProvider? timeProvider = null) { }
     }
@@ -1008,7 +1008,7 @@ namespace Quartz
     {
         public Quartz.Extensibility.IMutableTrigger Build() { }
         public Quartz.RecurrenceScheduleBuilder InTimeZone(System.TimeZoneInfo? timeZone) { }
-        public Quartz.RecurrenceScheduleBuilder WithMisfireHandlingInstruction(Quartz.RecurrenceTriggerMisfireInstruction instruction) { }
+        public Quartz.RecurrenceScheduleBuilder WithMisfireInstruction(Quartz.RecurrenceTriggerMisfireInstruction instruction) { }
         public static Quartz.RecurrenceScheduleBuilder Create(string recurrenceRule) { }
     }
     public enum RecurrenceTriggerMisfireInstruction
@@ -1143,7 +1143,7 @@ namespace Quartz
         public Quartz.Extensibility.IMutableTrigger Build() { }
         public Quartz.SimpleScheduleBuilder RepeatForever() { }
         public Quartz.SimpleScheduleBuilder WithInterval(System.TimeSpan timeSpan) { }
-        public Quartz.SimpleScheduleBuilder WithMisfireHandlingInstruction(Quartz.SimpleTriggerMisfireInstruction instruction) { }
+        public Quartz.SimpleScheduleBuilder WithMisfireInstruction(Quartz.SimpleTriggerMisfireInstruction instruction) { }
         public Quartz.SimpleScheduleBuilder WithRepeatCount(int repeatCount) { }
         public static Quartz.SimpleScheduleBuilder Create() { }
     }
@@ -1284,7 +1284,12 @@ namespace Quartz
         public Quartz.TriggerDetailsUpdate WithCalendarName(string? calendarName) { }
         public Quartz.TriggerDetailsUpdate WithDescription(string? description) { }
         public Quartz.TriggerDetailsUpdate WithJobDataMap(Quartz.JobDataMap jobDataMap) { }
-        public Quartz.TriggerDetailsUpdate WithMisfireInstruction(int misfireInstruction) { }
+        public Quartz.TriggerDetailsUpdate WithMisfireInstruction(Quartz.CalendarIntervalTriggerMisfireInstruction misfireInstruction) { }
+        public Quartz.TriggerDetailsUpdate WithMisfireInstruction(Quartz.CronTriggerMisfireInstruction misfireInstruction) { }
+        public Quartz.TriggerDetailsUpdate WithMisfireInstruction(Quartz.DailyTimeIntervalTriggerMisfireInstruction misfireInstruction) { }
+        public Quartz.TriggerDetailsUpdate WithMisfireInstruction(Quartz.RecurrenceTriggerMisfireInstruction misfireInstruction) { }
+        public Quartz.TriggerDetailsUpdate WithMisfireInstruction(Quartz.SimpleTriggerMisfireInstruction misfireInstruction) { }
+        public Quartz.TriggerDetailsUpdate WithMisfireInstructionCode(int misfireInstructionCode) { }
         public Quartz.TriggerDetailsUpdate WithPreferredNode(Quartz.PreferredNode preferredNode) { }
         public Quartz.TriggerDetailsUpdate WithPriority(int priority) { }
     }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -567,7 +567,6 @@ namespace Quartz
         System.DateTimeOffset? EndTimeUtc { get; }
         string? ExecutionGroup { get; }
         System.DateTimeOffset? FinalFireTimeUtc { get; }
-        bool HasMillisecondPrecision { get; }
         Quartz.JobDataMap JobDataMap { get; }
         Quartz.JobKey JobKey { get; }
         Quartz.TriggerKey Key { get; }
@@ -1254,6 +1253,7 @@ namespace Quartz
         public TriggerDetailsUpdate() { }
         public Quartz.TriggerDetailsUpdate WithCalendarName(string? calendarName) { }
         public Quartz.TriggerDetailsUpdate WithDescription(string? description) { }
+        public Quartz.TriggerDetailsUpdate WithExecutionGroup(string? executionGroup) { }
         public Quartz.TriggerDetailsUpdate WithJobDataMap(Quartz.JobDataMap jobDataMap) { }
         public Quartz.TriggerDetailsUpdate WithMisfireInstruction(Quartz.CalendarIntervalTriggerMisfireInstruction misfireInstruction) { }
         public Quartz.TriggerDetailsUpdate WithMisfireInstruction(Quartz.CronTriggerMisfireInstruction misfireInstruction) { }
@@ -2890,7 +2890,7 @@ namespace Quartz.Impl.Triggers
         public abstract System.DateTimeOffset? FinalFireTimeUtc { get; }
         public virtual string FireInstanceId { get; set; }
         public virtual bool HasAdditionalProperties { get; }
-        public abstract bool HasMillisecondPrecision { get; }
+        protected abstract bool HasMillisecondPrecision { get; }
         public virtual Quartz.JobDataMap JobDataMap { get; set; }
         public Quartz.JobKey JobKey { get; set; }
         public Quartz.TriggerKey Key { get; set; }
@@ -2929,7 +2929,7 @@ namespace Quartz.Impl.Triggers
         public CalendarIntervalTriggerImpl(string name, string group, string jobName, string jobGroup, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, Quartz.IntervalUnit intervalUnit, int repeatInterval, System.TimeProvider? timeProvider = null) { }
         public override System.DateTimeOffset? EndTimeUtc { get; set; }
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
-        public override bool HasMillisecondPrecision { get; }
+        protected override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
         public Quartz.CalendarIntervalTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
@@ -2966,7 +2966,7 @@ namespace Quartz.Impl.Triggers
         public string? CronExpressionString { get; set; }
         public override System.DateTimeOffset? EndTimeUtc { get; set; }
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
-        public override bool HasMillisecondPrecision { get; }
+        protected override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
         public Quartz.CronTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
@@ -3000,7 +3000,7 @@ namespace Quartz.Impl.Triggers
         public System.TimeOnly EndTimeOfDay { get; set; }
         public override System.DateTimeOffset? EndTimeUtc { get; set; }
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
-        public override bool HasMillisecondPrecision { get; }
+        protected override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
         public Quartz.DailyTimeIntervalTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
@@ -3027,7 +3027,7 @@ namespace Quartz.Impl.Triggers
         public RecurrenceTriggerImpl(string name, string group, string recurrenceRule, System.TimeProvider? timeProvider = null) { }
         public override System.DateTimeOffset? EndTimeUtc { get; set; }
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
-        public override bool HasMillisecondPrecision { get; }
+        protected override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
         public Quartz.RecurrenceTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
@@ -3061,7 +3061,7 @@ namespace Quartz.Impl.Triggers
         public SimpleTriggerImpl(string name, string group, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, int repeatCount, System.TimeSpan repeatInterval, System.TimeProvider? timeProvider = null) { }
         public SimpleTriggerImpl(string name, string group, string jobName, string jobGroup, System.DateTimeOffset startTimeUtc, System.DateTimeOffset? endTimeUtc, int repeatCount, System.TimeSpan repeatInterval, System.TimeProvider? timeProvider = null) { }
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
-        public override bool HasMillisecondPrecision { get; }
+        protected override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
         public Quartz.SimpleTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -268,6 +268,7 @@ namespace Quartz
     }
     public interface ICalendarIntervalTrigger : Quartz.ITrigger
     {
+        Quartz.CalendarIntervalTriggerMisfireInstruction MisfireInstruction { get; }
         bool PreserveHourOfDayAcrossDaylightSavings { get; }
         int RepeatInterval { get; }
         Quartz.IntervalUnit RepeatIntervalUnit { get; }
@@ -278,6 +279,7 @@ namespace Quartz
     public interface ICronTrigger : Quartz.ITrigger
     {
         string? CronExpressionString { get; }
+        Quartz.CronTriggerMisfireInstruction MisfireInstruction { get; }
         System.TimeZoneInfo TimeZone { get; }
         string? GetExpressionSummary();
     }
@@ -285,6 +287,7 @@ namespace Quartz
     {
         System.Collections.Generic.IReadOnlyCollection<System.DayOfWeek> DaysOfWeek { get; }
         System.TimeOnly EndTimeOfDay { get; }
+        Quartz.DailyTimeIntervalTriggerMisfireInstruction MisfireInstruction { get; }
         int RepeatCount { get; }
         int RepeatInterval { get; }
         Quartz.IntervalUnit RepeatIntervalUnit { get; }
@@ -449,6 +452,7 @@ namespace Quartz
     }
     public interface IRecurrenceTrigger : Quartz.ITrigger
     {
+        Quartz.RecurrenceTriggerMisfireInstruction MisfireInstruction { get; }
         string RecurrenceRule { get; }
         System.TimeZoneInfo TimeZone { get; }
         int TimesTriggered { get; }
@@ -551,6 +555,7 @@ namespace Quartz
     }
     public interface ISimpleTrigger : Quartz.ITrigger
     {
+        Quartz.SimpleTriggerMisfireInstruction MisfireInstruction { get; }
         int RepeatCount { get; }
         System.TimeSpan RepeatInterval { get; }
         int TimesTriggered { get; }
@@ -567,7 +572,7 @@ namespace Quartz
         Quartz.JobKey JobKey { get; }
         Quartz.TriggerKey Key { get; }
         bool MayFireAgain { get; }
-        int MisfireInstruction { get; }
+        int MisfireInstructionCode { get; }
         System.DateTimeOffset? NextFireTimeUtc { get; }
         Quartz.PreferredNode PreferredNode { get; }
         System.DateTimeOffset? PreviousFireTimeUtc { get; }
@@ -780,40 +785,6 @@ namespace Quartz
         public static bool operator ==(Quartz.Key<T>? left, Quartz.Key<T>? right) { }
         public static bool operator >(Quartz.Key<T> left, Quartz.Key<T> right) { }
         public static bool operator >=(Quartz.Key<T> left, Quartz.Key<T> right) { }
-    }
-    public static class MisfireInstruction
-    {
-        public const int IgnoreMisfirePolicy = -1;
-        public const int InstructionNotSet = 0;
-        public const int SmartPolicy = 0;
-        public static class CalendarIntervalTrigger
-        {
-            public const int DoNothing = 2;
-            public const int FireOnceNow = 1;
-        }
-        public static class CronTrigger
-        {
-            public const int DoNothing = 2;
-            public const int FireOnceNow = 1;
-        }
-        public static class DailyTimeIntervalTrigger
-        {
-            public const int DoNothing = 2;
-            public const int FireOnceNow = 1;
-        }
-        public static class RecurrenceTrigger
-        {
-            public const int DoNothing = 2;
-            public const int FireOnceNow = 1;
-        }
-        public static class SimpleTrigger
-        {
-            public const int FireNow = 1;
-            public const int RescheduleNextWithExistingCount = 5;
-            public const int RescheduleNextWithRemainingCount = 4;
-            public const int RescheduleNowWithExistingRepeatCount = 2;
-            public const int RescheduleNowWithRemainingRepeatCount = 3;
-        }
     }
     public sealed class NameMatcher<TKey> : Quartz.StringMatcher<TKey>
         where TKey : Quartz.Key<TKey>
@@ -1494,7 +1465,7 @@ namespace Quartz.Extensibility
         new Quartz.JobDataMap JobDataMap { get; set; }
         new Quartz.JobKey JobKey { get; set; }
         new Quartz.TriggerKey Key { get; set; }
-        new int MisfireInstruction { get; set; }
+        new int MisfireInstructionCode { get; set; }
         new System.DateTimeOffset? NextFireTimeUtc { get; set; }
         new Quartz.PreferredNode PreferredNode { get; set; }
         new System.DateTimeOffset? PreviousFireTimeUtc { get; set; }
@@ -2924,7 +2895,7 @@ namespace Quartz.Impl.Triggers
         public Quartz.JobKey JobKey { get; set; }
         public Quartz.TriggerKey Key { get; set; }
         public abstract bool MayFireAgain { get; }
-        public virtual int MisfireInstruction { get; set; }
+        public virtual int MisfireInstructionCode { get; set; }
         public abstract System.DateTimeOffset? NextFireTimeUtc { get; set; }
         public Quartz.PreferredNode PreferredNode { get; set; }
         public abstract System.DateTimeOffset? PreviousFireTimeUtc { get; set; }
@@ -2960,6 +2931,7 @@ namespace Quartz.Impl.Triggers
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
         public override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
+        public Quartz.CalendarIntervalTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
         public bool PreserveHourOfDayAcrossDaylightSavings { get; set; }
         public override System.DateTimeOffset? PreviousFireTimeUtc { get; set; }
@@ -2996,6 +2968,7 @@ namespace Quartz.Impl.Triggers
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
         public override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
+        public Quartz.CronTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
         public override System.DateTimeOffset? PreviousFireTimeUtc { get; set; }
         public override System.DateTimeOffset StartTimeUtc { get; set; }
@@ -3029,6 +3002,7 @@ namespace Quartz.Impl.Triggers
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
         public override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
+        public Quartz.DailyTimeIntervalTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
         public override System.DateTimeOffset? PreviousFireTimeUtc { get; set; }
         public int RepeatCount { get; set; }
@@ -3055,6 +3029,7 @@ namespace Quartz.Impl.Triggers
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
         public override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
+        public Quartz.RecurrenceTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
         public override System.DateTimeOffset? PreviousFireTimeUtc { get; set; }
         public string RecurrenceRule { get; set; }
@@ -3088,6 +3063,7 @@ namespace Quartz.Impl.Triggers
         public override System.DateTimeOffset? FinalFireTimeUtc { get; }
         public override bool HasMillisecondPrecision { get; }
         public override bool MayFireAgain { get; }
+        public Quartz.SimpleTriggerMisfireInstruction MisfireInstruction { get; }
         public override System.DateTimeOffset? NextFireTimeUtc { get; set; }
         public override System.DateTimeOffset? PreviousFireTimeUtc { get; set; }
         public int RepeatCount { get; set; }
@@ -3367,7 +3343,6 @@ namespace Quartz.Xml
         protected virtual void ProcessInternal(string xml) { }
         public virtual System.Threading.Tasks.ValueTask ProcessStream(System.IO.Stream stream, string? systemId, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask ProcessStreamAndScheduleJobs(System.IO.Stream stream, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
-        protected virtual int ReadMisfireInstructionFromString(string misfireInstruction) { }
         public virtual System.Threading.Tasks.ValueTask ScheduleJobs(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual bool TryParseEnum<T>(string value, out T result)
             where T :  struct { }

--- a/src/Quartz.Tests.Unit/Xml/XMLSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Unit/Xml/XMLSchedulingDataProcessorTest.cs
@@ -162,7 +162,7 @@ public class XMLSchedulingDataProcessorTest
         trigger.CalendarName.Should().Be("calendarName");
         trigger.StartTimeUtc.Should().Be(new DateTimeOffset(2020, 1, 1, 10, 0, 0, TimeSpan.Zero));
         trigger.EndTimeUtc.Should().Be(new DateTimeOffset(2030, 1, 1, 10, 0, 0, TimeSpan.Zero));
-        trigger.MisfireInstruction.Should().Be(MisfireInstruction.SimpleTrigger.FireNow);
+        trigger.MisfireInstructionCode.Should().Be(MisfireInstruction.SimpleTrigger.FireNow);
         trigger.JobDataMap.GetString("triggerKey").Should().Be("triggerValue");
 
         ISimpleTrigger simple = (ISimpleTrigger) trigger;
@@ -199,7 +199,7 @@ public class XMLSchedulingDataProcessorTest
         trigger.Should().BeAssignableTo<ICronTrigger>();
         trigger.Key.Should().Be(new TriggerKey("triggerName", "triggerGroup"));
         trigger.Priority.Should().Be(3);
-        trigger.MisfireInstruction.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
+        trigger.MisfireInstructionCode.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
 
         ICronTrigger cron = (ICronTrigger) trigger;
         cron.CronExpressionString.Should().Be("0 0/5 * * * ?");
@@ -229,7 +229,7 @@ public class XMLSchedulingDataProcessorTest
 
         ITrigger trigger = processor.SingleTrigger;
         trigger.Should().BeAssignableTo<ICalendarIntervalTrigger>();
-        trigger.MisfireInstruction.Should().Be(MisfireInstruction.CalendarIntervalTrigger.DoNothing);
+        trigger.MisfireInstructionCode.Should().Be(MisfireInstruction.CalendarIntervalTrigger.DoNothing);
 
         ICalendarIntervalTrigger calendarInterval = (ICalendarIntervalTrigger) trigger;
         calendarInterval.RepeatInterval.Should().Be(2);
@@ -305,7 +305,7 @@ public class XMLSchedulingDataProcessorTest
             </schedule>
             """));
 
-        processor.SingleTrigger.MisfireInstruction.Should().Be(expected);
+        processor.SingleTrigger.MisfireInstructionCode.Should().Be(expected);
     }
 
     [TestCase("SmartPolicy", MisfireInstruction.SmartPolicy)]
@@ -329,7 +329,7 @@ public class XMLSchedulingDataProcessorTest
             </schedule>
             """));
 
-        processor.SingleTrigger.MisfireInstruction.Should().Be(expected);
+        processor.SingleTrigger.MisfireInstructionCode.Should().Be(expected);
     }
 
     [TestCase("SmartPolicy", MisfireInstruction.SmartPolicy)]
@@ -354,7 +354,35 @@ public class XMLSchedulingDataProcessorTest
             </schedule>
             """));
 
-        processor.SingleTrigger.MisfireInstruction.Should().Be(expected);
+        processor.SingleTrigger.MisfireInstructionCode.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// XML gets its per-family misfire names from the schema, one <c>xs:pattern</c> set per trigger
+    /// type, so a name belonging to another family never reaches the name resolver. This is why the
+    /// silent cross-family mis-parse that the reflection-based lookup allowed was only ever
+    /// reachable through JSON, which has no schema.
+    /// </summary>
+    [Test]
+    public async Task TheSchemaRejectsAMisfireInstructionFromAnotherFamily()
+    {
+        Func<Task> act = async () => await Process(Document($"""
+            <schedule>
+              {Job}
+              <trigger>
+                <cron>
+                  <name>triggerName</name>
+                  <job-name>job1</job-name>
+                  <job-group>group1</job-group>
+                  <misfire-instruction>RescheduleNowWithExistingRepeatCount</misfire-instruction>
+                  <cron-expression>0 0 12 * * ?</cron-expression>
+                </cron>
+              </trigger>
+            </schedule>
+            """));
+
+        await act.Should().ThrowAsync<SchedulingDataValidationException>()
+            .WithMessage("*misfire-instruction*cron-trigger-misfire-instructionType*");
     }
 
     [TestCase("Second", IntervalUnit.Second)]
@@ -510,7 +538,7 @@ public class XMLSchedulingDataProcessorTest
         trigger.CalendarName.Should().BeNull();
         trigger.EndTimeUtc.Should().BeNull();
         trigger.Priority.Should().Be(TriggerConstants.DefaultPriority);
-        trigger.MisfireInstruction.Should().Be(MisfireInstruction.SmartPolicy);
+        trigger.MisfireInstructionCode.Should().Be(MisfireInstruction.SmartPolicy);
         ((ICronTrigger) trigger).TimeZone.Should().Be(TimeZoneInfo.Local);
     }
 

--- a/src/Quartz/CalendarIntervalScheduleBuilder.cs
+++ b/src/Quartz/CalendarIntervalScheduleBuilder.cs
@@ -102,7 +102,7 @@ public sealed class CalendarIntervalScheduleBuilder : IScheduleBuilder
     /// <see cref="CalendarIntervalTriggerMisfireInstruction.SmartPolicy" />.</param>
     /// <returns>the updated CalendarIntervalScheduleBuilder</returns>
     /// <seealso cref="CalendarIntervalTriggerMisfireInstruction" />
-    public CalendarIntervalScheduleBuilder WithMisfireHandlingInstruction(CalendarIntervalTriggerMisfireInstruction instruction)
+    public CalendarIntervalScheduleBuilder WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction instruction)
     {
         misfireInstruction = (int) instruction;
         return this;

--- a/src/Quartz/CalendarIntervalScheduleBuilder.cs
+++ b/src/Quartz/CalendarIntervalScheduleBuilder.cs
@@ -69,7 +69,7 @@ public sealed class CalendarIntervalScheduleBuilder : IScheduleBuilder
         CalendarIntervalTriggerImpl st = new CalendarIntervalTriggerImpl();
         st.RepeatInterval = interval;
         st.RepeatIntervalUnit = intervalUnit;
-        st.MisfireInstruction = misfireInstruction;
+        st.MisfireInstructionCode = misfireInstruction;
         st.timeZone = timeZone;
         st.PreserveHourOfDayAcrossDaylightSavings = preserveHourOfDayAcrossDaylightSavings;
         st.SkipDayIfHourDoesNotExist = skipDayIfHourDoesNotExist;

--- a/src/Quartz/CalendarIntervalTriggerMisfireInstruction.cs
+++ b/src/Quartz/CalendarIntervalTriggerMisfireInstruction.cs
@@ -24,7 +24,7 @@ namespace Quartz;
 /// </summary>
 /// <remarks>
 /// The values match the <see cref="MisfireInstruction" /> constants a trigger stores in
-/// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
+/// <see cref="ITrigger.MisfireInstructionCode" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
 /// <seealso cref="CalendarIntervalScheduleBuilder.WithMisfireInstruction" />

--- a/src/Quartz/CalendarIntervalTriggerMisfireInstruction.cs
+++ b/src/Quartz/CalendarIntervalTriggerMisfireInstruction.cs
@@ -27,13 +27,16 @@ namespace Quartz;
 /// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
-/// <seealso cref="CalendarIntervalScheduleBuilder.WithMisfireHandlingInstruction" />
+/// <seealso cref="CalendarIntervalScheduleBuilder.WithMisfireInstruction" />
 public enum CalendarIntervalTriggerMisfireInstruction
 {
     /// <summary>
     /// Let the scheduler pick the policy. This is the default, and for a calendar-interval trigger
     /// it means <see cref="FireAndProceed" />.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>SmartPolicy</c> in XML and JSON scheduling data.
+    /// </remarks>
     SmartPolicy = MisfireInstruction.SmartPolicy,
 
     /// <summary>
@@ -42,16 +45,23 @@ public enum CalendarIntervalTriggerMisfireInstruction
     /// <remarks>
     /// A trigger that missed many firings will fire that many times in rapid succession while it
     /// catches up.
+    /// <para>Spelled <c>IgnoreMisfirePolicy</c> in XML and JSON scheduling data.</para>
     /// </remarks>
     IgnoreMisfires = MisfireInstruction.IgnoreMisfirePolicy,
 
     /// <summary>
     /// Fire once now, then resume the schedule.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>FireOnceNow</c> in XML and JSON scheduling data.
+    /// </remarks>
     FireAndProceed = MisfireInstruction.CalendarIntervalTrigger.FireOnceNow,
 
     /// <summary>
     /// Skip the missed firings and resume at the next scheduled time.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>DoNothing</c> in XML and JSON scheduling data.
+    /// </remarks>
     DoNothing = MisfireInstruction.CalendarIntervalTrigger.DoNothing,
 }

--- a/src/Quartz/Configuration/JsonSchedulingHelper.cs
+++ b/src/Quartz/Configuration/JsonSchedulingHelper.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Reflection;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -301,7 +300,7 @@ internal static class JsonSchedulingHelper
         var misfireInstruction = section[nameof(JsonSimpleSchedule.MisfireInstruction)];
         if (misfireInstruction is not null)
         {
-            builder.WithMisfireInstruction((SimpleTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
+            builder.WithMisfireInstruction((SimpleTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Simple, misfireInstruction));
         }
 
         return builder;
@@ -336,7 +335,7 @@ internal static class JsonSchedulingHelper
         var misfireInstruction = section[nameof(JsonCronSchedule.MisfireInstruction)];
         if (misfireInstruction is not null)
         {
-            builder.WithMisfireInstruction((CronTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
+            builder.WithMisfireInstruction((CronTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Cron, misfireInstruction));
         }
 
         return builder;
@@ -355,7 +354,7 @@ internal static class JsonSchedulingHelper
         var misfireInstruction = section[nameof(JsonCalendarIntervalSchedule.MisfireInstruction)];
         if (misfireInstruction is not null)
         {
-            builder.WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
+            builder.WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.CalendarInterval, misfireInstruction));
         }
 
         return builder;
@@ -416,7 +415,7 @@ internal static class JsonSchedulingHelper
         var misfireInstruction = section[nameof(JsonDailyTimeIntervalSchedule.MisfireInstruction)];
         if (misfireInstruction is not null)
         {
-            var instruction = (DailyTimeIntervalTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction);
+            var instruction = (DailyTimeIntervalTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.DailyTimeInterval, misfireInstruction);
             if (Enum.IsDefined(instruction))
             {
                 builder.WithMisfireInstruction(instruction);
@@ -442,24 +441,6 @@ internal static class JsonSchedulingHelper
             throw new SchedulerConfigException($"TimeOfDay value '{value}' must not contain fractional seconds.");
         }
         return new TimeOnly(timeSpan.Hours, timeSpan.Minutes, timeSpan.Seconds);
-    }
-
-    private static int ParseMisfireInstruction(string value)
-    {
-        var misfireType = typeof(MisfireInstruction);
-        var types = new[] { misfireType }.Concat(misfireType.GetNestedTypes(BindingFlags.Public)).ToArray();
-        foreach (var type in types)
-        {
-            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Static))
-            {
-                if (string.Equals(field.Name, value, StringComparison.OrdinalIgnoreCase))
-                {
-                    return (int) field.GetValue(null)!;
-                }
-            }
-        }
-
-        throw new SchedulerConfigException($"Unknown misfire instruction: '{value}'");
     }
 
     private static bool ParseBool(string? value, string context = "")

--- a/src/Quartz/Configuration/JsonSchedulingHelper.cs
+++ b/src/Quartz/Configuration/JsonSchedulingHelper.cs
@@ -301,7 +301,7 @@ internal static class JsonSchedulingHelper
         var misfireInstruction = section[nameof(JsonSimpleSchedule.MisfireInstruction)];
         if (misfireInstruction is not null)
         {
-            builder.WithMisfireHandlingInstruction((SimpleTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
+            builder.WithMisfireInstruction((SimpleTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
         }
 
         return builder;
@@ -336,7 +336,7 @@ internal static class JsonSchedulingHelper
         var misfireInstruction = section[nameof(JsonCronSchedule.MisfireInstruction)];
         if (misfireInstruction is not null)
         {
-            builder.WithMisfireHandlingInstruction((CronTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
+            builder.WithMisfireInstruction((CronTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
         }
 
         return builder;
@@ -355,7 +355,7 @@ internal static class JsonSchedulingHelper
         var misfireInstruction = section[nameof(JsonCalendarIntervalSchedule.MisfireInstruction)];
         if (misfireInstruction is not null)
         {
-            builder.WithMisfireHandlingInstruction((CalendarIntervalTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
+            builder.WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction));
         }
 
         return builder;
@@ -419,7 +419,7 @@ internal static class JsonSchedulingHelper
             var instruction = (DailyTimeIntervalTriggerMisfireInstruction) ParseMisfireInstruction(misfireInstruction);
             if (Enum.IsDefined(instruction))
             {
-                builder.WithMisfireHandlingInstruction(instruction);
+                builder.WithMisfireInstruction(instruction);
             }
         }
 

--- a/src/Quartz/CronScheduleBuilder.cs
+++ b/src/Quartz/CronScheduleBuilder.cs
@@ -140,7 +140,7 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
 
         ct.CronExpression = cronExpression;
         ct.TimeZone = cronExpression.TimeZone;
-        ct.MisfireInstruction = misfireInstruction;
+        ct.MisfireInstructionCode = misfireInstruction;
 
         return ct;
     }

--- a/src/Quartz/CronScheduleBuilder.cs
+++ b/src/Quartz/CronScheduleBuilder.cs
@@ -240,7 +240,7 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
     /// <see cref="CronTriggerMisfireInstruction.SmartPolicy" />.</param>
     /// <returns>the updated CronScheduleBuilder</returns>
     /// <seealso cref="CronTriggerMisfireInstruction" />
-    public CronScheduleBuilder WithMisfireHandlingInstruction(CronTriggerMisfireInstruction instruction)
+    public CronScheduleBuilder WithMisfireInstruction(CronTriggerMisfireInstruction instruction)
     {
         misfireInstruction = (int) instruction;
         return this;

--- a/src/Quartz/CronTriggerMisfireInstruction.cs
+++ b/src/Quartz/CronTriggerMisfireInstruction.cs
@@ -27,13 +27,16 @@ namespace Quartz;
 /// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
-/// <seealso cref="CronScheduleBuilder.WithMisfireHandlingInstruction" />
+/// <seealso cref="CronScheduleBuilder.WithMisfireInstruction" />
 public enum CronTriggerMisfireInstruction
 {
     /// <summary>
     /// Let the scheduler pick the policy. This is the default, and for a cron trigger it means
     /// <see cref="FireAndProceed" />.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>SmartPolicy</c> in XML and JSON scheduling data.
+    /// </remarks>
     SmartPolicy = MisfireInstruction.SmartPolicy,
 
     /// <summary>
@@ -42,16 +45,23 @@ public enum CronTriggerMisfireInstruction
     /// <remarks>
     /// A trigger that missed many firings will fire that many times in rapid succession while it
     /// catches up.
+    /// <para>Spelled <c>IgnoreMisfirePolicy</c> in XML and JSON scheduling data.</para>
     /// </remarks>
     IgnoreMisfires = MisfireInstruction.IgnoreMisfirePolicy,
 
     /// <summary>
     /// Fire once now, then resume the schedule.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>FireOnceNow</c> in XML and JSON scheduling data.
+    /// </remarks>
     FireAndProceed = MisfireInstruction.CronTrigger.FireOnceNow,
 
     /// <summary>
     /// Skip the missed firings and resume at the next scheduled time.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>DoNothing</c> in XML and JSON scheduling data.
+    /// </remarks>
     DoNothing = MisfireInstruction.CronTrigger.DoNothing,
 }

--- a/src/Quartz/CronTriggerMisfireInstruction.cs
+++ b/src/Quartz/CronTriggerMisfireInstruction.cs
@@ -24,7 +24,7 @@ namespace Quartz;
 /// </summary>
 /// <remarks>
 /// The values match the <see cref="MisfireInstruction" /> constants a trigger stores in
-/// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
+/// <see cref="ITrigger.MisfireInstructionCode" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
 /// <seealso cref="CronScheduleBuilder.WithMisfireInstruction" />

--- a/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
+++ b/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
@@ -144,7 +144,7 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
         DailyTimeIntervalTriggerImpl st = new DailyTimeIntervalTriggerImpl();
         st.RepeatInterval = interval;
         st.RepeatIntervalUnit = intervalUnit;
-        st.MisfireInstruction = misfireInstruction;
+        st.MisfireInstructionCode = misfireInstruction;
         st.RepeatCount = repeatCount;
         st.timeZone = timeZone;
 

--- a/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
+++ b/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -351,7 +351,7 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
     /// <see cref="DailyTimeIntervalTriggerMisfireInstruction.SmartPolicy" />.</param>
     /// <returns>the updated DailyTimeIntervalScheduleBuilder</returns>
     /// <seealso cref="DailyTimeIntervalTriggerMisfireInstruction" />
-    public DailyTimeIntervalScheduleBuilder WithMisfireHandlingInstruction(DailyTimeIntervalTriggerMisfireInstruction instruction)
+    public DailyTimeIntervalScheduleBuilder WithMisfireInstruction(DailyTimeIntervalTriggerMisfireInstruction instruction)
     {
         misfireInstruction = (int) instruction;
         return this;

--- a/src/Quartz/DailyTimeIntervalTriggerMisfireInstruction.cs
+++ b/src/Quartz/DailyTimeIntervalTriggerMisfireInstruction.cs
@@ -27,13 +27,17 @@ namespace Quartz;
 /// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
-/// <seealso cref="DailyTimeIntervalScheduleBuilder.WithMisfireHandlingInstruction" />
+/// <seealso cref="DailyTimeIntervalScheduleBuilder.WithMisfireInstruction" />
 public enum DailyTimeIntervalTriggerMisfireInstruction
 {
     /// <summary>
     /// Let the scheduler pick the policy. This is the default, and for a daily-time-interval
     /// trigger it means <see cref="FireAndProceed" />.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>SmartPolicy</c> in JSON scheduling data. The XML scheduling-data schema has no
+    /// daily-time-interval trigger.
+    /// </remarks>
     SmartPolicy = MisfireInstruction.SmartPolicy,
 
     /// <summary>
@@ -42,16 +46,23 @@ public enum DailyTimeIntervalTriggerMisfireInstruction
     /// <remarks>
     /// A trigger that missed many firings will fire that many times in rapid succession while it
     /// catches up.
+    /// <para>Spelled <c>IgnoreMisfirePolicy</c> in JSON scheduling data.</para>
     /// </remarks>
     IgnoreMisfires = MisfireInstruction.IgnoreMisfirePolicy,
 
     /// <summary>
     /// Fire once now, then resume the schedule.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>FireOnceNow</c> in JSON scheduling data.
+    /// </remarks>
     FireAndProceed = MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow,
 
     /// <summary>
     /// Skip the missed firings and resume at the next scheduled time.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>DoNothing</c> in JSON scheduling data.
+    /// </remarks>
     DoNothing = MisfireInstruction.DailyTimeIntervalTrigger.DoNothing,
 }

--- a/src/Quartz/DailyTimeIntervalTriggerMisfireInstruction.cs
+++ b/src/Quartz/DailyTimeIntervalTriggerMisfireInstruction.cs
@@ -24,7 +24,7 @@ namespace Quartz;
 /// </summary>
 /// <remarks>
 /// The values match the <see cref="MisfireInstruction" /> constants a trigger stores in
-/// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
+/// <see cref="ITrigger.MisfireInstructionCode" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
 /// <seealso cref="DailyTimeIntervalScheduleBuilder.WithMisfireInstruction" />

--- a/src/Quartz/Extensibility/IJobStore.cs
+++ b/src/Quartz/Extensibility/IJobStore.cs
@@ -214,8 +214,7 @@ public interface IJobStore
     /// <param name="triggerKey">The key identifying the trigger to update.</param>
     /// <param name="update">
     /// The details to update. Only properties explicitly set will be changed.
-    /// May include <see cref="TriggerDetailsUpdate.CalendarName"/> and
-    /// <see cref="TriggerDetailsUpdate.MisfireInstruction"/> which can affect firing behavior.
+    /// May include the calendar name and the misfire instruction, which can affect firing behavior.
     /// </param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns><see langword="true"/> if the trigger was found and updated, <see langword="false"/> if not found.</returns>

--- a/src/Quartz/Extensibility/IMutableTrigger.cs
+++ b/src/Quartz/Extensibility/IMutableTrigger.cs
@@ -103,17 +103,15 @@ public interface IMutableTrigger : ITrigger
     new DateTimeOffset? PreviousFireTimeUtc { get; set; }
 
     /// <summary>
-    /// Set the instruction the <see cref="IScheduler" /> should be given for
-    /// handling misfire situations for this <see cref="ITrigger" />- the
-    /// concrete <see cref="ITrigger" /> type that you are using will have
-    /// defined a set of additional MisfireInstruction.XXX
-    /// constants that may be passed to this method.
+    /// The raw code of the instruction the <see cref="IScheduler" /> follows when this trigger
+    /// misses a firing.
     /// </summary>
     /// <remarks>
-    /// If not explicitly set, the default value is <see cref="Quartz.MisfireInstruction.SmartPolicy" />.
+    /// The value is validated against the concrete trigger's family, which rejects a code outside
+    /// its own range — but not one that is in range for two families and means something different
+    /// in each. Assign a value cast from the family's own misfire enum.
     /// </remarks>
-    /// <seealso cref="Quartz.MisfireInstruction.SmartPolicy" />
-    /// <seealso cref="ISimpleTrigger" />
-    /// <seealso cref="ICronTrigger" />
-    new int MisfireInstruction { get; set; }
+    /// <seealso cref="ISimpleTrigger.MisfireInstruction" />
+    /// <seealso cref="ICronTrigger.MisfireInstruction" />
+    new int MisfireInstructionCode { get; set; }
 }

--- a/src/Quartz/ICalendarIntervalTrigger.cs
+++ b/src/Quartz/ICalendarIntervalTrigger.cs
@@ -4,19 +4,24 @@ namespace Quartz;
 ///  A <see cref="ITrigger" /> that is used to fire a <see cref="IJobDetail" />
 ///  based upon repeating calendar time intervals.
 ///  </summary>
+/// <remarks>
+/// This is a read model: to change a trigger's schedule, rebuild it with
+/// <see cref="ITrigger.GetTriggerBuilder" /> and hand it to
+/// <see cref="IScheduler.RescheduleJob" />.
+/// </remarks>
 public interface ICalendarIntervalTrigger : ITrigger
 {
     /// <summary>
-    /// Get or set the interval unit - the time unit on with the interval applies.
+    /// The interval unit - the time unit on with the interval applies.
     /// </summary>
-    IntervalUnit RepeatIntervalUnit { get; set; }
+    IntervalUnit RepeatIntervalUnit { get; }
 
     /// <summary>
     /// Get the time interval that will be added to the <see cref="ICalendarIntervalTrigger" />'s
     /// fire time (in the set repeat interval unit) in order to calculate the time of the
     /// next trigger repeat.
     /// </summary>
-    int RepeatInterval { get; set; }
+    int RepeatInterval { get; }
 
     /// <summary>
     /// Get the number of times the <see cref="ICalendarIntervalTrigger" /> has already fired.

--- a/src/Quartz/ICalendarIntervalTrigger.cs
+++ b/src/Quartz/ICalendarIntervalTrigger.cs
@@ -29,6 +29,12 @@ public interface ICalendarIntervalTrigger : ITrigger
     int TimesTriggered { get; }
 
     /// <summary>
+    /// What the scheduler does when this trigger misses a firing.
+    /// </summary>
+    /// <seealso cref="CalendarIntervalScheduleBuilder.WithMisfireInstruction" />
+    CalendarIntervalTriggerMisfireInstruction MisfireInstruction { get; }
+
+    /// <summary>
     /// Gets the time zone within which time calculations related to this trigger will be performed.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/ICronTrigger.cs
+++ b/src/Quartz/ICronTrigger.cs
@@ -132,6 +132,12 @@ namespace Quartz;
 /// </para>
 ///
 /// <para>
+/// This is a read model: to change a trigger's schedule, rebuild it with
+/// <see cref="ITrigger.GetTriggerBuilder" /> and hand it to
+/// <see cref="IScheduler.RescheduleJob" />.
+/// </para>
+///
+/// <para>
 /// <b>NOTES:</b>
 /// <ul>
 /// <li>Support for specifying both a day-of-week and a day-of-month value is
@@ -152,24 +158,17 @@ namespace Quartz;
 public interface ICronTrigger : ITrigger
 {
     /// <summary>
-    /// Gets or sets the cron expression string.
+    /// The cron expression string.
     /// </summary>
     /// <value>The cron expression string.</value>
-    string? CronExpressionString { set; get; }
+    string? CronExpressionString { get; }
 
     /// <summary>
-    /// Sets the time zone for which the <see cref="CronExpressionString" /> of this
-    /// <see cref="ICronTrigger" /> will be resolved.
+    /// The time zone within which the <see cref="CronExpressionString" /> of this
+    /// <see cref="ICronTrigger" /> is resolved.
     /// </summary>
-    /// <remarks>
-    /// If <see cref="CronExpressionString" /> is set after this
-    /// property, the TimeZone setting on the CronExpression will "win".  However
-    /// if <see cref="CronExpressionString" /> is set after this property, the
-    /// time zone applied by this method will remain in effect, since the
-    /// string cron expression does not carry a time zone!
-    /// </remarks>
     /// <value>The time zone.</value>
-    TimeZoneInfo TimeZone { get; set; }
+    TimeZoneInfo TimeZone { get; }
 
     /// <summary>
     /// Gets the expression summary.

--- a/src/Quartz/ICronTrigger.cs
+++ b/src/Quartz/ICronTrigger.cs
@@ -171,6 +171,12 @@ public interface ICronTrigger : ITrigger
     TimeZoneInfo TimeZone { get; }
 
     /// <summary>
+    /// What the scheduler does when this trigger misses a firing.
+    /// </summary>
+    /// <seealso cref="CronScheduleBuilder.WithMisfireInstruction" />
+    CronTriggerMisfireInstruction MisfireInstruction { get; }
+
+    /// <summary>
     /// Gets the expression summary.
     /// </summary>
     /// <returns></returns>

--- a/src/Quartz/IDailyTimeIntervalTrigger.cs
+++ b/src/Quartz/IDailyTimeIntervalTrigger.cs
@@ -43,6 +43,10 @@ namespace Quartz;
 /// <para>If startTime is before startTimeOfDay, then it has no affect. Else if startTime after startTimeOfDay, then the first fire time
 /// for that day will be normal startTimeOfDay incremental values after startTime value. Same reversal logic is applied to endTime
 /// with endTimeOfDay.</para>
+///
+/// <para>This is a read model: to change a trigger's schedule, rebuild it with
+/// <see cref="ITrigger.GetTriggerBuilder" /> and hand it to
+/// <see cref="IScheduler.RescheduleJob" />.</para>
 /// </remarks>
 /// <see cref="DailyTimeIntervalTriggerImpl" />
 /// <see cref="DailyTimeIntervalScheduleBuilder"/>
@@ -94,7 +98,7 @@ public interface IDailyTimeIntervalTrigger : ITrigger
     /// A Set containing the integers representing the days of the week, per the values 0-6 as defined by
     /// DayOfWees.Sunday - DayOfWeek.Saturday.
     /// </returns>
-    IReadOnlyCollection<DayOfWeek> DaysOfWeek { get; set; }
+    IReadOnlyCollection<DayOfWeek> DaysOfWeek { get; }
 
     /// <summary>
     /// Get the number of times the <see cref="IDailyTimeIntervalTrigger" /> has already fired.

--- a/src/Quartz/IDailyTimeIntervalTrigger.cs
+++ b/src/Quartz/IDailyTimeIntervalTrigger.cs
@@ -106,6 +106,12 @@ public interface IDailyTimeIntervalTrigger : ITrigger
     int TimesTriggered { get; }
 
     /// <summary>
+    /// What the scheduler does when this trigger misses a firing.
+    /// </summary>
+    /// <seealso cref="DailyTimeIntervalScheduleBuilder.WithMisfireInstruction" />
+    DailyTimeIntervalTriggerMisfireInstruction MisfireInstruction { get; }
+
+    /// <summary>
     /// Gets the time zone within which time calculations related to this trigger will be performed.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/IRecurrenceTrigger.cs
+++ b/src/Quartz/IRecurrenceTrigger.cs
@@ -38,4 +38,10 @@ public interface IRecurrenceTrigger : ITrigger
     /// The number of times this trigger has already fired.
     /// </summary>
     int TimesTriggered { get; }
+
+    /// <summary>
+    /// What the scheduler does when this trigger misses a firing.
+    /// </summary>
+    /// <seealso cref="RecurrenceScheduleBuilder.WithMisfireInstruction" />
+    RecurrenceTriggerMisfireInstruction MisfireInstruction { get; }
 }

--- a/src/Quartz/IRecurrenceTrigger.cs
+++ b/src/Quartz/IRecurrenceTrigger.cs
@@ -14,6 +14,11 @@ namespace Quartz;
 /// The recurrence rule string follows the RFC 5545 RRULE format, for example:
 /// <c>FREQ=MONTHLY;BYDAY=2MO</c> or <c>FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR</c>.
 /// </para>
+/// <para>
+/// This is a read model: to change a trigger's schedule, rebuild it with
+/// <see cref="ITrigger.GetTriggerBuilder" /> and hand it to
+/// <see cref="IScheduler.RescheduleJob" />.
+/// </para>
 /// </remarks>
 /// <seealso cref="RecurrenceScheduleBuilder"/>
 public interface IRecurrenceTrigger : ITrigger
@@ -21,13 +26,13 @@ public interface IRecurrenceTrigger : ITrigger
     /// <summary>
     /// The RFC 5545 RRULE string, e.g. "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR".
     /// </summary>
-    string RecurrenceRule { get; set; }
+    string RecurrenceRule { get; }
 
     /// <summary>
     /// The time zone within which recurrence calculations are performed.
     /// Defaults to <see cref="TimeZoneInfo.Local"/> if not set.
     /// </summary>
-    TimeZoneInfo TimeZone { get; set; }
+    TimeZoneInfo TimeZone { get; }
 
     /// <summary>
     /// The number of times this trigger has already fired.

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -332,8 +332,9 @@ public interface IScheduler
 
     /// <summary>
     /// Updates trigger metadata and selected settings without rescheduling.
-    /// Fire times and trigger state are preserved. Supported properties include
-    /// Description, Priority, JobDataMap, CalendarName, and MisfireInstruction.
+    /// Fire times and trigger state are preserved. Supported properties are the description,
+    /// priority, job data map, calendar name, misfire instruction, execution group and
+    /// preferred node.
     /// </summary>
     /// <param name="triggerKey">The key identifying the trigger to update.</param>
     /// <param name="update">The details to update. See <see cref="TriggerDetailsUpdate"/> for available properties.</param>

--- a/src/Quartz/ISimpleTrigger.cs
+++ b/src/Quartz/ISimpleTrigger.cs
@@ -6,6 +6,11 @@ namespace Quartz;
 /// A <see cref="ITrigger" /> that is used to fire a <see cref="IJob" />
 /// at a given moment in time, and optionally repeated at a specified interval.
 /// </summary>
+/// <remarks>
+/// This is a read model: to change a trigger's schedule, rebuild it with
+/// <see cref="ITrigger.GetTriggerBuilder" /> and hand it to
+/// <see cref="IScheduler.RescheduleJob" />.
+/// </remarks>
 /// <seealso cref="TriggerBuilder" />
 /// <seealso cref="SimpleScheduleBuilder" />
 /// <author>James House</author>
@@ -14,16 +19,16 @@ namespace Quartz;
 public interface ISimpleTrigger : ITrigger
 {
     /// <summary>
-    /// Get or set the number of times the <see cref="ISimpleTrigger" /> should
+    /// The number of times the <see cref="ISimpleTrigger" /> should
     /// repeat, after which it will be automatically deleted.
     /// </summary>
     /// <seealso cref="SimpleTriggerImpl.RepeatIndefinitely" />
-    int RepeatCount { get; set; }
+    int RepeatCount { get; }
 
     /// <summary>
-    /// Get or set the time interval at which the <see cref="ISimpleTrigger" /> should repeat.
+    /// The time interval at which the <see cref="ISimpleTrigger" /> repeats.
     /// </summary>
-    TimeSpan RepeatInterval { get; set; }
+    TimeSpan RepeatInterval { get; }
 
     /// <summary>
     /// Get the number of times the <see cref="ISimpleTrigger" /> has already

--- a/src/Quartz/ISimpleTrigger.cs
+++ b/src/Quartz/ISimpleTrigger.cs
@@ -35,4 +35,10 @@ public interface ISimpleTrigger : ITrigger
     /// fired.
     /// </summary>
     int TimesTriggered { get; }
+
+    /// <summary>
+    /// What the scheduler does when this trigger misses a firing.
+    /// </summary>
+    /// <seealso cref="SimpleScheduleBuilder.WithMisfireInstruction" />
+    SimpleTriggerMisfireInstruction MisfireInstruction { get; }
 }

--- a/src/Quartz/ITrigger.cs
+++ b/src/Quartz/ITrigger.cs
@@ -217,7 +217,5 @@ public interface ITrigger
     /// </summary>
     DateTimeOffset? GetFireTimeAfter(DateTimeOffset? afterTime);
 
-    bool HasMillisecondPrecision { get; }
-
     ITrigger Clone();
 }

--- a/src/Quartz/ITrigger.cs
+++ b/src/Quartz/ITrigger.cs
@@ -127,19 +127,24 @@ public interface ITrigger
     DateTimeOffset? FinalFireTimeUtc { get; }
 
     /// <summary>
-    /// Get or set the instruction the <see cref="IScheduler" /> should be given for
-    /// handling misfire situations for this <see cref="ITrigger" />- the
-    /// concrete <see cref="ITrigger" /> type that you are using will have
-    /// defined a set of additional MISFIRE_INSTRUCTION_XXX
-    /// constants that may be set to this property.
-    /// <para>
-    /// If not explicitly set, the default value is <see cref="Quartz.MisfireInstruction.InstructionNotSet" />.
-    /// </para>
+    /// The raw code of the instruction the <see cref="IScheduler" /> follows when this trigger
+    /// misses a firing. This is the number the job store persists, and it is family-agnostic:
+    /// the same number means a different policy in each trigger family.
     /// </summary>
-    /// <seealso cref="Quartz.MisfireInstruction.InstructionNotSet" />
-    /// <seealso cref="ISimpleTrigger" />
-    /// <seealso cref="ICronTrigger" />
-    int MisfireInstruction { get; }
+    /// <remarks>
+    /// <para>
+    /// Read the policy from the family interface's own <c>MisfireInstruction</c> property instead
+    /// whenever the family is known — <see cref="ISimpleTrigger.MisfireInstruction" />,
+    /// <see cref="ICronTrigger.MisfireInstruction" /> and so on. This member exists for code that
+    /// is generic over every family: serializers, the wire contract, logging and diagnostics.
+    /// </para>
+    /// <para>
+    /// The default is <c>0</c>, the smart policy: the trigger's family picks the policy for it.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="ISimpleTrigger.MisfireInstruction" />
+    /// <seealso cref="ICronTrigger.MisfireInstruction" />
+    int MisfireInstructionCode { get; }
 
     /// <summary>
     /// Gets and sets the date/time on which the trigger must stop firing. This

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -1995,6 +1995,8 @@ public abstract class JobStoreSupport : IJobStore
                 return true;
             }
 
+            update.EnsureMisfireInstructionMatchesFamily(existing, triggerKey);
+
             if (update.HasCalendarName && update.CalendarName is not null)
             {
                 bool calExists = await CalendarExists(conn, update.CalendarName, cancellationToken).ConfigureAwait(false);
@@ -2034,7 +2036,7 @@ public abstract class JobStoreSupport : IJobStore
 
             if (update.HasMisfireInstruction)
             {
-                existing.MisfireInstruction = update.MisfireInstructionCode;
+                existing.MisfireInstructionCode = update.MisfireInstructionCode;
             }
 
             if (update.HasPreferredNode)
@@ -4344,7 +4346,7 @@ public abstract class JobStoreSupport : IJobStore
                                         SchedulerConstants.DefaultRecoveryGroup, ftRec.FireTimestamp);
 
                                 rcvryTrig.JobKey = jKey!;
-                                rcvryTrig.MisfireInstruction = MisfireInstruction.SimpleTrigger.FireNow;
+                                rcvryTrig.MisfireInstructionCode = MisfireInstruction.SimpleTrigger.FireNow;
                                 rcvryTrig.Priority = ftRec.Priority;
                                 JobDataMap jd = await Delegate.SelectTriggerJobDataMap(conn, tKey, cancellationToken).ConfigureAwait(false);
                                 jd[SchedulerConstants.FailedJobOriginalTriggerName] = tKey.Name;

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -2034,7 +2034,7 @@ public abstract class JobStoreSupport : IJobStore
 
             if (update.HasMisfireInstruction)
             {
-                existing.MisfireInstruction = update.MisfireInstruction;
+                existing.MisfireInstruction = update.MisfireInstructionCode;
             }
 
             if (update.HasPreferredNode)

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -1990,7 +1990,8 @@ public abstract class JobStoreSupport : IJobStore
             }
 
             if (!update.HasDescription && !update.HasPriority && !update.HasJobDataMap
-                && !update.HasCalendarName && !update.HasMisfireInstruction && !update.HasPreferredNode)
+                && !update.HasCalendarName && !update.HasMisfireInstruction && !update.HasPreferredNode
+                && !update.HasExecutionGroup)
             {
                 return true;
             }
@@ -2044,6 +2045,13 @@ public abstract class JobStoreSupport : IJobStore
                 // Setting the property marks the pin dirty, so the subsequent store writes the
                 // preferred node columns.
                 existing.PreferredNode = update.PreferredNode;
+            }
+
+            if (update.HasExecutionGroup)
+            {
+                // EXECUTION_GROUP is part of the generic trigger UPDATE below, so nothing more is
+                // needed to persist it.
+                existing.ExecutionGroup = update.ExecutionGroup;
             }
 
             StoredTriggerState state = await Delegate.SelectTriggerState(conn, triggerKey, cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -137,7 +137,7 @@ public partial class StdAdoDelegate
                         SchedulerConstants.DefaultRecoveryGroup, scheduledTime);
                     rcvryTrig.JobKey = new JobKey(jobName, jobGroup);
                     rcvryTrig.Priority = priority;
-                    rcvryTrig.MisfireInstruction = MisfireInstruction.IgnoreMisfirePolicy;
+                    rcvryTrig.MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy;
 
                     triggerData.Add((scheduledTime, firedTime));
                     triggers.Add(rcvryTrig);
@@ -278,7 +278,7 @@ public partial class StdAdoDelegate
         AddCommandParameter(cmd, "triggerStartTime", GetDbDateTimeValue(trigger.StartTimeUtc));
         AddCommandParameter(cmd, "triggerEndTime", GetDbDateTimeValue(trigger.EndTimeUtc));
         AddCommandParameter(cmd, "triggerCalendarName", trigger.CalendarName);
-        AddCommandParameter(cmd, "triggerMisfireInstruction", trigger.MisfireInstruction);
+        AddCommandParameter(cmd, "triggerMisfireInstruction", trigger.MisfireInstructionCode);
         AddCommandParameter(cmd, "triggerJobJobDataMap", jobData, DbProvider.Metadata.DbBinaryType);
 
         AddCommandParameter(cmd, "triggerPriority", trigger.Priority);
@@ -374,7 +374,7 @@ public partial class StdAdoDelegate
         AddCommandParameter(cmd, "triggerStartTime", GetDbDateTimeValue(trigger.StartTimeUtc));
         AddCommandParameter(cmd, "triggerEndTime", GetDbDateTimeValue(trigger.EndTimeUtc));
         AddCommandParameter(cmd, "triggerCalendarName", trigger.CalendarName);
-        AddCommandParameter(cmd, "triggerMisfireInstruction", trigger.MisfireInstruction);
+        AddCommandParameter(cmd, "triggerMisfireInstruction", trigger.MisfireInstructionCode);
         AddCommandParameter(cmd, "triggerPriority", trigger.Priority);
 
         const string JobDataMapParameter = "triggerJobJobDataMap";
@@ -724,7 +724,7 @@ public partial class StdAdoDelegate
     /// </summary>
     private static void ApplyTriggerFireState(IOperableTrigger trigger, TriggerRow row)
     {
-        trigger.MisfireInstruction = row.MisfireInstruction;
+        trigger.MisfireInstructionCode = row.MisfireInstruction;
         trigger.NextFireTimeUtc = row.NextFireTimeUtc;
         trigger.PreviousFireTimeUtc = row.PreviousFireTimeUtc;
 

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -660,6 +660,8 @@ public sealed class RAMJobStore : IJobStore
 
             IOperableTrigger trigger = tw.Trigger;
 
+            update.EnsureMisfireInstructionMatchesFamily(trigger, triggerKey);
+
             if (update.HasCalendarName && update.CalendarName is not null)
             {
                 if (!calendarsByName.ContainsKey(update.CalendarName))
@@ -700,7 +702,7 @@ public sealed class RAMJobStore : IJobStore
 
             if (update.HasMisfireInstruction)
             {
-                trigger.MisfireInstruction = update.MisfireInstructionCode;
+                trigger.MisfireInstructionCode = update.MisfireInstructionCode;
             }
 
             if (update.HasPreferredNode)
@@ -1991,7 +1993,7 @@ public sealed class RAMJobStore : IJobStore
     /// </returns>
     private async ValueTask<bool> ApplyMisfireNoLock(TriggerWrapper tw)
     {
-        if (tw.Trigger.MisfireInstruction == MisfireInstruction.IgnoreMisfirePolicy)
+        if (tw.Trigger.MisfireInstructionCode == MisfireInstruction.IgnoreMisfirePolicy)
         {
             return false;
         }

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -653,7 +653,8 @@ public sealed class RAMJobStore : IJobStore
             }
 
             if (!update.HasDescription && !update.HasPriority && !update.HasJobDataMap
-                && !update.HasCalendarName && !update.HasMisfireInstruction && !update.HasPreferredNode)
+                && !update.HasCalendarName && !update.HasMisfireInstruction && !update.HasPreferredNode
+                && !update.HasExecutionGroup)
             {
                 return true;
             }
@@ -710,6 +711,11 @@ public sealed class RAMJobStore : IJobStore
                 // The stored instance is the one mutated here - reads hand out clones of it - so the
                 // new pin is what every later reader sees, exactly as the ADO.NET store's update does.
                 trigger.PreferredNode = update.PreferredNode;
+            }
+
+            if (update.HasExecutionGroup)
+            {
+                trigger.ExecutionGroup = update.ExecutionGroup;
             }
 
             return true;

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -700,7 +700,7 @@ public sealed class RAMJobStore : IJobStore
 
             if (update.HasMisfireInstruction)
             {
-                trigger.MisfireInstruction = update.MisfireInstruction;
+                trigger.MisfireInstruction = update.MisfireInstructionCode;
             }
 
             if (update.HasPreferredNode)

--- a/src/Quartz/Impl/Triggers/AbstractTrigger.cs
+++ b/src/Quartz/Impl/Triggers/AbstractTrigger.cs
@@ -293,11 +293,9 @@ public abstract class AbstractTrigger : IOperableTrigger, IEquatable<AbstractTri
     public abstract DateTimeOffset? FinalFireTimeUtc { get; }
 
     /// <summary>
-    /// Get or set the instruction the <see cref="IScheduler" /> should be given for
-    /// handling misfire situations for this <see cref="ITrigger" />- the
-    /// concrete <see cref="ITrigger" /> type that you are using will have
-    /// defined a set of additional MISFIRE_INSTRUCTION_XXX
-    /// constants that may be passed to this method.
+    /// Get or set the raw code of the instruction the <see cref="IScheduler" /> follows when this
+    /// trigger misses a firing. The concrete trigger type validates the code against its own
+    /// family's range.
     /// <para>
     /// If not explicitly set, the default value is <see cref="Quartz.MisfireInstruction.InstructionNotSet" />.
     /// </para>
@@ -306,7 +304,7 @@ public abstract class AbstractTrigger : IOperableTrigger, IEquatable<AbstractTri
     /// <seealso cref="UpdateAfterMisfire(ICalendar?)" />
     /// <seealso cref="ISimpleTrigger" />
     /// <seealso cref="ICronTrigger" />
-    public virtual int MisfireInstruction
+    public virtual int MisfireInstructionCode
     {
         get => misfireInstruction;
 
@@ -665,7 +663,7 @@ public abstract class AbstractTrigger : IOperableTrigger, IEquatable<AbstractTri
     /// Return a simple string representation of this object.
     /// </summary>
     public override string ToString()
-        => $"Trigger '{key}':  triggerClass: '{GetType().FullName} calendar: '{CalendarName}' misfireInstruction: {MisfireInstruction} nextFireTime: {NextFireTimeUtc}";
+        => $"Trigger '{key}':  triggerClass: '{GetType().FullName} calendar: '{CalendarName}' misfireInstruction: {MisfireInstructionCode} nextFireTime: {NextFireTimeUtc}";
 
     /// <summary>
     /// Determines whether the specified <see cref="System.Object"></see> is equal to the current <see cref="System.Object"></see>.

--- a/src/Quartz/Impl/Triggers/AbstractTrigger.cs
+++ b/src/Quartz/Impl/Triggers/AbstractTrigger.cs
@@ -396,13 +396,14 @@ public abstract class AbstractTrigger : IOperableTrigger, IEquatable<AbstractTri
     }
 
     /// <summary>
-    /// Tells whether this Trigger instance can handle events
-    /// in millisecond precision.
+    /// Whether this trigger's fire times are meaningful to the millisecond. A trigger that says no
+    /// has its start time rounded down to the second.
     /// </summary>
-    public abstract bool HasMillisecondPrecision
-    {
-        get;
-    }
+    /// <remarks>
+    /// This is how a trigger describes its own schedule to <see cref="AbstractTrigger" />, not
+    /// something a caller reads: nothing outside the trigger acted on it.
+    /// </remarks>
+    protected abstract bool HasMillisecondPrecision { get; }
 
     protected AbstractTrigger()
     {

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -235,6 +235,9 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
     /// </summary>
     public override bool HasMillisecondPrecision => true;
 
+    /// <inheritdoc />
+    public CalendarIntervalTriggerMisfireInstruction MisfireInstruction => (CalendarIntervalTriggerMisfireInstruction) MisfireInstructionCode;
+
     /// <summary>
     /// Get the time at which the <see cref="ICalendarIntervalTrigger" /> should quit
     /// repeating.
@@ -370,15 +373,16 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
     /// was created.
     /// </summary>
     /// <remarks>
-    /// If the misfire instruction is set to <see cref="MisfireInstruction.SmartPolicy" />,
-    /// then the following scheme will be used:
+    /// If the misfire instruction is set to
+    /// <see cref="CalendarIntervalTriggerMisfireInstruction.SmartPolicy" />, then the following
+    /// scheme will be used:
     /// <ul>
-    ///     <li>The instruction will be interpreted as <see cref="MisfireInstruction.CalendarIntervalTrigger.FireOnceNow" /></li>
+    ///     <li>The instruction will be interpreted as <see cref="CalendarIntervalTriggerMisfireInstruction.FireAndProceed" /></li>
     /// </ul>
     /// </remarks>
     public override void UpdateAfterMisfire(ICalendar? calendar)
     {
-        int instr = MisfireInstruction;
+        int instr = MisfireInstructionCode;
 
         if (instr == Quartz.MisfireInstruction.IgnoreMisfirePolicy)
         {
@@ -929,7 +933,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
             .PreserveHourOfDayAcrossDaylightSavings(PreserveHourOfDayAcrossDaylightSavings)
             .SkipDayIfHourDoesNotExist(SkipDayIfHourDoesNotExist);
 
-        CalendarIntervalTriggerMisfireInstruction instruction = (CalendarIntervalTriggerMisfireInstruction) MisfireInstruction;
+        CalendarIntervalTriggerMisfireInstruction instruction = MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
             cb.WithMisfireInstruction(instruction);

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -233,7 +233,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
     /// Tells whether this Trigger instance can handle events
     /// in millisecond precision.
     /// </summary>
-    public override bool HasMillisecondPrecision => true;
+    protected override bool HasMillisecondPrecision => true;
 
     /// <inheritdoc />
     public CalendarIntervalTriggerMisfireInstruction MisfireInstruction => (CalendarIntervalTriggerMisfireInstruction) MisfireInstructionCode;

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -932,7 +932,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
         CalendarIntervalTriggerMisfireInstruction instruction = (CalendarIntervalTriggerMisfireInstruction) MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
-            cb.WithMisfireHandlingInstruction(instruction);
+            cb.WithMisfireInstruction(instruction);
         }
 
         return cb;

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -611,7 +611,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         CronTriggerMisfireInstruction instruction = (CronTriggerMisfireInstruction) MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
-            cb.WithMisfireHandlingInstruction(instruction);
+            cb.WithMisfireInstruction(instruction);
         }
         else
         {

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -604,11 +604,14 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         return pot;
     }
 
+    /// <inheritdoc />
+    public CronTriggerMisfireInstruction MisfireInstruction => (CronTriggerMisfireInstruction) MisfireInstructionCode;
+
     public override IScheduleBuilder GetScheduleBuilder()
     {
         CronScheduleBuilder cb = CronScheduleBuilder.CronSchedule(CronExpressionString!).InTimeZone(TimeZone);
 
-        CronTriggerMisfireInstruction instruction = (CronTriggerMisfireInstruction) MisfireInstruction;
+        CronTriggerMisfireInstruction instruction = MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
             cb.WithMisfireInstruction(instruction);
@@ -617,7 +620,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         {
             var logger = LogProvider.CreateLogger<CronTriggerImpl>();
             logger.LogWarning("Unrecognized misfire policy {MisfireInstruction}. Derived builder will use the default cron trigger behavior (FireOnceNow)",
-                MisfireInstruction);
+                MisfireInstructionCode);
         }
 
         return cb;
@@ -704,7 +707,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     /// <param name="calendar"></param>
     public override void UpdateAfterMisfire(ICalendar? calendar)
     {
-        int instr = MisfireInstruction;
+        int instr = MisfireInstructionCode;
 
         if (instr == Quartz.MisfireInstruction.SmartPolicy)
         {

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -661,7 +661,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     /// in millisecond precision.
     /// </summary>
     /// <value></value>
-    public override bool HasMillisecondPrecision => false;
+    protected override bool HasMillisecondPrecision => false;
 
     /// <summary>
     /// Used by the <see cref="IScheduler" /> to determine whether or not

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -1038,7 +1038,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         DailyTimeIntervalTriggerMisfireInstruction instruction = (DailyTimeIntervalTriggerMisfireInstruction) MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
-            cb.WithMisfireHandlingInstruction(instruction);
+            cb.WithMisfireInstruction(instruction);
         }
 
         return cb;

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -416,15 +416,16 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// was created.
     /// </summary>
     /// <remarks>
-    /// If the misfire instruction is set to <see cref="MisfireInstruction.SmartPolicy" />,
-    /// then the following scheme will be used:
+    /// If the misfire instruction is set to
+    /// <see cref="DailyTimeIntervalTriggerMisfireInstruction.SmartPolicy" />, then the following
+    /// scheme will be used:
     /// <ul>
-    ///     <li>The instruction will be interpreted as <see cref="MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow" /></li>
+    ///     <li>The instruction will be interpreted as <see cref="DailyTimeIntervalTriggerMisfireInstruction.FireAndProceed" /></li>
     /// </ul>
     /// </remarks>
     public override void UpdateAfterMisfire(ICalendar? calendar)
     {
-        int instr = MisfireInstruction;
+        int instr = MisfireInstructionCode;
 
         if (instr == Quartz.MisfireInstruction.IgnoreMisfirePolicy)
         {
@@ -1035,7 +1036,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
             .WithRepeatCount(RepeatCount)
             .InTimeZone(TimeZone);
 
-        DailyTimeIntervalTriggerMisfireInstruction instruction = (DailyTimeIntervalTriggerMisfireInstruction) MisfireInstruction;
+        DailyTimeIntervalTriggerMisfireInstruction instruction = MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
             cb.WithMisfireInstruction(instruction);
@@ -1049,4 +1050,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// in millisecond precision.
     /// </summary>
     public override bool HasMillisecondPrecision => true;
+
+    /// <inheritdoc />
+    public DailyTimeIntervalTriggerMisfireInstruction MisfireInstruction => (DailyTimeIntervalTriggerMisfireInstruction) MisfireInstructionCode;
 }

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -1049,7 +1049,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
     /// Tells whether this Trigger instance can handle events
     /// in millisecond precision.
     /// </summary>
-    public override bool HasMillisecondPrecision => true;
+    protected override bool HasMillisecondPrecision => true;
 
     /// <inheritdoc />
     public DailyTimeIntervalTriggerMisfireInstruction MisfireInstruction => (DailyTimeIntervalTriggerMisfireInstruction) MisfireInstructionCode;

--- a/src/Quartz/Impl/Triggers/RecurrenceTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/RecurrenceTriggerImpl.cs
@@ -137,9 +137,12 @@ public sealed class RecurrenceTriggerImpl : AbstractTrigger, IRecurrenceTrigger
     }
 
     /// <inheritdoc/>
+    public RecurrenceTriggerMisfireInstruction MisfireInstruction => (RecurrenceTriggerMisfireInstruction) MisfireInstructionCode;
+
+    /// <inheritdoc/>
     public override void UpdateAfterMisfire(ICalendar? calendar)
     {
-        int instr = MisfireInstruction;
+        int instr = MisfireInstructionCode;
 
         if (instr == Quartz.MisfireInstruction.IgnoreMisfirePolicy)
         {
@@ -353,7 +356,7 @@ public sealed class RecurrenceTriggerImpl : AbstractTrigger, IRecurrenceTrigger
         RecurrenceScheduleBuilder sb = RecurrenceScheduleBuilder.Create(recurrenceRuleString)
             .InTimeZone(TimeZone);
 
-        RecurrenceTriggerMisfireInstruction instruction = (RecurrenceTriggerMisfireInstruction) MisfireInstruction;
+        RecurrenceTriggerMisfireInstruction instruction = MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
             sb.WithMisfireInstruction(instruction);

--- a/src/Quartz/Impl/Triggers/RecurrenceTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/RecurrenceTriggerImpl.cs
@@ -102,7 +102,7 @@ public sealed class RecurrenceTriggerImpl : AbstractTrigger, IRecurrenceTrigger
     }
 
     /// <inheritdoc/>
-    public override bool HasMillisecondPrecision => false;
+    protected override bool HasMillisecondPrecision => false;
 
     /// <inheritdoc/>
     public override DateTimeOffset? EndTimeUtc

--- a/src/Quartz/Impl/Triggers/RecurrenceTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/RecurrenceTriggerImpl.cs
@@ -356,7 +356,7 @@ public sealed class RecurrenceTriggerImpl : AbstractTrigger, IRecurrenceTrigger
         RecurrenceTriggerMisfireInstruction instruction = (RecurrenceTriggerMisfireInstruction) MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
-            sb.WithMisfireHandlingInstruction(instruction);
+            sb.WithMisfireInstruction(instruction);
         }
 
         return sb;

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -257,13 +257,16 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
         set => timesTriggered = value;
     }
 
+    /// <inheritdoc />
+    public SimpleTriggerMisfireInstruction MisfireInstruction => (SimpleTriggerMisfireInstruction) MisfireInstructionCode;
+
     public override IScheduleBuilder GetScheduleBuilder()
     {
         SimpleScheduleBuilder sb = SimpleScheduleBuilder.Create()
             .WithInterval(RepeatInterval)
             .WithRepeatCount(RepeatCount);
 
-        SimpleTriggerMisfireInstruction instruction = (SimpleTriggerMisfireInstruction) MisfireInstruction;
+        SimpleTriggerMisfireInstruction instruction = MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
             sb.WithMisfireInstruction(instruction);
@@ -347,21 +350,21 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
     /// then the following scheme will be used: <br />
     /// <ul>
     /// <li>If the Repeat Count is 0, then the instruction will
-    /// be interpreted as <see cref="MisfireInstruction.SimpleTrigger.FireNow" />.</li>
+    /// be interpreted as <see cref="SimpleTriggerMisfireInstruction.FireNow" />.</li>
     /// <li>If the Repeat Count is <see cref="RepeatIndefinitely" />, then
-    /// the instruction will be interpreted as <see cref="MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount" />.
-    /// <b>WARNING:</b> using MisfirePolicy.SimpleTrigger.RescheduleNowWithRemainingRepeatCount
+    /// the instruction will be interpreted as <see cref="SimpleTriggerMisfireInstruction.NextWithRemainingCount" />.
+    /// <b>WARNING:</b> using <see cref="SimpleTriggerMisfireInstruction.NowWithRemainingCount" />
     /// with a trigger that has a non-null end-time may cause the trigger to
     /// never fire again if the end-time arrived during the misfire time span.
     /// </li>
     /// <li>If the Repeat Count is > 0, then the instruction
-    /// will be interpreted as <see cref="MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount" />.
+    /// will be interpreted as <see cref="SimpleTriggerMisfireInstruction.NowWithExistingCount" />.
     /// </li>
     /// </ul>
     /// </remarks>
     public override void UpdateAfterMisfire(ICalendar? calendar)
     {
-        int instr = MisfireInstruction;
+        int instr = MisfireInstructionCode;
         if (instr == Quartz.MisfireInstruction.SmartPolicy)
         {
             if (RepeatCount == 0)

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -266,7 +266,7 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
         SimpleTriggerMisfireInstruction instruction = (SimpleTriggerMisfireInstruction) MisfireInstruction;
         if (Enum.IsDefined(instruction))
         {
-            sb.WithMisfireHandlingInstruction(instruction);
+            sb.WithMisfireInstruction(instruction);
         }
 
         return sb;

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -317,7 +317,7 @@ public class SimpleTriggerImpl : AbstractTrigger, ISimpleTrigger
     /// in millisecond precision.
     /// </summary>
     /// <value></value>
-    public override bool HasMillisecondPrecision => true;
+    protected override bool HasMillisecondPrecision => true;
 
     /// <summary>
     /// Validates the misfire instruction.

--- a/src/Quartz/MisfireInstruction.cs
+++ b/src/Quartz/MisfireInstruction.cs
@@ -22,10 +22,18 @@
 namespace Quartz;
 
 ///<summary>
-/// Misfire instructions.
+/// The raw misfire instruction codes a trigger stores, grouped by the family they belong to.
 ///</summary>
+/// <remarks>
+/// These are storage-level numbers, not the vocabulary a caller uses: the same number means a
+/// different policy in each family. The public vocabulary is the five per-family enums —
+/// <see cref="SimpleTriggerMisfireInstruction" />, <see cref="CronTriggerMisfireInstruction" />,
+/// <see cref="CalendarIntervalTriggerMisfireInstruction" />,
+/// <see cref="DailyTimeIntervalTriggerMisfireInstruction" /> and
+/// <see cref="RecurrenceTriggerMisfireInstruction" /> — whose members carry exactly these values.
+/// </remarks>
 /// <author>Marko Lahma (.NET)</author>
-public static class MisfireInstruction
+internal static class MisfireInstruction
 {
     /// <summary>
     /// Instruction not set (yet).

--- a/src/Quartz/MisfireInstructionNames.cs
+++ b/src/Quartz/MisfireInstructionNames.cs
@@ -1,0 +1,240 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Diagnostics;
+using Quartz.Util;
+
+namespace Quartz;
+
+/// <summary>
+/// Resolves the misfire instruction names that appear in XML and JSON scheduling data into the
+/// codes a trigger stores, one map per trigger family.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This replaces a reflection sweep over <see cref="MisfireInstruction" /> and every one of its
+/// nested types, which resolved a name from <em>any</em> family for a trigger of <em>any</em>
+/// family: a cron trigger asking for <c>RescheduleNowWithExistingRepeatCount</c> silently became
+/// <c>DoNothing</c>, because both are 2. The reflection also never saw the calendar-interval names
+/// in the XML processor, which passed only two of the nested types.
+/// </para>
+/// <para>
+/// Each family accepts its own names, the family-agnostic root names, and the names of the enum
+/// members a caller would write in C#. A name belonging to another family still resolves when its
+/// value is legal for this one — that is what used to happen, and rejecting it outright would break
+/// working configuration — but it is logged as the wrong spelling it is, naming the policy the value
+/// actually selects and the name to write instead.
+/// </para>
+/// </remarks>
+internal static class MisfireInstructionNames
+{
+    private const int SmartPolicy = MisfireInstruction.SmartPolicy;
+    private const int IgnoreMisfires = MisfireInstruction.IgnoreMisfirePolicy;
+
+    /// <summary>Names every family understands, whatever it is called in.</summary>
+    private static readonly (string Name, int Value)[] rootNames =
+    [
+        ("SmartPolicy", SmartPolicy),
+        ("InstructionNotSet", SmartPolicy),
+        ("IgnoreMisfirePolicy", IgnoreMisfires),
+        ("IgnoreMisfires", IgnoreMisfires)
+    ];
+
+    private static readonly Dictionary<string, int> simpleNames = Build(
+        ("FireNow", MisfireInstruction.SimpleTrigger.FireNow),
+        ("RescheduleNowWithExistingRepeatCount", MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount),
+        ("RescheduleNowWithRemainingRepeatCount", MisfireInstruction.SimpleTrigger.RescheduleNowWithRemainingRepeatCount),
+        ("RescheduleNextWithRemainingCount", MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount),
+        ("RescheduleNextWithExistingCount", MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount),
+        // the enum spellings too, so C# and configuration can be read side by side
+        ("NowWithExistingCount", MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount),
+        ("NowWithRemainingCount", MisfireInstruction.SimpleTrigger.RescheduleNowWithRemainingRepeatCount),
+        ("NextWithRemainingCount", MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount),
+        ("NextWithExistingCount", MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount));
+
+    private static readonly Dictionary<string, int> cronNames = Build(
+        ("FireOnceNow", MisfireInstruction.CronTrigger.FireOnceNow),
+        ("DoNothing", MisfireInstruction.CronTrigger.DoNothing),
+        ("FireAndProceed", MisfireInstruction.CronTrigger.FireOnceNow));
+
+    private static readonly Dictionary<string, int> calendarIntervalNames = Build(
+        ("FireOnceNow", MisfireInstruction.CalendarIntervalTrigger.FireOnceNow),
+        ("DoNothing", MisfireInstruction.CalendarIntervalTrigger.DoNothing),
+        ("FireAndProceed", MisfireInstruction.CalendarIntervalTrigger.FireOnceNow));
+
+    private static readonly Dictionary<string, int> dailyTimeIntervalNames = Build(
+        ("FireOnceNow", MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow),
+        ("DoNothing", MisfireInstruction.DailyTimeIntervalTrigger.DoNothing),
+        ("FireAndProceed", MisfireInstruction.DailyTimeIntervalTrigger.FireOnceNow));
+
+    private static readonly Dictionary<string, int> recurrenceNames = Build(
+        ("FireOnceNow", MisfireInstruction.RecurrenceTrigger.FireOnceNow),
+        ("DoNothing", MisfireInstruction.RecurrenceTrigger.DoNothing),
+        ("FireAndProceed", MisfireInstruction.RecurrenceTrigger.FireOnceNow));
+
+    /// <summary>
+    /// Every name any family knows, used to tell "spelled for the wrong family" apart from "not a
+    /// misfire instruction at all".
+    /// </summary>
+    private static readonly Dictionary<string, int> allNames = BuildAll();
+
+    private static Dictionary<string, int> Build(params (string Name, int Value)[] familyNames)
+    {
+        Dictionary<string, int> map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach ((string name, int value) in rootNames)
+        {
+            map[name] = value;
+        }
+
+        foreach ((string name, int value) in familyNames)
+        {
+            map[name] = value;
+        }
+
+        return map;
+    }
+
+    private static Dictionary<string, int> BuildAll()
+    {
+        Dictionary<string, int> map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (Dictionary<string, int> family in new[] { simpleNames, cronNames, calendarIntervalNames, dailyTimeIntervalNames, recurrenceNames })
+        {
+            foreach (KeyValuePair<string, int> entry in family)
+            {
+                map[entry.Key] = entry.Value;
+            }
+        }
+
+        return map;
+    }
+
+    private static Dictionary<string, int> NamesFor(TriggerFamily family)
+    {
+        return family switch
+        {
+            TriggerFamily.Simple => simpleNames,
+            TriggerFamily.Cron => cronNames,
+            TriggerFamily.CalendarInterval => calendarIntervalNames,
+            TriggerFamily.DailyTimeInterval => dailyTimeIntervalNames,
+            _ => recurrenceNames
+        };
+    }
+
+    /// <summary>
+    /// Resolves the misfire instruction <paramref name="name" /> the way the given family spells it.
+    /// </summary>
+    /// <exception cref="SchedulerConfigException">
+    /// The name is not a misfire instruction, or names a policy this family has no code for.
+    /// </exception>
+    internal static int Resolve(TriggerFamily family, string name, ILogger? logger = null)
+    {
+        string trimmed = name.Trim();
+        Dictionary<string, int> names = NamesFor(family);
+
+        if (names.TryGetValue(trimmed, out int value))
+        {
+            return value;
+        }
+
+        // A name from another family. It resolved before these maps existed, so it still resolves -
+        // but say what it became, because that is the part nobody could see.
+        if (allNames.TryGetValue(trimmed, out int otherFamilyValue))
+        {
+            if (IsValidFor(family, otherFamilyValue))
+            {
+                ILogger log = logger ?? LogProvider.CreateLogger(typeof(MisfireInstructionNames).FullName!);
+                log.LogWarning(
+                    "Misfire instruction '{MisfireInstruction}' is not one of the {Family} trigger names. It resolves to code {Code}, which for this trigger means {Policy}; spell it '{Canonical}'",
+                    trimmed,
+                    family.DisplayName(),
+                    otherFamilyValue,
+                    PolicyName(family, otherFamilyValue),
+                    CanonicalName(family, otherFamilyValue));
+
+                return otherFamilyValue;
+            }
+
+            Throw.SchedulerConfigException(
+                $"Misfire instruction '{trimmed}' belongs to another trigger family, and its code {otherFamilyValue} is not valid for a {family.DisplayName()} trigger. Valid names: {ValidNames(family)}.");
+        }
+
+        Throw.SchedulerConfigException(
+            $"Unknown misfire instruction: '{trimmed}'. Valid names for a {family.DisplayName()} trigger: {ValidNames(family)}.");
+        return 0;
+    }
+
+    private static bool IsValidFor(TriggerFamily family, int value)
+    {
+        if (value is SmartPolicy or IgnoreMisfires)
+        {
+            return true;
+        }
+
+        int max = family == TriggerFamily.Simple
+            ? MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount
+            : MisfireInstruction.CronTrigger.DoNothing;
+
+        return value >= MisfireInstruction.SimpleTrigger.FireNow && value <= max;
+    }
+
+    /// <summary>What this family calls the code in C#.</summary>
+    private static string PolicyName(TriggerFamily family, int value)
+    {
+        return family switch
+        {
+            TriggerFamily.Simple => nameof(SimpleTriggerMisfireInstruction) + "." + (SimpleTriggerMisfireInstruction) value,
+            TriggerFamily.Cron => nameof(CronTriggerMisfireInstruction) + "." + (CronTriggerMisfireInstruction) value,
+            TriggerFamily.CalendarInterval => nameof(CalendarIntervalTriggerMisfireInstruction) + "." + (CalendarIntervalTriggerMisfireInstruction) value,
+            TriggerFamily.DailyTimeInterval => nameof(DailyTimeIntervalTriggerMisfireInstruction) + "." + (DailyTimeIntervalTriggerMisfireInstruction) value,
+            _ => nameof(RecurrenceTriggerMisfireInstruction) + "." + (RecurrenceTriggerMisfireInstruction) value
+        };
+    }
+
+    /// <summary>What this family calls the code in XML and JSON scheduling data.</summary>
+    private static string CanonicalName(TriggerFamily family, int value)
+    {
+        if (value == IgnoreMisfires)
+        {
+            return "IgnoreMisfirePolicy";
+        }
+
+        if (value == SmartPolicy)
+        {
+            return "SmartPolicy";
+        }
+
+        if (family != TriggerFamily.Simple)
+        {
+            return value == MisfireInstruction.CronTrigger.DoNothing ? "DoNothing" : "FireOnceNow";
+        }
+
+        return value switch
+        {
+            MisfireInstruction.SimpleTrigger.FireNow => "FireNow",
+            MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount => "RescheduleNowWithExistingRepeatCount",
+            MisfireInstruction.SimpleTrigger.RescheduleNowWithRemainingRepeatCount => "RescheduleNowWithRemainingRepeatCount",
+            MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount => "RescheduleNextWithRemainingCount",
+            _ => "RescheduleNextWithExistingCount"
+        };
+    }
+
+    private static string ValidNames(TriggerFamily family) => string.Join(", ", NamesFor(family).Keys.Order(StringComparer.Ordinal));
+}

--- a/src/Quartz/RecurrenceScheduleBuilder.cs
+++ b/src/Quartz/RecurrenceScheduleBuilder.cs
@@ -85,7 +85,7 @@ public sealed class RecurrenceScheduleBuilder : IScheduleBuilder
     /// <see cref="RecurrenceTriggerMisfireInstruction.SmartPolicy" />.</param>
     /// <returns>the updated RecurrenceScheduleBuilder</returns>
     /// <seealso cref="RecurrenceTriggerMisfireInstruction" />
-    public RecurrenceScheduleBuilder WithMisfireHandlingInstruction(RecurrenceTriggerMisfireInstruction instruction)
+    public RecurrenceScheduleBuilder WithMisfireInstruction(RecurrenceTriggerMisfireInstruction instruction)
     {
         misfireInstruction = (int) instruction;
         return this;

--- a/src/Quartz/RecurrenceScheduleBuilder.cs
+++ b/src/Quartz/RecurrenceScheduleBuilder.cs
@@ -62,7 +62,7 @@ public sealed class RecurrenceScheduleBuilder : IScheduleBuilder
     {
         RecurrenceTriggerImpl trigger = new RecurrenceTriggerImpl();
         trigger.RecurrenceRule = recurrenceRule;
-        trigger.MisfireInstruction = misfireInstruction;
+        trigger.MisfireInstructionCode = misfireInstruction;
         trigger.triggerTimeZone = timeZone;
         return trigger;
     }

--- a/src/Quartz/RecurrenceTriggerMisfireInstruction.cs
+++ b/src/Quartz/RecurrenceTriggerMisfireInstruction.cs
@@ -24,7 +24,7 @@ namespace Quartz;
 /// </summary>
 /// <remarks>
 /// The values match the <see cref="MisfireInstruction" /> constants a trigger stores in
-/// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
+/// <see cref="ITrigger.MisfireInstructionCode" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
 /// <seealso cref="RecurrenceScheduleBuilder.WithMisfireInstruction" />

--- a/src/Quartz/RecurrenceTriggerMisfireInstruction.cs
+++ b/src/Quartz/RecurrenceTriggerMisfireInstruction.cs
@@ -27,13 +27,17 @@ namespace Quartz;
 /// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
-/// <seealso cref="RecurrenceScheduleBuilder.WithMisfireHandlingInstruction" />
+/// <seealso cref="RecurrenceScheduleBuilder.WithMisfireInstruction" />
 public enum RecurrenceTriggerMisfireInstruction
 {
     /// <summary>
     /// Let the scheduler pick the policy. This is the default, and for a recurrence trigger it
     /// means <see cref="FireAndProceed" />.
     /// </summary>
+    /// <remarks>
+    /// Named <c>SmartPolicy</c> in the misfire vocabulary. Recurrence triggers have no XML or JSON
+    /// scheduling-data form, so the name only ever appears in code.
+    /// </remarks>
     SmartPolicy = MisfireInstruction.SmartPolicy,
 
     /// <summary>
@@ -42,16 +46,23 @@ public enum RecurrenceTriggerMisfireInstruction
     /// <remarks>
     /// A trigger that missed many firings will fire that many times in rapid succession while it
     /// catches up.
+    /// <para>Named <c>IgnoreMisfirePolicy</c> in the misfire vocabulary.</para>
     /// </remarks>
     IgnoreMisfires = MisfireInstruction.IgnoreMisfirePolicy,
 
     /// <summary>
     /// Fire once now, then resume the schedule.
     /// </summary>
+    /// <remarks>
+    /// Named <c>FireOnceNow</c> in the misfire vocabulary.
+    /// </remarks>
     FireAndProceed = MisfireInstruction.RecurrenceTrigger.FireOnceNow,
 
     /// <summary>
     /// Skip the missed firings and resume at the next scheduled time.
     /// </summary>
+    /// <remarks>
+    /// Named <c>DoNothing</c> in the misfire vocabulary.
+    /// </remarks>
     DoNothing = MisfireInstruction.RecurrenceTrigger.DoNothing,
 }

--- a/src/Quartz/Serialization/SystemTextJson/Converters/TriggerConverter.cs
+++ b/src/Quartz/Serialization/SystemTextJson/Converters/TriggerConverter.cs
@@ -50,7 +50,7 @@ internal sealed class TriggerConverter(SystemTextJsonSerializerRegistry registry
 
             if (trigger is IMutableTrigger mutableTrigger)
             {
-                mutableTrigger.MisfireInstruction = misfireInstruction;
+                mutableTrigger.MisfireInstructionCode = misfireInstruction;
 
                 // Written as the pair the triggers table stores, and absent altogether from payloads
                 // written before triggers could be pinned - a missing pair reads back as
@@ -100,7 +100,7 @@ internal sealed class TriggerConverter(SystemTextJsonSerializerRegistry registry
             writer.WriteString(options.GetPropertyName("CalendarName"), value.CalendarName);
             writer.WritePropertyName(options.GetPropertyName("JobDataMap"));
             writer.WriteJobDataMapValue(value.JobDataMap, options);
-            writer.WriteNumber(options.GetPropertyName("MisfireInstruction"), value.MisfireInstruction);
+            writer.WriteNumber(options.GetPropertyName("MisfireInstruction"), value.MisfireInstructionCode);
             writer.WriteString(options.GetPropertyName("StartTimeUtc"), value.StartTimeUtc);
             writer.WriteString(options.GetPropertyName("EndTimeUtc"), value.EndTimeUtc);
             writer.WriteNumber(options.GetPropertyName("Priority"), value.Priority);

--- a/src/Quartz/SimpleScheduleBuilder.cs
+++ b/src/Quartz/SimpleScheduleBuilder.cs
@@ -150,7 +150,7 @@ public sealed class SimpleScheduleBuilder : IScheduleBuilder
     /// <see cref="SimpleTriggerMisfireInstruction.SmartPolicy" />.</param>
     /// <returns>the updated SimpleScheduleBuilder</returns>
     /// <seealso cref="SimpleTriggerMisfireInstruction" />
-    public SimpleScheduleBuilder WithMisfireHandlingInstruction(SimpleTriggerMisfireInstruction instruction)
+    public SimpleScheduleBuilder WithMisfireInstruction(SimpleTriggerMisfireInstruction instruction)
     {
         misfireInstruction = (int) instruction;
         return this;

--- a/src/Quartz/SimpleScheduleBuilder.cs
+++ b/src/Quartz/SimpleScheduleBuilder.cs
@@ -92,7 +92,7 @@ public sealed class SimpleScheduleBuilder : IScheduleBuilder
         SimpleTriggerImpl st = new SimpleTriggerImpl();
         st.RepeatInterval = interval;
         st.RepeatCount = repeatCount;
-        st.MisfireInstruction = misfireInstruction;
+        st.MisfireInstructionCode = misfireInstruction;
 
         return st;
     }

--- a/src/Quartz/SimpleTriggerMisfireInstruction.cs
+++ b/src/Quartz/SimpleTriggerMisfireInstruction.cs
@@ -27,13 +27,16 @@ namespace Quartz;
 /// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
-/// <seealso cref="SimpleScheduleBuilder.WithMisfireHandlingInstruction" />
+/// <seealso cref="SimpleScheduleBuilder.WithMisfireInstruction" />
 public enum SimpleTriggerMisfireInstruction
 {
     /// <summary>
     /// Let the scheduler pick the policy, based on the trigger's repeat count and interval.
     /// This is the default.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>SmartPolicy</c> in XML and JSON scheduling data.
+    /// </remarks>
     SmartPolicy = MisfireInstruction.SmartPolicy,
 
     /// <summary>
@@ -43,6 +46,7 @@ public enum SimpleTriggerMisfireInstruction
     /// <remarks>
     /// A trigger that missed many firings will fire that many times in rapid succession while it
     /// catches up.
+    /// <para>Spelled <c>IgnoreMisfirePolicy</c> in XML and JSON scheduling data.</para>
     /// </remarks>
     IgnoreMisfires = MisfireInstruction.IgnoreMisfirePolicy,
 
@@ -52,6 +56,7 @@ public enum SimpleTriggerMisfireInstruction
     /// <remarks>
     /// Intended for one-shot (non-repeating) triggers. On a repeating trigger this behaves like
     /// <see cref="NowWithRemainingCount" />.
+    /// <para>Spelled <c>FireNow</c> in XML and JSON scheduling data.</para>
     /// </remarks>
     FireNow = MisfireInstruction.SimpleTrigger.FireNow,
 
@@ -61,6 +66,7 @@ public enum SimpleTriggerMisfireInstruction
     /// <remarks>
     /// The trigger forgets the start time and repeat count it was originally set up with. The
     /// trigger's end time is still honored, so a trigger whose end time has passed will not fire.
+    /// <para>Spelled <c>RescheduleNowWithExistingRepeatCount</c> in XML and JSON scheduling data.</para>
     /// </remarks>
     NowWithExistingCount = MisfireInstruction.SimpleTrigger.RescheduleNowWithExistingRepeatCount,
 
@@ -71,6 +77,7 @@ public enum SimpleTriggerMisfireInstruction
     /// <remarks>
     /// The trigger forgets the start time and repeat count it was originally set up with. If every
     /// remaining firing was missed, the trigger completes after firing now.
+    /// <para>Spelled <c>RescheduleNowWithRemainingRepeatCount</c> in XML and JSON scheduling data.</para>
     /// </remarks>
     NowWithRemainingCount = MisfireInstruction.SimpleTrigger.RescheduleNowWithRemainingRepeatCount,
 
@@ -80,11 +87,15 @@ public enum SimpleTriggerMisfireInstruction
     /// </summary>
     /// <remarks>
     /// If every firing was missed, the trigger goes straight to completed.
+    /// <para>Spelled <c>RescheduleNextWithRemainingCount</c> in XML and JSON scheduling data.</para>
     /// </remarks>
     NextWithRemainingCount = MisfireInstruction.SimpleTrigger.RescheduleNextWithRemainingCount,
 
     /// <summary>
     /// Reschedule to the next scheduled time after now, keeping the repeat count as it stands.
     /// </summary>
+    /// <remarks>
+    /// Spelled <c>RescheduleNextWithExistingCount</c> in XML and JSON scheduling data.
+    /// </remarks>
     NextWithExistingCount = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount,
 }

--- a/src/Quartz/SimpleTriggerMisfireInstruction.cs
+++ b/src/Quartz/SimpleTriggerMisfireInstruction.cs
@@ -24,7 +24,7 @@ namespace Quartz;
 /// </summary>
 /// <remarks>
 /// The values match the <see cref="MisfireInstruction" /> constants a trigger stores in
-/// <see cref="ITrigger.MisfireInstruction" />, which is family-agnostic and therefore still an
+/// <see cref="ITrigger.MisfireInstructionCode" />, which is family-agnostic and therefore still an
 /// <see cref="int" />.
 /// </remarks>
 /// <seealso cref="SimpleScheduleBuilder.WithMisfireInstruction" />

--- a/src/Quartz/TriggerDetailsUpdate.cs
+++ b/src/Quartz/TriggerDetailsUpdate.cs
@@ -37,6 +37,9 @@ public sealed class TriggerDetailsUpdate
     internal bool HasPreferredNode { get; private set; }
     internal PreferredNode PreferredNode { get; private set; }
 
+    internal bool HasExecutionGroup { get; private set; }
+    internal string? ExecutionGroup { get; private set; }
+
     /// <summary>
     /// Set the trigger's description.
     /// </summary>
@@ -161,6 +164,22 @@ public sealed class TriggerDetailsUpdate
     {
         HasPreferredNode = true;
         PreferredNode = preferredNode;
+        return this;
+    }
+
+    /// <summary>
+    /// Set the execution group whose per-node thread limit this trigger's job counts against, or
+    /// <see langword="null" /> to remove it from every group.
+    /// </summary>
+    /// <remarks>
+    /// The new group applies from the next acquisition cycle; a job already running keeps counting
+    /// against the group it was acquired under.
+    /// </remarks>
+    /// <seealso cref="ExecutionLimits" />
+    public TriggerDetailsUpdate WithExecutionGroup(string? executionGroup)
+    {
+        HasExecutionGroup = true;
+        ExecutionGroup = executionGroup;
         return this;
     }
 }

--- a/src/Quartz/TriggerDetailsUpdate.cs
+++ b/src/Quartz/TriggerDetailsUpdate.cs
@@ -5,10 +5,9 @@ namespace Quartz;
 /// Only properties explicitly set via the builder methods will be changed.
 /// </summary>
 /// <remarks>
-/// Most properties here are pure metadata, but <see cref="CalendarName"/> and
-/// <see cref="MisfireInstruction"/> can affect firing behavior. Changing them via this
-/// API does not recompute fire times — the new values take effect starting from the
-/// next scheduling evaluation.
+/// Most properties here are pure metadata, but the calendar name and the misfire instruction can
+/// affect firing behavior. Changing them via this API does not recompute fire times — the new
+/// values take effect starting from the next scheduling evaluation.
 /// </remarks>
 /// <seealso cref="IScheduler.UpdateTriggerDetails"/>
 public sealed class TriggerDetailsUpdate
@@ -26,7 +25,14 @@ public sealed class TriggerDetailsUpdate
     internal string? CalendarName { get; private set; }
 
     internal bool HasMisfireInstruction { get; private set; }
-    internal int MisfireInstruction { get; private set; }
+    internal int MisfireInstructionCode { get; private set; }
+
+    /// <summary>
+    /// The family the misfire instruction was given in, or <see langword="null" /> when it arrived
+    /// as a bare code through <see cref="WithMisfireInstructionCode" />. The store rejects an update
+    /// whose family is not the stored trigger's.
+    /// </summary>
+    internal TriggerFamily? MisfireInstructionFamily { get; private set; }
 
     internal bool HasPreferredNode { get; private set; }
     internal PreferredNode PreferredNode { get; private set; }
@@ -72,12 +78,73 @@ public sealed class TriggerDetailsUpdate
     }
 
     /// <summary>
-    /// Set the trigger's misfire instruction.
+    /// Set the misfire instruction of a simple trigger.
     /// </summary>
-    public TriggerDetailsUpdate WithMisfireInstruction(int misfireInstruction)
+    /// <remarks>
+    /// The update is rejected if the trigger the key resolves to is not a
+    /// <see cref="ISimpleTrigger" />.
+    /// </remarks>
+    public TriggerDetailsUpdate WithMisfireInstruction(SimpleTriggerMisfireInstruction misfireInstruction)
+        => SetMisfireInstruction((int) misfireInstruction, TriggerFamily.Simple);
+
+    /// <summary>
+    /// Set the misfire instruction of a cron trigger.
+    /// </summary>
+    /// <remarks>
+    /// The update is rejected if the trigger the key resolves to is not an
+    /// <see cref="ICronTrigger" />.
+    /// </remarks>
+    public TriggerDetailsUpdate WithMisfireInstruction(CronTriggerMisfireInstruction misfireInstruction)
+        => SetMisfireInstruction((int) misfireInstruction, TriggerFamily.Cron);
+
+    /// <summary>
+    /// Set the misfire instruction of a calendar-interval trigger.
+    /// </summary>
+    /// <remarks>
+    /// The update is rejected if the trigger the key resolves to is not an
+    /// <see cref="ICalendarIntervalTrigger" />.
+    /// </remarks>
+    public TriggerDetailsUpdate WithMisfireInstruction(CalendarIntervalTriggerMisfireInstruction misfireInstruction)
+        => SetMisfireInstruction((int) misfireInstruction, TriggerFamily.CalendarInterval);
+
+    /// <summary>
+    /// Set the misfire instruction of a daily-time-interval trigger.
+    /// </summary>
+    /// <remarks>
+    /// The update is rejected if the trigger the key resolves to is not an
+    /// <see cref="IDailyTimeIntervalTrigger" />.
+    /// </remarks>
+    public TriggerDetailsUpdate WithMisfireInstruction(DailyTimeIntervalTriggerMisfireInstruction misfireInstruction)
+        => SetMisfireInstruction((int) misfireInstruction, TriggerFamily.DailyTimeInterval);
+
+    /// <summary>
+    /// Set the misfire instruction of a recurrence trigger.
+    /// </summary>
+    /// <remarks>
+    /// The update is rejected if the trigger the key resolves to is not an
+    /// <see cref="IRecurrenceTrigger" />.
+    /// </remarks>
+    public TriggerDetailsUpdate WithMisfireInstruction(RecurrenceTriggerMisfireInstruction misfireInstruction)
+        => SetMisfireInstruction((int) misfireInstruction, TriggerFamily.Recurrence);
+
+    /// <summary>
+    /// Set the trigger's misfire instruction as the raw code a trigger stores, for callers that
+    /// have a number rather than a family — a value read off the wire, from configuration, or from
+    /// <see cref="ITrigger.MisfireInstruction" />.
+    /// </summary>
+    /// <remarks>
+    /// Prefer the family-typed <c>WithMisfireInstruction</c> overloads: the same number means a
+    /// different policy in each family, and only the typed form lets the store tell you that the
+    /// key resolved to a trigger of another one.
+    /// </remarks>
+    public TriggerDetailsUpdate WithMisfireInstructionCode(int misfireInstructionCode)
+        => SetMisfireInstruction(misfireInstructionCode, family: null);
+
+    private TriggerDetailsUpdate SetMisfireInstruction(int misfireInstructionCode, TriggerFamily? family)
     {
         HasMisfireInstruction = true;
-        MisfireInstruction = misfireInstruction;
+        MisfireInstructionCode = misfireInstructionCode;
+        MisfireInstructionFamily = family;
         return this;
     }
 

--- a/src/Quartz/TriggerDetailsUpdate.cs
+++ b/src/Quartz/TriggerDetailsUpdate.cs
@@ -130,7 +130,7 @@ public sealed class TriggerDetailsUpdate
     /// <summary>
     /// Set the trigger's misfire instruction as the raw code a trigger stores, for callers that
     /// have a number rather than a family — a value read off the wire, from configuration, or from
-    /// <see cref="ITrigger.MisfireInstruction" />.
+    /// <see cref="ITrigger.MisfireInstructionCode" />.
     /// </summary>
     /// <remarks>
     /// Prefer the family-typed <c>WithMisfireInstruction</c> overloads: the same number means a

--- a/src/Quartz/TriggerFamily.cs
+++ b/src/Quartz/TriggerFamily.cs
@@ -1,0 +1,69 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// The schedule families a trigger can belong to. A misfire instruction is only meaningful
+/// within one of them: the same number means a different policy in each.
+/// </summary>
+internal enum TriggerFamily
+{
+    Simple,
+    Cron,
+    CalendarInterval,
+    DailyTimeInterval,
+    Recurrence,
+}
+
+internal static class TriggerFamilyExtensions
+{
+    /// <summary>
+    /// The family the given trigger belongs to, or <see langword="null" /> when it belongs to
+    /// none of the built-in ones.
+    /// </summary>
+    internal static TriggerFamily? Family(this ITrigger trigger)
+    {
+        return trigger switch
+        {
+            ISimpleTrigger => TriggerFamily.Simple,
+            ICronTrigger => TriggerFamily.Cron,
+            ICalendarIntervalTrigger => TriggerFamily.CalendarInterval,
+            IDailyTimeIntervalTrigger => TriggerFamily.DailyTimeInterval,
+            IRecurrenceTrigger => TriggerFamily.Recurrence,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// The name of the family as it reads in an error message: the interface a caller would cast to.
+    /// </summary>
+    internal static string DisplayName(this TriggerFamily family)
+    {
+        return family switch
+        {
+            TriggerFamily.Simple => "simple",
+            TriggerFamily.Cron => "cron",
+            TriggerFamily.CalendarInterval => "calendar interval",
+            TriggerFamily.DailyTimeInterval => "daily time interval",
+            TriggerFamily.Recurrence => "recurrence",
+            _ => family.ToString()
+        };
+    }
+}

--- a/src/Quartz/TriggerFamily.cs
+++ b/src/Quartz/TriggerFamily.cs
@@ -17,6 +17,8 @@
  */
 #endregion
 
+using Quartz.Util;
+
 namespace Quartz;
 
 /// <summary>
@@ -49,6 +51,32 @@ internal static class TriggerFamilyExtensions
             IRecurrenceTrigger => TriggerFamily.Recurrence,
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Rejects an update whose misfire instruction was given in a family other than the stored
+    /// trigger's. A code that is in range for two families means a different policy in each, so
+    /// <see cref="Quartz.Impl.Triggers.AbstractTrigger" />'s range check lets the wrong one through
+    /// silently; only the update object knows which family the caller meant.
+    /// </summary>
+    /// <exception cref="JobPersistenceException">The families disagree.</exception>
+    internal static void EnsureMisfireInstructionMatchesFamily(this TriggerDetailsUpdate update, ITrigger trigger, TriggerKey triggerKey)
+    {
+        if (!update.HasMisfireInstruction || update.MisfireInstructionFamily is not TriggerFamily requested)
+        {
+            return;
+        }
+
+        TriggerFamily? actual = trigger.Family();
+        if (actual == requested)
+        {
+            return;
+        }
+
+        string actualName = actual is TriggerFamily family ? family.DisplayName() : trigger.GetType().Name;
+        Throw.JobPersistenceException(
+            $"Misfire instruction {update.MisfireInstructionCode} was given for a {requested.DisplayName()} trigger, but '{triggerKey}' is a {actualName} trigger. "
+            + $"The same code means a different policy in each family; use the {actualName} overload of WithMisfireInstruction, or WithMisfireInstructionCode if the code is already the stored one.");
     }
 
     /// <summary>

--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -16,7 +16,6 @@
  */
 
 using System.Globalization;
-using System.Reflection;
 using System.Xml;
 using System.Xml.Schema;
 
@@ -384,7 +383,7 @@ public class XMLSchedulingDataProcessor
 
                 if (!string.IsNullOrWhiteSpace(simpleTrigger.MisfireInstruction))
                 {
-                    ((SimpleScheduleBuilder) scheduleBuilder).WithMisfireInstruction((SimpleTriggerMisfireInstruction) ReadMisfireInstructionFromString(simpleTrigger.MisfireInstruction));
+                    ((SimpleScheduleBuilder) scheduleBuilder).WithMisfireInstruction((SimpleTriggerMisfireInstruction) ReadMisfireInstructionFromString(TriggerFamily.Simple, simpleTrigger.MisfireInstruction));
                 }
             }
             else if (triggerNode is CronTriggerDefinition cronTrigger)
@@ -398,7 +397,7 @@ public class XMLSchedulingDataProcessor
 
                 if (!string.IsNullOrWhiteSpace(cronTrigger.MisfireInstruction))
                 {
-                    ((CronScheduleBuilder) scheduleBuilder).WithMisfireInstruction((CronTriggerMisfireInstruction) ReadMisfireInstructionFromString(cronTrigger.MisfireInstruction));
+                    ((CronScheduleBuilder) scheduleBuilder).WithMisfireInstruction((CronTriggerMisfireInstruction) ReadMisfireInstructionFromString(TriggerFamily.Cron, cronTrigger.MisfireInstruction));
                 }
             }
             else if (triggerNode is CalendarIntervalTriggerDefinition calendarIntervalTrigger)
@@ -413,7 +412,7 @@ public class XMLSchedulingDataProcessor
 
                 if (!string.IsNullOrWhiteSpace(calendarIntervalTrigger.MisfireInstruction))
                 {
-                    ((CalendarIntervalScheduleBuilder) scheduleBuilder).WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) ReadMisfireInstructionFromString(calendarIntervalTrigger.MisfireInstruction));
+                    ((CalendarIntervalScheduleBuilder) scheduleBuilder).WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) ReadMisfireInstructionFromString(TriggerFamily.CalendarInterval, calendarIntervalTrigger.MisfireInstruction));
                 }
             }
             else
@@ -465,11 +464,17 @@ public class XMLSchedulingDataProcessor
         return value;
     }
 
-    protected virtual int ReadMisfireInstructionFromString(string misfireInstruction)
+    /// <summary>
+    /// Resolves a <c>misfire-instruction</c> element's text as the given trigger family spells it.
+    /// </summary>
+    /// <remarks>
+    /// A name belonging to another family is accepted with a warning when its code is valid here,
+    /// which is what the previous reflection-based lookup did silently. This used to be a
+    /// <c>protected virtual</c> seam that took no family, and so could not tell the families apart.
+    /// </remarks>
+    private int ReadMisfireInstructionFromString(TriggerFamily family, string misfireInstruction)
     {
-        Constants c = new Constants(typeof(MisfireInstruction), typeof(MisfireInstruction.CronTrigger),
-            typeof(MisfireInstruction.SimpleTrigger));
-        return c.AsNumber(misfireInstruction);
+        return MisfireInstructionNames.Resolve(family, misfireInstruction, logger);
     }
 
     protected virtual IntervalUnit ParseDateIntervalTriggerIntervalUnit(string? intervalUnit)
@@ -1042,34 +1047,5 @@ public class XMLSchedulingDataProcessor
     public void AddTriggerGroupToNeverDelete(string triggerGroupName)
     {
         triggerGroupsToNeverDelete.Add(triggerGroupName);
-    }
-
-    /// <summary>
-    /// Helper class to map constant names to their values.
-    /// </summary>
-    internal sealed class Constants
-    {
-        private readonly Type[] types;
-
-        public Constants(params Type[] reflectedTypes)
-        {
-            types = reflectedTypes;
-        }
-
-        public int AsNumber(string field)
-        {
-            foreach (Type type in types)
-            {
-                FieldInfo? fi = type.GetField(field);
-                if (fi is not null)
-                {
-                    return Convert.ToInt32(fi.GetValue(null), CultureInfo.InvariantCulture);
-                }
-            }
-
-            // not found
-            Throw.ArgumentException($"Unknown field '{field}'");
-            return 0;
-        }
     }
 }

--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -384,7 +384,7 @@ public class XMLSchedulingDataProcessor
 
                 if (!string.IsNullOrWhiteSpace(simpleTrigger.MisfireInstruction))
                 {
-                    ((SimpleScheduleBuilder) scheduleBuilder).WithMisfireHandlingInstruction((SimpleTriggerMisfireInstruction) ReadMisfireInstructionFromString(simpleTrigger.MisfireInstruction));
+                    ((SimpleScheduleBuilder) scheduleBuilder).WithMisfireInstruction((SimpleTriggerMisfireInstruction) ReadMisfireInstructionFromString(simpleTrigger.MisfireInstruction));
                 }
             }
             else if (triggerNode is CronTriggerDefinition cronTrigger)
@@ -398,7 +398,7 @@ public class XMLSchedulingDataProcessor
 
                 if (!string.IsNullOrWhiteSpace(cronTrigger.MisfireInstruction))
                 {
-                    ((CronScheduleBuilder) scheduleBuilder).WithMisfireHandlingInstruction((CronTriggerMisfireInstruction) ReadMisfireInstructionFromString(cronTrigger.MisfireInstruction));
+                    ((CronScheduleBuilder) scheduleBuilder).WithMisfireInstruction((CronTriggerMisfireInstruction) ReadMisfireInstructionFromString(cronTrigger.MisfireInstruction));
                 }
             }
             else if (triggerNode is CalendarIntervalTriggerDefinition calendarIntervalTrigger)
@@ -413,7 +413,7 @@ public class XMLSchedulingDataProcessor
 
                 if (!string.IsNullOrWhiteSpace(calendarIntervalTrigger.MisfireInstruction))
                 {
-                    ((CalendarIntervalScheduleBuilder) scheduleBuilder).WithMisfireHandlingInstruction((CalendarIntervalTriggerMisfireInstruction) ReadMisfireInstructionFromString(calendarIntervalTrigger.MisfireInstruction));
+                    ((CalendarIntervalScheduleBuilder) scheduleBuilder).WithMisfireInstruction((CalendarIntervalTriggerMisfireInstruction) ReadMisfireInstructionFromString(calendarIntervalTrigger.MisfireInstruction));
                 }
             }
             else


### PR DESCRIPTION
Part of the 4.0 API-finalization campaign (PR-2a of the ratified spec, with the verification amendments). Four commits.

## The family interfaces are read models

The nine schedule setters on `ISimpleTrigger` / `ICronTrigger` / `ICalendarIntervalTrigger` / `IDailyTimeIntervalTrigger` / `IRecurrenceTrigger` are gone. Setting one on a trigger retrieved from the scheduler compiled, ran, and changed nothing — stores hand out clones. The sanctioned paths (`GetTriggerBuilder()` + `RescheduleJob`, or `UpdateTriggerDetails`) were already public; the migration guide shows both. `AbstractTrigger`, the concrete triggers and `IMutableTrigger` keep their setters, and `ICalendar` deliberately keeps its two — it is an implementable SPI whose serializers assign through the interface.

(The spec said eleven setters; its own evidence list has nine, and nine exist.)

## Misfire policy is family-typed

- Each family interface gains a typed `MisfireInstruction` property; `ITrigger` keeps the family-agnostic number as get-only **`MisfireInstructionCode`** (serializers, the wire contract and the dashboard read it without knowing the family; the JSON property name on the wire is unchanged).
- `WithMisfireHandlingInstruction` → `WithMisfireInstruction` on all five schedule builders.
- `TriggerDetailsUpdate` replaces `WithMisfireInstruction(int)` with five family-typed overloads plus `WithMisfireInstructionCode(int)` for callers that genuinely hold a number. **Both stores now reject an update whose misfire family is not the stored trigger's** — previously a simple-trigger code applied to a cron trigger passed the range check and silently became a different policy. Rejection happens before any mutation and throws `JobPersistenceException`, matching the calendar-not-found precedent so both stores fail alike.
- The `MisfireInstruction` constant class is internal; the five enums are the vocabulary.

## The XML/JSON names are resolved per family

The two reflection-based name lookups (plus a third the spec missed, in Quartz.Plugins' `JsonSchedulingDataProcessor`) are replaced by explicit per-family maps that accept a superset of what parsed before: the XSD names, the enum member spellings, and — with a warning naming the policy actually selected — a name from another family whose code is legal here. This fixes a live JSON-only bug: a cron trigger configured with `"RescheduleNowWithExistingRepeatCount"` silently became `DoNothing` (both are 2). XML was never affected — the XSD restricts `misfire-instruction` per trigger type, so `XMLSchedulingDataProcessor.ReadMisfireInstructionFromString` (formerly `protected virtual`, now private: it took no family, and a family-blind seam is exactly the defect) never saw a foreign name.

## Also

- `TriggerDetailsUpdate.WithExecutionGroup` — `QRTZ_TRIGGERS.EXECUTION_GROUP` was already written by the generic update; RAMJobStore now applies it in place the same way it applies a preferred node (#3260), and `SmokeTestPerformer` round-trips it against every ADO database in CI.
- `HasMillisecondPrecision` left `ITrigger` and is `protected abstract` on `AbstractTrigger` — it is how a trigger describes its schedule to the base class, and nothing outside acted on it.

## Reviewer notes

- Latent inconsistency found and deliberately not fixed: `RecurrenceTriggerImpl` declares no millisecond precision but overrides `StartTimeUtc` and never reaches the base-class round-down, unlike `CronTriggerImpl`. Rounding it now would move existing triggers' fire times; the behaviour is pinned by a test (`TestStartTimeKeepsItsMilliseconds`) and left as a follow-up decision.
- Shares the public-API baseline and migration guide with #3262; whichever merges second gets rebased and its baseline re-approved.

Verified with `build.cmd Compile UnitTest` (2217 + 210 tests passing) plus the AspNetCore suite in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
