### PR TITLE
TimeZoneUtil joins Quartz; resolvers compose and unregister

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4275,12 +4275,12 @@ lifetime, and only the application can make that call. The same applies to a han
 `LogProvider.SetLogProvider(host.Services.GetRequiredService<ILoggerFactory>())`: it is correct as
 long as the host outlives the schedulers.
 
-`TimeZoneUtil.CustomResolver` is ambient for the same reason and is now nullable, `null` meaning
-"no custom resolver", so a resolver can be removed again rather than replaced with a lambda that
-returns `null`. `FindTimeZoneById` is reached from parsing a `CronExpression` and from deserializing
-a trigger out of a job store blob, neither of which has a scheduler in scope — which is why
-installing `Quartz.Plugins.TimeZoneConverter` in one scheduler changes id resolution for the whole
-process.
+`TimeZoneUtil.AddResolver` is ambient for the same reason. `FindTimeZoneById` is reached from
+parsing a `CronExpression` and from deserializing a trigger out of a job store blob, neither of
+which has a scheduler in scope — which is why installing `Quartz.Plugins.TimeZoneConverter` in one
+scheduler changes id resolution for the whole process, and why each registration is undone by
+disposing it rather than by anyone owning the slot — see
+[`TimeZoneUtil` moved to `Quartz`](#timezoneutil-moved-to-quartz).
 
 ## `TimeZoneUtil` moved to `Quartz`
 
@@ -4300,6 +4300,34 @@ the builders whose behavior it defines. Every file under a `Quartz.*` namespace 
 
 No configuration shim is needed: `TimeZoneUtil` is a static helper that is called, never a type a
 configuration string names and the scheduler instantiates.
+
+### `CustomResolver` became `AddResolver`
+
+`CustomResolver` was one settable delegate, which made every installer overwrite the previous one:
+two schedulers running `Quartz.Plugins.TimeZoneConverter` in the same process fought over the slot,
+and shutting either scheduler down left the winner's resolver installed for the rest of the
+process's life. `AddResolver` composes instead — each caller gets an `IDisposable` registration
+back, and disposing it removes exactly that resolver:
+
+```diff
+- TimeZoneUtil.CustomResolver = id => Resolve(id);
++ IDisposable registration = TimeZoneUtil.AddResolver(id => Resolve(id));
+  ...
+- TimeZoneUtil.CustomResolver = null;
++ registration.Dispose();
+```
+
+Resolvers are consulted **most recently added first**, so a later registration shadows an earlier
+one for the ids it resolves — which is exactly the last-write-wins behavior assigning
+`CustomResolver` had, minus the data loss. A resolver declines an id by returning `null`, or by
+throwing `TimeZoneNotFoundException` — the search catches it and continues with the next resolver,
+and `FindTimeZoneById` itself throws only after every fallback has failed.
+
+`TimeZoneConverterPlugin` now registers its own resolver on `Initialize` — targeting
+`TZConvert.TryGetTimeZoneInfo`, so an unknown id declines quietly instead of by exception — and
+disposes that registration on `Shutdown`. Shutting one scheduler down no longer changes time zone
+resolution for the other schedulers in the process, and no longer leaves a resolver installed after
+the last scheduler is gone.
 
 ## `TriggerUtils` moved to `Quartz.Extensibility`
 
@@ -4331,7 +4359,7 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `IDirectoryScanListener` is asynchronous | `FilesUpdatedOrAdded` and `FilesDeleted` return `ValueTask` and take a `CancellationToken` |
 | `LoggingJobHistoryPlugin.Name`, `LoggingTriggerHistoryPlugin.Name` are get-only | The name is handed to a plugin by `Initialize`; writing it afterwards did nothing |
 | `TimeSpanParseRuleAttribute` is public | It says how a bare number in configuration is read as a `TimeSpan`, which a component configured by the same keys needs to be able to say |
-| `TimeZoneUtil.CustomResolver` is a property | It was a public mutable field |
+| `TimeZoneUtil.CustomResolver` became `AddResolver(...)` | Returns an `IDisposable` whose disposal removes exactly that resolver; resolvers are consulted most recently added first — see [`CustomResolver` became `AddResolver`](#customresolver-became-addresolver) |
 | Setter-only members gained getters | `DbMetadata.DbBinaryTypeName` (now nullable) and `.ParameterDbTypePropertyName` |
 | `TriggerState.Executing` added | Reported where `Normal`, `Complete` or `Blocked` used to be, and `Blocked` narrowed to mean a sibling trigger is running (see [Executing is a trigger state](#executing-is-a-trigger-state)) |
 | `IDriverDelegate.IsTriggerCurrentlyExecuting` removed | Replaced by `SelectTriggerStateWithExecuting`, which reads the state and the execution in one statement and returns `TriggerExecutionState` |
@@ -4445,7 +4473,6 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `TriggerUtils` moved to `Quartz.Extensibility` | It is a helper over `IOperableTrigger`, not part of the scheduling API — see [`TriggerUtils` moved to `Quartz.Extensibility`](#triggerutils-moved-to-quartz-extensibility) |
 | `TimeZoneUtil` moved to `Quartz` | `FindTimeZoneById` and the wall-clock `GetUtcOffset` are scheduling API, not utilities — see [`TimeZoneUtil` moved to `Quartz`](#timezoneutil-moved-to-quartz) |
 | `Quartz.Util.ObjectExtensions` is internal | `AssemblyQualifiedNameWithoutVersion()` is how Quartz spells a type name into a blob or onto the wire, not a general-purpose helper |
-| `TimeZoneUtil.CustomResolver` is nullable | `null` means there is no custom resolver, which is how one is removed; it defaulted to a lambda returning `null` — see [The ambient logger factory stays ambient](#the-ambient-logger-factory-stays-ambient) |
 | `Quartz.Diagnostics.ActivityOptions` is `ActivityTags` | It holds `Activity` tag names, not options, and `*Options` names an options type everywhere else. It replaced 3.x's `DiagnosticHeaders`; the tag names and values are unchanged |
 | `DBSemaphore` is `DbSemaphore` | The last `DB` spelling, with `DBConnectionManager` → `DbConnectionManager`. The type is abstract and is never named in configuration |
 | `StartingDailyAt` / `EndingDailyAt` take a `timeOfDay` | The parameter was `timeOfDayUtc`, and the value is wall-clock in the trigger's time zone rather than UTC — the property it sets, `StartTimeOfDay`, never claimed otherwise. `DailyTimeIntervalTriggerImpl`'s five constructors say `startTimeOfDay` / `endTimeOfDay` for the same reason |
@@ -4613,4 +4640,5 @@ removals on types that are still public and still open, which no section above n
 | `StringKeyDirtyFlagMap.GetNullableGuid()`, `.TryGetNullableGuid()` | Removed | `TryGetGuid(key, out var value)`, whose `false` says the same thing as a `null` did — see [`JobDataMap`'s typed accessors are the ones it inherits](#jobdatamap-s-typed-accessors-are-the-ones-it-inherits) |
 | `StringKeyDirtyFlagMap.Put()` (eight overloads), `.PutAll()` | Removed; all were `[Obsolete]` in 3.x | `map[key] = value` |
 | `TaskSchedulingThreadPool.ThreadPriority` | Removed | No replacement; work runs on a `TaskScheduler`, which has no thread to prioritise — see [The thread pool is asynchronous](#the-thread-pool-is-asynchronous) |
+| `TimeZoneUtil.CustomResolver` | Removed | `AddResolver(...)`, whose `IDisposable` undoes the registration; the type also moved to `Quartz` — see [`CustomResolver` became `AddResolver`](#customresolver-became-addresolver) |
 | `ZeroSizeThreadPool.AvailableThreadCount` | Removed | `PoolSize`, which is `0` — the pool never had a thread to report |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4301,6 +4301,22 @@ the builders whose behavior it defines. Every file under a `Quartz.*` namespace 
 No configuration shim is needed: `TimeZoneUtil` is a static helper that is called, never a type a
 configuration string names and the scheduler instantiates.
 
+Two members went internal on the way: `ConvertTime(DateTimeOffset, TimeZoneInfo)` and
+`GetUtcOffset(DateTimeOffset, TimeZoneInfo)` were Mono-era shims over the `TimeZoneInfo` calls they
+forward to — call `TimeZoneInfo` directly. The wall-clock `GetUtcOffset(DateTime, TimeZoneInfo)`
+overload is the daylight saving policy, not a shim, and stays public.
+
+The id alias table also stays: on Windows, "Coordinated Universal Time" and "CET" fail
+`TimeZoneInfo.FindSystemTimeZoneById` and both `TryConvert*` conversions even on ICU, and resolve
+through the table alone. Its one dead entry — "US Central Standard Time" ↔ "US/Indiana-Stark",
+where each side aliased the other and neither is a system id on Windows — was pruned; both ids now
+fail with the exception that points at `Quartz.Plugins.TimeZoneConverter`. When the direct lookup
+and the aliases have both failed, `FindTimeZoneById` now also asks
+`TimeZoneInfo.TryConvertIanaIdToWindowsId` before consulting the registered resolvers. The
+conversion runs *after* the direct lookup on purpose: run first, it would turn "US/Eastern" into a
+`TimeZoneInfo` whose `Id` is "Eastern Standard Time", and that rewritten Id is what a job store
+writes back to `TIME_ZONE_ID`.
+
 ### `CustomResolver` became `AddResolver`
 
 `CustomResolver` was one settable delegate, which made every installer overwrite the previous one:
@@ -4640,5 +4656,6 @@ removals on types that are still public and still open, which no section above n
 | `StringKeyDirtyFlagMap.GetNullableGuid()`, `.TryGetNullableGuid()` | Removed | `TryGetGuid(key, out var value)`, whose `false` says the same thing as a `null` did — see [`JobDataMap`'s typed accessors are the ones it inherits](#jobdatamap-s-typed-accessors-are-the-ones-it-inherits) |
 | `StringKeyDirtyFlagMap.Put()` (eight overloads), `.PutAll()` | Removed; all were `[Obsolete]` in 3.x | `map[key] = value` |
 | `TaskSchedulingThreadPool.ThreadPriority` | Removed | No replacement; work runs on a `TaskScheduler`, which has no thread to prioritise — see [The thread pool is asynchronous](#the-thread-pool-is-asynchronous) |
+| `TimeZoneUtil.ConvertTime`, `.GetUtcOffset(DateTimeOffset, TimeZoneInfo)` | Internal | `TimeZoneInfo.ConvertTime` / `TimeZoneInfo.GetUtcOffset`, which they forwarded to (they were Mono-era shims); the wall-clock `GetUtcOffset(DateTime, TimeZoneInfo)` stays public — see [`TimeZoneUtil` moved to `Quartz`](#timezoneutil-moved-to-quartz) |
 | `TimeZoneUtil.CustomResolver` | Removed | `AddResolver(...)`, whose `IDisposable` undoes the registration; the type also moved to `Quartz` — see [`CustomResolver` became `AddResolver`](#customresolver-became-addresolver) |
 | `ZeroSizeThreadPool.AvailableThreadCount` | Removed | `PoolSize`, which is `0` — the pool never had a thread to report |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4282,6 +4282,25 @@ a trigger out of a job store blob, neither of which has a scheduler in scope —
 installing `Quartz.Plugins.TimeZoneConverter` in one scheduler changes id resolution for the whole
 process.
 
+## `TimeZoneUtil` moved to `Quartz`
+
+`FindTimeZoneById` is how a trigger built with `InTimeZone(...)` comes back out of a job store, and
+the wall-clock `GetUtcOffset(DateTime, TimeZoneInfo)` overload *is* the scheduler-wide daylight
+saving policy — an ambiguous local time resolves to the daylight offset, the first of the two
+occurrences. That is scheduling API, not a utility, so the type lives in the root namespace next to
+the builders whose behavior it defines. Every file under a `Quartz.*` namespace sees it without any
+`using`; elsewhere, `using Quartz.Util;` becomes `using Quartz;`:
+
+```diff
+- using Quartz.Util;
++ using Quartz;
+
+  var zone = TimeZoneUtil.FindTimeZoneById("Europe/Helsinki");
+```
+
+No configuration shim is needed: `TimeZoneUtil` is a static helper that is called, never a type a
+configuration string names and the scheduler instantiates.
+
 ## `TriggerUtils` moved to `Quartz.Extensibility`
 
 It computes fire times by advancing a copy of a trigger through its schedule, applying the calendar
@@ -4424,6 +4443,7 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `Quartz.AspNetCore.AddQuartzServer` removed | `AddQuartzHostedService` starts the scheduler and `AddQuartzHealthChecks` registers the check — see [`AddQuartzServer` is `AddQuartzHostedService`](#addquartzserver-is-addquartzhostedservice) |
 | `ISchedulerFactory.GetScheduler(name)` is `LookupScheduler(name)` | Two members named `GetScheduler` differed only in nullability. `GetScheduler()` builds this factory's scheduler and cannot return null; `LookupScheduler(name)` looks one up in the container's repository and can, which is what the verb now says. `Lookup` matches `ISchedulerRepository.Lookup` |
 | `TriggerUtils` moved to `Quartz.Extensibility` | It is a helper over `IOperableTrigger`, not part of the scheduling API — see [`TriggerUtils` moved to `Quartz.Extensibility`](#triggerutils-moved-to-quartz-extensibility) |
+| `TimeZoneUtil` moved to `Quartz` | `FindTimeZoneById` and the wall-clock `GetUtcOffset` are scheduling API, not utilities — see [`TimeZoneUtil` moved to `Quartz`](#timezoneutil-moved-to-quartz) |
 | `Quartz.Util.ObjectExtensions` is internal | `AssemblyQualifiedNameWithoutVersion()` is how Quartz spells a type name into a blob or onto the wire, not a general-purpose helper |
 | `TimeZoneUtil.CustomResolver` is nullable | `null` means there is no custom resolver, which is how one is removed; it defaulted to a lambda returning `null` — see [The ambient logger factory stays ambient](#the-ambient-logger-factory-stays-ambient) |
 | `Quartz.Diagnostics.ActivityOptions` is `ActivityTags` | It holds `Activity` tag names, not options, and `*Options` names an options type everywhere else. It replaced 3.x's `DiagnosticHeaders`; the tag names and values are unchanged |

--- a/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
@@ -114,7 +114,7 @@ using the builder's `InTimeZone` method:
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger1", "group1")
     .WithRecurrenceSchedule("FREQ=MONTHLY;BYDAY=2MO", b => b
-        .InTimeZone(Quartz.Util.TimeZoneUtil.FindTimeZoneById("Eastern Standard Time")))
+        .InTimeZone(TimeZoneUtil.FindTimeZoneById("Eastern Standard Time")))
     .StartNow()
     .Build();
 ```

--- a/src/Quartz.Plugins.TimeZoneConverter/Plugins/TimeZoneConverter/TimeZoneConverterPlugin.cs
+++ b/src/Quartz.Plugins.TimeZoneConverter/Plugins/TimeZoneConverter/TimeZoneConverterPlugin.cs
@@ -30,6 +30,8 @@ namespace Quartz.Plugins.TimeZoneConverter;
 /// </summary>
 public class TimeZoneConverterPlugin : ISchedulerPlugin
 {
+    private IDisposable? resolverRegistration;
+
     /// <summary>
     /// Called during creation of the <see cref="IScheduler" /> in order to give
     /// the <see cref="ISchedulerPlugin" /> a chance to Initialize.
@@ -39,7 +41,8 @@ public class TimeZoneConverterPlugin : ISchedulerPlugin
         IScheduler scheduler,
         CancellationToken cancellationToken = default)
     {
-        TimeZoneUtil.CustomResolver = TZConvert.GetTimeZoneInfo;
+        resolverRegistration = TimeZoneUtil.AddResolver(
+            static id => TZConvert.TryGetTimeZoneInfo(id, out TimeZoneInfo? timeZoneInfo) ? timeZoneInfo : null);
 
         return default;
     }
@@ -59,8 +62,15 @@ public class TimeZoneConverterPlugin : ISchedulerPlugin
     /// should free up all of it's resources because the scheduler is shutting
     /// down.
     /// </summary>
+    /// <remarks>
+    /// Disposes this plugin's resolver registration, so that shutting one scheduler down does not
+    /// change time zone resolution for the other schedulers in the process.
+    /// </remarks>
     public ValueTask Shutdown(CancellationToken cancellationToken = default)
     {
+        resolverRegistration?.Dispose();
+        resolverRegistration = null;
+
         return default;
     }
 }

--- a/src/Quartz.Plugins.TimeZoneConverter/Plugins/TimeZoneConverter/TimeZoneConverterPlugin.cs
+++ b/src/Quartz.Plugins.TimeZoneConverter/Plugins/TimeZoneConverter/TimeZoneConverterPlugin.cs
@@ -20,7 +20,6 @@
 #endregion
 
 using Quartz.Extensibility;
-using Quartz.Util;
 
 using TimeZoneConverter;
 

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CalendarIntervalTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CalendarIntervalTriggerSerializer.cs
@@ -1,8 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-using Quartz.Util;
-
 using Quartz.Impl.Triggers;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
@@ -1,8 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-using Quartz.Util;
-
 namespace Quartz.Serialization.Newtonsoft.Triggers;
 
 public class CronTriggerSerializer : TriggerSerializer<ICronTrigger>

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/DailyTimeIntervalTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/DailyTimeIntervalTriggerSerializer.cs
@@ -1,9 +1,8 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-using Quartz.Util;
-
 using Quartz.Impl.Triggers;
+using Quartz.Util;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;
 

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/RecurrenceTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/RecurrenceTriggerSerializer.cs
@@ -1,8 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-using Quartz.Util;
-
 using Quartz.Impl.Triggers;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -11,7 +11,6 @@ using Quartz.Serialization.Newtonsoft;
 using Quartz.Extensibility;
 using Quartz.Tests.Integration.Impl.AdoJobStore;
 using Quartz.Serialization.Newtonsoft.Triggers;
-using Quartz.Util;
 
 namespace Quartz.Tests.Integration.Impl;
 

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -18,6 +18,7 @@ public class SmokeTestPerformer
 {
     public async Task Test(IScheduler scheduler, bool clearJobs, bool scheduleJobs)
     {
+        IDisposable customTimeZoneResolverRegistration = null;
         try
         {
             if (clearJobs)
@@ -246,14 +247,14 @@ public class SmokeTestPerformer
                     null,
                     null);
 
-                TimeZoneUtil.CustomResolver = id =>
+                customTimeZoneResolverRegistration = TimeZoneUtil.AddResolver(id =>
                 {
                     if (id == CustomTimeZoneId)
                     {
                         return webTimezone;
                     }
                     return null;
-                };
+                });
 
                 var customTimeZoneTrigger = TriggerBuilder.Create()
                     .WithIdentity("customTimeZoneTrigger")
@@ -386,6 +387,7 @@ public class SmokeTestPerformer
         }
         finally
         {
+            customTimeZoneResolverRegistration?.Dispose();
             await scheduler.Shutdown(false);
         }
     }

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
@@ -3,7 +3,6 @@ using AwesomeAssertions.Execution;
 using Quartz.Impl.Triggers;
 using Quartz.Impl;
 using Quartz.Extensibility;
-using Quartz.Util;
 
 using TimeZoneConverter;
 

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -22,11 +22,9 @@
 using System.Collections;
 using System.Diagnostics;
 
-
 using Newtonsoft.Json;
 
 using Quartz.Impl;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit;
 

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -28,7 +28,6 @@ using Microsoft.Extensions.Time.Testing;
 using Quartz.Impl.Triggers;
 using Quartz.Jobs;
 using Quartz.Extensibility;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
@@ -21,7 +21,6 @@
 
 using Quartz.Impl.Calendar;
 using Quartz.Impl;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Impl.Calendar;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
@@ -19,12 +19,10 @@
 
 #endregion
 
-
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
 using Quartz.Impl;
 using Quartz.Extensibility;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Impl.Calendar;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
@@ -19,7 +19,6 @@
 
 using Quartz.Impl.Calendar;
 using Quartz.Impl;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Impl.Calendar;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/MonthlyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/MonthlyCalendarTest.cs
@@ -21,7 +21,6 @@
 
 using Quartz.Impl.Calendar;
 using Quartz.Impl;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Impl.Calendar;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/WeeklyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/WeeklyCalendarTest.cs
@@ -19,7 +19,6 @@
 
 using Quartz.Impl.Calendar;
 using Quartz.Impl;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Impl.Calendar;
 

--- a/src/Quartz.Tests.Unit/Impl/Recurrence/RecurrenceRuleTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Recurrence/RecurrenceRuleTest.cs
@@ -1,5 +1,4 @@
 using Quartz.Impl.Recurrence;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Impl.Recurrence;
 

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -23,7 +23,6 @@ using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
 using Quartz.Jobs;
 using Quartz.Extensibility;
-using Quartz.Util;
 
 using TimeZoneConverter;
 

--- a/src/Quartz.Tests.Unit/Plugins/TimeZoneConverter/TimeZoneConverterTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/TimeZoneConverter/TimeZoneConverterTest.cs
@@ -1,5 +1,4 @@
 using Quartz.Plugins.TimeZoneConverter;
-using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Plugin.TimeZoneConverter;
 

--- a/src/Quartz.Tests.Unit/Plugins/TimeZoneConverter/TimeZoneConverterTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/TimeZoneConverter/TimeZoneConverterTest.cs
@@ -1,22 +1,70 @@
 using Quartz.Plugins.TimeZoneConverter;
 
-namespace Quartz.Tests.Unit.Plugin.TimeZoneConverter;
+namespace Quartz.Tests.Unit.Plugins.TimeZoneConverter;
 
 public class TimeZoneConverterTest
 {
     [Test]
     public async Task ResolveIanaTimeZone()
     {
+        TimeZoneConverterPlugin plugin = new TimeZoneConverterPlugin();
+        await plugin.Initialize("timeZoneConverter", scheduler: null!);
         try
         {
-            var plugin = new TimeZoneConverterPlugin();
-            await plugin.Initialize("", null);
-
-            Assert.That(TimeZoneUtil.FindTimeZoneById("Canada/Saskatchewan"), Is.Not.Null);
+            TimeZoneUtil.FindTimeZoneById("Canada/Saskatchewan").Should().NotBeNull();
         }
         finally
         {
-            TimeZoneUtil.CustomResolver = null;
+            await plugin.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ShutdownDisposesOnlyItsOwnRegistration()
+    {
+        // On Windows "EET" is not a system id and is rescued by neither the BCL conversions nor
+        // the alias table, while TimeZoneConverter's own data resolves it - so only a plugin
+        // registration can produce it there. On platforms whose tzdata ships the zone the direct
+        // lookup succeeds, and the after-shutdown half below self-skips.
+        const string id = "EET";
+
+        TimeZoneConverterPlugin schedulerAPlugin = new TimeZoneConverterPlugin();
+        TimeZoneConverterPlugin schedulerBPlugin = new TimeZoneConverterPlugin();
+        await schedulerAPlugin.Initialize("timeZoneConverter", scheduler: null!);
+        await schedulerBPlugin.Initialize("timeZoneConverter", scheduler: null!);
+        try
+        {
+            await schedulerAPlugin.Shutdown();
+
+            TimeZoneUtil.FindTimeZoneById(id).Should().NotBeNull(
+                "the second scheduler's registration must survive the first scheduler's shutdown");
+        }
+        finally
+        {
+            await schedulerBPlugin.Shutdown();
+
+            // shutting down twice must be harmless
+            await schedulerAPlugin.Shutdown();
+        }
+
+        if (!IsSystemResolvable(id))
+        {
+            Func<TimeZoneInfo> act = () => TimeZoneUtil.FindTimeZoneById(id);
+            act.Should().Throw<TimeZoneNotFoundException>(
+                "after every scheduler's plugin has shut down, no resolver registration may linger");
+        }
+    }
+
+    private static bool IsSystemResolvable(string id)
+    {
+        try
+        {
+            TimeZoneInfo.FindSystemTimeZoneById(id);
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return false;
         }
     }
 }

--- a/src/Quartz.Tests.Unit/TestDates.cs
+++ b/src/Quartz.Tests.Unit/TestDates.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using Quartz.Util;
-
 namespace Quartz.Tests.Unit;
 
 /// <summary>

--- a/src/Quartz.Tests.Unit/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/TimeZoneUtilTest.cs
@@ -220,14 +220,56 @@ public class TimeZoneUtilTest
         TimeZoneInfo.ConvertTime(resolved, dublin).DateTime.Should().Be(new DateTime(2024, 3, 31, 2, 30, 0), "the instant renders at the delta-shifted wall clock after the gap");
     }
 
-    [TestCase("US/Eastern", "Eastern Standard Time")]
+    [TestCase("UTC", "Coordinated Universal Time")]
     [TestCase("CET", "Central European Standard Time")]
+    [TestCase("US/Eastern", "Eastern Standard Time")]
+    [TestCase("US/Central", "Central Standard Time")]
+    [TestCase("US/Mountain", "Mountain Standard Time")]
+    [TestCase("US/Arizona", "US Mountain Standard Time")]
+    [TestCase("US/Pacific", "Pacific Standard Time")]
+    [TestCase("US/Alaska", "Alaskan Standard Time")]
+    [TestCase("US/Hawaii", "Hawaiian Standard Time")]
+    [TestCase("Asia/Shanghai", "China Standard Time")]
+    [TestCase("Asia/Karachi", "Pakistan Standard Time")]
     public void FindTimeZoneById_ResolvesAliasPairsOnAnyPlatform(string first, string second)
     {
         TimeZoneInfo firstZone = TimeZoneUtil.FindTimeZoneById(first);
         TimeZoneInfo secondZone = TimeZoneUtil.FindTimeZoneById(second);
 
         firstZone.BaseUtcOffset.Should().Be(secondZone.BaseUtcOffset);
+    }
+
+    [TestCase("Coordinated Universal Time")]
+    [TestCase("CET")]
+    public void FindTimeZoneById_RescuesAliasEntriesTheBclCannotResolve(string id)
+    {
+        // On Windows with ICU these ids fail TimeZoneInfo.FindSystemTimeZoneById AND both
+        // TryConvert* conversions - they are why the alias table survives 4.0. On a platform
+        // whose tzdata resolves them directly (e.g. "CET" on Linux) the lookup passes trivially.
+        TimeZoneUtil.FindTimeZoneById(id).Should().NotBeNull();
+    }
+
+    [TestCase("US Central Standard Time")]
+    [TestCase("US/Indiana-Stark")]
+    public void FindTimeZoneById_PrunedDeadAliasPair_FailsWithGuidance(string id)
+    {
+        // The two ids aliased each other, but neither is a system id on Windows and neither is
+        // known to the BCL conversions or to TimeZoneConverter, so the alias never rescued
+        // anything - the pair was pruned in 4.0. A platform whose tzdata still ships the id
+        // resolves it directly, and this test self-skips there.
+        try
+        {
+            TimeZoneInfo.FindSystemTimeZoneById(id);
+            Assert.Ignore($"'{id}' is a system time zone on this platform");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+        }
+
+        Func<TimeZoneInfo> act = () => TimeZoneUtil.FindTimeZoneById(id);
+
+        act.Should().Throw<TimeZoneNotFoundException>()
+            .WithMessage("*Quartz.Plugins.TimeZoneConverter*", "the failure should point at the plugin that resolves more ids");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/TimeZoneUtilTest.cs
@@ -1,9 +1,8 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 using Quartz.Impl.Calendar;
-using Quartz.Util;
 
-namespace Quartz.Tests.Unit.Utils;
+namespace Quartz.Tests.Unit;
 
 public class TimeZoneUtilTest
 {

--- a/src/Quartz.Tests.Unit/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/TimeZoneUtilTest.cs
@@ -230,6 +230,85 @@ public class TimeZoneUtilTest
         firstZone.BaseUtcOffset.Should().Be(secondZone.BaseUtcOffset);
     }
 
+    [Test]
+    public void AddResolver_MostRecentlyAddedWins_AndDisposalUnregisters()
+    {
+        const string id = "Quartz/Test-Resolver-Ordering";
+        TimeZoneInfo earlierZone = TimeZoneInfo.CreateCustomTimeZone(id + "-earlier", TimeSpan.FromMinutes(30), null, null);
+        TimeZoneInfo laterZone = TimeZoneInfo.CreateCustomTimeZone(id + "-later", TimeSpan.FromMinutes(45), null, null);
+
+        IDisposable earlier = TimeZoneUtil.AddResolver(x => x == id ? earlierZone : null);
+        try
+        {
+            TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(earlierZone);
+
+            IDisposable later = TimeZoneUtil.AddResolver(x => x == id ? laterZone : null);
+            try
+            {
+                TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(laterZone,
+                    "resolvers are consulted most recently added first, preserving the last-write-wins semantics CustomResolver had");
+            }
+            finally
+            {
+                later.Dispose();
+            }
+
+            TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(earlierZone,
+                "a disposed resolver must no longer shadow the one registered before it");
+        }
+        finally
+        {
+            earlier.Dispose();
+        }
+
+        Func<TimeZoneInfo> act = () => TimeZoneUtil.FindTimeZoneById(id);
+        act.Should().Throw<TimeZoneNotFoundException>("every registration was disposed");
+    }
+
+    [Test]
+    public void AddResolver_DisposingTwice_IsANoOpAndRemovesNothingElse()
+    {
+        const string id = "Quartz/Test-Resolver-Double-Dispose";
+        TimeZoneInfo earlierZone = TimeZoneInfo.CreateCustomTimeZone(id + "-earlier", TimeSpan.FromMinutes(30), null, null);
+        TimeZoneInfo laterZone = TimeZoneInfo.CreateCustomTimeZone(id + "-later", TimeSpan.FromMinutes(45), null, null);
+
+        IDisposable earlier = TimeZoneUtil.AddResolver(x => x == id ? earlierZone : null);
+        try
+        {
+            IDisposable later = TimeZoneUtil.AddResolver(x => x == id ? laterZone : null);
+            later.Dispose();
+            later.Dispose();
+
+            TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(earlierZone,
+                "disposing a registration twice must not remove another resolver");
+        }
+        finally
+        {
+            earlier.Dispose();
+        }
+    }
+
+    [Test]
+    public void AddResolver_ResolverThrowingTimeZoneNotFound_FallsThroughToTheNextOne()
+    {
+        const string id = "Quartz/Test-Resolver-Throwing";
+        TimeZoneInfo zone = TimeZoneInfo.CreateCustomTimeZone(id + "-zone", TimeSpan.FromMinutes(15), null, null);
+
+        using IDisposable quiet = TimeZoneUtil.AddResolver(x => x == id ? zone : null);
+        using IDisposable loud = TimeZoneUtil.AddResolver(
+            x => x == id ? throw new TimeZoneNotFoundException("declining loudly") : null);
+
+        TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(zone,
+            "a resolver throwing TimeZoneNotFoundException declines the id and the search continues with the next resolver");
+    }
+
+    [Test]
+    public void AddResolver_NullResolver_Throws()
+    {
+        Action act = () => TimeZoneUtil.AddResolver(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
     private static TimeZoneInfo ResolveZone(string zoneKey)
     {
         switch (zoneKey)

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1223,7 +1223,7 @@ namespace Quartz
     }
     public static class TimeZoneUtil
     {
-        public static System.Func<string, System.TimeZoneInfo?>? CustomResolver { get; set; }
+        public static System.IDisposable AddResolver(System.Func<string, System.TimeZoneInfo?> resolver) { }
         public static System.DateTimeOffset ConvertTime(System.DateTimeOffset dateTimeOffset, System.TimeZoneInfo timeZoneInfo) { }
         public static System.TimeZoneInfo FindTimeZoneById(string id) { }
         public static System.TimeSpan GetUtcOffset(System.DateTime dateTime, System.TimeZoneInfo timeZoneInfo) { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1224,10 +1224,8 @@ namespace Quartz
     public static class TimeZoneUtil
     {
         public static System.IDisposable AddResolver(System.Func<string, System.TimeZoneInfo?> resolver) { }
-        public static System.DateTimeOffset ConvertTime(System.DateTimeOffset dateTimeOffset, System.TimeZoneInfo timeZoneInfo) { }
         public static System.TimeZoneInfo FindTimeZoneById(string id) { }
         public static System.TimeSpan GetUtcOffset(System.DateTime dateTime, System.TimeZoneInfo timeZoneInfo) { }
-        public static System.TimeSpan GetUtcOffset(System.DateTimeOffset dateTimeOffset, System.TimeZoneInfo timeZoneInfo) { }
     }
     public static class TriggerBuilder
     {

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1221,6 +1221,14 @@ namespace Quartz
         public TimeSpanParseRuleAttribute(Quartz.TimeSpanParseRule rule) { }
         public Quartz.TimeSpanParseRule Rule { get; }
     }
+    public static class TimeZoneUtil
+    {
+        public static System.Func<string, System.TimeZoneInfo?>? CustomResolver { get; set; }
+        public static System.DateTimeOffset ConvertTime(System.DateTimeOffset dateTimeOffset, System.TimeZoneInfo timeZoneInfo) { }
+        public static System.TimeZoneInfo FindTimeZoneById(string id) { }
+        public static System.TimeSpan GetUtcOffset(System.DateTime dateTime, System.TimeZoneInfo timeZoneInfo) { }
+        public static System.TimeSpan GetUtcOffset(System.DateTimeOffset dateTimeOffset, System.TimeZoneInfo timeZoneInfo) { }
+    }
     public static class TriggerBuilder
     {
         public static Quartz.TriggerBuilder<Quartz.IJob> Create(System.TimeProvider? timeProvider = null) { }
@@ -3327,14 +3335,6 @@ namespace Quartz.Util
         public virtual bool TryGetLong(string key, out long value) { }
         public virtual bool TryGetString(string key, out string? value) { }
         public virtual bool TryGetTimeSpan(string key, out System.TimeSpan value) { }
-    }
-    public static class TimeZoneUtil
-    {
-        public static System.Func<string, System.TimeZoneInfo?>? CustomResolver { get; set; }
-        public static System.DateTimeOffset ConvertTime(System.DateTimeOffset dateTimeOffset, System.TimeZoneInfo timeZoneInfo) { }
-        public static System.TimeZoneInfo FindTimeZoneById(string id) { }
-        public static System.TimeSpan GetUtcOffset(System.DateTime dateTime, System.TimeZoneInfo timeZoneInfo) { }
-        public static System.TimeSpan GetUtcOffset(System.DateTimeOffset dateTimeOffset, System.TimeZoneInfo timeZoneInfo) { }
     }
 }
 namespace Quartz.Xml

--- a/src/Quartz/DateBuilder.cs
+++ b/src/Quartz/DateBuilder.cs
@@ -19,8 +19,6 @@
 
 #endregion
 
-using Quartz.Util;
-
 namespace Quartz;
 
 /// <summary>

--- a/src/Quartz/Diagnostics/LogProvider.cs
+++ b/src/Quartz/Diagnostics/LogProvider.cs
@@ -10,7 +10,7 @@ namespace Quartz.Diagnostics;
 /// <para>
 /// This is ambient, mutable, process-wide state, and it stays that way on purpose. Nearly everything the
 /// scheduler is made of is built by a container and is injected an <see cref="ILogger" /> the ordinary
-/// way. What is left over cannot be: static helpers such as <see cref="Quartz.Util.TimeZoneUtil" />,
+/// way. What is left over cannot be: static helpers such as <see cref="Quartz.TimeZoneUtil" />,
 /// types a caller constructs directly — triggers, calendars, plugins, the jobs in <c>Quartz.Jobs</c> —
 /// and anything that runs while the container is still being built. A type cannot be handed a logger by
 /// a container that does not exist yet, so those sites read this instead of going unlogged.

--- a/src/Quartz/Impl/AdoJobStore/CalendarIntervalTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/CalendarIntervalTriggerPersistenceDelegate.cs
@@ -21,7 +21,6 @@
 
 using Quartz.Impl.Triggers;
 using Quartz.Extensibility;
-using Quartz.Util;
 
 namespace Quartz.Impl.AdoJobStore;
 

--- a/src/Quartz/Impl/AdoJobStore/DailyTimeIntervalTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/DailyTimeIntervalTriggerPersistenceDelegate.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -24,7 +24,6 @@ using System.Text;
 
 using Quartz.Impl.Triggers;
 using Quartz.Extensibility;
-using Quartz.Util;
 
 namespace Quartz.Impl.AdoJobStore;
 

--- a/src/Quartz/Impl/AdoJobStore/RecurrenceTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/RecurrenceTriggerPersistenceDelegate.cs
@@ -1,7 +1,6 @@
 
 using Quartz.Impl.Triggers;
 using Quartz.Extensibility;
-using Quartz.Util;
 
 namespace Quartz.Impl.AdoJobStore;
 

--- a/src/Quartz/Impl/Calendar/AnnualCalendar.cs
+++ b/src/Quartz/Impl/Calendar/AnnualCalendar.cs
@@ -22,8 +22,6 @@
 using System.Collections;
 using System.Runtime.Serialization;
 
-using Quartz.Util;
-
 namespace Quartz.Impl.Calendar;
 
 /// <summary>

--- a/src/Quartz/Impl/Calendar/BaseCalendar.cs
+++ b/src/Quartz/Impl/Calendar/BaseCalendar.cs
@@ -123,7 +123,7 @@ public class BaseCalendar : ICalendar, ISerializable, IEquatable<BaseCalendar>
                 var timeZoneId = (string) info.GetValue(prefix + "timeZoneId", typeof(string))!;
                 if (!string.IsNullOrEmpty(timeZoneId))
                 {
-                    timeZone = Util.TimeZoneUtil.FindTimeZoneById(timeZoneId);
+                    timeZone = TimeZoneUtil.FindTimeZoneById(timeZoneId);
                 }
                 break;
             default:

--- a/src/Quartz/Impl/Calendar/HolidayCalendar.cs
+++ b/src/Quartz/Impl/Calendar/HolidayCalendar.cs
@@ -21,8 +21,6 @@
 
 using System.Runtime.Serialization;
 
-using Quartz.Util;
-
 namespace Quartz.Impl.Calendar;
 
 /// <summary>

--- a/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
@@ -21,8 +21,6 @@
 
 using System.Runtime.Serialization;
 
-using Quartz.Util;
-
 namespace Quartz.Impl.Calendar;
 
 /// <summary>

--- a/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
@@ -21,8 +21,6 @@
 
 using System.Runtime.Serialization;
 
-using Quartz.Util;
-
 namespace Quartz.Impl.Calendar;
 
 /// <summary>

--- a/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
+++ b/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
@@ -1,8 +1,6 @@
 using System.Globalization;
 using System.Text;
 
-using Quartz.Util;
-
 namespace Quartz.Impl.Recurrence;
 
 /// <summary>

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -19,8 +19,6 @@
 
 #endregion
 
-using Quartz.Util;
-
 namespace Quartz.Impl.Triggers;
 
 /// <summary>

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -23,7 +23,6 @@ using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
-using Quartz.Util;
 
 namespace Quartz.Impl.Triggers;
 

--- a/src/Quartz/Serialization/SystemTextJson/SerializationExtensions.cs
+++ b/src/Quartz/Serialization/SystemTextJson/SerializationExtensions.cs
@@ -1,8 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
 
-using Quartz.Util;
-
 namespace Quartz.Serialization.SystemTextJson;
 
 internal static class Utf8JsonWriterExtensions

--- a/src/Quartz/TimeZoneUtil.cs
+++ b/src/Quartz/TimeZoneUtil.cs
@@ -71,24 +71,84 @@ public static class TimeZoneUtil
         timeZoneIdAliases["Asia/Karachi"] = "Pakistan Standard Time";
     }
 
+    private static readonly Lock resolverLock = new();
+
     /// <summary>
-    /// A last-resort resolver consulted when a time zone id is neither a system id nor one of the
-    /// aliases above. <see langword="null" /> — the default — means there is none.
+    /// The registered resolvers, most recently added first — the order they are consulted in.
+    /// Copy-on-write: mutated only under <see cref="resolverLock" />, read as a snapshot without it.
+    /// </summary>
+    private static ResolverRegistration[] resolvers = [];
+
+    /// <summary>
+    /// Registers a last-resort resolver, consulted when a time zone id is neither a system id nor one
+    /// of the aliases above. Disposing the returned registration removes the resolver again.
     /// </summary>
     /// <remarks>
     /// <para>
     /// This is process-wide, and deliberately so: <see cref="FindTimeZoneById" /> is reached from
     /// places that have no scheduler in scope — parsing a <see cref="CronExpression" />, deserializing
     /// a trigger or calendar out of a job store blob — so there is nothing scheduler-scoped to hang a
-    /// resolver on. Setting it from one scheduler changes id resolution for every scheduler in the
-    /// process, which is what installing <c>Quartz.Plugins.TimeZoneConverter</c> does.
+    /// resolver on. Adding a resolver from one scheduler changes id resolution for every scheduler in
+    /// the process, which is what installing <c>Quartz.Plugins.TimeZoneConverter</c> does; each such
+    /// plugin disposes its own registration when its scheduler shuts down.
     /// </para>
     /// <para>
-    /// Assign <see langword="null" /> to remove a resolver again; a resolver returning
-    /// <see langword="null" /> for an id it does not know is how it declines a single id.
+    /// Resolvers are consulted most recently added first, so a later registration shadows an earlier
+    /// one for the ids it resolves. A resolver declines an id by returning <see langword="null" /> or
+    /// by throwing <see cref="TimeZoneNotFoundException" />; either way the search continues with the
+    /// next resolver, and <see cref="FindTimeZoneById" /> throws only when every fallback has failed.
     /// </para>
     /// </remarks>
-    public static Func<string, TimeZoneInfo?>? CustomResolver { get; set; }
+    /// <param name="resolver">Maps a time zone id to a <see cref="TimeZoneInfo" />, or to
+    /// <see langword="null" /> for an id it does not know.</param>
+    /// <returns>A registration whose disposal removes the resolver. Disposing twice is a no-op.</returns>
+    public static IDisposable AddResolver(Func<string, TimeZoneInfo?> resolver)
+    {
+        ArgumentNullException.ThrowIfNull(resolver);
+
+        ResolverRegistration registration = new ResolverRegistration(resolver);
+        lock (resolverLock)
+        {
+            ResolverRegistration[] next = new ResolverRegistration[resolvers.Length + 1];
+            next[0] = registration;
+            Array.Copy(resolvers, sourceIndex: 0, next, destinationIndex: 1, resolvers.Length);
+            resolvers = next;
+        }
+
+        return registration;
+    }
+
+    private static void RemoveResolver(ResolverRegistration registration)
+    {
+        lock (resolverLock)
+        {
+            int index = Array.IndexOf(resolvers, registration);
+            if (index < 0)
+            {
+                return;
+            }
+
+            ResolverRegistration[] next = new ResolverRegistration[resolvers.Length - 1];
+            Array.Copy(resolvers, sourceIndex: 0, next, destinationIndex: 0, index);
+            Array.Copy(resolvers, sourceIndex: index + 1, next, destinationIndex: index, resolvers.Length - index - 1);
+            resolvers = next;
+        }
+    }
+
+    private sealed class ResolverRegistration : IDisposable
+    {
+        internal readonly Func<string, TimeZoneInfo?> resolver;
+
+        internal ResolverRegistration(Func<string, TimeZoneInfo?> resolver)
+        {
+            this.resolver = resolver;
+        }
+
+        public void Dispose()
+        {
+            RemoveResolver(this);
+        }
+    }
 
     /// <summary>
     /// TimeZoneInfo.ConvertTime is not supported under mono
@@ -251,7 +311,27 @@ public static class TimeZoneUtil
                 }
             }
 
-            info ??= CustomResolver?.Invoke(id);
+            if (info is null)
+            {
+                // snapshot read; registrations added most recently are consulted first, so a later
+                // registration shadows an earlier one for the ids it resolves
+                foreach (ResolverRegistration registration in resolvers)
+                {
+                    try
+                    {
+                        info = registration.resolver(id);
+                    }
+                    catch (TimeZoneNotFoundException)
+                    {
+                        // the resolver declined loudly; continue with the next one
+                    }
+
+                    if (info is not null)
+                    {
+                        break;
+                    }
+                }
+            }
 
             if (info is null)
             {

--- a/src/Quartz/TimeZoneUtil.cs
+++ b/src/Quartz/TimeZoneUtil.cs
@@ -1,8 +1,30 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
 using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
+using Quartz.Util;
 
-namespace Quartz.Util;
+namespace Quartz;
 
 public static class TimeZoneUtil
 {

--- a/src/Quartz/TimeZoneUtil.cs
+++ b/src/Quartz/TimeZoneUtil.cs
@@ -28,6 +28,13 @@ namespace Quartz;
 
 public static class TimeZoneUtil
 {
+    /// <summary>
+    /// Id spellings that some platform has used and some other platform cannot resolve. The BCL does
+    /// not make this table redundant: on Windows with ICU, "Coordinated Universal Time" and "CET"
+    /// fail both <see cref="TimeZoneInfo.FindSystemTimeZoneById" /> and the
+    /// <see cref="TimeZoneInfo.TryConvertIanaIdToWindowsId(string, out string)" /> conversions, and
+    /// resolve through this table alone.
+    /// </summary>
     private static readonly Dictionary<string, string> timeZoneIdAliases = new Dictionary<string, string>();
 
     static TimeZoneUtil()
@@ -45,9 +52,6 @@ public static class TimeZoneUtil
 
         timeZoneIdAliases["Central Standard Time"] = "US/Central";
         timeZoneIdAliases["US/Central"] = "Central Standard Time";
-
-        timeZoneIdAliases["US Central Standard Time"] = "US/Indiana-Stark";
-        timeZoneIdAliases["US/Indiana-Stark"] = "US Central Standard Time";
 
         timeZoneIdAliases["Mountain Standard Time"] = "US/Mountain";
         timeZoneIdAliases["US/Mountain"] = "Mountain Standard Time";
@@ -156,7 +160,7 @@ public static class TimeZoneUtil
     /// <param name="dateTimeOffset"></param>
     /// <param name="timeZoneInfo"></param>
     /// <returns></returns>
-    public static DateTimeOffset ConvertTime(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
+    internal static DateTimeOffset ConvertTime(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
     {
         return TimeZoneInfo.ConvertTime(dateTimeOffset, timeZoneInfo);
     }
@@ -167,7 +171,7 @@ public static class TimeZoneUtil
     /// <param name="dateTimeOffset"></param>
     /// <param name="timeZoneInfo"></param>
     /// <returns></returns>
-    public static TimeSpan GetUtcOffset(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
+    internal static TimeSpan GetUtcOffset(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
     {
         if (QuartzEnvironment.IsRunningOnMono)
         {
@@ -308,6 +312,23 @@ public static class TimeZoneUtil
                 {
                     var logger = LogProvider.CreateLogger(nameof(TimeZoneUtil));
                     logger.LogError("Could not find time zone using alias id {AliasId}", aliasedId);
+                }
+            }
+
+            // The BCL conversion runs only here, after the direct lookup has failed: run first, it
+            // would turn an id like "US/Eastern" into a TimeZoneInfo whose Id is "Eastern Standard
+            // Time", and that rewritten Id is what a job store writes back to TIME_ZONE_ID. On ICU
+            // builds FindSystemTimeZoneById already attempts this conversion internally, so this is
+            // a guard for environments where that internal fallback is unavailable.
+            if (info is null && TimeZoneInfo.TryConvertIanaIdToWindowsId(id, out string? windowsId))
+            {
+                try
+                {
+                    info = TimeZoneInfo.FindSystemTimeZoneById(windowsId);
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                    // the converted id is not present on this system either; continue with the resolvers
                 }
             }
 


### PR DESCRIPTION
Part of the 4.0 API-finalization campaign (PR-TZ of the ratified spec — split out of PR-3 for its own review). Three commits.

## What changes

- **`TimeZoneUtil` moves from `Quartz.Util` to `Quartz`.** No `SimpleTypeLoadHelper` shim: it is a static helper that is *called*, never named by a configuration type string — and a blanket `Quartz.Util.` namespace shim would be wrong while `DirtyFlagMap` legitimately remains there (PR-3's territory).
- **`CustomResolver` (a single settable delegate) becomes `AddResolver(Func<string, TimeZoneInfo?>): IDisposable`.** Registrations compose: most-recently-added is consulted first, preserving the old last-write-wins semantics; a resolver that throws `TimeZoneNotFoundException` declines loudly and the search continues; disposing unregisters (idempotent). Copy-on-write array under a lock, snapshot reads on the hot path.
- **The TimeZoneConverter plugin unregisters on Shutdown** — previously one scheduler's plugin set the global delegate and its shutdown left it dangling for every other scheduler in the process. It also retargets to `TZConvert.TryGetTimeZoneInfo` (no exception-based control flow).
- **The alias table stays.** The "the BCL makes it redundant on net10/ICU" claim was refuted — re-probed on this machine: "Coordinated Universal Time" and "CET" fail both `FindSystemTimeZoneById` and the IANA/Windows conversions, and resolve through the table alone. The BCL `TryConvertIanaIdToWindowsId` guard runs only inside the not-found catch, after the alias lookup — run first it would rewrite ids ("US/Eastern" → a `TimeZoneInfo` whose `Id` is "Eastern Standard Time"), and that rewritten Id is what job stores write back to `TIME_ZONE_ID`. The dead "US Central Standard Time" ↔ "US/Indiana-Stark" pair is pruned (nothing resolves it — not even TZConvert). The Mono-era `ConvertTime`/`GetUtcOffset(DateTimeOffset, …)` shims go internal.

## Reviewer notes

- The TimeZoneConverter package's own public-API baseline did **not** move — the plugin's registration is a private field; only the core baseline changes.
- Spec counts corrected by ground truth: the alias table had 24 entries (spec said 18), now 22; the "three BCL-uncovered entries" are actually four, two of which are the pruned dead pair.
- New tests: resolver ordering/shadowing/unshadowing, double-dispose, decline-and-continue, all 11 remaining alias pairs, the BCL-uncovered ids, and a two-scheduler plugin test proving one Shutdown no longer affects the other's resolution (self-skips on platforms whose tzdata resolves the probe id natively).

Verified with `build.cmd Compile UnitTest PublishAot` (2275 unit + 216 AspNetCore) and the AspNetCore suite in Release.

Shares the core baseline and migration guide with the in-flight PR-3; whichever merges second gets rebased and re-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
