### PR TITLE
Pin the SDK to the 10.0.3xx band until 10.0.400's test breakage is fixed

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestMinor"
+    "version": "10.0.303",
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
CI infrastructure hotfix — blocks nothing but unblocks everything.

The GitHub runner images rolled out .NET SDK **10.0.400** today, and its `dotnet test` fails inside the SDK's own targets before running a single test:

> `InvalidProjectFileException: The expression "[MSBuild]::GetTargetFrameworkIdentifier(net10.0)" cannot be evaluated. Could not load file or assembly 'NuGet.Frameworks, Version=7.9.0.0' … manifest definition does not match` (`sdk\10.0.400\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets`)

All three OS legs of #3270 failed identically on this; the same will hit every PR as the images finish rolling out. `rollForward: latestMinor` is what floated CI onto the new SDK the day it appeared — `latestPatch` from 10.0.303 stays on the proven feature band and still picks up servicing fixes. Relax back once a fixed 10.0.4xx ships.

The 3.x branch carries the same `global.json` policy and will need the same pin — companion PR to follow if its CI starts failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
