### PR TITLE
Add cluster-aware GetExecutingFireInstances API (#3205)

### DIFF
--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
@@ -33,6 +33,9 @@ internal static class JobEndpoints
         yield return builder.MapGet(patternPrefix + "/currently-executing", CurrentlyExecutingJobs)
             .WithQuartzDefaults(nameof(CurrentlyExecutingJobs), "Get currently executing jobs");
 
+        yield return builder.MapGet(patternPrefix + "/executing-fire-instances", ExecutingFireInstances)
+            .WithQuartzDefaults(nameof(ExecutingFireInstances), "Get executing fire instances");
+
         yield return builder.MapPost(patternPrefix + "/{jobGroup}/{jobName}/pause", PauseJob)
             .WithQuartzDefaults(nameof(PauseJob), "Pause job");
 
@@ -189,6 +192,27 @@ internal static class JobEndpoints
         {
             var currentlyExecutingJobs = await scheduler.GetCurrentlyExecutingJobs(cancellationToken).ConfigureAwait(false);
             var result = currentlyExecutingJobs.Select(CurrentlyExecutingJobDto.Create).ToArray();
+            return result;
+        });
+    }
+
+    [ProducesResponseType(typeof(ExecutingFireInstanceDto[]), StatusCodes.Status200OK)]
+    private static Task<IResult> ExecutingFireInstances(
+        EndpointHelper endpointHelper,
+        ISchedulerRepository schedulerRepository,
+        string schedulerName,
+        string? triggerName = null,
+        string? triggerGroup = null,
+        CancellationToken cancellationToken = default)
+    {
+        TriggerKey? triggerKey = triggerName is not null && triggerGroup is not null
+            ? new TriggerKey(triggerName, triggerGroup)
+            : null;
+
+        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        {
+            var executingFireInstances = await scheduler.GetExecutingFireInstances(triggerKey, cancellationToken).ConfigureAwait(false);
+            var result = executingFireInstances.Select(ExecutingFireInstanceDto.Create).ToArray();
             return result;
         });
     }

--- a/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
@@ -143,7 +143,7 @@
             JobPageDto jobs = await Api.GetJobs(schedulerName, groupFilter: null, page: 1, pageSize: 0);
             TriggerPageDto triggers = await Api.GetTriggers(schedulerName, groupFilter: null, state: null, page: 1, pageSize: 0);
             TriggerPageDto errorTriggers = await Api.GetTriggers(schedulerName, groupFilter: null, state: TriggerState.Error, page: 1, pageSize: 0);
-            List<CurrentlyExecutingJobDto> executing = await Api.GetCurrentlyExecutingJobs(schedulerName);
+            List<ExecutingFireInstanceDto> executing = await Api.GetExecutingFireInstances(schedulerName);
 
             _totalJobs = jobs.TotalCount;
             _totalTriggers = triggers.TotalCount;
@@ -223,7 +223,7 @@
                 return;
             }
 
-            List<CurrentlyExecutingJobDto> executing = await Api.GetCurrentlyExecutingJobs(schedulerName);
+            List<ExecutingFireInstanceDto> executing = await Api.GetExecutingFireInstances(schedulerName);
             _currentlyExecuting = executing.Count;
         }
         catch (Exception ex)

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -53,6 +53,12 @@ public interface IQuartzApiClient
     ValueTask<List<CurrentlyExecutingJobDto>> GetCurrentlyExecutingJobs(string schedulerName, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the fire instances currently executing across every node of the cluster, unlike
+    /// <see cref="GetCurrentlyExecutingJobs" /> which only sees the node it is called on.
+    /// </summary>
+    ValueTask<List<ExecutingFireInstanceDto>> GetExecutingFireInstances(string schedulerName, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Pauses the job. Returns <see langword="true" /> when the job existed and was paused,
     /// <see langword="false" /> when there was nothing to pause.
     /// </summary>
@@ -170,6 +176,14 @@ public sealed record CurrentlyExecutingJobDto(
     DateTimeOffset FireTimeUtc,
     string? FireInstanceId,
     string? ExecutionGroup = null);
+
+public sealed record ExecutingFireInstanceDto(
+    string FireInstanceId,
+    TriggerKeyDto TriggerKey,
+    JobKeyDto JobKey,
+    string SchedulerInstanceId,
+    DateTimeOffset FireTimeUtc,
+    DateTimeOffset? ScheduledFireTimeUtc);
 
 public sealed record TriggerDetailDto(JsonElement Value);
 

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -249,6 +249,27 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return result;
     }
 
+    public async ValueTask<List<ExecutingFireInstanceDto>> GetExecutingFireInstances(string schedulerName, CancellationToken cancellationToken = default)
+    {
+        IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
+        List<ExecutingFireInstance> executingFireInstances = await scheduler.GetExecutingFireInstances(null, cancellationToken).ConfigureAwait(false);
+
+        List<ExecutingFireInstanceDto> result = [];
+        foreach (ExecutingFireInstance instance in executingFireInstances)
+        {
+            result.Add(
+                new ExecutingFireInstanceDto(
+                    FireInstanceId: instance.FireInstanceId,
+                    TriggerKey: new TriggerKeyDto(instance.TriggerKey.Group, instance.TriggerKey.Name),
+                    JobKey: new JobKeyDto(instance.JobKey.Group, instance.JobKey.Name),
+                    SchedulerInstanceId: instance.SchedulerInstanceId,
+                    FireTimeUtc: instance.FireTimeUtc,
+                    ScheduledFireTimeUtc: instance.ScheduledFireTimeUtc));
+        }
+
+        return result;
+    }
+
     public ValueTask<bool> PauseJob(string schedulerName, string group, string name, CancellationToken cancellationToken = default)
     {
         EnsureWritable();

--- a/src/Quartz.Dashboard/Services/QuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/QuartzApiClient.cs
@@ -264,6 +264,38 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         return result;
     }
 
+    public async ValueTask<List<ExecutingFireInstanceDto>> GetExecutingFireInstances(string schedulerName, CancellationToken cancellationToken = default)
+    {
+        JsonElement json = await GetJson($"{GetSchedulerPath(schedulerName)}/jobs/executing-fire-instances", cancellationToken).ConfigureAwait(false);
+        if (json.ValueKind is not JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        List<ExecutingFireInstanceDto> result = [];
+        foreach (JsonElement item in json.EnumerateArray())
+        {
+            string fireInstanceId = GetStringProperty(item, "fireInstanceId");
+            string triggerName = GetStringProperty(item, "triggerName");
+            string triggerGroup = GetStringProperty(item, "triggerGroup");
+            string jobName = GetStringProperty(item, "jobName");
+            string jobGroup = GetStringProperty(item, "jobGroup");
+            string schedulerInstanceId = GetStringProperty(item, "schedulerInstanceId");
+            DateTimeOffset fireTimeUtc = GetDateTimeOffsetProperty(item, "fireTimeUtc");
+            DateTimeOffset? scheduledFireTimeUtc = GetNullableDateTimeOffsetProperty(item, "scheduledFireTimeUtc");
+
+            result.Add(new ExecutingFireInstanceDto(
+                FireInstanceId: fireInstanceId,
+                TriggerKey: new TriggerKeyDto(triggerGroup, triggerName),
+                JobKey: new JobKeyDto(jobGroup, jobName),
+                SchedulerInstanceId: schedulerInstanceId,
+                FireTimeUtc: fireTimeUtc,
+                ScheduledFireTimeUtc: scheduledFireTimeUtc));
+        }
+
+        return result;
+    }
+
     public ValueTask<bool> PauseJob(string schedulerName, string group, string name, CancellationToken cancellationToken = default)
     {
         return PostReadingAppliedFlag($"{GetSchedulerPath(schedulerName)}/jobs/{Uri.EscapeDataString(group)}/{Uri.EscapeDataString(name)}/pause", cancellationToken);
@@ -796,6 +828,32 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         }
 
         return default;
+    }
+
+    private static DateTimeOffset? GetNullableDateTimeOffsetProperty(JsonElement element, string propertyName)
+    {
+        if (element.ValueKind is not JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (!element.TryGetProperty(propertyName, out JsonElement value))
+        {
+            return null;
+        }
+
+        if (value.ValueKind is JsonValueKind.String &&
+            DateTimeOffset.TryParse(value.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset parsed))
+        {
+            return parsed;
+        }
+
+        if (value.ValueKind is JsonValueKind.Number && value.TryGetInt64(out long unixMilliseconds))
+        {
+            return DateTimeOffset.FromUnixTimeMilliseconds(unixMilliseconds);
+        }
+
+        return null;
     }
 
     private static JsonElement GetOptionalProperty(JsonElement element, string propertyName)

--- a/src/Quartz.HttpClient/HttpApiContract/ExecutingFireInstanceDto.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/ExecutingFireInstanceDto.cs
@@ -1,0 +1,62 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.HttpApiContract;
+
+internal sealed record ExecutingFireInstanceDto(
+    string FireInstanceId,
+    string TriggerName,
+    string TriggerGroup,
+    string JobName,
+    string JobGroup,
+    string SchedulerInstanceId,
+    DateTimeOffset FireTimeUtc,
+    DateTimeOffset? ScheduledFireTimeUtc)
+{
+    public static ExecutingFireInstanceDto Create(ExecutingFireInstance instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+
+        return new ExecutingFireInstanceDto(
+            FireInstanceId: instance.FireInstanceId,
+            TriggerName: instance.TriggerKey.Name,
+            TriggerGroup: instance.TriggerKey.Group,
+            JobName: instance.JobKey.Name,
+            JobGroup: instance.JobKey.Group,
+            SchedulerInstanceId: instance.SchedulerInstanceId,
+            FireTimeUtc: instance.FireTimeUtc,
+            ScheduledFireTimeUtc: instance.ScheduledFireTimeUtc
+        );
+    }
+
+    public ExecutingFireInstance AsExecutingFireInstance()
+    {
+        return new ExecutingFireInstance
+        {
+            FireInstanceId = FireInstanceId,
+            TriggerKey = new TriggerKey(TriggerName, TriggerGroup),
+            JobKey = new JobKey(JobName, JobGroup),
+            SchedulerInstanceId = SchedulerInstanceId,
+            FireTimeUtc = FireTimeUtc,
+            ScheduledFireTimeUtc = ScheduledFireTimeUtc
+        };
+    }
+}

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -136,6 +136,23 @@ public sealed class HttpScheduler : IScheduler
         return result;
     }
 
+    public async ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(TriggerKey? triggerKey, CancellationToken cancellationToken = default)
+    {
+        string query = triggerKey is null
+            ? string.Empty
+            : $"?triggerName={Uri.EscapeDataString(triggerKey.Name)}&triggerGroup={Uri.EscapeDataString(triggerKey.Group)}";
+
+        var dtos = await httpClient.Get<ExecutingFireInstanceDto[]>($"{JobEndpointUrl()}/executing-fire-instances{query}", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+
+        var result = new List<ExecutingFireInstance>(dtos.Length);
+        foreach (var dto in dtos)
+        {
+            result.Add(dto.AsExecutingFireInstance());
+        }
+
+        return result;
+    }
+
     public ValueTask Start(CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/start", jsonSerializerOptions, cancellationToken);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
@@ -276,6 +276,27 @@ public class JobEndpointsTest : WebApiTest
     }
 
     [Test]
+    public async Task GetExecutingFireInstancesShouldWork()
+    {
+        var instance = new ExecutingFireInstance
+        {
+            FireInstanceId = "fire1",
+            TriggerKey = new TriggerKey("trigger1", "group1"),
+            JobKey = jobKeyOne,
+            SchedulerInstanceId = "node-1",
+            FireTimeUtc = DateTimeOffset.UtcNow,
+            ScheduledFireTimeUtc = DateTimeOffset.UtcNow.AddSeconds(-1)
+        };
+
+        A.CallTo(() => FakeScheduler.GetExecutingFireInstances(A<TriggerKey>._, A<CancellationToken>._)).Returns([instance]);
+
+        var result = await HttpScheduler.GetExecutingFireInstances(null);
+
+        result.Should().ContainSingle();
+        result[0].Should().BeEquivalentTo(instance);
+    }
+
+    [Test]
     public async Task PauseJobShouldWork()
     {
         A.CallTo(() => FakeScheduler.PauseJob(jobKeyOne, A<CancellationToken>._)).Returns(true);

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -156,6 +156,16 @@ namespace Quartz.Dashboard.Services
         public int PageSize { get; init; }
         public int TotalCount { get; init; }
     }
+    public sealed class ExecutingFireInstanceDto : System.IEquatable<Quartz.Dashboard.Services.ExecutingFireInstanceDto>
+    {
+        public ExecutingFireInstanceDto(string FireInstanceId, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, Quartz.Dashboard.Services.JobKeyDto JobKey, string SchedulerInstanceId, System.DateTimeOffset FireTimeUtc, System.DateTimeOffset? ScheduledFireTimeUtc) { }
+        public string FireInstanceId { get; init; }
+        public System.DateTimeOffset FireTimeUtc { get; init; }
+        public Quartz.Dashboard.Services.JobKeyDto JobKey { get; init; }
+        public System.DateTimeOffset? ScheduledFireTimeUtc { get; init; }
+        public string SchedulerInstanceId { get; init; }
+        public Quartz.Dashboard.Services.TriggerKeyDto TriggerKey { get; init; }
+    }
     public sealed class ExecutionLimitsDto : System.IEquatable<Quartz.Dashboard.Services.ExecutionLimitsDto>
     {
         public ExecutionLimitsDto(System.Collections.Generic.Dictionary<string, int?> Limits) { }
@@ -175,6 +185,7 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.CalendarDetailDto> GetCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> GetCalendarNames(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.CurrentlyExecutingJobDto>> GetCurrentlyExecutingJobs(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.ExecutingFireInstanceDto>> GetExecutingFireInstances(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.ExecutionLimitsDto?> GetExecutionLimits(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.JobHistoryPageDto?> GetHistory(Quartz.Dashboard.Services.JobHistoryQueryDto query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.JobDetailDto> GetJob(string schedulerName, string group, string name, System.Threading.CancellationToken cancellationToken = default);

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -1003,6 +1003,76 @@ public class JobStoreSupportTest
 
     #endregion
 
+    #region GetExecutingFireInstances
+
+    [Test]
+    public async Task GetExecutingFireInstances_MapsFiredTriggerRecordsToExecutingFireInstances()
+    {
+        TransientTriggersFiredTestStore store = CreateTransientTriggersFiredTestStore();
+        IDriverDelegate del = A.Fake<IDriverDelegate>();
+        store.DirectDelegate = del;
+
+        var triggerKey = new TriggerKey("trigger1", "group1");
+        var jobKey = new JobKey("job1", "group1");
+        DateTimeOffset fireTime = DateTimeOffset.UtcNow;
+        DateTimeOffset scheduledTime = fireTime.AddSeconds(-1);
+
+        var record = new FiredTriggerRecord
+        {
+            FireInstanceId = "fire1",
+            FireInstanceState = StoredTriggerState.Executing,
+            TriggerKey = triggerKey,
+            SchedulerInstanceId = "node-1",
+            FireTimestamp = fireTime,
+            ScheduleTimestamp = scheduledTime,
+            JobKey = jobKey
+        };
+
+        A.CallTo(() => del.SelectExecutingFiredTriggers(A<ConnectionAndTransactionHolder>.Ignored, triggerKey, A<CancellationToken>.Ignored))
+            .Returns(new List<FiredTriggerRecord> { record });
+
+        List<ExecutingFireInstance> result = await store.GetExecutingFireInstances(triggerKey);
+
+        result.Should().ContainSingle();
+        ExecutingFireInstance instance = result[0];
+        instance.FireInstanceId.Should().Be("fire1");
+        instance.TriggerKey.Should().Be(triggerKey);
+        instance.JobKey.Should().Be(jobKey);
+        instance.SchedulerInstanceId.Should().Be("node-1");
+        instance.FireTimeUtc.Should().Be(fireTime);
+        instance.ScheduledFireTimeUtc.Should().Be(scheduledTime);
+    }
+
+    [Test]
+    public async Task GetExecutingFireInstances_SkipsRecordsWithoutJobKey()
+    {
+        // An EXECUTING row always carries its job columns; a record without one (e.g. still ACQUIRED)
+        // cannot be reported as an executing fire instance and must be skipped rather than throw.
+        TransientTriggersFiredTestStore store = CreateTransientTriggersFiredTestStore();
+        IDriverDelegate del = A.Fake<IDriverDelegate>();
+        store.DirectDelegate = del;
+
+        var record = new FiredTriggerRecord
+        {
+            FireInstanceId = "fire1",
+            FireInstanceState = StoredTriggerState.Acquired,
+            TriggerKey = new TriggerKey("trigger1", "group1"),
+            SchedulerInstanceId = "node-1",
+            FireTimestamp = DateTimeOffset.UtcNow,
+            ScheduleTimestamp = DateTimeOffset.UtcNow,
+            JobKey = null
+        };
+
+        A.CallTo(() => del.SelectExecutingFiredTriggers(A<ConnectionAndTransactionHolder>.Ignored, A<TriggerKey>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new List<FiredTriggerRecord> { record });
+
+        List<ExecutingFireInstance> result = await store.GetExecutingFireInstances(null);
+
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
     #region TriggersFired transient retry tests
 
     [Test]

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -113,6 +113,11 @@ public class QuartzHostedServiceTests
             throw new NotImplementedException();
         }
 
+        public ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public ValueTask<IJobDetail> GetJobDetail(JobKey jobKey, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -699,6 +699,119 @@ public class RAMJobStoreTest
             "ReleaseAcquiredTrigger should not unblock all triggers for DisallowConcurrentExecution jobs");
     }
 
+    [Test]
+    public async Task TestGetExecutingFireInstances_ReturnsDetailForFiredTrigger()
+    {
+        var d = TestDates.EvenMinuteDateAfterNow();
+        var trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group,
+            d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        trigger.ComputeFirstFireTimeUtc(null);
+        await fJobStore.AddTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
+        Assert.That(acquired, Has.Count.EqualTo(1));
+
+        var fired = await fJobStore.TriggersFired(acquired);
+        Assert.That(fired, Has.Count.EqualTo(1));
+        var bundle = fired[0].TriggerFiredBundle;
+
+        var executing = await fJobStore.GetExecutingFireInstances(null);
+
+        executing.Should().HaveCount(1);
+        var instance = executing[0];
+        instance.FireInstanceId.Should().Be(bundle.Trigger.FireInstanceId);
+        instance.TriggerKey.Should().Be(trigger.Key);
+        instance.JobKey.Should().Be(fJobDetail.Key);
+        instance.FireTimeUtc.Should().Be(bundle.FireTimeUtc);
+    }
+
+    [Test]
+    public async Task TestGetExecutingFireInstances_MultiplicityIsNotCollapsed()
+    {
+        // TriggerState.Executing only ever says "at least one execution is running"; unlike it,
+        // GetExecutingFireInstances must not collapse several concurrent executions into that single fact.
+        var d = TestDates.EvenMinuteDateAfterNow();
+        var trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group,
+            d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        var trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group,
+            d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        trigger1.ComputeFirstFireTimeUtc(null);
+        trigger2.ComputeFirstFireTimeUtc(null);
+        await fJobStore.AddTrigger(trigger1, false);
+        await fJobStore.AddTrigger(trigger2, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 2, TimeWindow = TimeSpan.Zero });
+        Assert.That(acquired, Has.Count.EqualTo(2));
+
+        var fired = await fJobStore.TriggersFired(acquired);
+        Assert.That(fired, Has.Count.EqualTo(2));
+
+        var executing = await fJobStore.GetExecutingFireInstances(null);
+
+        executing.Should().HaveCount(2);
+        executing.Select(x => x.FireInstanceId).Should().OnlyHaveUniqueItems();
+    }
+
+    [Test]
+    public async Task TestGetExecutingFireInstances_FiltersByTriggerKey()
+    {
+        var d = TestDates.EvenMinuteDateAfterNow();
+        var trigger1 = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group,
+            d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        var trigger2 = new SimpleTriggerImpl("trigger2", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group,
+            d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        trigger1.ComputeFirstFireTimeUtc(null);
+        trigger2.ComputeFirstFireTimeUtc(null);
+        await fJobStore.AddTrigger(trigger1, false);
+        await fJobStore.AddTrigger(trigger2, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 2, TimeWindow = TimeSpan.Zero });
+        await fJobStore.TriggersFired(acquired);
+
+        var executing = await fJobStore.GetExecutingFireInstances(trigger1.Key);
+
+        executing.Should().ContainSingle();
+        executing[0].TriggerKey.Should().Be(trigger1.Key);
+    }
+
+    [Test]
+    public async Task TestGetExecutingFireInstances_ReleasedAfterTriggeredJobComplete()
+    {
+        var d = TestDates.EvenMinuteDateAfterNow();
+        var trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group,
+            d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        trigger.ComputeFirstFireTimeUtc(null);
+        await fJobStore.AddTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
+        var fired = await fJobStore.TriggersFired(acquired);
+        var bundle = fired[0].TriggerFiredBundle;
+
+        (await fJobStore.GetExecutingFireInstances(null)).Should().HaveCount(1);
+
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.GetExecutingFireInstances(null)).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task TestGetExecutingFireInstances_AgreesWithTriggerStateExecuting()
+    {
+        // Complementary per issue #3205: TriggerState.Executing and GetExecutingFireInstances should
+        // never disagree about whether a trigger has an execution in flight.
+        var d = TestDates.EvenMinuteDateAfterNow();
+        var trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group,
+            d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
+        trigger.ComputeFirstFireTimeUtc(null);
+        await fJobStore.AddTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
+        await fJobStore.TriggersFired(acquired);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing);
+        (await fJobStore.GetExecutingFireInstances(trigger.Key)).Should().ContainSingle();
+    }
+
     /// <summary>
     /// Builds a repeating trigger for the concurrency-allowed job the fixture stores.
     /// </summary>

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
@@ -34,6 +34,7 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobExecutionContext>> GetCurrentlyExecutingJobs(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutingFireInstance>> GetExecutingFireInstances(Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.ExecutionLimits?> GetExecutionLimits(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -292,6 +292,16 @@ namespace Quartz
         public bool IsMatch(TKey key) { }
         public static Quartz.EverythingMatcher<TKey> All() { }
     }
+    public sealed class ExecutingFireInstance : System.IEquatable<Quartz.ExecutingFireInstance>
+    {
+        public ExecutingFireInstance() { }
+        public required string FireInstanceId { get; init; }
+        public required System.DateTimeOffset FireTimeUtc { get; init; }
+        public required Quartz.JobKey JobKey { get; init; }
+        public System.DateTimeOffset? ScheduledFireTimeUtc { get; init; }
+        public required string SchedulerInstanceId { get; init; }
+        public required Quartz.TriggerKey TriggerKey { get; init; }
+    }
     public readonly struct ExecutionGroupLimit : System.IEquatable<Quartz.ExecutionGroupLimit>
     {
         public ExecutionGroupLimit(Quartz.ExecutionGroupScope Scope, int? MaxConcurrent) { }
@@ -560,6 +570,7 @@ namespace Quartz
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobExecutionContext>> GetCurrentlyExecutingJobs(System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutingFireInstance>> GetExecutingFireInstances(Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ExecutionLimits?> GetExecutionLimits(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
@@ -1567,6 +1578,7 @@ namespace Quartz.Extensibility
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.TimeSpan GetAcquireRetryDelay(int failureCount);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutingFireInstance>> GetExecutingFireInstances(Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Extensibility.IOperableTrigger?> GetTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
@@ -1928,6 +1940,7 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask<int> RepinTriggersFromDeadNode(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string oldPreferredNode, string newPreferredNode, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar?> SelectCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> SelectCalendarNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.FiredTriggerRecord>> SelectExecutingFiredTriggers(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> SelectFiredTriggerInstanceNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.FiredTriggerRecord>> SelectFiredTriggerRecords(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.FiredTriggerQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> SelectJobDetail(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, Quartz.Extensibility.ITypeLoadHelper loadHelper, System.Threading.CancellationToken cancellationToken = default);
@@ -2087,6 +2100,8 @@ namespace Quartz.Impl.AdoJobStore
         protected virtual System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder> GetConnection(System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder?> GetEnlistedConnection(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutingFireInstance>> GetExecutingFireInstances(Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        protected virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutingFireInstance>> GetExecutingFireInstances(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual string GetFiredTriggerRecordId() { }
         public System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2393,6 +2408,7 @@ namespace Quartz.Impl.AdoJobStore
         protected string ReplaceTablePrefix(string query) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ICalendar?> SelectCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> SelectCalendarNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.FiredTriggerRecord>> SelectExecutingFiredTriggers(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> SelectFiredTriggerInstanceNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.FiredTriggerRecord>> SelectFiredTriggerRecords(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.FiredTriggerQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> SelectJobDetail(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, Quartz.Extensibility.ITypeLoadHelper loadHelper, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2761,6 +2777,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.TimeSpan GetAcquireRetryDelay(int failureCount) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutingFireInstance>> GetExecutingFireInstances(Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.Extensibility.IOperableTrigger?> GetTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2817,6 +2834,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobExecutionContext>> GetCurrentlyExecutingJobs(System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutingFireInstance>> GetExecutingFireInstances(Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ExecutionLimits?> GetExecutionLimits(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2915,6 +2933,7 @@ namespace Quartz.Impl
         public System.TimeSpan EstimatedTimeToReleaseAndAcquireTrigger { get; }
         [Quartz.TimeSpanParseRule(Quartz.TimeSpanParseRule.Milliseconds)]
         public System.TimeSpan MisfireThreshold { get; set; }
+        public string SchedulerInstanceId { get; set; }
         public bool SupportsPersistence { get; }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> AcquireNextTriggers(Quartz.Extensibility.TriggerAcquisitionRequest request, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask AddCalendar(string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2930,6 +2949,7 @@ namespace Quartz.Impl
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.TimeSpan GetAcquireRetryDelay(int failureCount) { }
         public System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutingFireInstance>> GetExecutingFireInstances(Quartz.TriggerKey? triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.Extensibility.IOperableTrigger?> GetTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1477,6 +1477,19 @@ internal sealed class QuartzScheduler
         return resources.JobStore.GetTriggerState(triggerKey, cancellationToken);
     }
 
+    /// <summary>
+    /// Gets the fire instances that are currently executing, across every node of the cluster.
+    /// </summary>
+    /// <seealso cref="ExecutingFireInstance" />
+    public ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(
+        TriggerKey? triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateState();
+
+        return resources.JobStore.GetExecutingFireInstances(triggerKey, cancellationToken);
+    }
+
     public ValueTask<bool> ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         ValidateState();

--- a/src/Quartz/ExecutingFireInstance.cs
+++ b/src/Quartz/ExecutingFireInstance.cs
@@ -1,0 +1,76 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// One execution of a job that is currently running somewhere in the scheduler's cluster, as recorded by
+/// the job store.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the cluster-aware complement to <see cref="IScheduler.GetCurrentlyExecutingJobs" />: with a
+/// persistent job store, every node's fired triggers are visible here, not only the node the call is made
+/// on. It is also richer than <see cref="TriggerState.Executing" />, which only says that at least one
+/// execution of a trigger is running — this returns every one of them, each identified by its own
+/// <see cref="FireInstanceId" />, so a trigger with several executions in flight at once is not collapsed
+/// into a single fact.
+/// </para>
+/// <para>
+/// Deliberately not <see cref="IJobExecutionContext" />: a remote node's job instance, result, merged job
+/// data map and cancellation handle cannot be reconstructed from another process, so this type only carries
+/// what the job store itself can answer for any node — identity and timing, not the live execution object.
+/// </para>
+/// </remarks>
+/// <seealso cref="IScheduler.GetExecutingFireInstances" />
+/// <seealso cref="TriggerState.Executing" />
+/// <author>Marko Lahma (.NET)</author>
+public sealed record ExecutingFireInstance
+{
+    /// <summary>
+    /// Identifies this execution, and only this one: a trigger that fires again gets a new value.
+    /// </summary>
+    public required string FireInstanceId { get; init; }
+
+    /// <summary>
+    /// The trigger that started this execution.
+    /// </summary>
+    public required TriggerKey TriggerKey { get; init; }
+
+    /// <summary>
+    /// The job being executed.
+    /// </summary>
+    public required JobKey JobKey { get; init; }
+
+    /// <summary>
+    /// The instance id of the scheduler node running this execution.
+    /// </summary>
+    public required string SchedulerInstanceId { get; init; }
+
+    /// <summary>
+    /// When this execution started.
+    /// </summary>
+    public required DateTimeOffset FireTimeUtc { get; init; }
+
+    /// <summary>
+    /// The time the trigger was scheduled to fire at, or <see langword="null" /> if the trigger has no
+    /// fixed schedule (e.g. it was fired manually).
+    /// </summary>
+    public DateTimeOffset? ScheduledFireTimeUtc { get; init; }
+}

--- a/src/Quartz/Extensibility/IJobStore.cs
+++ b/src/Quartz/Extensibility/IJobStore.cs
@@ -573,6 +573,15 @@ public interface IJobStore
     ValueTask TriggeredJobComplete(IOperableTrigger trigger, IJobDetail jobDetail, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the fire instances that are currently executing, across every node of the cluster.
+    /// </summary>
+    /// <param name="triggerKey">Limits the result to the fire instances of one trigger, or <see langword="null" /> for every executing fire instance.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>The currently executing fire instances, in no particular order.</returns>
+    /// <seealso cref="ExecutingFireInstance" />
+    ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(TriggerKey? triggerKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get the amount of time to wait when accessing this job store repeatedly fails.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -153,6 +153,33 @@ public interface IScheduler
     ValueTask<List<IJobExecutionContext>> GetCurrentlyExecutingJobs(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the fire instances that are currently executing, across every node of the cluster.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Unlike <see cref="GetCurrentlyExecutingJobs" />, this is cluster aware when a persistent job store
+    /// is used: it reports every node's executions, not only this one's. It is also richer than
+    /// <see cref="TriggerState.Executing" />, which only says that at least one execution of a trigger is
+    /// running — this returns every one of them individually, so a trigger with several executions in
+    /// flight is not collapsed into a single fact.
+    /// </para>
+    /// <para>
+    /// Deliberately not a list of <see cref="IJobExecutionContext" />: a remote node's live execution
+    /// object cannot be reconstructed from another process, so this only carries what any node can answer
+    /// for another — identity and timing.
+    /// </para>
+    /// <para>
+    /// Note that the list returned is an 'instantaneous' snapshot, and that as soon as it's returned, the
+    /// true list of executing fire instances may be different.
+    /// </para>
+    /// </remarks>
+    /// <param name="triggerKey">Limits the result to the fire instances of one trigger, or <see langword="null" /> for every executing fire instance.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <seealso cref="ExecutingFireInstance" />
+    /// <seealso cref="GetCurrentlyExecutingJobs" />
+    ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(TriggerKey? triggerKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get a reference to the scheduler's <see cref="IListenerManager" />,
     /// through which listeners may be registered.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -719,6 +719,20 @@ public interface IDriverDelegate
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Selects the fired-trigger records that are in the EXECUTING state, across every node of the
+    /// cluster. A listing-wide query rather than <see cref="SelectFiredTriggerRecords" /> filtered in
+    /// memory, so a caller answering a whole page does it in one query rather than one per row.
+    /// </summary>
+    /// <param name="conn">The DB Connection</param>
+    /// <param name="triggerKey">Limits the result to one trigger, or <see langword="null" /> for every executing fired trigger.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>A list of FiredTriggerRecord objects, all in the EXECUTING state.</returns>
+    ValueTask<List<FiredTriggerRecord>> SelectExecutingFiredTriggers(
+        ConnectionAndTransactionHolder conn,
+        TriggerKey? triggerKey,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Checks whether a job is currently being executed (has a fired trigger in EXECUTING state).
     /// Used to enforce <see cref="DisallowConcurrentExecutionAttribute"/> across cluster nodes.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -2148,6 +2148,61 @@ public abstract class JobStoreSupport : IJobStore
         }
     }
 
+    /// <inheritdoc />
+    public ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(
+        TriggerKey? triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        // no locks necessary for read...
+        return ExecuteWithoutLock(conn => GetExecutingFireInstances(conn, triggerKey, cancellationToken), cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the fire instances that are currently executing, across every node of the cluster.
+    /// </summary>
+    /// <param name="conn">The conn.</param>
+    /// <param name="triggerKey">Limits the result to one trigger, or <see langword="null" /> for every executing fire instance.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    protected virtual async ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(
+        ConnectionAndTransactionHolder conn,
+        TriggerKey? triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            List<FiredTriggerRecord> records = await Delegate
+                .SelectExecutingFiredTriggers(conn, triggerKey, cancellationToken).ConfigureAwait(false);
+
+            List<ExecutingFireInstance> result = new(records.Count);
+            foreach (FiredTriggerRecord record in records)
+            {
+                if (record.JobKey is null)
+                {
+                    // An EXECUTING row always has its job columns filled in; skip defensively rather than
+                    // report a fire instance with no job.
+                    continue;
+                }
+
+                result.Add(new ExecutingFireInstance
+                {
+                    FireInstanceId = record.FireInstanceId,
+                    TriggerKey = record.TriggerKey,
+                    JobKey = record.JobKey,
+                    SchedulerInstanceId = record.SchedulerInstanceId,
+                    FireTimeUtc = record.FireTimestamp,
+                    ScheduledFireTimeUtc = record.ScheduleTimestamp
+                });
+            }
+
+            return result;
+        }
+        catch (Exception e)
+        {
+            Throw.JobPersistenceException($"Couldn't retrieve executing fire instances: {e.Message}", e);
+            return default!;
+        }
+    }
+
     public async ValueTask<bool> ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         return await activityTracer.Trace(

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -190,6 +190,13 @@ internal static class StdAdoConstants
     public static readonly string SqlSelectFiredTriggerInstanceNames =
         Invariant($"SELECT DISTINCT {AdoConstants.ColumnInstanceName} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
 
+    /// <summary>
+    /// Selects every EXECUTING fired trigger of the scheduler; the caller appends
+    /// <see cref="SqlFiredTriggerTriggerPredicate" /> to narrow it to one trigger.
+    /// </summary>
+    public static readonly string SqlSelectExecutingFiredTriggers =
+        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnEntryState} = @executingState");
+
     public static readonly string SqlSelectCountExecutingFiredTriggersOfJob =
         Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup AND {AdoConstants.ColumnEntryState} = @executingState");
 

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -1297,6 +1297,38 @@ public partial class StdAdoDelegate
         return records;
     }
 
+    /// <inheritdoc />
+    public virtual async ValueTask<List<FiredTriggerRecord>> SelectExecutingFiredTriggers(
+        ConnectionAndTransactionHolder conn,
+        TriggerKey? triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        List<FiredTriggerRecord> records = [];
+
+        string sql = StdAdoConstants.SqlSelectExecutingFiredTriggers;
+        if (triggerKey is not null)
+        {
+            sql += StdAdoConstants.SqlFiredTriggerTriggerPredicate;
+        }
+
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
+        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, "executingState", StoredTriggerState.Executing.ToStoredValue());
+        if (triggerKey is not null)
+        {
+            AddCommandParameter(cmd, "triggerName", triggerKey.Name);
+            AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        }
+
+        using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            records.Add(ReadFiredTriggerRecord(rs));
+        }
+
+        return records;
+    }
+
     private FiredTriggerRecord ReadFiredTriggerRecord(DbDataReader rs)
     {
         StoredTriggerState state = StoredTriggerStates.FromStoredValue(rs.GetString(AdoConstants.ColumnEntryState));

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -141,6 +141,14 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
             }
         }
 
+        // Unlike JobStoreSupport, RAMJobStore has no constructor-time access to QuartzSchedulerOptions, so
+        // it never learns the configured instance id on its own — tell it now, whether that id came from
+        // configuration or was just generated above.
+        if (resources.JobStore is RAMJobStore ramJobStore)
+        {
+            ramJobStore.SchedulerInstanceId = resources.InstanceId;
+        }
+
         var threadPool = resources.ThreadPool;
         await threadPool.Initialize(cancellationToken).ConfigureAwait(false);
 

--- a/src/Quartz/Impl/DelegatingJobStore.cs
+++ b/src/Quartz/Impl/DelegatingJobStore.cs
@@ -295,6 +295,11 @@ public class DelegatingJobStore : IJobStore
         return jobStore.TriggeredJobComplete(trigger, jobDetail, triggerInstructionCode, cancellationToken);
     }
 
+    public virtual ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(TriggerKey? triggerKey, CancellationToken cancellationToken = default)
+    {
+        return jobStore.GetExecutingFireInstances(triggerKey, cancellationToken);
+    }
+
     public virtual TimeSpan GetAcquireRetryDelay(int failureCount)
     {
         return jobStore.GetAcquireRetryDelay(failureCount);

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -227,6 +227,11 @@ public class DelegatingScheduler : IScheduler
         return scheduler.GetTriggerState(triggerKey, cancellationToken);
     }
 
+    public virtual ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(TriggerKey? triggerKey, CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetExecutingFireInstances(triggerKey, cancellationToken);
+    }
+
     public virtual ValueTask<bool> ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         return scheduler.ResetTriggerFromErrorState(triggerKey, cancellationToken);

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -69,10 +69,31 @@ public sealed class RAMJobStore : IJobStore
     /// ADO store, where the answer comes from FIRED_TRIGGERS rows that likewise outlive a trigger update.
     /// </remarks>
     private readonly Dictionary<TriggerKey, HashSet<string>> executingFireInstances = [];
+
+    /// <summary>
+    /// The full detail of every execution recorded in <see cref="executingFireInstances" />, keyed by
+    /// <see cref="ExecutingFireInstance.FireInstanceId" /> rather than by trigger: unlike that dictionary,
+    /// this one backs <see cref="GetExecutingFireInstances" />, which identifies individual executions, so
+    /// it has to be able to look one up on its own key. Populated and released alongside it, in
+    /// <see cref="TriggersFired" /> and <see cref="ReleaseExecutionNoLock" />.
+    /// </summary>
+    private readonly Dictionary<string, ExecutingFireInstance> executingFireInstanceDetails = [];
+
     private TimeSpan misfireThreshold = TimeSpan.FromSeconds(5);
     private readonly ISchedulerSignaler signaler;
     private readonly TimeProvider timeProvider;
     private readonly ILogger logger;
+
+    /// <summary>
+    /// The instance id reported on <see cref="ExecutingFireInstance" /> results from this store.
+    /// </summary>
+    /// <remarks>
+    /// RAMJobStore is never clustered, so unlike <c>JobStoreSupport</c> it has no constructor-time access
+    /// to the scheduler's configured instance id — it is told this after construction, once the id is
+    /// known (see <c>DefaultSchedulerFactory</c>). Defaults to the same placeholder as an unconfigured
+    /// scheduler's instance id.
+    /// </remarks>
+    public string SchedulerInstanceId { get; set; } = "NON_CLUSTERED";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RAMJobStore"/> class.
@@ -215,6 +236,7 @@ public sealed class RAMJobStore : IJobStore
 
             resumedJobsInPausedGroups.Clear();
             executingFireInstances.Clear();
+            executingFireInstanceDetails.Clear();
         }
         finally
         {
@@ -539,9 +561,12 @@ public sealed class RAMJobStore : IJobStore
     // fired-trigger rows alone but deleting one removes them. There is no default: every caller says which.
     private async Task<bool> RemoveTriggerNoLock(TriggerKey key, bool removeOrphanedJob, bool keepExecutions, CancellationToken cancellationToken)
     {
-        if (!keepExecutions)
+        if (!keepExecutions && executingFireInstances.Remove(key, out var executionsToForget))
         {
-            executingFireInstances.Remove(key);
+            foreach (string fireInstanceId in executionsToForget)
+            {
+                executingFireInstanceDetails.Remove(fireInstanceId);
+            }
         }
 
         // remove from triggers by FQN map
@@ -847,11 +872,41 @@ public sealed class RAMJobStore : IJobStore
     /// </summary>
     private void ReleaseExecutionNoLock(TriggerKey triggerKey, string fireInstanceId)
     {
+        // Unlike the HashSet<string> below, Dictionary<string, T>.Remove throws on a null key instead of
+        // just reporting no match - and a trigger that was acquired but never fired has no FireInstanceId.
+        if (fireInstanceId is not null)
+        {
+            executingFireInstanceDetails.Remove(fireInstanceId);
+        }
+
         if (executingFireInstances.TryGetValue(triggerKey, out var fireInstances)
-            && fireInstances.Remove(fireInstanceId)
+            && fireInstances.Remove(fireInstanceId!)
             && fireInstances.Count == 0)
         {
             executingFireInstances.Remove(triggerKey);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(TriggerKey? triggerKey, CancellationToken cancellationToken = default)
+    {
+        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            List<ExecutingFireInstance> result = [];
+            foreach (ExecutingFireInstance instance in executingFireInstanceDetails.Values)
+            {
+                if (triggerKey is null || instance.TriggerKey.Equals(triggerKey))
+                {
+                    result.Add(instance);
+                }
+            }
+
+            return result;
+        }
+        finally
+        {
+            lockObject.Release();
         }
     }
 
@@ -2398,6 +2453,15 @@ public sealed class RAMJobStore : IJobStore
                 }
 
                 fireInstances.Add(trigger.FireInstanceId);
+                executingFireInstanceDetails[trigger.FireInstanceId] = new ExecutingFireInstance
+                {
+                    FireInstanceId = trigger.FireInstanceId,
+                    TriggerKey = tw.TriggerKey,
+                    JobKey = job.Key,
+                    SchedulerInstanceId = SchedulerInstanceId,
+                    FireTimeUtc = bndle.FireTimeUtc,
+                    ScheduledFireTimeUtc = bndle.ScheduledFireTimeUtc
+                };
 
                 results.Add(new TriggerFiredResult(bndle));
             }

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -510,6 +510,16 @@ internal sealed class StdScheduler : IScheduler
     /// <summary>
     /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
     /// </summary>
+    public ValueTask<List<ExecutingFireInstance>> GetExecutingFireInstances(
+        TriggerKey? triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetExecutingFireInstances(triggerKey, cancellationToken);
+    }
+
+    /// <summary>
+    /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
+    /// </summary>
     public ValueTask<bool> ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         return scheduler.ResetTriggerFromErrorState(triggerKey, cancellationToken);


### PR DESCRIPTION
## Summary

Implements the `GetExecutingFireInstances` API proposed in #3205: a cluster-aware complement to `GetCurrentlyExecutingJobs` and `TriggerState.Executing` (#1416) that returns the individual fire instances currently executing anywhere in the cluster, rather than collapsing them into a single per-node snapshot or a single enum value.

- **Core model**: `ExecutingFireInstance` (`FireInstanceId`, `TriggerKey`, `JobKey`, `SchedulerInstanceId`, `FireTimeUtc`, `ScheduledFireTimeUtc`), new `IJobStore`/`IScheduler` member `GetExecutingFireInstances(TriggerKey? triggerKey, ct)`.
- **RAMJobStore**: a new `FireInstanceId`-keyed dictionary alongside the existing `TriggerKey`-keyed one that backs `TriggerState.Executing` (left untouched — it's load-bearing). Since RAMJobStore has no constructor-time access to the scheduler's configured instance id, `DefaultSchedulerFactory` now tells it once the id is known, mirroring how `JobStoreSupport` already learns it.
- **ADO job store**: `IDriverDelegate.SelectExecutingFiredTriggers`, a new listing-wide `QRTZ_FIRED_TRIGGERS` query filtered to the `EXECUTING` state (reuses the existing `SCHED_NAME`/`TRIGGER_NAME`/`TRIGGER_GROUP` index — no schema changes needed). `JobStoreSupport.GetExecutingFireInstances` maps the results, following the same `ExecuteWithoutLock` pattern as `GetTriggerState`.
- **HTTP API**: new `GET .../jobs/executing-fire-instances` endpoint (mirrors `/currently-executing`), wired through `Quartz.HttpClient`'s `HttpScheduler`.
- **Blazor dashboard**: the "Currently Executing" stat tile on `Dashboard.razor` now uses the cluster-aware query instead of `GetCurrentlyExecutingJobs` — per the issue's "Bonus" note, that tile was already wrong in a cluster (it only counted the node the dashboard happened to be attached to). `CurrentlyExecuting.razor` (the per-node interrupt page) is intentionally left alone, since interrupting a job only ever works on the local node regardless of what query backs its listing.

This is organized as 5 commits, one per subsystem, in dependency order (core → ADO → HTTP client → HTTP endpoint → dashboard) — happy for it to be reviewed incrementally if that's easier than one pass.

## What's *not* included

- No database migration — the query reuses existing columns/indexes on `QRTZ_FIRED_TRIGGERS`.
- No changes to `docs/documentation/quartz-4.x/migration-guide.md` — this is additive API, not a 3.x→4.x contract change.
- Dialect-specific `IDriverDelegate` subclasses (SqlServer/PostgreSQL/Oracle/MySQL/SQLite/Firebird) inherit `StdAdoDelegate`'s implementation as-is (it's `virtual`, not `abstract`); none of them needed an override since the query has no vendor-specific paging or syntax.

## Test plan

- [x] `dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj` — 2319 passed, 4 skipped (pre-existing skips), 0 failed
- [x] `dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj` — 217 passed, 0 failed
- [x] New unit tests: `RAMJobStoreTest` (fire/complete/filter/multiplicity, plus a regression test tying `GetExecutingFireInstances` to `TriggerState.Executing`), `JobStoreSupportTest` (fake-delegate mapping + defensive null-JobKey skip), `JobEndpointsTest` (end-to-end HTTP round trip: fake scheduler → endpoint → `HttpScheduler`)
- [x] Public API `Verify` baselines (`Quartz`, `Quartz.HttpClient`, `Quartz.Dashboard`) reviewed and accepted — diffs contain exactly the new surface, nothing else
- [ ] Integration tests (`Quartz.Tests.Integration`) not run — they require Docker and weren't exercised in this environment; the ADO delegate change only adds a new read query reusing existing columns, but a maintainer with a DB-backed CI run may want to double check the SQL against a real database
- [ ] No manual verification against the actual Blazor dashboard UI (no browser session in this environment) — the API-level round trip is tested, but the rendered tile itself wasn't visually confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)