### PR TITLE
A blank calendar name is no calendar name (3.x)

### DIFF
--- a/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
@@ -89,10 +89,6 @@
                OnCancel="CancelUnscheduleAsync" />
 
 @code {
-    private static readonly JsonSerializerOptions requestSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
     private bool _isLoading = true;
     private string? _error;
     private object? _trigger;
@@ -236,7 +232,13 @@
             return;
         }
 
-        JsonElement newTrigger = BuildRescheduleTriggerPayload(cronExpression);
+        if (_trigger is not JsonElement triggerJson
+            || !TriggerPayloadBuilder.TryWithCronExpression(triggerJson, cronExpression, out JsonElement newTrigger))
+        {
+            Toasts.Error("This trigger cannot be rescheduled from the dashboard.");
+            return;
+        }
+
         RescheduleRequest request = new(newTrigger);
         _ = await ExecuteMutatingActionAsync(
             () => Api.RescheduleJob(schedulerName, Group, Name, request),
@@ -249,68 +251,6 @@
     {
         _editedCronExpression = _cronExpression ?? string.Empty;
         return Task.CompletedTask;
-    }
-
-    private JsonElement BuildRescheduleTriggerPayload(string cronExpression)
-    {
-        string jobName = DisplayValueHelper.GetString(_trigger, "JobKey.Name", "jobKey.name");
-        string jobGroup = DisplayValueHelper.GetString(_trigger, "JobKey.Group", "jobKey.group");
-        object? jobKey = string.IsNullOrWhiteSpace(jobName) || string.IsNullOrWhiteSpace(jobGroup)
-            ? null
-            : new { name = jobName, group = jobGroup };
-
-        string timeZone = DisplayValueHelper.GetString(_trigger, "TimeZone.Id", "timeZone.id", "TimeZone", "timeZone");
-        if (string.IsNullOrWhiteSpace(timeZone) || timeZone.StartsWith('{'))
-        {
-            timeZone = TimeZoneInfo.Utc.Id;
-        }
-
-        DateTimeOffset startTime = DisplayValueHelper.GetDateTimeOffset(_trigger, "StartTimeUtc", "startTimeUtc") ?? DateTimeOffset.UtcNow;
-        DateTimeOffset? endTime = DisplayValueHelper.GetDateTimeOffset(_trigger, "EndTimeUtc", "endTimeUtc");
-        int misfireInstruction = ParseIntOrDefault(_trigger, 0, "MisfireInstruction", "misfireInstruction");
-        int priority = ParseIntOrDefault(_trigger, 5, "Priority", "priority");
-        JsonElement jobDataMap = GetJobDataMapElement(_trigger);
-
-        object payload = new
-        {
-            triggerType = "CronTrigger",
-            key = new { name = Name, group = Group },
-            jobKey,
-            description = DisplayValueHelper.GetString(_trigger, "Description", "description"),
-            calendarName = DisplayValueHelper.GetString(_trigger, "CalendarName", "calendarName"),
-            jobDataMap,
-            misfireInstruction,
-            startTimeUtc = startTime,
-            endTimeUtc = endTime,
-            priority,
-            timeZone,
-            cronExpressionString = cronExpression,
-            executionGroup = DisplayValueHelper.GetString(_trigger, "ExecutionGroup", "executionGroup")
-        };
-
-        return JsonSerializer.SerializeToElement(payload, requestSerializerOptions);
-    }
-
-    private static int ParseIntOrDefault(object? source, int defaultValue, params string[] paths)
-    {
-        string value = DisplayValueHelper.GetString(source, paths);
-        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedValue))
-        {
-            return parsedValue;
-        }
-
-        return defaultValue;
-    }
-
-    private static JsonElement GetJobDataMapElement(object? source)
-    {
-        object? value = DisplayValueHelper.GetObject(source, "JobDataMap", "jobDataMap");
-        if (value is JsonElement element)
-        {
-            return element.Clone();
-        }
-
-        return JsonSerializer.SerializeToElement(new Dictionary<string, object?>(), requestSerializerOptions);
     }
 
     private void PromptUnschedule()

--- a/src/Quartz.Dashboard/Components/Shared/TriggerPayloadBuilder.cs
+++ b/src/Quartz.Dashboard/Components/Shared/TriggerPayloadBuilder.cs
@@ -1,0 +1,117 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Buffers;
+using System.Text.Json;
+
+namespace Quartz.Dashboard.Components.Shared;
+
+/// <summary>
+/// Builds the trigger payloads the dashboard posts back to the scheduler by editing the JSON the API
+/// returned, rather than re-assembling a trigger field by field.
+/// </summary>
+/// <remarks>
+/// Re-assembly silently dropped whatever it did not list. A null calendar name came back as an empty
+/// string, which every job store reads as a calendar it then cannot find, so the trigger stopped
+/// firing (#3294); the node pin was dropped altogether; and the trigger type was hardcoded, so a
+/// custom cron trigger was rewritten as a plain one. Editing the serialized trigger in place keeps
+/// every field the Quartz converters wrote, including ones added later.
+/// </remarks>
+internal static class TriggerPayloadBuilder
+{
+    private const string TriggerTypeProperty = "triggerType";
+    private const string CronExpressionProperty = "cronExpressionString";
+    private const string NextFireTimeProperty = "nextFireTimeUtc";
+
+    /// <summary>
+    /// Produces <paramref name="trigger"/> with its cron expression replaced by
+    /// <paramref name="cronExpression"/>, or <see langword="false"/> when the trigger cannot be sent
+    /// back to the scheduler at all.
+    /// </summary>
+    public static bool TryWithCronExpression(JsonElement trigger, string cronExpression, out JsonElement payload)
+    {
+        if (trigger.ValueKind != JsonValueKind.Object || !HasProperty(trigger, TriggerTypeProperty))
+        {
+            // A trigger type the Quartz converters do not know is serialized by the API client's
+            // reflection fallback, which omits the discriminator. Such a payload cannot be read
+            // back, so refuse it rather than post something that will not deserialize - or, as the
+            // hand-built payload did, quietly reschedule it as a different trigger type.
+            payload = default;
+            return false;
+        }
+
+        ArrayBufferWriter<byte> buffer = new();
+        using (Utf8JsonWriter writer = new(buffer))
+        {
+            writer.WriteStartObject();
+            bool cronWritten = false;
+            foreach (JsonProperty property in trigger.EnumerateObject())
+            {
+                if (Matches(property.Name, CronExpressionProperty))
+                {
+                    writer.WriteString(property.Name, cronExpression);
+                    cronWritten = true;
+                }
+                else if (Matches(property.Name, NextFireTimeProperty))
+                {
+                    // The schedule just changed, so the stored next fire time belongs to the old
+                    // expression, and RescheduleJob honours a non-null one verbatim. Clearing it
+                    // lets the first fire be computed from the expression the user just entered.
+                    writer.WriteNull(property.Name);
+                }
+                else
+                {
+                    property.WriteTo(writer);
+                }
+            }
+
+            if (!cronWritten)
+            {
+                writer.WriteString(CronExpressionProperty, cronExpression);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        using JsonDocument document = JsonDocument.Parse(buffer.WrittenMemory);
+        payload = document.RootElement.Clone();
+        return true;
+    }
+
+    private static bool HasProperty(JsonElement element, string name)
+    {
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (Matches(property.Name, name))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The serialized trigger is camelCased today, but the page reads it through
+    /// <see cref="DisplayValueHelper"/>, which tolerates either casing. This does the same so the
+    /// two cannot disagree about which trigger they are looking at.
+    /// </summary>
+    private static bool Matches(string propertyName, string name)
+        => string.Equals(propertyName, name, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -42,7 +42,8 @@ public class InProcessQuartzApiClientTest
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            // payload mirrors TriggerDetail.razor BuildRescheduleTriggerPayload
+            // a hand-written payload, to pin the shape the HTTP API accepts independently of
+            // whatever TriggerDetail.razor happens to send
             object payload = new
             {
                 triggerType = "CronTrigger",
@@ -69,6 +70,55 @@ public class InProcessQuartzApiClientTest
             cronTrigger.JobKey.Should().Be(jobKey);
             cronTrigger.Description.Should().Be("updated by dashboard");
             cronTrigger.ExecutionGroup.Should().Be("imports");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task RescheduleFromTriggerDetailPayloadChangesNothingButTheSchedule()
+    {
+        // regression test for #3294 - the detail page rebuilt the trigger from its display strings,
+        // so a trigger with no calendar came back with CALENDAR_NAME='', which every job store reads
+        // as a calendar it then cannot find. The trigger silently never fired again. The node pin
+        // was dropped outright, because the hand-written payload never listed it.
+        IScheduler scheduler = await CreateScheduler("RescheduleRoundTripTest");
+        try
+        {
+            JobKey jobKey = new("job1", "group1");
+            IJobDetail job = JobBuilder.Create<NoOpJob>()
+                .WithIdentity(jobKey)
+                .StoreDurably()
+                .Build();
+            TriggerKey triggerKey = new("trigger1", "group1");
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .WithCronSchedule("0 0 1 * * ?")
+                .WithPreferredNode("node-a")
+                .Build();
+            await scheduler.ScheduleJob(job, trigger);
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            // exactly what TriggerDetail.razor does: read the trigger, then edit its cron expression
+            TriggerDetailDto detail = await client.GetTrigger(scheduler.SchedulerName, triggerKey.Group, triggerKey.Name);
+            TriggerPayloadBuilder.TryWithCronExpression(detail.Value, "0 0 2 * * ?", out JsonElement newTrigger)
+                .Should().BeTrue();
+
+            await client.RescheduleJob(scheduler.SchedulerName, triggerKey.Group, triggerKey.Name, new RescheduleRequest(newTrigger));
+
+            ITrigger? updated = await scheduler.GetTrigger(triggerKey);
+            CronTriggerImpl cronTrigger = updated.Should().BeOfType<CronTriggerImpl>().Subject;
+            cronTrigger.CronExpressionString.Should().Be("0 0 2 * * ?");
+            cronTrigger.JobKey.Should().Be(jobKey);
+            cronTrigger.CalendarName.Should().BeNull(
+                "the trigger never had a calendar, and an empty name would name one that cannot be found");
+            cronTrigger.Description.Should().BeNull();
+            cronTrigger.PreferredNode.Should().Be("node-a", "editing a schedule must not unpin the trigger");
+            cronTrigger.GetNextFireTimeUtc().Should().NotBeNull("a rescheduled trigger has to keep firing");
         }
         finally
         {

--- a/src/Quartz.Tests.AspNetCore/Dashboard/TriggerPayloadBuilderTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/TriggerPayloadBuilderTest.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+
+using Quartz.Dashboard.Components.Shared;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+public class TriggerPayloadBuilderTest
+{
+    private static readonly JsonSerializerOptions serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// The shape the Quartz converters write and the dashboard's API client hands the detail page.
+    /// Every property is present; the unset ones are JSON null.
+    /// </summary>
+    private static JsonElement SerializedTrigger(object? description = null, object? calendarName = null)
+    {
+        return JsonSerializer.SerializeToElement(new
+        {
+            triggerType = "CronTrigger",
+            key = new { name = "trigger1", group = "group1" },
+            jobKey = new { name = "job1", group = "group1" },
+            description,
+            calendarName,
+            jobDataMap = new Dictionary<string, object?> { ["colour"] = "green" },
+            misfireInstruction = 0,
+            startTimeUtc = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            endTimeUtc = (DateTimeOffset?) null,
+            priority = 5,
+            nextFireTimeUtc = new DateTimeOffset(2025, 1, 2, 1, 0, 0, TimeSpan.Zero),
+            previousFireTimeUtc = (DateTimeOffset?) null,
+            executionGroup = "imports",
+            preferredNode = "node-a",
+            preferredNodeAuto = false,
+            cronExpressionString = "0 0 1 * * ?",
+            timeZone = "UTC"
+        }, serializerOptions);
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void TryWithCronExpressionLeavesTextTheTriggerDoesNotHaveAsNull()
+    {
+        TriggerPayloadBuilder.TryWithCronExpression(SerializedTrigger(), "0 0 2 * * ?", out JsonElement payload)
+            .Should().BeTrue();
+
+        payload.GetProperty("calendarName").ValueKind.Should().Be(JsonValueKind.Null,
+            "an empty calendar name names a calendar that cannot be found, and the trigger then never fires again");
+        payload.GetProperty("description").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Test]
+    public void TryWithCronExpressionCarriesEverythingElseThroughUntouched()
+    {
+        TriggerPayloadBuilder.TryWithCronExpression(
+            SerializedTrigger(description: "nightly import", calendarName: "holidays"),
+            "0 0 2 * * ?",
+            out JsonElement payload).Should().BeTrue();
+
+        payload.GetProperty("cronExpressionString").GetString().Should().Be("0 0 2 * * ?",
+            "the edited expression is the only thing a reschedule is meant to change");
+        payload.GetProperty("calendarName").GetString().Should().Be("holidays");
+        payload.GetProperty("description").GetString().Should().Be("nightly import");
+        payload.GetProperty("executionGroup").GetString().Should().Be("imports");
+        payload.GetProperty("preferredNode").GetString().Should().Be("node-a",
+            "the hand-written payload dropped the node pin, which silently unpinned the trigger");
+        payload.GetProperty("preferredNodeAuto").GetBoolean().Should().BeFalse();
+        payload.GetProperty("jobDataMap").GetProperty("colour").GetString().Should().Be("green");
+        payload.GetProperty("key").GetProperty("name").GetString().Should().Be("trigger1");
+        payload.GetProperty("jobKey").GetProperty("group").GetString().Should().Be("group1");
+        payload.GetProperty("priority").GetInt32().Should().Be(5);
+        payload.GetProperty("timeZone").GetString().Should().Be("UTC");
+    }
+
+    [Test]
+    public void TryWithCronExpressionClearsTheStoredNextFireTime()
+    {
+        TriggerPayloadBuilder.TryWithCronExpression(SerializedTrigger(), "0 0 2 * * ?", out JsonElement payload)
+            .Should().BeTrue();
+
+        payload.GetProperty("nextFireTimeUtc").ValueKind.Should().Be(JsonValueKind.Null,
+            "the stored time was computed from the old expression, and RescheduleJob honours a non-null one verbatim");
+    }
+
+    [Test]
+    public void TryWithCronExpressionMatchesPropertyNamesWhateverTheirCasing()
+    {
+        JsonElement trigger = JsonSerializer.SerializeToElement(new
+        {
+            TriggerType = "CronTrigger",
+            CalendarName = (string?) null,
+            NextFireTimeUtc = new DateTimeOffset(2025, 1, 2, 1, 0, 0, TimeSpan.Zero),
+            CronExpressionString = "0 0 1 * * ?"
+        });
+
+        TriggerPayloadBuilder.TryWithCronExpression(trigger, "0 0 2 * * ?", out JsonElement payload)
+            .Should().BeTrue();
+
+        payload.GetProperty("CronExpressionString").GetString().Should().Be("0 0 2 * * ?");
+        payload.GetProperty("NextFireTimeUtc").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Test]
+    public void TryWithCronExpressionRefusesATriggerItCannotIdentify()
+    {
+        // The API client falls back to reflection for trigger types the Quartz converters do not
+        // know, and that output carries no discriminator. Posting it back would either fail to
+        // deserialize or, as the hand-written payload did, reschedule it as some other type.
+        JsonElement reflected = JsonSerializer.SerializeToElement(new
+        {
+            key = new { name = "trigger1", group = "group1" },
+            cronExpressionString = "0 0 1 * * ?"
+        }, serializerOptions);
+
+        TriggerPayloadBuilder.TryWithCronExpression(reflected, "0 0 2 * * ?", out JsonElement payload)
+            .Should().BeFalse();
+        payload.ValueKind.Should().Be(JsonValueKind.Undefined);
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -470,6 +470,46 @@ public class JsonObjectSerializerTest
         await VerifyCreatedJson(trigger);
     }
 
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void DeserializeBlankCalendarNameAsNoCalendarAtAll()
+    {
+        // What the dashboard's reschedule wrote before #3294 was fixed, and what is therefore sitting
+        // in BLOB_TRIGGERS today: text the trigger did not have arrived as an empty string, not null.
+        const string json =
+            """
+            {
+              "TriggerType": "CronTrigger",
+              "Key": { "Name": "BlankTextTriggerKey", "Group": "BlankTextTriggerGroup" },
+              "JobKey": { "Name": "BlankTextJob", "Group": "BlankTextJobGroup" },
+              "Description": "",
+              "CalendarName": "",
+              "JobDataMap": {},
+              "MisfireInstruction": 0,
+              "StartTimeUtc": "2024-07-01T00:00:00+00:00",
+              "EndTimeUtc": null,
+              "Priority": 5,
+              "NextFireTimeUtc": null,
+              "PreviousFireTimeUtc": null,
+              "ExecutionGroup": "",
+              "PreferredNode": null,
+              "PreferredNodeAuto": false,
+              "CronExpressionString": "0 0/5 * * * ?",
+              "TimeZone": "UTC"
+            }
+            """;
+
+        byte[] bytes = Encoding.UTF8.GetBytes(json);
+
+        foreach (IObjectSerializer serializer in new IObjectSerializer[] { newtonsoftSerializer, systemTextJsonSerializer })
+        {
+            AbstractTrigger trigger = (AbstractTrigger) serializer.DeSerialize<IOperableTrigger>(bytes);
+
+            trigger.CalendarName.Should().BeNull(
+                "every job store gates its calendar lookup on a non-null name, so a blank one would be looked up, not found, and the trigger would never fire again (#3294)");
+            trigger.ExecutionGroup.Should().BeNull("the execution group setter has always normalized blanks");
+        }
+    }
+
     private void CompareSerialization<T>(
         T original,
         Action<T, T> asserter = null,

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -896,6 +896,35 @@ public class RAMJobStoreTest
     }
 
     /// <summary>
+    /// Regression test for #3294: the dashboard's reschedule wrote CALENDAR_NAME='' instead of NULL.
+    /// The store gates its calendar lookup on a non-null name, so the empty string passed the gate,
+    /// resolved to no calendar, and the trigger silently never fired again.
+    /// </summary>
+    [Test]
+    public async Task TriggersFired_BlankCalendarName_StillProducesABundle()
+    {
+        DateTimeOffset d = DateTimeOffset.UtcNow;
+
+        IOperableTrigger trigger = new SimpleTriggerImpl("blankCalendarTrigger", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, d.AddSeconds(1), d.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
+        trigger.CalendarName = "";
+        trigger.ComputeFirstFireTimeUtc(null);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        IOperableTrigger stored = await fJobStore.RetrieveTrigger(trigger.Key);
+        stored.CalendarName.Should().BeNull("a blank name is stored as no calendar, so nothing is ever looked up for it");
+
+        DateTimeOffset firstFireTime = trigger.GetNextFireTimeUtc()!.Value;
+        var acquired = await fJobStore.AcquireNextTriggers(firstFireTime.AddSeconds(10), 1, TimeSpan.Zero);
+        acquired.Should().HaveCount(1);
+
+        var fired = await fJobStore.TriggersFired(acquired.ToList());
+
+        fired.Should().HaveCount(1);
+        fired.First().TriggerFiredBundle.Should().NotBeNull(
+            "a trigger with no calendar has to fire; naming the empty string is naming no calendar");
+    }
+
+    /// <summary>
     /// Regression test for #1386: TriggersFired returns null bundle for triggers
     /// that changed state (e.g., paused) between acquire and fire.
     /// </summary>

--- a/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
 
+using Quartz.Spi;
+
 namespace Quartz.Tests.Unit;
 
 [NonParallelizable]
@@ -95,5 +97,52 @@ public class TriggerBuilderTest
             .Build();
 
         Assert.That(trigger.JobDataMap["key"], Is.EqualTo("overwritingvalue"));
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void ModifiedByCalendar_TreatsABlankNameAsNoCalendar()
+    {
+        TriggerBuilder.Create().ModifiedByCalendar("holidays").Build()
+            .CalendarName.Should().Be("holidays");
+
+        TriggerBuilder.Create().ModifiedByCalendar(null).Build()
+            .CalendarName.Should().BeNull();
+
+        TriggerBuilder.Create().ModifiedByCalendar("").Build()
+            .CalendarName.Should().BeNull(
+                "every job store gates its calendar lookup on a non-null name, so a blank one would be looked up, not found, and the trigger would silently stop firing");
+
+        TriggerBuilder.Create().ModifiedByCalendar("   ").Build()
+            .CalendarName.Should().BeNull();
+
+        TriggerBuilder.Create().ModifiedByCalendar(" holidays ").Build()
+            .CalendarName.Should().Be(" holidays ",
+                "a calendar is looked up by the exact name it was stored under, so trimming would break a calendar genuinely registered with padding");
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void CalendarName_TreatsABlankNameAsNoCalendar_WhenSetDirectly()
+    {
+        // The builder is not the only writer: the JSON converters, the ADO store and plain user code
+        // all assign the property, so the normalization has to live in the setter.
+        IMutableTrigger trigger = (IMutableTrigger) TriggerBuilder.Create().ModifiedByCalendar("holidays").Build();
+
+        trigger.CalendarName = "";
+        trigger.CalendarName.Should().BeNull();
+
+        trigger.CalendarName = "   ";
+        trigger.CalendarName.Should().BeNull();
+
+        trigger.CalendarName = "holidays";
+        trigger.CalendarName.Should().Be("holidays");
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void GetTriggerBuilder_DoesNotResurrectABlankCalendarName()
+    {
+        IMutableTrigger trigger = (IMutableTrigger) TriggerBuilder.Create().WithIdentity("t1").Build();
+        trigger.CalendarName = "";
+
+        trigger.GetTriggerBuilder().Build().CalendarName.Should().BeNull();
     }
 }

--- a/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
+++ b/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
@@ -201,6 +201,27 @@ public class UpdateTriggerDetailsTest
         Assert.IsNull(retrieved.CalendarName);
     }
 
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public async Task CalendarName_BlankClearsCalendarRatherThanFailingTheUpdate()
+    {
+        DateTimeOffset start = DateBuilder.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = new CronTriggerImpl("t1", "g1", jobDetail.Name, jobDetail.Group, start, null, "0/30 * * * * ?");
+        trigger.CalendarName = "myCal";
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        await jobStore.StoreCalendar("myCal", new BaseCalendar(), false, false);
+        await jobStore.StoreTrigger(trigger, false);
+
+        TriggerDetailsUpdate update = new TriggerDetailsUpdate()
+            .WithCalendarName("");
+
+        bool result = await jobStore.UpdateTriggerDetails(trigger.Key, update);
+
+        result.Should().BeTrue("a blank name means no calendar, so there is nothing whose existence to check");
+        IOperableTrigger retrieved = await jobStore.RetrieveTrigger(trigger.Key);
+        retrieved.CalendarName.Should().BeNull();
+    }
+
     [Test]
     public async Task CalendarName_SetsValidCalendar()
     {

--- a/src/Quartz/ITrigger.cs
+++ b/src/Quartz/ITrigger.cs
@@ -85,6 +85,11 @@ public interface ITrigger : IComparable<ITrigger>
     /// Get or set  the <see cref="ICalendar" /> with the given name with
     /// this Trigger. Use <see langword="null" /> when setting to dis-associate a Calendar.
     /// </summary>
+    /// <remarks>
+    /// A blank name means no calendar: the built-in trigger implementations store an empty or
+    /// whitespace-only name as <see langword="null" />, because a name no calendar can be found
+    /// under would otherwise stop the trigger from ever firing.
+    /// </remarks>
     string? CalendarName { get; }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -4328,6 +4328,7 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
             cal = await RetrieveCalendar(conn, trigger.CalendarName, cancellationToken).ConfigureAwait(false);
             if (cal == null)
             {
+                Log.Warn($"Trigger {trigger.Key} references calendar '{trigger.CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared.");
                 return null;
             }
         }

--- a/src/Quartz/Impl/Triggers/AbstractTrigger.cs
+++ b/src/Quartz/Impl/Triggers/AbstractTrigger.cs
@@ -281,7 +281,17 @@ public abstract class AbstractTrigger : IOperableTrigger, INextVersionTrigger, I
     /// Get or set  the <see cref="ICalendar" /> with the given name with
     /// this Trigger. Use <see langword="null" /> when setting to dis-associate a Calendar.
     /// </summary>
-    public virtual string? CalendarName { get; set; }
+    /// <remarks>
+    /// An empty or whitespace-only name is stored as <see langword="null" />. Every job store reads
+    /// a non-null calendar name as "this trigger observes a calendar" and silently drops the fire
+    /// when no such calendar exists, so a blank name has to mean no calendar rather than a calendar
+    /// nothing can find. The value is not trimmed: a calendar is looked up by its exact stored name.
+    /// </remarks>
+    public virtual string? CalendarName
+    {
+        get;
+        set => field = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
 
     /// <summary>
     /// Gets or sets the execution group for this trigger. Execution groups allow

--- a/src/Quartz/SPI/IMutableTrigger.cs
+++ b/src/Quartz/SPI/IMutableTrigger.cs
@@ -19,7 +19,9 @@ public interface IMutableTrigger : ITrigger
     new string? Description { get; set; }
 
     /// <summary>
-    /// Associate the <see cref="ICalendar" /> with the given name with this Trigger.
+    /// Associate the <see cref="ICalendar" /> with the given name with this Trigger. Use
+    /// <see langword="null" /> - or a blank name, which the built-in triggers store as
+    /// <see langword="null" /> - to dis-associate any calendar.
     /// </summary>
     new string? CalendarName { set; get; }
 

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1900,6 +1900,7 @@ public class RAMJobStore : IJobStore, INextVersionJobStore
                     calendarsByName.TryGetValue(tw.Trigger.CalendarName, out cal);
                     if (cal == null)
                     {
+                        Log.Warn($"Trigger {tw.Trigger.Key} references calendar '{tw.Trigger.CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared.");
                         results.Add(new TriggerFiredResult((TriggerFiredBundle?) null));
                         continue;
                     }

--- a/src/Quartz/TriggerDetailsUpdate.cs
+++ b/src/Quartz/TriggerDetailsUpdate.cs
@@ -64,10 +64,15 @@ public sealed class TriggerDetailsUpdate
     /// <summary>
     /// Set the trigger's associated calendar name, or <c>null</c> to disassociate.
     /// </summary>
+    /// <remarks>
+    /// A blank name disassociates as well. The store checks that a non-null name exists before it
+    /// assigns it, so without this a blank name would be rejected as a missing calendar rather than
+    /// clearing the association.
+    /// </remarks>
     public TriggerDetailsUpdate WithCalendarName(string? calendarName)
     {
         HasCalendarName = true;
-        CalendarName = calendarName;
+        CalendarName = string.IsNullOrWhiteSpace(calendarName) ? null : calendarName;
         return this;
     }
 


### PR DESCRIPTION
Fixes #3294. Companion to the `main` PR — see the link below.

## The bug

Editing a cron trigger's schedule from the dashboard wrote `CALENDAR_NAME = ''` instead of `NULL`, and the trigger then **stopped firing entirely**. Every job store gates its calendar lookup on `CalendarName is not null`, so the empty string passed the gate, the lookup found nothing, and the fire was silently dropped. The ADO store left a single `Couldn't find calendar with name ''` line from the delegate — which never says a fire was skipped — and `RAMJobStore` left nothing at all. Oracle hides it entirely, since `''` is `NULL` there, so it looks provider-specific.

Two defects compound.

**The dashboard rebuilt the trigger by hand.** `TriggerDetail.razor` re-assembled the whole trigger field by field out of its *display* projection, using `DisplayValueHelper.GetString` — which flattens both "member absent" and "JSON null" to `""`. That is right for rendering and wrong for a payload. The same hand-assembly silently dropped whatever it forgot to list (the node pin) and hardcoded `triggerType = "CronTrigger"`, so a custom `ICronTrigger` came back as a plain one.

**The core treated `""` as a real calendar name.** `AbstractTrigger.CalendarName` was a bare auto-property. The tell that this was an oversight rather than a decision: `ExecutionGroup`, a property on the *same class*, has always normalized blanks to `null` — which is exactly why `executionGroup = ""` from that same payload was harmless while `calendarName = ""` was fatal. The XML and JSON front ends already normalize calendar names too; only the object/JSON API did not, and that is also the HTTP API's path, so `POST .../reschedule` with `"calendarName": ""` reproduces this with no dashboard involved.

## The fix

**`AbstractTrigger.CalendarName` stores a blank name as `null`**, without trimming — the name is a lookup key against whatever `AddCalendar` stored, so trimming `" holidays "` would break a calendar genuinely registered with padding, creating the same bug from the other direction. That one setter is the choke point for `TriggerBuilder`, both JSON converters and the ADO read-back, which means **databases already holding `''` self-heal**: the row rehydrates as "no calendar", the trigger fires again on the next acquisition, and the column is written back as `NULL` next time it is persisted. No migration script.

It uses the `field` keyword rather than a hand-named backing field on purpose. `AbstractTrigger` is `[Serializable]`, `BinaryObjectSerializer` still ships here, and `BinaryFormatter` matches stream members *by field name* — a `private string? calendarName` would rename `<CalendarName>k__BackingField` and silently drop the value out of existing `BLOB_TRIGGERS` payloads. Verified against the built assembly, not just assumed.

**`TriggerDetailsUpdate.WithCalendarName` normalizes separately.** Both stores check the calendar exists *before* the value ever reaches the trigger setter, so `WithCalendarName("")` used to throw `Calendar '' does not exist.` where `WithCalendarName(null)` cleared.

**The dashboard now edits the trigger JSON it was already handed** instead of rebuilding it. A new internal `TriggerPayloadBuilder` copies the serialized trigger and rewrites only `cronExpressionString` — faithful by construction, immune to this whole bug class, and it preserves the node pin and the real trigger type for free. It also nulls `nextFireTimeUtc`, because that value belongs to the expression being replaced and `RescheduleJob` honours a non-null one verbatim; carrying it over would have made the new schedule skip a beat.

**Both stores now log when they skip a fire over a missing calendar.** This is the highest debugging-value line in the change — it turns this class of report from a mystery into a one-line diagnosis.

## Deliberately not here

`RescheduleJob` still accepts a calendar it cannot find. 4.x tightens that to match `ScheduleJob`, but on a released branch it would turn a long-standing silent success into a throw, and Java Quartz carries the same `ScheduleJob`/`RescheduleJob` asymmetry — inherited, not a .NET slip. With the normalization and the new warnings in place, #3294 is fixed here without it. `QuartzScheduler.cs` is untouched on this branch.

`Description` is not normalized either. It has no lookup semantics and `""` is inert; the empty descriptions the issue reports came from the dashboard, and that is fixed at the source.

## Testing

The new tests were checked against the *unfixed* core, not just against the fix — with the setter reverted, the builder test, the JSON round-trip and the `RAMJobStore` firing test all fail.

- `TriggerBuilderTest` — blank names normalize through the builder, through direct assignment, and through `GetTriggerBuilder()`; `" holidays "` is preserved verbatim, pinning the no-trim decision.
- `UpdateTriggerDetailsTest.CalendarName_BlankClearsCalendarRatherThanFailingTheUpdate` — beside the existing `CalendarName_ValidatesExistence`, which must still throw for a real-but-missing name. The pair is the contract.
- `JsonObjectSerializerTest.DeserializeBlankCalendarNameAsNoCalendarAtAll` — a raw `"CalendarName": ""` payload, run through both serializers, which is what is sitting in `BLOB_TRIGGERS` today.
- `RAMJobStoreTest.TriggersFired_BlankCalendarName_StillProducesABundle` — the test that would actually have caught the reported symptom, and the positive twin of the existing missing-calendar test.
- `TriggerPayloadBuilderTest` (new) and `InProcessQuartzApiClientTest.RescheduleFromTriggerDetailPayloadChangesNothingButTheSchedule` — the dashboard round trip end to end, asserting the calendar stays null, the node pin survives, and the trigger still has a next fire time.

The existing `RescheduleJobShouldAcceptCronTriggerPayload` is why nobody caught this: its comment said the payload "mirrors TriggerDetail.razor" and it then hand-copied the builder with `calendarName = (string?) null` — asserting the shape the bug never produces. It stays, re-labelled as what it actually is (a pin on the shape the API accepts), and the real path is covered by the new test.

Green locally: full solution build with 0 warnings, unit tests 1761 (net10.0) + 1750 (net472), AspNetCore tests 122. No Verify baseline moves — `PublicApiGenerator` prints `{ get; set; }` whether or not a property has a backing field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf
