### PR TITLE
JsonSerializerOptions are borrowed, not owned

### DIFF
--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/QuartzJsonOptionsSetup.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/QuartzJsonOptionsSetup.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
+
+using Quartz.Serialization.SystemTextJson;
+
+namespace Quartz.AspNetCore.HttpApi;
+
+/// <summary>
+/// Teaches the application's HTTP JSON options about Quartz's triggers, calendars and keys.
+/// </summary>
+/// <remarks>
+/// A type rather than a lambda so that registering it is idempotent: the options are the whole
+/// container's, and every <c>AddQuartzHttpApi</c> call wants the same converters on them.
+/// </remarks>
+internal sealed class QuartzJsonOptionsSetup : IConfigureOptions<JsonOptions>
+{
+    private readonly SystemTextJsonSerializerRegistry serializerRegistry;
+
+    public QuartzJsonOptionsSetup(SystemTextJsonSerializerRegistry serializerRegistry)
+    {
+        this.serializerRegistry = serializerRegistry;
+    }
+
+    public void Configure(JsonOptions options)
+    {
+        options.SerializerOptions?.AddQuartzConverters(serializerRegistry, newtonsoftCompatibilityMode: false);
+    }
+}

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/EndpointHelper.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/EndpointHelper.cs
@@ -8,7 +8,12 @@ namespace Quartz.AspNetCore.HttpApi.Util;
 
 internal sealed class EndpointHelper
 {
-    public static IResult JsonResponse(object data) => Results.Json(data);
+    /// <summary>
+    /// The one place the API turns a response into JSON. Generic because every caller already has the
+    /// static type in hand: erasing it to <see cref="object" /> binds the overload that has to rediscover
+    /// the type at runtime, where this one carries it through to the serializer.
+    /// </summary>
+    public static IResult JsonResponse<T>(T data) where T : notnull => Results.Json(data);
 
     public static GroupMatcher<T> GetGroupMatcher<T>(string? groupContains, string? groupEndsWith, string? groupStartsWith, string? groupEquals) where T : Key<T>
     {

--- a/src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs
+++ b/src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs
@@ -114,17 +114,14 @@ public static class QuartzAspNetCoreConfigurationExtensions
         // custom trigger or calendar serializer there to have the API understand it.
         builder.Services.TryAddSingleton<SystemTextJsonSerializerRegistry>();
 
-        // Add json converters into ASP.NET Core's default json options
-        builder.Services
-            .AddOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>()
-            .Configure<SystemTextJsonSerializerRegistry>(AddJsonConverters);
+        // Add json converters into ASP.NET Core's default json options. Those options belong to the whole
+        // container, not to this scheduler, so the setup is registered by type: calling AddQuartzHttpApi
+        // for a second scheduler must not stack the same converters onto them twice.
+        builder.Services.AddOptions();
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>, QuartzJsonOptionsSetup>());
 
         return builder;
-
-        static void AddJsonConverters(Microsoft.AspNetCore.Http.Json.JsonOptions options, SystemTextJsonSerializerRegistry registry)
-        {
-            options.SerializerOptions?.AddQuartzConverters(registry, newtonsoftCompatibilityMode: false);
-        }
     }
 
     /// <summary>

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -35,7 +35,10 @@ public sealed class HttpScheduler : IScheduler
 
     /// <param name="schedulerName">Name of the scheduler, must be same as the remote scheduler.</param>
     /// <param name="httpClient">The client to call the remote scheduler with.</param>
-    /// <param name="jsonSerializerOptions">Optional serializer options; Quartz's own converters are added to them.</param>
+    /// <param name="jsonSerializerOptions">
+    /// Optional serializer options. A copy is taken and Quartz's own converters are added to the copy,
+    /// so the instance passed in is left untouched.
+    /// </param>
     /// <param name="serializerRegistry">
     /// The trigger and calendar serializers to understand. Custom types are only readable over HTTP when
     /// their serializers are given here — the remote scheduler's own registrations are not visible in this
@@ -60,7 +63,13 @@ public sealed class HttpScheduler : IScheduler
             throw new ArgumentException("HttpClient's BaseAddress must end in /", nameof(httpClient));
         }
 
-        this.jsonSerializerOptions = jsonSerializerOptions ?? new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        // The caller's options are borrowed, not owned: adding our converters to their instance would
+        // throw once those options had been used for anything (they are read-only from then on), and
+        // would add the converters a second time when two clients share one instance.
+        this.jsonSerializerOptions = jsonSerializerOptions is null
+            ? new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            : new JsonSerializerOptions(jsonSerializerOptions);
+
         this.jsonSerializerOptions.AddQuartzConverters(
             serializerRegistry ?? new SystemTextJsonSerializerRegistry(),
             newtonsoftCompatibilityMode: false);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/QuartzHttpApiJsonOptionsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/QuartzHttpApiJsonOptionsTest.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// The HTTP API's converters go onto the container's JSON options, which every scheduler in it shares.
+/// </summary>
+public class QuartzHttpApiJsonOptionsTest
+{
+    [Test]
+    public void RegistrationTeachesTheContainerJsonOptionsAboutQuartzTypes()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("first", quartz => quartz.AddQuartzHttpApi());
+
+        QuartzConverterCount(services).Should().BeGreaterThan(0,
+            "the API cannot read a trigger or a calendar off the wire without Quartz's own converters");
+    }
+
+    [Test]
+    public void SecondRegistrationDoesNotAddTheSameConvertersAgain()
+    {
+        ServiceCollection one = new();
+        one.AddQuartz("first", quartz => quartz.AddQuartzHttpApi());
+
+        ServiceCollection two = new();
+        two.AddQuartz("first", quartz => quartz.AddQuartzHttpApi());
+        two.AddQuartz("second", quartz => quartz.AddQuartzHttpApi());
+
+        QuartzConverterCount(two).Should().Be(QuartzConverterCount(one),
+            "the JSON options belong to the container rather than to one scheduler, so serving a second scheduler over HTTP must not stack the same converters onto them twice");
+    }
+
+    private static int QuartzConverterCount(IServiceCollection services)
+    {
+        using ServiceProvider provider = services.BuildServiceProvider();
+        JsonOptions options = provider.GetRequiredService<IOptions<JsonOptions>>().Value;
+
+        return options.SerializerOptions.Converters.Count(converter => converter.GetType().Assembly == typeof(IScheduler).Assembly);
+    }
+}

--- a/src/Quartz.Tests.Unit/HttpApi/HttpSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/HttpApi/HttpSchedulerTest.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+namespace Quartz.Tests.Unit.HttpApi;
+
+/// <summary>
+/// The serializer options handed to the scheduler are borrowed, not owned.
+/// </summary>
+public class HttpSchedulerTest
+{
+    private HttpClient httpClient;
+
+    [SetUp]
+    public void SetUp()
+    {
+        httpClient = new HttpClient
+        {
+            BaseAddress = new Uri("http://localhost:8080")
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        httpClient?.Dispose();
+        httpClient = null;
+    }
+
+    [Test]
+    public void ShouldAcceptSerializerOptionsThatHaveAlreadyBeenUsed()
+    {
+        JsonSerializerOptions options = new(JsonSerializerDefaults.Web);
+
+        // Serializing with the options freezes them: anything writing to them from here on throws.
+        JsonSerializer.Serialize(42, options);
+        options.IsReadOnly.Should().BeTrue("the rest of this test is vacuous unless the options are frozen");
+
+        var act = () => new HttpScheduler("Scheduler", httpClient, options);
+
+        act.Should().NotThrow("the caller's options are copied before Quartz's converters go on");
+    }
+
+    [Test]
+    public void ShouldNotAddItsConvertersToTheSuppliedSerializerOptions()
+    {
+        JsonSerializerOptions options = new(JsonSerializerDefaults.Web);
+
+        _ = new HttpScheduler("Scheduler", httpClient, options);
+        _ = new HttpScheduler("SecondScheduler", httpClient, options);
+
+        options.Converters.Should().BeEmpty(
+            "the caller's options instance comes back untouched, so two clients sharing one cannot stack converters onto it");
+    }
+}


### PR DESCRIPTION
Three HTTP/serialization fixes from the .NET 10-native audit; all internal, public API baselines untouched in both locations.

- **`HttpScheduler` mutated the caller's `JsonSerializerOptions`**: adding Quartz's six converters to a supplied instance throws once those options have been used for anything (they freeze), and double-registers when two clients share one instance. It now takes a defensive copy (which preserves the caller's own converters). Two new unit tests pin this, including one that freezes the options first and asserts the guard isn't vacuous.
- **The server-side JsonOptions configurator stacked up once per `AddQuartzHttpApi` call** — two named schedulers double-added the converters to the container-wide options. The configure lambda captured nothing (its registry is a shared `TryAddSingleton`), so the honest fix is a typed `QuartzJsonOptionsSetup : IConfigureOptions<JsonOptions>` registered via `TryAddEnumerable`, which deduplicates by implementation type. New AspNetCore tests prove single registration of converters across two named-scheduler registrations — and were mutation-checked to fail against the unfixed code.
- **The HTTP API's one JSON sink stopped erasing to `object`**: `EndpointHelper.JsonResponse<T>` now binds the generic `Results.Json<TValue>` so the static type reaches the serializer (disassembly-verified). Honest note: both overloads carry the trim attributes, so this is a correctness-of-intent change, not a trim-warning delta.

Verified with `build.cmd Compile UnitTest PublishAot` (2325 + 218 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)