### PR TITLE
JobStorePersistent: repair the rename casualty on SchedulerMetadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ fallback in `SimpleTypeLoadHelper`, with a warning.
 | `ISchedulerListener.SchedulerShuttingdown` | `SchedulerShuttingDown` |
 | `IListenerManager.GetSchedulerListeners()` → `IReadOnlyCollection<T>` | `ISchedulerListener[]` |
 | `IJobStore.EstimatedTimeToReleaseAndAcquireTrigger` (`long` ms) | `TimeSpan` |
-| two `IJobStore.AcquireNextTriggers` overloads | one, with optional `executionLimits` |
+| two `IJobStore.AcquireNextTriggers` overloads | one, taking a `TriggerAcquisitionRequest` record |
 | `IScheduler`/`IJobStore` `GetJobKeys` / `GetTriggerKeys` | `QueryJobs` / `QueryTriggers` → `PagedResult<JobHeader\|TriggerHeader>` |
 | `Get{Job,Trigger}GroupNames`, `GetPausedTriggerGroups`, `Is{Job,Trigger}GroupPaused` | `Query{Job,Trigger}Groups` with `JobGroupQuery`/`TriggerGroupQuery.Paused` |
 | `GetCalendarNames` | `QueryCalendarNames(CalendarQuery)` |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3184,6 +3184,7 @@ The renamed and reshaped properties:
 | `ThreadPoolType` (`Type`) | `ThreadPoolTypeName` (`string`) |
 | `SchedulerRemote` / `IsRemote` | `IsProxy` |
 | `NumberOfJobsExecuted` | `JobsExecuted` |
+| `JobStoreSupportsPersistence` | `JobStorePersistent`, reading like its sibling `JobStoreClustered` |
 
 The `Type` members became assembly-qualified names (without version) because a proxy cannot promise to
 materialize them: an `HttpScheduler` reads the remote scheduler's metadata over the wire, and the remote's

--- a/src/Quartz.HttpClient/HttpApiContract/SchedulerDto.cs
+++ b/src/Quartz.HttpClient/HttpApiContract/SchedulerDto.cs
@@ -61,7 +61,7 @@ internal record SchedulerJobStoreDto(string Type, bool Clustered, bool Persisten
 {
     public static SchedulerJobStoreDto Create(SchedulerMetadata metadata)
     {
-        return new SchedulerJobStoreDto(metadata.JobStoreTypeName, metadata.JobStoreClustered, metadata.AdoJobStoreBasesPersistence);
+        return new SchedulerJobStoreDto(metadata.JobStoreTypeName, metadata.JobStoreClustered, metadata.JobStorePersistent);
     }
 }
 

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -109,7 +109,7 @@ public sealed class HttpScheduler : IScheduler
             JobsExecuted = schedulerDto.Statistics.JobsExecuted,
             // names pass through as strings: the remote types need not exist in this process
             JobStoreTypeName = schedulerDto.JobStore.Type,
-            AdoJobStoreBasesPersistence = schedulerDto.JobStore.Persistent,
+            JobStorePersistent = schedulerDto.JobStore.Persistent,
             JobStoreClustered = schedulerDto.JobStore.Clustered,
             ThreadPoolTypeName = schedulerDto.ThreadPool.Type,
             ThreadPoolSize = schedulerDto.ThreadPool.Size,

--- a/src/Quartz.Tests.AspNetCore/Support/TestData.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestData.cs
@@ -53,7 +53,7 @@ public static class TestData
             RunningSince = DateTimeOffset.Now.AddDays(-1),
             JobsExecuted = 1_000_000,
             JobStoreTypeName = typeof(RAMJobStore).AssemblyQualifiedNameWithoutVersion(),
-            AdoJobStoreBasesPersistence = false,
+            JobStorePersistent = false,
             JobStoreClustered = false,
             ThreadPoolTypeName = typeof(DefaultThreadPool).AssemblyQualifiedNameWithoutVersion(),
             ThreadPoolSize = 10,

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1180,10 +1180,10 @@ namespace Quartz
     public sealed class SchedulerMetadata : System.IEquatable<Quartz.SchedulerMetadata>
     {
         public SchedulerMetadata() { }
-        public bool AdoJobStoreBasesPersistence { get; init; }
         public bool InStandbyMode { get; init; }
         public bool IsProxy { get; init; }
         public bool JobStoreClustered { get; init; }
+        public bool JobStorePersistent { get; init; }
         public required string JobStoreTypeName { get; init; }
         public int JobsExecuted { get; init; }
         public System.DateTimeOffset? RunningSince { get; init; }

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -79,7 +79,7 @@ internal sealed class StdScheduler : IScheduler
             RunningSince = scheduler.RunningSince,
             JobsExecuted = scheduler.NumberOfJobsExecuted,
             JobStoreTypeName = scheduler.JobStoreType.AssemblyQualifiedNameWithoutVersion(),
-            AdoJobStoreBasesPersistence = scheduler.SupportsPersistence,
+            JobStorePersistent = scheduler.SupportsPersistence,
             JobStoreClustered = scheduler.Clustered,
             ThreadPoolTypeName = scheduler.ThreadPoolType.AssemblyQualifiedNameWithoutVersion(),
             ThreadPoolSize = scheduler.ThreadPoolSize,

--- a/src/Quartz/SchedulerMetadata.cs
+++ b/src/Quartz/SchedulerMetadata.cs
@@ -99,7 +99,7 @@ public sealed record SchedulerMetadata
     /// <summary>
     /// Whether the <see cref="IScheduler" />'s <see cref="IJobStore" /> supports persistence.
     /// </summary>
-    public bool AdoJobStoreBasesPersistence { get; init; }
+    public bool JobStorePersistent { get; init; }
 
     /// <summary>
     /// Whether the <see cref="IScheduler" />'s <see cref="IJobStore" /> is clustered.


### PR DESCRIPTION
PR #3270's `JobStoreSupport` → `AdoJobStoreBase` sweep also rewrote the unrelated metadata property `JobStoreSupportsPersistence` into `AdoJobStoreBasesPersistence` — a store-neutral flag ended up naming an ADO base class. This renames it to **`JobStorePersistent`**, reading like its sibling `JobStoreClustered` and like the wire field.

- The HTTP wire contract is untouched: `SchedulerJobStoreDto` always serialized the field as `persistent`; only the C# property was the casualty. The public API baseline moves by exactly this one line (and the property now alphabetizes right next to `JobStoreClustered`).
- Migration guide gains the member row in the existing `SchedulerMetaData` → `SchedulerMetadata` rename table.
- Drive-by: AGENTS.md's porting table said `AcquireNextTriggers` takes "optional `executionLimits`" — it takes a `TriggerAcquisitionRequest` record since the batching reshape; the row now says so.

Verified with `build.cmd Compile UnitTest PublishAot` (2322 + 216 tests green, AOT publish clean) and a repo-wide grep showing zero remaining hits of the corrupted name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)