### PR TITLE
Unbreak CI: patched SSH.NET via Testcontainers 4.14.0, and NuGet.Frameworks pinned forward for SDK 10.0.400

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,12 +59,12 @@
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
     <PackageVersion Include="System.Text.Json" Version="10.0.10" />
-    <PackageVersion Include="Testcontainers.FirebirdSql" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.MySql" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.Oracle" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.FirebirdSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.MySql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.Oracle" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.14.0" />
     <PackageVersion Include="StackExchange.Redis" Version="3.1.13" />
     <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
     <PackageVersion Include="Topshelf" Version="4.3.0" />

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -18,6 +18,17 @@
 
   <ItemGroup>
     <PackageReference Include="Fallout.Components" Version="10.4.0" />
+
+    <!--
+      SDK 10.0.400 ships NuGet.Frameworks 7.9.0.0 and its targets bind that assembly by strong
+      name. Fallout.Components resolves 6.14.3 transitively through NuGet.Packaging, and an
+      app-local assembly wins over the one MSBuildLocator registers, so the older copy shadows the
+      SDK's and every in-process project evaluation throws. Pinned forward rather than back: the
+      runtime is happy binding a higher version, so an SDK that still asks for 6.x is satisfied by
+      7.9.0 too. Remove once Fallout brings a NuGet.Packaging new enough to pull this in itself
+      (Fallout-build/Fallout#638).
+    -->
+    <PackageReference Include="NuGet.Frameworks" Version="7.9.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
CI infrastructure fix. `main` and every open PR are red right now for two unrelated reasons, neither
of them caused by anything in the repository. They have to land together: each one hides the other,
so a PR fixing only one still cannot go green.

## 1. SSH.NET advisory fails the restore

[GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) was published against
`SSH.NET <= 2025.1.0` — arbitrary file write through server-controlled SCP filenames on a recursive
`ScpClient` download. `Testcontainers` 4.13.0 pulls exactly that version into
`Quartz.Tests.Integration`, so `NuGetAudit` fails the whole solution restore:

```
error NU1903: Warning As Error: Package 'SSH.NET' 2025.1.0 has a known high severity vulnerability
```

Restore is the first target, so *nothing* after it runs — this is what killed the `main` build at
2a5ca72 and every leg of every PR since. `Testcontainers` 4.14.0 references the patched
`SSH.NET 2026.0.0`, so the six `Testcontainers.*` versions move to 4.14.0 rather than pinning the
transitive dependency behind its owner's back.

## 2. SDK 10.0.400 breaks in-process project evaluation

The hosted runner images moved to .NET SDK **10.0.400**, and the `UnitTest` target throws before a
single test runs:

```
Microsoft.Build.Exceptions.InvalidProjectFileException: The expression
"[MSBuild]::GetTargetFrameworkIdentifier(net10.0)" cannot be evaluated. Could not load file or
assembly 'NuGet.Frameworks, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
The located assembly's manifest definition does not match the assembly reference.
  /usr/share/dotnet/sdk/10.0.400/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets
```

(#3270, failing identically on `ubuntu-latest`, `windows-latest` and `macos-latest`)

`Compile` and `Pack` shell out to the `dotnet` CLI, so they are unaffected — which is what makes
this read as a test failure rather than a toolchain one. `UnitTest` is different: it asks each test
project which frameworks it targets, and that answer comes from `Project.GetTargetFrameworks()` →
`ProjectModelTasks.ParseProject`, which evaluates the project **in-process**, running the installed
SDK's own targets inside the Fallout process. Those targets bind `NuGet.Frameworks` by strong name:
SDK 10.0.400 wants `7.9.0.0`, while `Fallout.Components` 10.4.0 resolves `6.14.3` transitively
through `NuGet.Packaging`. An app-local assembly wins over the resolver `MSBuildLocator` installs,
so the older copy shadows the SDK's and every evaluation throws.

`global.json` says `rollForward: latestMinor`, so CI floats onto whatever the image ships. That is
why this began without a commit.

One `PackageReference` in `build/_build.csproj` (plus a comment recording why) fixes it:

```xml
<PackageReference Include="NuGet.Frameworks" Version="7.9.0" />
```

Pinned **forward** rather than pinning the SDK back to a working feature band, which is what #3271
did before I closed it in favour of this. The runtime binds a *higher* assembly version than the one
requested, so an SDK still asking for `6.14.3` is satisfied by `7.9.0` too — this fixes 10.0.400
without dating `global.json` to one feature band that has to be revisited every SDK release.
Removable once Fallout ships a `NuGet.Packaging` new enough to bring `7.9.0` in on its own:
[Fallout-build/Fallout#638](https://github.com/Fallout-build/Fallout/issues/638), where the bump is
being held for a major because NuGet 7.x drops `netstandard2.0`. The same forward pin is merged in
[adams85/acornima#45](https://github.com/adams85/acornima/pull/45), and another consumer reports it
holding on the Fallout issue.

## Verification

Locally on Windows with SDK 10.0.400 selected by `global.json`:

- before: `./build.cmd UnitTest --skip` throws `InvalidProjectFileException` in `< 1sec`,
  identically to CI.
- after: project evaluation succeeds, both test projects are discovered
  (`Unit tests: Quartz.Tests.Unit (net10.0)`, `Quartz.Tests.AspNetCore (net10.0)`) and `dotnet test`
  actually runs.
- `dotnet restore Quartz.slnx`: no `NU1903`, no warnings.
- `dotnet build src/Quartz.Tests.Integration`: 0 warnings, 0 errors on Testcontainers 4.14.0.
- `dotnet build build/_build.csproj`: 0 warnings, 0 errors — the forward pin raises no
  `NU1605`/`NU1701`.

No source changes, no `global.json` change. #3278 carries both fixes to `3.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
