### PR TITLE
CI hygiene: integration tests run on their declared TFMs, push leg scoped to basic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@
 #
 #     - To turn off auto-generation set:
 #
-#         [GitHubActions (AutoGenerate = false)]
+#         [DatabaseGitHubActions (AutoGenerate = false)]
 #
 #     - To trigger manual generation invoke:
 #
@@ -48,6 +48,7 @@ jobs:
         run: dotnet fallout Compile UnitTest IntegrationTest Pack Publish
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
+          Database: basic
       - name: 'Publish: packages'
         uses: actions/upload-artifact@v7
         if: ${{ runner.os == 'Windows' }}
@@ -70,6 +71,7 @@ jobs:
         run: dotnet fallout Compile UnitTest IntegrationTest Pack Publish
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
+          Database: basic
       - name: 'Publish: packages'
         uses: actions/upload-artifact@v7
         if: ${{ runner.os == 'Windows' }}
@@ -92,6 +94,7 @@ jobs:
         run: dotnet fallout Compile UnitTest IntegrationTest Pack Publish
         env:
           FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
+          Database: basic
       - name: 'Publish: packages'
         uses: actions/upload-artifact@v7
         if: ${{ runner.os == 'Windows' }}

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -30,8 +30,12 @@ using Quartz.Build;
 [DatabaseIntegrationGitHubActions("pr-integration-firebird", "firebird")]
 [DatabaseIntegrationGitHubActions("pr-integration-sqlite", "sqlite")]
 [DatabaseIntegrationGitHubActions("pr-integration-redis", "redis")]
-[GitHubActions(
+// The push leg runs 'basic' — the container-free negation of every db-* category. Left unset the build
+// defaults to "all", which starts six database containers inside a ten-minute job; per-database coverage
+// is what the pr-integration-* workflows above are for.
+[DatabaseGitHubActions(
     "build",
+    "basic",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
     GitHubActionsImage.MacOsLatest,
@@ -66,21 +70,42 @@ public partial class Build;
 namespace Quartz.Build
 {
     /// <summary>
-    /// Preset for the per-database integration workflows. The database under test is handed to the build
-    /// as an <c>env:</c> entry on the generated run step, which Fallout resolves into the <c>Database</c>
-    /// parameter — the same mechanism <see cref="GitHubActionsAttribute.ImportSecrets"/> uses, so no
-    /// custom step needs to be written.
+    /// A workflow that pins the database its integration tests run against. The database is handed to the
+    /// build as an <c>env:</c> entry on the generated run step, which Fallout resolves into the
+    /// <c>Database</c> parameter — the same mechanism <see cref="GitHubActionsAttribute.ImportSecrets"/>
+    /// uses, so no custom step needs to be written.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    internal sealed class DatabaseIntegrationGitHubActionsAttribute : GitHubActionsAttribute
+    internal class DatabaseGitHubActionsAttribute : GitHubActionsAttribute
     {
         readonly string database;
 
-        public DatabaseIntegrationGitHubActionsAttribute(string name, string database)
-            : base(name, GitHubActionsImage.UbuntuLatest)
+        public DatabaseGitHubActionsAttribute(
+            string name,
+            string database,
+            GitHubActionsImage image,
+            params GitHubActionsImage[] images)
+            : base(name, image, images)
         {
             this.database = database;
+        }
 
+        protected override IEnumerable<(string Key, string Value)> GetImports()
+        {
+            return base.GetImports().Concat([("Database", database)]);
+        }
+    }
+
+    /// <summary>
+    /// Preset for the per-database integration workflows: one Ubuntu job per database, triggered by pull
+    /// requests, running nothing but a compile and the integration tests for that one database.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    internal sealed class DatabaseIntegrationGitHubActionsAttribute : DatabaseGitHubActionsAttribute
+    {
+        public DatabaseIntegrationGitHubActionsAttribute(string name, string database)
+            : base(name, database, GitHubActionsImage.UbuntuLatest)
+        {
             OnPullRequestBranches = ["main", "3.x"];
             OnPullRequestIncludePaths = ["**/*"];
             OnPullRequestExcludePaths = ["docs/**/*", "package.json", "package-lock.json", "readme.md"];
@@ -90,11 +115,6 @@ namespace Quartz.Build
             TimeoutMinutes = 10;
             ConcurrencyCancelInProgress = true;
             ReadPermissions = [GitHubActionsPermissions.Contents];
-        }
-
-        protected override IEnumerable<(string Key, string Value)> GetImports()
-        {
-            return base.GetImports().Concat([("Database", database)]);
         }
     }
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -118,27 +118,34 @@ partial class Build : FalloutBuild, ICompile, IPack
             );
         });
 
+    /// <summary>
+    /// Pairs each named test project with every target framework it declares, rather than forcing one
+    /// framework on all of them. <c>dotnet test --framework X</c> against a project that does not target
+    /// X exits 0 having run nothing, so a pinned framework quietly becomes "no tests ran" the moment a
+    /// project moves — which is how the non-Windows legs ran no unit tests at all once everything moved
+    /// to net10.0. net4x needs the .NET Framework runtime, so it is the one framework that cannot run
+    /// off Windows.
+    /// </summary>
+    (Project Project, string Framework)[] GetTestRuns(params string[] projectNames)
+    {
+        var solution = ((IHasSolution) this).Solution;
+
+        return projectNames
+            .Select(x => solution.GetAllProjects(x).First())
+            .SelectMany(project => project.GetTargetFrameworks()
+                .Where(framework => IsRunningOnWindows || !framework.StartsWith("net4", StringComparison.Ordinal))
+                .Select(framework => (Project: project, Framework: framework)))
+            .OrderBy(x => x.Project.Name).ThenBy(x => x.Framework)
+            .ToArray();
+    }
+
     Target UnitTest => _ => _
         .DependsOn<ICompile>()
         .Before<IPack>()
         .Executes(() =>
         {
-            var solution = ((IHasSolution) this).Solution;
             var configuration = ((ICompile) this).Configuration;
-            var testProjects = new[] { "Quartz.Tests.Unit", "Quartz.Tests.AspNetCore" };
-
-            // Run each project once per target framework it declares, rather than forcing one
-            // framework on all of them. `dotnet test --framework X` against a project that does not
-            // target X exits 0 having run nothing, so the hardcoded net8.0 meant the non-Windows
-            // legs ran no unit tests at all once everything moved to net10.0. net4x needs the .NET
-            // Framework runtime, so it is the one framework that cannot run off Windows.
-            var testRuns = testProjects
-                .Select(x => solution.GetAllProjects(x).First())
-                .SelectMany(project => project.GetTargetFrameworks()
-                    .Where(framework => IsRunningOnWindows || !framework.StartsWith("net4", StringComparison.Ordinal))
-                    .Select(framework => (Project: project, Framework: framework)))
-                .OrderBy(x => x.Project.Name).ThenBy(x => x.Framework)
-                .ToArray();
+            var testRuns = GetTestRuns("Quartz.Tests.Unit", "Quartz.Tests.AspNetCore");
 
             foreach (var (project, framework) in testRuns)
             {
@@ -149,6 +156,9 @@ partial class Build : FalloutBuild, ICompile, IPack
                 .EnableNoRestore()
                 .EnableNoBuild()
                 .SetConfiguration(configuration)
+                // 'fragile' tests write into the application directory, so they collide with anything
+                // else running from it. They stay out until they are rewritten against a temp directory.
+                .SetFilter("TestCategory!=fragile")
                 .SetLoggers(GitHubActions.Instance is not null ? ["GitHubActions"] : [])
                 .CombineWith(testRuns, (_, run) => _
                     .SetProjectFile(run.Project)
@@ -184,15 +194,20 @@ partial class Build : FalloutBuild, ICompile, IPack
 
             var filter = GetTestFilter(database);
 
-            var solution = ((IHasSolution) this).Solution;
             var configuration = ((ICompile) this).Configuration;
-            var integrationTestProjects = new[] { "Quartz.Tests.Integration" };
+            var testRuns = GetTestRuns("Quartz.Tests.Integration");
+
+            foreach (var (project, framework) in testRuns)
+            {
+                Log.Information("Integration tests against {Database}: {Project} ({Framework})",
+                    database ?? "all", project.Name, framework);
+            }
+
             DotNetTest(s =>
             {
                 s = s.EnableNoRestore()
                     .EnableNoBuild()
                     .SetConfiguration(configuration)
-                    .SetFramework("net8.0")
                     .SetLoggers("GitHubActions");
 
                 if (!string.IsNullOrEmpty(filter))
@@ -200,8 +215,9 @@ partial class Build : FalloutBuild, ICompile, IPack
                     s = s.SetFilter(filter);
                 }
 
-                return s.CombineWith(integrationTestProjects, (_, testProject) => _
-                    .SetProjectFile(solution.GetAllProjects(testProject).First())
+                return s.CombineWith(testRuns, (_, run) => _
+                    .SetProjectFile(run.Project)
+                    .SetFramework(run.Framework)
                 );
             });
         });


### PR DESCRIPTION
Three small CI/test-infra corrections:

- **IntegrationTest ran `--framework net8.0` against a project that moved to net10.0 in #3164.** Today the test host warns about the mismatch and still runs the net10 DLL, but this is the same silent-no-op failure class that #3229 fixed for unit tests. The per-TFM enumeration UnitTest uses is extracted into a shared `GetTestRuns` helper and IntegrationTest now runs each declared framework.
- **The push workflow ran integration tests with `Database` unset**, which means `QUARTZ_TEST_DATABASE=all` — six database containers inside a ten-minute job. The generated `build.yml` now sets `Database: basic` (the container-free leg); per-database coverage already comes from the PR workflows. Change made in the Fallout generation attributes (a new `DatabaseGitHubActions` base attribute carries the env injection; the PR-preset attribute derives from it), and only `build.yml` regenerated — the eight `pr-*.yml` files are byte-identical.
- **The one `fragile` test** (writes files into the app directory) is now excluded from UnitTest via `TestCategory!=fragile` until it is rewritten against a temp directory. `windowstimezoneid` tests are deliberately untouched — they self-gate with `Assume` premises and carry real cross-platform DST coverage.

Verified: `build.cmd Compile UnitTest` green with the filter visible on every per-TFM run; suite went 2326 → 2325 tests and the delta was proven to be exactly the fragile test; regeneration is idempotent (`Compile` after produces no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)