### PR TITLE
A blank calendar name is no calendar name (4.x)

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1463,6 +1463,33 @@ trigger describes its own schedule to the base class — which rounds the start 
 is false — and nothing outside the trigger acted on it. A custom trigger changes `public override` to
 `protected override`; to test the behaviour, assert on `StartTimeUtc.Millisecond` instead of on the flag.
 
+## A blank calendar name is no calendar name
+
+`TriggerBase.CalendarName` stores an empty or whitespace-only name as `null`, and so do
+`TriggerBuilder.WithCalendarName` and `TriggerDetailsUpdate.WithCalendarName`, which assign through
+it. The name is not trimmed — a calendar is looked up by the exact name it was registered under —
+only blanks collapse.
+
+This closes a trap rather than changing a working behaviour. Every job store reads a non-null
+calendar name as "this trigger observes a calendar", looks it up, and drops the fire when it is not
+found. A trigger holding `""` therefore never fired again, and said so only through a single
+`Couldn't find calendar with name ''` line from the ADO delegate — nothing at all under
+`RAMJobStore`. Oracle hid the problem entirely, since `''` is `NULL` there.
+
+If a database already holds `CALENDAR_NAME = ''` rows — the dashboard's reschedule wrote them before
+[#3294](https://github.com/quartznet/quartznet/issues/3294) was fixed — **no migration script is
+needed**. Such a row rehydrates as "no calendar", so the trigger starts firing again on the next
+acquisition, and the column is written back as `NULL` the next time the trigger is persisted.
+
+The normalization and the missing-calendar warning both job stores now log are not 4.x-only: they
+ship on 3.x as well, so upgrading is not what fixes them. One part of #3294 *is* specific to 4.x:
+
+- `IScheduler.RescheduleJob` throws `SchedulerException` when the new trigger names a calendar that
+  does not exist, the way `ScheduleJob` always has. On 3.x it stores the trigger and leaves it
+  permanently unfireable, and that was left alone there rather than turning a long-standing silent
+  success into a throw on a released branch. If you reschedule onto a calendar you intend to add
+  afterwards, add the calendar first.
+
 ## JobKey and TriggerKey Null Validation
 
 `JobKey` and `TriggerKey` now throw `ArgumentNullException` when you specify `null` for `name` or `group`. Triggers can no longer be constructed with a null group name. If your code was relying on null group names, switch to an explicit group name.

--- a/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
@@ -90,10 +90,6 @@
                OnCancel="CancelUnscheduleAsync" />
 
 @code {
-    private static readonly JsonSerializerOptions requestSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
     private bool _isLoading = true;
     private string? _error;
     private object? _trigger;
@@ -240,7 +236,13 @@
             return;
         }
 
-        JsonElement newTrigger = BuildRescheduleTriggerPayload(cronExpression);
+        if (_trigger is not JsonElement triggerJson
+            || !TriggerPayloadBuilder.TryWithCronExpression(triggerJson, cronExpression, out JsonElement newTrigger))
+        {
+            Toasts.Error("This trigger cannot be rescheduled from the dashboard.");
+            return;
+        }
+
         RescheduleRequest request = new(newTrigger);
         _ = await ExecuteMutatingActionAsync(
             () => Api.RescheduleJob(schedulerName, Group, Name, request),
@@ -253,68 +255,6 @@
     {
         _editedCronExpression = _cronExpression ?? string.Empty;
         return Task.CompletedTask;
-    }
-
-    private JsonElement BuildRescheduleTriggerPayload(string cronExpression)
-    {
-        string jobName = DisplayValueHelper.GetString(_trigger, "JobKey.Name", "jobKey.name");
-        string jobGroup = DisplayValueHelper.GetString(_trigger, "JobKey.Group", "jobKey.group");
-        object? jobKey = string.IsNullOrWhiteSpace(jobName) || string.IsNullOrWhiteSpace(jobGroup)
-            ? null
-            : new { name = jobName, group = jobGroup };
-
-        string timeZone = DisplayValueHelper.GetString(_trigger, "TimeZone.Id", "timeZone.id", "TimeZone", "timeZone");
-        if (string.IsNullOrWhiteSpace(timeZone) || timeZone.StartsWith('{'))
-        {
-            timeZone = TimeZoneInfo.Utc.Id;
-        }
-
-        DateTimeOffset startTime = DisplayValueHelper.GetDateTimeOffset(_trigger, "StartTimeUtc", "startTimeUtc") ?? DateTimeOffset.UtcNow;
-        DateTimeOffset? endTime = DisplayValueHelper.GetDateTimeOffset(_trigger, "EndTimeUtc", "endTimeUtc");
-        int misfireInstruction = ParseIntOrDefault(_trigger, 0, "MisfireInstruction", "misfireInstruction");
-        int priority = ParseIntOrDefault(_trigger, 5, "Priority", "priority");
-        JsonElement jobDataMap = GetJobDataMapElement(_trigger);
-
-        object payload = new
-        {
-            triggerType = "CronTrigger",
-            key = new { name = Name, group = Group },
-            jobKey,
-            description = DisplayValueHelper.GetString(_trigger, "Description", "description"),
-            calendarName = DisplayValueHelper.GetString(_trigger, "CalendarName", "calendarName"),
-            jobDataMap,
-            misfireInstruction,
-            startTimeUtc = startTime,
-            endTimeUtc = endTime,
-            priority,
-            timeZone,
-            cronExpressionString = cronExpression,
-            executionGroup = DisplayValueHelper.GetString(_trigger, "ExecutionGroup", "executionGroup")
-        };
-
-        return JsonSerializer.SerializeToElement(payload, requestSerializerOptions);
-    }
-
-    private static int ParseIntOrDefault(object? source, int defaultValue, params string[] paths)
-    {
-        string value = DisplayValueHelper.GetString(source, paths);
-        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedValue))
-        {
-            return parsedValue;
-        }
-
-        return defaultValue;
-    }
-
-    private static JsonElement GetJobDataMapElement(object? source)
-    {
-        object? value = DisplayValueHelper.GetObject(source, "JobDataMap", "jobDataMap");
-        if (value is JsonElement element)
-        {
-            return element.Clone();
-        }
-
-        return JsonSerializer.SerializeToElement(new Dictionary<string, object?>(), requestSerializerOptions);
     }
 
     private void PromptUnschedule()

--- a/src/Quartz.Dashboard/Components/Shared/TriggerPayloadBuilder.cs
+++ b/src/Quartz.Dashboard/Components/Shared/TriggerPayloadBuilder.cs
@@ -1,0 +1,117 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Buffers;
+using System.Text.Json;
+
+namespace Quartz.Dashboard.Components.Shared;
+
+/// <summary>
+/// Builds the trigger payloads the dashboard posts back to the scheduler by editing the JSON the API
+/// returned, rather than re-assembling a trigger field by field.
+/// </summary>
+/// <remarks>
+/// Re-assembly silently dropped whatever it did not list. A null calendar name came back as an empty
+/// string, which every job store reads as a calendar it then cannot find, so the trigger stopped
+/// firing (#3294); the node pin was dropped altogether; and the trigger type was hardcoded, so a
+/// custom cron trigger was rewritten as a plain one. Editing the serialized trigger in place keeps
+/// every field the Quartz converters wrote, including ones added later.
+/// </remarks>
+internal static class TriggerPayloadBuilder
+{
+    private const string TriggerTypeProperty = "triggerType";
+    private const string CronExpressionProperty = "cronExpressionString";
+    private const string NextFireTimeProperty = "nextFireTimeUtc";
+
+    /// <summary>
+    /// Produces <paramref name="trigger"/> with its cron expression replaced by
+    /// <paramref name="cronExpression"/>, or <see langword="false"/> when the trigger cannot be sent
+    /// back to the scheduler at all.
+    /// </summary>
+    public static bool TryWithCronExpression(JsonElement trigger, string cronExpression, out JsonElement payload)
+    {
+        if (trigger.ValueKind != JsonValueKind.Object || !HasProperty(trigger, TriggerTypeProperty))
+        {
+            // A trigger type the Quartz converters do not know is serialized by the API client's
+            // reflection fallback, which omits the discriminator. Such a payload cannot be read
+            // back, so refuse it rather than post something that will not deserialize - or, as the
+            // hand-built payload did, quietly reschedule it as a different trigger type.
+            payload = default;
+            return false;
+        }
+
+        ArrayBufferWriter<byte> buffer = new();
+        using (Utf8JsonWriter writer = new(buffer))
+        {
+            writer.WriteStartObject();
+            bool cronWritten = false;
+            foreach (JsonProperty property in trigger.EnumerateObject())
+            {
+                if (Matches(property.Name, CronExpressionProperty))
+                {
+                    writer.WriteString(property.Name, cronExpression);
+                    cronWritten = true;
+                }
+                else if (Matches(property.Name, NextFireTimeProperty))
+                {
+                    // The schedule just changed, so the stored next fire time belongs to the old
+                    // expression, and RescheduleJob honours a non-null one verbatim. Clearing it
+                    // lets the first fire be computed from the expression the user just entered.
+                    writer.WriteNull(property.Name);
+                }
+                else
+                {
+                    property.WriteTo(writer);
+                }
+            }
+
+            if (!cronWritten)
+            {
+                writer.WriteString(CronExpressionProperty, cronExpression);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        using JsonDocument document = JsonDocument.Parse(buffer.WrittenMemory);
+        payload = document.RootElement.Clone();
+        return true;
+    }
+
+    private static bool HasProperty(JsonElement element, string name)
+    {
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (Matches(property.Name, name))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The serialized trigger is camelCased today, but the page reads it through
+    /// <see cref="DisplayValueHelper"/>, which tolerates either casing. This does the same so the
+    /// two cannot disagree about which trigger they are looking at.
+    /// </summary>
+    private static bool Matches(string propertyName, string name)
+        => string.Equals(propertyName, name, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -42,7 +42,8 @@ public class InProcessQuartzApiClientTest
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            // payload mirrors TriggerDetail.razor BuildRescheduleTriggerPayload
+            // a hand-written payload, to pin the shape the HTTP API accepts independently of
+            // whatever TriggerDetail.razor happens to send
             object payload = new
             {
                 triggerType = "CronTrigger",
@@ -69,6 +70,55 @@ public class InProcessQuartzApiClientTest
             cronTrigger.JobKey.Should().Be(jobKey);
             cronTrigger.Description.Should().Be("updated by dashboard");
             cronTrigger.ExecutionGroup.Should().Be("imports");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task RescheduleFromTriggerDetailPayloadChangesNothingButTheSchedule()
+    {
+        // regression test for #3294 - the detail page rebuilt the trigger from its display strings,
+        // so a trigger with no calendar came back with CALENDAR_NAME='', which every job store reads
+        // as a calendar it then cannot find. The trigger silently never fired again. The node pin
+        // was dropped outright, because the hand-written payload never listed it.
+        IScheduler scheduler = await CreateScheduler("RescheduleRoundTripTest");
+        try
+        {
+            JobKey jobKey = new("job1", "group1");
+            IJobDetail job = JobBuilder.Create<NoOpJob>()
+                .WithIdentity(jobKey)
+                .StoreDurably()
+                .Build();
+            TriggerKey triggerKey = new("trigger1", "group1");
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .WithCronSchedule("0 0 1 * * ?")
+                .WithPreferredNode(PreferredNode.For("node-a"))
+                .Build();
+            await scheduler.ScheduleJob(job, trigger);
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            // exactly what TriggerDetail.razor does: read the trigger, then edit its cron expression
+            TriggerDetailDto detail = await client.GetTrigger(scheduler.SchedulerName, triggerKey.Group, triggerKey.Name);
+            TriggerPayloadBuilder.TryWithCronExpression(detail.Value, "0 0 2 * * ?", out JsonElement newTrigger)
+                .Should().BeTrue();
+
+            await client.RescheduleJob(scheduler.SchedulerName, triggerKey.Group, triggerKey.Name, new RescheduleRequest(newTrigger));
+
+            ITrigger? updated = await scheduler.GetTrigger(triggerKey);
+            CronTriggerImpl cronTrigger = updated.Should().BeOfType<CronTriggerImpl>().Subject;
+            cronTrigger.CronExpressionString.Should().Be("0 0 2 * * ?");
+            cronTrigger.JobKey.Should().Be(jobKey);
+            cronTrigger.CalendarName.Should().BeNull(
+                "the trigger never had a calendar, and an empty name would name one that cannot be found");
+            cronTrigger.Description.Should().BeNull();
+            cronTrigger.PreferredNode.Node.Should().Be("node-a", "editing a schedule must not unpin the trigger");
+            cronTrigger.NextFireTimeUtc.Should().NotBeNull("a rescheduled trigger has to keep firing");
         }
         finally
         {

--- a/src/Quartz.Tests.AspNetCore/Dashboard/TriggerPayloadBuilderTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/TriggerPayloadBuilderTest.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+
+using Quartz.Dashboard.Components.Shared;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+public class TriggerPayloadBuilderTest
+{
+    private static readonly JsonSerializerOptions serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// The shape the Quartz converters write and the dashboard's API client hands the detail page.
+    /// Every property is present; the unset ones are JSON null.
+    /// </summary>
+    private static JsonElement SerializedTrigger(object? description = null, object? calendarName = null)
+    {
+        return JsonSerializer.SerializeToElement(new
+        {
+            triggerType = "CronTrigger",
+            key = new { name = "trigger1", group = "group1" },
+            jobKey = new { name = "job1", group = "group1" },
+            description,
+            calendarName,
+            jobDataMap = new Dictionary<string, object?> { ["colour"] = "green" },
+            misfireInstruction = 0,
+            startTimeUtc = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            endTimeUtc = (DateTimeOffset?) null,
+            priority = 5,
+            nextFireTimeUtc = new DateTimeOffset(2025, 1, 2, 1, 0, 0, TimeSpan.Zero),
+            previousFireTimeUtc = (DateTimeOffset?) null,
+            executionGroup = "imports",
+            preferredNode = "node-a",
+            preferredNodeAuto = false,
+            cronExpressionString = "0 0 1 * * ?",
+            timeZone = "UTC"
+        }, serializerOptions);
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void TryWithCronExpressionLeavesTextTheTriggerDoesNotHaveAsNull()
+    {
+        TriggerPayloadBuilder.TryWithCronExpression(SerializedTrigger(), "0 0 2 * * ?", out JsonElement payload)
+            .Should().BeTrue();
+
+        payload.GetProperty("calendarName").ValueKind.Should().Be(JsonValueKind.Null,
+            "an empty calendar name names a calendar that cannot be found, and the trigger then never fires again");
+        payload.GetProperty("description").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Test]
+    public void TryWithCronExpressionCarriesEverythingElseThroughUntouched()
+    {
+        TriggerPayloadBuilder.TryWithCronExpression(
+            SerializedTrigger(description: "nightly import", calendarName: "holidays"),
+            "0 0 2 * * ?",
+            out JsonElement payload).Should().BeTrue();
+
+        payload.GetProperty("cronExpressionString").GetString().Should().Be("0 0 2 * * ?",
+            "the edited expression is the only thing a reschedule is meant to change");
+        payload.GetProperty("calendarName").GetString().Should().Be("holidays");
+        payload.GetProperty("description").GetString().Should().Be("nightly import");
+        payload.GetProperty("executionGroup").GetString().Should().Be("imports");
+        payload.GetProperty("preferredNode").GetString().Should().Be("node-a",
+            "the hand-written payload dropped the node pin, which silently unpinned the trigger");
+        payload.GetProperty("preferredNodeAuto").GetBoolean().Should().BeFalse();
+        payload.GetProperty("jobDataMap").GetProperty("colour").GetString().Should().Be("green");
+        payload.GetProperty("key").GetProperty("name").GetString().Should().Be("trigger1");
+        payload.GetProperty("jobKey").GetProperty("group").GetString().Should().Be("group1");
+        payload.GetProperty("priority").GetInt32().Should().Be(5);
+        payload.GetProperty("timeZone").GetString().Should().Be("UTC");
+    }
+
+    [Test]
+    public void TryWithCronExpressionClearsTheStoredNextFireTime()
+    {
+        TriggerPayloadBuilder.TryWithCronExpression(SerializedTrigger(), "0 0 2 * * ?", out JsonElement payload)
+            .Should().BeTrue();
+
+        payload.GetProperty("nextFireTimeUtc").ValueKind.Should().Be(JsonValueKind.Null,
+            "the stored time was computed from the old expression, and RescheduleJob honours a non-null one verbatim");
+    }
+
+    [Test]
+    public void TryWithCronExpressionMatchesPropertyNamesWhateverTheirCasing()
+    {
+        JsonElement trigger = JsonSerializer.SerializeToElement(new
+        {
+            TriggerType = "CronTrigger",
+            CalendarName = (string?) null,
+            NextFireTimeUtc = new DateTimeOffset(2025, 1, 2, 1, 0, 0, TimeSpan.Zero),
+            CronExpressionString = "0 0 1 * * ?"
+        });
+
+        TriggerPayloadBuilder.TryWithCronExpression(trigger, "0 0 2 * * ?", out JsonElement payload)
+            .Should().BeTrue();
+
+        payload.GetProperty("CronExpressionString").GetString().Should().Be("0 0 2 * * ?");
+        payload.GetProperty("NextFireTimeUtc").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Test]
+    public void TryWithCronExpressionRefusesATriggerItCannotIdentify()
+    {
+        // The API client falls back to reflection for trigger types the Quartz converters do not
+        // know, and that output carries no discriminator. Posting it back would either fail to
+        // deserialize or, as the hand-written payload did, reschedule it as some other type.
+        JsonElement reflected = JsonSerializer.SerializeToElement(new
+        {
+            key = new { name = "trigger1", group = "group1" },
+            cronExpressionString = "0 0 1 * * ?"
+        }, serializerOptions);
+
+        TriggerPayloadBuilder.TryWithCronExpression(reflected, "0 0 2 * * ?", out JsonElement payload)
+            .Should().BeFalse();
+        payload.ValueKind.Should().Be(JsonValueKind.Undefined);
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
@@ -31,7 +31,8 @@ namespace Quartz.Tests.Unit.Simpl;
 /// <summary>
 /// Both JSON serializers must keep reading the payload shapes written before 4.0 - those payloads
 /// are sitting in users' job store blobs, and an upgrade is not allowed to make them unreadable.
-/// The literals below are verbatim output from 3.x.
+/// The literals below are verbatim output from 3.x, including shapes an older Quartz wrote by
+/// mistake and still has to be read back sensibly.
 /// </summary>
 /// <remarks>
 /// Only reading is covered. Writing the new shape is deliberate, and the round trip through the
@@ -216,6 +217,34 @@ public class LegacyJsonPayloadTest
         }
         """;
 
+    /// <summary>
+    /// What the dashboard's reschedule wrote before #3294 was fixed: the detail page collapsed a
+    /// JSON null to an empty string, so text the trigger did not have arrived as "" rather than null.
+    /// </summary>
+    private const string BlankTextCronTrigger =
+        """
+        {
+          "TriggerType": "CronTrigger",
+          "Key": {
+            "Name": "BlankTextTriggerKey",
+            "Group": "BlankTextTriggerGroup"
+          },
+          "JobKey": null,
+          "Description": "",
+          "CalendarName": "",
+          "JobDataMap": {},
+          "MisfireInstruction": 0,
+          "StartTimeUtc": "2024-07-01T00:00:00+00:00",
+          "EndTimeUtc": null,
+          "Priority": 5,
+          "NextFireTimeUtc": "2024-07-01T03:35:00+00:00",
+          "PreviousFireTimeUtc": null,
+          "ExecutionGroup": "",
+          "CronExpressionString": "0 0/5 * * * ?",
+          "TimeZone": "UTC"
+        }
+        """;
+
     private const string LegacyCalendarIntervalTrigger =
         """
         {
@@ -387,6 +416,16 @@ public class LegacyJsonPayloadTest
         cron.Priority.Should().Be(7);
         cron.MisfireInstructionCode.Should().Be(MisfireInstruction.CronTrigger.DoNothing);
         cron.EndTimeUtc.Should().BeNull();
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void BlankCalendarNameReadsBackAsNoCalendarAtAll()
+    {
+        var trigger = Deserialize<IOperableTrigger>(BlankTextCronTrigger);
+
+        trigger.CalendarName.Should().BeNull(
+            "every job store gates its calendar lookup on a non-null name, so a blank one would be looked up, not found, and the trigger would never fire again");
+        ((TriggerBase) trigger).ExecutionGroup.Should().BeNull("the execution group setter has always normalized blanks");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -968,6 +968,35 @@ public class RAMJobStoreTest
     }
 
     /// <summary>
+    /// The other side of that coin, and a regression test for #3294: the dashboard's reschedule
+    /// wrote CALENDAR_NAME='' instead of NULL. The store gates its calendar lookup on a non-null
+    /// name, so the empty string passed the gate, resolved to no calendar, and the trigger silently
+    /// never fired again.
+    /// </summary>
+    [Test]
+    public async Task TriggersFired_StillProducesABundle_WhenTheCalendarNameIsBlank()
+    {
+        DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
+        var trigger = ExecutingTestTrigger("blankCalendarTrigger", d);
+        trigger.CalendarName = "";
+        await fJobStore.AddTrigger(trigger, false);
+
+        (await fJobStore.GetTrigger(trigger.Key))!.CalendarName.Should().BeNull(
+            "a blank name is stored as no calendar, so nothing is ever looked up for it");
+
+        var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
+        acquired.Should().HaveCount(1);
+
+        var fired = await fJobStore.TriggersFired(acquired);
+
+        fired.Should().HaveCount(1);
+        fired[0].TriggerFiredBundle.Should().NotBeNull(
+            "a trigger with no calendar has to fire; naming the empty string is naming no calendar");
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing);
+    }
+
+    /// <summary>
     /// Releasing after the fire was recorded has to drop the record: the scheduler releases the whole
     /// batch when <c>TriggersFired</c> fails part-way, and no completion will arrive for the fires it had
     /// already recorded. Uses a concurrency-allowed job so the answer is not masked by the blocking

--- a/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
@@ -1,3 +1,5 @@
+using Quartz.Extensibility;
+
 namespace Quartz.Tests.Unit;
 
 [NonParallelizable]
@@ -142,6 +144,47 @@ public class TriggerBuilderTest
         trigger.CalendarName.Should().Be("holidays");
 
         TriggerBuilder.Create().WithCalendarName(null).Build().CalendarName.Should().BeNull();
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void WithCalendarName_TreatsABlankNameAsNoCalendar()
+    {
+        TriggerBuilder.Create().WithCalendarName("").Build()
+            .CalendarName.Should().BeNull(
+                "every job store gates its calendar lookup on a non-null name, so a blank one would be looked up, not found, and the trigger would silently stop firing");
+
+        TriggerBuilder.Create().WithCalendarName("   ").Build()
+            .CalendarName.Should().BeNull();
+
+        TriggerBuilder.Create().WithCalendarName(" holidays ").Build()
+            .CalendarName.Should().Be(" holidays ",
+                "a calendar is looked up by the exact name it was stored under, so trimming would break a calendar genuinely registered with padding");
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void CalendarName_TreatsABlankNameAsNoCalendar_WhenSetDirectly()
+    {
+        // The builder is not the only writer: the JSON converters, the ADO store and plain user code
+        // all assign the property, so the normalization has to live in the setter.
+        IMutableTrigger trigger = (IMutableTrigger) TriggerBuilder.Create().WithCalendarName("holidays").Build();
+
+        trigger.CalendarName = "";
+        trigger.CalendarName.Should().BeNull();
+
+        trigger.CalendarName = "   ";
+        trigger.CalendarName.Should().BeNull();
+
+        trigger.CalendarName = "holidays";
+        trigger.CalendarName.Should().Be("holidays");
+    }
+
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public void GetTriggerBuilder_DoesNotResurrectABlankCalendarName()
+    {
+        IMutableTrigger trigger = (IMutableTrigger) TriggerBuilder.Create().WithIdentity("t1").Build();
+        trigger.CalendarName = "";
+
+        trigger.GetTriggerBuilder().Build().CalendarName.Should().BeNull();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
+++ b/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
@@ -175,6 +175,23 @@ public class UpdateTriggerDetailsTest
         (await jobStore.GetTrigger(trigger.Key))!.CalendarName.Should().BeNull();
     }
 
+    [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
+    public async Task CalendarName_BlankClearsCalendarRatherThanFailingTheUpdate()
+    {
+        DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
+        IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
+        trigger.CalendarName = "myCal";
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        await jobStore.AddCalendar("myCal", new BaseCalendar());
+        await jobStore.AddTrigger(trigger, false);
+
+        bool result = await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithCalendarName(""));
+
+        result.Should().BeTrue("a blank name means no calendar, so there is nothing whose existence to check");
+        (await jobStore.GetTrigger(trigger.Key))!.CalendarName.Should().BeNull();
+    }
+
     [Test]
     public async Task EmptyUpdate_ReturnsTrueForExistingTrigger()
     {

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -864,6 +864,13 @@ internal sealed class QuartzScheduler
         if (newTrigger.CalendarName is not null)
         {
             calendar = await resources.JobStore.GetCalendar(newTrigger.CalendarName, cancellationToken).ConfigureAwait(false);
+            if (calendar is null)
+            {
+                // Rescheduling validates the calendar the same way scheduling does. Storing a
+                // trigger whose calendar cannot be found leaves it in place but never fires it,
+                // which is far harder to diagnose than a failed call.
+                Throw.SchedulerException($"Calendar not found: {newTrigger.CalendarName}");
+            }
         }
 
         DateTimeOffset? ft;

--- a/src/Quartz/Extensibility/IMutableTrigger.cs
+++ b/src/Quartz/Extensibility/IMutableTrigger.cs
@@ -38,7 +38,9 @@ public interface IMutableTrigger : ITrigger
     new PreferredNode PreferredNode { get; set; }
 
     /// <summary>
-    /// Associate the <see cref="ICalendar" /> with the given name with this Trigger.
+    /// Associate the <see cref="ICalendar" /> with the given name with this Trigger. Use
+    /// <see langword="null" /> - or a blank name, which the built-in triggers store as
+    /// <see langword="null" /> - to dis-associate any calendar.
     /// </summary>
     new string? CalendarName { get; set; }
 

--- a/src/Quartz/ITrigger.cs
+++ b/src/Quartz/ITrigger.cs
@@ -114,6 +114,11 @@ public interface ITrigger
     /// Get or set  the <see cref="ICalendar" /> with the given name with
     /// this Trigger. Use <see langword="null" /> when setting to dis-associate a Calendar.
     /// </summary>
+    /// <remarks>
+    /// A blank name means no calendar: the built-in trigger implementations store an empty or
+    /// whitespace-only name as <see langword="null" />, because a name no calendar can be found
+    /// under would otherwise stop the trigger from ever firing.
+    /// </remarks>
     string? CalendarName { get; }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -3617,6 +3617,7 @@ public abstract class AdoJobStoreBase : IJobStore
             calendar = await GetCalendar(conn, trigger.CalendarName, cancellationToken).ConfigureAwait(false);
             if (calendar is null)
             {
+                Logger.LogWarning("Trigger {TriggerKey} references calendar '{CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared.", trigger.Key, trigger.CalendarName);
                 return null;
             }
         }

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -2308,6 +2308,7 @@ public sealed class RAMJobStore : IJobStore
                     calendarsByName.TryGetValue(tw.Trigger.CalendarName, out calendar);
                     if (calendar is null)
                     {
+                        logger.LogWarning("Trigger {TriggerKey} references calendar '{CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared.", tw.Trigger.Key, tw.Trigger.CalendarName);
                         results.Add(new TriggerFiredResult((TriggerFiredBundle?) null));
                         continue;
                     }

--- a/src/Quartz/Impl/Triggers/TriggerBase.cs
+++ b/src/Quartz/Impl/Triggers/TriggerBase.cs
@@ -189,7 +189,17 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
     /// Get or set  the <see cref="ICalendar" /> with the given name with
     /// this Trigger. Use <see langword="null" /> when setting to dis-associate a Calendar.
     /// </summary>
-    public virtual string? CalendarName { get; set; }
+    /// <remarks>
+    /// An empty or whitespace-only name is stored as <see langword="null" />. Every job store reads
+    /// a non-null calendar name as "this trigger observes a calendar" and silently drops the fire
+    /// when no such calendar exists, so a blank name has to mean no calendar rather than a calendar
+    /// nothing can find. The value is not trimmed: a calendar is looked up by its exact stored name.
+    /// </remarks>
+    public virtual string? CalendarName
+    {
+        get;
+        set => field = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
 
     /// <summary>
     /// Gets or sets the execution group for this trigger. Execution groups allow

--- a/src/Quartz/TriggerDetailsUpdate.cs
+++ b/src/Quartz/TriggerDetailsUpdate.cs
@@ -73,10 +73,15 @@ public sealed class TriggerDetailsUpdate
     /// <summary>
     /// Set the trigger's associated calendar name, or <c>null</c> to disassociate.
     /// </summary>
+    /// <remarks>
+    /// A blank name disassociates as well. The store checks that a non-null name exists before it
+    /// assigns it, so without this a blank name would be rejected as a missing calendar rather than
+    /// clearing the association.
+    /// </remarks>
     public TriggerDetailsUpdate WithCalendarName(string? calendarName)
     {
         HasCalendarName = true;
-        CalendarName = calendarName;
+        CalendarName = string.IsNullOrWhiteSpace(calendarName) ? null : calendarName;
         return this;
     }
 


### PR DESCRIPTION
Fixes #3294. 4.x port of #3295 — please read that one for the full analysis; this description covers the port and the one deliberate difference.

## The bug, in short

Editing a cron trigger's schedule from the dashboard wrote `CALENDAR_NAME = ''` instead of `NULL`, and the trigger then **stopped firing entirely**: every job store gates its calendar lookup on `CalendarName is not null`, so the empty string passed the gate, resolved to nothing, and the fire was dropped. `TriggerDetail.razor` rebuilt the trigger from its display strings via `DisplayValueHelper.GetString`, which flattens both "absent" and "JSON null" to `""`, and `TriggerBase.CalendarName` accepted that verbatim.

`ExecutionGroup`, a property on the same class, has always normalized blanks to `null` — which is exactly why `executionGroup = ""` from that same payload was harmless while `calendarName = ""` was fatal. That asymmetry was the whole bug.

## What is identical to #3295

- `TriggerBase.CalendarName` stores a blank name as `null`, without trimming (the name is a lookup key against whatever `AddCalendar` stored). One choke point covers `TriggerBuilder`, both JSON converters and the ADO read-back, so **rows already holding `''` self-heal** and no migration script is needed.
- `TriggerDetailsUpdate.WithCalendarName` normalizes separately, because both stores check existence *before* the value reaches the trigger setter.
- The dashboard's new internal `TriggerPayloadBuilder` edits the serialized trigger it was already handed and rewrites only `cronExpressionString`, clearing `nextFireTimeUtc` (it belongs to the expression being replaced, and `RescheduleJob` honours a non-null one verbatim). That also stops the reschedule dropping `preferredNode` and rewriting a custom cron trigger's type — both silent losses in the hand-written payload.
- Both stores log a warning when they skip a fire over a missing calendar.

The `TriggerPayloadBuilder` and its test are byte-identical across the two branches.

## What is different here

**`QuartzScheduler.RescheduleJob` now throws when the new trigger names a calendar that does not exist**, the way `ScheduleJob` always has. It previously stored the trigger and left it permanently unfireable — silent data corruption dressed up as success.

This is intentionally **not** on 3.x: there it would turn a long-standing silent success into a throw on a released API, and Java Quartz carries the same `ScheduleJob`/`RescheduleJob` asymmetry, so it is inherited rather than a .NET slip.

That makes it the one part of #3294 that upgrading to 4.x actually changes, so the migration guide gains a section that says so plainly — and is explicit that the normalization and the new warnings are *not* 4.x-only, so nobody reads it as "upgrade to get this fixed". It also spells out the practical consequence: add the calendar before rescheduling onto it.

## Porting notes

`AbstractTrigger` → `TriggerBase`, `ModifiedByCalendar` → `WithCalendarName`, `RetrieveCalendar` → `GetCalendar`, `StoreTrigger`/`RetrieveTrigger`/`StoreCalendar` → `AddTrigger`/`GetTrigger`/`AddCalendar`, `throw new SchedulerException` → `Throw.SchedulerException`, `Task` → `ValueTask`. The JSON round-trip test lives in `LegacyJsonPayloadTest` here (3.x has no such fixture, so it went into `JsonObjectSerializerTest` there), and the `RAMJobStore` firing test could reuse the existing `ExecutingTestTrigger` helper and sit directly beside its negative twin, `GetTriggerState_RecordsNoExecution_WhenFiringBailsOut`.

The `field` keyword is used for the setter on both branches. It is only load-bearing on 3.x — `BinaryObjectSerializer` still ships there and `BinaryFormatter` matches fields by name — but keeping the two spellings the same makes the next port a straight copy.

## Testing

The new tests were checked against the *unfixed* core: with the setter reverted, the builder test, the JSON round-trip and the `RAMJobStore` firing test all fail.

Green locally: full solution build with 0 warnings, 2335 unit tests, 224 AspNetCore tests. No Verify baseline moves — `PublicApiGenerator` prints `{ get; set; }` whether or not a property has a backing field, as `ExecutionGroup` already demonstrates in the current baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf
