### PR TITLE
MisfireBatchRecoveryTest stops racing the misfire handler it started

### DIFF
--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
@@ -28,10 +28,12 @@ public class MisfireBatchRecoveryTest
     private string dbFileName;
     private IDbProvider dbProvider;
     private CountingSQLiteDelegate.Counter commandCounter;
+    private readonly List<TestLocalTransactionJobStore> jobStores = [];
 
     [SetUp]
     public async Task SetUp()
     {
+        jobStores.Clear();
         dbFileName = $"test-misfire-batch-{Guid.NewGuid():N}.db";
 
         await using (var connection = new SqliteConnection($"Data Source={dbFileName};"))
@@ -50,8 +52,15 @@ public class MisfireBatchRecoveryTest
     }
 
     [TearDown]
-    public void TearDown()
+    public async Task TearDown()
     {
+        foreach (TestLocalTransactionJobStore jobStore in jobStores)
+        {
+            await jobStore.Shutdown();
+        }
+
+        jobStores.Clear();
+
         CountingSQLiteDelegate.CurrentCounter = null;
 
         SqliteConnection.ClearAllPools();
@@ -235,9 +244,15 @@ public class MisfireBatchRecoveryTest
             InstanceName = SchedulerName,
         };
 
+        // Initialized but deliberately not started: SchedulerStarted() spawns the MisfireHandler loop,
+        // which sweeps for misfires on its own thread every MisfireHandlerFrequency - and that defaults
+        // to MisfireThreshold, one second here. A sweep landing between storing the triggers and the
+        // RecoverMisfires() call below recovers some of them first, and the explicit pass then sees a
+        // short count. These tests drive recovery by hand, so the loop can only race them.
         await jobStore.Initialize();
-        await jobStore.SchedulerStarted();
         await jobStore.Clear();
+
+        jobStores.Add(jobStore);
 
         return jobStore;
     }


### PR DESCRIPTION
Fixes the flake that hit three unrelated PRs since 2026-08-19 (`ReadCountDoesNotGrowWithBatchSize`: "Expected value to be 2, but found 1" on the basic leg).

**Root cause — no product bug.** The fixture called `SchedulerStarted()`, which spawns the background `MisfireHandler` loop. `MisfireHandlerFrequency` defaults to `MisfireThreshold`, which the fixture sets to one second — so the loop swept roughly every second, first sweep at an unbounded point after start, against the very triggers the test was about to recover by hand. A sweep landing between `StoreMisfiredTrigger` and the explicit `RecoverMisfires()` recovers some triggers itself (FireNow moves their next fire time to now), and the measured pass reports a short count. Reproduced verbatim and deterministically by standing in for a slow runner with a 1.3 s stall between the two stores.

The race predates Wave M (`git log -S` shows it shipped with the test in #3149); what changed on 2026-08-19 was CI-side — the basic leg grew and integration runs moved to their declared TFMs — and this race only needed machine contention.

**Fix (test-only):** the stores are initialized but deliberately not started — the tests drive recovery explicitly, so the loop could only ever race them; a comment records the reasoning. Stores are now also tracked and shut down in teardown, which stops each test leaking a foreground misfire-handler thread that kept sweeping a deleted SQLite file for the rest of the assembly run.

Verification: the fixture 12 consecutive runs green; full basic-leg integration suite 26/26; unit suite 2438 green; the stall experiment that reproduced the failure every time now passes with the stall raised to 3 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf