### PR TITLE
Unbreak CI: patched SSH.NET via Testcontainers 4.14.0, and NuGet.Frameworks pinned forward for SDK 10.0.400

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,6 +17,17 @@
 
   <ItemGroup>
     <PackageReference Include="Fallout.Common" Version="10.4.0" />
+
+    <!--
+      SDK 10.0.400 ships NuGet.Frameworks 7.9.0.0 and its targets bind that assembly by strong
+      name. Fallout.Common resolves 6.14.3 transitively through NuGet.Packaging, and an app-local
+      assembly wins over the one MSBuildLocator registers, so the older copy shadows the SDK's and
+      every in-process project evaluation throws. Pinned forward rather than back: the runtime is
+      happy binding a higher version, so an SDK that still asks for 6.x is satisfied by 7.9.0 too.
+      Remove once Fallout brings a NuGet.Packaging new enough to pull this in itself
+      (Fallout-build/Fallout#638).
+    -->
+    <PackageReference Include="NuGet.Frameworks" Version="7.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -34,12 +34,12 @@
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="10.0.0" Condition=" '$(TargetFramework)' == 'net10.0' " />
-    <PackageReference Include="Testcontainers.FirebirdSql" Version="4.13.0" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
-    <PackageReference Include="Testcontainers.MySql" Version="4.11.0" />
-    <PackageReference Include="Testcontainers.Oracle" Version="4.11.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.13.0" />
-    <PackageReference Include="Testcontainers.Redis" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.FirebirdSql" Version="4.14.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.14.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.14.0" />
+    <PackageReference Include="Testcontainers.Oracle" Version="4.14.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="4.14.0" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>


### PR DESCRIPTION
Companion to #3277 on `main` — the same two CI fixes, same reasoning, on the maintenance branch.
They have to land together: each one hides the other, so a PR fixing only one still cannot go green.

## 1. SSH.NET advisory fails the restore

[GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) was published against
`SSH.NET <= 2025.1.0` — arbitrary file write through server-controlled SCP filenames on a recursive
`ScpClient` download. `Testcontainers` 4.13.0 and 4.11.0 both pull exactly that version into
`Quartz.Tests.Integration`, so `NuGetAudit` fails the whole solution restore:

```
error NU1903: Warning As Error: Package 'SSH.NET' 2025.1.0 has a known high severity vulnerability
```

Restore is the first target, so *nothing* after it runs. `Testcontainers` 4.14.0 references the
patched `SSH.NET 2026.0.0`, so the six `Testcontainers.*` references move to 4.14.0 rather than
pinning the transitive dependency behind its owner's back — and stop being split across two versions
while we are here.

## 2. SDK 10.0.400 breaks in-process project evaluation

The hosted runner images moved to .NET SDK **10.0.400**. `3.x` has not been pushed since the
rollout, so its CI is still showing green from July, but the branch is affected identically — the
`UnitTest` target throws before a single test runs:

```
Microsoft.Build.Exceptions.InvalidProjectFileException: The expression
"[MSBuild]::GetTargetFrameworkIdentifier(net8.0)" cannot be evaluated. Could not load file or
assembly 'NuGet.Frameworks, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
The located assembly's manifest definition does not match the assembly reference.
```

`Compile` and `Pack` shell out to the `dotnet` CLI, so they are unaffected — which is what makes
this read as a test failure rather than a toolchain one. `UnitTest` is different: it asks each test
project which frameworks it targets (`build/Build.cs:141`), and that answer comes from evaluating
the project **in-process**, running the installed SDK's own targets inside the Fallout process.
Those targets bind `NuGet.Frameworks` by strong name: SDK 10.0.400 wants `7.9.0.0`, while
`Fallout.Common` 10.4.0 resolves `6.14.3` transitively through `NuGet.Packaging`. An app-local
assembly wins over the resolver `MSBuildLocator` installs, so the older copy shadows the SDK's and
every evaluation throws.

One `PackageReference` in `build/_build.csproj`, plus a comment recording why:

```xml
<PackageReference Include="NuGet.Frameworks" Version="7.9.0" />
```

Pinned **forward** rather than pinning the SDK back to a working feature band. The runtime binds a
*higher* assembly version than the one requested, so an SDK still asking for `6.14.3` is satisfied
by `7.9.0` too. Removable once Fallout ships a `NuGet.Packaging` new enough to bring it in on its
own: [Fallout-build/Fallout#638](https://github.com/Fallout-build/Fallout/issues/638), where the
bump is being held for a major because NuGet 7.x drops `netstandard2.0`.

## Verification

Locally on Windows with SDK 10.0.400 selected by `global.json`:

- before: `./build.cmd UnitTest --skip` throws `InvalidProjectFileException` in `< 1sec`.
- after: evaluation succeeds and all three runs are discovered —
  `Quartz.Tests.AspNetCore (net8.0)`, `Quartz.Tests.Unit (net10.0)`, `Quartz.Tests.Unit (net472)` —
  and `dotnet test` is invoked for each.
- `dotnet restore Quartz.slnx`: no `NU1903`, no warnings.
- `dotnet build src/Quartz.Tests.Integration`: 0 warnings, 0 errors on Testcontainers 4.14.0.

No source changes, no `global.json` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
