### PR TITLE
One Create() convention on builders; CronExpression becomes immutable

### DIFF
--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -129,7 +129,7 @@ the `CronExpression`:
 
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
-    .WithCronSchedule(CronScheduleBuilder.CronSchedule(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup")))
+    .WithCronSchedule(CronScheduleBuilder.Create(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup")))
     .Build();
 ```
 
@@ -161,7 +161,7 @@ CronExpression expression = CronExpressionBuilder.Create()
 
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("myTrigger")
-    .WithSchedule(CronScheduleBuilder.CronSchedule(expression))
+    .WithSchedule(CronScheduleBuilder.Create(expression))
     .Build();
 ```
 

--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -125,11 +125,11 @@ ITrigger trigger = TriggerBuilder.Create()
 ```
 
 You can also provide an explicit hash key, which does not require a trigger identity. The key rides on
-the `CronExpression`:
+the `CronExpression`, and `WithCronSchedule` takes one directly:
 
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
-    .WithCronSchedule(CronScheduleBuilder.Create(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup")))
+    .WithCronSchedule(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup"))
     .Build();
 ```
 
@@ -152,18 +152,19 @@ dropdowns instead of a free-form cron field - you can compose the expression wit
 `CronExpressionBuilder` instead of concatenating strings:
 
 ```csharp
-CronExpression expression = CronExpressionBuilder.Create()
-    .WithSecond(0)
-    .WithMinuteIncrements(0, 15) // every 15 minutes
-    .WithHourRange(8, 17)        // between 8:00 and 17:59
-    .OnWeekdays()                // Monday through Friday
-    .Build(); // "0 0/15 8-17 ? * MON-FRI"
-
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("myTrigger")
-    .WithSchedule(CronScheduleBuilder.Create(expression))
+    .WithCronSchedule(CronExpressionBuilder.Create()
+        .WithSecond(0)
+        .WithMinuteIncrements(0, 15) // every 15 minutes
+        .WithHourRange(8, 17)        // between 8:00 and 17:59
+        .OnWeekdays())               // "0 0/15 8-17 ? * MON-FRI"
     .Build();
 ```
+
+`WithCronSchedule` accepts the builder (or a built `CronExpression`) directly, so the chain closes
+without naming `CronScheduleBuilder`; call `Build()` yourself when you want the `CronExpression` as a
+value.
 
 Each field offers a single value, list, range and increment form (e.g. `WithHour`,
 `WithHours`, `WithHourRange`, `WithHourIncrements`), and the special characters are

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1793,7 +1793,7 @@ Three runtime checks come with the type parameter, all only on a builder whose `
 
 * `JobBuilder.Create<TJob>().OfType(type)` and `OfType<T>()` throw `ArgumentException` **at the `OfType`
   call** when the type is not a `TJob`. If you resolve a job type at runtime — from configuration, or a
-  decorator type — build it with `JobBuilder.Create(type)` rather than the generic overload.
+  decorator type — build it with `JobBuilder.Create().OfType(type)` rather than the generic overload.
 * `JobBuilder.Create<TJob>().OfType(typeName)` throws `InvalidOperationException` on `Build()` instead,
   because a type named by string is only known once it resolves.
 * `TriggerBuilder.Create<TJob>().ForJob(jobDetail)` throws `ArgumentException` when the detail is not for a
@@ -3179,7 +3179,7 @@ Deleted: `SimpleScheduleTriggerBuilderExtensions`, `CronScheduleTriggerBuilderEx
 | `WithSimpleSchedule(SimpleScheduleBuilder)` | `WithSimpleSchedule(SimpleScheduleBuilder schedule)` |
 | `WithCronSchedule(string)` | `WithCronSchedule(string cronExpression, Action<CronScheduleBuilder>? configure = null)` |
 | `WithCronSchedule(string, Action<CronScheduleBuilder>)` | same member |
-| `WithCronSchedule(string expr, string hashKey)` | `WithCronSchedule(CronScheduleBuilder.CronSchedule(new CronExpression(expr, hashKey)))` |
+| `WithCronSchedule(string expr, string hashKey)` | `WithCronSchedule(CronScheduleBuilder.Create(new CronExpression(expr, hashKey)))` |
 | `WithCronSchedule(string expr, string hashKey, Action<CronScheduleBuilder>)` | build the `CronScheduleBuilder`, configure it, pass it |
 | `WithCronSchedule(CronScheduleBuilder)` | `WithCronSchedule(CronScheduleBuilder schedule)` |
 | `WithCalendarIntervalSchedule()` | `WithCalendarIntervalSchedule(Action<CalendarIntervalScheduleBuilder>? configure = null)` |
@@ -3200,7 +3200,7 @@ Only two call shapes need editing:
 + .WithDailyTimeIntervalSchedule(x => x.WithInterval(10, IntervalUnit.Second))
 
 - .WithCronSchedule("0 H H(0-7) * * ?", "nightly-cleanup")
-+ .WithCronSchedule(CronScheduleBuilder.CronSchedule(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup")))
++ .WithCronSchedule(CronScheduleBuilder.Create(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup")))
 ```
 
 The hash-key overloads went because a hash key belongs to the expression, not to the way the expression is
@@ -3411,6 +3411,35 @@ could not tell the families apart, because it was not told which one it was read
 either way — `job_scheduling_data_2_0.xsd` restricts `misfire-instruction` per trigger type, so the schema
 rejects a foreign name before the resolver sees it.
 
+## Every builder starts with `Create`
+
+3.x taught a different way to start each builder: `Create()` on some, `CronSchedule(...)` on
+`CronScheduleBuilder`, `NewDate()` on `DateBuilder`, `new` on others. In 4.x every builder in the DSL
+is reached the same way — a static `Create(...)` taking only what cannot be defaulted.
+
+| 3.x | 4.x |
+|---|---|
+| `CronScheduleBuilder.CronSchedule(string)` | `CronScheduleBuilder.Create(string)` |
+| `CronScheduleBuilder.CronSchedule(CronExpression)` | `CronScheduleBuilder.Create(CronExpression)` |
+| `DateBuilder.NewDate()` | `DateBuilder.Create()` |
+| `DateBuilder.NewDateInTimeZone(tz)` | `DateBuilder.CreateInTimeZone(tz)` |
+| `JobBuilder.Create(Type)` | `JobBuilder.Create().OfType(type)` |
+
+`ExecutionLimitsBuilder`, new in 4.0, follows the same convention: its constructor is no longer
+public, so `new ExecutionLimitsBuilder()` becomes `ExecutionLimitsBuilder.Create()`.
+
+The `JobBuilder` row is the only one that is more than a rename. `Create(Type)` duplicated
+`OfType(Type)` on the same builder; when the job type only arrives at runtime — read from
+configuration, a database row, or a message — build the detail as:
+
+```csharp
+IJobDetail job = JobBuilder.Create().OfType(jobType).WithIdentity(name).Build();
+```
+
+`JobBuilder.Create()` / `Create<TJob>()` and `TriggerBuilder.Create()` / `Create<TJob>()` are
+unchanged — that generic/non-generic split carries real type information (see
+[The builders carry the job type](#the-builders-carry-the-job-type)).
+
 ## Intervals are said once per builder
 
 Every schedule builder had a `WithIntervalIn<Unit>` method per unit alongside a general `WithInterval`. The
@@ -3484,18 +3513,19 @@ Inside a `WithSimpleSchedule` delegate you never needed the factories at all:
 
 ## `CronScheduleBuilder`'s convenience factories are gone
 
-`CronSchedule(string)` and `CronSchedule(CronExpression)` stay. The six factories that assembled an expression
+`CronSchedule(string)` and `CronSchedule(CronExpression)` stay, spelled `Create(...)` now (see
+[Every builder starts with `Create`](#every-builder-starts-with-create)). The six factories that assembled an expression
 from numbers are replaced by `CronExpressionBuilder`, which names each field instead of relying on argument
 order — the old set used three different orders for the same three numbers.
 
 | 3.x | 4.x |
 |---|---|
-| `CronScheduleBuilder.DailyAtHourAndMinute(h, m)` | `CronScheduleBuilder.CronSchedule($"0 {m} {h} ? * *")` |
-| `CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(h, m, days)` | `CronScheduleBuilder.CronSchedule(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).OnDaysOfWeek(days).Build())` |
-| `CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(day, h, m)` | `CronScheduleBuilder.CronSchedule(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).OnDaysOfWeek(day).Build())` |
-| `CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(dom, h, m)` | `CronScheduleBuilder.CronSchedule(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).WithDayOfMonth(dom).Build())` |
-| `CronScheduleBuilder.CronScheduleWithHash(expr, hashKey)` | `CronScheduleBuilder.CronSchedule(new CronExpression(expr, hashKey))` |
-| `CronScheduleBuilder.CronScheduleWithHash(expr, hashSeed)` | `CronScheduleBuilder.CronSchedule(new CronExpression(expr, hashSeed))` |
+| `CronScheduleBuilder.DailyAtHourAndMinute(h, m)` | `CronScheduleBuilder.Create($"0 {m} {h} ? * *")` |
+| `CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(h, m, days)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).OnDaysOfWeek(days).Build())` |
+| `CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(day, h, m)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).OnDaysOfWeek(day).Build())` |
+| `CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(dom, h, m)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).WithDayOfMonth(dom).Build())` |
+| `CronScheduleBuilder.CronScheduleWithHash(expr, hashKey)` | `CronScheduleBuilder.Create(new CronExpression(expr, hashKey))` |
+| `CronScheduleBuilder.CronScheduleWithHash(expr, hashSeed)` | `CronScheduleBuilder.Create(new CronExpression(expr, hashSeed))` |
 
 ```diff
 - .WithSchedule(CronScheduleBuilder.DailyAtHourAndMinute(9, 30))
@@ -3551,19 +3581,20 @@ implements the interface and drops the `override`:
 
 ## `DateBuilder`'s static factories are gone
 
-The fluent API is unchanged: `DateBuilder.NewDate()`, `NewDateInTimeZone()`, the `At*`/`On*`/`In*` setters and
-`Build()`. The seventeen statics were doing two unrelated jobs under one name — naming a specific date, which
+The fluent API keeps its shape: `DateBuilder.Create()` (named `NewDate()` in 3.x), `CreateInTimeZone()`
+(3.x `NewDateInTimeZone()`), the `At*`/`On*`/`In*` setters and `Build()`. The seventeen statics were
+doing two unrelated jobs under one name — naming a specific date, which
 the fluent API does, and arithmetic on a `DateTimeOffset`, which `DateTimeOffset` does.
 
 ### Naming a date
 
 | 3.x | 4.x |
 |---|---|
-| `DateBuilder.DateOf(h, m, s)` | `DateBuilder.NewDate().AtHourMinuteAndSecond(h, m, s).Build()` |
-| `DateBuilder.TodayAt(h, m, s)` | `DateBuilder.NewDate().AtHourMinuteAndSecond(h, m, s).Build()` |
-| `DateBuilder.DateOf(h, m, s, day, month)` | `DateBuilder.NewDate().InMonthOnDay(month, day).AtHourMinuteAndSecond(h, m, s).Build()` |
-| `DateBuilder.DateOf(h, m, s, day, month, year)` | `DateBuilder.NewDate().InYear(year).InMonthOnDay(month, day).AtHourMinuteAndSecond(h, m, s).Build()` |
-| `DateBuilder.TomorrowAt(h, m, s)` | `DateBuilder.NewDate().AtHourMinuteAndSecond(h, m, s).Build().AddDays(1)` |
+| `DateBuilder.DateOf(h, m, s)` | `DateBuilder.Create().AtHourMinuteAndSecond(h, m, s).Build()` |
+| `DateBuilder.TodayAt(h, m, s)` | `DateBuilder.Create().AtHourMinuteAndSecond(h, m, s).Build()` |
+| `DateBuilder.DateOf(h, m, s, day, month)` | `DateBuilder.Create().InMonthOnDay(month, day).AtHourMinuteAndSecond(h, m, s).Build()` |
+| `DateBuilder.DateOf(h, m, s, day, month, year)` | `DateBuilder.Create().InYear(year).InMonthOnDay(month, day).AtHourMinuteAndSecond(h, m, s).Build()` |
+| `DateBuilder.TomorrowAt(h, m, s)` | `DateBuilder.Create().AtHourMinuteAndSecond(h, m, s).Build().AddDays(1)` |
 
 Note that `InMonthOnDay` takes the month first, where `DateOf` took the day first.
 
@@ -3821,7 +3852,7 @@ immutable snapshot that `Build()` returns and that the scheduler thread reads.
 
 ```diff
 - await scheduler.SetExecutionLimits(new ExecutionLimits()
-+ await scheduler.SetExecutionLimits(new ExecutionLimitsBuilder()
++ await scheduler.SetExecutionLimits(ExecutionLimitsBuilder.Create()
       .ForGroup("batch-jobs", 2)
       .ForDefaultGroup(10)
 -     .ForOtherGroups(5));

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3116,6 +3116,31 @@ If you author an `ITriggerPersistenceDelegate` of your own, note that `ObjectUti
 back to writable *interface* properties when the concrete type has none, and that fallback is now narrower.
 No built-in delegate depends on it — all five write only `timesTriggered`, which the concrete triggers expose.
 
+## `CronExpression` is immutable
+
+`CronExpression` always looked like a value — sealed, value equality, a get-only expression string — but
+carried one settable property, `TimeZone`. It is now immutable: the time zone arrives through a constructor
+or through `WithTimeZone`, which returns a retimed copy.
+
+| 3.x | 4.x |
+|---|---|
+| `expr.TimeZone = tz;` | `expr = expr.WithTimeZone(tz);` |
+| `new CronExpression(s) { TimeZone = tz }` | `new CronExpression(s, tz)` |
+| `expr.GetTimeAfter(d)` | `expr.GetNextValidTimeAfter(d)` — the two were verbatim aliases; one name remains |
+| `expr.GetFinalFireTime()` | Removed — it was never implemented and always returned `null` |
+
+`null` still means the system's local time zone, and an expression that was never given a zone still
+serializes with the local zone's id, so persisted payloads keep their meaning.
+
+The setter's removal also fixes a real defect: `CronScheduleBuilder` handed the *same* `CronExpression`
+instance to every trigger it built, so calling `InTimeZone` after the first `Build()` silently retimed
+triggers that were already built — and writing `TimeZone` on an expression you had passed to a builder
+retimed the builder behind your back. Both are now impossible: the builder reshapes its own copy, and
+already-built triggers keep the zone they were built with.
+
+`CronTriggerImpl.FinalFireTimeUtc` now returns `null` directly for a trigger with no end time, which is the
+value it always produced through `GetFinalFireTime`.
+
 ## Nine `UsingJobData` overloads became one
 
 `JobDataMap`'s indexer takes an `object?`, and every one of the nine primitive `UsingJobData` overloads had
@@ -4326,7 +4351,7 @@ removals on types that are still public and still open, which no section above n
 | `AbstractTrigger.CompareTo(ITrigger)` | Removed; `AbstractTrigger` no longer implements `IComparable<ITrigger>` | It compared keys — `trigger.Key.CompareTo(other.Key)` |
 | `AbstractTrigger.FullJobName` | Removed | `JobKey.ToString()`, alongside the four in [AbstractTrigger Property Removals](#abstracttrigger-property-removals) |
 | `CronExpression`'s `protected` constants and fields | Gone with the type, which is `sealed` now | No replacement; the parsed sets were never a contract — see [Sealed and Internalized Types](#sealed-and-internalized-types) |
-| `CronTriggerImpl.GetTimeAfter(DateTimeOffset)` | Removed (it was `protected`) | `GetFireTimeAfter(DateTimeOffset?)`, or `CronExpression.GetTimeAfter` for the expression on its own |
+| `CronTriggerImpl.GetTimeAfter(DateTimeOffset)` | Removed (it was `protected`) | `GetFireTimeAfter(DateTimeOffset?)`, or `CronExpression.GetNextValidTimeAfter` for the expression on its own |
 | `CronTriggerImpl.YearToGiveupSchedulingAt` | Removed (a `protected const`) | No replacement; where the search stops is the expression's business |
 | `DateBuilder.ValidateDayOfMonth`, `.ValidateHour`, `.ValidateMinute`, `.ValidateMonth`, `.ValidateSecond`, `.ValidateYear` | Removed | No replacement; the builder validates its own arguments, and it is `sealed` — see [`DateBuilder`'s static factories are gone](#datebuilder-s-static-factories-are-gone) |
 | `DbProvider.CreateParameter()` | Removed | `CreateCommand().CreateParameter()` |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3750,10 +3750,10 @@ thing being excluded, plus `AddExcludedDay` and `RemoveExcludedDay`, which retur
 
 | 3.x | 4.x |
 |---|---|
-| `AnnualCalendar.DaysExcluded` as a settable `IReadOnlyCollection<DateTime>` | `IReadOnlySet<DateOnly>`, get-only |
-| `annual.SetDayExcluded(day, true)` | `annual.AddExcludedDay(DateOnly)` |
-| `annual.SetDayExcluded(day, false)` | `annual.RemoveExcludedDay(DateOnly)` |
-| `annual.IsDayExcluded(DateTimeOffset)` | `annual.IsDayExcluded(DateOnly)` |
+| `AnnualCalendar.DaysExcluded` as a settable `IReadOnlyCollection<DateTime>` | `IReadOnlySet<MonthDay>`, get-only |
+| `annual.SetDayExcluded(day, true)` | `annual.AddExcludedDay(MonthDay)` |
+| `annual.SetDayExcluded(day, false)` | `annual.RemoveExcludedDay(MonthDay)` |
+| `annual.IsDayExcluded(DateTimeOffset)` | `annual.IsDayExcluded(MonthDay)` |
 | `HolidayCalendar.ExcludedDates` as a `List<DateTime>` copy | `HolidayCalendar.DaysExcluded` as `IReadOnlySet<DateOnly>` |
 | `holiday.AddExcludedDate(DateTime)` | `holiday.AddExcludedDay(DateOnly)` |
 | `holiday.RemoveExcludedDate(DateTime)` | `holiday.RemoveExcludedDay(DateOnly)` |
@@ -3769,12 +3769,18 @@ thing being excluded, plus `AddExcludedDay` and `RemoveExcludedDay`, which retur
 var holidays = new HolidayCalendar();
 holidays.AddExcludedDate(new DateTime(2025, 12, 25));
 
+var christmas = new AnnualCalendar();
+christmas.SetDayExcluded(new DateTime(2025, 12, 25), true);
+
 var weekends = new WeeklyCalendar();
 weekends.SetDayExcluded(DayOfWeek.Friday, true);
 
 // 4.x
 var holidays = new HolidayCalendar();
-holidays.AddExcludedDay(new DateOnly(2025, 12, 25));
+holidays.AddExcludedDay(new DateOnly(2025, 12, 25));   // a specific date, once
+
+var christmas = new AnnualCalendar();
+christmas.AddExcludedDay(new MonthDay(12, 25));        // the same date, every year
 
 var weekends = new WeeklyCalendar();
 weekends.AddExcludedDay(DayOfWeek.Friday);
@@ -3782,9 +3788,11 @@ weekends.AddExcludedDay(DayOfWeek.Friday);
 
 Two behaviors worth knowing:
 
-* `AnnualCalendar` still only cares about the month and the day. It normalizes what you give it onto a fixed
-  year, so `DaysExcluded` reads back with that year rather than the one you passed, and `IsDayExcluded`
-  answers the same for every year.
+* `AnnualCalendar` speaks `MonthDay` — a `readonly record struct` of month and day in the `Quartz`
+  namespace, with `MonthDay.From(DateOnly)` for when you hold a date. A `DateOnly` always carries a year,
+  so a set of them had to lie: what you put in was not what you read back, and `DaysExcluded.Contains`
+  disagreed with `AddExcludedDay`. `MonthDay` says exactly what is stored — the same date every year —
+  and February 29th is a valid value.
 * `AnnualCalendar.IsDayExcluded` now answers only about the calendar's own set. The base calendar is
   consulted by `IsTimeIncluded`, which is the member that asks a question about an instant.
 
@@ -3914,22 +3922,36 @@ Reading limits back is what changed shape, because the snapshot is not a diction
 
 | Before | 4.0 |
 |---|---|
-| `limits["heavy"]` | `limits.TryGetLimit("heavy", out int? maxConcurrent)` |
-| `limits[ExecutionLimits.DefaultGroupKey]` | `limits.TryGetLimit(null, out int? maxConcurrent)` |
-| `limits.ContainsKey("heavy")` | `limits.TryGetLimit("heavy", out _)` |
+| `limits["heavy"]` | `limits.TryGetLimit(ExecutionGroupScope.Named("heavy"), out int? maxConcurrent)` |
+| `limits[ExecutionLimits.DefaultGroupKey]` | `limits.TryGetLimit(ExecutionGroupScope.Default, out int? maxConcurrent)` |
+| `limits["*"]` | `limits.TryGetLimit(ExecutionGroupScope.OtherGroups, out int? maxConcurrent)` |
+| `limits.ContainsKey("heavy")` | `limits.TryGetLimit(ExecutionGroupScope.Named("heavy"), out _)` |
 | `limits.Count` | `limits.Groups.Count`, or `limits.IsEmpty` for the question actually being asked |
 | `foreach (KeyValuePair<string, int?> pair in limits)` | `foreach (ExecutionGroupLimit limit in limits.Groups)` |
 
-`TryGetLimit` returning `false` is not the same as unlimited: it means the group has no entry of its own, and a
-named group without one still falls back to `OtherGroups`. That distinction was invisible when the type was a
-dictionary, and it is the reason the lookup is a `TryGet` rather than an indexer.
+`TryGetLimit` returning `false` is not the same as unlimited: it means the scope has no entry of its own, and a
+named group without one still falls back to `ExecutionGroupScope.OtherGroups`. That distinction was invisible when
+the type was a dictionary, and it is the reason the lookup is a `TryGet` rather than an indexer.
 
-The sentinel keys are named instead of spelled. `ExecutionLimits.OtherGroups` (`"*"`) stays public, because it is a
-key you can write in configuration. The empty-string key for the default group is internal now: an
-`ExecutionGroupLimit.Group` is `null` for it, matching `ITrigger.ExecutionGroup` being `null` for a trigger with no
-execution group, and `ForDefaultGroup` is how you configure it. `"_"` and `"null"` are still accepted as aliases for
-it in `quartz.executionLimit.*` keys and in the HTTP API, because neither a property key nor a JSON object key can
-be empty. All three remain reserved: a trigger cannot have `"*"`, `"_"` or `"null"` as its execution group.
+The read side is typed instead of spelled. `ExecutionGroupScope` is a readonly record struct with exactly the
+three cases the builder can write — `Default` (triggers with no execution group), `OtherGroups` (the catch-all)
+and `Named(name)` — mirroring how `PreferredNode` models none/auto/named rather than using a nullable string
+with a sentinel. `ExecutionGroupLimit.Scope` replaces `ExecutionGroupLimit.Group`, so enumerating `Groups` no
+longer requires knowing that `null` meant the default bucket and `"*"` meant the catch-all:
+
+```csharp
+foreach (ExecutionGroupLimit limit in limits.Groups)
+{
+    string label = limit.Scope.IsDefault ? "(default)"
+        : limit.Scope.IsOtherGroups ? "(other groups)"
+        : limit.Scope.Name!;
+}
+```
+
+The configuration spellings are unchanged: `quartz.executionLimit.*` keys and the HTTP API still say `*` for the
+catch-all and `_` or `null` for the default bucket (neither a property key nor a JSON object key can be empty).
+All three remain reserved: a trigger cannot have `"*"`, `"_"` or `"null"` as its execution group, and
+`ExecutionGroupScope.Named` rejects them the same way `ExecutionLimitsBuilder.ForGroup` does.
 
 ### A job store is handed the limits, and a way to spend them
 
@@ -4215,7 +4237,8 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `ExecutionLimits` split into a builder and a snapshot | `ExecutionLimitsBuilder` mutates, `ExecutionLimits` is immutable and is no longer an `IReadOnlyDictionary<string, int?>` — see [Execution limits are built once, then frozen](#execution-limits-are-built-once-then-frozen) |
 | `IQuartzBuilder.UseExecutionLimits` takes an `Action<ExecutionLimitsBuilder>` | The lambda body is unchanged |
 | `TriggerAcquisitionRequest.ExecutionLimits` and `TriggerAcquisitionCriteria.ExecutionLimits` are `ExecutionLimits?` | They were `IReadOnlyDictionary<string, int?>?`; spend the slots through `CreateSlots()` — see [A job store is handed the limits, and a way to spend them](#a-job-store-is-handed-the-limits-and-a-way-to-spend-them) |
-| `Quartz.ExecutionSlots` and `Quartz.ExecutionGroupLimit` added | The slot-counting rule and one group's entry in a snapshot, both of which a job store outside Quartz needs to honour execution groups |
+| `Quartz.ExecutionSlots`, `Quartz.ExecutionGroupLimit` and `Quartz.ExecutionGroupScope` added | The slot-counting rule, one scope's entry in a snapshot, and the typed default/other/named scope those entries carry — see [Execution limits are built once, then frozen](#execution-limits-are-built-once-then-frozen) |
+| `Quartz.MonthDay` added | The month-and-day value `AnnualCalendar` excludes — see [Excluded days are a read-only set](#excluded-days-are-a-read-only-set) |
 | `ICancellableJobExecutionContext` removed | Interruption is `IScheduler.Interrupt` / `InterruptFireInstance` to request and `IJobExecutionContext.CancellationToken` to observe — see [Interruption has two names, not three](#interruption-has-two-names-not-three) |
 | `Quartz.Diagnostics.IJobDiagnosticData` removed | It was the payload contract of the `DiagnosticSource` events `Quartz.OpenTracing` consumed. Both the package and the events are gone; job execution is on `Activity` through `QuartzActivitySource`, and `IJobExecutionContext` is what a listener reads |
 | `CronExpression.Clone()` returns `CronExpression` | It returned `object`, unlike `ITrigger.Clone`, `IJobDetail.Clone` and `ICalendar.Clone`; the casts at the call sites can go |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3577,6 +3577,24 @@ The three `public static readonly` day sets are gone. They existed only to be ha
 
 If you used a set for something other than the builder, `Enum.GetValues<DayOfWeek>()` is the whole week.
 
+## `EndingDailyAfterCount` is computed at `Build()`
+
+In 3.x, `EndingDailyAfterCount(count)` resolved the daily window immediately, against the wall clock
+and against whatever start time, interval and time zone happened to be configured *before* the call —
+which is why its documentation had to insist on call order. The computation now runs when the trigger
+is built:
+
+* It sees the schedule as finally configured, so `EndingDailyAfterCount` no longer has to be the last
+  method in the chain.
+* It runs against the clock of the `TriggerBuilder` that builds the trigger, so a scheduler configured
+  with a custom `TimeProvider` (a `FakeTimeProvider` in tests) is honored. Previously the builder read
+  the wall clock and a configured clock was silently ignored.
+* Validation moves with it: "count too large" and "start time not set" are now reported by `Build()`,
+  not by the `EndingDailyAfterCount` call. A count that is not positive is still rejected immediately.
+
+`DailyTimeIntervalScheduleBuilder.Create()` takes no `TimeProvider` — none of the schedule builders
+do; the clock belongs to `TriggerBuilder.Create(TimeProvider?)`.
+
 ## `InTimeZone` is nullable everywhere
 
 `CronScheduleBuilder` and `DailyTimeIntervalScheduleBuilder` declared `InTimeZone(TimeZoneInfo)` while

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1672,6 +1672,11 @@ The cron expression parser now supports additional syntax:
 * Day-of-month and day-of-week can now be specified together in the same expression
 * `H` (hash) tokens for [load distribution](cron-expressions.md#h-hash-for-load-distribution) across triggers
 
+Parse errors name the fix instead of only the constraint. A 5-field Unix/crontab expression — the shape every
+online cron generator emits — is still rejected (Quartz cron puts seconds first), but the error now shows the
+corrected 6-field expression to use, and the day-of-week range error explains that Quartz numbers days 1-7
+starting at Sunday where Unix cron uses 0-6, recommending names (`SUN`, `MON`, …) as the unambiguous spelling.
+
 ## Daylight saving time
 
 Two schedules fire at different times than they did on 3.x. Neither needs a code change, but both change
@@ -3190,7 +3195,7 @@ wants, so it is internal now.
 
 Attaching a schedule to a trigger was spread over six static extension classes and twenty-nine methods, half
 of them existing only because `TriggerBuilder<TJob>` and `ITriggerConfigurator<TJob>` each needed their own
-copy of the same body. `Quartz.TriggerConfiguratorExtensions` replaces all six with ten methods that are
+copy of the same body. `Quartz.TriggerConfiguratorExtensions` replaces all six with twelve methods that are
 generic in the receiver and return it unchanged, so one method serves both and the chain keeps its type.
 
 Deleted: `SimpleScheduleTriggerBuilderExtensions`, `CronScheduleTriggerBuilderExtensions`,
@@ -3204,9 +3209,11 @@ Deleted: `SimpleScheduleTriggerBuilderExtensions`, `CronScheduleTriggerBuilderEx
 | `WithSimpleSchedule(SimpleScheduleBuilder)` | `WithSimpleSchedule(SimpleScheduleBuilder schedule)` |
 | `WithCronSchedule(string)` | `WithCronSchedule(string cronExpression, Action<CronScheduleBuilder>? configure = null)` |
 | `WithCronSchedule(string, Action<CronScheduleBuilder>)` | same member |
-| `WithCronSchedule(string expr, string hashKey)` | `WithCronSchedule(CronScheduleBuilder.Create(new CronExpression(expr, hashKey)))` |
-| `WithCronSchedule(string expr, string hashKey, Action<CronScheduleBuilder>)` | build the `CronScheduleBuilder`, configure it, pass it |
+| `WithCronSchedule(string expr, string hashKey)` | `WithCronSchedule(new CronExpression(expr, hashKey))` |
+| `WithCronSchedule(string expr, string hashKey, Action<CronScheduleBuilder>)` | `WithCronSchedule(new CronExpression(expr, hashKey), configure)` |
 | `WithCronSchedule(CronScheduleBuilder)` | `WithCronSchedule(CronScheduleBuilder schedule)` |
+| — | `WithCronSchedule(CronExpression cronExpression, Action<CronScheduleBuilder>? configure = null)` — new; also the home of the hash-key shape |
+| — | `WithCronSchedule(CronExpressionBuilder cronExpression, Action<CronScheduleBuilder>? configure = null)` — new; closes the [`CronExpressionBuilder`](#cronschedulebuilder-s-convenience-factories-are-gone) chain without naming `CronScheduleBuilder` |
 | `WithCalendarIntervalSchedule()` | `WithCalendarIntervalSchedule(Action<CalendarIntervalScheduleBuilder>? configure = null)` |
 | `WithCalendarIntervalSchedule(Action<CalendarIntervalScheduleBuilder>)` | same member |
 | `WithCalendarIntervalSchedule(CalendarIntervalScheduleBuilder)` | `WithCalendarIntervalSchedule(CalendarIntervalScheduleBuilder schedule)` |
@@ -3225,12 +3232,12 @@ Only two call shapes need editing:
 + .WithDailyTimeIntervalSchedule(x => x.WithInterval(10, IntervalUnit.Second))
 
 - .WithCronSchedule("0 H H(0-7) * * ?", "nightly-cleanup")
-+ .WithCronSchedule(CronScheduleBuilder.Create(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup")))
++ .WithCronSchedule(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup"))
 ```
 
 The hash-key overloads went because a hash key belongs to the expression, not to the way the expression is
-attached to a trigger — `new CronExpression(expr, hashKey)` takes it, and one builder-taking overload carries
-the result. Without a key, `H` tokens still hash on the trigger's identity.
+attached to a trigger — `new CronExpression(expr, hashKey)` takes it, and the `CronExpression`-taking overload
+carries the result. Without a key, `H` tokens still hash on the trigger's identity.
 
 ### `ITriggerConfigurator` gained a non-generic base
 
@@ -3543,11 +3550,18 @@ Inside a `WithSimpleSchedule` delegate you never needed the factories at all:
 from numbers are replaced by `CronExpressionBuilder`, which names each field instead of relying on argument
 order — the old set used three different orders for the same three numbers.
 
+`CronExpressionBuilder` spells "restrict this field to these values" as `With*` on every field, day-of-week
+included (`WithDaysOfWeek`, `WithDayOfWeekRange`, `WithDayOfWeekIncrements`); the `On*` prefix is only for the
+positional and special forms (`OnWeekdays`, `OnLastDayOfMonth`, `OnLastDayOfWeek`, `OnLastDayOfWeekOfMonth`,
+`OnNthDayOfWeekOfMonth`, `OnNearestWeekdayOfMonth`). A trigger takes the builder — or a built
+`CronExpression` — directly through `WithCronSchedule`, so the chain closes without naming
+`CronScheduleBuilder`.
+
 | 3.x | 4.x |
 |---|---|
 | `CronScheduleBuilder.DailyAtHourAndMinute(h, m)` | `CronScheduleBuilder.Create($"0 {m} {h} ? * *")` |
-| `CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(h, m, days)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).OnDaysOfWeek(days).Build())` |
-| `CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(day, h, m)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).OnDaysOfWeek(day).Build())` |
+| `CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(h, m, days)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).WithDaysOfWeek(days).Build())` |
+| `CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(day, h, m)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).WithDaysOfWeek(day).Build())` |
 | `CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(dom, h, m)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).WithDayOfMonth(dom).Build())` |
 | `CronScheduleBuilder.CronScheduleWithHash(expr, hashKey)` | `CronScheduleBuilder.Create(new CronExpression(expr, hashKey))` |
 | `CronScheduleBuilder.CronScheduleWithHash(expr, hashSeed)` | `CronScheduleBuilder.Create(new CronExpression(expr, hashSeed))` |

--- a/docs/documentation/quartz-4.x/tutorial/execution-groups.md
+++ b/docs/documentation/quartz-4.x/tutorial/execution-groups.md
@@ -99,7 +99,7 @@ services.AddQuartz(q =>
 
 ```csharp
 await scheduler.SetExecutionLimits(
-    new ExecutionLimitsBuilder()
+    ExecutionLimitsBuilder.Create()
         .ForGroup("batch-jobs", 2)
         .ForDefaultGroup(10)
         .ForOtherGroups(5)

--- a/docs/documentation/quartz-4.x/tutorial/execution-groups.md
+++ b/docs/documentation/quartz-4.x/tutorial/execution-groups.md
@@ -108,15 +108,21 @@ await scheduler.SetExecutionLimits(
 
 `ExecutionLimitsBuilder` is mutable and `ExecutionLimits` — what `Build()` returns and what the scheduler
 reads — is not, so limits cannot change underneath the scheduler thread that is acquiring triggers with them.
-Read one back with `TryGetLimit(group, out int? maxConcurrent)`, or enumerate `Groups`, whose entries report the
-default group as a `null` name:
+Read one back with `TryGetLimit(scope, out int? maxConcurrent)`, or enumerate `Groups`. Each entry's
+`ExecutionGroupScope` is one of exactly three cases — `Default` (triggers with no execution group),
+`OtherGroups` (the catch-all) and `Named(name)` — so reading limits never involves sentinel strings:
 
 ```csharp
 ExecutionLimits? limits = await scheduler.GetExecutionLimits();
 foreach (ExecutionGroupLimit limit in limits?.Groups ?? [])
 {
-    Console.WriteLine($"{limit.Group ?? "(no group)"}: {limit.MaxConcurrent?.ToString() ?? "unlimited"}");
+    string scope = limit.Scope.IsDefault ? "(no group)"
+        : limit.Scope.IsOtherGroups ? "(other groups)"
+        : limit.Scope.Name!;
+    Console.WriteLine($"{scope}: {limit.MaxConcurrent?.ToString() ?? "unlimited"}");
 }
+
+limits?.TryGetLimit(ExecutionGroupScope.Named("batch-jobs"), out int? batchLimit);
 ```
 
 Limits take effect on the next trigger acquisition cycle. Pass `null` to clear all limits:
@@ -124,6 +130,20 @@ Limits take effect on the next trigger acquisition cycle. Pass `null` to clear a
 ```csharp
 await scheduler.SetExecutionLimits(null);
 ```
+
+### The `*` in configuration keys, and the other `*`
+
+Configuration spells the scopes with reserved key spellings: `_` (or `null`) for the default group and `*`
+for the catch-all. Quartz has one other `*` sentinel, in trigger preferred-node pinning, and the two mean
+different things — the table below puts them side by side so neither is read as the other:
+
+| Where it appears | What `*` means there | Typed reading |
+|---|---|---|
+| `quartz.executionLimit.*` key / execution-limits HTTP body | The catch-all limit applied to any *named* group without a limit of its own (never to ungrouped triggers) | `ExecutionGroupScope.OtherGroups` |
+| A trigger row's preferred-node column | An automatic pin no node has claimed yet — the trigger runs anywhere until one node fires it first and keeps it | `PreferredNode.Auto` |
+
+In both places `*` is reserved vocabulary, not a name: a trigger cannot have `*` as its execution group, and
+a node cannot have `*` as its scheduler instance id.
 
 ## How it works
 

--- a/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
@@ -51,7 +51,7 @@ occurrence counting.
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("monthlyTrigger", "group1")
     .WithRecurrenceSchedule("FREQ=MONTHLY;BYDAY=2MO")
-    .StartAt(DateBuilder.NewDate().InYear(2025).InMonthOnDay(1, 1).AtHourMinuteAndSecond(9, 0, 0).Build())
+    .StartAt(DateBuilder.Create().InYear(2025).InMonthOnDay(1, 1).AtHourMinuteAndSecond(9, 0, 0).Build())
     .Build();
 ```
 

--- a/docs/documentation/quartz-4.x/tutorial/simpletriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/simpletriggers.md
@@ -77,7 +77,7 @@ ITrigger trigger = TriggerBuilder.Create()
     .WithSimpleSchedule(x => x
         .WithInterval(TimeSpan.FromMinutes(5))
         .RepeatForever())
-    .EndAt(DateBuilder.NewDate().AtHourMinuteAndSecond(22, 0, 0).Build())
+    .EndAt(DateBuilder.Create().AtHourMinuteAndSecond(22, 0, 0).Build())
     .Build();
 ```
 
@@ -86,7 +86,7 @@ __Build a trigger that will fire at the top of the next hour, then repeat every 
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger8") // because group is not specified, "trigger8" will be in the default group
-    .StartAt(DateBuilder.NewDate().AtMinute(0).AtSecond(0).Build().AddHours(1)) // the next even hour
+    .StartAt(DateBuilder.Create().AtMinute(0).AtSecond(0).Build().AddHours(1)) // the next even hour
     .WithSimpleSchedule(x => x
         .WithInterval(TimeSpan.FromHours(2))
         .RepeatForever())

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -179,7 +179,7 @@ internal static class SchedulerEndpoints
                 dict = new Dictionary<string, int?>();
                 foreach (ExecutionGroupLimit limit in limits.Groups)
                 {
-                    dict[limit.Group ?? ExecutionLimits.DefaultGroupAlias] = limit.MaxConcurrent;
+                    dict[limit.Scope.ToConfigurationKey()] = limit.MaxConcurrent;
                 }
             }
             return new ExecutionLimitsResponse(dict);

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -201,7 +201,7 @@ internal static class SchedulerEndpoints
             ExecutionLimits? limits = null;
             if (request.Limits is { Count: > 0 })
             {
-                ExecutionLimitsBuilder builder = new();
+                ExecutionLimitsBuilder builder = ExecutionLimitsBuilder.Create();
                 foreach (KeyValuePair<string, int?> kvp in request.Limits)
                 {
                     string key = kvp.Key.Trim();

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -79,7 +79,7 @@ public class JobRunShellBenchmark
 
     private static IJobDetail CreateJobDetail(string group, Type jobType)
     {
-        return JobBuilder.Create(jobType).WithIdentity(Guid.NewGuid().ToString(), group).Build();
+        return JobBuilder.Create().OfType(jobType).WithIdentity(Guid.NewGuid().ToString(), group).Build();
     }
 
     [DisallowConcurrentExecution]

--- a/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
@@ -424,7 +424,7 @@ public class QuartSchedulerBenchmark
 
     private static IJobDetail CreateJobDetail(string group, Type jobType)
     {
-        return JobBuilder.Create(jobType).WithIdentity(Guid.NewGuid().ToString(), group).Build();
+        return JobBuilder.Create().OfType(jobType).WithIdentity(Guid.NewGuid().ToString(), group).Build();
     }
 
     private static void RunConcurrently(QuartzScheduler scheduler, int threadCount, int iterationsPerThread, Action<QuartzScheduler> action)

--- a/src/Quartz.Benchmark/SchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/SchedulerBenchmark.cs
@@ -594,7 +594,7 @@ public class SchedulerBenchmark
 
     private static IJobDetail CreateJobDetail(string group, Type jobType, bool disableConcurrentExecution, bool persistJobDataAfterExecution)
     {
-        return JobBuilder.Create(jobType)
+        return JobBuilder.Create().OfType(jobType)
             .WithIdentity(Guid.NewGuid().ToString(), group)
             .DisallowConcurrentExecution(disableConcurrentExecution)
             .PersistJobDataAfterExecution(persistJobDataAfterExecution)

--- a/src/Quartz.Dashboard/Components/Shared/CronNextFires.razor
+++ b/src/Quartz.Dashboard/Components/Shared/CronNextFires.razor
@@ -58,7 +58,7 @@
 
             for (int i = 0; i < max; i++)
             {
-                DateTimeOffset? nextFire = cronExpression.GetTimeAfter(current);
+                DateTimeOffset? nextFire = cronExpression.GetNextValidTimeAfter(current);
                 if (nextFire is null)
                 {
                     break;

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -660,7 +660,8 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
             foreach (ExecutionGroupLimit limit in limits.Groups)
             {
                 // Use display-friendly keys
-                dict[limit.Group ?? "(default)"] = limit.MaxConcurrent;
+                string key = limit.Scope.IsDefault ? "(default)" : limit.Scope.ToConfigurationKey();
+                dict[key] = limit.MaxConcurrent;
             }
 
             return new ExecutionLimitsDto(dict);

--- a/src/Quartz.Examples/08_ExcludeTimePeriodsUsingCalendars/ExcludeTimePeriodsUsingCalendarsExample.cs
+++ b/src/Quartz.Examples/08_ExcludeTimePeriodsUsingCalendars/ExcludeTimePeriodsUsingCalendarsExample.cs
@@ -48,15 +48,15 @@ public class ExcludeTimePeriodsUsingCalendarsExample : IExample
 
         // fourth of July (July 4)
         DateOnly fourthOfJuly = new DateOnly(DateTime.UtcNow.Year, 7, 4);
-        holidays.AddExcludedDay(fourthOfJuly);
+        holidays.AddExcludedDay(MonthDay.From(fourthOfJuly));
 
         // halloween (Oct 31)
         DateOnly halloween = new DateOnly(DateTime.UtcNow.Year, 10, 31);
-        holidays.AddExcludedDay(halloween);
+        holidays.AddExcludedDay(MonthDay.From(halloween));
 
         // christmas (Dec 25)
         DateOnly christmas = new DateOnly(DateTime.UtcNow.Year, 12, 25);
-        holidays.AddExcludedDay(christmas);
+        holidays.AddExcludedDay(MonthDay.From(christmas));
 
         // tell the schedule about our holiday calendar
         await scheduler.AddCalendar("holidays", holidays);

--- a/src/Quartz.Examples/08_ExcludeTimePeriodsUsingCalendars/ExcludeTimePeriodsUsingCalendarsExample.cs
+++ b/src/Quartz.Examples/08_ExcludeTimePeriodsUsingCalendars/ExcludeTimePeriodsUsingCalendarsExample.cs
@@ -64,7 +64,7 @@ public class ExcludeTimePeriodsUsingCalendarsExample : IExample
         // schedule a job to run hourly, starting on halloween
         // at 10 am
 
-        DateTimeOffset runDate = DateBuilder.NewDate().InMonthOnDay(10, 31).AtHourMinuteAndSecond(0, 0, 10).Build();
+        DateTimeOffset runDate = DateBuilder.Create().InMonthOnDay(10, 31).AtHourMinuteAndSecond(0, 0, 10).Build();
 
         IJobDetail job = JobBuilder.Create<SimpleJob>()
             .WithIdentity("job1", "group1")

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -264,7 +264,7 @@ public sealed class HttpScheduler : IScheduler
             Dictionary<string, int?> dict = new();
             foreach (ExecutionGroupLimit limit in limits.Groups)
             {
-                dict[limit.Group ?? ExecutionLimits.DefaultGroupAlias] = limit.MaxConcurrent;
+                dict[limit.Scope.ToConfigurationKey()] = limit.MaxConcurrent;
             }
             await httpClient.Post(
                 $"{SchedulerEndpointUrl()}/execution-limits",

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -282,7 +282,7 @@ public sealed class HttpScheduler : IScheduler
             return null;
         }
 
-        ExecutionLimitsBuilder builder = new();
+        ExecutionLimitsBuilder builder = ExecutionLimitsBuilder.Create();
         foreach (KeyValuePair<string, int?> kvp in response.Limits)
         {
             if (kvp.Key == ExecutionLimits.OtherGroups)

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
@@ -251,7 +251,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
                 ?? throw new SchedulerConfigException($"JSON job definition '{jobName}': could not load type '{jobTypeName}'.");
 
             var jobGroup = NormalizeEmpty(jobDef.Group);
-            var builder = JobBuilder.Create(jobType);
+            var builder = JobBuilder.Create().OfType(jobType);
             if (jobGroup is not null) builder.WithIdentity(jobName, jobGroup);
             else builder.WithIdentity(jobName);
 
@@ -368,7 +368,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
         CronScheduleBuilder builder;
         try
         {
-            builder = CronScheduleBuilder.CronSchedule(cron.Expression);
+            builder = CronScheduleBuilder.Create(cron.Expression);
         }
         catch (Exception ex)
         {

--- a/src/Quartz.Serialization.Newtonsoft/Calendars/AnnualCalendarSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Calendars/AnnualCalendarSerializer.cs
@@ -16,7 +16,8 @@ internal sealed class AnnualCalendarSerializer : CalendarSerializer<AnnualCalend
 
     protected override void SerializeFields(JsonWriter writer, AnnualCalendar calendar)
     {
-        writer.WriteDateOnlyArray("ExcludedDays", calendar.DaysExcluded);
+        // The payload keeps its date shape: each MonthDay is written pinned to the fixed year.
+        writer.WriteDateOnlyArray("ExcludedDays", calendar.DaysExcluded.Select(static day => day.ToDateOnly()));
     }
 
     protected override void DeserializeFields(AnnualCalendar calendar, JObject source)
@@ -24,7 +25,7 @@ internal sealed class AnnualCalendarSerializer : CalendarSerializer<AnnualCalend
         // Payloads written before 4.0 carry full timestamps here rather than dates.
         foreach (var day in source["ExcludedDays"]!.GetDateOnlyArray())
         {
-            calendar.AddExcludedDay(day);
+            calendar.AddExcludedDay(MonthDay.From(day));
         }
     }
 }

--- a/src/Quartz.Serialization.Newtonsoft/Converters/CronExpressionConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/CronExpressionConverter.cs
@@ -29,9 +29,8 @@ internal sealed class CronExpressionConverter : JsonConverter
         JObject jObject = JObject.Load(reader);
         var cronExpressionString = jObject["CronExpression"]!.Value<string>()!;
 
-        var cronExpression = new CronExpression(cronExpressionString);
-        cronExpression.TimeZone = TimeZoneUtil.FindTimeZoneById(jObject["TimeZoneId"]!.Value<string>()!);
-        return cronExpression;
+        TimeZoneInfo timeZone = TimeZoneUtil.FindTimeZoneById(jObject["TimeZoneId"]!.Value<string>()!);
+        return new CronExpression(cronExpressionString, timeZone);
     }
 
     public override bool CanConvert(Type objectType)

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
@@ -14,7 +14,7 @@ public class CronTriggerSerializer : TriggerSerializer<ICronTrigger>
         var cronExpressionString = source.Value<string>("CronExpressionString")!;
         var timeZone = TimeZoneUtil.FindTimeZoneById(source.Value<string>("TimeZone")!);
 
-        return CronScheduleBuilder.CronSchedule(cronExpressionString)
+        return CronScheduleBuilder.Create(cronExpressionString)
             .InTimeZone(timeZone);
     }
 

--- a/src/Quartz.Tests.AspNetCore/HttpApi/OpenApiCalendarSchemaTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/OpenApiCalendarSchemaTest.cs
@@ -40,7 +40,7 @@ public class OpenApiCalendarSchemaTest
     private static ICalendar[] BuiltInCalendars()
     {
         AnnualCalendar annual = new AnnualCalendar { Description = "annual" };
-        annual.AddExcludedDay(new DateOnly(2024, 7, 1));
+        annual.AddExcludedDay(new MonthDay(7, 1));
 
         HolidayCalendar holiday = new HolidayCalendar { Description = "holiday" };
         holiday.AddExcludedDay(new DateOnly(2024, 12, 25));

--- a/src/Quartz.Tests.AspNetCore/Support/TestData.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestData.cs
@@ -71,7 +71,7 @@ public static class TestData
             Description = "Test AnnualCalendar",
             CalendarBase = BaseCalendar
         };
-        AnnualCalendar.AddExcludedDay(DateOnly.FromDateTime(DateTime.Today));
+        AnnualCalendar.AddExcludedDay(MonthDay.From(DateOnly.FromDateTime(DateTime.Today)));
 
         CronCalendar = new CronCalendar("0 0 * * * ?")
         {

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/DeleteNonExistsJobTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/DeleteNonExistsJobTest.cs
@@ -83,7 +83,7 @@ public class DeleteNonExistsJobTest
         IJobDetail jobDetail = JobBuilder.Create<TestJob>().WithIdentity("testjob2").StoreDurably().Build();
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity("testjob2")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("* * * * * ?"))
+            .WithSchedule(CronScheduleBuilder.Create("* * * * * ?"))
             .Build();
 
         await scheduler.ScheduleJob(jobDetail, trigger);
@@ -98,7 +98,7 @@ public class DeleteNonExistsJobTest
         IJobDetail jobDetail = JobBuilder.Create<TestJob>().WithIdentity("testjob3").StoreDurably().Build();
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity("testjob3")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("* * * * * ?"))
+            .WithSchedule(CronScheduleBuilder.Create("* * * * * ?"))
             .Build();
         await scheduler.ScheduleJob(jobDetail, trigger);
         await ModifyStoredJobClassName();
@@ -112,7 +112,7 @@ public class DeleteNonExistsJobTest
         IJobDetail jobDetail = JobBuilder.Create<TestJob>().WithIdentity("testjob3").StoreDurably().Build();
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity("testjob3")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("* * * * * ?"))
+            .WithSchedule(CronScheduleBuilder.Create("* * * * * ?"))
             .Build();
         await scheduler.ScheduleJob(jobDetail, trigger);
         await ModifyStoredJobClassName();

--- a/src/Quartz.Tests.Integration/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/Calendar/AnnualCalendarTest.cs
@@ -56,7 +56,7 @@ public class AnnualCalendarTest : IntegrationTest
             .Build();
 
         AnnualCalendar calendar = new AnnualCalendar();
-        calendar.AddExcludedDay(DateOnly.FromDateTime(DateTime.Now));
+        calendar.AddExcludedDay(MonthDay.From(DateOnly.FromDateTime(DateTime.Now)));
         await scheduler.AddCalendar("calendar", calendar, new AddCalendarOptions { Replace = true, UpdateTriggers = true });
 
         await scheduler.ScheduleJob(jobDetail, trigger);
@@ -72,7 +72,7 @@ public class AnnualCalendarTest : IntegrationTest
         await Task.Delay(TimeSpan.FromSeconds(20));
         Assert.That(TestJob.JobHasFired, Is.False, "task must not be neglected - it is forbidden by the calendar");
 
-        calendar.RemoveExcludedDay(DateOnly.FromDateTime(DateTime.Now));
+        calendar.RemoveExcludedDay(MonthDay.From(DateOnly.FromDateTime(DateTime.Now)));
         await scheduler.AddCalendar("calendar", calendar, new AddCalendarOptions { Replace = true, UpdateTriggers = true });
         await Task.Delay(TimeSpan.FromSeconds(20));
         Assert.That(TestJob.JobHasFired, Is.True, "task must be neglected - it is permitted by the calendar");

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -36,7 +36,7 @@ public class SmokeTestPerformer
                 Assert.That(t, Is.Null);
 
                 AnnualCalendar calendar = new AnnualCalendar();
-                calendar.AddExcludedDay(new DateOnly(2018, 7, 4));
+                calendar.AddExcludedDay(new MonthDay(7, 4));
                 await scheduler.AddCalendar("annualCalendar", calendar, new AddCalendarOptions { UpdateTriggers = true });
 
                 IOperableTrigger calendarsTrigger = new SimpleTriggerImpl("calendarsTrigger", "test", 20, TimeSpan.FromHours(2));
@@ -437,9 +437,9 @@ public class SmokeTestPerformer
 
         ExecutionLimits limits = await scheduler.GetExecutionLimits().ConfigureAwait(false);
         limits.Should().NotBeNull();
-        limits.TryGetLimit("batch-jobs", out int? batchLimit).Should().BeTrue();
+        limits.TryGetLimit(ExecutionGroupScope.Named("batch-jobs"), out int? batchLimit).Should().BeTrue();
         batchLimit.Should().Be(2);
-        limits.TryGetLimit(ExecutionLimits.OtherGroups, out int? otherLimit).Should().BeTrue();
+        limits.TryGetLimit(ExecutionGroupScope.OtherGroups, out int? otherLimit).Should().BeTrue();
         otherLimit.Should().Be(5);
 
         // Clear limits

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -430,7 +430,7 @@ public class SmokeTestPerformer
         Assert.That(retrievedNoGroup.ExecutionGroup, Is.Null, "Trigger without execution group should have null");
 
         // Test execution limits API
-        await scheduler.SetExecutionLimits(new ExecutionLimitsBuilder()
+        await scheduler.SetExecutionLimits(ExecutionLimitsBuilder.Create()
             .ForGroup("batch-jobs", 2)
             .ForOtherGroups(5)
             .Build()).ConfigureAwait(false);

--- a/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
@@ -327,7 +327,7 @@ public class XMLSchedulingDataProcessorTest
                 .Build();
             ITrigger trigger = TriggerBuilder.Create()
                 .WithIdentity(jobName, "DEFAULT")
-                .WithSchedule(CronScheduleBuilder.CronSchedule("* * * * * ?"))
+                .WithSchedule(CronScheduleBuilder.Create("* * * * * ?"))
                 .Build();
 
             await scheduler.ScheduleJob(jobDetail, trigger);
@@ -384,7 +384,7 @@ public class XMLSchedulingDataProcessorTest
                 .Build();
             ITrigger trigger = TriggerBuilder.Create()
                 .WithIdentity(jobName, "DEFAULT")
-                .WithSchedule(CronScheduleBuilder.CronSchedule("* * * * * ?"))
+                .WithSchedule(CronScheduleBuilder.Create("* * * * * ?"))
                 .Build();
 
             await scheduler.ScheduleJob(jobDetail, trigger);

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
@@ -331,12 +331,12 @@ public class ConfigurationIsNeverSilentlyDroppedTest
     }
 
     /// <summary>
-    /// Reads one group's limit off a scheduler's snapshot, asserting the group is configured at all.
+    /// Reads one scope's limit off a scheduler's snapshot, asserting the scope is configured at all.
     /// </summary>
-    private static int? LimitFor(ExecutionLimits? limits, string group)
+    private static int? LimitFor(ExecutionLimits? limits, ExecutionGroupScope scope)
     {
         limits.Should().NotBeNull();
-        limits!.TryGetLimit(group, out int? limit).Should().BeTrue($"execution group '{group}' should be configured");
+        limits!.TryGetLimit(scope, out int? limit).Should().BeTrue($"execution scope '{scope}' should be configured");
         return limit;
     }
 
@@ -376,7 +376,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
         try
         {
-            LimitFor(provider.GetRequiredService<QuartzScheduler>().GetExecutionLimits(), "heavy")
+            LimitFor(provider.GetRequiredService<QuartzScheduler>().GetExecutionLimits(), ExecutionGroupScope.Named("heavy"))
                 .Should().Be(2, "quartz.executionLimit.* keys must reach the scheduler like limits set in code");
         }
         finally
@@ -397,7 +397,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
         try
         {
-            LimitFor(provider.GetRequiredService<QuartzScheduler>().GetExecutionLimits(), "heavy")
+            LimitFor(provider.GetRequiredService<QuartzScheduler>().GetExecutionLimits(), ExecutionGroupScope.Named("heavy"))
                 .Should().Be(9, "code beats strings, as everywhere else");
         }
         finally
@@ -422,7 +422,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
         try
         {
-            LimitFor(provider.GetRequiredService<QuartzScheduler>().GetExecutionLimits(), "heavy")
+            LimitFor(provider.GetRequiredService<QuartzScheduler>().GetExecutionLimits(), ExecutionGroupScope.Named("heavy"))
                 .Should().Be(2, "a group left uncapped saturates the whole thread pool");
         }
         finally
@@ -443,8 +443,8 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var ingest = await provider.GetRequiredKeyedService<ISchedulerFactory>("ingest").GetScheduler();
         try
         {
-            LimitFor(await reporting.GetExecutionLimits(), "heavy").Should().Be(2);
-            LimitFor(await ingest.GetExecutionLimits(), "heavy").Should().Be(7);
+            LimitFor(await reporting.GetExecutionLimits(), ExecutionGroupScope.Named("heavy")).Should().Be(2);
+            LimitFor(await ingest.GetExecutionLimits(), ExecutionGroupScope.Named("heavy")).Should().Be(7);
         }
         finally
         {

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -280,7 +280,7 @@ public class QuartzSchedulerTest
         bool disableConcurrentExecution,
         bool persistJobDataAfterExecution)
     {
-        return JobBuilder.Create(jobType)
+        return JobBuilder.Create().OfType(jobType)
             .WithIdentity(Guid.NewGuid().ToString(), group)
             .DisallowConcurrentExecution(disableConcurrentExecution)
             .PersistJobDataAfterExecution(persistJobDataAfterExecution)

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -63,10 +63,10 @@ public class CronExpressionBuilderTest
     [Test]
     public void TestDayOfWeekField()
     {
-        CronExpressionBuilder.Create().OnDaysOfWeek(DayOfWeek.Thursday).ToString().Should().Be("* * * ? * THU");
-        CronExpressionBuilder.Create().OnDaysOfWeek(DayOfWeek.Sunday, DayOfWeek.Wednesday).ToString().Should().Be("* * * ? * SUN,WED");
-        CronExpressionBuilder.Create().OnDayOfWeekRange(DayOfWeek.Monday, DayOfWeek.Friday).ToString().Should().Be("* * * ? * MON-FRI");
-        CronExpressionBuilder.Create().OnDayOfWeekRange(DayOfWeek.Thursday, DayOfWeek.Sunday).ToString().Should().Be("* * * ? * THU-SUN");
+        CronExpressionBuilder.Create().WithDaysOfWeek(DayOfWeek.Thursday).ToString().Should().Be("* * * ? * THU");
+        CronExpressionBuilder.Create().WithDaysOfWeek(DayOfWeek.Sunday, DayOfWeek.Wednesday).ToString().Should().Be("* * * ? * SUN,WED");
+        CronExpressionBuilder.Create().WithDayOfWeekRange(DayOfWeek.Monday, DayOfWeek.Friday).ToString().Should().Be("* * * ? * MON-FRI");
+        CronExpressionBuilder.Create().WithDayOfWeekRange(DayOfWeek.Thursday, DayOfWeek.Sunday).ToString().Should().Be("* * * ? * THU-SUN");
         CronExpressionBuilder.Create().OnNthDayOfWeekOfMonth(DayOfWeek.Sunday, 3).ToString().Should().Be("* * * ? * SUN#3");
         CronExpressionBuilder.Create().OnLastDayOfWeekOfMonth(DayOfWeek.Thursday).ToString().Should().Be("* * * ? * THUL");
         CronExpressionBuilder.Create().OnLastDayOfWeek().ToString().Should().Be("* * * ? * L");
@@ -76,10 +76,10 @@ public class CronExpressionBuilderTest
     [Test]
     public void TestDayOfWeekIncrementsExpandToExplicitList()
     {
-        CronExpressionBuilder.Create().OnDayOfWeekIncrements(DayOfWeek.Monday, 2).ToString().Should().Be("* * * ? * MON,WED,FRI");
-        CronExpressionBuilder.Create().OnDayOfWeekIncrements(DayOfWeek.Sunday, 3).ToString().Should().Be("* * * ? * SUN,WED,SAT");
-        CronExpressionBuilder.Create().OnDayOfWeekIncrements(DayOfWeek.Friday, 2).ToString().Should().Be("* * * ? * FRI");
-        CronExpressionBuilder.Create().OnDayOfWeekIncrements(DayOfWeek.Sunday, 1).ToString().Should().Be("* * * ? * SUN,MON,TUE,WED,THU,FRI,SAT");
+        CronExpressionBuilder.Create().WithDayOfWeekIncrements(DayOfWeek.Monday, 2).ToString().Should().Be("* * * ? * MON,WED,FRI");
+        CronExpressionBuilder.Create().WithDayOfWeekIncrements(DayOfWeek.Sunday, 3).ToString().Should().Be("* * * ? * SUN,WED,SAT");
+        CronExpressionBuilder.Create().WithDayOfWeekIncrements(DayOfWeek.Friday, 2).ToString().Should().Be("* * * ? * FRI");
+        CronExpressionBuilder.Create().WithDayOfWeekIncrements(DayOfWeek.Sunday, 1).ToString().Should().Be("* * * ? * SUN,MON,TUE,WED,THU,FRI,SAT");
     }
 
     [Test]
@@ -92,7 +92,7 @@ public class CronExpressionBuilderTest
             .WithSecond(0)
             .WithMinute(0)
             .WithHour(12)
-            .OnDayOfWeekIncrements(DayOfWeek.Monday, 2)
+            .WithDayOfWeekIncrements(DayOfWeek.Monday, 2)
             .Build();
         CronExpression numeric = new CronExpression("0 0 12 ? * 2/2");
 
@@ -132,7 +132,7 @@ public class CronExpressionBuilderTest
         Invoking(x => x.WithMonth(0)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithMonth(13)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithYear(1969)).Should().Throw<ArgumentOutOfRangeException>();
-        Invoking(x => x.OnDaysOfWeek((DayOfWeek) 7)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithDaysOfWeek((DayOfWeek) 7)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 0)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 6)).Should().Throw<ArgumentOutOfRangeException>();
     }
@@ -146,8 +146,8 @@ public class CronExpressionBuilderTest
         Invoking(x => x.WithHourIncrements(0, 24)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithDayOfMonthIncrements(1, 32)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithMonthIncrements(1, 13)).Should().Throw<ArgumentOutOfRangeException>();
-        Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 0)).Should().Throw<ArgumentOutOfRangeException>();
-        Invoking(x => x.OnDayOfWeekIncrements(DayOfWeek.Monday, 8)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithDayOfWeekIncrements(DayOfWeek.Monday, 0)).Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(x => x.WithDayOfWeekIncrements(DayOfWeek.Monday, 8)).Should().Throw<ArgumentOutOfRangeException>();
         Invoking(x => x.WithYearIncrements(2030, 0)).Should().Throw<ArgumentOutOfRangeException>();
         // An unbounded year increment would overflow the "i += incr" loop in CronExpression.AddToSet
         // and silently produce a wrong schedule; the builder must reject it up front like every other field.
@@ -162,7 +162,7 @@ public class CronExpressionBuilderTest
         Invoking(x => x.WithHours()).Should().Throw<ArgumentException>();
         Invoking(x => x.WithDaysOfMonth()).Should().Throw<ArgumentException>();
         Invoking(x => x.WithMonths()).Should().Throw<ArgumentException>();
-        Invoking(x => x.OnDaysOfWeek()).Should().Throw<ArgumentException>();
+        Invoking(x => x.WithDaysOfWeek()).Should().Throw<ArgumentException>();
         Invoking(x => x.WithYears()).Should().Throw<ArgumentException>();
     }
 
@@ -181,15 +181,15 @@ public class CronExpressionBuilderTest
         Invoking(x => x.WithHour(1).WithHours(2, 3)).Should().Throw<InvalidOperationException>().WithMessage("Hour has already been configured.");
         Invoking(x => x.OnLastDayOfMonth().WithDayOfMonth(3)).Should().Throw<InvalidOperationException>().WithMessage("Day-of-month has already been configured.");
         Invoking(x => x.WithMonth(1).WithMonthRange(2, 5)).Should().Throw<InvalidOperationException>().WithMessage("Month has already been configured.");
-        Invoking(x => x.OnWeekdays().OnDaysOfWeek(DayOfWeek.Sunday)).Should().Throw<InvalidOperationException>().WithMessage("Day-of-week has already been configured.");
+        Invoking(x => x.OnWeekdays().WithDaysOfWeek(DayOfWeek.Sunday)).Should().Throw<InvalidOperationException>().WithMessage("Day-of-week has already been configured.");
         Invoking(x => x.WithYear(2030).WithYearRange(2031, 2032)).Should().Throw<InvalidOperationException>().WithMessage("Year has already been configured.");
     }
 
     [Test]
     public void TestDayOfMonthAndDayOfWeekAreMutuallyExclusive()
     {
-        Invoking(x => x.WithDayOfMonth(10).OnDaysOfWeek(DayOfWeek.Monday)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
-        Invoking(x => x.OnDaysOfWeek(DayOfWeek.Monday).WithDayOfMonth(10)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
+        Invoking(x => x.WithDayOfMonth(10).WithDaysOfWeek(DayOfWeek.Monday)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
+        Invoking(x => x.WithDaysOfWeek(DayOfWeek.Monday).WithDayOfMonth(10)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
         Invoking(x => x.OnLastDayOfMonth().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
     }
 
@@ -217,7 +217,7 @@ public class CronExpressionBuilderTest
             CronExpressionBuilder.Create().OnLastDayOfWeekOfMonth(DayOfWeek.Thursday),
             CronExpressionBuilder.Create().OnLastDayOfWeek(),
             CronExpressionBuilder.Create().OnWeekdays(),
-            CronExpressionBuilder.Create().OnDayOfWeekRange(DayOfWeek.Thursday, DayOfWeek.Sunday),
+            CronExpressionBuilder.Create().WithDayOfWeekRange(DayOfWeek.Thursday, DayOfWeek.Sunday),
             CronExpressionBuilder.Create().WithSecondRange(55, 5).WithHourRange(22, 2),
             CronExpressionBuilder.Create().WithYearRange(2030, 2035),
             CronExpressionBuilder.Create().WithYearIncrements(2030, 2)

--- a/src/Quartz.Tests.Unit/CronExpressionDifferentialTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDifferentialTest.cs
@@ -128,7 +128,7 @@ public class CronExpressionDifferentialTest
             HashSet<int> hours = RandomSubset(random, 0, 23, maxCount: 4);
 
             string expr = $"{Join(secs)} {Join(mins)} {Join(hours)} * * ?";
-            var cron = new CronExpression(expr) { TimeZone = TimeZoneInfo.Utc };
+            var cron = new CronExpression(expr, TimeZoneInfo.Utc);
 
             // Random start somewhere across a few years, truncated to seconds.
             DateTimeOffset start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)
@@ -169,7 +169,7 @@ public class CronExpressionDifferentialTest
             HashSet<int> months = RandomSubset(random, 1, 12, maxCount: 4);
 
             string expr = $"0 0 12 {Join(days)} {Join(months)} ?";
-            var cron = new CronExpression(expr) { TimeZone = TimeZoneInfo.Utc };
+            var cron = new CronExpression(expr, TimeZoneInfo.Utc);
 
             DateTimeOffset start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)
                 .AddDays(random.Next(0, 2 * 365));
@@ -260,7 +260,7 @@ public class CronExpressionDifferentialTest
             }
 
             string expr = $"0 0 12 {string.Join(",", parts)} * ?";
-            var cron = new CronExpression(expr) { TimeZone = TimeZoneInfo.Utc };
+            var cron = new CronExpression(expr, TimeZoneInfo.Utc);
 
             DateTimeOffset start = new DateTimeOffset(2023, 1, 1, 0, 0, 0, TimeSpan.Zero)
                 .AddDays(random.Next(0, 3 * 365));

--- a/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
@@ -73,9 +73,7 @@ public class CronExpressionDstTests
 
     private static CronExpression CronIn(string expression, TimeZoneInfo zone)
     {
-        CronExpression cron = new CronExpression(expression);
-        cron.TimeZone = zone;
-        return cron;
+        return new CronExpression(expression, zone);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
@@ -513,8 +513,7 @@ public class CronExpressionHashTest
     [Test]
     public void HashExpression_ProducesValidFireTimes()
     {
-        CronExpression expr = new CronExpression("H H H * * ?", "test-job");
-        expr.TimeZone = TimeZoneInfo.Utc;
+        CronExpression expr = new CronExpression("H H H * * ?", "test-job").WithTimeZone(TimeZoneInfo.Utc);
         DateTimeOffset now = DateTimeOffset.UtcNow;
 
         DateTimeOffset? next = expr.GetNextValidTimeAfter(now);
@@ -534,8 +533,7 @@ public class CronExpressionHashTest
     [Test]
     public void HashExpression_WithHourRange_FiresInRange()
     {
-        CronExpression expr = new CronExpression("0 H H(9-17) * * ?", "work-hours");
-        expr.TimeZone = TimeZoneInfo.Utc;
+        CronExpression expr = new CronExpression("0 H H(9-17) * * ?", "work-hours").WithTimeZone(TimeZoneInfo.Utc);
 
         // Get next fire time
         DateTimeOffset now = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
@@ -388,7 +388,7 @@ public class CronExpressionHashTest
     {
         // When using explicit hash key, no trigger identity is required
         ITrigger trigger = TriggerBuilder.Create()
-            .WithCronSchedule(CronScheduleBuilder.CronSchedule(new CronExpression("H H * * * ?", "custom-key")))
+            .WithCronSchedule(CronScheduleBuilder.Create(new CronExpression("H H * * * ?", "custom-key")))
             .Build();
 
         Assert.IsNotNull(trigger);
@@ -424,7 +424,7 @@ public class CronExpressionHashTest
     [Test]
     public void CronScheduleFromHashedExpression_ProducesValidSchedule()
     {
-        CronScheduleBuilder builder = CronScheduleBuilder.CronSchedule(new CronExpression("H H(0-7) * * * ?", "nightly"));
+        CronScheduleBuilder builder = CronScheduleBuilder.Create(new CronExpression("H H(0-7) * * * ?", "nightly"));
         IMutableTrigger trigger = builder.Build();
         Assert.IsNotNull(trigger);
     }

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -369,6 +369,27 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     }
 
     [Test]
+    public void FiveFieldUnixExpressionsAreRejectedWithGuidance()
+    {
+        Action act = () => new CronExpression("30 4 * * 1");
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*Unix/crontab*", "the most common first-run failure is a 5-field expression copied from crontab or Kubernetes")
+            .WithMessage("*\"0 30 4 * * 1\"*", "the error must show the fixed expression, not just the constraint")
+            .WithMessage("*days of week 1-7*", "a Unix expression's numeric day-of-week also means a different day in Quartz");
+    }
+
+    [Test]
+    public void TooFewFieldsNamesTheRequiredFields()
+    {
+        Action act = () => new CronExpression("0 30 4");
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*has 3 fields, but 6 or 7 are required*")
+            .WithMessage("*seconds, minutes, hours, day-of-month, month, day-of-week*");
+    }
+
+    [Test]
     public void CronExpression_Throw_Error_Constructed_With_Null()
     {
         Action act = () => new CronExpression(null);
@@ -530,7 +551,8 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         }
         catch (FormatException fe)
         {
-            Assert.That(fe.Message, Is.EqualTo("Day-of-Week values must be between 1 and 7"));
+            fe.Message.Should().StartWith("Day-of-Week values must be between 1 and 7")
+                .And.Contain("Unix cron numbers days 0-6", "the error must teach the Quartz-vs-Unix numbering difference");
         }
     }
 

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -49,8 +49,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     /// <returns></returns>
     protected override CronExpression GetTargetObject()
     {
-        CronExpression cronExpression = new CronExpression("0 15 10 * * ? 2005");
-        cronExpression.TimeZone = testTimeZone;
+        CronExpression cronExpression = new CronExpression("0 15 10 * * ? 2005", testTimeZone);
 
         return cronExpression;
     }
@@ -216,8 +215,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     [TestCase("0 15 10 1 * * 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 }, "10:15am Every Day of Month October 2010, Wildcard specified")]
     public void CanUse_DayOfMonth_And_DayOfWeek_Together(string cronExpression, int[] expectedDays, string scenario = "")
     {
-        var expr = new CronExpression(cronExpression);
-        expr.TimeZone = TimeZoneInfo.Utc;
+        var expr = new CronExpression(cronExpression, TimeZoneInfo.Utc);
         var templateDate = new DateTime(2010, 10, 1, 10, 15, 0, DateTimeKind.Utc);
 
         foreach (var day in expectedDays)
@@ -313,6 +311,37 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         expr1.Equals(expr2).Should().BeTrue();
 
         expr1.Equals((object) expr2).Should().BeTrue();
+    }
+
+    [Test]
+    public void WithTimeZoneReturnsARetimedCopyAndLeavesTheOriginalAlone()
+    {
+        CronExpression original = new CronExpression("0 15 10 * * ?");
+
+        CronExpression retimed = original.WithTimeZone(TimeZoneInfo.Utc);
+
+        retimed.Should().NotBeSameAs(original, "CronExpression is immutable; retiming produces a copy");
+        retimed.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        retimed.CronExpressionString.Should().Be(original.CronExpressionString);
+        original.TimeZone.Should().Be(TimeZoneInfo.Local);
+    }
+
+    [Test]
+    public void WithTimeZoneNullMeansTheLocalTimeZone()
+    {
+        CronExpression utc = new CronExpression("0 15 10 * * ?", TimeZoneInfo.Utc);
+
+        CronExpression local = utc.WithTimeZone(null);
+
+        local.TimeZone.Should().Be(TimeZoneInfo.Local);
+    }
+
+    [Test]
+    public void WithTimeZoneReturnsTheSameInstanceWhenNothingChanges()
+    {
+        CronExpression utc = new CronExpression("0 15 10 * * ?", TimeZoneInfo.Utc);
+
+        utc.WithTimeZone(TimeZoneInfo.Utc).Should().BeSameAs(utc, "an immutable value can be shared when the zone is unchanged");
     }
 
     [TestCase("0 15 10 15,L-31 * ? 2010")]
@@ -784,8 +813,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     public void TestDaylightSavingsDoesNotMatchAnHourBefore()
     {
         TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
-        CronExpression expression = new CronExpression("0 15 15 5 11 ?");
-        expression.TimeZone = est;
+        CronExpression expression = new CronExpression("0 15 15 5 11 ?", est);
 
         DateTimeOffset startTime = new DateTimeOffset(2012, 11, 4, 0, 0, 0, TimeSpan.Zero);
 
@@ -800,8 +828,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     {
         //another case
         TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
-        CronExpression expression = new CronExpression("0 0 0 ? * THU");
-        expression.TimeZone = est;
+        CronExpression expression = new CronExpression("0 0 0 ? * THU", est);
 
         DateTimeOffset startTime = new DateTimeOffset(2012, 11, 4, 0, 0, 0, TimeSpan.Zero);
 
@@ -995,14 +1022,6 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
 
 
     [Test]
-    public void GetFinalFireTime_IsNotImplement_AndAlwaysReturnsNull()
-    {
-        CronExpression expression = new CronExpression("0 15 15 5 11 ?");
-        var sut = expression.GetFinalFireTime();
-        sut.Should().Be(null);
-    }
-
-    [Test]
     public void CanGetNextInvalidTime()
     {
         CronExpression expression = new CronExpression("0 15 15 5 11 ?");
@@ -1048,7 +1067,7 @@ years: *
     {
         string expression = $"0 0 0 1 {monthAbbr} ? *";
 
-        CronExpression ce = new(expression) { TimeZone = TimeZoneInfo.Utc };
+        CronExpression ce = new(expression, TimeZoneInfo.Utc);
         var startTime = new DateTimeOffset(2024, 7, 22, 12, 0, 0, TimeSpan.Zero);
         var expectedTimeAfter = new DateTimeOffset(2024, monthNumber, 1, 0, 0, 0, TimeSpan.Zero);
 
@@ -1066,7 +1085,7 @@ years: *
         // GetTimeAfter produced a UTC instant before year 1.
         TimeZoneInfo plus11 = TimeZoneInfo.CreateCustomTimeZone(
             "Test+11", TimeSpan.FromHours(11), "Test+11", "Test+11");
-        CronExpression cron = new CronExpression("0 0 0 ? * FRI *") { TimeZone = plus11 };
+        CronExpression cron = new CronExpression("0 0 0 ? * FRI *", plus11);
         DateTimeOffset time = new DateTimeOffset(2026, 4, 16, 0, 0, 0, TimeSpan.Zero);
 
         DateTimeOffset? before = null;
@@ -1201,7 +1220,7 @@ public class CronTestScenarios
             long interval1 = test.Length > 1 ? (long)test[1] : -1;
             long interval2 = test.Length > 2 ? (long)test[2] : interval1;
 
-            var cron = new CronExpression(expression) { TimeZone = TimeZoneInfo.Utc };
+            var cron = new CronExpression(expression, TimeZoneInfo.Utc);
             var now = DateTimeOffset.UtcNow;
 
             DateTimeOffset? after = cron.GetTimeAfter(now);

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -64,6 +64,42 @@ public class CronScheduleBuilderTest
     }
 
     [Test]
+    public void ChangingTheTimeZoneDoesNotRetimeAlreadyBuiltTriggers()
+    {
+        CronScheduleBuilder schedule = CronScheduleBuilder.Create("0 20 10 ? * *");
+
+        ICronTrigger first = (ICronTrigger) TriggerBuilder.Create()
+            .WithIdentity("first")
+            .WithSchedule(schedule)
+            .Build();
+
+        schedule.InTimeZone(TestTimeZones.CentralEuropean);
+
+        ICronTrigger second = (ICronTrigger) TriggerBuilder.Create()
+            .WithIdentity("second")
+            .WithSchedule(schedule)
+            .Build();
+
+        first.TimeZone.Should().Be(TimeZoneInfo.Local,
+            "the builder used to hand every trigger the same mutable CronExpression, so a later InTimeZone silently retimed triggers that were already built");
+        second.TimeZone.Should().Be(TestTimeZones.CentralEuropean);
+    }
+
+    [Test]
+    public void ChangingTheTimeZoneDoesNotRetimeTheCallersExpression()
+    {
+        CronExpression expression = new CronExpression("0 20 10 ? * *");
+
+        TriggerBuilder.Create()
+            .WithIdentity("test")
+            .WithSchedule(CronScheduleBuilder.Create(expression).InTimeZone(TestTimeZones.CentralEuropean))
+            .Build();
+
+        expression.TimeZone.Should().Be(TimeZoneInfo.Local,
+            "InTimeZone must reshape the builder's copy, not write through the instance the caller still holds");
+    }
+
+    [Test]
     public void DefaultsToTheSmartMisfirePolicy()
     {
         ITrigger trigger = TriggerBuilder.Create()

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -20,7 +20,7 @@ public class CronScheduleBuilderTest
             .WithSecond(0)
             .WithMinute(0)
             .WithHour(10)
-            .OnDaysOfWeek(DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Friday)
+            .WithDaysOfWeek(DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Friday)
             .Build();
 
         ICronTrigger trigger = (ICronTrigger) TriggerBuilder.Create()
@@ -29,6 +29,38 @@ public class CronScheduleBuilderTest
             .Build();
 
         trigger.CronExpressionString.Should().Be("0 0 10 ? * MON,THU,FRI");
+    }
+
+    [Test]
+    public void WithCronScheduleTakesACronExpressionDirectly()
+    {
+        CronExpression expression = new CronExpression("0 0 10 ? * MON", TimeZoneInfo.Utc);
+
+        ICronTrigger trigger = (ICronTrigger) TriggerBuilder.Create()
+            .WithIdentity("test")
+            .WithCronSchedule(expression)
+            .Build();
+
+        trigger.CronExpressionString.Should().Be("0 0 10 ? * MON");
+        trigger.TimeZone.Should().Be(TimeZoneInfo.Utc);
+    }
+
+    [Test]
+    public void WithCronScheduleTakesACronExpressionBuilderDirectly()
+    {
+        ICronTrigger trigger = (ICronTrigger) TriggerBuilder.Create()
+            .WithIdentity("test")
+            .WithCronSchedule(
+                CronExpressionBuilder.Create()
+                    .WithSecond(0)
+                    .WithMinuteIncrements(0, 15)
+                    .WithHourRange(8, 17)
+                    .OnWeekdays(),
+                x => x.InTimeZone(TimeZoneInfo.Utc))
+            .Build();
+
+        trigger.CronExpressionString.Should().Be("0 0/15 8-17 ? * MON-FRI");
+        trigger.TimeZone.Should().Be(TimeZoneInfo.Utc);
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -7,7 +7,7 @@ public class CronScheduleBuilderTest
     {
         ICronTrigger trigger = (ICronTrigger) TriggerBuilder.Create()
             .WithIdentity("test")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 20 10 ? * *"))
+            .WithSchedule(CronScheduleBuilder.Create("0 20 10 ? * *"))
             .Build();
 
         trigger.CronExpressionString.Should().Be("0 20 10 ? * *");
@@ -25,7 +25,7 @@ public class CronScheduleBuilderTest
 
         ICronTrigger trigger = (ICronTrigger) TriggerBuilder.Create()
             .WithIdentity("test")
-            .WithSchedule(CronScheduleBuilder.CronSchedule(expression))
+            .WithSchedule(CronScheduleBuilder.Create(expression))
             .Build();
 
         trigger.CronExpressionString.Should().Be("0 0 10 ? * MON,THU,FRI");
@@ -34,7 +34,7 @@ public class CronScheduleBuilderTest
     [Test]
     public void RejectsAnExpressionItCannotParse()
     {
-        Action act = () => CronScheduleBuilder.CronSchedule("not a cron expression");
+        Action act = () => CronScheduleBuilder.Create("not a cron expression");
 
         act.Should().Throw<FormatException>();
     }
@@ -46,7 +46,7 @@ public class CronScheduleBuilderTest
 
         ICronTrigger trigger = (ICronTrigger) TriggerBuilder.Create()
             .WithIdentity("test")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 20 10 ? * *").InTimeZone(timeZone))
+            .WithSchedule(CronScheduleBuilder.Create("0 20 10 ? * *").InTimeZone(timeZone))
             .Build();
 
         trigger.TimeZone.Should().Be(timeZone);
@@ -57,7 +57,7 @@ public class CronScheduleBuilderTest
     {
         ICronTrigger trigger = (ICronTrigger) TriggerBuilder.Create()
             .WithIdentity("test")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 20 10 ? * *").InTimeZone(null))
+            .WithSchedule(CronScheduleBuilder.Create("0 20 10 ? * *").InTimeZone(null))
             .Build();
 
         trigger.TimeZone.Should().Be(TimeZoneInfo.Local);
@@ -68,7 +68,7 @@ public class CronScheduleBuilderTest
     {
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity("test")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 20 10 ? * *"))
+            .WithSchedule(CronScheduleBuilder.Create("0 20 10 ? * *"))
             .Build();
 
         trigger.MisfireInstructionCode.Should().Be(MisfireInstruction.SmartPolicy);

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -23,6 +23,8 @@ using System.Collections.Specialized;
 
 using AwesomeAssertions.Execution;
 
+using Microsoft.Extensions.Time.Testing;
+
 using Quartz.Impl.Triggers;
 using Quartz.Jobs;
 using Quartz.Extensibility;
@@ -443,6 +445,59 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(times, Has.Count.EqualTo(2), "wrong occurrancy count");
             Assert.That(times[1].ToLocalTime().DateTime, Is.EqualTo(new DateTime(2015, 1, 1, 10, 0, 0)), "wrong occurrancy count");
         });
+    }
+
+    [Test]
+    public void EndingDailyAfterCountComputesAgainstTheTriggerBuildersClock()
+    {
+        // On 2026-03-08 America/New_York springs forward, so that day is 23 hours long. Only a
+        // schedule builder that reads the trigger builder's clock can know that: the old builder
+        // read the wall clock inside the EndingDailyAfterCount call, so a configured
+        // FakeTimeProvider was silently ignored.
+        TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Eastern, new DateTime(2026, 3, 8, 2, 30, 0));
+
+        FakeTimeProvider springForwardDay = new FakeTimeProvider(new DateTimeOffset(2026, 3, 8, 12, 0, 0, TimeSpan.Zero));
+
+        Action buildOneTooMany = () => TriggerBuilder.Create(springForwardDay)
+            .WithIdentity("test")
+            .WithDailyTimeIntervalSchedule(x => x
+                .InTimeZone(TestTimeZones.Eastern)
+                .StartingDailyAt(new TimeOnly(0, 0))
+                .WithInterval(1, IntervalUnit.Hour)
+                .EndingDailyAfterCount(24))
+            .Build();
+
+        buildOneTooMany.Should().Throw<ArgumentException>()
+            .WithMessage("*too large*", "the builder's clock says it is the 23-hour spring-forward day, which only fits 23 hourly firings");
+
+        FakeTimeProvider ordinaryDay = new FakeTimeProvider(new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero));
+
+        IDailyTimeIntervalTrigger trigger = (IDailyTimeIntervalTrigger) TriggerBuilder.Create(ordinaryDay)
+            .WithIdentity("test")
+            .WithDailyTimeIntervalSchedule(x => x
+                .InTimeZone(TestTimeZones.Eastern)
+                .StartingDailyAt(new TimeOnly(0, 0))
+                .WithInterval(1, IntervalUnit.Hour)
+                .EndingDailyAfterCount(24))
+            .Build();
+
+        trigger.EndTimeOfDay.Should().Be(new TimeOnly(23, 0));
+    }
+
+    [Test]
+    public void EndingDailyAfterCountSeesTheScheduleAsFinallyConfigured()
+    {
+        // The computation is deferred to Build(), so the count no longer has to be the last thing
+        // configured: a start time or interval set afterwards is what the window is computed from.
+        IDailyTimeIntervalTrigger trigger = (IDailyTimeIntervalTrigger) TriggerBuilder.Create()
+            .WithIdentity("test")
+            .WithDailyTimeIntervalSchedule(x => x
+                .EndingDailyAfterCount(12)
+                .StartingDailyAt(new TimeOnly(8, 0))
+                .WithInterval(15, IntervalUnit.Minute))
+            .Build();
+
+        trigger.EndTimeOfDay.Should().Be(new TimeOnly(10, 45));
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -49,7 +49,7 @@ public class DailyTimeIntervalScheduleBuilderTest
 
         ISchedulerFactory factory = QuartzSchedulerBuilder.Create().UseProperties(properties).Build();
         IScheduler scheduler = await factory.GetScheduler();
-        IJobDetail job = JobBuilder.Create(typeof(NoOpJob)).Build();
+        IJobDetail job = JobBuilder.Create().OfType(typeof(NoOpJob)).Build();
 
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity("test")

--- a/src/Quartz.Tests.Unit/DateBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DateBuilderTest.cs
@@ -5,7 +5,7 @@ public class DateBuilderTest
     [Test]
     public void BuildsTheDateItWasTold()
     {
-        DateTimeOffset date = DateBuilder.NewDate()
+        DateTimeOffset date = DateBuilder.Create()
             .InYear(2011)
             .InMonthOnDay(11, 14)
             .AtHourMinuteAndSecond(21, 59, 0)
@@ -24,7 +24,7 @@ public class DateBuilderTest
     {
         DateTimeOffset now = DateTimeOffset.Now;
 
-        DateTimeOffset date = DateBuilder.NewDate().AtHourMinuteAndSecond(3, 4, 5).Build();
+        DateTimeOffset date = DateBuilder.Create().AtHourMinuteAndSecond(3, 4, 5).Build();
 
         date.Year.Should().Be(now.Year);
         date.Month.Should().Be(now.Month);
@@ -38,7 +38,7 @@ public class DateBuilderTest
     {
         TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
 
-        DateTimeOffset date = DateBuilder.NewDateInTimeZone(timeZone)
+        DateTimeOffset date = DateBuilder.CreateInTimeZone(timeZone)
             .InYear(2011)
             .InMonthOnDay(11, 14)
             .AtHourMinuteAndSecond(21, 59, 0)
@@ -51,7 +51,7 @@ public class DateBuilderTest
     [TestCase(-1)]
     public void RejectsAnHourOutsideTheDay(int hour)
     {
-        Action act = () => DateBuilder.NewDate().AtHourOfDay(hour);
+        Action act = () => DateBuilder.Create().AtHourOfDay(hour);
 
         act.Should().Throw<ArgumentException>().WithMessage("*hour*");
     }
@@ -60,7 +60,7 @@ public class DateBuilderTest
     [TestCase(32)]
     public void RejectsADayOutsideTheMonth(int day)
     {
-        Action act = () => DateBuilder.NewDate().OnDay(day);
+        Action act = () => DateBuilder.Create().OnDay(day);
 
         act.Should().Throw<ArgumentException>().WithMessage("*day of month*");
     }

--- a/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
+++ b/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
@@ -43,7 +43,7 @@ public class DaylightSavingTimeTest
 
         ITrigger trigger = TriggerBuilder.Create(new TestTimeProvider(new DateTimeOffset(2016, 1, 1, 0, 0, 0, TimeSpan.Zero)))
             .WithIdentity("trigger1", "group1")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 30 2 ? * *").InTimeZone(tz))
+            .WithSchedule(CronScheduleBuilder.Create("0 30 2 ? * *").InTimeZone(tz))
             .ForJob("job1", "group1")
             .Build();
 
@@ -69,7 +69,7 @@ public class DaylightSavingTimeTest
 
         ITrigger trigger = TriggerBuilder.Create(new TestTimeProvider(new DateTimeOffset(2016, 1, 1, 0, 0, 0, TimeSpan.Zero)))
             .WithIdentity("trigger1", "group1")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 30 1 ? * *").InTimeZone(tz))
+            .WithSchedule(CronScheduleBuilder.Create("0 30 1 ? * *").InTimeZone(tz))
             .ForJob("job1", "group1")
             .Build();
 
@@ -95,7 +95,7 @@ public class DaylightSavingTimeTest
 
         ITrigger trigger = TriggerBuilder.Create(new TestTimeProvider(new DateTimeOffset(2016, 1, 1, 0, 0, 0, TimeSpan.Zero)))
             .WithIdentity("trigger1", "group1")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 30 1 ? * *").InTimeZone(tz))
+            .WithSchedule(CronScheduleBuilder.Create("0 30 1 ? * *").InTimeZone(tz))
             .ForJob("job1", "group1")
             .Build();
 
@@ -124,7 +124,7 @@ public class DaylightSavingTimeTest
 
         ITrigger trigger = TriggerBuilder.Create(new TestTimeProvider(new DateTimeOffset(2023, 1, 1, 0, 0, 0, TimeSpan.Zero)))
             .WithIdentity("trigger1", "group1")
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 * * * * ?").InTimeZone(tz))
+            .WithSchedule(CronScheduleBuilder.Create("0 * * * * ?").InTimeZone(tz))
             .ForJob("job1", "group1")
             .Build();
 

--- a/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
+++ b/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
@@ -150,7 +150,7 @@ public class DaylightSavingTimeTest
         // Amsterdam: CEST (UTC+2) → CET (UTC+1) on October 29, 2023 at 3:00 AM CEST (= 1:00 AM UTC).
         // The local hour 02:00-02:59 occurs twice: first in CEST, then in CET.
         TimeZoneInfo tz = TZConvert.GetTimeZoneInfo("W. Europe Standard Time");
-        var cron = new CronExpression("* * * ? 10 * *") { TimeZone = tz };
+        var cron = new CronExpression("* * * ? 10 * *", tz);
 
         // Exact moment of fall-back: 01:00:00 UTC = 02:00:00 CET (second occurrence)
         var atFallBack = new DateTimeOffset(2023, 10, 29, 1, 0, 0, TimeSpan.Zero);
@@ -178,7 +178,7 @@ public class DaylightSavingTimeTest
     {
         // Use UTC timezone to avoid any DST confusion — the cron expression should match
         // every second in October regardless of local system timezone settings.
-        var cron = new CronExpression("* * * ? 10 * *") { TimeZone = TimeZoneInfo.Utc };
+        var cron = new CronExpression("* * * ? 10 * *", TimeZoneInfo.Utc);
 
         // October 29, 2023 01:00:00 UTC — in UTC this is unambiguously October
         var atFallBack = new DateTimeOffset(2023, 10, 29, 1, 0, 0, TimeSpan.Zero);
@@ -201,7 +201,7 @@ public class DaylightSavingTimeTest
     public void GetTimeAfter_ShouldProduceStrictlyIncreasingTimes_AcrossDstFallBack()
     {
         TimeZoneInfo tz = TZConvert.GetTimeZoneInfo("W. Europe Standard Time");
-        var cron = new CronExpression("0 * * ? * * *") { TimeZone = tz };
+        var cron = new CronExpression("0 * * ? * * *", tz);
 
         // Start 30 minutes before the fall-back: 00:30:00 UTC = 02:30:00 CEST
         DateTimeOffset current = new DateTimeOffset(2023, 10, 29, 0, 30, 0, TimeSpan.Zero);
@@ -225,7 +225,7 @@ public class DaylightSavingTimeTest
     public void GetTimeAfter_ShouldProduceStrictlyIncreasingTimes_AcrossDstSpringForward()
     {
         TimeZoneInfo tz = TZConvert.GetTimeZoneInfo("Central Standard Time");
-        var cron = new CronExpression("0 * * ? * * *") { TimeZone = tz };
+        var cron = new CronExpression("0 * * ? * * *", tz);
 
         // Start 30 minutes before spring-forward: 2024-03-10 07:30:00 UTC = 01:30:00 CST
         // Spring-forward: 02:00 CST → 03:00 CDT (08:00 UTC)
@@ -251,7 +251,7 @@ public class DaylightSavingTimeTest
     public void IsSatisfiedBy_EveryMinuteInOctober_ShouldNotReturnFalseDuringDstFallBack_Issue2156()
     {
         TimeZoneInfo tz = TZConvert.GetTimeZoneInfo("W. Europe Standard Time");
-        var cron = new CronExpression("* * * ? 10 * *") { TimeZone = tz };
+        var cron = new CronExpression("* * * ? 10 * *", tz);
 
         // Walk through October 28-30 minute by minute across the CET fall-back
         // Fall-back: Oct 29, 2023 at 03:00 CEST → 02:00 CET (= 01:00 UTC)

--- a/src/Quartz.Tests.Unit/ExecutionGroupsTest.cs
+++ b/src/Quartz.Tests.Unit/ExecutionGroupsTest.cs
@@ -56,12 +56,12 @@ public sealed class ExecutionGroupsTest
     }
 
     /// <summary>
-    /// Reads the limit configured for one group, asserting that the group has an entry of its own.
+    /// Reads the limit configured for one scope, asserting that the scope has an entry of its own.
     /// </summary>
-    private static int? LimitFor(ExecutionLimits limits, string group)
+    private static int? LimitFor(ExecutionLimits limits, ExecutionGroupScope scope)
     {
-        limits.TryGetLimit(group, out int? limit)
-            .Should().BeTrue($"execution group '{group ?? "(default)"}' should be configured");
+        limits.TryGetLimit(scope, out int? limit)
+            .Should().BeTrue($"execution scope '{scope}' should be configured");
         return limit;
     }
 
@@ -73,8 +73,8 @@ public sealed class ExecutionGroupsTest
             .ForGroup("high-cpu", 5)
             .Build();
 
-        LimitFor(limits, "batch-jobs").Should().Be(2);
-        LimitFor(limits, "high-cpu").Should().Be(5);
+        LimitFor(limits, ExecutionGroupScope.Named("batch-jobs")).Should().Be(2);
+        LimitFor(limits, ExecutionGroupScope.Named("high-cpu")).Should().Be(5);
         limits.Groups.Should().HaveCount(2);
     }
 
@@ -85,8 +85,8 @@ public sealed class ExecutionGroupsTest
             .ForDefaultGroup(10)
             .Build();
 
-        LimitFor(limits, null).Should().Be(10);
-        limits.Groups.Should().ContainSingle().Which.Should().Be(new ExecutionGroupLimit(null, 10),
+        LimitFor(limits, ExecutionGroupScope.Default).Should().Be(10);
+        limits.Groups.Should().ContainSingle().Which.Should().Be(new ExecutionGroupLimit(ExecutionGroupScope.Default, 10),
             "triggers without an execution group fall into the default group, which has no name");
     }
 
@@ -97,7 +97,7 @@ public sealed class ExecutionGroupsTest
             .ForOtherGroups(3)
             .Build();
 
-        LimitFor(limits, ExecutionLimits.OtherGroups).Should().Be(3);
+        LimitFor(limits, ExecutionGroupScope.OtherGroups).Should().Be(3);
     }
 
     [Test]
@@ -107,7 +107,7 @@ public sealed class ExecutionGroupsTest
             .Unlimited("batch-jobs")
             .Build();
 
-        LimitFor(limits, "batch-jobs").Should().BeNull();
+        LimitFor(limits, ExecutionGroupScope.Named("batch-jobs")).Should().BeNull();
     }
 
     [Test]
@@ -129,6 +129,55 @@ public sealed class ExecutionGroupsTest
 
         Action unlimited = () => ExecutionLimitsBuilder.Create().Unlimited(group);
         unlimited.Should().Throw<ArgumentException>().WithMessage("*reserved*");
+    }
+
+    [Test]
+    public void ExecutionGroupScope_DistinguishesItsThreeCases()
+    {
+        ExecutionGroupScope.Default.IsDefault.Should().BeTrue();
+        ExecutionGroupScope.Default.IsOtherGroups.Should().BeFalse();
+        ExecutionGroupScope.Default.Name.Should().BeNull();
+
+        ExecutionGroupScope.OtherGroups.IsDefault.Should().BeFalse();
+        ExecutionGroupScope.OtherGroups.IsOtherGroups.Should().BeTrue();
+        ExecutionGroupScope.OtherGroups.Name.Should().BeNull("the catch-all is not a group name a trigger can carry");
+
+        ExecutionGroupScope named = ExecutionGroupScope.Named("batch-jobs");
+        named.IsDefault.Should().BeFalse();
+        named.IsOtherGroups.Should().BeFalse();
+        named.Name.Should().Be("batch-jobs");
+
+        default(ExecutionGroupScope).Should().Be(ExecutionGroupScope.Default, "an uninitialized scope must read as the default bucket");
+    }
+
+    [TestCase("*")]
+    [TestCase("_")]
+    [TestCase("null")]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void ExecutionGroupScope_Named_RejectsReservedAndBlankNames(string name)
+    {
+        Action act = () => ExecutionGroupScope.Named(name);
+
+        act.Should().Throw<ArgumentException>(
+            "the sentinels stay in configuration spelling; the typed scope exists so they can never be mistaken for group names");
+    }
+
+    [Test]
+    public void ExecutionGroupScope_ReportsTheScopesTheBuilderWrote()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("batch-jobs", 2)
+            .ForDefaultGroup(10)
+            .ForOtherGroups(5)
+            .Build();
+
+        limits.Groups.Should().BeEquivalentTo(
+        [
+            new ExecutionGroupLimit(ExecutionGroupScope.Named("batch-jobs"), 2),
+            new ExecutionGroupLimit(ExecutionGroupScope.Default, 10),
+            new ExecutionGroupLimit(ExecutionGroupScope.OtherGroups, 5)
+        ]);
     }
 
     [Test]
@@ -237,7 +286,7 @@ public sealed class ExecutionGroupsTest
 
         ExecutionSlots second = limits.CreateSlots();
         second.TryTake("batch-jobs").Should().BeTrue("a retried acquisition starts from the limits again");
-        LimitFor(limits, "batch-jobs").Should().Be(2);
+        LimitFor(limits, ExecutionGroupScope.Named("batch-jobs")).Should().Be(2);
     }
 
     [Test]
@@ -250,9 +299,9 @@ public sealed class ExecutionGroupsTest
             .Build();
 
         limits.Groups.Should().HaveCount(3);
-        LimitFor(limits, "batch-jobs").Should().Be(2);
-        LimitFor(limits, null).Should().Be(10);
-        LimitFor(limits, ExecutionLimits.OtherGroups).Should().Be(5);
+        LimitFor(limits, ExecutionGroupScope.Named("batch-jobs")).Should().Be(2);
+        LimitFor(limits, ExecutionGroupScope.Default).Should().Be(10);
+        LimitFor(limits, ExecutionGroupScope.OtherGroups).Should().Be(5);
     }
 
     [Test]
@@ -285,9 +334,9 @@ public sealed class ExecutionGroupsTest
         // Keep configuring the builder after the snapshot was taken
         builder.ForGroup("a", 99).ForGroup("b", 10);
 
-        LimitFor(snapshot, "a").Should().Be(5);
+        LimitFor(snapshot, ExecutionGroupScope.Named("a")).Should().Be(5);
         snapshot.Groups.Should().ContainSingle();
-        snapshot.TryGetLimit("b", out _).Should().BeFalse();
+        snapshot.TryGetLimit(ExecutionGroupScope.Named("b"), out _).Should().BeFalse();
     }
 
     [Test]
@@ -306,10 +355,10 @@ public sealed class ExecutionGroupsTest
         {
             ExecutionLimits limits = await scheduler.GetExecutionLimits().ConfigureAwait(false);
             limits.Should().NotBeNull();
-            LimitFor(limits, "batch-jobs").Should().Be(2);
-            LimitFor(limits, "high-cpu").Should().Be(5);
-            LimitFor(limits, null).Should().Be(10);
-            LimitFor(limits, ExecutionLimits.OtherGroups).Should().Be(3);
+            LimitFor(limits, ExecutionGroupScope.Named("batch-jobs")).Should().Be(2);
+            LimitFor(limits, ExecutionGroupScope.Named("high-cpu")).Should().Be(5);
+            LimitFor(limits, ExecutionGroupScope.Default).Should().Be(10);
+            LimitFor(limits, ExecutionGroupScope.OtherGroups).Should().Be(3);
         }
         finally
         {
@@ -334,11 +383,11 @@ public sealed class ExecutionGroupsTest
         {
             ExecutionLimits limits = await scheduler.GetExecutionLimits().ConfigureAwait(false);
             limits.Should().NotBeNull();
-            LimitFor(limits, "a").Should().BeNull();  // "unlimited" → null
-            LimitFor(limits, "b").Should().BeNull();  // "none" → null
-            LimitFor(limits, "c").Should().BeNull();  // "null" value → null (unlimited)
-            LimitFor(limits, "d").Should().Be(5);
-            LimitFor(limits, null).Should().Be(8); // "_" key → default group
+            LimitFor(limits, ExecutionGroupScope.Named("a")).Should().BeNull();  // "unlimited" → null
+            LimitFor(limits, ExecutionGroupScope.Named("b")).Should().BeNull();  // "none" → null
+            LimitFor(limits, ExecutionGroupScope.Named("c")).Should().BeNull();  // "null" value → null (unlimited)
+            LimitFor(limits, ExecutionGroupScope.Named("d")).Should().Be(5);
+            LimitFor(limits, ExecutionGroupScope.Default).Should().Be(8); // "_" key → default group
         }
         finally
         {
@@ -359,7 +408,7 @@ public sealed class ExecutionGroupsTest
         {
             ExecutionLimits limits = await scheduler.GetExecutionLimits().ConfigureAwait(false);
             limits.Should().NotBeNull();
-            LimitFor(limits, null).Should().Be(7);
+            LimitFor(limits, ExecutionGroupScope.Default).Should().Be(7);
         }
         finally
         {

--- a/src/Quartz.Tests.Unit/ExecutionGroupsTest.cs
+++ b/src/Quartz.Tests.Unit/ExecutionGroupsTest.cs
@@ -68,7 +68,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void ExecutionLimits_ForGroup_SetsLimit()
     {
-        ExecutionLimits limits = new ExecutionLimitsBuilder()
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
             .ForGroup("batch-jobs", 2)
             .ForGroup("high-cpu", 5)
             .Build();
@@ -81,7 +81,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void ExecutionLimits_ForDefaultGroup_ReportsTheGroupAsNull()
     {
-        ExecutionLimits limits = new ExecutionLimitsBuilder()
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
             .ForDefaultGroup(10)
             .Build();
 
@@ -93,7 +93,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void ExecutionLimits_ForOtherGroups_SetsAsteriskKey()
     {
-        ExecutionLimits limits = new ExecutionLimitsBuilder()
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
             .ForOtherGroups(3)
             .Build();
 
@@ -103,7 +103,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void ExecutionLimits_Unlimited_SetsNull()
     {
-        ExecutionLimits limits = new ExecutionLimitsBuilder()
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
             .Unlimited("batch-jobs")
             .Build();
 
@@ -113,8 +113,8 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void ExecutionLimits_IsEmpty_WhenNothingWasConfigured()
     {
-        new ExecutionLimitsBuilder().Build().IsEmpty.Should().BeTrue();
-        new ExecutionLimitsBuilder().ForGroup("a", 1).Build().IsEmpty.Should().BeFalse();
+        ExecutionLimitsBuilder.Create().Build().IsEmpty.Should().BeTrue();
+        ExecutionLimitsBuilder.Create().ForGroup("a", 1).Build().IsEmpty.Should().BeFalse();
     }
 
     [TestCase("*")]
@@ -124,17 +124,17 @@ public sealed class ExecutionGroupsTest
     [TestCase(" * ")]
     public void ExecutionLimits_ForGroup_RejectsReservedNames(string group)
     {
-        Action forGroup = () => new ExecutionLimitsBuilder().ForGroup(group, 1);
+        Action forGroup = () => ExecutionLimitsBuilder.Create().ForGroup(group, 1);
         forGroup.Should().Throw<ArgumentException>().WithMessage("*reserved*");
 
-        Action unlimited = () => new ExecutionLimitsBuilder().Unlimited(group);
+        Action unlimited = () => ExecutionLimitsBuilder.Create().Unlimited(group);
         unlimited.Should().Throw<ArgumentException>().WithMessage("*reserved*");
     }
 
     [Test]
     public void TryTake_NoLimits_ReturnsTrue()
     {
-        ExecutionSlots slots = new ExecutionLimitsBuilder().Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().Build().CreateSlots();
 
         slots.TryTake("batch-jobs").Should().BeTrue();
     }
@@ -142,7 +142,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void TryTake_Unlimited_ReturnsTrue()
     {
-        ExecutionSlots slots = new ExecutionLimitsBuilder().Unlimited("batch-jobs").Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().Unlimited("batch-jobs").Build().CreateSlots();
 
         slots.TryTake("batch-jobs").Should().BeTrue();
         slots.TryTake("batch-jobs").Should().BeTrue();
@@ -151,7 +151,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void TryTake_Forbidden_ReturnsFalse()
     {
-        ExecutionSlots slots = new ExecutionLimitsBuilder().ForGroup("batch-jobs", 0).Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().ForGroup("batch-jobs", 0).Build().CreateSlots();
 
         slots.TryTake("batch-jobs").Should().BeFalse();
     }
@@ -159,7 +159,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void TryTake_Available_DecrementsAndReturnsTrue()
     {
-        ExecutionSlots slots = new ExecutionLimitsBuilder().ForGroup("batch-jobs", 2).Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().ForGroup("batch-jobs", 2).Build().CreateSlots();
 
         slots.TryTake("batch-jobs").Should().BeTrue();
         Remaining(slots, "batch-jobs").Should().Be(1);
@@ -173,7 +173,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void TryTake_FallsBackToOtherGroups()
     {
-        ExecutionSlots slots = new ExecutionLimitsBuilder().ForOtherGroups(1).Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().ForOtherGroups(1).Build().CreateSlots();
 
         slots.TryTake("unknown-group").Should().BeTrue();
         Remaining(slots, "unknown-group").Should().Be(0,
@@ -185,7 +185,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void TryTake_NullGroup_DoesNotFallBackToOtherGroups()
     {
-        ExecutionSlots slots = new ExecutionLimitsBuilder().ForOtherGroups(0).Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().ForOtherGroups(0).Build().CreateSlots();
 
         slots.TryTake(null).Should().BeTrue("'*' is a catch-all for named groups, not for ungrouped triggers");
     }
@@ -193,7 +193,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void TryTake_NullGroup_UsesDefaultGroup()
     {
-        ExecutionSlots slots = new ExecutionLimitsBuilder().ForDefaultGroup(1).Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().ForDefaultGroup(1).Build().CreateSlots();
 
         slots.TryTake(null).Should().BeTrue();
         slots.TryTake(null).Should().BeFalse();
@@ -202,7 +202,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void TryTake_GroupNotConfigured_NoDefault_ReturnsTrue()
     {
-        ExecutionSlots slots = new ExecutionLimitsBuilder().ForGroup("batch-jobs", 0).Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().ForGroup("batch-jobs", 0).Build().CreateSlots();
 
         slots.TryTake("other-group").Should().BeTrue();
     }
@@ -211,7 +211,7 @@ public sealed class ExecutionGroupsTest
     public void TryTake_ThreeTriggersLimitTwo()
     {
         // Simulate what a job store does: walk the candidates and ask for a slot for each
-        ExecutionSlots slots = new ExecutionLimitsBuilder().ForGroup("batch-jobs", 2).Build().CreateSlots();
+        ExecutionSlots slots = ExecutionLimitsBuilder.Create().ForGroup("batch-jobs", 2).Build().CreateSlots();
 
         int allowed = 0;
         for (int i = 0; i < 3; i++)
@@ -228,7 +228,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void CreateSlots_LeavesTheSnapshotAlone()
     {
-        ExecutionLimits limits = new ExecutionLimitsBuilder().ForGroup("batch-jobs", 2).Build();
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create().ForGroup("batch-jobs", 2).Build();
 
         ExecutionSlots first = limits.CreateSlots();
         first.TryTake("batch-jobs").Should().BeTrue();
@@ -243,7 +243,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void ExecutionLimits_FluentChaining()
     {
-        ExecutionLimits limits = new ExecutionLimitsBuilder()
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
             .ForGroup("batch-jobs", 2)
             .ForDefaultGroup(10)
             .ForOtherGroups(5)
@@ -258,28 +258,28 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void ExecutionLimits_ForGroup_RejectsNegativeValue()
     {
-        Action act = () => new ExecutionLimitsBuilder().ForGroup("x", -1);
+        Action act = () => ExecutionLimitsBuilder.Create().ForGroup("x", -1);
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Test]
     public void ExecutionLimits_ForDefaultGroup_RejectsNegativeValue()
     {
-        Action act = () => new ExecutionLimitsBuilder().ForDefaultGroup(-1);
+        Action act = () => ExecutionLimitsBuilder.Create().ForDefaultGroup(-1);
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Test]
     public void ExecutionLimits_ForOtherGroups_RejectsNegativeValue()
     {
-        Action act = () => new ExecutionLimitsBuilder().ForOtherGroups(-1);
+        Action act = () => ExecutionLimitsBuilder.Create().ForOtherGroups(-1);
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Test]
     public void ExecutionLimits_Build_IsIndependentOfLaterBuilderChanges()
     {
-        ExecutionLimitsBuilder builder = new ExecutionLimitsBuilder().ForGroup("a", 5);
+        ExecutionLimitsBuilder builder = ExecutionLimitsBuilder.Create().ForGroup("a", 5);
         ExecutionLimits snapshot = builder.Build();
 
         // Keep configuring the builder after the snapshot was taken
@@ -403,7 +403,7 @@ public sealed class ExecutionGroupsTest
     [Test]
     public void Slots_UnlistedGroupUsesTheCatchAll()
     {
-        ExecutionLimits limits = new ExecutionLimitsBuilder()
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
             .ForGroup("batch", 5)
             .ForOtherGroups(3)
             .Build();

--- a/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
@@ -48,38 +48,34 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     {
         // we're local by default
         DateTime d = new DateTime(2005, 1, 1);
-        calendar.AddExcludedDay(DateOnly.FromDateTime(d));
+        calendar.AddExcludedDay(new MonthDay(1, 1));
 
         calendar.IsTimeIncluded(d.ToUniversalTime()).Should().BeFalse("the excluded day's time must not be included");
-        calendar.IsDayExcluded(DateOnly.FromDateTime(d)).Should().BeTrue();
-        calendar.DaysExcluded.Should().ContainSingle();
-        calendar.DaysExcluded.Single().Day.Should().Be(d.Day);
-        calendar.DaysExcluded.Single().Month.Should().Be(d.Month);
+        calendar.IsDayExcluded(new MonthDay(1, 1)).Should().BeTrue();
+        calendar.DaysExcluded.Should().ContainSingle().Which.Should().Be(new MonthDay(1, 1));
     }
 
     [Test]
     public void TestDayInclusionAfterExclusion()
     {
-        DateOnly d = new DateOnly(2005, 1, 1);
+        MonthDay d = new MonthDay(1, 1);
         calendar.AddExcludedDay(d).Should().BeTrue();
         calendar.RemoveExcludedDay(d).Should().BeTrue();
         calendar.RemoveExcludedDay(d).Should().BeFalse("the day was already included again");
 
-        calendar.IsTimeIncluded(d.ToDateTime(TimeOnly.MinValue)).Should().BeTrue();
+        calendar.IsTimeIncluded(new DateTime(2005, 1, 1)).Should().BeTrue();
         calendar.IsDayExcluded(d).Should().BeFalse();
     }
 
     [Test]
     public void TestDayExclusionDifferentYears()
     {
-        const string ErrMessage = "only the month and the day are significant";
-        DateOnly d = new DateOnly(2005, 1, 1);
-        calendar.AddExcludedDay(d);
+        const string ErrMessage = "a MonthDay carries no year, so the same date is excluded every year";
+        calendar.AddExcludedDay(MonthDay.From(new DateOnly(2005, 1, 1)));
 
-        calendar.IsDayExcluded(d).Should().BeTrue(ErrMessage);
-        calendar.IsDayExcluded(d.AddYears(-2)).Should().BeTrue(ErrMessage);
-        calendar.IsDayExcluded(d.AddYears(2)).Should().BeTrue(ErrMessage);
-        calendar.IsDayExcluded(d.AddYears(100)).Should().BeTrue(ErrMessage);
+        calendar.IsDayExcluded(MonthDay.From(new DateOnly(2003, 1, 1))).Should().BeTrue(ErrMessage);
+        calendar.IsDayExcluded(MonthDay.From(new DateOnly(2007, 1, 1))).Should().BeTrue(ErrMessage);
+        calendar.IsDayExcluded(MonthDay.From(new DateOnly(2105, 1, 1))).Should().BeTrue(ErrMessage);
     }
 
     [Test]
@@ -89,7 +85,7 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         DateTimeOffset test = DateTimeOffset.UtcNow.Date;
         Assert.That(calendar.GetNextIncludedTimeUtc(test), Is.EqualTo(test), "Did not get today as date when nothing was excluded");
 
-        calendar.AddExcludedDay(DateOnly.FromDateTime(test.Date));
+        calendar.AddExcludedDay(MonthDay.From(DateOnly.FromDateTime(test.Date)));
         Assert.That(calendar.GetNextIncludedTimeUtc(test), Is.EqualTo(test.AddDays(1)), "Did not get next day when current day excluded");
     }
 
@@ -101,13 +97,10 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     {
         AnnualCalendar annualCalendar = new AnnualCalendar();
 
-        DateOnly day = new DateOnly(2005, 6, 23);
-        annualCalendar.AddExcludedDay(day);
+        annualCalendar.AddExcludedDay(new MonthDay(6, 23));
+        annualCalendar.AddExcludedDay(new MonthDay(2, 1));
 
-        day = new DateOnly(2008, 2, 1);
-        annualCalendar.AddExcludedDay(day);
-
-        annualCalendar.IsDayExcluded(day).Should().BeTrue("the day 1 February is expected to be excluded");
+        annualCalendar.IsDayExcluded(new MonthDay(2, 1)).Should().BeTrue("the day 1 February is expected to be excluded");
     }
 
     /// <summary>
@@ -118,14 +111,12 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     {
         AnnualCalendar annualCalendar = new AnnualCalendar();
 
-        DateOnly day = new DateOnly(2005, 6, 23);
-        annualCalendar.AddExcludedDay(day);
+        // days excluded via dates in different years name the same day of every year
+        annualCalendar.AddExcludedDay(MonthDay.From(new DateOnly(2005, 6, 23)));
 
-        // Trying to remove the 23th of June
-        day = new DateOnly(2008, 6, 23);
-        annualCalendar.RemoveExcludedDay(day).Should().BeTrue("only the month and the day are significant");
+        annualCalendar.RemoveExcludedDay(MonthDay.From(new DateOnly(2008, 6, 23))).Should().BeTrue("a MonthDay carries no year");
 
-        annualCalendar.IsDayExcluded(day).Should().BeFalse("the day 23 June is not expected to be excluded");
+        annualCalendar.IsDayExcluded(new MonthDay(6, 23)).Should().BeFalse("the day 23 June is not expected to be excluded");
     }
 
     [Test]
@@ -135,8 +126,7 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
         AnnualCalendar c = new AnnualCalendar();
         c.TimeZone = tz;
 
-        DateOnly excludedDay = new DateOnly(2012, 11, 4);
-        c.AddExcludedDay(excludedDay);
+        c.AddExcludedDay(new MonthDay(11, 4));
 
         // 11/5/2012 12:00:00 AM -04:00  translate into 11/4/2012 11:00:00 PM -05:00 (EST)
         DateTimeOffset date = new DateTimeOffset(2012, 11, 5, 0, 0, 0, TimeSpan.FromHours(-4));
@@ -155,7 +145,7 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     [Test]
     public void BaseCalendarShouldNotAffectSettingInternalDataStructures()
     {
-        var dayToExclude = new DateOnly(2015, 1, 1);
+        var dayToExclude = new MonthDay(1, 1);
 
         AnnualCalendar a = new AnnualCalendar();
         a.AddExcludedDay(dayToExclude);
@@ -177,8 +167,7 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     {
         AnnualCalendar c = new AnnualCalendar();
         c.Description = "description";
-        DateOnly date = new DateOnly(2005, 1, 20);
-        c.AddExcludedDay(date);
+        c.AddExcludedDay(new MonthDay(1, 20));
         return c;
     }
 

--- a/src/Quartz.Tests.Unit/Impl/Triggers/RecurrenceTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/RecurrenceTriggerImplTest.cs
@@ -101,7 +101,7 @@ public class RecurrenceTriggerImplTest
 
         // Exclude Jan 2 via AnnualCalendar
         AnnualCalendar calendar = new AnnualCalendar();
-        calendar.AddExcludedDay(new DateOnly(2025, 1, 2));
+        calendar.AddExcludedDay(new MonthDay(1, 2));
 
         trigger.ComputeFirstFireTimeUtc(calendar);
         // First fire = Jan 1

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -63,7 +63,7 @@ public class JsonObjectSerializerTest
             }
         };
 
-        calendar.AddExcludedDay(DateOnly.FromDateTime(timeProvider.GetUtcNow().Date));
+        calendar.AddExcludedDay(MonthDay.From(DateOnly.FromDateTime(timeProvider.GetUtcNow().Date)));
 
         CompareSerialization(calendar);
         await VerifyCreatedJson(calendar);
@@ -244,7 +244,7 @@ public class JsonObjectSerializerTest
 
         var annualCalendar = new AnnualCalendar();
         annualCalendar.Description = "description";
-        annualCalendar.AddExcludedDay(DateOnly.FromDateTime(timeProvider.GetUtcNow().Date));
+        annualCalendar.AddExcludedDay(MonthDay.From(DateOnly.FromDateTime(timeProvider.GetUtcNow().Date)));
         annualCalendar.TimeZone = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
 
         var cronCalendar = new CronCalendar("0/5 * * * * ?");

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -277,10 +277,7 @@ public class JsonObjectSerializerTest
     [Test]
     public async Task SerializeCronExpression()
     {
-        var cronExpression = new CronExpression("0/5 * * * * ?")
-        {
-            TimeZone = TimeZoneInfo.Utc
-        };
+        var cronExpression = new CronExpression("0/5 * * * * ?", TimeZoneInfo.Utc);
 
         CompareSerialization(cronExpression);
         await VerifyCreatedJson(cronExpression);

--- a/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
@@ -292,8 +292,8 @@ public class LegacyJsonPayloadTest
 
         calendar.Description.Should().Be("Test AnnualCalendar");
         calendar.CalendarBase.Should().BeOfType<BaseCalendar>();
-        calendar.DaysExcluded.Should().BeEquivalentTo([new DateOnly(2000, 7, 1), new DateOnly(2000, 12, 25)]);
-        calendar.IsDayExcluded(new DateOnly(2031, 7, 1)).Should().BeTrue("only the month and the day are significant");
+        calendar.DaysExcluded.Should().BeEquivalentTo([new MonthDay(7, 1), new MonthDay(12, 25)]);
+        calendar.IsDayExcluded(new MonthDay(7, 1)).Should().BeTrue("the legacy timestamps collapse to the month and the day");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/TestDates.cs
+++ b/src/Quartz.Tests.Unit/TestDates.cs
@@ -28,7 +28,7 @@ namespace Quartz.Tests.Unit;
 /// These used to be static conveniences on <see cref="DateBuilder" />. They are test scaffolding
 /// rather than API: the tests below are about triggers, and only need a compact way to name a
 /// wall-clock instant. Production code should say what it means with <see cref="DateTimeOffset" />
-/// arithmetic, or build a specific date with <see cref="DateBuilder.NewDate" />.
+/// arithmetic, or build a specific date with <see cref="DateBuilder.Create" />.
 /// </remarks>
 public static class TestDates
 {

--- a/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
@@ -179,7 +179,7 @@ public class TriggerBuilderTest
         // WithSchedule is redeclared on the generic configurator for the same reason: losing TJob
         // here would lose the property-named job data that comes after it.
         ITriggerConfigurator<TestJob> configured = ((ITriggerConfigurator<TestJob>) TriggerBuilder.Create<TestJob>())
-            .WithSchedule(CronScheduleBuilder.CronSchedule("0 0 12 * * ?"))
+            .WithSchedule(CronScheduleBuilder.Create("0 0 12 * * ?"))
             .WithDescription("noon");
 
         ((TriggerBuilder<TestJob>) configured).Build().Description.Should().Be("noon");
@@ -190,7 +190,7 @@ public class TriggerBuilderTest
     {
         // The hash-key cron overloads are gone; a hash key rides on the CronExpression instead.
         ITrigger trigger = TriggerBuilder.Create()
-            .WithCronSchedule(CronScheduleBuilder.CronSchedule(new CronExpression("H H * * * ?", "custom-key")))
+            .WithCronSchedule(CronScheduleBuilder.Create(new CronExpression("H H * * * ?", "custom-key")))
             .Build();
 
         trigger.Should().BeAssignableTo<ICronTrigger>();

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -222,9 +222,19 @@ namespace Quartz
     }
     public readonly struct ExecutionGroupLimit : System.IEquatable<Quartz.ExecutionGroupLimit>
     {
-        public ExecutionGroupLimit(string? Group, int? MaxConcurrent) { }
-        public string? Group { get; init; }
+        public ExecutionGroupLimit(Quartz.ExecutionGroupScope Scope, int? MaxConcurrent) { }
         public int? MaxConcurrent { get; init; }
+        public Quartz.ExecutionGroupScope Scope { get; init; }
+    }
+    public readonly struct ExecutionGroupScope : System.IEquatable<Quartz.ExecutionGroupScope>
+    {
+        public bool IsDefault { get; }
+        public bool IsOtherGroups { get; }
+        public string? Name { get; }
+        public static Quartz.ExecutionGroupScope Default { get; }
+        public static Quartz.ExecutionGroupScope OtherGroups { get; }
+        public override string ToString() { }
+        public static Quartz.ExecutionGroupScope Named(string name) { }
     }
     public sealed class ExecutionLimits
     {
@@ -232,7 +242,7 @@ namespace Quartz
         public System.Collections.Generic.IReadOnlyList<Quartz.ExecutionGroupLimit> Groups { get; }
         public bool IsEmpty { get; }
         public Quartz.ExecutionSlots CreateSlots() { }
-        public bool TryGetLimit(string? executionGroup, out int? maxConcurrent) { }
+        public bool TryGetLimit(Quartz.ExecutionGroupScope scope, out int? maxConcurrent) { }
     }
     public sealed class ExecutionLimitsBuilder
     {
@@ -783,6 +793,19 @@ namespace Quartz
         public static bool operator ==(Quartz.Key<T>? left, Quartz.Key<T>? right) { }
         public static bool operator >(Quartz.Key<T> left, Quartz.Key<T> right) { }
         public static bool operator >=(Quartz.Key<T> left, Quartz.Key<T> right) { }
+    }
+    public readonly struct MonthDay : System.IComparable<Quartz.MonthDay>, System.IEquatable<Quartz.MonthDay>
+    {
+        public MonthDay(int month, int day) { }
+        public int Day { get; }
+        public int Month { get; }
+        public int CompareTo(Quartz.MonthDay other) { }
+        public override string ToString() { }
+        public static Quartz.MonthDay From(System.DateOnly date) { }
+        public static bool operator <(Quartz.MonthDay left, Quartz.MonthDay right) { }
+        public static bool operator <=(Quartz.MonthDay left, Quartz.MonthDay right) { }
+        public static bool operator >(Quartz.MonthDay left, Quartz.MonthDay right) { }
+        public static bool operator >=(Quartz.MonthDay left, Quartz.MonthDay right) { }
     }
     public sealed class NameMatcher<TKey> : Quartz.StringMatcher<TKey>
         where TKey : Quartz.Key<TKey>
@@ -2456,8 +2479,8 @@ namespace Quartz.Impl.Calendar
     {
         public AnnualCalendar() { }
         public AnnualCalendar(Quartz.ICalendar baseCalendar) { }
-        public System.Collections.Generic.IReadOnlySet<System.DateOnly> DaysExcluded { get; }
-        public bool AddExcludedDay(System.DateOnly day) { }
+        public System.Collections.Generic.IReadOnlySet<Quartz.MonthDay> DaysExcluded { get; }
+        public bool AddExcludedDay(Quartz.MonthDay day) { }
         public override Quartz.ICalendar Clone() { }
         public bool Equals(Quartz.Impl.Calendar.AnnualCalendar obj) { }
         public override bool Equals(object? obj) { }
@@ -2465,9 +2488,9 @@ namespace Quartz.Impl.Calendar
         public override System.DateTimeOffset GetNextIncludedTimeUtc(System.DateTimeOffset timeStampUtc) { }
         [System.Security.SecurityCritical]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public bool IsDayExcluded(System.DateOnly day) { }
+        public bool IsDayExcluded(Quartz.MonthDay day) { }
         public override bool IsTimeIncluded(System.DateTimeOffset dateUtc) { }
-        public bool RemoveExcludedDay(System.DateOnly day) { }
+        public bool RemoveExcludedDay(Quartz.MonthDay day) { }
     }
     [System.Serializable]
     public class BaseCalendar : Quartz.ICalendar, System.IEquatable<Quartz.Impl.Calendar.BaseCalendar>, System.Runtime.Serialization.ISerializable

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -150,8 +150,8 @@ namespace Quartz
         public Quartz.Extensibility.IMutableTrigger Build() { }
         public Quartz.CronScheduleBuilder InTimeZone(System.TimeZoneInfo? timeZone) { }
         public Quartz.CronScheduleBuilder WithMisfireInstruction(Quartz.CronTriggerMisfireInstruction instruction) { }
-        public static Quartz.CronScheduleBuilder CronSchedule(Quartz.CronExpression cronExpression) { }
-        public static Quartz.CronScheduleBuilder CronSchedule(string cronExpression) { }
+        public static Quartz.CronScheduleBuilder Create(Quartz.CronExpression cronExpression) { }
+        public static Quartz.CronScheduleBuilder Create(string cronExpression) { }
     }
     public enum CronTriggerMisfireInstruction
     {
@@ -203,8 +203,8 @@ namespace Quartz
         public Quartz.DateBuilder InTimeZone(System.TimeZoneInfo? timeZone) { }
         public Quartz.DateBuilder InYear(int year) { }
         public Quartz.DateBuilder OnDay(int day) { }
-        public static Quartz.DateBuilder NewDate(System.TimeProvider? timeProvider = null) { }
-        public static Quartz.DateBuilder NewDateInTimeZone(System.TimeZoneInfo timeZone, System.TimeProvider? timeProvider = null) { }
+        public static Quartz.DateBuilder Create(System.TimeProvider? timeProvider = null) { }
+        public static Quartz.DateBuilder CreateInTimeZone(System.TimeZoneInfo timeZone, System.TimeProvider? timeProvider = null) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface)]
     public sealed class DisallowConcurrentExecutionAttribute : System.Attribute
@@ -236,12 +236,12 @@ namespace Quartz
     }
     public sealed class ExecutionLimitsBuilder
     {
-        public ExecutionLimitsBuilder() { }
         public Quartz.ExecutionLimits Build() { }
         public Quartz.ExecutionLimitsBuilder ForDefaultGroup(int maxConcurrent) { }
         public Quartz.ExecutionLimitsBuilder ForGroup(string group, int maxConcurrent) { }
         public Quartz.ExecutionLimitsBuilder ForOtherGroups(int maxConcurrent) { }
         public Quartz.ExecutionLimitsBuilder Unlimited(string group) { }
+        public static Quartz.ExecutionLimitsBuilder Create() { }
     }
     public sealed class ExecutionSlots
     {
@@ -636,7 +636,6 @@ namespace Quartz
     public static class JobBuilder
     {
         public static Quartz.JobBuilder<Quartz.IJob> Create() { }
-        public static Quartz.JobBuilder<Quartz.IJob> Create([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] System.Type jobType) { }
         public static Quartz.JobBuilder<T> Create<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>()
             where T : Quartz.IJob { }
     }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -81,24 +81,24 @@ namespace Quartz
     public sealed class CronExpression : System.Runtime.Serialization.ISerializable
     {
         public CronExpression(string cronExpression) { }
+        public CronExpression(string cronExpression, System.TimeZoneInfo? timeZone) { }
         public CronExpression(string cronExpression, int hashSeed) { }
         public CronExpression(string cronExpression, string hashKey) { }
         public string CronExpressionString { get; }
-        public System.TimeZoneInfo TimeZone { get; set; }
+        public System.TimeZoneInfo TimeZone { get; }
         public Quartz.CronExpression Clone() { }
         public bool Equals(Quartz.CronExpression other) { }
         public override bool Equals(object? obj) { }
         public string GetExpressionSummary() { }
-        public System.DateTimeOffset? GetFinalFireTime() { }
         public override int GetHashCode() { }
         public System.DateTimeOffset? GetNextInvalidTimeAfter(System.DateTimeOffset date) { }
         public System.DateTimeOffset? GetNextValidTimeAfter(System.DateTimeOffset date) { }
         [System.Security.SecurityCritical]
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public System.DateTimeOffset? GetTimeAfter(System.DateTimeOffset afterTimeUtc) { }
         public System.DateTimeOffset? GetTimeBefore(System.DateTimeOffset endTime) { }
         public bool IsSatisfiedBy(System.DateTimeOffset dateUtc) { }
         public override string ToString() { }
+        public Quartz.CronExpression WithTimeZone(System.TimeZoneInfo? timeZone) { }
         public static bool IsValidExpression(string cronExpression) { }
         public static bool IsValidExpression(string cronExpression, string hashKey) { }
         public static string ResolveHash(string cronExpression, int hashSeed) { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -109,9 +109,6 @@ namespace Quartz
     public sealed class CronExpressionBuilder
     {
         public Quartz.CronExpression Build() { }
-        public Quartz.CronExpressionBuilder OnDayOfWeekIncrements(System.DayOfWeek start, int increment) { }
-        public Quartz.CronExpressionBuilder OnDayOfWeekRange(System.DayOfWeek start, System.DayOfWeek end) { }
-        public Quartz.CronExpressionBuilder OnDaysOfWeek(params System.DayOfWeek[] daysOfWeek) { }
         public Quartz.CronExpressionBuilder OnLastDayOfMonth() { }
         public Quartz.CronExpressionBuilder OnLastDayOfWeek() { }
         public Quartz.CronExpressionBuilder OnLastDayOfWeekOfMonth(System.DayOfWeek dayOfWeek) { }
@@ -122,7 +119,10 @@ namespace Quartz
         public Quartz.CronExpressionBuilder WithDayOfMonth(int day) { }
         public Quartz.CronExpressionBuilder WithDayOfMonthIncrements(int start, int increment) { }
         public Quartz.CronExpressionBuilder WithDayOfMonthRange(int start, int end) { }
+        public Quartz.CronExpressionBuilder WithDayOfWeekIncrements(System.DayOfWeek start, int increment) { }
+        public Quartz.CronExpressionBuilder WithDayOfWeekRange(System.DayOfWeek start, System.DayOfWeek end) { }
         public Quartz.CronExpressionBuilder WithDaysOfMonth(params int[] days) { }
+        public Quartz.CronExpressionBuilder WithDaysOfWeek(params System.DayOfWeek[] daysOfWeek) { }
         public Quartz.CronExpressionBuilder WithHour(int hour) { }
         public Quartz.CronExpressionBuilder WithHourIncrements(int start, int increment) { }
         public Quartz.CronExpressionBuilder WithHourRange(int start, int end) { }
@@ -1250,6 +1250,10 @@ namespace Quartz
         public static TConfigurator WithCalendarIntervalSchedule<TConfigurator>(this TConfigurator configurator, System.Action<Quartz.CalendarIntervalScheduleBuilder>? configure = null)
             where TConfigurator : Quartz.ITriggerConfigurator { }
         public static TConfigurator WithCronSchedule<TConfigurator>(this TConfigurator configurator, Quartz.CronScheduleBuilder schedule)
+            where TConfigurator : Quartz.ITriggerConfigurator { }
+        public static TConfigurator WithCronSchedule<TConfigurator>(this TConfigurator configurator, Quartz.CronExpression cronExpression, System.Action<Quartz.CronScheduleBuilder>? configure = null)
+            where TConfigurator : Quartz.ITriggerConfigurator { }
+        public static TConfigurator WithCronSchedule<TConfigurator>(this TConfigurator configurator, Quartz.CronExpressionBuilder cronExpression, System.Action<Quartz.CronScheduleBuilder>? configure = null)
             where TConfigurator : Quartz.ITriggerConfigurator { }
         public static TConfigurator WithCronSchedule<TConfigurator>(this TConfigurator configurator, string cronExpression, System.Action<Quartz.CronScheduleBuilder>? configure = null)
             where TConfigurator : Quartz.ITriggerConfigurator { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -174,7 +174,7 @@ namespace Quartz
         public Quartz.DailyTimeIntervalScheduleBuilder WithInterval(int interval, Quartz.IntervalUnit unit) { }
         public Quartz.DailyTimeIntervalScheduleBuilder WithMisfireInstruction(Quartz.DailyTimeIntervalTriggerMisfireInstruction instruction) { }
         public Quartz.DailyTimeIntervalScheduleBuilder WithRepeatCount(int repeatCount) { }
-        public static Quartz.DailyTimeIntervalScheduleBuilder Create(System.TimeProvider? timeProvider = null) { }
+        public static Quartz.DailyTimeIntervalScheduleBuilder Create() { }
     }
     public enum DailyTimeIntervalTriggerMisfireInstruction
     {

--- a/src/Quartz/Configuration/ExecutionLimitsParser.cs
+++ b/src/Quartz/Configuration/ExecutionLimitsParser.cs
@@ -14,7 +14,7 @@ internal static class ExecutionLimitsParser
     /// </summary>
     public static ExecutionLimits? Parse(NameValueCollection properties)
     {
-        var builder = new ExecutionLimitsBuilder();
+        var builder = ExecutionLimitsBuilder.Create();
         var prefix = LegacyPropertyKeys.ExecutionLimitPrefix + ".";
         var configured = false;
 

--- a/src/Quartz/Configuration/JsonSchedulingHelper.cs
+++ b/src/Quartz/Configuration/JsonSchedulingHelper.cs
@@ -96,7 +96,7 @@ internal static class JsonSchedulingHelper
             var jobType = typeLoadHelper.LoadType(jobTypeName!)
                 ?? throw new SchedulerConfigException($"JSON job definition '{name}': could not load type '{jobTypeName}'.");
 
-            var builder = JobBuilder.Create(jobType);
+            var builder = JobBuilder.Create().OfType(jobType);
             if (group is not null)
             {
                 builder.WithIdentity(name!, group);
@@ -320,7 +320,7 @@ internal static class JsonSchedulingHelper
         CronScheduleBuilder builder;
         try
         {
-            builder = CronScheduleBuilder.CronSchedule(expression!);
+            builder = CronScheduleBuilder.Create(expression!);
         }
         catch (Exception ex)
         {

--- a/src/Quartz/Configuration/QuartzBuilder.cs
+++ b/src/Quartz/Configuration/QuartzBuilder.cs
@@ -304,7 +304,7 @@ internal sealed class QuartzBuilder : IQuartzBuilder
     {
         ArgumentNullException.ThrowIfNull(configure);
 
-        var builder = new ExecutionLimitsBuilder();
+        var builder = ExecutionLimitsBuilder.Create();
         configure(builder);
         ExecutionLimits limits = builder.Build();
 

--- a/src/Quartz/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/ServiceCollectionExtensions.cs
@@ -410,7 +410,7 @@ public static class ServiceCollectionExtensions
 
         SchedulerContent.Register(builder.Services, builder.SchedulerName, serviceProvider =>
             new SchedulerContent().Add(
-                ConfigureAndBuildJobDetail(serviceProvider, JobBuilder.Create(jobType), configure)));
+                ConfigureAndBuildJobDetail(serviceProvider, JobBuilder.Create().OfType(jobType), configure)));
 
         return builder;
     }

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -211,6 +211,10 @@ namespace Quartz;
 [Serializable]
 public sealed class CronExpression : ISerializable
 {
+    private const string DayOfWeekRangeMessage =
+        "Day-of-Week values must be between 1 and 7, with 1 = Sunday and 7 = Saturday. "
+        + "Unix cron numbers days 0-6 starting at Sunday; use names (SUN, MON, ...) to stay unambiguous.";
+
     private TimeZoneInfo? timeZone;
 
     [NonSerialized] private readonly CronField seconds = [];
@@ -679,7 +683,10 @@ public sealed class CronExpression : ISerializable
 
         if (fieldCount < 6 || fieldCount > 7)
         {
-            throw new FormatException($"Invalid cron expression (expected 6-7 fields): {upperExpression}");
+            string unixHint = fieldCount == 5
+                ? $" A 5-field expression is the Unix/crontab form; Quartz cron puts seconds first - prepend a seconds field: \"0 {upperExpression}\"."
+                : "";
+            throw new FormatException($"Invalid cron expression (expected 6-7 fields, got {fieldCount}): {upperExpression}.{unixHint}");
         }
 
         return result.ToString();
@@ -886,7 +893,17 @@ public sealed class CronExpression : ISerializable
 
             if (exprOn <= CronExpressionConstants.DayOfWeek)
             {
-                Throw.FormatException("Unexpected end of expression.");
+                if (count == 5)
+                {
+                    Throw.FormatException(
+                        $"Cron expression '{expression}' has 5 fields, which is the Unix/crontab form; Quartz cron has 6 or 7 fields with seconds first. "
+                        + $"Prepend a seconds field: \"0 {expression}\". "
+                        + "Note that Quartz numbers days of week 1-7 starting at Sunday where Unix cron uses 0-6, so respell numeric day-of-week values or use names (SUN, MON, ...).");
+                }
+
+                Throw.FormatException(
+                    $"Cron expression '{expression}' has {count} fields, but 6 or 7 are required: "
+                    + "seconds, minutes, hours, day-of-month, month, day-of-week, and optionally year.");
             }
 
             if (exprOn <= CronExpressionConstants.Year)
@@ -1400,7 +1417,7 @@ public sealed class CronExpression : ISerializable
             {
                 if (val is < 1 or > 7)
                 {
-                    Throw.FormatException("Day-of-Week values must be between 1 and 7");
+                    Throw.FormatException(DayOfWeekRangeMessage);
                 }
             }
         }
@@ -1440,7 +1457,7 @@ public sealed class CronExpression : ISerializable
         {
             if (val is < 1 or > 7)
             {
-                Throw.FormatException("Day-of-Week values must be between 1 and 7");
+                Throw.FormatException(DayOfWeekRangeMessage);
             }
 
             lastDayOfWeek = true;
@@ -1514,7 +1531,7 @@ public sealed class CronExpression : ISerializable
             CronExpressionConstants.Month
                 => (1, 12, "Month values must be between 1 and 12"),
             CronExpressionConstants.DayOfWeek
-                => (1, 7, "Day-of-Week values must be between 1 and 7"),
+                => (1, 7, DayOfWeekRangeMessage),
             CronExpressionConstants.Year
                 => (TriggerConstants.EarliestYear, TriggerConstants.YearToGiveUpSchedulingAt, $"Year values must be between {TriggerConstants.EarliestYear} and {TriggerConstants.YearToGiveUpSchedulingAt}"),
             _ => throw new ArgumentOutOfRangeException(nameof(type), "Invalid cron expression type")

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -298,6 +298,17 @@ public sealed class CronExpression : ISerializable
     }
 
     /// <summary>
+    /// Constructs a new <see cref="CronExpression" /> resolved in the given time zone.
+    /// </summary>
+    /// <param name="cronExpression">String representation of the cron expression the new object should represent</param>
+    /// <param name="timeZone">The time zone the expression's times are resolved in;
+    /// <see langword="null" /> means the system's local time zone.</param>
+    public CronExpression(string cronExpression, TimeZoneInfo? timeZone) : this(cronExpression)
+    {
+        this.timeZone = timeZone;
+    }
+
+    /// <summary>
     /// Constructs a new <see cref="CronExpression" /> with H (hash) tokens resolved
     /// using the specified hash key. The hash key is typically the trigger or job name,
     /// producing deterministic but spread-out fire times across different triggers.
@@ -344,7 +355,7 @@ public sealed class CronExpression : ISerializable
         {
             case 0:
                 CronExpressionString = info.GetValue<string>("cronExpressionString")!;
-                TimeZone = info.GetValue<TimeZoneInfo>("timeZone")!;
+                timeZone = info.GetValue<TimeZoneInfo>("timeZone")!;
                 break;
             case 1:
                 CronExpressionString = info.GetValue<string>("cronExpression")!;
@@ -440,13 +451,30 @@ public sealed class CronExpression : ISerializable
     }
 
     /// <summary>
-    /// Sets or gets the time zone for which the <see cref="CronExpression" /> of this
-    /// <see cref="ICronTrigger" /> will be resolved.
+    /// Gets the time zone the expression's times are resolved in. Defaults to the system's local
+    /// time zone.
     /// </summary>
-    public TimeZoneInfo TimeZone
+    /// <remarks>
+    /// A <see cref="CronExpression" /> is immutable; use <see cref="WithTimeZone" /> to get a copy
+    /// resolved in another time zone.
+    /// </remarks>
+    public TimeZoneInfo TimeZone => timeZone ?? TimeZoneInfo.Local;
+
+    /// <summary>
+    /// Returns a copy of this expression resolved in the given time zone.
+    /// </summary>
+    /// <param name="timeZone">The time zone the copy's times are resolved in;
+    /// <see langword="null" /> means the system's local time zone.</param>
+    /// <returns>A new <see cref="CronExpression" /> with the same expression string, or this
+    /// instance when the time zone would not change.</returns>
+    public CronExpression WithTimeZone(TimeZoneInfo? timeZone)
     {
-        set => timeZone = value;
-        get => timeZone ??= TimeZoneInfo.Local;
+        if (Equals(this.timeZone, timeZone))
+        {
+            return this;
+        }
+
+        return new CronExpression(CronExpressionString, timeZone);
     }
 
     /// <summary>
@@ -2354,7 +2382,7 @@ public sealed class CronExpression : ISerializable
     /// </remarks>
     /// <param name="afterTimeUtc">The UTC time to start searching from.</param>
     /// <returns></returns>
-    public DateTimeOffset? GetTimeAfter(DateTimeOffset afterTimeUtc)
+    internal DateTimeOffset? GetTimeAfter(DateTimeOffset afterTimeUtc)
     {
         // move ahead one second, since we're computing the time *after* the
         // given time
@@ -2573,19 +2601,6 @@ public sealed class CronExpression : ISerializable
     }
 
     /// <summary>
-    /// NOT YET IMPLEMENTED: Returns the final time that the
-    /// <see cref="CronExpression" /> will match.
-    /// </summary>
-    /// <returns></returns>
-#pragma warning disable CA1822
-    public DateTimeOffset? GetFinalFireTime()
-#pragma warning restore CA1822
-    {
-        // TODO: implement QUARTZ-423
-        return null;
-    }
-
-    /// <summary>
     /// Gets the last day of month.
     /// </summary>
     private static int GetLastDayOfMonth(int monthNum, int year)
@@ -2608,7 +2623,7 @@ public sealed class CronExpression : ISerializable
     /// </returns>
     public CronExpression Clone()
     {
-        return new CronExpression(CronExpressionString) { TimeZone = TimeZone };
+        return new CronExpression(CronExpressionString, timeZone);
     }
 
     /// <summary>

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -39,16 +39,13 @@ namespace Quartz;
 /// Client code can use the builder to write code such as this:
 /// </para>
 /// <code>
-/// CronExpression expression = CronExpressionBuilder.Create()
-///     .WithSecond(0)
-///     .WithMinuteIncrements(0, 15)
-///     .WithHourRange(8, 17)
-///     .OnWeekdays()
-///     .Build(); // "0 0/15 8-17 ? * MON-FRI"
-///
 /// ITrigger trigger = TriggerBuilder.Create()
 ///     .WithIdentity("myTrigger")
-///     .WithSchedule(CronScheduleBuilder.Create(expression))
+///     .WithCronSchedule(CronExpressionBuilder.Create()
+///         .WithSecond(0)
+///         .WithMinuteIncrements(0, 15)
+///         .WithHourRange(8, 17)
+///         .OnWeekdays()) // "0 0/15 8-17 ? * MON-FRI"
 ///     .Build();
 /// </code>
 /// </remarks>
@@ -367,7 +364,7 @@ public sealed class CronExpressionBuilder
     /// </summary>
     /// <param name="daysOfWeek">the days of the week to fire on</param>
     /// <returns>the updated CronExpressionBuilder</returns>
-    public CronExpressionBuilder OnDaysOfWeek(params DayOfWeek[] daysOfWeek)
+    public CronExpressionBuilder WithDaysOfWeek(params DayOfWeek[] daysOfWeek)
     {
         if (daysOfWeek is null || daysOfWeek.Length == 0)
         {
@@ -391,7 +388,7 @@ public sealed class CronExpressionBuilder
     /// <param name="start">the first day of the range</param>
     /// <param name="end">the last day of the range</param>
     /// <returns>the updated CronExpressionBuilder</returns>
-    public CronExpressionBuilder OnDayOfWeekRange(DayOfWeek start, DayOfWeek end)
+    public CronExpressionBuilder WithDayOfWeekRange(DayOfWeek start, DayOfWeek end)
     {
         return SetDayOfWeek($"{GetDayName(start, nameof(start))}-{GetDayName(end, nameof(end))}");
     }
@@ -411,7 +408,7 @@ public sealed class CronExpressionBuilder
     /// <param name="start">the day of the week to start at</param>
     /// <param name="increment">the number of days between values (1-7)</param>
     /// <returns>the updated CronExpressionBuilder</returns>
-    public CronExpressionBuilder OnDayOfWeekIncrements(DayOfWeek start, int increment)
+    public CronExpressionBuilder WithDayOfWeekIncrements(DayOfWeek start, int increment)
     {
         ValidateIncrement(increment, 7);
         GetDayName(start, nameof(start));

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -48,7 +48,7 @@ namespace Quartz;
 ///
 /// ITrigger trigger = TriggerBuilder.Create()
 ///     .WithIdentity("myTrigger")
-///     .WithSchedule(CronScheduleBuilder.CronSchedule(expression))
+///     .WithSchedule(CronScheduleBuilder.Create(expression))
 ///     .Build();
 /// </code>
 /// </remarks>

--- a/src/Quartz/CronScheduleBuilder.cs
+++ b/src/Quartz/CronScheduleBuilder.cs
@@ -138,8 +138,9 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
 
         CronTriggerImpl ct = new CronTriggerImpl();
 
+        // CronExpression is immutable, so every trigger built here can safely share this instance;
+        // its setter also adopts the expression's time zone as the trigger's.
         ct.CronExpression = cronExpression;
-        ct.TimeZone = cronExpression.TimeZone;
         ct.MisfireInstructionCode = misfireInstruction;
 
         return ct;
@@ -223,8 +224,9 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
     {
         if (cronExpression is not null)
         {
-            // CronExpression falls back to the local time zone when its backing field is null
-            cronExpression.TimeZone = timeZone!;
+            // Rebind rather than mutate: an expression already handed to a built trigger - or the
+            // caller's own instance - must not be retimed behind its back.
+            cronExpression = cronExpression.WithTimeZone(timeZone);
         }
         else
         {
@@ -261,7 +263,7 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
             cronExpression = new CronExpression(deferredHashExpression, hashKey);
             if (deferredTimeZone is not null)
             {
-                cronExpression.TimeZone = deferredTimeZone;
+                cronExpression = cronExpression.WithTimeZone(deferredTimeZone);
             }
         }
     }

--- a/src/Quartz/CronScheduleBuilder.cs
+++ b/src/Quartz/CronScheduleBuilder.cs
@@ -39,7 +39,7 @@ namespace Quartz;
 /// <para>
 /// This is internal because only <see cref="TriggerBuilder{TJob}" /> is in a position to call it.
 /// Callers who want to choose the hash key themselves build the expression directly:
-/// <c>CronScheduleBuilder.CronSchedule(new CronExpression(expression, hashKey))</c>.
+/// <c>CronScheduleBuilder.Create(new CronExpression(expression, hashKey))</c>.
 /// </para>
 /// </remarks>
 internal interface IHashKeyAwareScheduleBuilder
@@ -85,7 +85,7 @@ internal interface IHashKeyAwareScheduleBuilder
 /// <para>
 /// For schedules that are easier to describe than to spell as a cron string, build the expression
 /// with <see cref="CronExpressionBuilder" /> and pass it to
-/// <see cref="CronSchedule(CronExpression)" />.
+/// <see cref="Create(CronExpression)" />.
 /// </para>
 /// </remarks>
 /// <seealso cref="CronExpression" />
@@ -133,7 +133,7 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
             Throw.FormatException(
                 "Cron expression contains H (hash) tokens which require a trigger identity for resolution. "
                 + "Use TriggerBuilder with WithIdentity(), or provide an explicit hash key via "
-                + "CronScheduleBuilder.CronSchedule(new CronExpression(expression, hashKey)).");
+                + "CronScheduleBuilder.Create(new CronExpression(expression, hashKey)).");
         }
 
         CronTriggerImpl ct = new CronTriggerImpl();
@@ -155,7 +155,7 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
     /// <param name="cronExpression">the cron expression to base the schedule on.</param>
     /// <returns>the new CronScheduleBuilder</returns>
     /// <seealso cref="CronExpression" />
-    public static CronScheduleBuilder CronSchedule(string cronExpression)
+    public static CronScheduleBuilder Create(string cronExpression)
     {
         if (cronExpression is null)
         {
@@ -185,7 +185,7 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
     {
         try
         {
-            return CronSchedule(new CronExpression(presumedValidCronExpression));
+            return Create(new CronExpression(presumedValidCronExpression));
         }
         catch (FormatException e)
         {
@@ -200,12 +200,12 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
     /// </summary>
     /// <remarks>
     /// This is also the way to resolve <c>H</c> (hash) tokens against something other than the
-    /// trigger's own key: <c>CronSchedule(new CronExpression(expression, hashKey))</c>.
+    /// trigger's own key: <c>Create(new CronExpression(expression, hashKey))</c>.
     /// </remarks>
     /// <param name="cronExpression">the cron expression to base the schedule on.</param>
     /// <returns>the new CronScheduleBuilder</returns>
     /// <seealso cref="CronExpression" />
-    public static CronScheduleBuilder CronSchedule(CronExpression cronExpression)
+    public static CronScheduleBuilder Create(CronExpression cronExpression)
     {
         return new CronScheduleBuilder(cronExpression);
     }

--- a/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
+++ b/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
@@ -26,6 +26,26 @@ using Quartz.Util;
 namespace Quartz;
 
 /// <summary>
+/// Lets <see cref="TriggerBuilder{TJob}" /> hand a schedule builder its clock before it builds, so
+/// that schedule computation deferred to <see cref="IScheduleBuilder.Build" /> runs against the same
+/// <see cref="TimeProvider" /> the trigger builder carries.
+/// </summary>
+/// <remarks>
+/// This is the sibling of <see cref="IHashKeyAwareScheduleBuilder" />: both exist because a schedule
+/// builder learns some inputs only from the trigger builder that finally builds it. A schedule
+/// builder whose <see cref="IScheduleBuilder.Build" /> is called directly falls back to
+/// <see cref="TimeProvider.System" />.
+/// </remarks>
+internal interface ITimeProviderAwareScheduleBuilder
+{
+    /// <summary>
+    /// Hand the builder the clock to compute against. Called by
+    /// <see cref="TriggerBuilder{TJob}.Build" /> before <see cref="IScheduleBuilder.Build" />.
+    /// </summary>
+    void SetTimeProvider(TimeProvider timeProvider);
+}
+
+/// <summary>
 /// A <see cref="IScheduleBuilder"/> implementation that build schedule for DailyTimeIntervalTrigger.
 /// </summary>
 /// <remarks>
@@ -67,15 +87,16 @@ namespace Quartz;
 /// <author>James House</author>
 /// <author>Zemian Deng saltnlight5@gmail.com</author>
 /// <author>Nuno Maia (.NET)</author>
-public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
+public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder, ITimeProviderAwareScheduleBuilder
 {
-    private readonly TimeProvider timeProvider;
+    private TimeProvider timeProvider = TimeProvider.System;
 
     private int interval = 1;
     private IntervalUnit intervalUnit = IntervalUnit.Minute;
     private HashSet<DayOfWeek>? daysOfWeek;
     private TimeOnly? startTimeOfDay;
     private TimeOnly? endTimeOfDay;
+    private int? endingDailyAfterCount;
     private int repeatCount = DailyTimeIntervalTriggerImpl.RepeatIndefinitely;
     private TimeZoneInfo? timeZone;
 
@@ -118,19 +139,27 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
         DayOfWeek.Saturday
     };
 
-    private DailyTimeIntervalScheduleBuilder(TimeProvider timeProvider)
+    private DailyTimeIntervalScheduleBuilder()
     {
-        this.timeProvider = timeProvider;
     }
 
     /// <summary>
     /// Create a DailyTimeIntervalScheduleBuilder
     /// </summary>
-    /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
+    /// <remarks>
+    /// The clock <see cref="EndingDailyAfterCount" /> computes against comes from the
+    /// <see cref="TriggerBuilder{TJob}" /> that builds the trigger, so a scheduler configured with a
+    /// custom <see cref="TimeProvider" /> is honored without handing one to this builder.
+    /// </remarks>
     /// <returns>The new DailyTimeIntervalScheduleBuilder</returns>
-    public static DailyTimeIntervalScheduleBuilder Create(TimeProvider? timeProvider = null)
+    public static DailyTimeIntervalScheduleBuilder Create()
     {
-        return new DailyTimeIntervalScheduleBuilder(timeProvider ?? TimeProvider.System);
+        return new DailyTimeIntervalScheduleBuilder();
+    }
+
+    void ITimeProviderAwareScheduleBuilder.SetTimeProvider(TimeProvider timeProvider)
+    {
+        this.timeProvider = timeProvider;
     }
 
     /// <summary>
@@ -141,6 +170,15 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
     /// <returns></returns>
     public IMutableTrigger Build()
     {
+        // Deferred from EndingDailyAfterCount so the computation runs against the trigger
+        // builder's clock and the schedule's final start time, interval and time zone. Computed
+        // into a local so the builder stays reusable: a later Build() recomputes.
+        TimeOnly? effectiveEndTimeOfDay = endTimeOfDay;
+        if (endingDailyAfterCount.HasValue)
+        {
+            effectiveEndTimeOfDay = ComputeEndTimeOfDayFromCount(endingDailyAfterCount.Value);
+        }
+
         DailyTimeIntervalTriggerImpl st = new DailyTimeIntervalTriggerImpl();
         st.RepeatInterval = interval;
         st.RepeatIntervalUnit = intervalUnit;
@@ -157,7 +195,7 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
             st.DaysOfWeek = new HashSet<DayOfWeek>(AllDaysOfTheWeek);
         }
 
-        st.EndTimeOfDay = endTimeOfDay ?? DailyTimeIntervalTriggerImpl.DefaultEndTimeOfDay;
+        st.EndTimeOfDay = effectiveEndTimeOfDay ?? DailyTimeIntervalTriggerImpl.DefaultEndTimeOfDay;
         st.StartTimeOfDay = startTimeOfDay ?? DailyTimeIntervalTriggerImpl.DefaultStartTimeOfDay;
 
         return st;
@@ -269,14 +307,22 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
     {
         TimeOnlyExtensions.ValidateWholeSeconds(timeOfDay, nameof(timeOfDay));
         endTimeOfDay = timeOfDay;
+        endingDailyAfterCount = null;
         return this;
     }
 
     /// <summary>
-    /// Calculate and set the EndTimeOfDay using count, interval and StarTimeOfDay. This means
-    /// that these must be set before this method is call.
+    /// End the daily window after the given number of firings: the EndTimeOfDay is calculated from
+    /// the count, the interval and the StartTimeOfDay.
     /// </summary>
-    /// <param name="count"></param>
+    /// <remarks>
+    /// The calculation is deferred to <see cref="Build" />, so it sees the schedule's final start
+    /// time, interval and time zone regardless of the order the builder was configured in, and it
+    /// runs against the clock of the <see cref="TriggerBuilder{TJob}" /> that builds the trigger.
+    /// A count too large for the daily window is therefore reported by <see cref="Build" />, not by
+    /// this call.
+    /// </remarks>
+    /// <param name="count">the number of firings per day (&gt;= 1).</param>
     /// <returns>the updated DailyTimeIntervalScheduleBuilder</returns>
     public DailyTimeIntervalScheduleBuilder EndingDailyAfterCount(int count)
     {
@@ -285,9 +331,20 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
             Throw.ArgumentException("Ending daily after count must be a positive number!");
         }
 
+        endingDailyAfterCount = count;
+        endTimeOfDay = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Resolves <see cref="EndingDailyAfterCount" /> into a concrete end time of day, against the
+    /// builder's clock and the schedule as finally configured.
+    /// </summary>
+    private TimeOnly ComputeEndTimeOfDayFromCount(int count)
+    {
         if (startTimeOfDay is null)
         {
-            Throw.ArgumentException("You must set the StartDailyAt() before calling this EndingDailyAfterCount()!");
+            Throw.ArgumentException("You must set the StartingDailyAt() when using EndingDailyAfterCount()!");
         }
 
         DateTimeOffset today = timeProvider.GetUtcNow();
@@ -316,7 +373,7 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
         else
         {
             Throw.ArgumentException("The IntervalUnit: " + intervalUnit + " is invalid for this trigger.");
-            return this;
+            return default;
         }
 
         if (remainingMillisInDay < intervalInMillis)
@@ -338,10 +395,9 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder
             Throw.ArgumentException("The given count " + count + " is too large! The max you can set is " + maxNumOfCount);
         }
 
-        DateTime date = timeProvider.GetUtcNow().Date;
+        DateTime date = today.Date;
         date = date.Add(endTimeOfDayDate.TimeOfDay);
-        endTimeOfDay = new TimeOnly(date.Hour, date.Minute, date.Second);
-        return this;
+        return new TimeOnly(date.Hour, date.Minute, date.Second);
     }
 
     /// <summary>

--- a/src/Quartz/DateBuilder.cs
+++ b/src/Quartz/DateBuilder.cs
@@ -46,7 +46,7 @@ namespace Quartz;
 ///     .WithSimpleSchedule(x => x
 ///         .WithInterval(TimeSpan.FromHours(1))
 ///         .RepeatForever())
-///     .StartAt(DateBuilder.NewDate().AtHourMinuteAndSecond(10, 0, 0).Build())
+///     .StartAt(DateBuilder.Create().AtHourMinuteAndSecond(10, 0, 0).Build())
 ///     .Build();
 /// await scheduler.ScheduleJob(job, trigger);
 /// </code>
@@ -91,20 +91,26 @@ public sealed class DateBuilder
     /// <summary>
     /// Create a DateBuilder, with initial settings for the current date and time in the system default timezone.
     /// </summary>
-    /// <param name="timeProvider"></param>
-    /// <returns></returns>
-    public static DateBuilder NewDate(TimeProvider? timeProvider = null)
+    /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
+    /// <returns>the new DateBuilder</returns>
+    public static DateBuilder Create(TimeProvider? timeProvider = null)
     {
         return new DateBuilder(timeProvider ?? TimeProvider.System);
     }
 
     /// <summary>
-    /// Create a DateBuilder, with initial settings for the current date and time in the given timezone.
+    /// Create a DateBuilder seeded with the machine's current local date and time, whose result is
+    /// built in the given time zone.
     /// </summary>
+    /// <remarks>
+    /// The seed values come from the clock's local time, not from the given zone's wall clock; the
+    /// zone decides the offset the built <see cref="DateTimeOffset" /> carries. Set the fields that
+    /// matter explicitly rather than relying on the seed.
+    /// </remarks>
     /// <param name="timeZone">Time zone to use.</param>
-    /// <param name="timeProvider"></param>
-    /// <returns></returns>
-    public static DateBuilder NewDateInTimeZone(TimeZoneInfo timeZone, TimeProvider? timeProvider = null)
+    /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
+    /// <returns>the new DateBuilder</returns>
+    public static DateBuilder CreateInTimeZone(TimeZoneInfo timeZone, TimeProvider? timeProvider = null)
     {
         return new DateBuilder(timeProvider ?? TimeProvider.System, timeZone);
     }

--- a/src/Quartz/ExecutionLimits.cs
+++ b/src/Quartz/ExecutionLimits.cs
@@ -49,8 +49,9 @@ public sealed class ExecutionLimits
     /// <summary>
     /// The key used internally to represent triggers that have no execution group
     /// (<see cref="ITrigger.ExecutionGroup"/> is <see langword="null"/>). It is never a group name a
-    /// caller can use: <see cref="ExecutionGroupLimit.Group"/> reports the default group as
-    /// <see langword="null"/>, and <see cref="ExecutionLimitsBuilder.ForDefaultGroup"/> configures it.
+    /// caller can use: <see cref="ExecutionGroupLimit.Scope"/> reports the default group as
+    /// <see cref="ExecutionGroupScope.Default"/>, and
+    /// <see cref="ExecutionLimitsBuilder.ForDefaultGroup"/> configures it.
     /// </summary>
     internal const string DefaultGroupKey = "";
 
@@ -85,17 +86,19 @@ public sealed class ExecutionLimits
     public IReadOnlyList<ExecutionGroupLimit> Groups => groups ??= Materialize();
 
     /// <summary>
-    /// Reads the limit configured for one execution group.
+    /// Reads the limit configured for one scope.
     /// </summary>
-    /// <param name="executionGroup">The group name, <see langword="null"/> for triggers that have no
-    /// execution group, or <see cref="OtherGroups"/> for the catch-all.</param>
-    /// <param name="maxConcurrent">The limit: a positive count, <c>0</c> when the group is forbidden,
+    /// <param name="scope">The scope to read: <see cref="ExecutionGroupScope.Default"/>,
+    /// <see cref="ExecutionGroupScope.OtherGroups"/>, or a named group via
+    /// <see cref="ExecutionGroupScope.Named"/>.</param>
+    /// <param name="maxConcurrent">The limit: a positive count, <c>0</c> when the scope is forbidden,
     /// or <see langword="null"/> when it is explicitly unlimited.</param>
-    /// <returns><see langword="true"/> when the group has a limit of its own. <see langword="false"/>
-    /// does not mean unlimited — <see cref="OtherGroups"/> may still apply to a named group.</returns>
-    public bool TryGetLimit(string? executionGroup, out int? maxConcurrent)
+    /// <returns><see langword="true"/> when the scope has a limit of its own. <see langword="false"/>
+    /// does not mean unlimited — <see cref="ExecutionGroupScope.OtherGroups"/> may still apply to a
+    /// named group.</returns>
+    public bool TryGetLimit(ExecutionGroupScope scope, out int? maxConcurrent)
     {
-        return limits.TryGetValue(NormalizeGroupKey(executionGroup), out maxConcurrent);
+        return limits.TryGetValue(scope.StorageKey, out maxConcurrent);
     }
 
     private ExecutionGroupLimit[] Materialize()
@@ -104,7 +107,7 @@ public sealed class ExecutionLimits
         int i = 0;
         foreach (KeyValuePair<string, int?> pair in limits)
         {
-            result[i++] = new ExecutionGroupLimit(pair.Key == DefaultGroupKey ? null : pair.Key, pair.Value);
+            result[i++] = new ExecutionGroupLimit(ExecutionGroupScope.FromStorageKey(pair.Key), pair.Value);
         }
         return result;
     }
@@ -156,10 +159,135 @@ public sealed class ExecutionLimits
 }
 
 /// <summary>
-/// One execution group's entry in an <see cref="ExecutionLimits"/> snapshot.
+/// One entry in an <see cref="ExecutionLimits"/> snapshot.
 /// </summary>
-/// <param name="Group">The execution group, <see langword="null"/> for triggers that have no
-/// execution group, or <see cref="ExecutionLimits.OtherGroups"/> for the catch-all.</param>
-/// <param name="MaxConcurrent">The limit: a positive count, <c>0</c> when the group is forbidden on
+/// <param name="Scope">Which bucket the limit applies to: the default (ungrouped) bucket, the
+/// catch-all for other groups, or one named group.</param>
+/// <param name="MaxConcurrent">The limit: a positive count, <c>0</c> when the scope is forbidden on
 /// this node, or <see langword="null"/> when it is explicitly unlimited.</param>
-public readonly record struct ExecutionGroupLimit(string? Group, int? MaxConcurrent);
+public readonly record struct ExecutionGroupLimit(ExecutionGroupScope Scope, int? MaxConcurrent);
+
+/// <summary>
+/// Which bucket an execution limit applies to: the default (ungrouped) bucket, the catch-all for
+/// groups not explicitly configured, or one named group.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the read-side shape of what <see cref="ExecutionLimitsBuilder"/> writes:
+/// <see cref="ExecutionLimitsBuilder.ForDefaultGroup"/> configures <see cref="Default"/>,
+/// <see cref="ExecutionLimitsBuilder.ForOtherGroups"/> configures <see cref="OtherGroups"/>, and
+/// <see cref="ExecutionLimitsBuilder.ForGroup"/> / <see cref="ExecutionLimitsBuilder.Unlimited"/>
+/// configure <see cref="Named"/> scopes. Configuration keys keep their own spellings (<c>_</c> or
+/// <c>null</c> for the default bucket, <c>*</c> for the catch-all); this type exists so code reading
+/// limits back never has to know them.
+/// </para>
+/// <para>
+/// Modeled on <see cref="PreferredNode"/>, the other place a closed set of cases refuses to be a
+/// nullable string with a sentinel.
+/// </para>
+/// </remarks>
+public readonly record struct ExecutionGroupScope
+{
+    // The key the limits dictionary holds: "" or null for the default bucket, "*" for the
+    // catch-all, otherwise the group name. Keeping storage's own shape makes reading a limit a
+    // plain dictionary hit.
+    private readonly string? name;
+
+    private ExecutionGroupScope(string? name)
+    {
+        this.name = name;
+    }
+
+    /// <summary>
+    /// The bucket for triggers that have no execution group
+    /// (<see cref="ITrigger.ExecutionGroup"/> is <see langword="null"/>). The default value of
+    /// this type.
+    /// </summary>
+    public static ExecutionGroupScope Default => default;
+
+    /// <summary>
+    /// The catch-all applied to any named group not explicitly configured. It never applies to
+    /// ungrouped triggers — those always read <see cref="Default"/>.
+    /// </summary>
+    public static ExecutionGroupScope OtherGroups => new(ExecutionLimits.OtherGroups);
+
+    /// <summary>
+    /// The scope of one named execution group.
+    /// </summary>
+    /// <param name="name">The execution group name.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is blank or one of the names
+    /// reserved by limits configuration. Use <see cref="Default"/> for ungrouped triggers and
+    /// <see cref="OtherGroups"/> for the catch-all.</exception>
+    public static ExecutionGroupScope Named(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        string trimmed = name.Trim();
+
+        if (trimmed.Length == 0)
+        {
+            Throw.ArgumentException("An execution group scope needs a group name; use ExecutionGroupScope.Default for triggers that have none.", nameof(name));
+        }
+
+        if (ExecutionLimits.IsReservedGroupName(trimmed))
+        {
+            Throw.ArgumentException($"Group name '{trimmed}' is reserved. Use ExecutionGroupScope.Default for the default bucket or ExecutionGroupScope.OtherGroups for the catch-all.", nameof(name));
+        }
+
+        return new ExecutionGroupScope(trimmed);
+    }
+
+    /// <summary>
+    /// Whether this is the bucket for triggers that have no execution group.
+    /// </summary>
+    public bool IsDefault => string.IsNullOrEmpty(name);
+
+    /// <summary>
+    /// Whether this is the catch-all for named groups not explicitly configured.
+    /// </summary>
+    public bool IsOtherGroups => name == ExecutionLimits.OtherGroups;
+
+    /// <summary>
+    /// The group name of a <see cref="Named"/> scope; <see langword="null"/> for
+    /// <see cref="Default"/> and <see cref="OtherGroups"/>.
+    /// </summary>
+    public string? Name => IsDefault || IsOtherGroups ? null : name;
+
+    /// <summary>
+    /// The key the limits dictionary holds for this scope.
+    /// </summary>
+    internal string StorageKey => name ?? ExecutionLimits.DefaultGroupKey;
+
+    /// <summary>
+    /// Rebuilds the scope from a limits-dictionary key.
+    /// </summary>
+    internal static ExecutionGroupScope FromStorageKey(string key)
+    {
+        return key == ExecutionLimits.DefaultGroupKey ? default : new ExecutionGroupScope(key);
+    }
+
+    /// <summary>
+    /// The spelling configuration and the HTTP API use for this scope: the group name, <c>*</c> for
+    /// the catch-all, and <c>_</c> for the default bucket (a property or JSON key cannot be empty).
+    /// </summary>
+    internal string ToConfigurationKey()
+    {
+        return IsDefault ? ExecutionLimits.DefaultGroupAlias : name!;
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        if (IsDefault)
+        {
+            return "default";
+        }
+
+        if (IsOtherGroups)
+        {
+            return "other groups";
+        }
+
+        return name!;
+    }
+}

--- a/src/Quartz/ExecutionLimitsBuilder.cs
+++ b/src/Quartz/ExecutionLimitsBuilder.cs
@@ -37,7 +37,7 @@ namespace Quartz;
 /// </remarks>
 /// <example>
 /// <code>
-/// ExecutionLimits limits = new ExecutionLimitsBuilder()
+/// ExecutionLimits limits = ExecutionLimitsBuilder.Create()
 ///     .ForGroup("high-cpu", 2)
 ///     .ForOtherGroups(5)
 ///     .Build();
@@ -46,6 +46,19 @@ namespace Quartz;
 public sealed class ExecutionLimitsBuilder
 {
     private readonly Dictionary<string, int?> limits = new(StringComparer.Ordinal);
+
+    internal ExecutionLimitsBuilder()
+    {
+    }
+
+    /// <summary>
+    /// Create an ExecutionLimitsBuilder with no limits configured.
+    /// </summary>
+    /// <returns>the new ExecutionLimitsBuilder</returns>
+    public static ExecutionLimitsBuilder Create()
+    {
+        return new ExecutionLimitsBuilder();
+    }
 
     /// <summary>
     /// Set the concurrency limit for a named execution group.

--- a/src/Quartz/Impl/AdoJobStore/CronTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/CronTriggerPersistenceDelegate.cs
@@ -130,7 +130,7 @@ public sealed class CronTriggerPersistenceDelegate : ITriggerPersistenceDelegate
         var cronExpr = rs.GetString(AdoConstants.ColumnCronExpression)!;
         var timeZoneId = rs.GetString(AdoConstants.ColumnTimeZoneId);
 
-        CronScheduleBuilder cb = CronScheduleBuilder.CronSchedule(cronExpr);
+        CronScheduleBuilder cb = CronScheduleBuilder.Create(cronExpr);
 
         if (timeZoneId is not null)
         {

--- a/src/Quartz/Impl/Calendar/AnnualCalendar.cs
+++ b/src/Quartz/Impl/Calendar/AnnualCalendar.cs
@@ -37,9 +37,10 @@ namespace Quartz.Impl.Calendar;
 [Serializable]
 public sealed class AnnualCalendar : BaseCalendar
 {
-    private SortedSet<DateOnly> excludeDays = new SortedSet<DateOnly>();
+    private SortedSet<MonthDay> excludeDays = new SortedSet<MonthDay>();
 
-    // year to use as fixed year
+    // the year serialized payloads pin their date-shaped values to; a leap year so that
+    // February 29th survives the round-trip
     private const int FixedYear = 2000;
 
     /// <summary>
@@ -85,7 +86,7 @@ public sealed class AnnualCalendar : BaseCalendar
                     foreach (DateTime dateTime in oldFormat)
 #pragma warning restore 8605
                     {
-                        excludeDays.Add(Normalize(DateOnly.FromDateTime(dateTime)));
+                        excludeDays.Add(new MonthDay(dateTime.Month, dateTime.Day));
                     }
                 }
                 else
@@ -93,7 +94,7 @@ public sealed class AnnualCalendar : BaseCalendar
                     // must be new..
                     foreach (var offset in (List<DateTimeOffset>) o)
                     {
-                        excludeDays.Add(Normalize(DateOnly.FromDateTime(offset.Date)));
+                        excludeDays.Add(new MonthDay(offset.Month, offset.Day));
                     }
                 }
                 break;
@@ -101,14 +102,14 @@ public sealed class AnnualCalendar : BaseCalendar
                 var dateTimeOffsets = (List<DateTimeOffset>) info.GetValue("excludeDays", typeof(List<DateTimeOffset>))!;
                 foreach (var offset in dateTimeOffsets)
                 {
-                    excludeDays.Add(Normalize(DateOnly.FromDateTime(offset.Date)));
+                    excludeDays.Add(new MonthDay(offset.Month, offset.Day));
                 }
                 break;
             case 2:
                 var dateTimes = (SortedSet<DateTime>) info.GetValue("excludeDays", typeof(SortedSet<DateTime>))!;
                 foreach (var dateTime in dateTimes)
                 {
-                    excludeDays.Add(Normalize(DateOnly.FromDateTime(dateTime)));
+                    excludeDays.Add(new MonthDay(dateTime.Month, dateTime.Day));
                 }
                 break;
             default:
@@ -122,49 +123,42 @@ public sealed class AnnualCalendar : BaseCalendar
     {
         base.GetObjectData(info, context);
 
-        // Keep writing the version 2 layout - a sorted set of DateTime - so a payload written here
-        // stays readable by the versions that only know that shape.
+        // Keep writing the version 2 layout - a sorted set of DateTime pinned to the fixed year -
+        // so a payload written here stays readable by the versions that only know that shape.
         info.AddValue("version", 2);
-        info.AddValue("excludeDays", new SortedSet<DateTime>(excludeDays.Select(d => d.ToDateTime(TimeOnly.MinValue))));
+        info.AddValue("excludeDays", new SortedSet<DateTime>(excludeDays.Select(d => new DateTime(FixedYear, d.Month, d.Day))));
     }
 
     /// <summary>
-    /// The days excluded by this calendar.
+    /// The days excluded by this calendar, every year.
     /// </summary>
-    /// <remarks>
-    /// Only the month and the day of a value are significant - the calendar excludes the same
-    /// date every year - so the days come back normalized onto a single fixed year.
-    /// </remarks>
-    public IReadOnlySet<DateOnly> DaysExcluded => excludeDays;
+    public IReadOnlySet<MonthDay> DaysExcluded => excludeDays;
 
     /// <summary>
-    /// Excludes the given day of every year. Only the month and the day are significant.
+    /// Excludes the given day of every year.
     /// </summary>
     /// <returns><see langword="true" /> if the day was not already excluded.</returns>
-    public bool AddExcludedDay(DateOnly day)
+    public bool AddExcludedDay(MonthDay day)
     {
-        return excludeDays.Add(Normalize(day));
+        return excludeDays.Add(day);
     }
 
     /// <summary>
-    /// Stops excluding the given day. Only the month and the day are significant.
+    /// Stops excluding the given day.
     /// </summary>
     /// <returns><see langword="true" /> if the day was excluded.</returns>
-    public bool RemoveExcludedDay(DateOnly day)
+    public bool RemoveExcludedDay(MonthDay day)
     {
-        return excludeDays.Remove(Normalize(day));
+        return excludeDays.Remove(day);
     }
 
     /// <summary>
-    /// Returns <see langword="true" /> if the given day is excluded by this calendar. Only the
-    /// month and the day are significant.
+    /// Returns <see langword="true" /> if the given day is excluded by this calendar.
     /// </summary>
-    public bool IsDayExcluded(DateOnly day)
+    public bool IsDayExcluded(MonthDay day)
     {
-        return excludeDays.Contains(Normalize(day));
+        return excludeDays.Contains(day);
     }
-
-    private static DateOnly Normalize(DateOnly day) => new DateOnly(FixedYear, day.Month, day.Day);
 
     private bool IsDateTimeExcluded(DateTimeOffset day, bool checkBaseCalendar)
     {
@@ -174,7 +168,7 @@ public sealed class AnnualCalendar : BaseCalendar
             return true;
         }
 
-        return excludeDays.Contains(new DateOnly(FixedYear, day.Month, day.Day));
+        return excludeDays.Contains(new MonthDay(day.Month, day.Day));
     }
 
     /// <summary>
@@ -273,7 +267,7 @@ public sealed class AnnualCalendar : BaseCalendar
     {
         var clone = new AnnualCalendar();
         CloneFields(clone);
-        clone.excludeDays = new SortedSet<DateOnly>(excludeDays);
+        clone.excludeDays = new SortedSet<MonthDay>(excludeDays);
         return clone;
     }
 }

--- a/src/Quartz/Impl/Calendar/CronCalendar.cs
+++ b/src/Quartz/Impl/Calendar/CronCalendar.cs
@@ -132,7 +132,8 @@ public sealed class CronCalendar : BaseCalendar
     public override TimeZoneInfo TimeZone
     {
         get => cronExpression.TimeZone;
-        set => cronExpression.TimeZone = value;
+        // CronExpression is immutable, so changing the calendar's zone rebuilds its expression
+        set => cronExpression = cronExpression.WithTimeZone(value);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -609,7 +609,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
 
     public override IScheduleBuilder GetScheduleBuilder()
     {
-        CronScheduleBuilder cb = CronScheduleBuilder.CronSchedule(CronExpressionString!).InTimeZone(TimeZone);
+        CronScheduleBuilder cb = CronScheduleBuilder.Create(CronExpressionString!).InTimeZone(TimeZone);
 
         CronTriggerMisfireInstruction instruction = MisfireInstruction;
         if (Enum.IsDefined(instruction))

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -449,8 +449,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         set
         {
             TimeZoneInfo originalTimeZone = TimeZone;
-            cronEx = new CronExpression(value!);
-            cronEx.TimeZone = originalTimeZone;
+            cronEx = new CronExpression(value!, originalTimeZone);
         }
         get => cronEx?.CronExpressionString;
     }
@@ -565,7 +564,9 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         {
             if (cronEx is not null)
             {
-                cronEx.TimeZone = value;
+                // CronExpression is immutable and may be shared with other triggers built from the
+                // same schedule builder, so retiming this trigger means rebuilding its own copy.
+                cronEx = cronEx.WithTimeZone(value);
             }
             timeZone = value;
         }
@@ -637,16 +638,13 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     {
         get
         {
-            DateTimeOffset? resultTime;
-            if (EndTimeUtc.HasValue)
+            if (!EndTimeUtc.HasValue)
             {
-                resultTime = GetTimeBefore(EndTimeUtc.Value.AddSeconds(1));
-            }
-            else
-            {
-                resultTime = cronEx?.GetFinalFireTime();
+                // a cron schedule without an end bound has no final fire time
+                return null;
             }
 
+            DateTimeOffset? resultTime = GetTimeBefore(EndTimeUtc.Value.AddSeconds(1));
             if (resultTime.HasValue && resultTime.Value < StartTimeUtc)
             {
                 return null;

--- a/src/Quartz/JobBuilder.cs
+++ b/src/Quartz/JobBuilder.cs
@@ -77,18 +77,6 @@ public static class JobBuilder
     }
 
     /// <summary>
-    /// Create a JobBuilder with which to define a <see cref="IJobDetail" />,
-    /// and set the class name of the job to be executed.
-    /// </summary>
-    /// <returns>a new JobBuilder</returns>
-    public static JobBuilder<IJob> Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] Type jobType)
-    {
-        var b = new JobBuilder<IJob>();
-        b.OfType(jobType);
-        return b;
-    }
-
-    /// <summary>
     /// Create a JobBuilder for a known job type, with which to define a <see cref="IJobDetail" />.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/MonthDay.cs
+++ b/src/Quartz/MonthDay.cs
@@ -1,0 +1,120 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Runtime.InteropServices;
+
+namespace Quartz;
+
+/// <summary>
+/// A day of the year with no year attached — "December 25th", every year.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the value <see cref="Quartz.Impl.Calendar.AnnualCalendar" /> excludes: the same date
+/// every year. A <see cref="DateOnly" /> always carries a year, so a set of them either lies about
+/// the year or fails its own membership test; this type says exactly what is stored.
+/// </para>
+/// <para>
+/// February 29th is a valid value — in years without one, no day matches it.
+/// </para>
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct MonthDay : IComparable<MonthDay>
+{
+    // Validation and ordering use a leap year so February 29th is representable; the value itself
+    // carries no year.
+    private const int LeapYear = 2000;
+
+    /// <summary>
+    /// Initializes a new <see cref="MonthDay" />.
+    /// </summary>
+    /// <param name="month">The month (1-12).</param>
+    /// <param name="day">The day of the month (1 through the month's length; February counts 29).</param>
+    /// <exception cref="ArgumentOutOfRangeException">The pair is not a valid day of any year.</exception>
+    public MonthDay(int month, int day)
+    {
+        if (month is < 1 or > 12)
+        {
+            throw new ArgumentOutOfRangeException(nameof(month), month, "Month must be between 1 and 12.");
+        }
+
+        if (day < 1 || day > DateTime.DaysInMonth(LeapYear, month))
+        {
+            throw new ArgumentOutOfRangeException(nameof(day), day, $"Day must be between 1 and {DateTime.DaysInMonth(LeapYear, month)} for month {month}.");
+        }
+
+        Month = month;
+        Day = day;
+    }
+
+    /// <summary>
+    /// The month (1-12).
+    /// </summary>
+    public int Month { get; }
+
+    /// <summary>
+    /// The day of the month (1-31).
+    /// </summary>
+    public int Day { get; }
+
+    /// <summary>
+    /// The month and day of the given date, with its year dropped.
+    /// </summary>
+    public static MonthDay From(DateOnly date)
+    {
+        return new MonthDay(date.Month, date.Day);
+    }
+
+    /// <summary>
+    /// The value as a <see cref="DateOnly" /> pinned to a fixed leap year, which is the date-shaped
+    /// form serialized payloads carry.
+    /// </summary>
+    internal DateOnly ToDateOnly()
+    {
+        return new DateOnly(LeapYear, Month, Day);
+    }
+
+    /// <inheritdoc />
+    public int CompareTo(MonthDay other)
+    {
+        int byMonth = Month.CompareTo(other.Month);
+        return byMonth != 0 ? byMonth : Day.CompareTo(other.Day);
+    }
+
+    /// <summary>Compares two values in calendar order.</summary>
+    public static bool operator <(MonthDay left, MonthDay right) => left.CompareTo(right) < 0;
+
+    /// <summary>Compares two values in calendar order.</summary>
+    public static bool operator <=(MonthDay left, MonthDay right) => left.CompareTo(right) <= 0;
+
+    /// <summary>Compares two values in calendar order.</summary>
+    public static bool operator >(MonthDay left, MonthDay right) => left.CompareTo(right) > 0;
+
+    /// <summary>Compares two values in calendar order.</summary>
+    public static bool operator >=(MonthDay left, MonthDay right) => left.CompareTo(right) >= 0;
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        // ISO 8601 spells a recurring month-day "--MM-DD"
+        return $"--{Month:00}-{Day:00}";
+    }
+}

--- a/src/Quartz/Serialization/SystemTextJson/Calendars/AnnualCalendarSerializer.cs
+++ b/src/Quartz/Serialization/SystemTextJson/Calendars/AnnualCalendarSerializer.cs
@@ -15,7 +15,8 @@ internal sealed class AnnualCalendarSerializer : CalendarSerializer<AnnualCalend
 
     protected override void SerializeFields(Utf8JsonWriter writer, AnnualCalendar calendar, JsonSerializerOptions options)
     {
-        writer.WriteDateOnlyArray(options.GetPropertyName("ExcludedDays"), calendar.DaysExcluded);
+        // The payload keeps its date shape: each MonthDay is written pinned to the fixed year.
+        writer.WriteDateOnlyArray(options.GetPropertyName("ExcludedDays"), calendar.DaysExcluded.Select(static day => day.ToDateOnly()));
     }
 
     protected override void DeserializeFields(AnnualCalendar calendar, JsonElement jsonElement, JsonSerializerOptions options)
@@ -24,7 +25,7 @@ internal sealed class AnnualCalendarSerializer : CalendarSerializer<AnnualCalend
         var excludedDays = jsonElement.GetProperty(options.GetPropertyName("ExcludedDays")).GetDateOnlyArray();
         foreach (var day in excludedDays)
         {
-            calendar.AddExcludedDay(day);
+            calendar.AddExcludedDay(MonthDay.From(day));
         }
     }
 }

--- a/src/Quartz/Serialization/SystemTextJson/Converters/CronExpressionConverter.cs
+++ b/src/Quartz/Serialization/SystemTextJson/Converters/CronExpressionConverter.cs
@@ -24,12 +24,8 @@ internal sealed class CronExpressionConverter : JsonConverter<CronExpression>
 
         var cronExpressionString = rootElement.GetProperty(options.GetPropertyName("CronExpression")).GetString()!;
 
-        var cronExpression = new CronExpression(cronExpressionString);
         string? timeZoneId = rootElement.GetProperty(options.GetPropertyName("TimeZoneId")).GetString();
-        if (!string.IsNullOrEmpty(timeZoneId))
-        {
-            cronExpression.TimeZone = TimeZoneUtil.FindTimeZoneById(timeZoneId!);
-        }
-        return cronExpression;
+        TimeZoneInfo? timeZone = !string.IsNullOrEmpty(timeZoneId) ? TimeZoneUtil.FindTimeZoneById(timeZoneId!) : null;
+        return new CronExpression(cronExpressionString, timeZone);
     }
 }

--- a/src/Quartz/Serialization/SystemTextJson/Triggers/CronTriggerSerializer.cs
+++ b/src/Quartz/Serialization/SystemTextJson/Triggers/CronTriggerSerializer.cs
@@ -11,7 +11,7 @@ public class CronTriggerSerializer : TriggerSerializer<ICronTrigger>
         var cronExpressionString = jsonElement.GetProperty(options.GetPropertyName("CronExpressionString")).GetString()!;
         var timeZone = jsonElement.GetProperty(options.GetPropertyName("TimeZone")).GetTimeZone();
 
-        return CronScheduleBuilder.CronSchedule(cronExpressionString)
+        return CronScheduleBuilder.Create(cronExpressionString)
             .InTimeZone(timeZone);
     }
 

--- a/src/Quartz/SimpleScheduleBuilder.cs
+++ b/src/Quartz/SimpleScheduleBuilder.cs
@@ -48,7 +48,7 @@ namespace Quartz;
 ///     .WithSimpleSchedule(x => x
 ///         .WithInterval(TimeSpan.FromHours(1))
 ///         .RepeatForever())
-///     .StartAt(DateBuilder.NewDate().AtHourMinuteAndSecond(10, 0, 0).Build())
+///     .StartAt(DateBuilder.Create().AtHourMinuteAndSecond(10, 0, 0).Build())
 ///     .Build();
 /// await scheduler.ScheduleJob(job, trigger);
 /// </code>

--- a/src/Quartz/TriggerBuilder.cs
+++ b/src/Quartz/TriggerBuilder.cs
@@ -154,6 +154,13 @@ public sealed class TriggerBuilder<TJob> : ITriggerConfigurator<TJob> where TJob
             hashAware.SetHashKey(key);
         }
 
+        // Hand the schedule builder this builder's clock, so schedule computation deferred to
+        // Build() (EndingDailyAfterCount) runs against the same TimeProvider the trigger does.
+        if (scheduleBuilder is ITimeProviderAwareScheduleBuilder timeProviderAware)
+        {
+            timeProviderAware.SetTimeProvider(timeProvider);
+        }
+
         IMutableTrigger trig = scheduleBuilder.Build();
 
         trig.CalendarName = calendarName;

--- a/src/Quartz/TriggerConfiguratorExtensions.cs
+++ b/src/Quartz/TriggerConfiguratorExtensions.cs
@@ -75,7 +75,7 @@ public static class TriggerConfiguratorExtensions
         string cronExpression,
         Action<CronScheduleBuilder>? configure = null) where TConfigurator : ITriggerConfigurator
     {
-        CronScheduleBuilder builder = CronScheduleBuilder.CronSchedule(cronExpression);
+        CronScheduleBuilder builder = CronScheduleBuilder.Create(cronExpression);
         configure?.Invoke(builder);
         configurator.WithSchedule(builder);
         return configurator;
@@ -87,7 +87,7 @@ public static class TriggerConfiguratorExtensions
     /// <remarks>
     /// This is the overload to reach for when the expression carries <c>H</c> (hash) tokens that
     /// should be spread by something other than the trigger's own key:
-    /// <c>CronScheduleBuilder.CronSchedule(new CronExpression(expression, hashKey))</c>.
+    /// <c>CronScheduleBuilder.Create(new CronExpression(expression, hashKey))</c>.
     /// </remarks>
     /// <param name="configurator">the trigger being configured.</param>
     /// <param name="schedule">the schedule to use.</param>

--- a/src/Quartz/TriggerConfiguratorExtensions.cs
+++ b/src/Quartz/TriggerConfiguratorExtensions.cs
@@ -82,13 +82,48 @@ public static class TriggerConfiguratorExtensions
     }
 
     /// <summary>
-    /// Set the trigger to fire on the given cron schedule.
+    /// Set the trigger to fire on a cron schedule defined by an already-built
+    /// <see cref="CronExpression" />.
     /// </summary>
     /// <remarks>
-    /// This is the overload to reach for when the expression carries <c>H</c> (hash) tokens that
-    /// should be spread by something other than the trigger's own key:
-    /// <c>CronScheduleBuilder.Create(new CronExpression(expression, hashKey))</c>.
+    /// This is also the overload to reach for when the expression carries <c>H</c> (hash) tokens
+    /// that should be spread by something other than the trigger's own key:
+    /// <c>WithCronSchedule(new CronExpression(expression, hashKey))</c>.
     /// </remarks>
+    /// <param name="configurator">the trigger being configured.</param>
+    /// <param name="cronExpression">the cron expression the trigger fires on.</param>
+    /// <param name="configure">configures the rest of the schedule, such as its time zone.</param>
+    public static TConfigurator WithCronSchedule<TConfigurator>(
+        this TConfigurator configurator,
+        CronExpression cronExpression,
+        Action<CronScheduleBuilder>? configure = null) where TConfigurator : ITriggerConfigurator
+    {
+        CronScheduleBuilder builder = CronScheduleBuilder.Create(cronExpression);
+        configure?.Invoke(builder);
+        configurator.WithSchedule(builder);
+        return configurator;
+    }
+
+    /// <summary>
+    /// Set the trigger to fire on a cron schedule assembled with a
+    /// <see cref="CronExpressionBuilder" />, so the fluent chain closes without naming
+    /// <see cref="CronScheduleBuilder" />.
+    /// </summary>
+    /// <param name="configurator">the trigger being configured.</param>
+    /// <param name="cronExpression">the builder holding the assembled expression; it is built here.</param>
+    /// <param name="configure">configures the rest of the schedule, such as its time zone.</param>
+    public static TConfigurator WithCronSchedule<TConfigurator>(
+        this TConfigurator configurator,
+        CronExpressionBuilder cronExpression,
+        Action<CronScheduleBuilder>? configure = null) where TConfigurator : ITriggerConfigurator
+    {
+        ArgumentNullException.ThrowIfNull(cronExpression);
+        return configurator.WithCronSchedule(cronExpression.Build(), configure);
+    }
+
+    /// <summary>
+    /// Set the trigger to fire on the given cron schedule.
+    /// </summary>
     /// <param name="configurator">the trigger being configured.</param>
     /// <param name="schedule">the schedule to use.</param>
     public static TConfigurator WithCronSchedule<TConfigurator>(

--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -313,7 +313,7 @@ public class XMLSchedulingDataProcessor
 
             Type jobType = TypeLoadHelper.LoadType(jobTypeName!)!;
 
-            IJobDetail jobDetail = JobBuilder.Create(jobType)
+            IJobDetail jobDetail = JobBuilder.Create().OfType(jobType)
                 .WithIdentity(jobName!, jobGroup)
                 .WithDescription(jobDescription)
                 .StoreDurably(jobDefinition.Durable)
@@ -392,7 +392,7 @@ public class XMLSchedulingDataProcessor
                 var timezoneString = cronTrigger.TimeZone.TrimEmptyToNull();
 
                 TimeZoneInfo? tz = timezoneString is not null ? TimeZoneUtil.FindTimeZoneById(timezoneString) : null;
-                scheduleBuilder = CronScheduleBuilder.CronSchedule(cronExpression!)
+                scheduleBuilder = CronScheduleBuilder.Create(cronExpression!)
                     .InTimeZone(tz);
 
                 if (!string.IsNullOrWhiteSpace(cronTrigger.MisfireInstruction))


### PR DESCRIPTION
Part of the 4.0 API-finalization campaign (PR-2b of the ratified spec: items 5, 7–11, 13 of the PR-2 section, with the V1 amendments). Five commits, each compiling and passing the suite on its own.

## One factory convention

Every builder now starts with `Create(...)`: `CronScheduleBuilder.Create(string/CronExpression)` (the mandatory argument stays on the factory), `DateBuilder.Create(TimeProvider?)` / `CreateInTimeZone(...)`, `ExecutionLimitsBuilder.Create()` (ctor internal). `JobBuilder.Create(Type)` is deleted — runtime job types spell `Create().OfType(type)`, and the migration guide gives that one-liner since config/db-driven job types are a real pattern.

## CronExpression is immutable

`TimeZone` is get-only; `WithTimeZone(TimeZoneInfo?)` returns a copy (or `this` when unchanged); a `CronExpression(string, TimeZoneInfo?)` constructor completes the set. This fixes real aliasing: one schedule builder handed the *same* expression instance to every trigger it built, so a later `InTimeZone` silently retimed already-built triggers — tests now prove both directions are gone. The serialization contract is untouched: the v0 `ISerializable` branch assigns the field instead of the property, `Clone()` passes the field so "unset" stays unset, and `GetObjectData` still writes `TimeZone.Id` with the `TimeZoneInfo.Local` fallback byte-for-byte. `GetTimeAfter` is internal (`GetNextValidTimeAfter` is the API), and the always-null `GetFinalFireTime` is deleted — an unbounded cron trigger's `FinalFireTimeUtc` returns null directly.

## EndingDailyAfterCount computes at Build()

`DailyTimeIntervalScheduleBuilder.Create()` loses its `TimeProvider` parameter; the count→end-time computation is deferred to `Build()` against the *trigger builder's* clock via the same internal mechanism that hands cron builders their hash key. Previously a `FakeTimeProvider` given to `TriggerBuilder` was silently ignored here — the new test proves the builder clock is honored (a 23-hour spring-forward day rejects count 24), and the builder stays reusable (each `Build()` recomputes).

## Typed read models

- `ExecutionGroupScope` (readonly struct: `Default` / `OtherGroups` / `Named(name)`) replaces `string?` + `"*"` on the read side of `ExecutionGroupLimit`/`TryGetLimit`. Config spellings (`*`, `_`, null) are unchanged, and the docs now put the two `*` sentinels side by side (execution-limits "other groups" vs preferred-node "unpinned") — they mean different things.
- `MonthDay(month, day)` for `AnnualCalendar`'s excluded days; serialized payloads unchanged (the legacy timestamp-array payload still loads, assertions retyped in the existing fixture test).

## CronExpressionBuilder polish

`WithCronSchedule(CronExpression)` / `(CronExpressionBuilder)` overloads close the builder's own chain; `On*` → `With*` for the day-of-week field-restriction members (positional/special forms keep `On*`). Cron parse errors now name the fix: a 5-field expression gets "prepend a seconds field: \"0 …\"" (the Unix/crontab trap) and day-of-week errors state the Quartz numbering.

## Reviewer notes — where the spec was wrong, code won

- The spec's `JobBuilder.Create(Type)` call-site list named two files that already used `Create().OfType(...)`; the real nine sites are listed in the report and all moved.
- V1's "three CronTriggerImpl write-throughs": the third only assigns the trigger's own fields and never mutated the expression — no rebuild applies there.
- Spec's "builder materializes per Build" is implemented as rebind-on-`InTimeZone` instead: with the expression immutable, sharing one instance across Builds is safe and skips a re-parse per trigger. The aliasing tests pin the observable behavior the spec wanted.
- `new CronExpression(expr, null)` with a literal null needs a cast against the `(string, string hashKey)` overload; no in-repo caller is affected.

Verified with `build.cmd Compile UnitTest PublishAot` (2244 unit tests) and the AspNetCore suite in Release (211). Baselines re-approved per commit; migration guide updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
