### PR TITLE
XmlSchedulingDataProcessorPluginTest works out of temp paths, fragile filter retired

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -156,9 +156,6 @@ partial class Build : FalloutBuild, ICompile, IPack
                 .EnableNoRestore()
                 .EnableNoBuild()
                 .SetConfiguration(configuration)
-                // 'fragile' tests write into the application directory, so they collide with anything
-                // else running from it. They stay out until they are rewritten against a temp directory.
-                .SetFilter("TestCategory!=fragile")
                 .SetLoggers(GitHubActions.Instance is not null ? ["GitHubActions"] : [])
                 .CombineWith(testRuns, (_, run) => _
                     .SetProjectFile(run.Project)

--- a/src/Quartz.Tests.Unit/Plugins/Xml/XmlSchedulingDataProcessorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/Xml/XmlSchedulingDataProcessorPluginTest.cs
@@ -10,53 +10,52 @@ public class XmlSchedulingDataProcessorPluginTest
     [Test]
     public async Task WhenFullPathFilesAreSeparatedByCommaSpaceThenPurgeSpaces()
     {
-        string fp1 = Path.GetTempFileName();
-        using (File.Create(fp1))
+        DirectoryInfo tempDir = Directory.CreateTempSubdirectory("quartz-xml-plugin-test-");
+        try
         {
+            string fp1 = Path.Combine(tempDir.FullName, "job-data-1.xml");
+            string fp2 = Path.Combine(tempDir.FullName, "job-data-2.xml");
+            File.WriteAllText(fp1, "");
+            File.WriteAllText(fp2, "");
+
+            var dataProcessor = new XmlSchedulingDataProcessorPlugin
+            {
+                FileNames = fp1 + ", " + fp2
+            };
+            var mockScheduler = A.Fake<IScheduler>();
+
+            await dataProcessor.Initialize("something", mockScheduler);
+
+            dataProcessor.JobFiles.Should().HaveCount(2);
+            dataProcessor.JobFiles.Select(x => x.Key).Should().Equal(fp1, fp2);
         }
-        string fp2 = Path.GetTempFileName();
-        using (File.Create(fp2))
+        finally
         {
+            tempDir.Delete(recursive: true);
         }
+    }
+
+    [Test]
+    public async Task WhenRelativePathFilesAreSeparatedByCommaSpaceThenPurgeSpaces()
+    {
+        // '~' always resolves against the application base directory, so the files must not be
+        // created there; FailOnFileNotFound = false lets initialization resolve missing files.
+        string configuredFileName1 = $"~/{Guid.NewGuid():N}.xml";
+        string configuredFileName2 = $"~/{Guid.NewGuid():N}.xml";
+        string expectedPathFile1 = FileUtil.ResolveFile(configuredFileName1);
+        string expectedPathFile2 = FileUtil.ResolveFile(configuredFileName2);
 
         var dataProcessor = new XmlSchedulingDataProcessorPlugin
         {
-            FileNames = fp1 + ", " + fp2
+            FileNames = configuredFileName1 + ", " + configuredFileName2,
+            FailOnFileNotFound = false
         };
         var mockScheduler = A.Fake<IScheduler>();
 
         await dataProcessor.Initialize("something", mockScheduler);
 
-        Assert.That(dataProcessor.JobFiles, Has.Count.EqualTo(2));
-        Assert.That(dataProcessor.JobFiles.Select(x => x.Key), Is.EqualTo(new[] { fp1, fp2 }));
-    }
-
-    [Test]
-    [Category("fragile")]
-    public async Task WhenRelativePathFilesAreSeparatedByCommaSpaceThenPurgeSpaces()
-    {
-        string configuredFileName1 = "~/File1.xml";
-        string expectedPathFile1 = FileUtil.ResolveFile(configuredFileName1);
-        if (!File.Exists(expectedPathFile1))
-        {
-            File.Create(expectedPathFile1).Close();
-        }
-
-        string configuredFileName2 = "~/File2.xml";
-        string expectedPathFile2 = FileUtil.ResolveFile(configuredFileName2);
-        if (!File.Exists(expectedPathFile2))
-        {
-            File.Create(expectedPathFile2).Close();
-        }
-
-        var dataProcessor = new XmlSchedulingDataProcessorPlugin();
-        dataProcessor.FileNames = configuredFileName1 + ", " + configuredFileName2;
-        var mockScheduler = A.Fake<IScheduler>();
-
-        await dataProcessor.Initialize("something", mockScheduler);
-
-        Assert.That(dataProcessor.JobFiles, Has.Count.EqualTo(2));
-        Assert.That(dataProcessor.JobFiles.Select(x => x.Key).ToArray(), Is.EqualTo(new[] { expectedPathFile1, expectedPathFile2 }));
+        dataProcessor.JobFiles.Should().HaveCount(2);
+        dataProcessor.JobFiles.Select(x => x.Key).Should().Equal(expectedPathFile1, expectedPathFile2);
     }
 
     [Test]


### PR DESCRIPTION
Fixes #3286.

The relative-path test created `File1.xml`/`File2.xml` in the application base directory and never deleted them, which is why it carried `Category("fragile")` and, since #3285, sat excluded from the UnitTest target.

The `~` prefix can only ever resolve against the app base directory (`FileUtil.ResolveFile` hard-wires `AppContext.BaseDirectory`), so a temp directory cannot satisfy it. Instead the test now creates **no files at all**: `FailOnFileNotFound = false` lets initialization resolve missing files while still recording the resolved path, and GUID-based names keep a stale leftover from an old run from ever satisfying the lookup.

The full-path test moves off `Path.GetTempFileName()`, which leaked two files per run, to a temp subdirectory deleted in `finally`.

With no fragile tests left anywhere, the build-side `TestCategory!=fragile` filter goes away and the tests rejoin CI. Verified with a full `build.cmd Compile UnitTest` run (2332 tests, unfiltered, green) and by checking that no files remain in the app directory or `%TEMP%` after the run.

A 3.x companion PR applies the same test rewrite there (3.x has no build filter; its copy still ran in CI and polluted the bin directory on every run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)