### PR TITLE
Add job type exclusion filter to trigger acquisition (#2238)

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/custom-job-store.md
+++ b/docs/documentation/quartz-4.x/how-tos/custom-job-store.md
@@ -257,6 +257,45 @@ recomputed, which is deliberate.
 added later will default to "no additional filtering" — an override that starts from `base` and adjusts
 one field keeps working.
 
+### Excluding job types from acquisition
+
+`ExcludedJobTypeNames` is the first of those properties, and it is how a node declines whole classes
+of work: names in the set are kept out of the acquisition query's result set, so an excluded job type
+never occupies one of the `MaxCount` rows a post-filter would have to discard.
+
+<!-- snippet: sample_custom_job_store_excluded_job_types -->
+```csharp
+// JobType.FullName is the spelling the store persists - "Namespace.TypeName, AssemblyName".
+// Type.FullName carries no assembly name and would never match a stored row.
+private static readonly string reportingJobTypeName = new JobType(typeof(ReportingJob)).FullName;
+
+protected override TriggerAcquisitionCriteria CreateAcquisitionCriteria(TriggerAcquisitionRequest request)
+{
+    // Asked again on every acquisition attempt, so a window that opens between two of them takes
+    // effect on the next one without restarting anything.
+    string[]? excluded = this.maintenanceWindow.IsOpen ? [reportingJobTypeName] : null;
+
+    return base.CreateAcquisitionCriteria(request) with { ExcludedJobTypeNames = excluded };
+}
+```
+<!-- endSnippet -->
+
+Two things to get right:
+
+- **Name the type the way the store persists it.** That is `JobType.FullName` —
+  `Namespace.TypeName, AssemblyName`, the same string `TriggerAcquireResult.JobTypeName` carries and
+  the same one the ADO schema keeps in `JOB_CLASS_NAME`. `Type.FullName` has no assembly name and will
+  never match a stored row.
+- **Matching is exact.** There is no prefix or wildcard form. The SQL comparison follows the
+  `JOB_CLASS_NAME` column's collation, so its case sensitivity is the database's, not .NET's; the
+  in-memory store compares ordinally. Rows written by Quartz 2.x or 3.x can carry an older spelling,
+  and the read side never rewrites a stored name, so an exclusion will not match those.
+
+The property is also on `TriggerAcquisitionRequest`, which every shipped store honours — set it there
+when the caller knows the exclusions, and override `CreateAcquisitionCriteria` when the *store* does.
+Entries must be non-blank and there may be at most 1000 of them, both checked at construction; 1000 is
+Oracle's ceiling on an `IN` list.
+
 ## Rebuilding jobs and triggers
 
 A store that reads its data back has to reconstruct `IJobDetail` and `IOperableTrigger`. The two are

--- a/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
+++ b/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
@@ -33,7 +33,7 @@ that happens to be `protected virtual` so the class can be composed — treat th
 
 | Member | Override when |
 |---|---|
-| `protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount)` | your database limits rows differently from ANSI |
+| `protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)` | your database limits rows differently from ANSI |
 | `protected virtual string GetSelectMisfiredTriggersToRecoverSql(int count)` | the same, for the misfire scan; `count == -1` means "no limit" |
 | `protected virtual string GetCountMisfiredTriggersInStateSql()` | the counting form needs a different shape |
 | `protected virtual string ApplyPaging(string sql, bool takeLimited)` | `OFFSET … FETCH NEXT …` is not understood |
@@ -51,8 +51,8 @@ appear among the shipped dialects:
 <!-- snippet: sample_dialect_delegate_row_limiting -->
 ```csharp
 // append (PostgreSQL, Firebird)
-protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
-    => base.GetSelectNextTriggerToAcquireSql(maxCount) + " LIMIT " + maxCount;
+protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+    => base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " LIMIT " + maxCount;
 
 // splice a prefix (SQL Server: SELECT TOP n)
 // wrap the whole statement (Oracle: SELECT * FROM ( … ) WHERE rownum <= n)
@@ -131,8 +131,9 @@ not a contract; the schema it addresses is, and that lives in `AdoConstants`, wh
 For a delegate in your own assembly this means two things:
 
 - You cannot write `StdAdoConstants.SqlSelectNextTriggerToAcquire`. Derive your statement from what the
-  base returns — `base.GetSelectNextTriggerToAcquireSql(maxCount)` — and transform the string, which is
-  exactly what MySQL's `.Replace("{0}TRIGGERS t", …)` does. Or write the statement whole.
+  base returns — `base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket)` — and
+  transform the string, which is exactly what MySQL's `.Replace("{0}TRIGGERS t", …)` does. Or write
+  the statement whole.
 - You *can* name tables, columns, trigger types and state values: `AdoConstants.TableTriggers`,
   `AdoConstants.ColumnTriggerName`, `AdoConstants.StateWaiting` and the rest are public precisely so a
   dialect can build its own SQL against the schema.

--- a/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
+++ b/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
@@ -33,7 +33,7 @@ that happens to be `protected virtual` so the class can be composed — treat th
 
 | Member | Override when |
 |---|---|
-| `protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)` | your database limits rows differently from ANSI |
+| `protected virtual string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)` | your database limits rows differently from ANSI |
 | `protected virtual string GetSelectMisfiredTriggersToRecoverSql(int count)` | the same, for the misfire scan; `count == -1` means "no limit" |
 | `protected virtual string GetCountMisfiredTriggersInStateSql()` | the counting form needs a different shape |
 | `protected virtual string ApplyPaging(string sql, bool takeLimited)` | `OFFSET … FETCH NEXT …` is not understood |
@@ -44,21 +44,28 @@ that happens to be `protected virtual` so the class can be composed — treat th
 
 ### Row limiting
 
-The default `GetSelectNextTriggerToAcquireSql` ignores `maxCount` entirely — *"by default we don't
-support limits, this is db specific"* — so a dialect that can limit rows should say so. Four shapes
-appear among the shipped dialects:
+The default `GetSelectNextTriggerToAcquireSql` ignores `shape.MaxCount` entirely — *"by default we
+don't support limits, this is db specific"* — so a dialect that can limit rows should say so. Four
+shapes appear among the shipped dialects:
 
 <!-- snippet: sample_dialect_delegate_row_limiting -->
 ```csharp
 // append (PostgreSQL, Firebird)
-protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
-    => base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " LIMIT " + maxCount;
+protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
+    => base.GetSelectNextTriggerToAcquireSql(shape) + " LIMIT " + shape.MaxCount;
 
 // splice a prefix (SQL Server: SELECT TOP n)
 // wrap the whole statement (Oracle: SELECT * FROM ( … ) WHERE rownum <= n)
 // append with an index hint (MySQL: FORCE INDEX (…) … LIMIT n)
 ```
 <!-- endSnippet -->
+
+`TriggerAcquisitionSqlShape` carries everything about an acquisition attempt that changes the text of
+the statement — the row limit, and how many job-type exclusion terms the `NOT IN` clause needs. Read
+`shape.MaxCount` and hand the whole shape to `base`: a dimension added later becomes a property on
+the record, so an override written today keeps compiling and keeps applying it. It is also the key
+the finished statement is cached under, which is why it holds the bucketed exclusion count rather
+than the caller's exact one.
 
 ### Paging
 
@@ -131,9 +138,8 @@ not a contract; the schema it addresses is, and that lives in `AdoConstants`, wh
 For a delegate in your own assembly this means two things:
 
 - You cannot write `StdAdoConstants.SqlSelectNextTriggerToAcquire`. Derive your statement from what the
-  base returns — `base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket)` — and
-  transform the string, which is exactly what MySQL's `.Replace("{0}TRIGGERS t", …)` does. Or write
-  the statement whole.
+  base returns — `base.GetSelectNextTriggerToAcquireSql(shape)` — and transform the string, which is
+  exactly what MySQL's `.Replace("{0}TRIGGERS t", …)` does. Or write the statement whole.
 - You *can* name tables, columns, trigger types and state values: `AdoConstants.TableTriggers`,
   `AdoConstants.ColumnTriggerName`, `AdoConstants.StateWaiting` and the rest are public precisely so a
   dialect can build its own SQL against the schema.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4898,11 +4898,14 @@ which always projects `EXECUTION_GROUP` and always carries the preferred-node fi
 which is the one that was already there:
 
 ```csharp
-protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+protected virtual string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
 ```
 
-Its `excludedJobTypeBucket` parameter is new — pass it to `base` and the job-type exclusions ride
-along — and it is still the only thing the dialects differed in: `FirebirdDelegate` appends
+Its parameter is new: `TriggerAcquisitionSqlShape` carries everything about an acquisition attempt
+that changes the statement's text — `MaxCount`, and `ExcludedJobTypeBucket` for the job-type
+exclusion clause — so the next acquisition dimension is a property on the record rather than another
+parameter here. Read `shape.MaxCount` and pass the whole shape to `base`. It is still the only thing
+the dialects differed in: `FirebirdDelegate` appends
 `ROWS n`, `SqlServerDelegate` splices in `SELECT TOP n`, `OracleDelegate` wraps the statement in a
 `rownum` filter, and the rest append `LIMIT n`. **A dialect delegate of your own should keep its
 `GetSelectNextTriggerToAcquireSql` override and delete the other three.**
@@ -7663,7 +7666,7 @@ Parameters and behavior are unchanged:
 | `IDriverDelegate.UpdateFiredTrigger` removed | `ApplyTriggerFired` writes the fired-trigger row as one command of its batch, and nothing else called it; an override of it would have stopped taking effect silently — see [Batched trigger fire](#batched-trigger-fire) |
 | `StdAdoDelegate`'s column probes removed | The three `Has*Column` properties, the three `Supports*Column` probes and `VerifyTriggersTableReachable`. The columns they probed for are required on 4.x, so the schema migration replaces them — see [The optional columns are required, so the probes are gone](#the-optional-columns-are-required-so-the-probes-are-gone) |
 | `GetSelectNextTriggerToAcquireWith*Sql` removed | The `…WithExecutionGroupSql`, `…WithPreferredNodeSql` and `…WithPreferredNodeOnlySql` hooks, on `StdAdoDelegate` and all six dialect delegates. One statement covers every case now, so a dialect delegate keeps only its `GetSelectNextTriggerToAcquireSql` override — see [The three extra acquisition SQL hooks went with them](#the-three-extra-acquisition-sql-hooks-went-with-them) |
-| `StdAdoDelegate.GetSelectNextTriggerToAcquireSql(int maxCount)` | `GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)`; a custom dialect override must pass the bucket through when it adds its row limit |
+| `StdAdoDelegate.GetSelectNextTriggerToAcquireSql(int maxCount)` | `GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)`; a custom dialect override reads `shape.MaxCount` for its row limit and passes the whole shape to `base`, so the next acquisition dimension is a property on the record rather than another parameter |
 | `IDbConnectionManager` / `DbConnectionManager` removed | The container is the provider registry, keyed by scheduler name; register a provider with `UseConnectionProvider` — see [The connection manager is gone](#the-connection-manager-is-gone) |
 | `AdoJobStoreOptions.TxIsolationLevelSerializable` is `TransactionIsolationLevel` | An `IsolationLevel?` rather than a `bool`, so `Snapshot` and the rest are expressible. The legacy key still translates — see [The isolation level is an isolation level](#the-isolation-level-is-an-isolation-level) |
 | `AdoJobStoreOptions.CommandTimeout` added | Bounds every statement the store issues, the lock handler's included; it reaches them through `DriverDelegateContext.CommandTimeout` and `SemaphoreContext.CommandTimeout`. Unset keeps each provider's own default, so nothing changes for a store that does not set it. 3.x had no way to say this at all — there was no `quartz.*` key for it, so nothing needs translating |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4898,10 +4898,11 @@ which always projects `EXECUTION_GROUP` and always carries the preferred-node fi
 which is the one that was already there:
 
 ```csharp
-protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount)
+protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
 ```
 
-It is unchanged, and it is still the only thing the dialects differed in: `FirebirdDelegate` appends
+Its `excludedJobTypeBucket` parameter is new — pass it to `base` and the job-type exclusions ride
+along — and it is still the only thing the dialects differed in: `FirebirdDelegate` appends
 `ROWS n`, `SqlServerDelegate` splices in `SELECT TOP n`, `OracleDelegate` wraps the statement in a
 `rownum` filter, and the rest append `LIMIT n`. **A dialect delegate of your own should keep its
 `GetSelectNextTriggerToAcquireSql` override and delete the other three.**
@@ -5417,8 +5418,13 @@ above.
 `TriggerAcquisitionRequest` lives in `Quartz.Extensibility`. Acquisition keeps growing dimensions — the
 batching window, per-execution-group limits, node affinity — and each one used to be another parameter on the
 hot path of every store. As a record, the next one is an added optional property a store can ignore. It is the
-store-level counterpart of the delegate-level `TriggerAcquisitionCriteria`, which is unchanged. `TimeWindow`
+store-level counterpart of the delegate-level `TriggerAcquisitionCriteria`. `TimeWindow`
 rejects a negative value at construction, where `AdoJobStoreBase` used to throw from inside acquisition.
+
+Both records also expose optional `ExcludedJobTypeNames` collections. `AdoJobStoreBase` copies the request
+property into its delegate criteria, and the standard ADO.NET delegates apply it in the acquisition SQL.
+Names use the stored `TriggerAcquireResult.JobTypeName` spelling. Comparison follows the database job-class
+column's collation, including its case-sensitivity rules.
 
 ## Options records replace boolean parameters
 
@@ -7606,6 +7612,7 @@ Parameters and behavior are unchanged:
 | `IDriverDelegate.SelectJobForTrigger`'s `loadJobType` is required | It defaulted in front of the cancellation token; pass `loadJobType: true` for the old default |
 | `IDriverDelegate.UpdateTriggerPreferredNodeConditional` takes a `PreferredNodeTransition` | Four loose compare-and-swap parameters became one record naming `Expected` and `New` |
 | `TriggerAcquisitionCriteria.LiveNodeCutoff` is a `required DateTimeOffset` | It was an optional `long` of `UtcTicks` beside two required `DateTimeOffset` siblings, and omitting it silently meant "every node is dead". The tick conversion happens in `AddPreferredNodeParameters`, whose parameter is a `DateTimeOffset` too |
+| `TriggerAcquisitionRequest.ExcludedJobTypeNames` and `TriggerAcquisitionCriteria.ExcludedJobTypeNames` added | Optional exact job-type-name exclusions for acquisition. The ADO.NET store applies them in SQL; comparison follows the `JOB_CLASS_NAME` column's collation |
 | `StdAdoDelegate.AddPagingParameters(cmd, int skip, int take, bool)` | `skip`/`take` were `long` while `PagedQuery.Skip`/`.Take` are `int`; the dialect override contract now matches the query object it serves |
 | `StdAdoDelegate.ReadBytesFromBlob` takes a `DbDataReader` and is asynchronous | It took a `System.Data.IDataReader` — the last legacy `System.Data.I*` interface anywhere in the public surface — which forced a synchronous, thread-blocking read that ignored the cancellation token it was handed. It is `async ValueTask<byte[]?>` over `IsDBNullAsync` / `GetFieldValueAsync<byte[]>`. **The behaviour contract is unchanged**: a `NULL` column still yields `null`, and an empty blob still yields an empty array, which the only caller (`GetObjectFromBlob`) has always treated the same as `null` by testing `Length > 0`. An override changes its parameter type; every reader the store passes was already a `DbDataReader` |
 | `StdAdoDelegate`'s date/time and time-span conversions are non-virtual | UTC ticks and whole milliseconds are the schema contract the liveness SQL assumes; only the boolean pair remains a dialect seam. A delegate that changes the storage format implements `IDriverDelegate` itself — see [If you implement `IDriverDelegate`: the listing members](#if-you-implement-idriverdelegate-the-listing-members) |
@@ -7654,6 +7661,7 @@ Parameters and behavior are unchanged:
 | `IDriverDelegate.UpdateFiredTrigger` removed | `ApplyTriggerFired` writes the fired-trigger row as one command of its batch, and nothing else called it; an override of it would have stopped taking effect silently — see [Batched trigger fire](#batched-trigger-fire) |
 | `StdAdoDelegate`'s column probes removed | The three `Has*Column` properties, the three `Supports*Column` probes and `VerifyTriggersTableReachable`. The columns they probed for are required on 4.x, so the schema migration replaces them — see [The optional columns are required, so the probes are gone](#the-optional-columns-are-required-so-the-probes-are-gone) |
 | `GetSelectNextTriggerToAcquireWith*Sql` removed | The `…WithExecutionGroupSql`, `…WithPreferredNodeSql` and `…WithPreferredNodeOnlySql` hooks, on `StdAdoDelegate` and all six dialect delegates. One statement covers every case now, so a dialect delegate keeps only its `GetSelectNextTriggerToAcquireSql` override — see [The three extra acquisition SQL hooks went with them](#the-three-extra-acquisition-sql-hooks-went-with-them) |
+| `StdAdoDelegate.GetSelectNextTriggerToAcquireSql(int maxCount)` | `GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)`; a custom dialect override must pass the bucket through when it adds its row limit |
 | `IDbConnectionManager` / `DbConnectionManager` removed | The container is the provider registry, keyed by scheduler name; register a provider with `UseConnectionProvider` — see [The connection manager is gone](#the-connection-manager-is-gone) |
 | `AdoJobStoreOptions.TxIsolationLevelSerializable` is `TransactionIsolationLevel` | An `IsolationLevel?` rather than a `bool`, so `Snapshot` and the rest are expressible. The legacy key still translates — see [The isolation level is an isolation level](#the-isolation-level-is-an-isolation-level) |
 | `AdoJobStoreOptions.CommandTimeout` added | Bounds every statement the store issues, the lock handler's included; it reaches them through `DriverDelegateContext.CommandTimeout` and `SemaphoreContext.CommandTimeout`. Unset keeps each provider's own default, so nothing changes for a store that does not set it. 3.x had no way to say this at all — there was no `quartz.*` key for it, so nothing needs translating |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5421,10 +5421,12 @@ hot path of every store. As a record, the next one is an added optional property
 store-level counterpart of the delegate-level `TriggerAcquisitionCriteria`. `TimeWindow`
 rejects a negative value at construction, where `AdoJobStoreBase` used to throw from inside acquisition.
 
-Both records also expose optional `ExcludedJobTypeNames` collections. `AdoJobStoreBase` copies the request
-property into its delegate criteria, and the standard ADO.NET delegates apply it in the acquisition SQL.
-Names use the stored `TriggerAcquireResult.JobTypeName` spelling. Comparison follows the database job-class
-column's collation, including its case-sensitivity rules.
+Both records also expose optional `ExcludedJobTypeNames` collections, and **every shipped store honours the
+request-level one**. `AdoJobStoreBase` copies it into its delegate criteria and the standard ADO.NET delegates
+keep the rows out in the acquisition SQL; `RAMJobStore` skips a candidate whose job type name is in the set.
+Names use the stored `TriggerAcquireResult.JobTypeName` spelling, which is `JobType.FullName`. `RAMJobStore`
+compares ordinally; SQL comparison follows the database job-class column's collation, including its
+case-sensitivity rules.
 
 ## Options records replace boolean parameters
 
@@ -7612,7 +7614,7 @@ Parameters and behavior are unchanged:
 | `IDriverDelegate.SelectJobForTrigger`'s `loadJobType` is required | It defaulted in front of the cancellation token; pass `loadJobType: true` for the old default |
 | `IDriverDelegate.UpdateTriggerPreferredNodeConditional` takes a `PreferredNodeTransition` | Four loose compare-and-swap parameters became one record naming `Expected` and `New` |
 | `TriggerAcquisitionCriteria.LiveNodeCutoff` is a `required DateTimeOffset` | It was an optional `long` of `UtcTicks` beside two required `DateTimeOffset` siblings, and omitting it silently meant "every node is dead". The tick conversion happens in `AddPreferredNodeParameters`, whose parameter is a `DateTimeOffset` too |
-| `TriggerAcquisitionRequest.ExcludedJobTypeNames` and `TriggerAcquisitionCriteria.ExcludedJobTypeNames` added | Optional exact job-type-name exclusions for acquisition. The ADO.NET store applies them in SQL; comparison follows the `JOB_CLASS_NAME` column's collation |
+| `TriggerAcquisitionRequest.ExcludedJobTypeNames` and `TriggerAcquisitionCriteria.ExcludedJobTypeNames` added | Optional exact job-type-name exclusions for acquisition, honoured by every shipped store. The ADO.NET store applies them in SQL, where comparison follows the `JOB_CLASS_NAME` column's collation; `RAMJobStore` compares `JobType.FullName` ordinally |
 | `StdAdoDelegate.AddPagingParameters(cmd, int skip, int take, bool)` | `skip`/`take` were `long` while `PagedQuery.Skip`/`.Take` are `int`; the dialect override contract now matches the query object it serves |
 | `StdAdoDelegate.ReadBytesFromBlob` takes a `DbDataReader` and is asynchronous | It took a `System.Data.IDataReader` — the last legacy `System.Data.I*` interface anywhere in the public surface — which forced a synchronous, thread-blocking read that ignored the cancellation token it was handed. It is `async ValueTask<byte[]?>` over `IsDBNullAsync` / `GetFieldValueAsync<byte[]>`. **The behaviour contract is unchanged**: a `NULL` column still yields `null`, and an empty blob still yields an empty array, which the only caller (`GetObjectFromBlob`) has always treated the same as `null` by testing `Length > 0`. An override changes its parameter type; every reader the store passes was already a `DbDataReader` |
 | `StdAdoDelegate`'s date/time and time-span conversions are non-virtual | UTC ticks and whole milliseconds are the schema contract the liveness SQL assumes; only the boolean pair remains a dialect seam. A delegate that changes the storage format implements `IDriverDelegate` itself — see [If you implement `IDriverDelegate`: the listing members](#if-you-implement-idriverdelegate-the-listing-members) |

--- a/src/Quartz.Documentation.Samples/HowTos/CustomJobStoreSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/CustomJobStoreSamples.cs
@@ -103,3 +103,56 @@ internal sealed class BudgetedJobStore(
 
     #endregion
 }
+
+/// <summary>
+/// The same scaffolding as <see cref="BudgetedJobStore" />, for the second override the page shows.
+/// </summary>
+internal sealed class MaintenanceWindowJobStore(
+    ISchedulerSignaler schedulerSignaler,
+    ITypeLoader typeLoader,
+    TimeProvider timeProvider,
+    IOptions<QuartzSchedulerOptions> schedulerOptions,
+    IOptions<AdoJobStoreOptions> storeOptions,
+    IOptions<ClusteringOptions> clusteringOptions,
+    IObjectSerializer objectSerializer,
+    IDbProvider dbProvider,
+    IDriverDelegate driverDelegate)
+    : LocalTransactionJobStore(
+        schedulerSignaler,
+        typeLoader,
+        timeProvider,
+        schedulerOptions,
+        storeOptions,
+        clusteringOptions,
+        objectSerializer,
+        dbProvider,
+        driverDelegate)
+{
+    private readonly IMaintenanceWindow maintenanceWindow = null!;
+
+    #region sample_custom_job_store_excluded_job_types
+
+    // JobType.FullName is the spelling the store persists - "Namespace.TypeName, AssemblyName".
+    // Type.FullName carries no assembly name and would never match a stored row.
+    private static readonly string reportingJobTypeName = new JobType(typeof(ReportingJob)).FullName;
+
+    protected override TriggerAcquisitionCriteria CreateAcquisitionCriteria(TriggerAcquisitionRequest request)
+    {
+        // Asked again on every acquisition attempt, so a window that opens between two of them takes
+        // effect on the next one without restarting anything.
+        string[]? excluded = this.maintenanceWindow.IsOpen ? [reportingJobTypeName] : null;
+
+        return base.CreateAcquisitionCriteria(request) with { ExcludedJobTypeNames = excluded };
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// The deployment's own notion of when the heavy jobs are not welcome. Named only so the sample above
+/// compiles.
+/// </summary>
+public interface IMaintenanceWindow
+{
+    bool IsOpen { get; }
+}

--- a/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
@@ -25,8 +25,8 @@ internal sealed class DialectDelegateOverrides : StdAdoDelegate
     #region sample_dialect_delegate_row_limiting
 
     // append (PostgreSQL, Firebird)
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
-        => base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " LIMIT " + maxCount;
+    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
+        => base.GetSelectNextTriggerToAcquireSql(shape) + " LIMIT " + shape.MaxCount;
 
     // splice a prefix (SQL Server: SELECT TOP n)
     // wrap the whole statement (Oracle: SELECT * FROM ( … ) WHERE rownum <= n)

--- a/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
@@ -25,8 +25,8 @@ internal sealed class DialectDelegateOverrides : StdAdoDelegate
     #region sample_dialect_delegate_row_limiting
 
     // append (PostgreSQL, Firebird)
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
-        => base.GetSelectNextTriggerToAcquireSql(maxCount) + " LIMIT " + maxCount;
+    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+        => base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " LIMIT " + maxCount;
 
     // splice a prefix (SQL Server: SELECT TOP n)
     // wrap the whole statement (Oracle: SELECT * FROM ( … ) WHERE rownum <= n)

--- a/src/Quartz.Documentation.Samples/HowTos/HowToSampleTypes.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/HowToSampleTypes.cs
@@ -36,3 +36,8 @@ public sealed class AnExampleJob : IJob
 {
     public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 }
+
+public sealed class ReportingJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SQLiteJobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SQLiteJobStoreContractTest.cs
@@ -98,6 +98,49 @@ public sealed class SQLiteJobStoreContractTest : JobStoreContractTest
         return default;
     }
 
+    [Test]
+    public async Task AcquisitionExcludesRequestedJobTypes()
+    {
+        IJobDetail includedJob = JobBuilder.Create<JobStoreContractTest.ContractTestJob>()
+            .WithIdentity("included", "jobs")
+            .Build();
+        IJobDetail excludedJob = JobBuilder.Create<ExcludedContractTestJob>()
+            .WithIdentity("excluded", "jobs")
+            .Build();
+
+        IOperableTrigger includedTrigger = CreateDueTrigger("included", includedJob.Key);
+        IOperableTrigger excludedTrigger = CreateDueTrigger("excluded", excludedJob.Key);
+        await Store.ScheduleJob(includedJob, includedTrigger);
+        await Store.ScheduleJob(excludedJob, excludedTrigger);
+
+        List<IOperableTrigger> acquired = await Store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = TimeProvider.System.GetUtcNow().AddMinutes(1),
+            MaxCount = 5,
+            TimeWindow = TimeSpan.FromMinutes(1),
+            ExcludedJobTypeNames = [excludedJob.JobType.FullName]
+        });
+
+        acquired.Select(x => x.Key).Should().Equal([includedTrigger.Key]);
+    }
+
+    private static IOperableTrigger CreateDueTrigger(string name, JobKey jobKey)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity(name, "triggers")
+            .ForJob(jobKey)
+            .StartAt(TimeProvider.System.GetUtcNow().AddSeconds(5))
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    public sealed class ExcludedContractTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
     private static string LoadSqliteTableScript()
     {
         string path = File.Exists("../../../../database/tables/tables_sqlite.sql")

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SQLiteJobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SQLiteJobStoreContractTest.cs
@@ -98,49 +98,6 @@ public sealed class SQLiteJobStoreContractTest : JobStoreContractTest
         return default;
     }
 
-    [Test]
-    public async Task AcquisitionExcludesRequestedJobTypes()
-    {
-        IJobDetail includedJob = JobBuilder.Create<JobStoreContractTest.ContractTestJob>()
-            .WithIdentity("included", "jobs")
-            .Build();
-        IJobDetail excludedJob = JobBuilder.Create<ExcludedContractTestJob>()
-            .WithIdentity("excluded", "jobs")
-            .Build();
-
-        IOperableTrigger includedTrigger = CreateDueTrigger("included", includedJob.Key);
-        IOperableTrigger excludedTrigger = CreateDueTrigger("excluded", excludedJob.Key);
-        await Store.ScheduleJob(includedJob, includedTrigger);
-        await Store.ScheduleJob(excludedJob, excludedTrigger);
-
-        List<IOperableTrigger> acquired = await Store.AcquireNextTriggers(new TriggerAcquisitionRequest
-        {
-            NoLaterThan = TimeProvider.System.GetUtcNow().AddMinutes(1),
-            MaxCount = 5,
-            TimeWindow = TimeSpan.FromMinutes(1),
-            ExcludedJobTypeNames = [excludedJob.JobType.FullName]
-        });
-
-        acquired.Select(x => x.Key).Should().Equal([includedTrigger.Key]);
-    }
-
-    private static IOperableTrigger CreateDueTrigger(string name, JobKey jobKey)
-    {
-        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
-            .WithIdentity(name, "triggers")
-            .ForJob(jobKey)
-            .StartAt(TimeProvider.System.GetUtcNow().AddSeconds(5))
-            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
-            .Build();
-        trigger.ComputeFirstFireTimeUtc(null);
-        return trigger;
-    }
-
-    public sealed class ExcludedContractTestJob : IJob
-    {
-        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
-    }
-
     private static string LoadSqliteTableScript()
     {
         string path = File.Exists("../../../../database/tables/tables_sqlite.sql")

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -1416,6 +1416,76 @@ public abstract class JobStoreContractTest
             "the ceiling is per execution group, so work in one group is not charged to another");
     }
 
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Job type exclusions
+    //
+    // The ADO.NET store keeps these out of the acquisition result set with a NOT IN clause and the
+    // in-memory store compares the name it holds, so the two arrive at the same answer by different
+    // routes. That is exactly why the assertion belongs here: a store that grew the property and
+    // ignored it would look identical from the outside until a node ran work it was told to leave
+    // alone.
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task AcquisitionSkipsATriggerWhoseJobTypeIsExcluded()
+    {
+        await GivenTwoDueTriggersOfDifferentJobTypes();
+
+        List<IOperableTrigger> acquired = await AcquireExcluding(typeof(OtherContractTestJob));
+
+        acquired.Should().ContainSingle(x => x.Key.Name == "included",
+            "the excluded job type's trigger is due and would otherwise be acquired, so only the exclusion can account for its absence");
+    }
+
+    [Test]
+    public async Task AnExcludedTriggerIsAcquirableAgainOnceTheExclusionIsLifted()
+    {
+        await GivenTwoDueTriggersOfDifferentJobTypes();
+
+        await AcquireExcluding(typeof(OtherContractTestJob));
+
+        List<IOperableTrigger> acquired = await Store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddMinutes(1),
+            MaxCount = 5,
+            TimeWindow = TimeSpan.FromMinutes(1)
+        });
+
+        acquired.Should().Contain(x => x.Key.Name == "excluded",
+            "an exclusion declines a trigger for one attempt, it does not retire it - the next request may carry a different set");
+    }
+
+    /// <summary>
+    /// Schedules two due triggers whose jobs are of different types, named for what the exclusion
+    /// tests do to each.
+    /// </summary>
+    private async Task GivenTwoDueTriggersOfDifferentJobTypes()
+    {
+        IJobDetail included = CreateJob("included", JobGroupA);
+        await Store.ScheduleJob(included, CreateTrigger("included", TriggerGroupA, included.Key,
+            startAt: DateTimeOffset.UtcNow.AddSeconds(5)));
+
+        IJobDetail excluded = JobBuilder.Create<OtherContractTestJob>()
+            .WithIdentity("excluded", JobGroupA)
+            .Build();
+        await Store.ScheduleJob(excluded, CreateTrigger("excluded", TriggerGroupA, excluded.Key,
+            startAt: DateTimeOffset.UtcNow.AddSeconds(5)));
+    }
+
+    /// <summary>
+    /// Acquires with the given job types excluded, naming them the way the store persists them.
+    /// </summary>
+    private ValueTask<List<IOperableTrigger>> AcquireExcluding(params Type[] jobTypes)
+    {
+        return Store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddMinutes(1),
+            MaxCount = 5,
+            TimeWindow = TimeSpan.FromMinutes(1),
+            ExcludedJobTypeNames = jobTypes.Select(x => new JobType(x).FullName).ToArray()
+        });
+    }
+
     /// <summary>
     /// Schedules one due trigger per name, all in the same execution group.
     /// </summary>
@@ -1632,6 +1702,14 @@ public abstract class JobStoreContractTest
     }
 
     public sealed class ContractTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// A second job type, so that a test can tell two jobs apart by their type rather than their key.
+    /// </summary>
+    public sealed class OtherContractTestJob : IJob
     {
         public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
     }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AcquisitionSqlTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AcquisitionSqlTest.cs
@@ -1,0 +1,112 @@
+using System.Text;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The acquisition statement every shipped dialect produces when nothing is excluded, pinned as a
+/// snapshot.
+/// </summary>
+/// <remarks>
+/// The statement is assembled from a shared template, a per-dialect row-limiting splice and an
+/// optional job-type exclusion clause. The text here is the one from before that assembly was
+/// consolidated into a single template, so a change that is meant to leave the no-exclusion
+/// statement alone has to prove it did — including the parts that look like whitespace and are not,
+/// such as SQL Server's <c>Substring(6)</c> splice and MySQL's index hint, both of which are
+/// positional and would break silently if the projection moved.
+/// </remarks>
+public class AcquisitionSqlTest
+{
+    private const int MaxCount = 5;
+
+    [Test]
+    public async Task EveryDialectBuildsTheAcquisitionStatementItAlwaysDidWhenNothingIsExcluded()
+    {
+        StringBuilder statements = new StringBuilder();
+
+        foreach (IAcquisitionSql dialect in Dialects())
+        {
+            statements.Append("=== ").Append(dialect.GetType().BaseType!.Name).AppendLine(" ===");
+            statements.AppendLine(dialect.NoExclusions(MaxCount));
+            statements.AppendLine();
+        }
+
+        await Verify(statements.ToString(), extension: "txt")
+            .UseDirectory("../../Verify")
+            .UseFileName("AcquisitionSqlTest_NoExclusions")
+            .DisableRequireUniquePrefix();
+    }
+
+    [Test]
+    public async Task TheExclusionClauseSitsBetweenTheNodeFilterAndTheOrdering()
+    {
+        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 4);
+
+        // Placement is what makes "no per-dialect SQL change" true: every dialect splices its row
+        // limit into the projection or around the whole statement, so a clause that landed after
+        // ORDER BY - or inside the projection - would break one of them without breaking the rest.
+        await Verify(sql, extension: "txt")
+            .UseDirectory("../../Verify")
+            .UseFileName("AcquisitionSqlTest_FourExclusions")
+            .DisableRequireUniquePrefix();
+    }
+
+    private static IAcquisitionSql[] Dialects() =>
+    [
+        new AcquisitionSqlStdAdoDelegate(),
+        new AcquisitionSqlSqlServerDelegate(),
+        new AcquisitionSqlPostgreSQLDelegate(),
+        new AcquisitionSqlMySQLDelegate(),
+        new AcquisitionSqlSQLiteDelegate(),
+        new AcquisitionSqlOracleDelegate(),
+        new AcquisitionSqlFirebirdDelegate()
+    ];
+
+    /// <summary>
+    /// What each dialect is asked for. The hook is protected, so reaching it means deriving — which
+    /// is what a dialect author does anyway.
+    /// </summary>
+    private interface IAcquisitionSql
+    {
+        string NoExclusions(int maxCount);
+    }
+
+    private sealed class AcquisitionSqlStdAdoDelegate : StdAdoDelegate, IAcquisitionSql
+    {
+        public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+    }
+
+    private sealed class AcquisitionSqlSqlServerDelegate : SqlServerDelegate, IAcquisitionSql
+    {
+        public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+    }
+
+    private sealed class AcquisitionSqlPostgreSQLDelegate : PostgreSQLDelegate, IAcquisitionSql
+    {
+        public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+    }
+
+    private sealed class AcquisitionSqlMySQLDelegate : MySQLDelegate, IAcquisitionSql
+    {
+        public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+    }
+
+    private sealed class AcquisitionSqlSQLiteDelegate : SQLiteDelegate, IAcquisitionSql
+    {
+        public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+    }
+
+    private sealed class AcquisitionSqlOracleDelegate : OracleDelegate, IAcquisitionSql
+    {
+        public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+    }
+
+    private sealed class AcquisitionSqlFirebirdDelegate : FirebirdDelegate, IAcquisitionSql
+    {
+        public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+    }
+
+    private static TriggerAcquisitionSqlShape Shape(int maxCount) =>
+        new TriggerAcquisitionSqlShape(maxCount, ExcludedJobTypeBucket: 0);
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -1533,6 +1533,37 @@ public class AdoJobStoreBaseTest
 
     #region Acquisition criteria
 
+    [TestCase("")]
+    [TestCase(" ")]
+    [TestCase(null)]
+    public void TriggerAcquisitionRequest_ShouldRejectInvalidExcludedJobTypeNames(string name)
+    {
+        Action act = () => _ = new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow,
+            ExcludedJobTypeNames = [name]
+        };
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("ExcludedJobTypeNames must not contain null, empty, or whitespace entries.*");
+    }
+
+    [Test]
+    public void TriggerAcquisitionRequest_ShouldRejectTooManyExcludedJobTypeNames()
+    {
+        string[] names = Enumerable.Range(0, TriggerAcquisitionRequest.MaxExcludedJobTypeNames + 1)
+            .Select(index => "Job" + index)
+            .ToArray();
+        Action act = () => _ = new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow,
+            ExcludedJobTypeNames = names
+        };
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage($"ExcludedJobTypeNames must not exceed {TriggerAcquisitionRequest.MaxExcludedJobTypeNames} entries.*");
+    }
+
     /// <summary>
     /// Arranges the acquisition read to find nothing, so the acquisition loop exits on its first pass,
     /// and hands back the criteria the delegate was called with — one entry per attempt.
@@ -1565,6 +1596,7 @@ public class AdoJobStoreBaseTest
             TimeWindow = TimeSpan.FromSeconds(30),
             MaxCount = 5,
             ExecutionLimits = limits,
+            ExcludedJobTypeNames = ["Excluded.Job"],
         };
 
         await jobStoreSupport.AcquireNextTriggers(request);
@@ -1577,6 +1609,8 @@ public class AdoJobStoreBaseTest
         criteria.MaxCount.Should().Be(request.MaxCount, "the request caps the batch size");
         criteria.ExecutionLimits.Should().BeSameAs(limits,
             "the caller's snapshot is handed through untouched, so a delegate counting slots down works on a copy");
+        criteria.ExcludedJobTypeNames.Should().BeSameAs(request.ExcludedJobTypeNames,
+            "the request's exclusions are handed to the delegate unchanged");
         criteria.LiveNodeCutoff.Should().Be(clock.GetUtcNow() - jobStoreSupport.ClusterCheckinMisfireThreshold,
             "the cutoff is exactly now less the check-in misfire threshold, so a node that checked in more recently than that keeps its pinned triggers");
     }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -1551,7 +1551,7 @@ public class AdoJobStoreBaseTest
     [Test]
     public void TriggerAcquisitionRequest_ShouldRejectTooManyExcludedJobTypeNames()
     {
-        string[] names = Enumerable.Range(0, TriggerAcquisitionRequest.MaxExcludedJobTypeNames + 1)
+        string[] names = Enumerable.Range(0, JobTypeExclusions.MaxNames + 1)
             .Select(index => "Job" + index)
             .ToArray();
         Action act = () => _ = new TriggerAcquisitionRequest
@@ -1561,7 +1561,46 @@ public class AdoJobStoreBaseTest
         };
 
         act.Should().Throw<ArgumentException>()
-            .WithMessage($"ExcludedJobTypeNames must not exceed {TriggerAcquisitionRequest.MaxExcludedJobTypeNames} entries.*");
+            .WithMessage($"ExcludedJobTypeNames must not exceed {JobTypeExclusions.MaxNames} entries.*");
+    }
+
+    [TestCase("")]
+    [TestCase(" ")]
+    [TestCase(null)]
+    public void TriggerAcquisitionCriteria_ShouldRejectInvalidExcludedJobTypeNames(string name)
+    {
+        Action act = () => _ = new TriggerAcquisitionCriteria
+        {
+            NoLaterThan = DateTimeOffset.UtcNow,
+            NoEarlierThan = DateTimeOffset.UtcNow,
+            MaxCount = 1,
+            LiveNodeCutoff = DateTimeOffset.UtcNow,
+            ExcludedJobTypeNames = [name]
+        };
+
+        act.Should().Throw<ArgumentException>(
+                "a derived store sets its exclusions on the criteria and never touches the request, so the check has to hold here too - a blank entry would make the clause NOT IN (..., NULL), which matches no row and would stop the node acquiring anything at all")
+            .WithMessage("ExcludedJobTypeNames must not contain null, empty, or whitespace entries.*");
+    }
+
+    [Test]
+    public void TriggerAcquisitionCriteria_ShouldRejectTooManyExcludedJobTypeNames()
+    {
+        string[] names = Enumerable.Range(0, JobTypeExclusions.MaxNames + 1)
+            .Select(index => "Job" + index)
+            .ToArray();
+        Action act = () => _ = new TriggerAcquisitionCriteria
+        {
+            NoLaterThan = DateTimeOffset.UtcNow,
+            NoEarlierThan = DateTimeOffset.UtcNow,
+            MaxCount = 1,
+            LiveNodeCutoff = DateTimeOffset.UtcNow,
+            ExcludedJobTypeNames = names
+        };
+
+        act.Should().Throw<ArgumentException>(
+                "the cap is Oracle's IN-list ceiling, which the criteria reach as surely as the request does")
+            .WithMessage($"ExcludedJobTypeNames must not exceed {JobTypeExclusions.MaxNames} entries.*");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
@@ -91,8 +91,8 @@ public class MySQLDelegateTest
 
     private sealed class TestMySQLDelegate : MySQLDelegate
     {
-        public string GetSelectNextTriggerToAcquireSqlPublic(int maxCount)
-            => GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket: 0);
+        public string GetSelectNextTriggerToAcquireSqlPublic(int maxCount, int excludedJobTypeBucket = 0)
+            => GetSelectNextTriggerToAcquireSql(new TriggerAcquisitionSqlShape(maxCount, excludedJobTypeBucket));
 
         public string GetCountMisfiredTriggersInStateSqlPublic()
             => GetCountMisfiredTriggersInStateSql();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
@@ -92,7 +92,7 @@ public class MySQLDelegateTest
     private sealed class TestMySQLDelegate : MySQLDelegate
     {
         public string GetSelectNextTriggerToAcquireSqlPublic(int maxCount)
-            => GetSelectNextTriggerToAcquireSql(maxCount);
+            => GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket: 0);
 
         public string GetCountMisfiredTriggersInStateSqlPublic()
             => GetCountMisfiredTriggersInStateSql();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
@@ -64,7 +64,8 @@ public class StdAdoConstantsTest
     {
         string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 0);
 
-        sql.Should().Be(StdAdoConstants.SqlSelectNextTriggerToAcquire);
+        sql.Should().BeSameAs(StdAdoConstants.SqlSelectNextTriggerToAcquire,
+            "the two are one template with an empty exclusion clause, so asking for no exclusions hands back the very string every exclusion-free caller already uses rather than an equal copy built beside it");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
@@ -59,6 +59,33 @@ public class StdAdoConstantsTest
         sql.Should().Contain("ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC");
     }
 
+    [Test]
+    public void BuildSqlSelectNextTriggerToAcquire_WithNoExclusions_ShouldKeepExistingSqlExactly()
+    {
+        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 0);
+
+        sql.Should().Be(StdAdoConstants.SqlSelectNextTriggerToAcquire);
+    }
+
+    [Test]
+    public void BuildSqlSelectNextTriggerToAcquire_ShouldUseFixedWidthExclusionParameters()
+    {
+        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 16);
+
+        sql.Should().Contain("AND jd.JOB_CLASS_NAME NOT IN (@excludedJobType0000, @excludedJobType0001");
+        sql.Should().Contain("@excludedJobType0009, @excludedJobType0010");
+        sql.Should().Contain("@excludedJobType0015)");
+        sql.Should().NotContain("@excludedJobType0016");
+    }
+
+    [Test]
+    public void RoundUpExcludedJobTypeCount_ShouldRoundPastBucketBoundary()
+    {
+        int bucket = StdAdoConstants.RoundUpExcludedJobTypeCount(129);
+
+        bucket.Should().Be(256);
+    }
+
     /// <summary>
     /// Returns the selected column expressions, in order, of a single-SELECT statement.
     /// </summary>

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -90,6 +90,80 @@ public class StdAdoDelegateTest
     private sealed class NonSerializableTestClass;
 
     [Test]
+    public async Task SelectTriggersToAcquire_ShouldBindExcludedJobTypesInSqlOrder()
+    {
+        IDbProvider dbProvider = A.Fake<IDbProvider>();
+        DbConnection connection = A.Fake<DbConnection>();
+        DbTransaction transaction = A.Fake<DbTransaction>();
+        DbCommand command = A.Fake<StubCommand>();
+        DbDataReader dataReader = A.Fake<DbDataReader>();
+        DbParameterCollection parameterCollection = A.Fake<DbParameterCollection>();
+        List<DbParameter> boundParameters = [];
+
+        A.CallTo(() => dbProvider.Metadata).Returns(new DbMetadata
+        {
+            BindByName = true,
+            ParameterNamePrefix = "@"
+        });
+        A.CallTo(() => dbProvider.CreateCommand()).Returns(command);
+        A.CallTo(command).Where(x => x.Method.Name == "get_DbParameterCollection")
+            .WithReturnType<DbParameterCollection>()
+            .Returns(parameterCollection);
+        A.CallTo(command).Where(x => x.Method.Name == "CreateDbParameter")
+            .WithReturnType<DbParameter>()
+            .ReturnsLazily(() => new SqlParameter());
+        A.CallTo(command).Where(x => x.Method.Name == "ExecuteDbDataReaderAsync")
+            .WithReturnType<Task<DbDataReader>>()
+            .Returns(Task.FromResult(dataReader));
+        A.CallTo(() => dataReader.ReadAsync(CancellationToken.None)).Returns(false);
+        A.CallTo(() => parameterCollection.Add(A<object>._)).ReturnsLazily((object value) =>
+        {
+            boundParameters.Add((DbParameter) value);
+            return boundParameters.Count - 1;
+        });
+
+        StdAdoDelegate adoDelegate = new();
+        adoDelegate.Initialize(new DriverDelegateContext
+        {
+            TablePrefix = "QRTZ_",
+            InstanceId = "TESTSCHED",
+            SchedulerName = "INSTANCE",
+            TypeLoader = new SimpleTypeLoader(),
+            UseProperties = false,
+            DbProvider = dbProvider,
+            ObjectSerializer = serializer
+        });
+
+        ConnectionAndTransactionHolder conn = new(connection, transaction);
+        await adoDelegate.SelectTriggersToAcquire(conn, new TriggerAcquisitionCriteria
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddMinutes(1),
+            NoEarlierThan = DateTimeOffset.UtcNow.AddMinutes(-1),
+            MaxCount = 5,
+            LiveNodeCutoff = DateTimeOffset.UtcNow.AddMinutes(-2),
+            ExcludedJobTypeNames = ["First.Job", "Second.Job", "Third.Job"]
+        });
+
+        boundParameters.Select(x => x.ParameterName).Should().Equal(
+            "@schedulerName",
+            "@state",
+            "@noLaterThan",
+            "@noEarlierThan",
+            "@instanceId",
+            "@autoPinSentinel",
+            "@liveNodeCutoff",
+            "@excludedJobType0000",
+            "@excludedJobType0001",
+            "@excludedJobType0002",
+            "@excludedJobType0003");
+        boundParameters.Skip(7).Select(x => x.Value).Should().Equal(
+            "First.Job",
+            "Second.Job",
+            "Third.Job",
+            "Third.Job");
+    }
+
+    [Test]
     public async Task TestSelectBlobTriggerWithNoBlobContent()
     {
         var dbProvider = A.Fake<IDbProvider>();

--- a/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_FourExclusions.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_FourExclusions.verified.txt
@@ -1,0 +1,13 @@
+﻿SELECT
+                t.TRIGGER_NAME, t.TRIGGER_GROUP, jd.JOB_CLASS_NAME, t.EXECUTION_GROUP
+              FROM
+                {0}TRIGGERS t
+              JOIN
+                {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
+              WHERE
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
+                     OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
+                AND jd.JOB_CLASS_NAME NOT IN (@excludedJobType0000, @excludedJobType0001, @excludedJobType0002, @excludedJobType0003)
+              ORDER BY
+                NEXT_FIRE_TIME ASC, PRIORITY DESC

--- a/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_NoExclusions.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_NoExclusions.verified.txt
@@ -1,0 +1,98 @@
+﻿=== StdAdoDelegate ===
+SELECT
+                t.TRIGGER_NAME, t.TRIGGER_GROUP, jd.JOB_CLASS_NAME, t.EXECUTION_GROUP
+              FROM
+                {0}TRIGGERS t
+              JOIN
+                {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
+              WHERE
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
+                     OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
+              ORDER BY
+                NEXT_FIRE_TIME ASC, PRIORITY DESC
+
+=== SqlServerDelegate ===
+SELECT TOP 5 
+                t.TRIGGER_NAME, t.TRIGGER_GROUP, jd.JOB_CLASS_NAME, t.EXECUTION_GROUP
+              FROM
+                {0}TRIGGERS t
+              JOIN
+                {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
+              WHERE
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
+                     OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
+              ORDER BY
+                NEXT_FIRE_TIME ASC, PRIORITY DESC
+
+=== PostgreSQLDelegate ===
+SELECT
+                t.TRIGGER_NAME, t.TRIGGER_GROUP, jd.JOB_CLASS_NAME, t.EXECUTION_GROUP
+              FROM
+                {0}TRIGGERS t
+              JOIN
+                {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
+              WHERE
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
+                     OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
+              ORDER BY
+                NEXT_FIRE_TIME ASC, PRIORITY DESC LIMIT 5
+
+=== MySQLDelegate ===
+SELECT
+                t.TRIGGER_NAME, t.TRIGGER_GROUP, jd.JOB_CLASS_NAME, t.EXECUTION_GROUP
+              FROM
+                {0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST)
+              JOIN
+                {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
+              WHERE
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
+                     OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
+              ORDER BY
+                NEXT_FIRE_TIME ASC, PRIORITY DESC LIMIT 5
+
+=== SQLiteDelegate ===
+SELECT
+                t.TRIGGER_NAME, t.TRIGGER_GROUP, jd.JOB_CLASS_NAME, t.EXECUTION_GROUP
+              FROM
+                {0}TRIGGERS t
+              JOIN
+                {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
+              WHERE
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
+                     OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
+              ORDER BY
+                NEXT_FIRE_TIME ASC, PRIORITY DESC LIMIT 5
+
+=== OracleDelegate ===
+SELECT * FROM (SELECT
+                t.TRIGGER_NAME, t.TRIGGER_GROUP, jd.JOB_CLASS_NAME, t.EXECUTION_GROUP
+              FROM
+                {0}TRIGGERS t
+              JOIN
+                {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
+              WHERE
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
+                     OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
+              ORDER BY
+                NEXT_FIRE_TIME ASC, PRIORITY DESC) WHERE rownum <= 5
+
+=== FirebirdDelegate ===
+SELECT
+                t.TRIGGER_NAME, t.TRIGGER_GROUP, jd.JOB_CLASS_NAME, t.EXECUTION_GROUP
+              FROM
+                {0}TRIGGERS t
+              JOIN
+                {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
+              WHERE
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
+                     OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
+              ORDER BY
+                NEXT_FIRE_TIME ASC, PRIORITY DESC ROWS 5
+

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1980,6 +1980,7 @@ namespace Quartz.Extensibility
     public sealed class TriggerAcquisitionRequest : System.IEquatable<Quartz.Extensibility.TriggerAcquisitionRequest>
     {
         public TriggerAcquisitionRequest() { }
+        public System.Collections.Generic.IReadOnlyCollection<string>? ExcludedJobTypeNames { get; init; }
         public Quartz.ExecutionLimits? ExecutionLimits { get; init; }
         public int MaxCount { get; init; }
         public required System.DateTimeOffset NoLaterThan { get; init; }
@@ -2335,7 +2336,7 @@ namespace Quartz.Impl.AdoJobStore
     {
         public FirebirdDelegate() { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount) { }
+        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
     }
     public sealed class FiredTriggerQuery : System.IEquatable<Quartz.Impl.AdoJobStore.FiredTriggerQuery>
     {
@@ -2511,7 +2512,7 @@ namespace Quartz.Impl.AdoJobStore
         protected override string ApplyPaging(string sql, bool takeLimited) { }
         protected override string GetCountMisfiredTriggersInStateSql() { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount) { }
+        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
     }
     public sealed class NoSuchDelegateException : Quartz.JobPersistenceException
     {
@@ -2524,13 +2525,13 @@ namespace Quartz.Impl.AdoJobStore
         public override bool GetBooleanFromDbValue(object columnValue) { }
         public override object GetDbBooleanValue(bool booleanValue) { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount) { }
+        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
     }
     public class PostgreSQLDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public PostgreSQLDelegate() { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount) { }
+        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
     }
     public class PostgreSqlSelectForUpdateSemaphore : Quartz.Impl.AdoJobStore.SelectForUpdateSemaphore
     {
@@ -2565,7 +2566,7 @@ namespace Quartz.Impl.AdoJobStore
         protected override void AddPagingParameters(System.Data.Common.DbCommand cmd, int skip, int take, bool takeLimited) { }
         protected override string ApplyPaging(string sql, bool takeLimited) { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount) { }
+        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
     }
     public enum SchedulerLock
     {
@@ -2669,7 +2670,7 @@ namespace Quartz.Impl.AdoJobStore
         public SqlServerDelegate() { }
         public override void AddCommandParameter(System.Data.Common.DbCommand cmd, string paramName, object? paramValue, System.Enum? dataType = null, int? size = default) { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount) { }
+        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
     }
     public sealed class SqlServerMemoryOptimizedUpdateRowSemaphore : Quartz.Impl.AdoJobStore.UpdateRowSemaphore
     {
@@ -2733,7 +2734,7 @@ namespace Quartz.Impl.AdoJobStore
         protected virtual System.Threading.Tasks.ValueTask<T?> GetObjectFromBlob<T>(System.Data.Common.DbDataReader rs, int colIndex, System.Threading.CancellationToken cancellationToken = default)
             where T :  class { }
         protected virtual string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount) { }
+        protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
         public System.TimeSpan? GetTimeSpanFromDbValue(object columnValue) { }
         public virtual void Initialize(Quartz.Impl.AdoJobStore.DriverDelegateContext context) { }
         public virtual System.Threading.Tasks.ValueTask<int> InsertBlobTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2846,6 +2847,7 @@ namespace Quartz.Impl.AdoJobStore
     {
         public TriggerAcquisitionCriteria() { }
         public System.Collections.Generic.IReadOnlyCollection<Quartz.ExecutionGroupInFlight>? ClusterInFlight { get; init; }
+        public System.Collections.Generic.IReadOnlyCollection<string>? ExcludedJobTypeNames { get; init; }
         public Quartz.ExecutionLimits? ExecutionLimits { get; init; }
         public required System.DateTimeOffset LiveNodeCutoff { get; init; }
         public required int MaxCount { get; init; }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -2336,7 +2336,7 @@ namespace Quartz.Impl.AdoJobStore
     {
         public FirebirdDelegate() { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
+        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
     }
     public sealed class FiredTriggerQuery : System.IEquatable<Quartz.Impl.AdoJobStore.FiredTriggerQuery>
     {
@@ -2512,7 +2512,7 @@ namespace Quartz.Impl.AdoJobStore
         protected override string ApplyPaging(string sql, bool takeLimited) { }
         protected override string GetCountMisfiredTriggersInStateSql() { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
+        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
     }
     public sealed class NoSuchDelegateException : Quartz.JobPersistenceException
     {
@@ -2525,13 +2525,13 @@ namespace Quartz.Impl.AdoJobStore
         public override bool GetBooleanFromDbValue(object columnValue) { }
         public override object GetDbBooleanValue(bool booleanValue) { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
+        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
     }
     public class PostgreSQLDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public PostgreSQLDelegate() { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
+        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
     }
     public class PostgreSqlSelectForUpdateSemaphore : Quartz.Impl.AdoJobStore.SelectForUpdateSemaphore
     {
@@ -2566,7 +2566,7 @@ namespace Quartz.Impl.AdoJobStore
         protected override void AddPagingParameters(System.Data.Common.DbCommand cmd, int skip, int take, bool takeLimited) { }
         protected override string ApplyPaging(string sql, bool takeLimited) { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
+        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
     }
     public enum SchedulerLock
     {
@@ -2670,7 +2670,7 @@ namespace Quartz.Impl.AdoJobStore
         public SqlServerDelegate() { }
         public override void AddCommandParameter(System.Data.Common.DbCommand cmd, string paramName, object? paramValue, System.Enum? dataType = null, int? size = default) { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
+        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
     }
     public sealed class SqlServerMemoryOptimizedUpdateRowSemaphore : Quartz.Impl.AdoJobStore.UpdateRowSemaphore
     {
@@ -2734,7 +2734,7 @@ namespace Quartz.Impl.AdoJobStore
         protected virtual System.Threading.Tasks.ValueTask<T?> GetObjectFromBlob<T>(System.Data.Common.DbDataReader rs, int colIndex, System.Threading.CancellationToken cancellationToken = default)
             where T :  class { }
         protected virtual string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket) { }
+        protected virtual string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
         public System.TimeSpan? GetTimeSpanFromDbValue(object columnValue) { }
         public virtual void Initialize(Quartz.Impl.AdoJobStore.DriverDelegateContext context) { }
         public virtual System.Threading.Tasks.ValueTask<int> InsertBlobTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2853,6 +2853,12 @@ namespace Quartz.Impl.AdoJobStore
         public required int MaxCount { get; init; }
         public required System.DateTimeOffset NoEarlierThan { get; init; }
         public required System.DateTimeOffset NoLaterThan { get; init; }
+    }
+    public readonly struct TriggerAcquisitionSqlShape : System.IEquatable<Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape>
+    {
+        public TriggerAcquisitionSqlShape(int MaxCount, int ExcludedJobTypeBucket) { }
+        public int ExcludedJobTypeBucket { get; init; }
+        public int MaxCount { get; init; }
     }
     public readonly struct TriggerExecutionState : System.IEquatable<Quartz.Impl.AdoJobStore.TriggerExecutionState>
     {

--- a/src/Quartz/Extensibility/JobTypeExclusions.cs
+++ b/src/Quartz/Extensibility/JobTypeExclusions.cs
@@ -1,0 +1,74 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Extensibility;
+
+/// <summary>
+/// What every <c>ExcludedJobTypeNames</c> property accepts, in one place.
+/// </summary>
+/// <remarks>
+/// The rule has to hold on both the store-level <see cref="TriggerAcquisitionRequest" /> and the
+/// delegate-level <c>TriggerAcquisitionCriteria</c>, because a derived ADO.NET store sets the
+/// exclusions on the criteria and never touches the request. Checking only one of them would leave
+/// the documented path unguarded.
+/// </remarks>
+internal static class JobTypeExclusions
+{
+    /// <summary>
+    /// The most names an exclusion set may hold. Oracle refuses an <c>IN</c> list of more than a
+    /// thousand expressions, and a clear error here beats ORA-01795 at two in the morning.
+    /// </summary>
+    internal const int MaxNames = 1000;
+
+    /// <summary>
+    /// Returns the names unchanged, having established that the acquisition query built from them
+    /// will mean what the caller intended.
+    /// </summary>
+    /// <remarks>
+    /// A blank entry is rejected rather than skipped because of what it would otherwise become: one
+    /// <see langword="null" /> in the list makes the clause <c>NOT IN (…, NULL)</c>, which evaluates
+    /// to UNKNOWN for every row, and the node then quietly acquires nothing at all — the worst way
+    /// for a filter to fail.
+    /// </remarks>
+    /// <exception cref="ArgumentException">An entry is blank, or there are too many of them.</exception>
+    internal static IReadOnlyCollection<string>? Validated(IReadOnlyCollection<string>? names, string parameterName)
+    {
+        if (names is null)
+        {
+            return null;
+        }
+
+        foreach (string name in names)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                Throw.ArgumentException("ExcludedJobTypeNames must not contain null, empty, or whitespace entries.", parameterName);
+            }
+        }
+
+        if (names.Count > MaxNames)
+        {
+            Throw.ArgumentException($"ExcludedJobTypeNames must not exceed {MaxNames} entries.", parameterName);
+        }
+
+        return names;
+    }
+}

--- a/src/Quartz/Extensibility/TriggerAcquisitionRequest.cs
+++ b/src/Quartz/Extensibility/TriggerAcquisitionRequest.cs
@@ -36,9 +36,6 @@ namespace Quartz.Extensibility;
 /// <seealso cref="IJobStore.AcquireNextTriggers" />
 public sealed record TriggerAcquisitionRequest
 {
-    // Oracle limits an IN list to 1000 expressions.
-    internal const int MaxExcludedJobTypeNames = 1000;
-
     /// <summary>
     /// Highest value of <see cref="ITrigger.NextFireTimeUtc" /> of the triggers to acquire. A
     /// store must not return a trigger that would fire later than this.
@@ -113,29 +110,15 @@ public sealed record TriggerAcquisitionRequest
     /// rewrites a stored name, so an exclusion will not match such a row. Matching is exact: there is
     /// no prefix or wildcard form.
     /// </para>
+    /// <para>
+    /// Entries must be non-blank, and there may be at most 1,000 of them — Oracle's ceiling on an
+    /// <c>IN</c> list. Both are checked here rather than at acquisition time.
+    /// </para>
     /// </remarks>
+    /// <exception cref="ArgumentException">An entry is blank, or there are too many of them.</exception>
     public IReadOnlyCollection<string>? ExcludedJobTypeNames
     {
         get;
-        init
-        {
-            if (value is not null)
-            {
-                foreach (string name in value)
-                {
-                    if (string.IsNullOrWhiteSpace(name))
-                    {
-                        throw new ArgumentException("ExcludedJobTypeNames must not contain null, empty, or whitespace entries.", nameof(value));
-                    }
-                }
-
-                if (value.Count > MaxExcludedJobTypeNames)
-                {
-                    throw new ArgumentException($"ExcludedJobTypeNames must not exceed {MaxExcludedJobTypeNames} entries.", nameof(value));
-                }
-            }
-
-            field = value;
-        }
+        init => field = JobTypeExclusions.Validated(value, nameof(value));
     }
 }

--- a/src/Quartz/Extensibility/TriggerAcquisitionRequest.cs
+++ b/src/Quartz/Extensibility/TriggerAcquisitionRequest.cs
@@ -97,11 +97,23 @@ public sealed record TriggerAcquisitionRequest
     /// <summary>
     /// Job type names to exclude, spelled as
     /// <see cref="Quartz.Impl.AdoJobStore.TriggerAcquireResult.JobTypeName" /> stores them.
-    /// <see langword="null" /> means no exclusion. Comparison is exact according to the database
-    /// column's collation; case sensitivity follows that collation and is not guaranteed to be
-    /// ordinal. This is the store-level counterpart threaded into
-    /// <see cref="Quartz.Impl.AdoJobStore.TriggerAcquisitionCriteria.ExcludedJobTypeNames" />.
+    /// <see langword="null" /> means no exclusion.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every shipped store honours this. The in-memory store compares
+    /// <see cref="JobType.FullName" /> ordinally; the ADO.NET store threads the names into
+    /// <see cref="Quartz.Impl.AdoJobStore.TriggerAcquisitionCriteria.ExcludedJobTypeNames" /> and
+    /// excludes the rows in SQL, where comparison is exact according to the job-class column's
+    /// collation — case sensitivity follows that collation and is not guaranteed to be ordinal. The
+    /// two agree in practice because 4.x writes the name the same way it compares it.
+    /// </para>
+    /// <para>
+    /// A row written by 2.x or 3.x can carry an older spelling, and the read side deliberately never
+    /// rewrites a stored name, so an exclusion will not match such a row. Matching is exact: there is
+    /// no prefix or wildcard form.
+    /// </para>
+    /// </remarks>
     public IReadOnlyCollection<string>? ExcludedJobTypeNames
     {
         get;

--- a/src/Quartz/Extensibility/TriggerAcquisitionRequest.cs
+++ b/src/Quartz/Extensibility/TriggerAcquisitionRequest.cs
@@ -36,6 +36,9 @@ namespace Quartz.Extensibility;
 /// <seealso cref="IJobStore.AcquireNextTriggers" />
 public sealed record TriggerAcquisitionRequest
 {
+    // Oracle limits an IN list to 1000 expressions.
+    internal const int MaxExcludedJobTypeNames = 1000;
+
     /// <summary>
     /// Highest value of <see cref="ITrigger.NextFireTimeUtc" /> of the triggers to acquire. A
     /// store must not return a trigger that would fire later than this.
@@ -90,4 +93,37 @@ public sealed record TriggerAcquisitionRequest
     /// </para>
     /// </remarks>
     public ExecutionLimits? ExecutionLimits { get; init; }
+
+    /// <summary>
+    /// Job type names to exclude, spelled as
+    /// <see cref="Quartz.Impl.AdoJobStore.TriggerAcquireResult.JobTypeName" /> stores them.
+    /// <see langword="null" /> means no exclusion. Comparison is exact according to the database
+    /// column's collation; case sensitivity follows that collation and is not guaranteed to be
+    /// ordinal. This is the store-level counterpart threaded into
+    /// <see cref="Quartz.Impl.AdoJobStore.TriggerAcquisitionCriteria.ExcludedJobTypeNames" />.
+    /// </summary>
+    public IReadOnlyCollection<string>? ExcludedJobTypeNames
+    {
+        get;
+        init
+        {
+            if (value is not null)
+            {
+                foreach (string name in value)
+                {
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        throw new ArgumentException("ExcludedJobTypeNames must not contain null, empty, or whitespace entries.", nameof(value));
+                    }
+                }
+
+                if (value.Count > MaxExcludedJobTypeNames)
+                {
+                    throw new ArgumentException($"ExcludedJobTypeNames must not exceed {MaxExcludedJobTypeNames} entries.", nameof(value));
+                }
+            }
+
+            field = value;
+        }
+    }
 }

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -3654,6 +3654,7 @@ public abstract class AdoJobStoreBase : IJobStore
             NoEarlierThan = MisfireTime,
             MaxCount = request.MaxCount,
             ExecutionLimits = request.ExecutionLimits,
+            ExcludedJobTypeNames = request.ExcludedJobTypeNames,
             LiveNodeCutoff = liveNodeCutoff,
         };
     }
@@ -3678,6 +3679,11 @@ public abstract class AdoJobStoreBase : IJobStore
             {
                 // Built inside the loop, so each retry asks again and sees the time it retried at.
                 TriggerAcquisitionCriteria criteria = CreateAcquisitionCriteria(request);
+                // This delegate fallback deliberately compares ordinally; SQL filtering follows the
+                // job-class column's collation and is not guaranteed to agree.
+                HashSet<string>? excludedJobTypeNames = criteria.ExcludedJobTypeNames is { Count: > 0 } names
+                    ? new HashSet<string>(names, StringComparer.Ordinal)
+                    : null;
 
                 // A cluster-scoped limit is counted against the fired-triggers table, so the count is
                 // read here rather than derived from anything this node remembers. One aggregate per
@@ -3736,6 +3742,11 @@ public abstract class AdoJobStoreBase : IJobStore
                             Logger.LogError(ex, "Unable to set trigger state to ERROR.");
                         }
                         continue;
+                    }
+
+                    if (excludedJobTypeNames is not null && excludedJobTypeNames.Contains(result.JobTypeName))
+                    {
+                        continue; // next trigger — this delegate did not filter it out itself
                     }
 
                     // The same question JobDetailImpl answers, answered the same way: the attribute is

--- a/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
@@ -10,9 +10,9 @@ public class FirebirdDelegate : StdAdoDelegate
     /// FireBird version with ROWS support.
     /// </summary>
     /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
+    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
     {
-        return StdAdoConstants.SqlSelectNextTriggerToAcquire + " ROWS " + maxCount;
+        return base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " ROWS " + maxCount;
     }
 
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)

--- a/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
@@ -10,9 +10,9 @@ public class FirebirdDelegate : StdAdoDelegate
     /// FireBird version with ROWS support.
     /// </summary>
     /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
-        return base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " ROWS " + maxCount;
+        return base.GetSelectNextTriggerToAcquireSql(shape) + " ROWS " + shape.MaxCount;
     }
 
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -59,9 +59,9 @@ public class MySQLDelegate : StdAdoDelegate
     /// Gets the select next trigger to acquire SQL clause.
     /// MySQL version with LIMIT support and a FORCE INDEX hint pointing at IDX_*_T_NFT_ST.
     /// </summary>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
+    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
     {
-        return StdAdoConstants.SqlSelectNextTriggerToAcquire
+        return base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket)
             .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST)")
             + " LIMIT " + maxCount;
     }

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -59,11 +59,11 @@ public class MySQLDelegate : StdAdoDelegate
     /// Gets the select next trigger to acquire SQL clause.
     /// MySQL version with LIMIT support and a FORCE INDEX hint pointing at IDX_*_T_NFT_ST.
     /// </summary>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
-        return base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket)
+        return base.GetSelectNextTriggerToAcquireSql(shape)
             .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST)")
-            + " LIMIT " + maxCount;
+            + " LIMIT " + shape.MaxCount;
     }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
@@ -30,9 +30,9 @@ public class OracleDelegate : StdAdoDelegate
     /// <summary>
     /// Creates the SQL for select next trigger to acquire.
     /// </summary>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
+    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
     {
-        return "SELECT * FROM (" + StdAdoConstants.SqlSelectNextTriggerToAcquire + ") WHERE rownum <= " + maxCount;
+        return "SELECT * FROM (" + base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + ") WHERE rownum <= " + maxCount;
     }
 
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)

--- a/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
@@ -30,9 +30,9 @@ public class OracleDelegate : StdAdoDelegate
     /// <summary>
     /// Creates the SQL for select next trigger to acquire.
     /// </summary>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
-        return "SELECT * FROM (" + base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + ") WHERE rownum <= " + maxCount;
+        return "SELECT * FROM (" + base.GetSelectNextTriggerToAcquireSql(shape) + ") WHERE rownum <= " + shape.MaxCount;
     }
 
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)

--- a/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
@@ -32,9 +32,9 @@ public class PostgreSQLDelegate : StdAdoDelegate
     /// MySQL version with LIMIT support.
     /// </summary>
     /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
+    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
     {
-        return StdAdoConstants.SqlSelectNextTriggerToAcquire + " LIMIT " + maxCount;
+        return base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " LIMIT " + maxCount;
     }
 
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)

--- a/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
@@ -32,9 +32,9 @@ public class PostgreSQLDelegate : StdAdoDelegate
     /// MySQL version with LIMIT support.
     /// </summary>
     /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
-        return base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " LIMIT " + maxCount;
+        return base.GetSelectNextTriggerToAcquireSql(shape) + " LIMIT " + shape.MaxCount;
     }
 
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)

--- a/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
@@ -55,9 +55,9 @@ public class SQLiteDelegate : StdAdoDelegate
     /// SQLite version with LIMIT support.
     /// </summary>
     /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
-        return base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " LIMIT " + maxCount;
+        return base.GetSelectNextTriggerToAcquireSql(shape) + " LIMIT " + shape.MaxCount;
     }
 
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)

--- a/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
@@ -55,9 +55,9 @@ public class SQLiteDelegate : StdAdoDelegate
     /// SQLite version with LIMIT support.
     /// </summary>
     /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
+    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
     {
-        return StdAdoConstants.SqlSelectNextTriggerToAcquire + " LIMIT " + maxCount;
+        return base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket) + " LIMIT " + maxCount;
     }
 
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)

--- a/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
@@ -34,12 +34,12 @@ public class SqlServerDelegate : StdAdoDelegate
     /// SQL Server specific version with TOP functionality
     /// </summary>
     /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
-        string sqlSelectNextTriggerToAcquire = base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket);
+        string sqlSelectNextTriggerToAcquire = base.GetSelectNextTriggerToAcquireSql(shape);
 
         // add limit clause to correct place
-        sqlSelectNextTriggerToAcquire = "SELECT TOP " + maxCount + " " + sqlSelectNextTriggerToAcquire.Substring(6);
+        sqlSelectNextTriggerToAcquire = "SELECT TOP " + shape.MaxCount + " " + sqlSelectNextTriggerToAcquire.Substring(6);
 
         return sqlSelectNextTriggerToAcquire;
     }

--- a/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
@@ -34,9 +34,9 @@ public class SqlServerDelegate : StdAdoDelegate
     /// SQL Server specific version with TOP functionality
     /// </summary>
     /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
+    protected override string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
     {
-        string sqlSelectNextTriggerToAcquire = StdAdoConstants.SqlSelectNextTriggerToAcquire;
+        string sqlSelectNextTriggerToAcquire = base.GetSelectNextTriggerToAcquireSql(maxCount, excludedJobTypeBucket);
 
         // add limit clause to correct place
         sqlSelectNextTriggerToAcquire = "SELECT TOP " + maxCount + " " + sqlSelectNextTriggerToAcquire.Substring(6);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -304,7 +304,7 @@ internal static class StdAdoConstants
     /// Exclusion counts are rounded up and padded to one of these sizes, limiting the acquisition
     /// query shapes seen by the database plan cache.
     /// </summary>
-    private static readonly int[] excludedJobTypeBuckets = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, TriggerAcquisitionRequest.MaxExcludedJobTypeNames];
+    private static readonly int[] excludedJobTypeBuckets = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, JobTypeExclusions.MaxNames];
 
     // Unsynchronized on purpose: two threads racing here just build the same string twice and one
     // reference assignment wins, which costs nothing and cannot produce a wrong value.
@@ -328,7 +328,7 @@ internal static class StdAdoConstants
             }
         }
 
-        Throw.ArgumentOutOfRangeException(nameof(count), $"Excluded job type count must not exceed {TriggerAcquisitionRequest.MaxExcludedJobTypeNames}");
+        Throw.ArgumentOutOfRangeException(nameof(count), $"Excluded job type count must not exceed {JobTypeExclusions.MaxNames}");
         return default;
     }
 

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -276,9 +276,16 @@ internal static class StdAdoConstants
         Invariant($@"AND (t.{AdoConstants.ColumnPreferredNode} IS NULL OR t.{AdoConstants.ColumnPreferredNode} = @instanceId OR t.{AdoConstants.ColumnPreferredNode} = @autoPinSentinel
                      OR t.{AdoConstants.ColumnPreferredNode} NOT IN (SELECT ss.{AdoConstants.ColumnInstanceName} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} ss WHERE ss.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND ss.{AdoConstants.ColumnLastCheckinTime} + ss.{AdoConstants.ColumnCheckinInterval} * 10000 >= @liveNodeCutoff))");
 
+    // The one acquisition statement. Everything a caller can vary about it is the job-type exclusion
+    // clause, which is empty when nothing is excluded - so SqlSelectNextTriggerToAcquire below is
+    // literally the no-exclusion case of this template rather than a second copy kept in step by eye,
+    // and a change to the projection, the join, the predicates or the ORDER BY is a change in one
+    // place. The clause carries its own leading newline and indent, so passing an empty one yields
+    // the statement byte for byte as it was before there was a clause to pass.
+    //
     // PREFERRED_NODE is filtered entirely in PreferredNodeWhereClause and is not projected —
     // acquisition never reads it from the result (the trigger is reloaded via GetTrigger).
-    public static readonly string SqlSelectNextTriggerToAcquire =
+    private static string SelectNextTriggerToAcquire(string exclusionClause) =>
         Invariant($@"SELECT
                 t.{AdoConstants.ColumnTriggerName}, t.{AdoConstants.ColumnTriggerGroup}, jd.{AdoConstants.ColumnJobClass}, t.{AdoConstants.ColumnExecutionGroup}
               FROM
@@ -287,9 +294,11 @@ internal static class StdAdoConstants
                 {TablePrefixSubst}{AdoConstants.TableJobDetails} jd ON (jd.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND  jd.{AdoConstants.ColumnJobGroup} = t.{AdoConstants.ColumnJobGroup} AND jd.{AdoConstants.ColumnJobName} = t.{AdoConstants.ColumnJobName})
               WHERE
                 t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerState} = @state AND {AdoConstants.ColumnNextFireTime} <= @noLaterThan AND ({AdoConstants.ColumnMisfireInstruction} = -1 OR ({AdoConstants.ColumnMisfireInstruction} <> -1 AND {AdoConstants.ColumnNextFireTime} >= @noEarlierThan))
-                {PreferredNodeWhereClause}
+                {PreferredNodeWhereClause}{exclusionClause}
               ORDER BY
                 {AdoConstants.ColumnNextFireTime} ASC, {AdoConstants.ColumnPriority} DESC");
+
+    public static readonly string SqlSelectNextTriggerToAcquire = SelectNextTriggerToAcquire(exclusionClause: "");
 
     /// <summary>
     /// Exclusion counts are rounded up and padded to one of these sizes, limiting the acquisition
@@ -345,38 +354,42 @@ internal static class StdAdoConstants
             return cached;
         }
 
-        StringBuilder exclusionClause = new StringBuilder("AND jd.").Append(AdoConstants.ColumnJobClass).Append(" NOT IN (");
-        for (int i = 0; i < excludedJobTypeBucket; i++)
-        {
-            if (i > 0)
-            {
-                exclusionClause.Append(", ");
-            }
-
-            exclusionClause.Append('@').Append(ExcludedJobTypeParameter(i));
-        }
-
-        exclusionClause.Append(')');
-
-        // Same shape as SqlSelectNextTriggerToAcquire above, plus the exclusion clause - kept as a
-        // second copy rather than spliced at runtime, so this stays as easy to read (and to keep in
-        // sync by eye) as the query it is built from.
-        string predicateSql = Invariant($@"SELECT
-                t.{AdoConstants.ColumnTriggerName}, t.{AdoConstants.ColumnTriggerGroup}, jd.{AdoConstants.ColumnJobClass}, t.{AdoConstants.ColumnExecutionGroup}
-              FROM
-                {TablePrefixSubst}{AdoConstants.TableTriggers} t
-              JOIN
-                {TablePrefixSubst}{AdoConstants.TableJobDetails} jd ON (jd.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND  jd.{AdoConstants.ColumnJobGroup} = t.{AdoConstants.ColumnJobGroup} AND jd.{AdoConstants.ColumnJobName} = t.{AdoConstants.ColumnJobName})
-              WHERE
-                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerState} = @state AND {AdoConstants.ColumnNextFireTime} <= @noLaterThan AND ({AdoConstants.ColumnMisfireInstruction} = -1 OR ({AdoConstants.ColumnMisfireInstruction} <> -1 AND {AdoConstants.ColumnNextFireTime} >= @noEarlierThan))
-                {PreferredNodeWhereClause}
-                {exclusionClause}
-              ORDER BY
-                {AdoConstants.ColumnNextFireTime} ASC, {AdoConstants.ColumnPriority} DESC");
+        string predicateSql = SelectNextTriggerToAcquire(ExcludedJobTypeWhereClause(excludedJobTypeBucket));
 
         sqlSelectNextTriggerToAcquireByExcludedJobTypeBucket[bucketIndex] = predicateSql;
         return predicateSql;
     }
+
+    /// <summary>
+    /// The exclusion clause the acquisition template splices in, on a line of its own and indented to
+    /// match the predicate above it. The parameter names are fixed-width so that no name is a prefix
+    /// of another — see the remarks above <see cref="PreferredNodeWhereClause" />.
+    /// </summary>
+    private static string ExcludedJobTypeWhereClause(int excludedJobTypeBucket)
+    {
+        StringBuilder clause = new StringBuilder(ClauseSeparator)
+            .Append("AND jd.")
+            .Append(AdoConstants.ColumnJobClass)
+            .Append(" NOT IN (");
+
+        for (int i = 0; i < excludedJobTypeBucket; i++)
+        {
+            if (i > 0)
+            {
+                clause.Append(", ");
+            }
+
+            clause.Append('@').Append(ExcludedJobTypeParameter(i));
+        }
+
+        return clause.Append(')').ToString();
+    }
+
+    /// <summary>
+    /// What separates one optional WHERE clause of the acquisition statement from the next: a line
+    /// break and the indent the template's own predicates sit at.
+    /// </summary>
+    private const string ClauseSeparator = "\n                ";
 
     internal static string ExcludedJobTypeParameter(int index) =>
         "excludedJobType" + index.ToString("D4", CultureInfo.InvariantCulture);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -19,6 +19,11 @@
 
 #endregion
 
+using System.Globalization;
+using System.Text;
+
+using Quartz.Extensibility;
+
 using static System.FormattableString;
 
 namespace Quartz.Impl.AdoJobStore;
@@ -285,6 +290,96 @@ internal static class StdAdoConstants
                 {PreferredNodeWhereClause}
               ORDER BY
                 {AdoConstants.ColumnNextFireTime} ASC, {AdoConstants.ColumnPriority} DESC");
+
+    /// <summary>
+    /// Exclusion counts are rounded up and padded to one of these sizes, limiting the acquisition
+    /// query shapes seen by the database plan cache.
+    /// </summary>
+    private static readonly int[] excludedJobTypeBuckets = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, TriggerAcquisitionRequest.MaxExcludedJobTypeNames];
+
+    // Unsynchronized on purpose: two threads racing here just build the same string twice and one
+    // reference assignment wins, which costs nothing and cannot produce a wrong value.
+    private static readonly string?[] sqlSelectNextTriggerToAcquireByExcludedJobTypeBucket = new string?[excludedJobTypeBuckets.Length];
+
+    /// <summary>
+    /// Rounds an exclusion count up to the next query bucket. Zero means no exclusion.
+    /// </summary>
+    internal static int RoundUpExcludedJobTypeCount(int count)
+    {
+        if (count <= 0)
+        {
+            return 0;
+        }
+
+        foreach (int bucket in excludedJobTypeBuckets)
+        {
+            if (count <= bucket)
+            {
+                return bucket;
+            }
+        }
+
+        Throw.ArgumentOutOfRangeException(nameof(count), $"Excluded job type count must not exceed {TriggerAcquisitionRequest.MaxExcludedJobTypeNames}");
+        return default;
+    }
+
+    /// <summary>
+    /// Builds the trigger-acquisition query for an already-rounded job-type exclusion bucket.
+    /// </summary>
+    internal static string BuildSqlSelectNextTriggerToAcquire(int excludedJobTypeBucket)
+    {
+        if (excludedJobTypeBucket == 0)
+        {
+            return SqlSelectNextTriggerToAcquire;
+        }
+
+        int bucketIndex = Array.IndexOf(excludedJobTypeBuckets, excludedJobTypeBucket);
+        if (bucketIndex < 0)
+        {
+            Throw.ArgumentOutOfRangeException(nameof(excludedJobTypeBucket), "Excluded job type count must be rounded to a query bucket first");
+        }
+
+        string? cached = sqlSelectNextTriggerToAcquireByExcludedJobTypeBucket[bucketIndex];
+        if (cached is not null)
+        {
+            return cached;
+        }
+
+        StringBuilder exclusionClause = new StringBuilder("AND jd.").Append(AdoConstants.ColumnJobClass).Append(" NOT IN (");
+        for (int i = 0; i < excludedJobTypeBucket; i++)
+        {
+            if (i > 0)
+            {
+                exclusionClause.Append(", ");
+            }
+
+            exclusionClause.Append('@').Append(ExcludedJobTypeParameter(i));
+        }
+
+        exclusionClause.Append(')');
+
+        // Same shape as SqlSelectNextTriggerToAcquire above, plus the exclusion clause - kept as a
+        // second copy rather than spliced at runtime, so this stays as easy to read (and to keep in
+        // sync by eye) as the query it is built from.
+        string predicateSql = Invariant($@"SELECT
+                t.{AdoConstants.ColumnTriggerName}, t.{AdoConstants.ColumnTriggerGroup}, jd.{AdoConstants.ColumnJobClass}, t.{AdoConstants.ColumnExecutionGroup}
+              FROM
+                {TablePrefixSubst}{AdoConstants.TableTriggers} t
+              JOIN
+                {TablePrefixSubst}{AdoConstants.TableJobDetails} jd ON (jd.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND  jd.{AdoConstants.ColumnJobGroup} = t.{AdoConstants.ColumnJobGroup} AND jd.{AdoConstants.ColumnJobName} = t.{AdoConstants.ColumnJobName})
+              WHERE
+                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerState} = @state AND {AdoConstants.ColumnNextFireTime} <= @noLaterThan AND ({AdoConstants.ColumnMisfireInstruction} = -1 OR ({AdoConstants.ColumnMisfireInstruction} <> -1 AND {AdoConstants.ColumnNextFireTime} >= @noEarlierThan))
+                {PreferredNodeWhereClause}
+                {exclusionClause}
+              ORDER BY
+                {AdoConstants.ColumnNextFireTime} ASC, {AdoConstants.ColumnPriority} DESC");
+
+        sqlSelectNextTriggerToAcquireByExcludedJobTypeBucket[bucketIndex] = predicateSql;
+        return predicateSql;
+    }
+
+    internal static string ExcludedJobTypeParameter(int index) =>
+        "excludedJobType" + index.ToString("D4", CultureInfo.InvariantCulture);
 
     public static readonly string SqlSelectNumTriggersForJob =
         Invariant($"SELECT COUNT({AdoConstants.ColumnTriggerName}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -1327,10 +1327,12 @@ public partial class StdAdoDelegate
         return await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) is not null;
     }
 
-    protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount)
+    protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
     {
         // by default we don't support limits, this is db specific
-        return StdAdoConstants.SqlSelectNextTriggerToAcquire;
+        return excludedJobTypeBucket == 0
+            ? StdAdoConstants.SqlSelectNextTriggerToAcquire
+            : StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket);
     }
 
     /// <summary>
@@ -1404,10 +1406,14 @@ public partial class StdAdoDelegate
     {
         // we want at least one trigger back
         int maxCount = criteria.MaxCount < 1 ? 1 : criteria.MaxCount;
+        List<string>? excludedJobTypeNames = criteria.ExcludedJobTypeNames is { Count: > 0 } names
+            ? [.. names]
+            : null;
+        int excludedJobTypeBucket = StdAdoConstants.RoundUpExcludedJobTypeCount(excludedJobTypeNames?.Count ?? 0);
 
         string sql = acquisitionSqlByMaxCount.GetOrAdd(
-            maxCount,
-            static (limit, self) => self.ReplaceTablePrefix(self.GetSelectNextTriggerToAcquireSql(limit)),
+            (maxCount, excludedJobTypeBucket),
+            static (key, self) => self.ReplaceTablePrefix(self.GetSelectNextTriggerToAcquireSql(key.MaxCount, key.ExcludedJobTypeBucket)),
             this);
 
         using var cmd = PrepareCommand(conn, sql);
@@ -1418,6 +1424,17 @@ public partial class StdAdoDelegate
         AddCommandParameter(cmd, "noLaterThan", GetDbDateTimeValue(criteria.NoLaterThan));
         AddCommandParameter(cmd, "noEarlierThan", GetDbDateTimeValue(criteria.NoEarlierThan));
         AddPreferredNodeParameters(cmd, criteria.LiveNodeCutoff);
+
+        if (excludedJobTypeNames is not null)
+        {
+            for (int i = 0; i < excludedJobTypeBucket; i++)
+            {
+                // Pad to the bucket size by repeating the last name. A duplicate NOT IN term cannot
+                // change which rows match.
+                string jobTypeName = excludedJobTypeNames[Math.Min(i, excludedJobTypeNames.Count - 1)];
+                AddCommandParameter(cmd, StdAdoConstants.ExcludedJobTypeParameter(i), jobTypeName);
+            }
+        }
 
         // Work on a copy: the slots are decremented as rows are taken, and the caller may reuse the
         // criteria across retries. Cluster-scoped limits arrive already lowered by what the cluster

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -1327,12 +1327,10 @@ public partial class StdAdoDelegate
         return await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) is not null;
     }
 
-    protected virtual string GetSelectNextTriggerToAcquireSql(int maxCount, int excludedJobTypeBucket)
+    protected virtual string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
         // by default we don't support limits, this is db specific
-        return excludedJobTypeBucket == 0
-            ? StdAdoConstants.SqlSelectNextTriggerToAcquire
-            : StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket);
+        return StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(shape.ExcludedJobTypeBucket);
     }
 
     /// <summary>
@@ -1411,9 +1409,9 @@ public partial class StdAdoDelegate
             : null;
         int excludedJobTypeBucket = StdAdoConstants.RoundUpExcludedJobTypeCount(excludedJobTypeNames?.Count ?? 0);
 
-        string sql = acquisitionSqlByMaxCount.GetOrAdd(
-            (maxCount, excludedJobTypeBucket),
-            static (key, self) => self.ReplaceTablePrefix(self.GetSelectNextTriggerToAcquireSql(key.MaxCount, key.ExcludedJobTypeBucket)),
+        string sql = acquisitionSqlByShape.GetOrAdd(
+            new TriggerAcquisitionSqlShape(maxCount, excludedJobTypeBucket),
+            static (shape, self) => self.ReplaceTablePrefix(self.GetSelectNextTriggerToAcquireSql(shape)),
             this);
 
         using var cmd = PrepareCommand(conn, sql);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -91,8 +91,9 @@ public partial class StdAdoDelegate : IDriverDelegate, IDbAccessor
     /// Both statements carry their limit in the text — a <c>SELECT TOP n</c> spliced into the projection
     /// on SQL Server, a <c>rownum</c> wrapper on Oracle, a trailing <c>LIMIT n</c> elsewhere — so the
     /// dialect rebuilds around a kilobyte of SQL for every acquisition, and the table-prefix cache then
-    /// hashes all of it to hand back a string it already had. Both are pure functions of the limit, so
-    /// the finished statement is remembered against it instead.
+    /// hashes all of it to hand back a string it already had. Each is a pure function of its limit;
+    /// acquisition also depends on the job-type exclusion bucket, so the finished statements are
+    /// remembered against those inputs.
     /// </para>
     /// <para>
     /// The limits take few distinct values: acquisition asks for the smaller of the free thread count
@@ -100,7 +101,7 @@ public partial class StdAdoDelegate : IDriverDelegate, IDbAccessor
     /// settle within a handful of entries.
     /// </para>
     /// </remarks>
-    private readonly ConcurrentDictionary<int, string> acquisitionSqlByMaxCount = new();
+    private readonly ConcurrentDictionary<(int MaxCount, int ExcludedJobTypeBucket), string> acquisitionSqlByMaxCount = new();
 
     private readonly ConcurrentDictionary<int, string> misfireRecoverySqlByCount = new();
 

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -83,25 +83,30 @@ public partial class StdAdoDelegate : IDriverDelegate, IDbAccessor
     private readonly ConcurrentDictionary<string, string> cachedQueries = new();
 
     /// <summary>
-    /// The acquisition statement, and the misfire recovery statement, for each row limit they have been
-    /// asked for.
+    /// The acquisition statement for each <see cref="TriggerAcquisitionSqlShape" /> it has been asked
+    /// for.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Both statements carry their limit in the text — a <c>SELECT TOP n</c> spliced into the projection
+    /// The statement carries its limit in the text — a <c>SELECT TOP n</c> spliced into the projection
     /// on SQL Server, a <c>rownum</c> wrapper on Oracle, a trailing <c>LIMIT n</c> elsewhere — so the
     /// dialect rebuilds around a kilobyte of SQL for every acquisition, and the table-prefix cache then
-    /// hashes all of it to hand back a string it already had. Each is a pure function of its limit;
-    /// acquisition also depends on the job-type exclusion bucket, so the finished statements are
-    /// remembered against those inputs.
+    /// hashes all of it to hand back a string it already had. It is a pure function of its shape, so
+    /// the finished statement is remembered against the shape instead — which is why the shape is a
+    /// record: adding an acquisition dimension extends the key without touching this cache.
     /// </para>
     /// <para>
-    /// The limits take few distinct values: acquisition asks for the smaller of the free thread count
-    /// and the configured batch size, and recovery for the configured misfire batch, so both dictionaries
-    /// settle within a handful of entries.
+    /// The shape takes few distinct values: acquisition asks for the smaller of the free thread count
+    /// and the configured batch size, and the exclusion count is bucketed, so the dictionary settles
+    /// within a handful of entries.
     /// </para>
     /// </remarks>
-    private readonly ConcurrentDictionary<(int MaxCount, int ExcludedJobTypeBucket), string> acquisitionSqlByMaxCount = new();
+    private readonly ConcurrentDictionary<TriggerAcquisitionSqlShape, string> acquisitionSqlByShape = new();
+
+    /// <summary>
+    /// The misfire recovery statement for each row limit it has been asked for, remembered for the
+    /// same reason and settling on as few entries.
+    /// </summary>
 
     private readonly ConcurrentDictionary<int, string> misfireRecoverySqlByCount = new();
 

--- a/src/Quartz/Impl/AdoJobStore/TriggerAcquisitionCriteria.cs
+++ b/src/Quartz/Impl/AdoJobStore/TriggerAcquisitionCriteria.cs
@@ -65,6 +65,12 @@ public sealed record TriggerAcquisitionCriteria
     public ExecutionLimits? ExecutionLimits { get; init; }
 
     /// <summary>
+    /// Job type names to exclude from acquisition, copied from
+    /// <see cref="Quartz.Extensibility.TriggerAcquisitionRequest.ExcludedJobTypeNames" />.
+    /// </summary>
+    public IReadOnlyCollection<string>? ExcludedJobTypeNames { get; init; }
+
+    /// <summary>
     /// What the whole cluster already holds in flight per (execution group, trigger group) pair, which
     /// is what a <see cref="ExecutionLimitScope.Cluster" /> limit is counted against.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/TriggerAcquisitionCriteria.cs
+++ b/src/Quartz/Impl/AdoJobStore/TriggerAcquisitionCriteria.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using Quartz.Extensibility;
+
 namespace Quartz.Impl.AdoJobStore;
 
 /// <summary>
@@ -66,9 +68,31 @@ public sealed record TriggerAcquisitionCriteria
 
     /// <summary>
     /// Job type names to exclude from acquisition, copied from
-    /// <see cref="Quartz.Extensibility.TriggerAcquisitionRequest.ExcludedJobTypeNames" />.
+    /// <see cref="Quartz.Extensibility.TriggerAcquisitionRequest.ExcludedJobTypeNames" /> — or set by
+    /// a derived store's <c>CreateAcquisitionCriteria</c>, which is how a deployment says what this
+    /// node will not pick up.
     /// </summary>
-    public IReadOnlyCollection<string>? ExcludedJobTypeNames { get; init; }
+    /// <remarks>
+    /// <para>
+    /// <see cref="StdAdoDelegate" /> keeps the rows out in the acquisition SQL, where comparison
+    /// follows the job-class column's collation. A delegate is free to ignore the property, as it is
+    /// with every other one here — <see cref="AdoJobStoreBase" /> post-filters the results ordinally
+    /// afterwards, so an uncooperative delegate degrades to a wasted read rather than to running work
+    /// the deployment excluded.
+    /// </para>
+    /// <para>
+    /// Entries must be non-blank, and there may be at most 1,000 of them — Oracle's ceiling on an
+    /// <c>IN</c> list. Blank is rejected rather than skipped because one would make the clause
+    /// <c>NOT IN (…, NULL)</c>, which matches no row at all and would stop the node acquiring
+    /// anything.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentException">An entry is blank, or there are too many of them.</exception>
+    public IReadOnlyCollection<string>? ExcludedJobTypeNames
+    {
+        get;
+        init => field = JobTypeExclusions.Validated(value, nameof(value));
+    }
 
     /// <summary>
     /// What the whole cluster already holds in flight per (execution group, trigger group) pair, which

--- a/src/Quartz/Impl/AdoJobStore/TriggerAcquisitionSqlShape.cs
+++ b/src/Quartz/Impl/AdoJobStore/TriggerAcquisitionSqlShape.cs
@@ -1,0 +1,55 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Runtime.InteropServices;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// Everything about one acquisition attempt that changes the text of the statement, and nothing that
+/// does not.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is what <see cref="StdAdoDelegate.GetSelectNextTriggerToAcquireSql" /> is handed, and it is
+/// also the key the finished statement is cached under — the same object, because a statement is a
+/// pure function of its shape. Two attempts of the same shape are the same string, so the dialect
+/// builds it once.
+/// </para>
+/// <para>
+/// It exists so that the next acquisition dimension adds a property here rather than a parameter to
+/// every dialect delegate that overrides the hook. A dialect that only splices in a row limit reads
+/// <see cref="MaxCount" /> and hands the whole shape to <c>base</c>, and so keeps working when a
+/// dimension it has never heard of is added.
+/// </para>
+/// </remarks>
+/// <param name="MaxCount">
+/// The most rows the statement may return, already clamped to at least one by the caller. A dialect
+/// splices this into its <c>TOP</c>, <c>LIMIT</c>, <c>ROWS</c> or <c>rownum</c> clause.
+/// </param>
+/// <param name="ExcludedJobTypeBucket">
+/// How many <c>NOT IN</c> terms the job-type exclusion clause carries, or zero for no clause at all.
+/// It is a bucket rather than the caller's exact count because the parameter list is padded up to
+/// one of a few sizes, which is what keeps the statement cache — and the database's plan cache —
+/// from growing an entry per distinct exclusion count.
+/// </param>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct TriggerAcquisitionSqlShape(int MaxCount, int ExcludedJobTypeBucket);

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -2482,6 +2482,13 @@ public sealed class RAMJobStore : IJobStore
             ExecutionSlots? executionSlots = request.ExecutionLimits?.CreateSlots(
                 request.ExecutionLimits.HasClusterScopedLimits ? CollectInFlightExecutionGroupsNoLock() : null);
 
+            // The names are compared against JobType.FullName, which is the same string the ADO store
+            // writes into JOB_CLASS_NAME and compares its NOT IN clause against, so one exclusion set
+            // means the same thing to both stores. Ordinal, because a type name is not prose.
+            HashSet<string>? excludedJobTypeNames = request.ExcludedJobTypeNames is { Count: > 0 } names
+                ? new HashSet<string>(names, StringComparer.Ordinal)
+                : null;
+
             while (true)
             {
                 var tw = timeTriggers.Min;
@@ -2539,6 +2546,17 @@ public sealed class RAMJobStore : IJobStore
                 }
 
                 IJobDetail job = jobWrapper.JobDetail;
+
+                // An excluded job type is declined for this attempt only, so the trigger goes back into
+                // timeTriggers with the rest of the turned-away ones rather than being dropped: the next
+                // request may carry a different exclusion set, and a trigger left out of timeTriggers
+                // stays out until something stores or resumes it again.
+                if (excludedJobTypeNames is not null && excludedJobTypeNames.Contains(job.JobType.FullName))
+                {
+                    excludedTriggers ??= [];
+                    excludedTriggers.Add(tw);
+                    continue;
+                }
 
                 // If trigger's job disallows concurrent execution and the job was already added to the result,
                 // then we'll add the trigger to the list of excluded triggers (which we'll add back to the set


### PR DESCRIPTION
Implements #2238: a job-type exclusion filter for trigger acquisition, pushed down into the SQL instead of over-fetching triggers and discarding unwanted ones in memory.

**⚠️ No prior maintainer confirmation.** I [posted on the issue](https://github.com/quartznet/quartznet/issues/2238#issuecomment-5333611370) proposing this approach and asking for a nod before investing time across all the DB delegates, since it touches `IDriverDelegate`'s data contract. The issue had been open ~2.5 years with zero maintainer response and got none in the time I waited either, so I went ahead per my own judgment rather than leave it stalled indefinitely. Please review the design choices below with extra scrutiny — I'm glad to rework the shape if you'd rather see something else.

### What changed

The original issue (filed against an older `SelectTriggerToAcquire` shape) sketched adding a `Type[] jobTypesToExclude` parameter directly to `IDriverDelegate.SelectTriggerToAcquire` and building the exclusion into `GetSelectNextTriggerToAcquireSql` via string-interpolated SQL.

Since then the delegate signature changed to `SelectTriggersToAcquire(conn, TriggerAcquisitionCriteria, ct)`, and `TriggerAcquisitionCriteria`'s own doc comment already flags itself as "the extension point for acquisition filtering (see issue #2238)" — every future acquisition dimension is meant to land as an additive optional property rather than a signature change. So instead of touching `IDriverDelegate`, this PR:

1. Adds `JobTypesToExclude` (`IReadOnlyCollection<string>?`, job class names — the same format `TriggerAcquireResult.JobTypeName` and `JobHeader.JobTypeName` already store) as an optional property on both `TriggerAcquisitionRequest` (store-level) and `TriggerAcquisitionCriteria` (delegate-level), mirroring exactly how `ExecutionLimits` already flows through both layers. `null`/empty means no filtering, so every existing caller is unaffected.
2. `JobStoreSupport.AcquireNextTrigger` threads `request.JobTypesToExclude` into the criteria it builds, same as it already does for `ExecutionLimits`.
3. `StdAdoConstants.SqlSelectNextTriggerToAcquire` becomes `BuildSqlSelectNextTriggerToAcquire(int jobTypesToExcludeCount)`, which appends a **parameterized** `AND JOB_CLASS_NAME NOT IN (@excludedJobType0, @excludedJobType1, ...)` clause only when the count is non-zero — unlike the string-interpolated `NOT IN` in the issue's sketch, this avoids any injection risk. `jd.JOB_CLASS_NAME` was already joined and selected by this query, so no schema/join changes were needed.
4. `StdAdoDelegate.SelectTriggersToAcquire` binds the `@excludedJobTypeN` parameters (after the existing preferred-node parameters, matching the clause's position in the SQL, for providers that bind positionally).
5. Every dialect override of `GetSelectNextTriggerToAcquireSql` (`SqlServerDelegate`, `PostgreSQLDelegate`, `MySQLDelegate`, `SQLiteDelegate`, `OracleDelegate`, `FirebirdDelegate`) just wraps the same base SQL string to splice in `TOP`/`LIMIT`/`ROWS`/`rownum` paging, so threading the exclusion count through was a mechanical signature change in each — no per-dialect SQL rewrite needed, so the filter is consistent everywhere the same query construction pattern already was.

`IDriverDelegate`'s interface signature is untouched, as is the database schema (no migration needed — `JOB_CLASS_NAME` was already selected).

### Testing

- Unit tests (`StdAdoConstantsTest`) cover `BuildSqlSelectNextTriggerToAcquire` with and without exclusions.
- A new SQLite-backed integration test (`AdoJobStoreTriggerAcquisitionFilterTest`) schedules two jobs of different types against a real SQLite database, calls `AcquireNextTriggers` with one type excluded, and asserts only the non-excluded trigger comes back — verifying the filter actually excludes rows in a real query, not just that the code compiles.
- `PublicApiTest_Quartz.verified.txt` updated for the two new public properties.
- Full `Quartz.Tests.Unit` suite: 2314 passed, 4 skipped (pre-existing, unrelated to this change), 0 failed.
- `dotnet build` on `Quartz`, `Quartz.Tests.Unit`, and `Quartz.Tests.Integration` all succeed with 0 warnings/errors.

Closes #2238 (pending your review of the approach).
