### PR TITLE
Publish-after-populate, honest clocks, and cheaper idle jitter

### DIFF
--- a/src/Quartz.Tests.Unit/Core/QuartzRandomTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzRandomTest.cs
@@ -8,42 +8,72 @@ public class QuartzRandomTest
     [Test]
     public void TestNextValidatesPositiveRange()
     {
-        var result = QuartzRandom.Next(2, 6);
+        int result = QuartzRandom.Next(2, 6);
 
-        Assert.That(result, Is.GreaterThanOrEqualTo(2));
-        Assert.That(result, Is.LessThanOrEqualTo(6));
+        result.Should().BeGreaterThanOrEqualTo(2).And.BeLessThan(6,
+            "the upper bound is exclusive");
     }
 
     [Test]
     public void TestNextValidatesNegativeRange()
     {
-        var result = QuartzRandom.Next(-6, -2);
+        int result = QuartzRandom.Next(-6, -2);
 
-        Assert.That(result, Is.GreaterThanOrEqualTo(-6));
-        Assert.That(result, Is.LessThanOrEqualTo(-2));
+        result.Should().BeGreaterThanOrEqualTo(-6).And.BeLessThan(-2,
+            "the upper bound is exclusive");
     }
 
     [Test]
     public void TestNextValidatesPositiveNegativeRange()
     {
-        var result = QuartzRandom.Next(-6, 6);
+        int result = QuartzRandom.Next(-6, 6);
 
-        Assert.That(result, Is.GreaterThanOrEqualTo(-6));
-        Assert.That(result, Is.LessThanOrEqualTo(6));
+        result.Should().BeGreaterThanOrEqualTo(-6).And.BeLessThan(6,
+            "the upper bound is exclusive");
     }
 
     [Test]
     public void TestNextDoesntIntegerOverflow()
     {
-        var result = QuartzRandom.Next(-1, int.MaxValue);
+        int result = QuartzRandom.Next(-1, int.MaxValue);
 
-        Assert.That(result, Is.GreaterThanOrEqualTo(-1));
-        Assert.That(result, Is.LessThanOrEqualTo(int.MaxValue));
+        result.Should().BeGreaterThanOrEqualTo(-1).And.BeLessThan(int.MaxValue,
+            "a range that spans almost the whole int domain must still be handled without overflow");
+    }
+
+    [Test]
+    public void TestNextNeverReturnsTheExclusiveUpperBound()
+    {
+        // A single-value range is the deterministic way to observe exclusivity: the only value the
+        // generator may return is the lower bound, no matter how many times it is asked.
+        for (int i = 0; i < 1000; i++)
+        {
+            QuartzRandom.Next(0, 1).Should().Be(0, "maxValue is exclusive, so only minValue can be drawn");
+        }
+    }
+
+    [Test]
+    public void TestNextSingleArgumentIsBoundedByMaxValue()
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            QuartzRandom.Next(4).Should().BeInRange(0, 3, "the single-argument overload draws from [0, maxValue)");
+        }
     }
 
     [Test]
     public void TestMinimumGreaterThanMaximum()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => QuartzRandom.Next(3, 2));
+        Action act = () => QuartzRandom.Next(3, 2);
+
+        act.Should().Throw<ArgumentOutOfRangeException>("maxValue must be larger than minValue");
+    }
+
+    [Test]
+    public void TestMinimumEqualToMaximum()
+    {
+        Action act = () => QuartzRandom.Next(2, 2);
+
+        act.Should().Throw<ArgumentOutOfRangeException>("an empty range has no value to return");
     }
 }

--- a/src/Quartz.Tests.Unit/JobExecutionContextTest.cs
+++ b/src/Quartz.Tests.Unit/JobExecutionContextTest.cs
@@ -17,7 +17,10 @@
  */
 #endregion
 
+using Quartz.Extensibility;
 using Quartz.Impl;
+using Quartz.Impl.Triggers;
+using Quartz.Jobs;
 
 namespace Quartz.Tests.Unit;
 
@@ -48,5 +51,42 @@ public class JobExecutionContextTest
             Assert.That(recoveringTriggerKey.Name, Is.EqualTo("originalTriggerName"));
             Assert.That(recoveringTriggerKey.Group, Is.EqualTo("originalTriggerGroup"));
         });
+    }
+
+    [Test]
+    public void MergedJobDataMapIsFullyPopulatedAndBuiltOnce()
+    {
+        IJobDetail jobDetail = JobBuilder.Create<NoOpJob>()
+            .WithIdentity(new JobKey("jobName", "jobGroup"))
+            .UsingJobData("jobOnly", "jobValue")
+            .UsingJobData("shared", "fromJob")
+            .Build();
+
+        IOperableTrigger trigger = new SimpleTriggerImpl("triggerName", "triggerGroup");
+        trigger.JobDataMap["triggerOnly"] = "triggerValue";
+        trigger.JobDataMap["shared"] = "fromTrigger";
+
+        TriggerFiredBundle bundle = new TriggerFiredBundle
+        {
+            JobDetail = jobDetail,
+            Trigger = trigger,
+            Recovering = false,
+            FireTimeUtc = DateTimeOffset.UtcNow,
+            ScheduledFireTimeUtc = null,
+            PreviousFireTimeUtc = null,
+            NextFireTimeUtc = null,
+        };
+
+        IJobExecutionContext ctx = new JobExecutionContextImpl(null, bundle, null);
+
+        JobDataMap merged = ctx.MergedJobDataMap;
+
+        merged.Count.Should().Be(3, "the merged map holds the union of the job's and the trigger's keys");
+        merged.GetString("jobOnly").Should().Be("jobValue");
+        merged.GetString("triggerOnly").Should().Be("triggerValue");
+        merged.GetString("shared").Should().Be("fromTrigger", "the trigger's value overrides the job's");
+
+        ctx.MergedJobDataMap.Should().BeSameAs(merged,
+            "the map is merged once and then published, so every later read sees that same fully built instance");
     }
 }

--- a/src/Quartz/Core/QuartzRandom.cs
+++ b/src/Quartz/Core/QuartzRandom.cs
@@ -4,19 +4,11 @@ namespace Quartz.Core;
 
 internal static class QuartzRandom
 {
-    private static double NextDouble()
-    {
-        using RandomNumberGenerator random = RandomNumberGenerator.Create();
-        Span<byte> buf = stackalloc byte[4];
-        random.GetBytes(buf);
-        return (double) BitConverter.ToUInt32(buf) / uint.MaxValue;
-    }
-
     /// <summary>
     /// Random number generator
     /// </summary>
     /// <param name="maxValue"></param>
-    /// <returns>int between 0 and maxValue</returns>
+    /// <returns>int between 0 (inclusive) and maxValue (exclusive)</returns>
     public static int Next(int maxValue)
     {
         return Next(0, maxValue);
@@ -36,7 +28,7 @@ internal static class QuartzRandom
     /// </summary>
     /// <param name="minValue"></param>
     /// <param name="maxValue"></param>
-    /// <returns>integer between minValue and maxValue</returns>
+    /// <returns>integer between minValue (inclusive) and maxValue (exclusive)</returns>
     public static int Next(int minValue, int maxValue)
     {
         if (maxValue <= minValue)
@@ -44,7 +36,8 @@ internal static class QuartzRandom
             Throw.ArgumentOutOfRangeException(nameof(maxValue), "maxValue must be larger then minValue");
         }
 
-        long range = (long) maxValue - minValue;
-        return (int) Math.Floor(NextDouble() * range) + minValue;
+        // Rejection-sampled by the framework, so the distribution is uniform and the upper bound is
+        // genuinely exclusive. It also draws from a shared generator rather than creating one per call.
+        return RandomNumberGenerator.GetInt32(minValue, maxValue);
     }
 }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -53,6 +53,12 @@ internal sealed class QuartzScheduler
     internal readonly QuartzSchedulerThread schedThread = null!;
     private readonly List<ISchedulerListener> internalSchedulerListeners = new List<ISchedulerListener>(10);
 
+    /// <summary>
+    /// Guards <see cref="internalSchedulerListeners" />. A dedicated lock rather than the list itself, so
+    /// that what is synchronized on is an object nothing outside this class can reach.
+    /// </summary>
+    private readonly Lock internalSchedulerListenersLock = new();
+
     private IJobFactory jobFactory = new PropertySettingJobFactory();
     private readonly ExecutingJobsManager jobMgr;
     private readonly List<object> holdToPreventGc = new List<object>(5);
@@ -180,7 +186,7 @@ internal sealed class QuartzScheduler
     /// <param name="schedulerListener"></param>
     public void AddInternalSchedulerListener(ISchedulerListener schedulerListener)
     {
-        lock (internalSchedulerListeners)
+        lock (internalSchedulerListenersLock)
         {
             internalSchedulerListeners.Add(schedulerListener);
         }
@@ -194,7 +200,7 @@ internal sealed class QuartzScheduler
     /// <returns>true if the identified listener was found in the list, and removed.</returns>
     public bool RemoveInternalSchedulerListener(ISchedulerListener schedulerListener)
     {
-        lock (internalSchedulerListeners)
+        lock (internalSchedulerListenersLock)
         {
             return internalSchedulerListeners.Remove(schedulerListener);
         }
@@ -208,7 +214,7 @@ internal sealed class QuartzScheduler
     {
         get
         {
-            lock (internalSchedulerListeners)
+            lock (internalSchedulerListenersLock)
             {
                 return new List<ISchedulerListener>(internalSchedulerListeners);
             }

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -303,7 +303,7 @@ internal sealed class QuartzSchedulerThread
                         // Cancellable so that shutdown does not stall for the remainder of the
                         // back-off; the catch swallows the OperationCanceledException and the
                         // halted/cancellation checks right below exit the loop.
-                        await Task.Delay(delay, cancellationTokenSource.Token).ConfigureAwait(false);
+                        await Task.Delay(delay, qsRsrcs.TimeProvider, cancellationTokenSource.Token).ConfigureAwait(false);
                     }
                     catch
                     {
@@ -423,35 +423,7 @@ internal sealed class QuartzSchedulerThread
                             continue;
                         }
 
-                        // set triggers to 'executing'
-                        List<TriggerFiredResult> bndles = new List<TriggerFiredResult>();
-
-                        bool goAhead = !halted;
-
-                        if (goAhead)
-                        {
-                            try
-                            {
-                                var res = await qsRsrcs.JobStore.TriggersFired(triggers, CancellationToken.None).ConfigureAwait(false);
-                                if (res is not null)
-                                {
-                                    bndles = res.ToList();
-                                }
-                            }
-                            catch (SchedulerException se)
-                            {
-                                var msg = "An error occurred while firing triggers '" + triggers + "'";
-                                await qs.NotifySchedulerListenersError(msg, se, CancellationToken.None).ConfigureAwait(false);
-                                // QTZ-179 : a problem occurred interacting with the triggers from the db
-                                // we release them and loop again
-                                foreach (IOperableTrigger t in triggers)
-                                {
-                                    await SafeReleaseAcquiredTrigger(t, "after TriggersFired failure").ConfigureAwait(false);
-                                }
-                                continue;
-                            }
-                        }
-                        else
+                        if (halted)
                         {
                             // Scheduler is shutting down - release acquired triggers
                             // so they don't remain stuck in ACQUIRED state
@@ -462,9 +434,30 @@ internal sealed class QuartzSchedulerThread
                             continue;
                         }
 
-                        for (int i = 0; i < bndles.Count; i++)
+                        // set triggers to 'executing'
+                        List<TriggerFiredResult> bundles;
+                        try
                         {
-                            TriggerFiredResult result = bndles[i];
+                            // The store hands back a list it built for this call and does not keep it,
+                            // and nothing below mutates it, so it is read as-is rather than copied.
+                            bundles = await qsRsrcs.JobStore.TriggersFired(triggers, CancellationToken.None).ConfigureAwait(false);
+                        }
+                        catch (SchedulerException se)
+                        {
+                            var msg = "An error occurred while firing triggers '" + string.Join(", ", triggers.Select(t => t.Key)) + "'";
+                            await qs.NotifySchedulerListenersError(msg, se, CancellationToken.None).ConfigureAwait(false);
+                            // QTZ-179 : a problem occurred interacting with the triggers from the db
+                            // we release them and loop again
+                            foreach (IOperableTrigger t in triggers)
+                            {
+                                await SafeReleaseAcquiredTrigger(t, "after TriggersFired failure").ConfigureAwait(false);
+                            }
+                            continue;
+                        }
+
+                        for (int i = 0; i < bundles.Count; i++)
+                        {
+                            TriggerFiredResult result = bundles[i];
                             var bndle = result.TriggerFiredBundle;
                             var exception = result.Exception;
 

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -4155,7 +4155,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
 
             // Delay before the next attempt
-            await Task.Delay(TransientRetryInterval, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(TransientRetryInterval, timeProvider, cancellationToken).ConfigureAwait(false);
         }
 
         Throw.InvalidOperationException("DoCheckin retry loop exited unexpectedly");
@@ -4923,7 +4923,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
 
             // retry every N seconds (the db connection must be failed)
-            await Task.Delay(DbRetryInterval, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(DbRetryInterval, timeProvider, cancellationToken).ConfigureAwait(false);
         }
 
         Throw.InvalidOperationException("JobStore is shutdown - aborting retry");
@@ -5089,7 +5089,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
 
             // Delay before the next attempt
-            await Task.Delay(TransientRetryInterval, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(TransientRetryInterval, timeProvider, cancellationToken).ConfigureAwait(false);
         }
 
         Throw.InvalidOperationException("ExecuteInLocalTransactionLock retry loop exited unexpectedly");

--- a/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
+++ b/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
@@ -54,7 +54,9 @@ internal sealed class ClusterManager
         // 2. If the task was never scheduled, no amount of waiting will help
         try
         {
-            await task.WaitAsync(ShutdownTimeout, jobStoreSupport.timeProvider).ConfigureAwait(false);
+            // CancellationToken.None deliberately: the loop's own token is already cancelled at this
+            // point, and passing it would abort the graceful wait we are here for.
+            await task.WaitAsync(ShutdownTimeout, jobStoreSupport.timeProvider, CancellationToken.None).ConfigureAwait(false);
         }
         catch (TimeoutException)
         {

--- a/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
+++ b/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
@@ -43,9 +43,9 @@ internal sealed class ClusterManager
     public async Task Shutdown()
     {
         cancellationTokenSource.Cancel();
-        
+
         taskScheduler.Dispose();
-        
+
         // Wait for the task to complete, but with a timeout to handle the race condition where
         // the scheduler was disposed before it could schedule the task.
         // In that scenario, the task will remain in WaitingForActivation indefinitely.
@@ -54,18 +54,11 @@ internal sealed class ClusterManager
         // 2. If the task was never scheduled, no amount of waiting will help
         try
         {
-            using CancellationTokenSource timeoutCts = new CancellationTokenSource();
-            var timeoutTask = Task.Delay(ShutdownTimeout, timeoutCts.Token);
-            var completedTask = await Task.WhenAny(task, timeoutTask).ConfigureAwait(false);
-            
-            if (completedTask == task)
-            {
-                // Task completed normally, cancel the timeout timer to free resources
-                await timeoutCts.CancelAsync().ConfigureAwait(false);
-                // Await the task to propagate any exceptions
-                await task.ConfigureAwait(false);
-            }
-            // else: Task didn't complete within timeout, it was likely never scheduled
+            await task.WaitAsync(ShutdownTimeout, jobStoreSupport.timeProvider).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // The task didn't complete within the timeout, it was likely never scheduled
         }
         catch (OperationCanceledException)
         {
@@ -106,7 +99,7 @@ internal sealed class ClusterManager
                 jobStoreSupport.DbRetryInterval,
                 numFails);
 
-            await Task.Delay(timeToSleep, token).ConfigureAwait(false);
+            await Task.Delay(timeToSleep, jobStoreSupport.timeProvider, token).ConfigureAwait(false);
 
             token.ThrowIfCancellationRequested();
 

--- a/src/Quartz/Impl/AdoJobStore/MisfireHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/MisfireHandler.cs
@@ -62,7 +62,7 @@ internal sealed class MisfireHandler
                 jobStoreSupport.DbRetryInterval,
                 numFails);
 
-            await Task.Delay(timeToSleep, token).ConfigureAwait(false);
+            await Task.Delay(timeToSleep, jobStoreSupport.timeProvider, token).ConfigureAwait(false);
         }
     }
 
@@ -113,9 +113,9 @@ internal sealed class MisfireHandler
     public async ValueTask Shutdown()
     {
         cancellationTokenSource.Cancel();
-        
+
         taskScheduler.Dispose();
-        
+
         // Wait for the task to complete, but with a timeout to handle the race condition where
         // the scheduler was disposed before it could schedule the task.
         // In that scenario, the task will remain in WaitingForActivation indefinitely.
@@ -124,18 +124,11 @@ internal sealed class MisfireHandler
         // 2. If the task was never scheduled, no amount of waiting will help
         try
         {
-            using CancellationTokenSource timeoutCts = new CancellationTokenSource();
-            var timeoutTask = Task.Delay(ShutdownTimeout, timeoutCts.Token);
-            var completedTask = await Task.WhenAny(task, timeoutTask).ConfigureAwait(false);
-            
-            if (completedTask == task)
-            {
-                // Task completed normally, cancel the timeout timer to free resources
-                await timeoutCts.CancelAsync().ConfigureAwait(false);
-                // Await the task to propagate any exceptions
-                await task.ConfigureAwait(false);
-            }
-            // else: Task didn't complete within timeout, it was likely never scheduled
+            await task.WaitAsync(ShutdownTimeout, jobStoreSupport.timeProvider).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // The task didn't complete within the timeout, it was likely never scheduled
         }
         catch (OperationCanceledException)
         {

--- a/src/Quartz/Impl/AdoJobStore/MisfireHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/MisfireHandler.cs
@@ -124,7 +124,9 @@ internal sealed class MisfireHandler
         // 2. If the task was never scheduled, no amount of waiting will help
         try
         {
-            await task.WaitAsync(ShutdownTimeout, jobStoreSupport.timeProvider).ConfigureAwait(false);
+            // CancellationToken.None deliberately: the loop's own token is already cancelled at this
+            // point, and passing it would abort the graceful wait we are here for.
+            await task.WaitAsync(ShutdownTimeout, jobStoreSupport.timeProvider, CancellationToken.None).ConfigureAwait(false);
         }
         catch (TimeoutException)
         {

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -71,13 +71,22 @@ public sealed class JobExecutionContextImpl : IInterruptableJobExecutionContext,
 {
     private readonly ITrigger trigger;
     private readonly IJobDetail jobDetail;
-    private JobDataMap? jobDataMap;
+
+    /// <summary>
+    /// The merged map, published only once it is fully populated. Volatile because the fast path in
+    /// <see cref="MergedJobDataMap" /> reads it without taking <see cref="lazyInitLock" />.
+    /// </summary>
+    private volatile JobDataMap? jobDataMap;
+
     private readonly IScheduler scheduler;
 
     private int numRefires;
     private TimeSpan? jobRunTime;
 
-    private CancellationTokenSource? cancellationTokenSource;
+    /// <summary>
+    /// Volatile for the same reason as <see cref="jobDataMap" />: the fast path reads it outside the lock.
+    /// </summary>
+    private volatile CancellationTokenSource? cancellationTokenSource;
 
     internal readonly IJob jobInstance;
 
@@ -171,26 +180,36 @@ public sealed class JobExecutionContextImpl : IInterruptableJobExecutionContext,
     {
         get
         {
-            if (jobDataMap is null)
+            JobDataMap? current = jobDataMap;
+            if (current is not null)
             {
-                lock (lazyInitLock)
-                {
-                    if (jobDataMap is null)
-                    {
-                        jobDataMap = new JobDataMap(jobDetail.JobDataMap.Count + trigger.JobDataMap.Count);
-                        foreach (var pair in jobDetail.JobDataMap)
-                        {
-                            jobDataMap[pair.Key] = pair.Value;
-                        }
-                        foreach (var pair in trigger.JobDataMap)
-                        {
-                            jobDataMap[pair.Key] = pair.Value;
-                        }
-                    }
-                }
+                return current;
             }
 
-            return jobDataMap;
+            lock (lazyInitLock)
+            {
+                current = jobDataMap;
+                if (current is not null)
+                {
+                    return current;
+                }
+
+                // Merge into a local and publish the reference only once it is fully populated: the
+                // fast path above reads the field without the lock, so a reference stored first and
+                // filled afterwards would let a racing reader see a half-built map.
+                JobDataMap merged = new JobDataMap(jobDetail.JobDataMap.Count + trigger.JobDataMap.Count);
+                foreach (var pair in jobDetail.JobDataMap)
+                {
+                    merged[pair.Key] = pair.Value;
+                }
+                foreach (var pair in trigger.JobDataMap)
+                {
+                    merged[pair.Key] = pair.Value;
+                }
+
+                jobDataMap = merged;
+                return merged;
+            }
         }
     }
 
@@ -324,18 +343,16 @@ public sealed class JobExecutionContextImpl : IInterruptableJobExecutionContext,
     {
         get
         {
-            if (cancellationTokenSource is null)
+            CancellationTokenSource? current = cancellationTokenSource;
+            if (current is not null)
             {
-                lock (lazyInitLock)
-                {
-                    if (cancellationTokenSource is null)
-                    {
-                        cancellationTokenSource = new CancellationTokenSource();
-                    }
-                }
+                return current;
             }
 
-            return cancellationTokenSource;
+            lock (lazyInitLock)
+            {
+                return cancellationTokenSource ??= new CancellationTokenSource();
+            }
         }
     }
 

--- a/src/Quartz/Impl/TaskSchedulingThreadPool.cs
+++ b/src/Quartz/Impl/TaskSchedulingThreadPool.cs
@@ -21,6 +21,12 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
     private readonly CancellationTokenSource shutdownCancellation = new CancellationTokenSource();
 
     /// <summary>
+    /// Guards <see cref="runningTasksCountdown" />. A lock of its own, because the countdown itself is
+    /// replaced by <see cref="Initialize" /> and is a BCL type others could lock on.
+    /// </summary>
+    private readonly Lock runningTasksLock = new();
+
+    /// <summary>
     /// Allows us to wait until no running tasks remain.
     /// </summary>
     private CountdownEvent runningTasksCountdown = null!;
@@ -131,8 +137,13 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
         // Initialize the concurrency semaphore with the proper initial count
         concurrencySemaphore = new SemaphoreSlim(MaxConcurrency);
 
-        // We start with an initial count of one to make sure it doesn't start in "signaled" state
-        runningTasksCountdown = new CountdownEvent(1);
+        // We start with an initial count of one to make sure it doesn't start in "signaled" state.
+        // Assigned under the lock that guards it, so that a caller already inside TryRun cannot add a
+        // count to the countdown this replaces.
+        lock (runningTasksLock)
+        {
+            runningTasksCountdown = new CountdownEvent(1);
+        }
 
         // Reduce allocations by caching the delegate to mark a task as complete
         completeTask = SignalTaskComplete;
@@ -225,7 +236,7 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
         // Unrap the task so that we can work with the underlying task
         var unwrappedTask = task.Unwrap();
 
-        lock (runningTasksCountdown)
+        lock (runningTasksLock)
         {
             // Now that the lock is held, shutdown can't proceed,
             // so double-check that no shutdown has started since the initial check.
@@ -306,7 +317,7 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
         // If waitForJobsToComplete is true, wait for running tasks to complete
         if (waitForJobsToComplete)
         {
-            lock (runningTasksCountdown)
+            lock (runningTasksLock)
             {
                 // Cancellation has been signaled, so no new tasks will begin once
                 // shutdown has acquired this lock. CurrentCount includes the +1 guard


### PR DESCRIPTION
Six internal fixes from the .NET 10-native audit; the public API baseline is untouched.

- **`JobExecutionContextImpl.MergedJobDataMap` had a broken double-checked lock**: the map reference was published before the merge loops filled it, so a racing reader on the lock-free fast path could observe an empty or half-merged map. It now merges into a local and publishes only the finished map; both lazily-created fields are `volatile` with the fast path reading a local.
- **Background loops now sleep on the clock they compute with.** `MisfireHandler`, `ClusterManager`, three `AdoJobStoreBase` retry waits and the scheduler thread's error back-off computed durations from the configured `TimeProvider` and then slept on the system clock; they now use `Task.Delay(delay, timeProvider, ct)` (the pattern `QuartzScheduler` already used). This also makes the misfire/cluster loops drivable by `FakeTimeProvider` in tests. The two semaphore retry delays are deliberately left: neither type holds a `TimeProvider`, and plumbing one through the public `SemaphoreContext` record is a separate API decision.
- **The 15-line `WhenAny`+CTS shutdown dance** in `MisfireHandler`/`ClusterManager` collapses to `task.WaitAsync(timeout, timeProvider)`; the silent-on-timeout behavior is preserved exactly.
- **`QuartzRandom` built and disposed a full CSPRNG on every idle iteration of the scheduling loop**, and its bound math returned the exclusive upper bound once per ~4 billion draws. Now `RandomNumberGenerator.GetInt32`. Tests tightened to pin the exclusive bound.
- **Firing-failure diagnostics**: the `TriggersFired` error message concatenated the `List<>` itself (printing the type name); it now joins the trigger keys. The same block dropped a dead list allocation and a redundant `ToList()` per batch — both in-box stores hand back a fresh list and the loop only reads it (comment records this).
- **Two locks stop locking objects they don't own**: `TaskSchedulingThreadPool` locked a reassignable `CountdownEvent` field (the `Initialize` reassignment now happens under the new dedicated `Lock` too), and `QuartzScheduler` locked the listener list it hands copies of.

Verified with `build.cmd Compile UnitTest PublishAot` (2327 + 216 green) and PublicApiTest producing no baseline diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)