### PR TITLE
TimeZoneUtil becomes TimeZones; TriggerUtils becomes TriggerFireTimes

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -89,10 +89,11 @@ public async Task DoSomething(IScheduler schedule, CancellationToken ct)
 
 ## Trigger Tips
 
-### Use TriggerUtils
+### Use TriggerFireTimes
 
-TriggerUtils offers helpers for analyzing triggers: computing a trigger's next fire times, the fire
-times it produces between two instants, and the end time that would allow exactly N firings.
+TriggerFireTimes answers what a trigger would fire without scheduling it: a trigger's next fire
+times, the fire times it produces between two instants, and the end time that would allow exactly
+N firings. On Quartz 3.x the same helpers live on `TriggerUtils`.
 
 ### Use ScheduleJobs
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4348,16 +4348,27 @@ disposes that registration on `Shutdown`. Shutting one scheduler down no longer 
 resolution for the other schedulers in the process, and no longer leaves a resolver installed after
 the last scheduler is gone.
 
-## `TriggerUtils` moved to `Quartz.Extensibility`
+## `TriggerUtils` became `TriggerFireTimes`
 
 It computes fire times by advancing a copy of a trigger through its schedule, applying the calendar
-at each step, which is exactly what `IOperableTrigger` adds over `ITrigger` — so it belongs with that
-contract rather than in the root namespace next to `IScheduler`. The methods are unchanged:
+at each step, which is exactly what `IOperableTrigger` adds over `ITrigger` — so it is named for the
+fire times it computes and lives in `Quartz.Extensibility` with that contract, rather than in the
+root namespace next to `IScheduler`. The type name carries the "fire times" half, so the methods
+stop repeating it:
+
+| 3.x | 4.0 |
+|-----|-----|
+| `TriggerUtils.ComputeFireTimes(...)` | `TriggerFireTimes.Compute(...)` |
+| `TriggerUtils.ComputeFireTimesBetween(...)` | `TriggerFireTimes.ComputeBetween(...)` |
+| `TriggerUtils.ComputeEndTimeToAllowParticularNumberOfFirings(...)` | `TriggerFireTimes.ComputeEndTimeForCount(...)` |
+
+Parameters and behavior are unchanged:
 
 ```diff
 + using Quartz.Extensibility;
 
-  var times = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, calendar, 10);
+- var times = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, calendar, 10);
++ var times = TriggerFireTimes.Compute((IOperableTrigger) trigger, calendar, 10);
 ```
 
 ## Other Breaking Changes
@@ -4489,7 +4500,7 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `JobDataMap`'s sixty typed accessors removed | The inherited `StringKeyDirtyFlagMap` set does the same job — see [`JobDataMap`'s typed accessors are the ones it inherits](#jobdatamap-s-typed-accessors-are-the-ones-it-inherits) |
 | `Quartz.AspNetCore.AddQuartzServer` removed | `AddQuartzHostedService` starts the scheduler and `AddQuartzHealthChecks` registers the check — see [`AddQuartzServer` is `AddQuartzHostedService`](#addquartzserver-is-addquartzhostedservice) |
 | `ISchedulerFactory.GetScheduler(name)` is `LookupScheduler(name)` | Two members named `GetScheduler` differed only in nullability. `GetScheduler()` builds this factory's scheduler and cannot return null; `LookupScheduler(name)` looks one up in the container's repository and can, which is what the verb now says. `Lookup` matches `ISchedulerRepository.Lookup` |
-| `TriggerUtils` moved to `Quartz.Extensibility` | It is a helper over `IOperableTrigger`, not part of the scheduling API — see [`TriggerUtils` moved to `Quartz.Extensibility`](#triggerutils-moved-to-quartz-extensibility) |
+| `TriggerUtils` became `Quartz.Extensibility.TriggerFireTimes` | A fire-time calculator over `IOperableTrigger`, named for what it computes; the three `Compute*` methods shortened with it — see [`TriggerUtils` became `TriggerFireTimes`](#triggerutils-became-triggerfiretimes) |
 | `TimeZoneUtil` became `Quartz.TimeZones` | `FindTimeZoneById` — now `FindById` — and the wall-clock `GetUtcOffset` are scheduling API, not utilities — see [`TimeZoneUtil` became `Quartz.TimeZones`](#timezoneutil-became-quartz-timezones) |
 | `Quartz.Util.ObjectExtensions` is internal | `AssemblyQualifiedNameWithoutVersion()` is how Quartz spells a type name into a blob or onto the wire, not a general-purpose helper |
 | `Quartz.Diagnostics.ActivityOptions` is `ActivityTags` | It holds `Activity` tag names, not options, and `*Options` names an options type everywhere else. It replaced 3.x's `DiagnosticHeaders`; the tag names and values are unchanged |
@@ -4499,7 +4510,7 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `IDriverDelegate.SelectNumTriggersForJob` is `CountTriggersForJob` | Matching `CountMisfiredTriggersInState`, and spelling out the last `Num` |
 | `SimpleTriggerImpl.ComputeNumTimesFiredBetween` is `ComputeNumberOfTimesFiredBetween` | As above |
 | `TriggerAcquireResult.JobType` is `JobTypeName` | It holds `JOB_CLASS_NAME` — a type name, the same thing `JobHeader.JobTypeName` carries — and was documented as a discriminator, which it is not. `TriggerHeader.TriggerType` really is a discriminator and keeps its name |
-| Parameter names spelled out on the ADO.NET surface | `IDriverDelegate.SelectJobDetail`'s `classLoadHelper` is `loadHelper` (the implementation already called it that, so named arguments disagreed with the interface); `ts` is `misfireTime`; `JobStoreSupport.ReleaseLock`'s `doIt` is `shouldRelease`; `StdAdoDelegate.AddTriggerPersistenceDelegate`'s `del` is `persistenceDelegate`; `TriggerPropertyBundle`'s `sb` is `scheduleBuilder`; `CronTriggerImpl.WillFireOn`'s `test` is `timeUtc`; `TriggerUtils.ComputeFireTimes`'s `numTimes` is `numberOfTimes` |
+| Parameter names spelled out on the ADO.NET surface | `IDriverDelegate.SelectJobDetail`'s `classLoadHelper` is `loadHelper` (the implementation already called it that, so named arguments disagreed with the interface); `ts` is `misfireTime`; `JobStoreSupport.ReleaseLock`'s `doIt` is `shouldRelease`; `StdAdoDelegate.AddTriggerPersistenceDelegate`'s `del` is `persistenceDelegate`; `TriggerPropertyBundle`'s `sb` is `scheduleBuilder`; `CronTriggerImpl.WillFireOn`'s `test` is `timeUtc`; `TriggerFireTimes.Compute`'s `numTimes` is `numberOfTimes` |
 
 ## Appendix: what happened to a name
 
@@ -4510,7 +4521,7 @@ explaining it a second time.
 
 It is derived mechanically, by diffing the public API baselines both branches keep under
 `src/Quartz.Tests.Unit/Verify/` and `src/Quartz.Tests.AspNetCore/Verify/`, so it names **every**
-public type 3.x had and 4.0 does not — all 93, across every package — rather than the ones that came
+public type 3.x had and 4.0 does not — all 94, across every package — rather than the ones that came
 to mind.
 
 Two whole-surface changes are deliberately left out, because repeating them per type would bury
@@ -4622,6 +4633,7 @@ namespace, and `Type.Member` for the second one.
 | `Quartz.TriggerExtensions` | Removed | `TriggerConfiguratorExtensions` — see [One family of `WithXSchedule` extensions](#one-family-of-withxschedule-extensions) |
 | `Quartz.Impl.AdoJobStore.TriggerStatus` | Removed | `StoredTriggerHeader`, returned by `IDriverDelegate.SelectTriggerHeader` — see [The driver delegate speaks in records](#the-driver-delegate-speaks-in-records) |
 | `Quartz.TriggerTimeComparator` | Internal | No replacement; it ordered by next fire time, then priority descending, then key — write that inline if you need it |
+| `Quartz.TriggerUtils` | Renamed `Quartz.Extensibility.TriggerFireTimes` | `ComputeFireTimes` is `Compute`, `ComputeFireTimesBetween` is `ComputeBetween` and `ComputeEndTimeToAllowParticularNumberOfFirings` is `ComputeEndTimeForCount`, with parameters and behavior unchanged — see [`TriggerUtils` became `TriggerFireTimes`](#triggerutils-became-triggerfiretimes) |
 | `Quartz.Simpl.TriggerWrapper` | Internal | No replacement; it is `RAMJobStore`'s per-trigger state — see [`RAMJobStore` is sealed](#ramjobstore-is-sealed) |
 | `Quartz.UnableToInterruptJobException` | Removed | Nothing throws it: interruption is cancellation, and every job receives the token — see [`UnableToInterruptJobException` is gone](#unabletointerruptjobexception-is-gone) |
 | `Quartz.XmlSchedulingOptions` | Merged into `FileSchedulingOptions` | See [Other Breaking Changes](#other-breaking-changes) |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4261,7 +4261,7 @@ The health-check overload that took `IEnumerable<string> healthCheckTags` is gon
 Quartz, and it is deliberate rather than overlooked.
 
 Almost everything the scheduler is made of is built by a container and is injected an `ILogger` the
-ordinary way. What is left over cannot be: static helpers such as `TimeZoneUtil`, types a caller
+ordinary way. What is left over cannot be: static classes such as `TimeZones`, types a caller
 constructs directly — triggers, calendars, plugins, the jobs in `Quartz.Jobs` — and anything that
 runs while the container is still being built. A type cannot be handed a logger by a container that
 does not exist yet, so those sites read the ambient factory instead of going unlogged.
@@ -4275,30 +4275,33 @@ lifetime, and only the application can make that call. The same applies to a han
 `LogProvider.SetLogProvider(host.Services.GetRequiredService<ILoggerFactory>())`: it is correct as
 long as the host outlives the schedulers.
 
-`TimeZoneUtil.AddResolver` is ambient for the same reason. `FindTimeZoneById` is reached from
+`TimeZones.AddResolver` is ambient for the same reason. `FindById` is reached from
 parsing a `CronExpression` and from deserializing a trigger out of a job store blob, neither of
 which has a scheduler in scope — which is why installing `Quartz.Plugins.TimeZoneConverter` in one
 scheduler changes id resolution for the whole process, and why each registration is undone by
 disposing it rather than by anyone owning the slot — see
-[`TimeZoneUtil` moved to `Quartz`](#timezoneutil-moved-to-quartz).
+[`TimeZoneUtil` became `Quartz.TimeZones`](#timezoneutil-became-quartz-timezones).
 
-## `TimeZoneUtil` moved to `Quartz`
+## `TimeZoneUtil` became `Quartz.TimeZones`
 
 `FindTimeZoneById` is how a trigger built with `InTimeZone(...)` comes back out of a job store, and
 the wall-clock `GetUtcOffset(DateTime, TimeZoneInfo)` overload *is* the scheduler-wide daylight
 saving policy — an ambiguous local time resolves to the daylight offset, the first of the two
-occurrences. That is scheduling API, not a utility, so the type lives in the root namespace next to
-the builders whose behavior it defines. Every file under a `Quartz.*` namespace sees it without any
-`using`; elsewhere, `using Quartz.Util;` becomes `using Quartz;`:
+occurrences. That is scheduling API, not a utility, so 4.0 stops calling it one: the type is
+`TimeZones` — a static class named by its domain, the way `Matchers` is — and it lives in the root
+namespace next to the builders whose behavior it defines. `FindTimeZoneById` sheds the words the
+type name now carries and reads `TimeZones.FindById(id)`. Every file under a `Quartz.*` namespace
+sees it without any `using`; elsewhere, `using Quartz.Util;` becomes `using Quartz;`:
 
 ```diff
 - using Quartz.Util;
 + using Quartz;
 
-  var zone = TimeZoneUtil.FindTimeZoneById("Europe/Helsinki");
+- var zone = TimeZoneUtil.FindTimeZoneById("Europe/Helsinki");
++ var zone = TimeZones.FindById("Europe/Helsinki");
 ```
 
-No configuration shim is needed: `TimeZoneUtil` is a static helper that is called, never a type a
+No configuration shim is needed: `TimeZones` is a static class that is called, never a type a
 configuration string names and the scheduler instantiates.
 
 Two members went internal on the way: `ConvertTime(DateTimeOffset, TimeZoneInfo)` and
@@ -4311,7 +4314,7 @@ The id alias table also stays: on Windows, "Coordinated Universal Time" and "CET
 through the table alone. Its one dead entry — "US Central Standard Time" ↔ "US/Indiana-Stark",
 where each side aliased the other and neither is a system id on Windows — was pruned; both ids now
 fail with the exception that points at `Quartz.Plugins.TimeZoneConverter`. When the direct lookup
-and the aliases have both failed, `FindTimeZoneById` now also asks
+and the aliases have both failed, `FindById` now also asks
 `TimeZoneInfo.TryConvertIanaIdToWindowsId` before consulting the registered resolvers. The
 conversion runs *after* the direct lookup on purpose: run first, it would turn "US/Eastern" into a
 `TimeZoneInfo` whose `Id` is "Eastern Standard Time", and that rewritten Id is what a job store
@@ -4327,7 +4330,7 @@ back, and disposing it removes exactly that resolver:
 
 ```diff
 - TimeZoneUtil.CustomResolver = id => Resolve(id);
-+ IDisposable registration = TimeZoneUtil.AddResolver(id => Resolve(id));
++ IDisposable registration = TimeZones.AddResolver(id => Resolve(id));
   ...
 - TimeZoneUtil.CustomResolver = null;
 + registration.Dispose();
@@ -4337,7 +4340,7 @@ Resolvers are consulted **most recently added first**, so a later registration s
 one for the ids it resolves — which is exactly the last-write-wins behavior assigning
 `CustomResolver` had, minus the data loss. A resolver declines an id by returning `null`, or by
 throwing `TimeZoneNotFoundException` — the search catches it and continues with the next resolver,
-and `FindTimeZoneById` itself throws only after every fallback has failed.
+and `FindById` itself throws only after every fallback has failed.
 
 `TimeZoneConverterPlugin` now registers its own resolver on `Initialize` — targeting
 `TZConvert.TryGetTimeZoneInfo`, so an unknown id declines quietly instead of by exception — and
@@ -4375,7 +4378,7 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `IDirectoryScanListener` is asynchronous | `FilesUpdatedOrAdded` and `FilesDeleted` return `ValueTask` and take a `CancellationToken` |
 | `LoggingJobHistoryPlugin.Name`, `LoggingTriggerHistoryPlugin.Name` are get-only | The name is handed to a plugin by `Initialize`; writing it afterwards did nothing |
 | `TimeSpanParseRuleAttribute` is public | It says how a bare number in configuration is read as a `TimeSpan`, which a component configured by the same keys needs to be able to say |
-| `TimeZoneUtil.CustomResolver` became `AddResolver(...)` | Returns an `IDisposable` whose disposal removes exactly that resolver; resolvers are consulted most recently added first — see [`CustomResolver` became `AddResolver`](#customresolver-became-addresolver) |
+| `TimeZoneUtil.CustomResolver` became `TimeZones.AddResolver(...)` | Returns an `IDisposable` whose disposal removes exactly that resolver; resolvers are consulted most recently added first — see [`CustomResolver` became `AddResolver`](#customresolver-became-addresolver) |
 | Setter-only members gained getters | `DbMetadata.DbBinaryTypeName` (now nullable) and `.ParameterDbTypePropertyName` |
 | `TriggerState.Executing` added | Reported where `Normal`, `Complete` or `Blocked` used to be, and `Blocked` narrowed to mean a sibling trigger is running (see [Executing is a trigger state](#executing-is-a-trigger-state)) |
 | `IDriverDelegate.IsTriggerCurrentlyExecuting` removed | Replaced by `SelectTriggerStateWithExecuting`, which reads the state and the execution in one statement and returns `TriggerExecutionState` |
@@ -4487,7 +4490,7 @@ contract rather than in the root namespace next to `IScheduler`. The methods are
 | `Quartz.AspNetCore.AddQuartzServer` removed | `AddQuartzHostedService` starts the scheduler and `AddQuartzHealthChecks` registers the check — see [`AddQuartzServer` is `AddQuartzHostedService`](#addquartzserver-is-addquartzhostedservice) |
 | `ISchedulerFactory.GetScheduler(name)` is `LookupScheduler(name)` | Two members named `GetScheduler` differed only in nullability. `GetScheduler()` builds this factory's scheduler and cannot return null; `LookupScheduler(name)` looks one up in the container's repository and can, which is what the verb now says. `Lookup` matches `ISchedulerRepository.Lookup` |
 | `TriggerUtils` moved to `Quartz.Extensibility` | It is a helper over `IOperableTrigger`, not part of the scheduling API — see [`TriggerUtils` moved to `Quartz.Extensibility`](#triggerutils-moved-to-quartz-extensibility) |
-| `TimeZoneUtil` moved to `Quartz` | `FindTimeZoneById` and the wall-clock `GetUtcOffset` are scheduling API, not utilities — see [`TimeZoneUtil` moved to `Quartz`](#timezoneutil-moved-to-quartz) |
+| `TimeZoneUtil` became `Quartz.TimeZones` | `FindTimeZoneById` — now `FindById` — and the wall-clock `GetUtcOffset` are scheduling API, not utilities — see [`TimeZoneUtil` became `Quartz.TimeZones`](#timezoneutil-became-quartz-timezones) |
 | `Quartz.Util.ObjectExtensions` is internal | `AssemblyQualifiedNameWithoutVersion()` is how Quartz spells a type name into a blob or onto the wire, not a general-purpose helper |
 | `Quartz.Diagnostics.ActivityOptions` is `ActivityTags` | It holds `Activity` tag names, not options, and `*Options` names an options type everywhere else. It replaced 3.x's `DiagnosticHeaders`; the tag names and values are unchanged |
 | `DBSemaphore` is `DbSemaphore` | The last `DB` spelling, with `DBConnectionManager` → `DbConnectionManager`. The type is abstract and is never named in configuration |
@@ -4507,7 +4510,7 @@ explaining it a second time.
 
 It is derived mechanically, by diffing the public API baselines both branches keep under
 `src/Quartz.Tests.Unit/Verify/` and `src/Quartz.Tests.AspNetCore/Verify/`, so it names **every**
-public type 3.x had and 4.0 does not — all 92, across every package — rather than the ones that came
+public type 3.x had and 4.0 does not — all 93, across every package — rather than the ones that came
 to mind.
 
 Two whole-surface changes are deliberately left out, because repeating them per type would bury
@@ -4615,6 +4618,7 @@ namespace, and `Type.Member` for the second one.
 | `Quartz.Simpl.SystemPropertyInstanceIdGenerator` | Internal | `quartz.scheduler.instanceId = SYS_PROP` still selects it; in code, register your own `IInstanceIdGenerator` |
 | `Quartz.SystemTime` | Removed | `TimeProvider` — see [SystemTime Replaced with TimeProvider](#systemtime-replaced-with-timeprovider) |
 | `Quartz.TimeOfDay` | Removed | `TimeOnly` — see [`TimeOfDay` became `TimeOnly`](#timeofday-became-timeonly) |
+| `Quartz.Util.TimeZoneUtil` | Renamed `Quartz.TimeZones` | `FindTimeZoneById` is `FindById`; `CustomResolver` is `AddResolver(...)`, whose `IDisposable` undoes the registration; the Mono-era `ConvertTime` / `GetUtcOffset(DateTimeOffset, TimeZoneInfo)` shims went internal, while the wall-clock `GetUtcOffset(DateTime, TimeZoneInfo)` stays public — see [`TimeZoneUtil` became `Quartz.TimeZones`](#timezoneutil-became-quartz-timezones) |
 | `Quartz.TriggerExtensions` | Removed | `TriggerConfiguratorExtensions` — see [One family of `WithXSchedule` extensions](#one-family-of-withxschedule-extensions) |
 | `Quartz.Impl.AdoJobStore.TriggerStatus` | Removed | `StoredTriggerHeader`, returned by `IDriverDelegate.SelectTriggerHeader` — see [The driver delegate speaks in records](#the-driver-delegate-speaks-in-records) |
 | `Quartz.TriggerTimeComparator` | Internal | No replacement; it ordered by next fire time, then priority descending, then key — write that inline if you need it |
@@ -4656,6 +4660,4 @@ removals on types that are still public and still open, which no section above n
 | `StringKeyDirtyFlagMap.GetNullableGuid()`, `.TryGetNullableGuid()` | Removed | `TryGetGuid(key, out var value)`, whose `false` says the same thing as a `null` did — see [`JobDataMap`'s typed accessors are the ones it inherits](#jobdatamap-s-typed-accessors-are-the-ones-it-inherits) |
 | `StringKeyDirtyFlagMap.Put()` (eight overloads), `.PutAll()` | Removed; all were `[Obsolete]` in 3.x | `map[key] = value` |
 | `TaskSchedulingThreadPool.ThreadPriority` | Removed | No replacement; work runs on a `TaskScheduler`, which has no thread to prioritise — see [The thread pool is asynchronous](#the-thread-pool-is-asynchronous) |
-| `TimeZoneUtil.ConvertTime`, `.GetUtcOffset(DateTimeOffset, TimeZoneInfo)` | Internal | `TimeZoneInfo.ConvertTime` / `TimeZoneInfo.GetUtcOffset`, which they forwarded to (they were Mono-era shims); the wall-clock `GetUtcOffset(DateTime, TimeZoneInfo)` stays public — see [`TimeZoneUtil` moved to `Quartz`](#timezoneutil-moved-to-quartz) |
-| `TimeZoneUtil.CustomResolver` | Removed | `AddResolver(...)`, whose `IDisposable` undoes the registration; the type also moved to `Quartz` — see [`CustomResolver` became `AddResolver`](#customresolver-became-addresolver) |
 | `ZeroSizeThreadPool.AvailableThreadCount` | Removed | `PoolSize`, which is `0` — the pool never had a thread to report |

--- a/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
@@ -114,7 +114,7 @@ using the builder's `InTimeZone` method:
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger1", "group1")
     .WithRecurrenceSchedule("FREQ=MONTHLY;BYDAY=2MO", b => b
-        .InTimeZone(TimeZoneUtil.FindTimeZoneById("Eastern Standard Time")))
+        .InTimeZone(TimeZones.FindById("Eastern Standard Time")))
     .StartNow()
     .Build();
 ```

--- a/src/Quartz.Plugins.TimeZoneConverter/Plugins/TimeZoneConverter/TimeZoneConverterPlugin.cs
+++ b/src/Quartz.Plugins.TimeZoneConverter/Plugins/TimeZoneConverter/TimeZoneConverterPlugin.cs
@@ -41,7 +41,7 @@ public class TimeZoneConverterPlugin : ISchedulerPlugin
         IScheduler scheduler,
         CancellationToken cancellationToken = default)
     {
-        resolverRegistration = TimeZoneUtil.AddResolver(
+        resolverRegistration = TimeZones.AddResolver(
             static id => TZConvert.TryGetTimeZoneInfo(id, out TimeZoneInfo? timeZoneInfo) ? timeZoneInfo : null);
 
         return default;

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
@@ -377,7 +377,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
             throw new SchedulerConfigException($"JSON trigger '{triggerName}': invalid cron expression '{cron.Expression}'. {ex.Message}", ex);
         }
 
-        if (cron.TimeZone is not null) builder.InTimeZone(TimeZoneUtil.FindTimeZoneById(cron.TimeZone));
+        if (cron.TimeZone is not null) builder.InTimeZone(TimeZones.FindById(cron.TimeZone));
         if (cron.MisfireInstruction is not null) builder.WithMisfireInstruction((CronTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Cron, cron.MisfireInstruction, logger));
         return builder;
     }
@@ -404,7 +404,7 @@ internal sealed class JsonSchedulingDataProcessor : XMLSchedulingDataProcessor
             builder.OnDaysOfTheWeek(days);
         }
 
-        if (daily.TimeZone is not null) builder.InTimeZone(TimeZoneUtil.FindTimeZoneById(daily.TimeZone));
+        if (daily.TimeZone is not null) builder.InTimeZone(TimeZones.FindById(daily.TimeZone));
 
         if (daily.MisfireInstruction is not null)
         {

--- a/src/Quartz.Serialization.Newtonsoft/Converters/CalendarConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/CalendarConverter.cs
@@ -55,7 +55,7 @@ internal sealed class CalendarConverter(NewtonsoftJsonSerializerRegistry registr
         if (calendar is BaseCalendar target)
         {
             target.Description = jObject["Description"]!.Value<string>();
-            target.TimeZone = TimeZoneUtil.FindTimeZoneById(jObject["TimeZoneId"]!.Value<string>()!);
+            target.TimeZone = TimeZones.FindById(jObject["TimeZoneId"]!.Value<string>()!);
             var baseCalendar = jObject["BaseCalendar"]!.Value<JObject>();
             if (baseCalendar is not null)
             {

--- a/src/Quartz.Serialization.Newtonsoft/Converters/CronExpressionConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/CronExpressionConverter.cs
@@ -29,7 +29,7 @@ internal sealed class CronExpressionConverter : JsonConverter
         JObject jObject = JObject.Load(reader);
         var cronExpressionString = jObject["CronExpression"]!.Value<string>()!;
 
-        TimeZoneInfo timeZone = TimeZoneUtil.FindTimeZoneById(jObject["TimeZoneId"]!.Value<string>()!);
+        TimeZoneInfo timeZone = TimeZones.FindById(jObject["TimeZoneId"]!.Value<string>()!);
         return new CronExpression(cronExpressionString, timeZone);
     }
 

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CalendarIntervalTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CalendarIntervalTriggerSerializer.cs
@@ -13,7 +13,7 @@ public class CalendarIntervalTriggerSerializer : TriggerSerializer<CalendarInter
     {
         var repeatIntervalUnit = source["RepeatIntervalUnit"]!.ToObject<IntervalUnit>();
         var repeatInterval = source.Value<int>("RepeatInterval");
-        var timeZone = TimeZoneUtil.FindTimeZoneById(source.Value<string>("TimeZone")!);
+        var timeZone = TimeZones.FindById(source.Value<string>("TimeZone")!);
         var preserveHourOfDayAcrossDaylightSavings = source.Value<bool>("PreserveHourOfDayAcrossDaylightSavings");
         var skipDayIfHourDoesNotExist = source.Value<bool>("SkipDayIfHourDoesNotExist");
 

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
@@ -10,7 +10,7 @@ public class CronTriggerSerializer : TriggerSerializer<ICronTrigger>
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {
         var cronExpressionString = source.Value<string>("CronExpressionString")!;
-        var timeZone = TimeZoneUtil.FindTimeZoneById(source.Value<string>("TimeZone")!);
+        var timeZone = TimeZones.FindById(source.Value<string>("TimeZone")!);
 
         return CronScheduleBuilder.Create(cronExpressionString)
             .InTimeZone(timeZone);

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/DailyTimeIntervalTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/DailyTimeIntervalTriggerSerializer.cs
@@ -18,7 +18,7 @@ public class DailyTimeIntervalTriggerSerializer : TriggerSerializer<DailyTimeInt
         var startTimeOfDay = source.Value<JObject>("StartTimeOfDay")!.GetTimeOfDay();
         var endTimeOfDay = source.Value<JObject>("EndTimeOfDay")!.GetTimeOfDay();
         var daysOfWeek = source.Value<JArray>("DaysOfWeek")!.Select(x => (DayOfWeek) Enum.Parse(typeof(DayOfWeek), x.Value<string>()!)).ToArray();
-        var timeZone = TimeZoneUtil.FindTimeZoneById(source.Value<string>("TimeZone")!);
+        var timeZone = TimeZones.FindById(source.Value<string>("TimeZone")!);
 
         return DailyTimeIntervalScheduleBuilder.Create()
             .WithRepeatCount(repeatCount)

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/RecurrenceTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/RecurrenceTriggerSerializer.cs
@@ -12,7 +12,7 @@ public sealed class RecurrenceTriggerSerializer : TriggerSerializer<RecurrenceTr
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {
         var recurrenceRule = source.Value<string>("RecurrenceRule")!;
-        var timeZone = TimeZoneUtil.FindTimeZoneById(source.Value<string>("TimeZone")!);
+        var timeZone = TimeZones.FindById(source.Value<string>("TimeZone")!);
 
         return RecurrenceScheduleBuilder.Create(recurrenceRule)
             .InTimeZone(timeZone);

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -185,8 +185,8 @@ public class SmokeTestPerformer
                 // ask scheduler to re-Execute this job if it was in progress when
                 // the scheduler went down...
 
-                var timeZone1 = TimeZoneUtil.FindTimeZoneById("Central European Standard Time");
-                var timeZone2 = TimeZoneUtil.FindTimeZoneById("Mountain Standard Time");
+                var timeZone1 = TimeZones.FindById("Central European Standard Time");
+                var timeZone2 = TimeZones.FindById("Mountain Standard Time");
 
                 DailyTimeIntervalTriggerImpl nt = new DailyTimeIntervalTriggerImpl("nth_trig_" + count, schedId, new TimeOnly(1, 1, 1), new TimeOnly(23, 30, 0), IntervalUnit.Hour, 1);
                 nt.StartTimeUtc = DateTime.Now.Date.AddMilliseconds(1000);
@@ -247,7 +247,7 @@ public class SmokeTestPerformer
                     null,
                     null);
 
-                customTimeZoneResolverRegistration = TimeZoneUtil.AddResolver(id =>
+                customTimeZoneResolverRegistration = TimeZones.AddResolver(id =>
                 {
                     if (id == CustomTimeZoneId)
                     {
@@ -747,7 +747,7 @@ internal sealed class CustomNewtonsoftTriggerSerializer : CronTriggerSerializer
     {
         base.DeserializeFields(trigger, source);
         ((CustomTrigger) trigger).CronExpressionString = source.Value<string>("CronExpressionString");
-        ((CustomTrigger) trigger).TimeZone = TimeZoneUtil.FindTimeZoneById(source.Value<string>("TimeZone")!);
+        ((CustomTrigger) trigger).TimeZone = TimeZones.FindById(source.Value<string>("TimeZone")!);
         ((CustomTrigger) trigger).SomeCustomProperty = source.Value<bool>("SomeCustomProperty");
     }
 
@@ -779,7 +779,7 @@ internal sealed class CustomSystemTextJsonTriggerSerializer : Serialization.Syst
     {
         base.DeserializeFields(trigger, jsonElement, options);
         ((CustomTrigger) trigger).CronExpressionString = jsonElement.GetProperty("CronExpressionString").GetString();
-        ((CustomTrigger) trigger).TimeZone = TimeZoneUtil.FindTimeZoneById(jsonElement.GetProperty("TimeZone").GetString());
+        ((CustomTrigger) trigger).TimeZone = TimeZones.FindById(jsonElement.GetProperty("TimeZone").GetString());
         ((CustomTrigger) trigger).SomeCustomProperty = jsonElement.GetProperty("SomeCustomProperty").GetBoolean();
     }
 

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerDstTests.cs
@@ -141,7 +141,7 @@ public class CalendarIntervalTriggerDstTests
             .ToList();
 
         // 01:30 happens twice on 2024-11-03. The trigger fires once, and on the first (daylight, -04:00)
-        // occurrence, because the re-anchoring goes through TimeZoneUtil.GetUtcOffset(DateTime, ...)
+        // occurrence, because the re-anchoring goes through TimeZones.GetUtcOffset(DateTime, ...)
         // which resolves an ambiguous wall-clock time to the daylight offset.
         onTransitionDay.Should().Equal(TestTimeZones.Local("2024-11-03 01:30 -04:00"));
 
@@ -236,7 +236,7 @@ public class CalendarIntervalTriggerDstTests
     /// <summary>
     /// When the preserved wall-clock time is itself the ambiguous one, the trigger fires on the first
     /// (daylight) occurrence of it, not the second. The re-anchoring resolves the local time through
-    /// <c>TimeZoneUtil.GetUtcOffset(DateTime, ...)</c>, which prefers the daylight offset.
+    /// <c>TimeZones.GetUtcOffset(DateTime, ...)</c>, which prefers the daylight offset.
     /// </summary>
     [Test]
     public void PreserveHour_AmbiguousScheduledHour_Sydney_PicksFirstOccurrence()

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
@@ -31,7 +31,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset targetCalendar = startCalendar.AddYears(4);
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 4);
+        var fireTimes = TriggerFireTimes.Compute(yearlyTrigger, null, 4);
         DateTimeOffset thirdTime = fireTimes[2]; // get the third fire time
 
         Assert.That(thirdTime, Is.EqualTo(targetCalendar), "Year increment result not as expected.");
@@ -51,7 +51,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset targetCalendar = startCalendar.AddMonths(25); // jump 25 five months (5 intervals)
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(yearlyTrigger, null, 6);
         DateTimeOffset sixthTime = fireTimes[5]; // get the sixth fire time
 
         Assert.That(sixthTime, Is.EqualTo(targetCalendar), "Month increment result not as expected.");
@@ -71,7 +71,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset targetCalendar = startCalendar.AddDays(7 * 6 * 4); // jump 24 weeks (4 intervals)
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 7);
+        var fireTimes = TriggerFireTimes.Compute(yearlyTrigger, null, 7);
         DateTimeOffset fifthTime = fireTimes[4]; // get the fifth fire time
 
         Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Week increment result not as expected.");
@@ -91,7 +91,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset targetCalendar = startCalendar.AddDays(360); // jump 360 days (4 intervals)
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(dailyTrigger, null, 6);
         DateTimeOffset fifthTime = fireTimes[4]; // get the fifth fire time
 
         Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Day increment result not as expected.");
@@ -111,7 +111,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset targetCalendar = startCalendar.AddHours(400); // jump 400 hours (4 intervals)
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(yearlyTrigger, null, 6);
         DateTimeOffset fifthTime = fireTimes[4]; // get the fifth fire time
 
         Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Hour increment result not as expected.");
@@ -131,7 +131,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset targetCalendar = startCalendar.AddMinutes(400); // jump 400 minutes (4 intervals)
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(yearlyTrigger, null, 6);
         DateTimeOffset fifthTime = fireTimes[4]; // get the fifth fire time
 
         Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Minutes increment result not as expected.");
@@ -151,7 +151,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset targetCalendar = startCalendar.AddSeconds(400); // jump 400 seconds (4 intervals)
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(yearlyTrigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(yearlyTrigger, null, 6);
         DateTimeOffset fifthTime = fireTimes[4]; // get the third fire time
 
         Assert.That(fifthTime, Is.EqualTo(targetCalendar), "Seconds increment result not as expected.");
@@ -173,7 +173,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         DateTimeOffset targetCalendar = startCalendar.AddDays(10); // jump 10 days (2 intervals)
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(dailyTrigger, null, 6);
         DateTimeOffset testTime = fireTimes[2]; // get the third fire time
 
         Assert.That(testTime, Is.EqualTo(targetCalendar), "Day increment result not as expected over spring 2010 daylight savings transition.");
@@ -189,7 +189,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetCalendar = startCalendar.AddDays(2); // jump 2 days (2 intervals)
 
-        fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
+        fireTimes = TriggerFireTimes.Compute(dailyTrigger, null, 6);
         testTime = fireTimes[2]; // get the third fire time
 
         Assert.That(testTime, Is.EqualTo(targetCalendar), "Day increment result not as expected over spring 2011 daylight savings transition.");
@@ -207,7 +207,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         targetCalendar = TimeZones.ConvertTime(startCalendar, cetTimeZone);
         targetCalendar = targetCalendar.AddDays(2); // jump 2 days (2 intervals)
 
-        fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
+        fireTimes = TriggerFireTimes.Compute(dailyTrigger, null, 6);
 
         testTime = fireTimes[2]; // get the third fire time
 
@@ -228,7 +228,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetCalendar = startCalendar.AddDays(2); // jump 2 days (2 intervals)
 
-        fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
+        fireTimes = TriggerFireTimes.Compute(dailyTrigger, null, 6);
 
         testTime = fireTimes[1]; // get the second fire time
 
@@ -249,7 +249,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         targetCalendar = startCalendar.AddDays(15); // jump 15 days (3 intervals)
 
-        fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
+        fireTimes = TriggerFireTimes.Compute(dailyTrigger, null, 6);
         testTime = fireTimes[3]; // get the fourth fire time
 
         Assert.That(testTime, Is.EqualTo(targetCalendar), "Day increment result not as expected over fall daylight savings transition.");
@@ -334,7 +334,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             StartTimeUtc = new DateTimeOffset(2012, 11, 2, 12, 0, 0, TimeSpan.FromHours(-4))
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 6);
 
         var expected = new DateTimeOffset(2012, 11, 2, 12, 0, 0, TimeSpan.FromHours(-4));
         Assert.That(fireTimes[0], Is.EqualTo(expected));
@@ -373,7 +373,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         DateTimeOffset startDate = new DateTimeOffset(2012, 3, 10, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
 
-        var fires = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        var fires = TriggerFireTimes.Compute(trigger, null, 5);
 
         var targetTime = fires[1]; //get second fire
 
@@ -395,7 +395,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         startDate = new DateTimeOffset(2012, 3, 4, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
 
-        fires = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        fires = TriggerFireTimes.Compute(trigger, null, 5);
 
         targetTime = fires[1]; //get second fire
 
@@ -418,7 +418,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         startDate = new DateTimeOffset(2012, 2, 11, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
 
-        fires = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        fires = TriggerFireTimes.Compute(trigger, null, 5);
 
         targetTime = fires[1]; //get second fire
 
@@ -443,7 +443,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         startDate = new DateTimeOffset(2011, 3, 11, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
 
-        fires = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        fires = TriggerFireTimes.Compute(trigger, null, 5);
 
         targetTime = fires[1]; //get second fire
 
@@ -480,7 +480,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         DateTimeOffset startDate = new DateTimeOffset(2012, 3, 10, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
 
-        var fires = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        var fires = TriggerFireTimes.Compute(trigger, null, 5);
 
         var targetTime = fires[1]; //get second fire
 
@@ -505,7 +505,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         startDate = new DateTimeOffset(2012, 3, 4, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
 
-        fires = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        fires = TriggerFireTimes.Compute(trigger, null, 5);
 
         targetTime = fires[1]; //get second fire
 
@@ -530,7 +530,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         startDate = new DateTimeOffset(2012, 2, 11, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
 
-        fires = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        fires = TriggerFireTimes.Compute(trigger, null, 5);
 
         targetTime = fires[1]; //get second fire
 
@@ -556,7 +556,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         startDate = new DateTimeOffset(2011, 3, 11, 2, 0, 0, 0, TimeSpan.FromHours(-5));
         trigger.StartTimeUtc = startDate;
 
-        fires = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        fires = TriggerFireTimes.Compute(trigger, null, 5);
 
         targetTime = fires[1]; //get second fire
 
@@ -583,7 +583,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             TimeZone = est
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(t, null, 10);
+        var fireTimes = TriggerFireTimes.Compute(t, null, 10);
 
         var firstFire = fireTimes[0];
         var secondFire = fireTimes[1];
@@ -607,7 +607,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             TimeZone = est
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(t, null, 10);
+        var fireTimes = TriggerFireTimes.Compute(t, null, 10);
 
         var firstFire = fireTimes[0];
         var secondFire = fireTimes[1];
@@ -626,7 +626,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             TimeZone = est
         };
 
-        fireTimes = TriggerUtils.ComputeFireTimes(t, null, 10);
+        fireTimes = TriggerFireTimes.Compute(t, null, 10);
 
         Assert.That(secondFire, Is.Not.EqualTo(firstFire));
     }
@@ -644,7 +644,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         dailyTrigger.TimeZone = cetTimeZone;
         dailyTrigger.PreserveHourOfDayAcrossDaylightSavings = true;
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(dailyTrigger, null, 6);
 
         //none of these should match the previous fire time.
         for (int i = 1; i < fireTimes.Count; i++)
@@ -757,7 +757,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
                 .InTimeZone(tz))
             .Build();
 
-        var firstFireTime = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 1).First();
+        var firstFireTime = TriggerFireTimes.Compute(dailyTrigger, null, 1).First();
         Assert.That(firstFireTime, Is.EqualTo(new DateTimeOffset(2017, 1, 4, 13, 0, 0, TimeSpan.FromHours(-2))));
     }
 
@@ -805,8 +805,8 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             StartTimeUtc = startDate
         };
 
-        // Compute the first few fire times using TriggerUtils.ComputeFireTimes
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 10);
+        // Compute the first few fire times using TriggerFireTimes.Compute
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 10);
 
         // Expected fire times:
         // 1. 2/25/2024 2:01 AM CST
@@ -922,7 +922,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             StartTimeUtc = startDate
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 5);
 
         Assert.That(fireTimes, Is.Not.Null);
         Assert.That(fireTimes.Count, Is.GreaterThanOrEqualTo(4));
@@ -1016,7 +1016,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             StartTimeUtc = startDate
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 10);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 10);
 
         Assert.That(fireTimes, Is.Not.Null);
         Assert.That(fireTimes.Count, Is.GreaterThanOrEqualTo(6));
@@ -1061,7 +1061,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             StartTimeUtc = startDate
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 6);
 
         Assert.That(fireTimes, Is.Not.Null);
         Assert.That(fireTimes.Count, Is.GreaterThanOrEqualTo(5));
@@ -1106,7 +1106,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
             StartTimeUtc = startDate
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 5);
 
         Assert.That(fireTimes, Is.Not.Null);
         Assert.That(fireTimes.Count, Is.GreaterThanOrEqualTo(4));

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerTest.cs
@@ -196,7 +196,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         // And again, Pick a day before a spring daylight savings transition... (QTZ-240) - and prove time of day is not preserved without setPreserveHourOfDayAcrossDaylightSavings(true)
 
-        var cetTimeZone = TimeZoneUtil.FindTimeZoneById("Central European Standard Time");
+        var cetTimeZone = TimeZones.FindById("Central European Standard Time");
         startCalendar = TimeZoneInfo.ConvertTime(new DateTime(2011, 3, 26, 4, 0, 0), cetTimeZone);
 
         dailyTrigger = new CalendarIntervalTriggerImpl();
@@ -204,20 +204,20 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         dailyTrigger.RepeatIntervalUnit = IntervalUnit.Day;
         dailyTrigger.RepeatInterval = 1; // every day
 
-        targetCalendar = TimeZoneUtil.ConvertTime(startCalendar, cetTimeZone);
+        targetCalendar = TimeZones.ConvertTime(startCalendar, cetTimeZone);
         targetCalendar = targetCalendar.AddDays(2); // jump 2 days (2 intervals)
 
         fireTimes = TriggerUtils.ComputeFireTimes(dailyTrigger, null, 6);
 
         testTime = fireTimes[2]; // get the third fire time
 
-        DateTimeOffset testCal = TimeZoneUtil.ConvertTime(testTime, cetTimeZone);
+        DateTimeOffset testCal = TimeZones.ConvertTime(testTime, cetTimeZone);
 
         Assert.That(testCal.Hour, Is.Not.EqualTo(targetCalendar.Hour), "Day increment time-of-day result not as expected over spring 2011 daylight savings transition.");
 
         // And again, Pick a day before a spring daylight savings transition... (QTZ-240) - and prove time of day is preserved with setPreserveHourOfDayAcrossDaylightSavings(true)
 
-        startCalendar = TimeZoneUtil.ConvertTime(new DateTime(2011, 3, 26, 4, 0, 0), cetTimeZone);
+        startCalendar = TimeZones.ConvertTime(new DateTime(2011, 3, 26, 4, 0, 0), cetTimeZone);
 
         dailyTrigger = new CalendarIntervalTriggerImpl();
         dailyTrigger.StartTimeUtc = startCalendar;
@@ -232,7 +232,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
 
         testTime = fireTimes[1]; // get the second fire time
 
-        testCal = TimeZoneUtil.ConvertTime(testTime, cetTimeZone);
+        testCal = TimeZones.ConvertTime(testTime, cetTimeZone);
 
         Assert.That(testCal.Hour, Is.EqualTo(targetCalendar.Hour), "Day increment time-of-day result not as expected over spring 2011 daylight savings transition.");
 
@@ -326,7 +326,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Test]
     public void TestTimeZoneTransition()
     {
-        TimeZoneInfo timeZone = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo timeZone = TimeZones.FindById("Eastern Standard Time");
 
         CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl("trigger", IntervalUnit.Day, 1)
         {
@@ -353,7 +353,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Test]
     public void TestSkipDayIfItDoesNotExists()
     {
-        TimeZoneInfo timeZone = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo timeZone = TimeZones.FindById("Eastern Standard Time");
 
         //March 11, 2012, EST DST starts at 2am and jumps to 3.
         // 3/11/2012 2:00:00 AM is an invalid time
@@ -456,7 +456,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Test]
     public void TestSkipDayIfItDoesNotExistsIsFalse()
     {
-        TimeZoneInfo timeZone = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo timeZone = TimeZones.FindById("Eastern Standard Time");
 
         //March 11, 2012, EST DST starts at 2am and jumps to 3.
         // 3/11/2012 2:00:00 AM is an invalid time
@@ -570,7 +570,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Test]
     public void TestStartTimeOnDayInDifferentOffset()
     {
-        TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo est = TimeZones.FindById("Eastern Standard Time");
         DateTimeOffset startDate = new DateTimeOffset(2012, 3, 11, 12, 0, 0, TimeSpan.FromHours(-5));
 
         CalendarIntervalTriggerImpl t = new CalendarIntervalTriggerImpl
@@ -594,7 +594,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Test]
     public void TestMovingAcrossDSTAvoidsInfiniteLoop()
     {
-        TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo est = TimeZones.FindById("Eastern Standard Time");
         DateTimeOffset startDate = new DateTimeOffset(1990, 10, 27, 0, 0, 0, TimeSpan.FromHours(-4));
 
         CalendarIntervalTriggerImpl t = new CalendarIntervalTriggerImpl
@@ -634,8 +634,8 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Test]
     public void TestCrossingDSTBoundary()
     {
-        TimeZoneInfo cetTimeZone = TimeZoneUtil.FindTimeZoneById("Central European Standard Time");
-        DateTimeOffset startCalendar = TimeZoneUtil.ConvertTime(new DateTime(2011, 3, 26, 4, 0, 0), cetTimeZone);
+        TimeZoneInfo cetTimeZone = TimeZones.FindById("Central European Standard Time");
+        DateTimeOffset startCalendar = TimeZones.ConvertTime(new DateTime(2011, 3, 26, 4, 0, 0), cetTimeZone);
 
         CalendarIntervalTriggerImpl dailyTrigger = new CalendarIntervalTriggerImpl();
         dailyTrigger.StartTimeUtc = startCalendar;
@@ -659,7 +659,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Test]
     public void TestPreserveHourOfDayAcrossDaylightSavingsNotHanging()
     {
-        TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo est = TimeZones.FindById("Eastern Standard Time");
 
         DateTimeOffset startTime = new DateTimeOffset(2013, 3, 1, 4, 0, 0, TimeSpan.FromHours(-5));
 
@@ -790,7 +790,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         // - Should fire at 2:01 AM on 3/10/2024 (but that time doesn't exist - spring forward)
         // - Quartz correctly sets next fire to 3/10/2024 3:00 AM
         // - When 3:00 AM comes around, the trigger should fire ONCE and compute the next fire time correctly
-        var centralTimeZone = TimeZoneUtil.FindTimeZoneById("Central Standard Time");
+        var centralTimeZone = TimeZones.FindById("Central Standard Time");
 
         // 2/25/2024 2:01 AM CST (UTC-6)
         var startDate = new DateTimeOffset(2024, 2, 25, 2, 1, 0, TimeSpan.FromHours(-6));
@@ -864,7 +864,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         // This test demonstrates the bug: when a CalendarIntervalTrigger with a weekly interval
         // encounters a DST spring-forward transition where the scheduled time doesn't exist,
         // GetFireTimeAfter() returns the same time repeatedly, causing an infinite loop.
-        var centralTimeZone = TimeZoneUtil.FindTimeZoneById("Central Standard Time");
+        var centralTimeZone = TimeZones.FindById("Central Standard Time");
 
         // Start 2 weeks before DST (2/25/2024 2:01 AM CST)
         var startDate = new DateTimeOffset(2024, 2, 25, 2, 1, 0, TimeSpan.FromHours(-6));
@@ -907,7 +907,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Description("Variant test with SkipDayIfHourDoesNotExist=true during spring-forward")]
     public void TestWeeklyTriggerSkipsDayDuringSpringForward()
     {
-        var centralTimeZone = TimeZoneUtil.FindTimeZoneById("Central Standard Time");
+        var centralTimeZone = TimeZones.FindById("Central Standard Time");
 
         // Start 2 weeks before DST transition
         var startDate = new DateTimeOffset(2024, 2, 25, 2, 1, 0, TimeSpan.FromHours(-6));
@@ -953,7 +953,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
         // times, so the guarantees the guard existed for are asserted directly: every fire is at
         // the scheduled local time (or the end of a spring-forward gap), strictly increasing, and
         // never at or past EndTimeUtc.
-        var timeZone = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        var timeZone = TimeZones.FindById("Eastern Standard Time");
         var scheduledStart = new DateTime(2024, 2, 25, 2, 1, 0);
         var startDate = new DateTimeOffset(scheduledStart, timeZone.GetUtcOffset(scheduledStart));
         var endDate = startDate.AddDays(30); // spans the 2024-03-10 spring-forward transition
@@ -1001,7 +1001,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Description("Daily interval trigger should not loop infinitely during spring-forward DST transition")]
     public void TestDailyTriggerDoesNotFireInfinitelyDuringSpringForward()
     {
-        var centralTimeZone = TimeZoneUtil.FindTimeZoneById("Central Standard Time");
+        var centralTimeZone = TimeZones.FindById("Central Standard Time");
 
         // Start a few days before DST spring-forward (3/10/2024)
         var startDate = new DateTimeOffset(2024, 3, 7, 2, 1, 0, TimeSpan.FromHours(-6));
@@ -1046,7 +1046,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     [Description("Monthly interval trigger should not loop infinitely during spring-forward DST transition")]
     public void TestMonthlyTriggerDoesNotFireInfinitelyDuringSpringForward()
     {
-        var centralTimeZone = TimeZoneUtil.FindTimeZoneById("Central Standard Time");
+        var centralTimeZone = TimeZones.FindById("Central Standard Time");
 
         // Start on 1/10/2024 at 2:01 AM CST - the March fire lands on 3/10 (DST day)
         var startDate = new DateTimeOffset(2024, 1, 10, 2, 1, 0, TimeSpan.FromHours(-6));
@@ -1091,7 +1091,7 @@ public class CalendarIntervalTriggerTest : SerializationTestSupport<CalendarInte
     {
         // EU DST spring-forward: last Sunday of March, clocks go from 2:00 AM to 3:00 AM CET to CEST
         // In 2024, this is March 31
-        var cetTimeZone = TimeZoneUtil.FindTimeZoneById("Central European Standard Time");
+        var cetTimeZone = TimeZones.FindById("Central European Standard Time");
 
         // Start 2 weeks before EU DST (3/17/2024 2:01 AM CET)
         var startDate = new DateTimeOffset(2024, 3, 17, 2, 1, 0, TimeSpan.FromHours(1));

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -755,9 +755,9 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         DateTimeOffset test = new DateTimeOffset(2009, 3, 8, 0, 0, 0, TimeSpan.Zero); //Sunday
         DateTimeOffset d = expression.GetNextValidTimeAfter(test).Value;
         // 2009-04-06 is Monday, Sunday is invalid for W
-        Assert.That(d, Is.EqualTo(new DateTimeOffset(2009, 4, 6, 13, 5, 0, TimeZoneUtil.GetUtcOffset(d, TimeZoneInfo.Local)).ToUniversalTime()));
+        Assert.That(d, Is.EqualTo(new DateTimeOffset(2009, 4, 6, 13, 5, 0, TimeZones.GetUtcOffset(d, TimeZoneInfo.Local)).ToUniversalTime()));
         d = expression.GetNextValidTimeAfter(d).Value;
-        Assert.That(d, Is.EqualTo(new DateTimeOffset(2009, 5, 5, 13, 5, 0, TimeZoneUtil.GetUtcOffset(d, TimeZoneInfo.Local))));
+        Assert.That(d, Is.EqualTo(new DateTimeOffset(2009, 5, 5, 13, 5, 0, TimeZones.GetUtcOffset(d, TimeZoneInfo.Local))));
     }
 
     [Test]
@@ -832,7 +832,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     [Test]
     public void TestDaylightSavingsDoesNotMatchAnHourBefore()
     {
-        TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo est = TimeZones.FindById("Eastern Standard Time");
         CronExpression expression = new CronExpression("0 15 15 5 11 ?", est);
 
         DateTimeOffset startTime = new DateTimeOffset(2012, 11, 4, 0, 0, 0, TimeSpan.Zero);
@@ -847,7 +847,7 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     public void TestDaylightSavingsDoesNotMatchAnHourBefore2()
     {
         //another case
-        TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo est = TimeZones.FindById("Eastern Standard Time");
         CronExpression expression = new CronExpression("0 0 0 ? * THU", est);
 
         DateTimeOffset startTime = new DateTimeOffset(2012, 11, 4, 0, 0, 0, TimeSpan.Zero);

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -131,7 +131,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Hour));
         });
         //Assert.AreEqual(1, trigger.RepeatInterval);
-        var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute((IOperableTrigger) trigger, null, 48);
         Assert.That(fireTimes, Has.Count.EqualTo(48));
     }
 
@@ -158,7 +158,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOnly(8, 0)));
             Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOnly(17, 0)));
         });
-        var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute((IOperableTrigger) trigger, null, 48);
         Assert.That(fireTimes, Has.Count.EqualTo(48));
     }
 
@@ -188,7 +188,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.StartTimeOfDay, Is.EqualTo(new TimeOnly(10, 0, 0)));
             Assert.That(trigger.EndTimeOfDay, Is.EqualTo(new TimeOnly(23, 59, 59)));
         });
-        var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute((IOperableTrigger) trigger, null, 48);
         Assert.That(fireTimes, Has.Count.EqualTo(48));
     }
 
@@ -208,7 +208,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.RepeatInterval, Is.EqualTo(1));
         });
         // repeatCount=9 means 10 fires per day; trigger continues on subsequent days
-        var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute((IOperableTrigger) trigger, null, 48);
         Assert.That(fireTimes, Has.Count.EqualTo(48));
     }
 
@@ -230,7 +230,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.Key.Group, Is.EqualTo("DEFAULT"));
             Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Minute));
         });
-        var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute((IOperableTrigger) trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -259,7 +259,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             Assert.That(trigger.RepeatIntervalUnit, Is.EqualTo(IntervalUnit.Minute));
         });
         ((IOperableTrigger) trigger).Validate();
-        var fireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger) trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute((IOperableTrigger) trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -438,7 +438,7 @@ public class DailyTimeIntervalScheduleBuilderTest
             .StartAt(startDate)
             .Build();
 
-        var times = TriggerUtils.ComputeFireTimesBetween(trigger, null, startDate, new DateTime(2015, 1, 2));
+        var times = TriggerFireTimes.ComputeBetween(trigger, null, startDate, new DateTime(2015, 1, 2));
         Assert.Multiple(() =>
         {
             Assert.That(times, Has.Count.EqualTo(2), "wrong occurrancy count");

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -378,7 +378,7 @@ public class DailyTimeIntervalScheduleBuilderTest
     [Test]
     public void TestCanSetTimeZone()
     {
-        TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo est = TimeZones.FindById("Eastern Standard Time");
 
         IDailyTimeIntervalTrigger trigger = (IDailyTimeIntervalTrigger) TriggerBuilder.Create()
             .WithDailyTimeIntervalSchedule(x => x.WithInterval(1, IntervalUnit.Hour)

--- a/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
@@ -121,7 +121,7 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     [Test]
     public void TestAnnualCalendarTimeZone()
     {
-        TimeZoneInfo tz = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo tz = TimeZones.FindById("Eastern Standard Time");
         AnnualCalendar c = new AnnualCalendar();
         c.TimeZone = tz;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
@@ -106,7 +106,7 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
     [Test]
     public void TestTimeZone()
     {
-        TimeZoneInfo tz = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo tz = TimeZones.FindById("Eastern Standard Time");
 
         DailyCalendar dailyCalendar = new DailyCalendar(new TimeOnly(12, 0, 0), new TimeOnly(14, 0, 0))
         {

--- a/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/DailyCalendarTest.cs
@@ -137,7 +137,7 @@ public class DailyCalendarTest : SerializationTestSupport<DailyCalendar, ICalend
                 .RepeatForever())
             .Build();
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, dailyCalendar, (int)TimeSpan.FromDays(1).TotalMinutes);
+        var fireTimes = TriggerFireTimes.Compute(trigger, dailyCalendar, (int)TimeSpan.FromDays(1).TotalMinutes);
 
         var timeZoneOffset = TimeZoneInfo.Local.BaseUtcOffset;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/HolidayCalendarTest.cs
@@ -75,7 +75,7 @@ public class HolidayCalendarTest : SerializationTestSupport<HolidayCalendar, ICa
     [Test]
     public void TestTimeZone()
     {
-        TimeZoneInfo tz = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo tz = TimeZones.FindById("Eastern Standard Time");
         HolidayCalendar c = new HolidayCalendar();
         c.TimeZone = tz;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/MonthlyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/MonthlyCalendarTest.cs
@@ -77,7 +77,7 @@ public class MonthlyCalendarTest : SerializationTestSupport<MonthlyCalendar, ICa
     [Test]
     public void TestTimeZone()
     {
-        TimeZoneInfo tz = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo tz = TimeZones.FindById("Eastern Standard Time");
         MonthlyCalendar monthlyCalendar = new MonthlyCalendar();
         monthlyCalendar.TimeZone = tz;
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/WeeklyCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/WeeklyCalendarTest.cs
@@ -64,7 +64,7 @@ public class WeeklyCalendarTest : SerializationTestSupport<WeeklyCalendar, ICale
     [Test]
     public void TestDaylightSavingTransition()
     {
-        calendar.TimeZone = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        calendar.TimeZone = TimeZones.FindById("Eastern Standard Time");
         calendar.RemoveExcludedDay(DayOfWeek.Monday); //Monday only
         calendar.AddExcludedDay(DayOfWeek.Tuesday);
         calendar.AddExcludedDay(DayOfWeek.Wednesday);

--- a/src/Quartz.Tests.Unit/Impl/Recurrence/RecurrenceRuleTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Recurrence/RecurrenceRuleTest.cs
@@ -501,7 +501,7 @@ public class RecurrenceRuleTest
     {
         // US Eastern: March 9, 2025, 2:00 AM doesn't exist (clocks jump to 3:00 AM)
         RecurrenceRule rule = RecurrenceRule.Parse("FREQ=DAILY");
-        TimeZoneInfo eastern = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo eastern = TimeZones.FindById("Eastern Standard Time");
         // Start at 2:30 AM local
         DateTimeOffset start = new DateTimeOffset(2025, 3, 8, 7, 30, 0, TimeSpan.Zero); // 2:30 AM EST = 7:30 UTC
         DateTimeOffset after = start;
@@ -519,7 +519,7 @@ public class RecurrenceRuleTest
     {
         // US Eastern: Nov 2, 2025, 1:30 AM exists twice (clocks fall back at 2:00 AM)
         RecurrenceRule rule = RecurrenceRule.Parse("FREQ=DAILY");
-        TimeZoneInfo eastern = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo eastern = TimeZones.FindById("Eastern Standard Time");
         // Start at 1:30 AM local on Nov 1
         DateTimeOffset start = new DateTimeOffset(2025, 11, 1, 5, 30, 0, TimeSpan.Zero); // 1:30 AM EDT = 5:30 UTC
         DateTimeOffset after = start;

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -750,7 +750,7 @@ public class DailyTimeIntervalTriggerImplTest
     [Test]
     public void TestFollowsTimeZone1()
     {
-        TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo est = TimeZones.FindById("Eastern Standard Time");
 
         DateTimeOffset startTime = new DateTimeOffset(2012, 3, 9, 23, 0, 0, TimeSpan.FromHours(-5));
 
@@ -794,7 +794,7 @@ public class DailyTimeIntervalTriggerImplTest
     [Test]
     public void TestFollowsTimeZone2()
     {
-        TimeZoneInfo est = TimeZoneUtil.FindTimeZoneById("Eastern Standard Time");
+        TimeZoneInfo est = TimeZones.FindById("Eastern Standard Time");
 
         DateTimeOffset startTime = new DateTimeOffset(2012, 11, 2, 12, 0, 0, TimeSpan.FromHours(-4));
 

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -51,7 +51,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 72 // this interval will give three firings per day (8:00, 9:12, and 10:24)
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -73,7 +73,7 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         CronCalendar cronCal = new CronCalendar("* * 9-12 * * ?"); // exclude 9-12
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, cronCal, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, cronCal, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes.Count, Is.EqualTo(48));
@@ -133,7 +133,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -155,7 +155,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(47));
@@ -177,7 +177,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -208,7 +208,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         Assert.That(trigger.GetFireTimeAfter(dateOf(6, 0, 0, 22, 5, 2010)), Is.EqualTo(dateOf(8, 0, 0, 3, 1, 2011)));
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -230,7 +230,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -254,7 +254,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(35));
@@ -279,7 +279,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(36));
@@ -304,7 +304,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -331,7 +331,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(30));
@@ -356,7 +356,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -382,7 +382,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -409,7 +409,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         
         Assert.Multiple(() =>
         {
@@ -440,7 +440,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -475,7 +475,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 60
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>{
             Assert.That(fireTimes, Has.Count.EqualTo(48));
             Assert.That(fireTimes[0], Is.EqualTo(TestDates.DateOf(8, 0, 0, 3, 1, 2011)));
@@ -504,7 +504,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 23
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(18));
@@ -531,7 +531,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 2
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -555,7 +555,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatInterval = 72
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -582,7 +582,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         // Setting this (which is default) should make the trigger just as normal one.
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -609,7 +609,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         // repeatCount=7 allows 8 fires/day, but 8:00-11:00 with 72min interval only allows 3/day
         // so endTimeOfDay is the effective limiter; trigger continues across days
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(48));
@@ -635,7 +635,7 @@ public class DailyTimeIntervalTriggerImplTest
         };
 
         // repeatCount=0 means 1 fire per day (at startTimeOfDay), continuing daily
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 5);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 5);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(5));
@@ -663,7 +663,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatCount = 2 // 3 fires per day: 8:00, 9:00, 10:00
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 9);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 9);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(9));
@@ -700,7 +700,7 @@ public class DailyTimeIntervalTriggerImplTest
             RepeatCount = 1 // 2 fires per day: 8:00, 9:00
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 48);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 48);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(4));
@@ -731,7 +731,7 @@ public class DailyTimeIntervalTriggerImplTest
             DaysOfWeek = new HashSet<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Friday }
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 6);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 6);
         Assert.Multiple(() =>
         {
             Assert.That(fireTimes, Has.Count.EqualTo(6));
@@ -766,7 +766,7 @@ public class DailyTimeIntervalTriggerImplTest
             TimeZone = est
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 8);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 8);
 
         DateTimeOffset expected0 = new DateTimeOffset(2012, 3, 10, 8, 0, 0, 0, TimeSpan.FromHours(-5));
         DateTimeOffset expected1 = new DateTimeOffset(2012, 3, 10, 9, 0, 0, 0, TimeSpan.FromHours(-5));
@@ -810,7 +810,7 @@ public class DailyTimeIntervalTriggerImplTest
             TimeZone = est
         };
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 8);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 8);
 
         DateTimeOffset expected0 = new DateTimeOffset(2012, 11, 3, 8, 0, 0, 0, TimeSpan.FromHours(-4));
         DateTimeOffset expected1 = new DateTimeOffset(2012, 11, 3, 9, 0, 0, 0, TimeSpan.FromHours(-4));
@@ -1109,7 +1109,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         trigger.StartTimeUtc = new DateTimeOffset(2015, 1, 11, 23, 57, 0, 0, TimeSpan.Zero);
 
-        var fireTimes = TriggerUtils.ComputeFireTimes(trigger, null, 100);
+        var fireTimes = TriggerFireTimes.Compute(trigger, null, 100);
         foreach (var fireTime in fireTimes)
         {
             // Console.WriteLine(fireTime.LocalDateTime);
@@ -1182,7 +1182,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         var from = new DateTimeOffset(2018, 3, 25, 0, 0, 0, TimeSpan.Zero);
         var to = new DateTimeOffset(2018, 3, 27, 0, 0, 0, TimeSpan.Zero);
-        var times = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        var times = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
         Assert.That(times, Has.Count.LessThan(200));
     }
 
@@ -1280,7 +1280,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         DateTimeOffset from = new DateTimeOffset(2020, 10, 24, 22, 0, 0, TimeSpan.Zero);
         DateTimeOffset to = new DateTimeOffset(2020, 10, 27, 23, 0, 0, TimeSpan.Zero);
-        IReadOnlyList<DateTimeOffset> times = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        IReadOnlyList<DateTimeOffset> times = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
 
         Assert.That(times, Has.Count.EqualTo(3),
             $"Expected 3 fire times but got {times.Count}: {string.Join(", ", times.Select(t => TimeZoneInfo.ConvertTime(t, timeZoneInfo)))}");
@@ -1312,7 +1312,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         DateTimeOffset from = new DateTimeOffset(2020, 10, 24, 22, 0, 0, TimeSpan.Zero);
         DateTimeOffset to = new DateTimeOffset(2020, 10, 27, 23, 0, 0, TimeSpan.Zero);
-        IReadOnlyList<DateTimeOffset> times = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        IReadOnlyList<DateTimeOffset> times = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
 
         // Oct 25 is the fall-back day; should get one fire per day, no duplicate on Oct 25
         Assert.That(times, Has.Count.EqualTo(3),
@@ -1339,7 +1339,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         DateTimeOffset from = new DateTimeOffset(2020, 11, 1, 4, 0, 0, TimeSpan.Zero);
         DateTimeOffset to = new DateTimeOffset(2020, 11, 3, 5, 0, 0, TimeSpan.Zero);
-        IReadOnlyList<DateTimeOffset> times = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        IReadOnlyList<DateTimeOffset> times = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
 
         // Nov 1 is the fall-back day; should get one fire per day, no duplicate on Nov 1
         Assert.That(times, Has.Count.EqualTo(3),
@@ -1366,7 +1366,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         DateTimeOffset from = new DateTimeOffset(2020, 10, 24, 22, 0, 0, TimeSpan.Zero);
         DateTimeOffset to = new DateTimeOffset(2020, 10, 27, 23, 0, 0, TimeSpan.Zero);
-        IReadOnlyList<DateTimeOffset> times = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        IReadOnlyList<DateTimeOffset> times = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
 
         Assert.That(times, Has.Count.EqualTo(3),
             $"Expected 3 fire times but got {times.Count}: {string.Join(", ", times.Select(t => TimeZoneInfo.ConvertTime(t, timeZoneInfo)))}");
@@ -1392,7 +1392,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         DateTimeOffset from = new DateTimeOffset(2020, 10, 24, 22, 0, 0, TimeSpan.Zero);
         DateTimeOffset to = new DateTimeOffset(2020, 10, 27, 23, 0, 0, TimeSpan.Zero);
-        IReadOnlyList<DateTimeOffset> times = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        IReadOnlyList<DateTimeOffset> times = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
 
         Assert.That(times, Has.Count.EqualTo(3),
             $"Expected 3 fire times but got {times.Count}: {string.Join(", ", times.Select(t => TimeZoneInfo.ConvertTime(t, timeZoneInfo)))}");
@@ -1420,7 +1420,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         DateTimeOffset from = new DateTimeOffset(2020, 10, 24, 0, 0, 0, TimeSpan.Zero);
         DateTimeOffset to = new DateTimeOffset(2020, 10, 27, 23, 0, 0, TimeSpan.Zero);
-        IReadOnlyList<DateTimeOffset> times = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        IReadOnlyList<DateTimeOffset> times = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
 
         Assert.That(times, Has.Count.EqualTo(4),
             $"Expected 4 fire times but got {times.Count}: {string.Join(", ", times.Select(t => TimeZoneInfo.ConvertTime(t, timeZoneInfo)))}");
@@ -1496,7 +1496,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         // The spring-forward day is 23 hours long, so a 5 minute trigger fires 276 times
         // instead of the usual 288, and never during the local hour that does not exist.
-        List<DateTimeOffset> springForwardDay = TriggerUtils.ComputeFireTimes(trigger, null, 400)
+        List<DateTimeOffset> springForwardDay = TriggerFireTimes.Compute(trigger, null, 400)
             .Select(t => TimeZoneInfo.ConvertTime(t, timeZoneInfo))
             .Where(t => t.Date == new DateTime(2018, 3, 25))
             .ToList();
@@ -1547,7 +1547,7 @@ public class DailyTimeIntervalTriggerImplTest
 
         // enough fire times to get past the end of the spring-forward day
         int count = (int) (TimeSpan.FromHours(26).Ticks / intervalSpan.Ticks) + 5;
-        IReadOnlyList<DateTimeOffset> times = TriggerUtils.ComputeFireTimes(trigger, null, count);
+        IReadOnlyList<DateTimeOffset> times = TriggerFireTimes.Compute(trigger, null, count);
 
         for (int i = 1; i < times.Count; i++)
         {
@@ -1581,7 +1581,7 @@ public class DailyTimeIntervalTriggerImplTest
         trigger.StartTimeUtc = new DateTimeOffset(2018, 10, 27, 22, 0, 0, TimeSpan.Zero);
         trigger.ComputeFirstFireTimeUtc(null);
 
-        List<DateTimeOffset> fallBackDay = TriggerUtils.ComputeFireTimes(trigger, null, 400)
+        List<DateTimeOffset> fallBackDay = TriggerFireTimes.Compute(trigger, null, 400)
             .Select(t => TimeZoneInfo.ConvertTime(t, timeZoneInfo))
             .Where(t => t.Date == new DateTime(2018, 10, 28))
             .ToList();
@@ -1628,7 +1628,7 @@ public class DailyTimeIntervalTriggerImplTest
         // 00:00 does not exist on Sep 6, so the first instant that does is 01:00 -03:00 = 04:00 UTC
         next.Should().Be(new DateTimeOffset(2026, 9, 6, 4, 0, 0, TimeSpan.Zero));
 
-        IReadOnlyList<DateTimeOffset> times = TriggerUtils.ComputeFireTimes(trigger, null, 40);
+        IReadOnlyList<DateTimeOffset> times = TriggerFireTimes.Compute(trigger, null, 40);
         for (int i = 1; i < times.Count; i++)
         {
             times[i].Should().BeAfter(times[i - 1], $"fire time {i} must come after fire time {i - 1}");

--- a/src/Quartz.Tests.Unit/Plugins/TimeZoneConverter/TimeZoneConverterTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/TimeZoneConverter/TimeZoneConverterTest.cs
@@ -11,7 +11,7 @@ public class TimeZoneConverterTest
         await plugin.Initialize("timeZoneConverter", scheduler: null!);
         try
         {
-            TimeZoneUtil.FindTimeZoneById("Canada/Saskatchewan").Should().NotBeNull();
+            TimeZones.FindById("Canada/Saskatchewan").Should().NotBeNull();
         }
         finally
         {
@@ -36,7 +36,7 @@ public class TimeZoneConverterTest
         {
             await schedulerAPlugin.Shutdown();
 
-            TimeZoneUtil.FindTimeZoneById(id).Should().NotBeNull(
+            TimeZones.FindById(id).Should().NotBeNull(
                 "the second scheduler's registration must survive the first scheduler's shutdown");
         }
         finally
@@ -49,7 +49,7 @@ public class TimeZoneConverterTest
 
         if (!IsSystemResolvable(id))
         {
-            Func<TimeZoneInfo> act = () => TimeZoneUtil.FindTimeZoneById(id);
+            Func<TimeZoneInfo> act = () => TimeZones.FindById(id);
             act.Should().Throw<TimeZoneNotFoundException>(
                 "after every scheduler's plugin has shut down, no resolver registration may linger");
         }

--- a/src/Quartz.Tests.Unit/TestDates.cs
+++ b/src/Quartz.Tests.Unit/TestDates.cs
@@ -53,7 +53,7 @@ public static class TestDates
     public static DateTimeOffset DateOf(int hour, int minute, int second, int dayOfMonth, int month, int year)
     {
         DateTime dt = new DateTime(year, month, dayOfMonth, hour, minute, second);
-        return new DateTimeOffset(dt, TimeZoneUtil.GetUtcOffset(dt, TimeZoneInfo.Local));
+        return new DateTimeOffset(dt, TimeZones.GetUtcOffset(dt, TimeZoneInfo.Local));
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/TimeZonesTest.cs
+++ b/src/Quartz.Tests.Unit/TimeZonesTest.cs
@@ -4,13 +4,13 @@ using Quartz.Impl.Calendar;
 
 namespace Quartz.Tests.Unit;
 
-public class TimeZoneUtilTest
+public class TimeZonesTest
 {
     [Test]
     public void ShouldBeAbleToFindWithAlias()
     {
-        var infoWithUtc = TimeZoneUtil.FindTimeZoneById("UTC");
-        var infoWithUniversalCoordinatedTime = TimeZoneUtil.FindTimeZoneById("Coordinated Universal Time");
+        var infoWithUtc = TimeZones.FindById("UTC");
+        var infoWithUniversalCoordinatedTime = TimeZones.FindById("Coordinated Universal Time");
 
         Assert.That(infoWithUniversalCoordinatedTime, Is.EqualTo(infoWithUtc));
     }
@@ -54,7 +54,7 @@ public class TimeZoneUtilTest
         DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
         TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
 
-        TimeZoneUtil.GetUtcOffset(local, zone).Should().Be(TimeSpan.FromHours(expectedOffsetHours));
+        TimeZones.GetUtcOffset(local, zone).Should().Be(TimeSpan.FromHours(expectedOffsetHours));
     }
 
     // An invalid (spring-forward gap) local time is not special-cased: it resolves to the
@@ -69,7 +69,7 @@ public class TimeZoneUtilTest
         DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
         TestTimeZones.AssumeInvalidLocalTime(zone, local);
 
-        TimeZoneUtil.GetUtcOffset(local, zone).Should().Be(TimeSpan.FromHours(expectedOffsetHours));
+        TimeZones.GetUtcOffset(local, zone).Should().Be(TimeSpan.FromHours(expectedOffsetHours));
     }
 
     [Test]
@@ -83,8 +83,8 @@ public class TimeZoneUtilTest
         DateTimeOffset standardPassInstant = TestTimeZones.Local("2024-11-03 01:30 -05:00");
         TestTimeZones.AssumeAmbiguousLocalTime(eastern, standardPassInstant.DateTime);
 
-        TimeZoneUtil.GetUtcOffset(standardPassInstant, eastern).Should().Be(TimeSpan.FromHours(-5));
-        TimeZoneUtil.GetUtcOffset(standardPassInstant.DateTime, eastern).Should().Be(TimeSpan.FromHours(-4));
+        TimeZones.GetUtcOffset(standardPassInstant, eastern).Should().Be(TimeSpan.FromHours(-5));
+        TimeZones.GetUtcOffset(standardPassInstant.DateTime, eastern).Should().Be(TimeSpan.FromHours(-4));
     }
 
     // ResolveLocal must agree with the wall-clock GetUtcOffset policy for every time that exists
@@ -98,10 +98,10 @@ public class TimeZoneUtilTest
         DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
         TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
 
-        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(local, zone);
+        DateTimeOffset resolved = TimeZones.ResolveLocal(local, zone);
 
         resolved.DateTime.Should().Be(local, "the wall clock must be kept as given");
-        resolved.Offset.Should().Be(TimeZoneUtil.GetUtcOffset(local, zone), "an ambiguous time resolves to the daylight/first occurrence");
+        resolved.Offset.Should().Be(TimeZones.GetUtcOffset(local, zone), "an ambiguous time resolves to the daylight/first occurrence");
     }
 
     // An in-gap time pairs with the pre-transition offset, which renders in the zone as the same
@@ -115,7 +115,7 @@ public class TimeZoneUtilTest
         DateTime local = DateTime.Parse(localTime, CultureInfo.InvariantCulture);
         TestTimeZones.AssumeInvalidLocalTime(zone, local);
 
-        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(local, zone);
+        DateTimeOffset resolved = TimeZones.ResolveLocal(local, zone);
 
         resolved.Offset.Should().Be(TimeSpan.FromHours(expectedOffsetHours), "an in-gap time pairs with the offset in effect just before the gap");
         TimeZoneInfo.ConvertTime(resolved, zone).DateTime
@@ -142,8 +142,8 @@ public class TimeZoneUtilTest
         for (int minute = -180; minute <= 180; minute++)
         {
             DateTime probe = center.AddMinutes(minute);
-            DateTimeOffset legacy = new DateTimeOffset(probe, TimeZoneUtil.GetUtcOffset(probe, zone));
-            TimeZoneUtil.ResolveLocal(probe, zone).Should().Be(legacy, $"probe {probe:yyyy-MM-dd HH:mm} must resolve exactly as the previous inline logic did");
+            DateTimeOffset legacy = new DateTimeOffset(probe, TimeZones.GetUtcOffset(probe, zone));
+            TimeZones.ResolveLocal(probe, zone).Should().Be(legacy, $"probe {probe:yyyy-MM-dd HH:mm} must resolve exactly as the previous inline logic did");
         }
     }
 
@@ -157,7 +157,7 @@ public class TimeZoneUtilTest
         DateTime local = DateTime.Parse(ambiguousLocal, CultureInfo.InvariantCulture);
         TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
 
-        TimeZoneUtil.TryGetAmbiguousWindow(local, zone, out DateTime windowStart, out DateTime windowEnd).Should().BeTrue();
+        TimeZones.TryGetAmbiguousWindow(local, zone, out DateTime windowStart, out DateTime windowEnd).Should().BeTrue();
 
         windowStart.Should().Be(DateTime.Parse(expectedStart, CultureInfo.InvariantCulture));
         windowEnd.Should().Be(DateTime.Parse(expectedEnd, CultureInfo.InvariantCulture));
@@ -168,7 +168,7 @@ public class TimeZoneUtilTest
         DateTimeOffset transition = new DateTimeOffset(windowStart, standardOffset);
         TimeZoneInfo.ConvertTime(transition, zone).DateTime.Should().Be(windowStart);
 
-        TimeZoneUtil.TryGetAmbiguousWindow(local.Date.AddHours(12), zone, out _, out _)
+        TimeZones.TryGetAmbiguousWindow(local.Date.AddHours(12), zone, out _, out _)
             .Should().BeFalse("noon is not ambiguous");
     }
 
@@ -181,11 +181,11 @@ public class TimeZoneUtilTest
         DateTime local = DateTime.Parse(invalidLocal, CultureInfo.InvariantCulture);
         TestTimeZones.AssumeInvalidLocalTime(zone, local);
 
-        TimeZoneUtil.WalkToGapEnd(local, zone).Should().Be(DateTime.Parse(expectedGapEnd, CultureInfo.InvariantCulture));
+        TimeZones.WalkToGapEnd(local, zone).Should().Be(DateTime.Parse(expectedGapEnd, CultureInfo.InvariantCulture));
 
         // noon, not midnight - in a midnight-gap zone like Santiago the date's own 00:00 is invalid
         DateTime alreadyValid = local.Date.AddHours(12);
-        TimeZoneUtil.WalkToGapEnd(alreadyValid, zone).Should().Be(alreadyValid, "a valid time is returned unchanged");
+        TimeZones.WalkToGapEnd(alreadyValid, zone).Should().Be(alreadyValid, "a valid time is returned unchanged");
     }
 
     [Test]
@@ -198,7 +198,7 @@ public class TimeZoneUtilTest
         TimeZoneInfo dublin;
         try
         {
-            dublin = TimeZoneUtil.FindTimeZoneById("Europe/Dublin");
+            dublin = TimeZones.FindById("Europe/Dublin");
         }
         catch (TimeZoneNotFoundException)
         {
@@ -214,7 +214,7 @@ public class TimeZoneUtilTest
         Assume.That(negativeDelta, "test premise: the zone data models Dublin with a negative daylight delta (TZif); on Windows this is positive and the hazard does not exist");
 
         DateTimeOffset justBeforeGap = new DateTimeOffset(new DateTime(2024, 3, 31, 0, 59, 0), dublin.GetUtcOffset(new DateTime(2024, 3, 31, 0, 59, 0)));
-        DateTimeOffset resolved = TimeZoneUtil.ResolveLocal(inGap, dublin);
+        DateTimeOffset resolved = TimeZones.ResolveLocal(inGap, dublin);
 
         resolved.Should().BeAfter(justBeforeGap, "an in-gap time must resolve forward across the gap, never backwards");
         TimeZoneInfo.ConvertTime(resolved, dublin).DateTime.Should().Be(new DateTime(2024, 3, 31, 2, 30, 0), "the instant renders at the delta-shifted wall clock after the gap");
@@ -231,27 +231,27 @@ public class TimeZoneUtilTest
     [TestCase("US/Hawaii", "Hawaiian Standard Time")]
     [TestCase("Asia/Shanghai", "China Standard Time")]
     [TestCase("Asia/Karachi", "Pakistan Standard Time")]
-    public void FindTimeZoneById_ResolvesAliasPairsOnAnyPlatform(string first, string second)
+    public void FindById_ResolvesAliasPairsOnAnyPlatform(string first, string second)
     {
-        TimeZoneInfo firstZone = TimeZoneUtil.FindTimeZoneById(first);
-        TimeZoneInfo secondZone = TimeZoneUtil.FindTimeZoneById(second);
+        TimeZoneInfo firstZone = TimeZones.FindById(first);
+        TimeZoneInfo secondZone = TimeZones.FindById(second);
 
         firstZone.BaseUtcOffset.Should().Be(secondZone.BaseUtcOffset);
     }
 
     [TestCase("Coordinated Universal Time")]
     [TestCase("CET")]
-    public void FindTimeZoneById_RescuesAliasEntriesTheBclCannotResolve(string id)
+    public void FindById_RescuesAliasEntriesTheBclCannotResolve(string id)
     {
         // On Windows with ICU these ids fail TimeZoneInfo.FindSystemTimeZoneById AND both
         // TryConvert* conversions - they are why the alias table survives 4.0. On a platform
         // whose tzdata resolves them directly (e.g. "CET" on Linux) the lookup passes trivially.
-        TimeZoneUtil.FindTimeZoneById(id).Should().NotBeNull();
+        TimeZones.FindById(id).Should().NotBeNull();
     }
 
     [TestCase("US Central Standard Time")]
     [TestCase("US/Indiana-Stark")]
-    public void FindTimeZoneById_PrunedDeadAliasPair_FailsWithGuidance(string id)
+    public void FindById_PrunedDeadAliasPair_FailsWithGuidance(string id)
     {
         // The two ids aliased each other, but neither is a system id on Windows and neither is
         // known to the BCL conversions or to TimeZoneConverter, so the alias never rescued
@@ -266,7 +266,7 @@ public class TimeZoneUtilTest
         {
         }
 
-        Func<TimeZoneInfo> act = () => TimeZoneUtil.FindTimeZoneById(id);
+        Func<TimeZoneInfo> act = () => TimeZones.FindById(id);
 
         act.Should().Throw<TimeZoneNotFoundException>()
             .WithMessage("*Quartz.Plugins.TimeZoneConverter*", "the failure should point at the plugin that resolves more ids");
@@ -279,15 +279,15 @@ public class TimeZoneUtilTest
         TimeZoneInfo earlierZone = TimeZoneInfo.CreateCustomTimeZone(id + "-earlier", TimeSpan.FromMinutes(30), null, null);
         TimeZoneInfo laterZone = TimeZoneInfo.CreateCustomTimeZone(id + "-later", TimeSpan.FromMinutes(45), null, null);
 
-        IDisposable earlier = TimeZoneUtil.AddResolver(x => x == id ? earlierZone : null);
+        IDisposable earlier = TimeZones.AddResolver(x => x == id ? earlierZone : null);
         try
         {
-            TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(earlierZone);
+            TimeZones.FindById(id).Should().BeSameAs(earlierZone);
 
-            IDisposable later = TimeZoneUtil.AddResolver(x => x == id ? laterZone : null);
+            IDisposable later = TimeZones.AddResolver(x => x == id ? laterZone : null);
             try
             {
-                TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(laterZone,
+                TimeZones.FindById(id).Should().BeSameAs(laterZone,
                     "resolvers are consulted most recently added first, preserving the last-write-wins semantics CustomResolver had");
             }
             finally
@@ -295,7 +295,7 @@ public class TimeZoneUtilTest
                 later.Dispose();
             }
 
-            TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(earlierZone,
+            TimeZones.FindById(id).Should().BeSameAs(earlierZone,
                 "a disposed resolver must no longer shadow the one registered before it");
         }
         finally
@@ -303,7 +303,7 @@ public class TimeZoneUtilTest
             earlier.Dispose();
         }
 
-        Func<TimeZoneInfo> act = () => TimeZoneUtil.FindTimeZoneById(id);
+        Func<TimeZoneInfo> act = () => TimeZones.FindById(id);
         act.Should().Throw<TimeZoneNotFoundException>("every registration was disposed");
     }
 
@@ -314,14 +314,14 @@ public class TimeZoneUtilTest
         TimeZoneInfo earlierZone = TimeZoneInfo.CreateCustomTimeZone(id + "-earlier", TimeSpan.FromMinutes(30), null, null);
         TimeZoneInfo laterZone = TimeZoneInfo.CreateCustomTimeZone(id + "-later", TimeSpan.FromMinutes(45), null, null);
 
-        IDisposable earlier = TimeZoneUtil.AddResolver(x => x == id ? earlierZone : null);
+        IDisposable earlier = TimeZones.AddResolver(x => x == id ? earlierZone : null);
         try
         {
-            IDisposable later = TimeZoneUtil.AddResolver(x => x == id ? laterZone : null);
+            IDisposable later = TimeZones.AddResolver(x => x == id ? laterZone : null);
             later.Dispose();
             later.Dispose();
 
-            TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(earlierZone,
+            TimeZones.FindById(id).Should().BeSameAs(earlierZone,
                 "disposing a registration twice must not remove another resolver");
         }
         finally
@@ -336,18 +336,18 @@ public class TimeZoneUtilTest
         const string id = "Quartz/Test-Resolver-Throwing";
         TimeZoneInfo zone = TimeZoneInfo.CreateCustomTimeZone(id + "-zone", TimeSpan.FromMinutes(15), null, null);
 
-        using IDisposable quiet = TimeZoneUtil.AddResolver(x => x == id ? zone : null);
-        using IDisposable loud = TimeZoneUtil.AddResolver(
+        using IDisposable quiet = TimeZones.AddResolver(x => x == id ? zone : null);
+        using IDisposable loud = TimeZones.AddResolver(
             x => x == id ? throw new TimeZoneNotFoundException("declining loudly") : null);
 
-        TimeZoneUtil.FindTimeZoneById(id).Should().BeSameAs(zone,
+        TimeZones.FindById(id).Should().BeSameAs(zone,
             "a resolver throwing TimeZoneNotFoundException declines the id and the search continues with the next resolver");
     }
 
     [Test]
     public void AddResolver_NullResolver_Throws()
     {
-        Action act = () => TimeZoneUtil.AddResolver(null!);
+        Action act = () => TimeZones.AddResolver(null!);
         act.Should().Throw<ArgumentNullException>();
     }
 

--- a/src/Quartz.Tests.Unit/TriggerFireTimesTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerFireTimesTest.cs
@@ -2,10 +2,10 @@ using Quartz.Extensibility;
 
 namespace Quartz.Tests.Unit;
 
-public class TriggerUtilsTest
+public class TriggerFireTimesTest
 {
     [Test]
-    public void ComputeFireTimesBetween_ShouldPreserveTriggerStartTime()
+    public void ComputeBetween_ShouldPreserveTriggerStartTime()
     {
         var startAt = DateTimeOffset.Parse("2026-01-01 08:00:00Z");
         var endAt = DateTimeOffset.Parse("2026-01-07 08:00:01Z");
@@ -19,7 +19,7 @@ public class TriggerUtilsTest
         // Query with 'from' 10 minutes earlier than trigger's start
         var from = DateTimeOffset.Parse("2026-01-01 07:50:00Z");
         var to = DateTimeOffset.Parse("2026-01-07 08:00:01Z");
-        var fireTimes = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        var fireTimes = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
 
         // All fire times should be at 08:00, not at 07:50
         Assert.That(fireTimes.Count, Is.EqualTo(7));
@@ -31,7 +31,7 @@ public class TriggerUtilsTest
     }
 
     [Test]
-    public void ComputeFireTimesBetween_MatchingFromAndStart_WorksCorrectly()
+    public void ComputeBetween_MatchingFromAndStart_WorksCorrectly()
     {
         var startAt = DateTimeOffset.Parse("2026-01-01 08:00:00Z");
         var endAt = DateTimeOffset.Parse("2026-01-07 08:00:01Z");
@@ -44,7 +44,7 @@ public class TriggerUtilsTest
 
         var from = DateTimeOffset.Parse("2026-01-01 08:00:00Z");
         var to = DateTimeOffset.Parse("2026-01-07 08:00:01Z");
-        var fireTimes = TriggerUtils.ComputeFireTimesBetween(trigger, null, from, to);
+        var fireTimes = TriggerFireTimes.ComputeBetween(trigger, null, from, to);
 
         Assert.That(fireTimes.Count, Is.EqualTo(7));
         Assert.That(fireTimes[0], Is.EqualTo(startAt));

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1221,10 +1221,10 @@ namespace Quartz
         public TimeSpanParseRuleAttribute(Quartz.TimeSpanParseRule rule) { }
         public Quartz.TimeSpanParseRule Rule { get; }
     }
-    public static class TimeZoneUtil
+    public static class TimeZones
     {
         public static System.IDisposable AddResolver(System.Func<string, System.TimeZoneInfo?> resolver) { }
-        public static System.TimeZoneInfo FindTimeZoneById(string id) { }
+        public static System.TimeZoneInfo FindById(string id) { }
         public static System.TimeSpan GetUtcOffset(System.DateTime dateTime, System.TimeZoneInfo timeZoneInfo) { }
     }
     public static class TriggerBuilder

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1574,6 +1574,12 @@ namespace Quartz.Extensibility
         public required System.DateTimeOffset NoLaterThan { get; init; }
         public System.TimeSpan TimeWindow { get; init; }
     }
+    public static class TriggerFireTimes
+    {
+        public static System.Collections.Generic.List<System.DateTimeOffset> Compute(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numberOfTimes) { }
+        public static System.Collections.Generic.List<System.DateTimeOffset> ComputeBetween(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, System.DateTimeOffset from, System.DateTimeOffset to) { }
+        public static System.DateTimeOffset? ComputeEndTimeForCount(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numberOfTimes) { }
+    }
     public sealed class TriggerFiredBundle
     {
         public TriggerFiredBundle(Quartz.IJobDetail job, Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, bool jobIsRecovering, System.DateTimeOffset fireTimeUtc, System.DateTimeOffset? scheduledFireTimeUtc, System.DateTimeOffset? previousFireTimeUtc, System.DateTimeOffset? nextFireTimeUtc) { }
@@ -1592,12 +1598,6 @@ namespace Quartz.Extensibility
         public TriggerFiredResult(System.Exception exception) { }
         public System.Exception? Exception { get; }
         public Quartz.Extensibility.TriggerFiredBundle? TriggerFiredBundle { get; }
-    }
-    public static class TriggerUtils
-    {
-        public static System.DateTimeOffset? ComputeEndTimeToAllowParticularNumberOfFirings(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numberOfTimes) { }
-        public static System.Collections.Generic.List<System.DateTimeOffset> ComputeFireTimes(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, int numberOfTimes) { }
-        public static System.Collections.Generic.List<System.DateTimeOffset> ComputeFireTimesBetween(Quartz.Extensibility.IOperableTrigger trigger, Quartz.ICalendar? calendar, System.DateTimeOffset from, System.DateTimeOffset to) { }
     }
 }
 namespace Quartz.Impl.AdoJobStore

--- a/src/Quartz/Configuration/JsonSchedulingHelper.cs
+++ b/src/Quartz/Configuration/JsonSchedulingHelper.cs
@@ -315,7 +315,7 @@ internal static class JsonSchedulingHelper
         }
 
         var timeZoneStr = section[nameof(JsonCronSchedule.TimeZone)];
-        var tz = timeZoneStr is not null ? TimeZoneUtil.FindTimeZoneById(timeZoneStr) : null;
+        var tz = timeZoneStr is not null ? TimeZones.FindById(timeZoneStr) : null;
 
         CronScheduleBuilder builder;
         try
@@ -409,7 +409,7 @@ internal static class JsonSchedulingHelper
 
         if (timeZoneStr is not null)
         {
-            builder.InTimeZone(TimeZoneUtil.FindTimeZoneById(timeZoneStr));
+            builder.InTimeZone(TimeZones.FindById(timeZoneStr));
         }
 
         var misfireInstruction = section[nameof(JsonDailyTimeIntervalSchedule.MisfireInstruction)];

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -366,7 +366,7 @@ public sealed class CronExpression : ISerializable
                 var timeZoneId = info.GetValue<string>("timeZoneId")!;
                 if (!string.IsNullOrEmpty(timeZoneId))
                 {
-                    timeZone = TimeZoneUtil.FindTimeZoneById(timeZoneId);
+                    timeZone = TimeZones.FindById(timeZoneId);
                 }
 
                 break;
@@ -2413,7 +2413,7 @@ public sealed class CronExpression : ISerializable
         var afterTimeUtcFloor = d;
 
         // change to specified time zone
-        d = TimeZoneUtil.ConvertTime(d, TimeZone);
+        d = TimeZones.ConvertTime(d, TimeZone);
 
         var nextFireTimeCursor = new NextFireTimeCursor(false, d);
         var foundNextFireTime = false;
@@ -2438,7 +2438,7 @@ public sealed class CronExpression : ISerializable
 
             // apply the proper offset for this date
             var localDateTime = nextFireTimeCursor.Date.Value.DateTime;
-            d = TimeZoneUtil.ResolveLocal(localDateTime, TimeZone);
+            d = TimeZones.ResolveLocal(localDateTime, TimeZone);
             foundNextFireTime = true;
 
             // During DST fall-back transitions an ambiguous local time resolves to its first
@@ -2480,7 +2480,7 @@ public sealed class CronExpression : ISerializable
     /// </remarks>
     private DateTimeOffset ApplySecondAmbiguousPassIfNeeded(DateTimeOffset candidate, DateTimeOffset afterTimeUtcFloor)
     {
-        var afterLocal = TimeZoneUtil.ConvertTime(afterTimeUtcFloor, TimeZone);
+        var afterLocal = TimeZones.ConvertTime(afterTimeUtcFloor, TimeZone);
         DateTime afterWallClock = afterLocal.DateTime;
 
         if (!TimeZone.IsAmbiguousTime(afterWallClock))
@@ -2496,7 +2496,7 @@ public sealed class CronExpression : ISerializable
             return candidate;
         }
 
-        if (!TimeZoneUtil.TryGetAmbiguousWindow(afterWallClock, TimeZone, out DateTime windowStart, out _))
+        if (!TimeZones.TryGetAmbiguousWindow(afterWallClock, TimeZone, out DateTime windowStart, out _))
         {
             return candidate;
         }

--- a/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
+++ b/src/Quartz/DailyTimeIntervalScheduleBuilder.cs
@@ -353,8 +353,8 @@ public sealed class DailyTimeIntervalScheduleBuilder : IScheduleBuilder, ITimePr
 
         //apply proper offsets according to timezone
         TimeZoneInfo targetTimeZone = timeZone ?? TimeZoneInfo.Local;
-        startTimeOfDayDate = TimeZoneUtil.ResolveLocal(startTimeOfDayDate.DateTime, targetTimeZone);
-        tomorrow = TimeZoneUtil.ResolveLocal(tomorrow.DateTime, targetTimeZone);
+        startTimeOfDayDate = TimeZones.ResolveLocal(startTimeOfDayDate.DateTime, targetTimeZone);
+        tomorrow = TimeZones.ResolveLocal(tomorrow.DateTime, targetTimeZone);
 
         TimeSpan remainingMillisInDay = tomorrow - startTimeOfDayDate;
         TimeSpan intervalInMillis;

--- a/src/Quartz/DateBuilder.cs
+++ b/src/Quartz/DateBuilder.cs
@@ -120,7 +120,7 @@ public sealed class DateBuilder
     public DateTimeOffset Build()
     {
         DateTime dt = new DateTime(year, month, day, hour, minute, second);
-        TimeSpan offset = TimeZoneUtil.GetUtcOffset(dt, tz ?? TimeZoneInfo.Local);
+        TimeSpan offset = TimeZones.GetUtcOffset(dt, tz ?? TimeZoneInfo.Local);
         return new DateTimeOffset(dt, offset);
     }
 

--- a/src/Quartz/Diagnostics/LogProvider.cs
+++ b/src/Quartz/Diagnostics/LogProvider.cs
@@ -10,7 +10,7 @@ namespace Quartz.Diagnostics;
 /// <para>
 /// This is ambient, mutable, process-wide state, and it stays that way on purpose. Nearly everything the
 /// scheduler is made of is built by a container and is injected an <see cref="ILogger" /> the ordinary
-/// way. What is left over cannot be: static helpers such as <see cref="Quartz.TimeZoneUtil" />,
+/// way. What is left over cannot be: static helpers such as <see cref="Quartz.TimeZones" />,
 /// types a caller constructs directly — triggers, calendars, plugins, the jobs in <c>Quartz.Jobs</c> —
 /// and anything that runs while the container is still being built. A type cannot be handed a logger by
 /// a container that does not exist yet, so those sites read this instead of going unlogged.

--- a/src/Quartz/Extensibility/TriggerFireTimes.cs
+++ b/src/Quartz/Extensibility/TriggerFireTimes.cs
@@ -36,7 +36,7 @@ namespace Quartz.Extensibility;
 /// <seealso cref="ISimpleTrigger" />
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
-public static class TriggerUtils
+public static class TriggerFireTimes
 {
     /// <summary>
     /// Returns a list of Dates that are the next fire times of a
@@ -47,7 +47,7 @@ public static class TriggerUtils
     /// <param name="trigger">The trigger upon which to do the work</param>
     /// <param name="calendar">The calendar to apply to the trigger's schedule</param>
     /// <param name="numberOfTimes">The number of next fire times to produce</param>
-    public static List<DateTimeOffset> ComputeFireTimes(IOperableTrigger trigger, ICalendar? calendar, int numberOfTimes)
+    public static List<DateTimeOffset> Compute(IOperableTrigger trigger, ICalendar? calendar, int numberOfTimes)
     {
         List<DateTimeOffset> lst = new List<DateTimeOffset>();
 
@@ -88,7 +88,7 @@ public static class TriggerUtils
     /// <param name="calendar">The calendar to apply to the trigger's schedule</param>
     /// <param name="numberOfTimes">The number of next fire times to produce</param>
     /// <returns>the computed Date, or null if the trigger (as configured) will not fire that many times</returns>
-    public static DateTimeOffset? ComputeEndTimeToAllowParticularNumberOfFirings(IOperableTrigger trigger, ICalendar? calendar, int numberOfTimes)
+    public static DateTimeOffset? ComputeEndTimeForCount(IOperableTrigger trigger, ICalendar? calendar, int numberOfTimes)
     {
         IOperableTrigger t = (IOperableTrigger) trigger.Clone();
 
@@ -144,7 +144,7 @@ public static class TriggerUtils
     /// <param name="calendar">The calendar to apply to the trigger's schedule</param>
     /// <param name="from">The starting date at which to find fire times</param>
     /// <param name="to">The ending date at which to stop finding fire times</param>
-    public static List<DateTimeOffset> ComputeFireTimesBetween(IOperableTrigger trigger, ICalendar? calendar, DateTimeOffset from, DateTimeOffset to)
+    public static List<DateTimeOffset> ComputeBetween(IOperableTrigger trigger, ICalendar? calendar, DateTimeOffset from, DateTimeOffset to)
     {
         List<DateTimeOffset> lst = new List<DateTimeOffset>();
 

--- a/src/Quartz/Impl/AdoJobStore/CalendarIntervalTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/CalendarIntervalTriggerPersistenceDelegate.cs
@@ -70,7 +70,7 @@ public sealed class CalendarIntervalTriggerPersistenceDelegate : SimplePropertie
         }
         if (!string.IsNullOrEmpty(tzId) && tzId is not null)
         {
-            tz = TimeZoneUtil.FindTimeZoneById(tzId);
+            tz = TimeZones.FindById(tzId);
         }
 
         CalendarIntervalScheduleBuilder sb = CalendarIntervalScheduleBuilder.Create()

--- a/src/Quartz/Impl/AdoJobStore/CronTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/CronTriggerPersistenceDelegate.cs
@@ -134,7 +134,7 @@ public sealed class CronTriggerPersistenceDelegate : ITriggerPersistenceDelegate
 
         if (timeZoneId is not null)
         {
-            cb.InTimeZone(TimeZoneUtil.FindTimeZoneById(timeZoneId));
+            cb.InTimeZone(TimeZones.FindById(timeZoneId));
         }
 
         return new TriggerPropertyBundle(cb);

--- a/src/Quartz/Impl/AdoJobStore/DailyTimeIntervalTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/DailyTimeIntervalTriggerPersistenceDelegate.cs
@@ -93,7 +93,7 @@ public sealed class DailyTimeIntervalTriggerPersistenceDelegate : SimpleProperti
 
         if (!string.IsNullOrEmpty(props.TimeZoneId) && props.TimeZoneId is not null)
         {
-            scheduleBuilder.InTimeZone(TimeZoneUtil.FindTimeZoneById(props.TimeZoneId));
+            scheduleBuilder.InTimeZone(TimeZones.FindById(props.TimeZoneId));
         }
 
         if (daysOfWeekStr is not null)

--- a/src/Quartz/Impl/AdoJobStore/RecurrenceTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/RecurrenceTriggerPersistenceDelegate.cs
@@ -48,7 +48,7 @@ public sealed class RecurrenceTriggerPersistenceDelegate : SimplePropertiesTrigg
         string? tzId = props.TimeZoneId;
         if (!string.IsNullOrEmpty(tzId))
         {
-            tz = TimeZoneUtil.FindTimeZoneById(tzId!);
+            tz = TimeZones.FindById(tzId!);
         }
 
         RecurrenceScheduleBuilder sb = RecurrenceScheduleBuilder.Create(props.String1!)

--- a/src/Quartz/Impl/Calendar/AnnualCalendar.cs
+++ b/src/Quartz/Impl/Calendar/AnnualCalendar.cs
@@ -186,7 +186,7 @@ public sealed class AnnualCalendar : BaseCalendar
         }
 
         //apply the timezone
-        dateUtc = TimeZoneUtil.ConvertTime(dateUtc, TimeZone);
+        dateUtc = TimeZones.ConvertTime(dateUtc, TimeZone);
 
         return !IsDateTimeExcluded(dateUtc, checkBaseCalendar: true);
     }
@@ -209,7 +209,7 @@ public sealed class AnnualCalendar : BaseCalendar
         }
 
         //apply the timezone
-        timeStampUtc = TimeZoneUtil.ConvertTime(timeStampUtc, TimeZone);
+        timeStampUtc = TimeZones.ConvertTime(timeStampUtc, TimeZone);
 
         // Get timestamp for 00:00:00, in the correct timezone offset
         DateTimeOffset day = new DateTimeOffset(timeStampUtc.Date, timeStampUtc.Offset);

--- a/src/Quartz/Impl/Calendar/BaseCalendar.cs
+++ b/src/Quartz/Impl/Calendar/BaseCalendar.cs
@@ -123,7 +123,7 @@ public class BaseCalendar : ICalendar, ISerializable, IEquatable<BaseCalendar>
                 var timeZoneId = (string) info.GetValue(prefix + "timeZoneId", typeof(string))!;
                 if (!string.IsNullOrEmpty(timeZoneId))
                 {
-                    timeZone = TimeZoneUtil.FindTimeZoneById(timeZoneId);
+                    timeZone = TimeZones.FindById(timeZoneId);
                 }
                 break;
             default:

--- a/src/Quartz/Impl/Calendar/DailyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/DailyCalendar.cs
@@ -164,7 +164,7 @@ public sealed class DailyCalendar : BaseCalendar
         }
 
         //Before we start, apply the correct timezone offsets.
-        timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
+        timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone);
 
         DateTimeOffset startOfDayInMillis = GetStartOfDay(timeUtc);
         DateTimeOffset endOfDayInMillis = GetEndOfDay(timeUtc);

--- a/src/Quartz/Impl/Calendar/HolidayCalendar.cs
+++ b/src/Quartz/Impl/Calendar/HolidayCalendar.cs
@@ -154,7 +154,7 @@ public sealed class HolidayCalendar : BaseCalendar
     private bool IsTimeIncludedThisCalendar(DateTimeOffset timeStampUtc)
     {
         // apply the timezone
-        timeStampUtc = TimeZoneUtil.ConvertTime(timeStampUtc, TimeZone);
+        timeStampUtc = TimeZones.ConvertTime(timeStampUtc, TimeZone);
         return !dates.Contains(DateOnly.FromDateTime(timeStampUtc.Date));
     }
 
@@ -175,7 +175,7 @@ public sealed class HolidayCalendar : BaseCalendar
         }
 
         //apply the timezone
-        timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
+        timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone);
 
         // Get timestamp for 00:00:00, with the correct timezone offset
         DateTimeOffset day = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);

--- a/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
@@ -185,7 +185,7 @@ public sealed class MonthlyCalendar : BaseCalendar
             return false;
         }
 
-        timeStampUtc = TimeZoneUtil.ConvertTime(timeStampUtc, TimeZone); //apply the timezone
+        timeStampUtc = TimeZones.ConvertTime(timeStampUtc, TimeZone); //apply the timezone
 
         return !excludeDays.Contains(timeStampUtc.Day);
     }
@@ -213,7 +213,7 @@ public sealed class MonthlyCalendar : BaseCalendar
         }
 
         //apply the timezone
-        timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
+        timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone);
 
         // Get timestamp for 00:00:00, in the correct timezone offset
         DateTimeOffset newTimeStamp = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);

--- a/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
@@ -174,7 +174,7 @@ public sealed class WeeklyCalendar : BaseCalendar
             return false;
         }
 
-        timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone); //apply the timezone
+        timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone); //apply the timezone
         return !excludeDays.Contains(timeUtc.DayOfWeek);
     }
 
@@ -201,7 +201,7 @@ public sealed class WeeklyCalendar : BaseCalendar
         }
 
         //apply the timezone
-        timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
+        timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone);
 
         // Get timestamp for 00:00:00, in the correct timezone offset
         DateTimeOffset d = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);

--- a/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
+++ b/src/Quartz/Impl/Recurrence/RecurrenceRule.cs
@@ -434,8 +434,8 @@ internal sealed class RecurrenceRule
     private LocalTimes ConvertToLocal(DateTimeOffset dtStart, DateTimeOffset after, TimeZoneInfo? timeZone, DateTimeOffset? endTime)
     {
         TimeZoneInfo tz = timeZone ?? TimeZoneInfo.Utc;
-        DateTime localStart = TimeZoneUtil.ConvertTime(dtStart, tz).DateTime;
-        DateTime localAfter = TimeZoneUtil.ConvertTime(after, tz).DateTime;
+        DateTime localStart = TimeZones.ConvertTime(dtStart, tz).DateTime;
+        DateTime localAfter = TimeZones.ConvertTime(after, tz).DateTime;
 
         DateTime? localUntil = null;
         if (Until != null)
@@ -448,7 +448,7 @@ internal sealed class RecurrenceRule
         DateTime? localEnd = null;
         if (endTime != null)
         {
-            localEnd = TimeZoneUtil.ConvertTime(endTime.Value, tz).DateTime;
+            localEnd = TimeZones.ConvertTime(endTime.Value, tz).DateTime;
         }
 
         return new LocalTimes(localStart, localAfter, localUntil, localEnd, tz);
@@ -811,12 +811,12 @@ internal sealed class RecurrenceRule
             // 02:30 in a one hour gap comes back as 03:30 at the post-transition offset). Deriving
             // the shift this way is robust for transition deltas that are not whole hours and for
             // zones modeled with a negative daylight delta.
-            return TimeZoneInfo.ConvertTime(TimeZoneUtil.ResolveLocal(local, tz), tz);
+            return TimeZoneInfo.ConvertTime(TimeZones.ResolveLocal(local, tz), tz);
         }
 
         // Ambiguous times (DST overlap / fall back) resolve to the daylight offset - the first of
         // the two occurrences - matching the shared scheduler-wide policy.
-        return TimeZoneUtil.ResolveLocal(local, tz);
+        return TimeZones.ResolveLocal(local, tz);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -526,7 +526,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
     /// </returns>
     public override DateTimeOffset? ComputeFirstFireTimeUtc(ICalendar? calendar)
     {
-        NextFireTimeUtc = TimeZoneUtil.ConvertTime(StartTimeUtc, TimeZone);
+        NextFireTimeUtc = TimeZones.ConvertTime(StartTimeUtc, TimeZone);
 
         while (NextFireTimeUtc is not null && calendar is not null
                                        && !calendar.IsTimeIncluded(NextFireTimeUtc.Value))
@@ -616,7 +616,7 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
         DateTimeOffset sTime = StartTimeUtc;
         if (timeZone is not null)
         {
-            sTime = TimeZoneUtil.ConvertTime(sTime, timeZone);
+            sTime = TimeZones.ConvertTime(sTime, timeZone);
         }
 
         if (RepeatIntervalUnit == IntervalUnit.Second)
@@ -782,10 +782,10 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
     {
         if (afterTime.UtcDateTime <= StartTimeUtc.UtcDateTime)
         {
-            return TimeZoneUtil.ConvertTime(StartTimeUtc, TimeZone);
+            return TimeZones.ConvertTime(StartTimeUtc, TimeZone);
         }
 
-        DateTime candidateLocal = TimeZoneUtil.ConvertTime(StartTimeUtc, TimeZone).DateTime;
+        DateTime candidateLocal = TimeZones.ConvertTime(StartTimeUtc, TimeZone).DateTime;
 
         // day-based steps are linear in the local calendar, so jump most of the way there instead
         // of iterating; aim short of the target because DST makes the UTC distance and the calendar
@@ -821,11 +821,11 @@ public sealed class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarInte
                     continue;
                 }
 
-                resolved = TimeZoneUtil.ResolveLocal(TimeZoneUtil.WalkToGapEnd(candidateLocal, TimeZone), TimeZone);
+                resolved = TimeZones.ResolveLocal(TimeZones.WalkToGapEnd(candidateLocal, TimeZone), TimeZone);
             }
             else
             {
-                resolved = TimeZoneUtil.ResolveLocal(candidateLocal, TimeZone);
+                resolved = TimeZones.ResolveLocal(candidateLocal, TimeZone);
             }
 
             if (resolved.UtcDateTime >= afterTime.UtcDateTime || candidateLocal.Year > TriggerConstants.YearToGiveUpSchedulingAt)

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -783,7 +783,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
             return false;
         }
 
-        DateTimeOffset p = TimeZoneUtil.ConvertTime(fta.Value, TimeZone);
+        DateTimeOffset p = TimeZones.ConvertTime(fta.Value, TimeZone);
 
         if (dayOnly)
         {

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -594,7 +594,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
 
     private DateTimeOffset CreateCalendarTime(DateTimeOffset dateTime)
     {
-        return TimeZoneUtil.ConvertTime(dateTime, TimeZone);
+        return TimeZones.ConvertTime(dateTime, TimeZone);
     }
 
     /// <summary>
@@ -650,7 +650,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         }
 
         // now change to local time zone
-        afterTime = TimeZoneUtil.ConvertTime(afterTime.Value, TimeZone);
+        afterTime = TimeZones.ConvertTime(afterTime.Value, TimeZone);
 
         // b.Check to see if afterTime is after endTimeOfDay or not.
         // If yes, then we need to advance to next day as well.
@@ -669,13 +669,13 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
         DateTimeOffset fireTimeEndDate = endTimeOfDay.OnDate(fireTime.Value);
 
         // apply the proper offset for the end date
-        fireTimeEndDate = TimeZoneUtil.ResolveLocal(fireTimeEndDate.DateTime, TimeZone);
+        fireTimeEndDate = TimeZones.ResolveLocal(fireTimeEndDate.DateTime, TimeZone);
 
         // e. Check fireTime against startTime or startTimeOfDay to see which go first.
         DateTimeOffset fireTimeStartDate = startTimeOfDay.OnDate(fireTime.Value);
 
         // apply the proper offset for the start date
-        fireTimeStartDate = TimeZoneUtil.ResolveLocal(fireTimeStartDate.DateTime, TimeZone);
+        fireTimeStartDate = TimeZones.ResolveLocal(fireTimeStartDate.DateTime, TimeZone);
 
         if (fireTime < fireTimeStartDate)
         {
@@ -684,7 +684,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
 
         // f. Continue to calculate the fireTime by incremental unit of intervals.
         // recall that if fireTime was less that fireTimeStartDate, we didn't get this far
-        DateTimeOffset startOfDayUtc = TimeZoneUtil.ConvertTime(fireTimeStartDate, TimeZone);
+        DateTimeOffset startOfDayUtc = TimeZones.ConvertTime(fireTimeStartDate, TimeZone);
         long secondsAfterStart = (long) (fireTime.Value - startOfDayUtc).TotalSeconds;
         long repeatLong = RepeatInterval;
 
@@ -700,7 +700,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
             }
 
             sTime = sTime.AddSeconds(RepeatInterval * (int) jumpCount);
-            fireTime = TimeZoneUtil.ConvertTime(sTime, TimeZone);
+            fireTime = TimeZones.ConvertTime(sTime, TimeZone);
         }
         else if (repeatUnit == IntervalUnit.Minute)
         {
@@ -710,7 +710,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
                 jumpCount++;
             }
             sTime = sTime.AddMinutes(RepeatInterval * (int) jumpCount);
-            fireTime = TimeZoneUtil.ConvertTime(sTime, TimeZone);
+            fireTime = TimeZones.ConvertTime(sTime, TimeZone);
         }
         else if (repeatUnit == IntervalUnit.Hour)
         {
@@ -720,7 +720,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
                 jumpCount++;
             }
             sTime = sTime.AddHours(RepeatInterval * (int) jumpCount);
-            fireTime = TimeZoneUtil.ConvertTime(sTime, TimeZone);
+            fireTime = TimeZones.ConvertTime(sTime, TimeZone);
         }
 
         // g. Check if we've exceeded the per-day repeat count.
@@ -753,7 +753,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
 
             if (expectedLocalTime.Date != fireTime.Value.DateTime.Date)
             {
-                DateTimeOffset corrected = TimeZoneUtil.ResolveLocal(expectedLocalTime, TimeZone);
+                DateTimeOffset corrected = TimeZones.ResolveLocal(expectedLocalTime, TimeZone);
 
                 // GetFireTimeAfter must never move backwards
                 if (corrected > fireTime.Value)
@@ -797,7 +797,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
 
         // For a local time that does not exist (skipped by a spring-forward transition) the resolved
         // offset is the one from before the transition, which lands on the first instant that does exist.
-        return TimeZoneUtil.ResolveLocal(startOfDay.Value.DateTime, TimeZone);
+        return TimeZones.ResolveLocal(startOfDay.Value.DateTime, TimeZone);
     }
 
     /// <summary>
@@ -854,7 +854,7 @@ public sealed class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIn
                     // crosses a DST transition, and an instant-based resolution would place an
                     // in-gap start-of-day one transition delta too early, before the EndTimeUtc
                     // check below sees it
-                    fireTime = TimeZoneUtil.ResolveLocal(fireTime.DateTime, TimeZone);
+                    fireTime = TimeZones.ResolveLocal(fireTime.DateTime, TimeZone);
                     break;
                 }
             }

--- a/src/Quartz/Serialization/SystemTextJson/Converters/CronExpressionConverter.cs
+++ b/src/Quartz/Serialization/SystemTextJson/Converters/CronExpressionConverter.cs
@@ -25,7 +25,7 @@ internal sealed class CronExpressionConverter : JsonConverter<CronExpression>
         var cronExpressionString = rootElement.GetProperty(options.GetPropertyName("CronExpression")).GetString()!;
 
         string? timeZoneId = rootElement.GetProperty(options.GetPropertyName("TimeZoneId")).GetString();
-        TimeZoneInfo? timeZone = !string.IsNullOrEmpty(timeZoneId) ? TimeZoneUtil.FindTimeZoneById(timeZoneId!) : null;
+        TimeZoneInfo? timeZone = !string.IsNullOrEmpty(timeZoneId) ? TimeZones.FindById(timeZoneId!) : null;
         return new CronExpression(cronExpressionString, timeZone);
     }
 }

--- a/src/Quartz/Serialization/SystemTextJson/SerializationExtensions.cs
+++ b/src/Quartz/Serialization/SystemTextJson/SerializationExtensions.cs
@@ -47,7 +47,7 @@ internal static class Utf8JsonWriterExtensions
     public static TimeZoneInfo GetTimeZone(this JsonElement jsonElement)
     {
         var timeZoneId = jsonElement.GetString();
-        return TimeZoneUtil.FindTimeZoneById(timeZoneId!);
+        return TimeZones.FindById(timeZoneId!);
     }
 
     public static void WriteEnum<T>(this Utf8JsonWriter writer, string propertyName, T value) where T : Enum

--- a/src/Quartz/TimeZones.cs
+++ b/src/Quartz/TimeZones.cs
@@ -26,7 +26,7 @@ using Quartz.Util;
 
 namespace Quartz;
 
-public static class TimeZoneUtil
+public static class TimeZones
 {
     /// <summary>
     /// Id spellings that some platform has used and some other platform cannot resolve. The BCL does
@@ -37,7 +37,7 @@ public static class TimeZoneUtil
     /// </summary>
     private static readonly Dictionary<string, string> timeZoneIdAliases = new Dictionary<string, string>();
 
-    static TimeZoneUtil()
+    static TimeZones()
     {
         // Azure has had issues with having both formats
         timeZoneIdAliases["UTC"] = "Coordinated Universal Time";
@@ -89,7 +89,7 @@ public static class TimeZoneUtil
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This is process-wide, and deliberately so: <see cref="FindTimeZoneById" /> is reached from
+    /// This is process-wide, and deliberately so: <see cref="FindById" /> is reached from
     /// places that have no scheduler in scope — parsing a <see cref="CronExpression" />, deserializing
     /// a trigger or calendar out of a job store blob — so there is nothing scheduler-scoped to hang a
     /// resolver on. Adding a resolver from one scheduler changes id resolution for every scheduler in
@@ -100,7 +100,7 @@ public static class TimeZoneUtil
     /// Resolvers are consulted most recently added first, so a later registration shadows an earlier
     /// one for the ids it resolves. A resolver declines an id by returning <see langword="null" /> or
     /// by throwing <see cref="TimeZoneNotFoundException" />; either way the search continues with the
-    /// next resolver, and <see cref="FindTimeZoneById" /> throws only when every fallback has failed.
+    /// next resolver, and <see cref="FindById" /> throws only when every fallback has failed.
     /// </para>
     /// </remarks>
     /// <param name="resolver">Maps a time zone id to a <see cref="TimeZoneInfo" />, or to
@@ -293,7 +293,7 @@ public static class TimeZoneUtil
     /// </summary>
     /// <param name="id">System id of the time zone.</param>
     /// <returns></returns>
-    public static TimeZoneInfo FindTimeZoneById(string id)
+    public static TimeZoneInfo FindById(string id)
     {
         TimeZoneInfo? info = null;
         try
@@ -310,7 +310,7 @@ public static class TimeZoneUtil
                 }
                 catch
                 {
-                    var logger = LogProvider.CreateLogger(nameof(TimeZoneUtil));
+                    var logger = LogProvider.CreateLogger(nameof(TimeZones));
                     logger.LogError("Could not find time zone using alias id {AliasId}", aliasedId);
                 }
             }

--- a/src/Quartz/Util/TimeOnlyExtensions.cs
+++ b/src/Quartz/Util/TimeOnlyExtensions.cs
@@ -35,7 +35,7 @@ internal static class TimeOnlyExtensions
     /// The returned value inherits the offset carried by <paramref name="dateTime" /> without
     /// consulting any time zone. Around a daylight saving transition that inherited offset can be
     /// wrong for the produced wall-clock time (see #3190), so callers that cross transitions must
-    /// re-resolve the result, for example with <see cref="TimeZoneUtil.ResolveLocal" />.
+    /// re-resolve the result, for example with <see cref="TimeZones.ResolveLocal" />.
     /// </remarks>
     internal static DateTimeOffset OnDate(this TimeOnly timeOfDay, DateTimeOffset dateTime)
     {

--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -391,7 +391,7 @@ public class XMLSchedulingDataProcessor
                 var cronExpression = cronTrigger.CronExpression.TrimEmptyToNull();
                 var timezoneString = cronTrigger.TimeZone.TrimEmptyToNull();
 
-                TimeZoneInfo? tz = timezoneString is not null ? TimeZoneUtil.FindTimeZoneById(timezoneString) : null;
+                TimeZoneInfo? tz = timezoneString is not null ? TimeZones.FindById(timezoneString) : null;
                 scheduleBuilder = CronScheduleBuilder.Create(cronExpression!)
                     .InTimeZone(tz);
 


### PR DESCRIPTION
Part of the 4.0 API-finalization campaign — the first two renames ratified from the naming-suffix audit (the "final coherence pass" the campaign ledger left pending). Two commits, one per rename, each building green on its own.

## `TimeZoneUtil` → `TimeZones`, `FindTimeZoneById` → `FindById`

The last `*Util` type in the public API (the `Quartz.Util` namespace itself is dissolving — after PR #3267 it is gone entirely). `FindTimeZoneById` is how a trigger built with `InTimeZone(...)` comes back out of a job store, and the wall-clock `GetUtcOffset` overload *is* the scheduler-wide DST policy — that is scheduling API, not a utility, so the type is named by its domain the way `Matchers` is: `TimeZones.FindById(id)`, `TimeZones.AddResolver(...)`. No shim needed — never named by configuration strings (established in #3266).

## `TriggerUtils` → `TriggerFireTimes`

It is a fire-time calculator, so it is named one. Methods shorten with it: `ComputeFireTimes` → `Compute`, `ComputeFireTimesBetween` → `ComputeBetween`, and `ComputeEndTimeToAllowParticularNumberOfFirings` (44 characters of Java) → `ComputeEndTimeForCount`. Signatures otherwise identical.

## Notes

- 4.0 is unreleased, so the migration guide tells each move as **one** 3.x→4.x step: #3266's fresh "TimeZoneUtil moved to Quartz" section is retitled and reworded in place (`Quartz.Util.TimeZoneUtil` → `Quartz.TimeZones`, with `CustomResolver` → `AddResolver` and `FindById` inside it) rather than stacking a second rename section. Anchors updated, appendix rows folded per the table's own rules.
- Remaining ratified renames ride their planned vehicles: `AdoJobStoreBase`/`…TriggerPersistenceDelegateBase`/`TriggerBase` in PR-4, `ITypeLoader` in PR-5.
- Shares the core baseline with #3267; whichever merges second gets rebased and re-approved.

Verified with `build.cmd Compile UnitTest` green at both commit states (rebase-merge safe) + the AspNetCore suite in Release (2274 unit + 216 AspNetCore tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
