### PR TITLE
Pin the HTTP API's wire format with JSON snapshots

### DIFF
--- a/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
@@ -1,0 +1,281 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+using AwesomeAssertions.Execution;
+
+using FakeItEasy;
+
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// Pins the JSON bodies the HTTP API puts on the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other test in this folder reads the API through <see cref="HttpScheduler" />, which means a
+/// serializer change that renamed, dropped or re-cased a field would keep passing as long as both ends
+/// changed together — and every consumer that is not this client would break. So these tests speak raw
+/// <see cref="HttpClient" /> and snapshot the bytes.
+/// </para>
+/// <para>
+/// The data comes from <see cref="TestData.Wire" />, which is fixed instants and UTC throughout, so
+/// almost nothing here needs scrubbing. Reviewing a diff on one of these files means asking whether
+/// the API's consumers were meant to see it.
+/// </para>
+/// </remarks>
+public class WireFormatSnapshotTest : WebApiTest
+{
+    private const string SchedulerUrl = "schedulers/" + TestData.SchedulerName;
+
+    private static readonly JobKey jobKey = TestData.JobDetail.Key;
+
+    [Test]
+    public async Task JobDetailBody()
+    {
+        A.CallTo(() => FakeScheduler.GetJobDetail(jobKey, A<CancellationToken>._)).Returns(TestData.JobDetail);
+
+        string body = await Get($"{SchedulerUrl}/jobs/{jobKey.Group}/{jobKey.Name}");
+        await VerifyBody(body);
+    }
+
+    [Test]
+    public async Task SimpleTriggerBody() => await VerifyTriggerBody(TestData.Wire.SimpleTrigger);
+
+    [Test]
+    public async Task CronTriggerBody() => await VerifyTriggerBody(TestData.Wire.CronTrigger);
+
+    [Test]
+    public async Task CalendarIntervalTriggerBody() => await VerifyTriggerBody(TestData.Wire.CalendarIntervalTrigger);
+
+    [Test]
+    public async Task DailyTimeIntervalTriggerBody() => await VerifyTriggerBody(TestData.Wire.DailyTimeIntervalTrigger);
+
+    [Test]
+    public async Task RecurrenceTriggerBody() => await VerifyTriggerBody(TestData.Wire.RecurrenceTrigger);
+
+    [Test]
+    public async Task CalendarBody()
+    {
+        A.CallTo(() => FakeScheduler.GetCalendar("HolidayCalendar", A<CancellationToken>._)).Returns(TestData.Wire.HolidayCalendar);
+
+        string body = await Get($"{SchedulerUrl}/calendars/HolidayCalendar");
+        await VerifyBody(body);
+    }
+
+    [Test]
+    public async Task PagedListingBody()
+    {
+        // one page of a larger result: the envelope has to carry both the "there is more" flag and the
+        // total the caller asked to be counted
+        A.CallTo(() => FakeScheduler.QueryJobs(A<JobQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<JobHeader>([JobHeaderFor(TestData.JobDetail)], HasMore: true, TotalCount: 5));
+
+        string body = await Get($"{SchedulerUrl}/jobs?skip=2&take=1&includeTotalCount=true");
+        await VerifyBody(body);
+    }
+
+    [Test]
+    public async Task SchedulerBody()
+    {
+        A.CallTo(() => FakeScheduler.GetMetadata(A<CancellationToken>._)).Returns(TestData.Wire.Metadata);
+        A.CallTo(() => FakeScheduler.IsStarted).Returns(TestData.Wire.Metadata.Started);
+        A.CallTo(() => FakeScheduler.InStandbyMode).Returns(TestData.Wire.Metadata.InStandbyMode);
+        A.CallTo(() => FakeScheduler.IsShutdown).Returns(TestData.Wire.Metadata.Shutdown);
+
+        string body = await Get(SchedulerUrl);
+        await VerifyBody(body);
+    }
+
+    [Test]
+    public async Task ValidationProblemDetailsBody()
+    {
+        // a job detail with no name: the request never reaches the scheduler, and the caller gets the
+        // validation message rather than a bare status code
+        const string requestJson = """
+            {
+              "job": { "group": "DummyGroup", "jobType": "Quartz.Tests.AspNetCore.Support.DummyJob" },
+              "replace": false
+            }
+            """;
+
+        string body = await Post($"{SchedulerUrl}/jobs", requestJson, HttpStatusCode.BadRequest);
+
+        A.CallTo(() => FakeScheduler.AddJob(A<IJobDetail>._, A<AddJobOptions>._, A<CancellationToken>._)).MustNotHaveHappened();
+        await VerifyBody(body);
+    }
+
+    [Test]
+    public async Task UnknownSchedulerProblemDetailsBody()
+    {
+        string body = await Get("schedulers/no-such-scheduler", HttpStatusCode.NotFound);
+        await VerifyBody(body);
+    }
+
+    [Test]
+    public async Task UnknownJobProblemDetailsBody()
+    {
+        A.CallTo(() => FakeScheduler.GetJobDetail(A<JobKey>._, A<CancellationToken>._)).Returns(null);
+
+        string body = await Get($"{SchedulerUrl}/jobs/DummyGroup/no-such-job", HttpStatusCode.NotFound);
+        await VerifyBody(body);
+    }
+
+    /// <summary>
+    /// The status code an operation answers with is as much of a contract as the body, and the
+    /// conventions are not the obvious ones: a mutation that found nothing to change still answers 200
+    /// with a flag in the body, and only a missing scheduler or a missing read target is a 404.
+    /// </summary>
+    [Test]
+    public async Task StatusCodesFollowTheApiConventions()
+    {
+        JobKey existingJob = new("existing", "group");
+        JobKey missingJob = new("missing", "group");
+        TriggerKey existingTrigger = new("existing", "group");
+        TriggerKey missingTrigger = new("missing", "group");
+
+        A.CallTo(() => FakeScheduler.GetJobDetail(existingJob, A<CancellationToken>._)).Returns(TestData.JobDetail);
+        A.CallTo(() => FakeScheduler.GetJobDetail(missingJob, A<CancellationToken>._)).Returns(null);
+        A.CallTo(() => FakeScheduler.GetTrigger(existingTrigger, A<CancellationToken>._)).Returns(TestData.Wire.SimpleTrigger);
+        A.CallTo(() => FakeScheduler.GetTrigger(missingTrigger, A<CancellationToken>._)).Returns(null);
+        A.CallTo(() => FakeScheduler.GetCalendar("existing", A<CancellationToken>._)).Returns(TestData.Wire.HolidayCalendar);
+        A.CallTo(() => FakeScheduler.GetCalendar("missing", A<CancellationToken>._)).Returns(null);
+        A.CallTo(() => FakeScheduler.PauseJob(existingJob, A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.PauseJob(missingJob, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => FakeScheduler.ResumeJob(existingJob, A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.DeleteJob(existingJob, A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.DeleteJob(missingJob, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => FakeScheduler.DeleteCalendar("existing", A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.DeleteCalendar("missing", A<CancellationToken>._)).Returns(false);
+
+        const string addJobJson = """
+            {
+              "job": {
+                "name": "existing",
+                "group": "group",
+                "jobType": "Quartz.Tests.AspNetCore.Support.DummyJob",
+                "durable": true,
+                "requestsRecovery": false,
+                "concurrentExecutionDisallowed": false,
+                "persistJobDataAfterExecution": false,
+                "jobDataMap": { "TestKey": "TestValue" }
+              },
+              "replace": true
+            }
+            """;
+
+        using HttpClient httpClient = WebApplicationFactory.CreateClient();
+        using (new AssertionScope())
+        {
+            // reads: found is 200, missing is 404 with problem details
+            await Row(HttpMethod.Get, $"{SchedulerUrl}/jobs/group/existing", HttpStatusCode.OK);
+            await Row(HttpMethod.Get, $"{SchedulerUrl}/jobs/group/missing", HttpStatusCode.NotFound);
+            await Row(HttpMethod.Get, $"{SchedulerUrl}/triggers/group/existing", HttpStatusCode.OK);
+            await Row(HttpMethod.Get, $"{SchedulerUrl}/triggers/group/missing", HttpStatusCode.NotFound);
+            await Row(HttpMethod.Get, $"{SchedulerUrl}/calendars/existing", HttpStatusCode.OK);
+            await Row(HttpMethod.Get, $"{SchedulerUrl}/calendars/missing", HttpStatusCode.NotFound);
+
+            // an unknown scheduler is a 404 whatever the operation was
+            await Row(HttpMethod.Get, "schedulers/no-such-scheduler", HttpStatusCode.NotFound);
+            await Row(HttpMethod.Get, "schedulers/no-such-scheduler/jobs/group/existing", HttpStatusCode.NotFound);
+            await Row(HttpMethod.Post, "schedulers/no-such-scheduler/jobs/group/existing/pause", HttpStatusCode.NotFound);
+
+            // writes that succeeded but produced nothing to say: 200 with an empty body
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs", HttpStatusCode.OK, addJobJson, expectedBody: "");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/trigger", HttpStatusCode.OK, expectedBody: "");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/pause-all", HttpStatusCode.OK, expectedBody: "");
+
+            // pause/resume: a key that was not there is not an error, it is 200 with applied=false
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/pause", HttpStatusCode.OK, expectedBody: """{"applied":true}""");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/missing/pause", HttpStatusCode.OK, expectedBody: """{"applied":false}""");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/resume", HttpStatusCode.OK, expectedBody: """{"applied":true}""");
+
+            // deletes follow the same rule, under a name of their own
+            await Row(HttpMethod.Delete, $"{SchedulerUrl}/jobs/group/existing", HttpStatusCode.OK, expectedBody: """{"jobFound":true}""");
+            await Row(HttpMethod.Delete, $"{SchedulerUrl}/jobs/group/missing", HttpStatusCode.OK, expectedBody: """{"jobFound":false}""");
+            await Row(HttpMethod.Delete, $"{SchedulerUrl}/calendars/existing", HttpStatusCode.OK, expectedBody: """{"calendarFound":true}""");
+            await Row(HttpMethod.Delete, $"{SchedulerUrl}/calendars/missing", HttpStatusCode.OK, expectedBody: """{"calendarFound":false}""");
+
+            // a malformed request is a 400, never a 404 or a 500
+            await Row(HttpMethod.Get, $"{SchedulerUrl}/jobs?skip=-1", HttpStatusCode.BadRequest);
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs", HttpStatusCode.BadRequest, """{"replace":true}""");
+        }
+
+        async Task Row(HttpMethod method, string url, HttpStatusCode expectedStatusCode, string? requestJson = null, string? expectedBody = null)
+        {
+            using HttpRequestMessage request = new(method, url);
+            if (requestJson is not null)
+            {
+                request.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            }
+
+            using HttpResponseMessage response = await httpClient.SendAsync(request);
+            string body = await response.Content.ReadAsStringAsync();
+
+            response.StatusCode.Should().Be(expectedStatusCode, $"{method} {url} answers {expectedStatusCode:D}, body was {body}");
+            if (expectedBody is not null)
+            {
+                body.Should().Be(expectedBody, $"{method} {url} answers with exactly this body");
+            }
+        }
+    }
+
+    private async Task VerifyTriggerBody(ITrigger trigger, [CallerMemberName] string testMethod = "")
+    {
+        A.CallTo(() => FakeScheduler.GetTrigger(trigger.Key, A<CancellationToken>._)).Returns(trigger);
+
+        string body = await Get($"{SchedulerUrl}/triggers/{trigger.Key.Group}/{trigger.Key.Name}");
+        await VerifyBody(body, testMethod);
+    }
+
+    private async Task<string> Get(string url, HttpStatusCode expectedStatusCode = HttpStatusCode.OK)
+    {
+        using HttpClient httpClient = WebApplicationFactory.CreateClient();
+        using HttpResponseMessage response = await httpClient.GetAsync(url);
+
+        string body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(expectedStatusCode, $"GET {url} answers {expectedStatusCode:D}, body was {body}");
+        return body;
+    }
+
+    private async Task<string> Post(string url, string requestJson, HttpStatusCode expectedStatusCode = HttpStatusCode.OK)
+    {
+        using HttpClient httpClient = WebApplicationFactory.CreateClient();
+        using StringContent content = new(requestJson, Encoding.UTF8, "application/json");
+        using HttpResponseMessage response = await httpClient.PostAsync(url, content);
+
+        string body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(expectedStatusCode, $"POST {url} answers {expectedStatusCode:D}, body was {body}");
+        return body;
+    }
+
+    private static SettingsTask VerifyBody(string body, [CallerMemberName] string testMethod = "")
+    {
+        return VerifyJson(body)
+            // strict JSON, so that the snapshot keeps the one thing a relaxed rendering drops: whether a
+            // value went out as a string or as a number. A job data map entry's JSON type is part of the
+            // contract - the reader branches on it.
+            .UseStrictJson()
+            // an empty job data map is a field the API emits and its readers parse, so it belongs in the
+            // snapshot; Verify drops empty collections unless told not to
+            .DontIgnoreEmptyCollections()
+            // the instants in these bodies are fixed by TestData.Wire, and pinning them is the point -
+            // Verify's default scrubbing would replace them with placeholders
+            .DontScrubDateTimes()
+            .DontScrubGuids()
+            .UseDirectory("../Verify")
+            .UseFileName($"WireFormatSnapshotTest_{testMethod}")
+            .DisableRequireUniquePrefix();
+    }
+
+    private static JobHeader JobHeaderFor(IJobDetail jobDetail) => new(
+        jobDetail.Key,
+        Description: jobDetail.Description,
+        JobTypeName: jobDetail.JobType.FullName!,
+        Durable: jobDetail.Durable,
+        ConcurrentExecutionDisallowed: jobDetail.ConcurrentExecutionDisallowed,
+        PersistJobDataAfterExecution: jobDetail.PersistJobDataAfterExecution,
+        RequestsRecovery: jobDetail.RequestsRecovery);
+}

--- a/src/Quartz.Tests.AspNetCore/Support/TestData.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestData.cs
@@ -230,4 +230,155 @@ public static class TestData
             job: new DummyJob()
         );
     }
+
+    /// <summary>
+    /// Test data for the tests that snapshot the bytes the HTTP API puts on the wire.
+    /// </summary>
+    /// <remarks>
+    /// The rest of <see cref="TestData" /> is built off the wall clock and the machine's time zone, which
+    /// costs those tests nothing because they only round-trip it. A wire snapshot has to compare equal
+    /// tomorrow, and on a machine in another time zone, so everything here is a constant instead: fixed
+    /// instants, UTC throughout, and fire times assigned rather than computed. Anything left to move
+    /// would have to be scrubbed, and a scrubbed field is a field the snapshot no longer pins.
+    /// </remarks>
+    public static class Wire
+    {
+        public static readonly DateTimeOffset StartTime = new(2024, 7, 1, 12, 0, 0, TimeSpan.Zero);
+        public static readonly DateTimeOffset EndTime = new(2025, 7, 1, 12, 0, 0, TimeSpan.Zero);
+        public static readonly DateTimeOffset PreviousFireTime = new(2024, 8, 1, 6, 30, 0, TimeSpan.Zero);
+        public static readonly DateTimeOffset NextFireTime = new(2024, 8, 1, 12, 30, 0, TimeSpan.Zero);
+
+        public static readonly SchedulerMetadata Metadata;
+
+        public static readonly HolidayCalendar HolidayCalendar;
+
+        public static readonly ITrigger SimpleTrigger;
+        public static readonly ITrigger CronTrigger;
+        public static readonly ITrigger CalendarIntervalTrigger;
+        public static readonly ITrigger DailyTimeIntervalTrigger;
+        public static readonly ITrigger RecurrenceTrigger;
+
+        static Wire()
+        {
+            Metadata = new SchedulerMetadata
+            {
+                SchedulerName = SchedulerName,
+                SchedulerInstanceId = SchedulerInstanceId,
+                SchedulerTypeName = typeof(IScheduler).AssemblyQualifiedNameWithoutVersion(),
+                IsProxy = false,
+                Started = true,
+                InStandbyMode = false,
+                Shutdown = false,
+                RunningSince = StartTime,
+                JobsExecuted = 1_000_000,
+                JobStoreTypeName = typeof(RAMJobStore).AssemblyQualifiedNameWithoutVersion(),
+                JobStorePersistent = false,
+                JobStoreClustered = false,
+                ThreadPoolTypeName = typeof(DefaultThreadPool).AssemblyQualifiedNameWithoutVersion(),
+                ThreadPoolSize = 10,
+                Version = "1.2.3",
+            };
+
+            HolidayCalendar = new HolidayCalendar
+            {
+                TimeZone = TimeZoneInfo.Utc,
+                Description = "Test HolidayCalendar",
+                // chained, so the snapshot also pins how a base calendar nests on the wire
+                CalendarBase = new BaseCalendar
+                {
+                    TimeZone = TimeZoneInfo.Utc,
+                    Description = "Test BaseCalendar"
+                }
+            };
+            HolidayCalendar.AddExcludedDay(new DateOnly(2024, 12, 24));
+            HolidayCalendar.AddExcludedDay(new DateOnly(2024, 12, 25));
+
+            SimpleTrigger = WithFireTimes(TriggerBuilder.Create()
+                .WithSimpleSchedule(builder => builder
+                    .WithInterval(new TimeSpan(120, 2, 30, 59, 999))
+                    .WithRepeatCount(1_000)
+                )
+                .WithIdentity("SimpleTriggerKey", "SimpleTriggerGroup")
+                .ForJob("SimpleJobKey", "SimpleJobGroup")
+                .WithDescription("SimpleTrigger description")
+                .WithCalendarName("SomeOtherCalendar")
+                .UsingJobData("TestKey", "150")
+                .StartAt(StartTime)
+                .EndAt(EndTime)
+                .WithPriority(150_000)
+                .Build());
+
+            CronTrigger = WithFireTimes(TriggerBuilder.Create()
+                .WithCronSchedule("0/25 * * * * ?", builder => builder
+                    .InTimeZone(TimeZoneInfo.Utc)
+                )
+                .WithIdentity("CronTriggerKey", "CronTriggerGroup")
+                .ForJob("CronJobKey", "CronJobGroup")
+                .WithDescription("CronTrigger description")
+                .WithCalendarName("SomeCalendar")
+                .StartAt(StartTime)
+                .EndAt(EndTime)
+                .WithPriority(1)
+                .Build());
+
+            CalendarIntervalTrigger = WithFireTimes(TriggerBuilder.Create()
+                .WithCalendarIntervalSchedule(builder => builder
+                    .WithInterval(10, IntervalUnit.Minute)
+                    .InTimeZone(TimeZoneInfo.Utc)
+                    .PreserveHourOfDayAcrossDaylightSavings(true)
+                    .SkipDayIfHourDoesNotExist(false)
+                )
+                .WithIdentity("CalendarIntervalTriggerKey", "CalendarIntervalTriggerGroup")
+                .ForJob("CalendarIntervalJobKey", "CalendarIntervalJobGroup")
+                .WithDescription("CalendarIntervalTrigger description")
+                .WithCalendarName("SomeCalendar")
+                .UsingJobData("TestKey", "TestValue")
+                .StartAt(StartTime)
+                .EndAt(null)
+                .WithPriority(10)
+                .Build());
+
+            DailyTimeIntervalTrigger = WithFireTimes(TriggerBuilder.Create()
+                .WithDailyTimeIntervalSchedule(builder => builder
+                    .WithRepeatCount(1_000)
+                    .WithInterval(5, IntervalUnit.Hour)
+                    .StartingDailyAt(new TimeOnly(10, 0, 0))
+                    .EndingDailyAt(new TimeOnly(20, 0, 0))
+                    .OnDaysOfTheWeek(DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Friday)
+                    .InTimeZone(TimeZoneInfo.Utc)
+                )
+                .WithIdentity("DailyTimeIntervalTriggerKey", "DailyTimeIntervalTriggerGroup")
+                .ForJob("DailyTimeIntervalJobKey", "DailyTimeIntervalJobGroup")
+                .WithDescription("DailyTimeIntervalTrigger description")
+                .WithCalendarName(null)
+                .StartAt(StartTime)
+                .EndAt(null)
+                .Build());
+
+            RecurrenceTrigger = WithFireTimes(TriggerBuilder.Create()
+                .WithRecurrenceSchedule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR", builder => builder
+                    .InTimeZone(TimeZoneInfo.Utc)
+                )
+                .WithIdentity("RecurrenceTriggerKey", "RecurrenceTriggerGroup")
+                .ForJob("RecurrenceJobKey", "RecurrenceJobGroup")
+                .WithDescription("RecurrenceTrigger description")
+                .WithCalendarName(null)
+                .StartAt(StartTime)
+                .EndAt(EndTime)
+                .WithPriority(5)
+                .Build());
+        }
+
+        /// <summary>
+        /// Assigns the fire times the scheduler would otherwise have advanced, so that the snapshot pins
+        /// them as values rather than as nulls.
+        /// </summary>
+        private static ITrigger WithFireTimes(ITrigger trigger)
+        {
+            IMutableTrigger mutableTrigger = (IMutableTrigger) trigger;
+            mutableTrigger.PreviousFireTimeUtc = PreviousFireTime;
+            mutableTrigger.NextFireTimeUtc = NextFireTime;
+            return trigger;
+        }
+    }
 }

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_CalendarBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_CalendarBody.verified.json
@@ -1,0 +1,15 @@
+﻿{
+  "type": "HolidayCalendar",
+  "description": "Test HolidayCalendar",
+  "timeZoneId": "UTC",
+  "baseCalendar": {
+    "type": "BaseCalendar",
+    "description": "Test BaseCalendar",
+    "timeZoneId": "UTC",
+    "baseCalendar": null
+  },
+  "excludedDates": [
+    "2024-12-24",
+    "2024-12-25"
+  ]
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_CalendarIntervalTriggerBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_CalendarIntervalTriggerBody.verified.json
@@ -1,0 +1,31 @@
+﻿{
+  "triggerType": "CalendarIntervalTrigger",
+  "key": {
+    "name": "CalendarIntervalTriggerKey",
+    "group": "CalendarIntervalTriggerGroup"
+  },
+  "jobKey": {
+    "name": "CalendarIntervalJobKey",
+    "group": "CalendarIntervalJobGroup"
+  },
+  "description": "CalendarIntervalTrigger description",
+  "calendarName": "SomeCalendar",
+  "jobDataMap": {
+    "TestKey": "TestValue"
+  },
+  "misfireInstruction": 0,
+  "startTimeUtc": "2024-07-01T12:00:00+00:00",
+  "endTimeUtc": null,
+  "priority": 10,
+  "nextFireTimeUtc": "2024-08-01T12:30:00+00:00",
+  "previousFireTimeUtc": "2024-08-01T06:30:00+00:00",
+  "executionGroup": null,
+  "preferredNode": null,
+  "preferredNodeAuto": false,
+  "repeatInterval": 10,
+  "repeatIntervalUnit": "Minute",
+  "timeZone": "UTC",
+  "preserveHourOfDayAcrossDaylightSavings": true,
+  "skipDayIfHourDoesNotExist": false,
+  "timesTriggered": 0
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_CronTriggerBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_CronTriggerBody.verified.json
@@ -1,0 +1,25 @@
+﻿{
+  "triggerType": "CronTrigger",
+  "key": {
+    "name": "CronTriggerKey",
+    "group": "CronTriggerGroup"
+  },
+  "jobKey": {
+    "name": "CronJobKey",
+    "group": "CronJobGroup"
+  },
+  "description": "CronTrigger description",
+  "calendarName": "SomeCalendar",
+  "jobDataMap": {},
+  "misfireInstruction": 0,
+  "startTimeUtc": "2024-07-01T12:00:00+00:00",
+  "endTimeUtc": "2025-07-01T12:00:00+00:00",
+  "priority": 1,
+  "nextFireTimeUtc": "2024-08-01T12:30:00+00:00",
+  "previousFireTimeUtc": "2024-08-01T06:30:00+00:00",
+  "executionGroup": null,
+  "preferredNode": null,
+  "preferredNodeAuto": false,
+  "cronExpressionString": "0/25 * * * * ?",
+  "timeZone": "UTC"
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_DailyTimeIntervalTriggerBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_DailyTimeIntervalTriggerBody.verified.json
@@ -1,0 +1,43 @@
+﻿{
+  "triggerType": "DailyTimeIntervalTrigger",
+  "key": {
+    "name": "DailyTimeIntervalTriggerKey",
+    "group": "DailyTimeIntervalTriggerGroup"
+  },
+  "jobKey": {
+    "name": "DailyTimeIntervalJobKey",
+    "group": "DailyTimeIntervalJobGroup"
+  },
+  "description": "DailyTimeIntervalTrigger description",
+  "calendarName": null,
+  "jobDataMap": {},
+  "misfireInstruction": 0,
+  "startTimeUtc": "2024-07-01T12:00:00+00:00",
+  "endTimeUtc": null,
+  "priority": 5,
+  "nextFireTimeUtc": "2024-08-01T12:30:00+00:00",
+  "previousFireTimeUtc": "2024-08-01T06:30:00+00:00",
+  "executionGroup": null,
+  "preferredNode": null,
+  "preferredNodeAuto": false,
+  "repeatCount": 1000,
+  "repeatInterval": 5,
+  "repeatIntervalUnit": "Hour",
+  "startTimeOfDay": {
+    "hour": 10,
+    "minute": 0,
+    "second": 0
+  },
+  "endTimeOfDay": {
+    "hour": 20,
+    "minute": 0,
+    "second": 0
+  },
+  "daysOfWeek": [
+    "Monday",
+    "Wednesday",
+    "Friday"
+  ],
+  "timeZone": "UTC",
+  "timesTriggered": 0
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_JobDetailBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_JobDetailBody.verified.json
@@ -1,0 +1,13 @@
+﻿{
+  "name": "DummyJob",
+  "group": "DummyGroup",
+  "jobType": "Quartz.Tests.AspNetCore.Support.DummyJob, Quartz.Tests.AspNetCore",
+  "description": "Dummy job description",
+  "durable": true,
+  "requestsRecovery": true,
+  "concurrentExecutionDisallowed": true,
+  "persistJobDataAfterExecution": true,
+  "jobDataMap": {
+    "TestKey": "TestValue"
+  }
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_PagedListingBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_PagedListingBody.verified.json
@@ -1,0 +1,16 @@
+﻿{
+  "items": [
+    {
+      "name": "DummyJob",
+      "group": "DummyGroup",
+      "description": "Dummy job description",
+      "jobTypeName": "Quartz.Tests.AspNetCore.Support.DummyJob, Quartz.Tests.AspNetCore",
+      "durable": true,
+      "concurrentExecutionDisallowed": true,
+      "persistJobDataAfterExecution": true,
+      "requestsRecovery": true
+    }
+  ],
+  "hasMore": true,
+  "totalCount": 5
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_RecurrenceTriggerBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_RecurrenceTriggerBody.verified.json
@@ -1,0 +1,26 @@
+﻿{
+  "triggerType": "RecurrenceTrigger",
+  "key": {
+    "name": "RecurrenceTriggerKey",
+    "group": "RecurrenceTriggerGroup"
+  },
+  "jobKey": {
+    "name": "RecurrenceJobKey",
+    "group": "RecurrenceJobGroup"
+  },
+  "description": "RecurrenceTrigger description",
+  "calendarName": null,
+  "jobDataMap": {},
+  "misfireInstruction": 0,
+  "startTimeUtc": "2024-07-01T12:00:00+00:00",
+  "endTimeUtc": "2025-07-01T12:00:00+00:00",
+  "priority": 5,
+  "nextFireTimeUtc": "2024-08-01T12:30:00+00:00",
+  "previousFireTimeUtc": "2024-08-01T06:30:00+00:00",
+  "executionGroup": null,
+  "preferredNode": null,
+  "preferredNodeAuto": false,
+  "recurrenceRule": "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+  "timeZone": "UTC",
+  "timesTriggered": 0
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SchedulerBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SchedulerBody.verified.json
@@ -1,0 +1,19 @@
+﻿{
+  "schedulerInstanceId": "TEST_NON_CLUSTERED",
+  "name": "TestScheduler",
+  "status": 1,
+  "threadPool": {
+    "type": "Quartz.Impl.DefaultThreadPool, Quartz",
+    "size": 10
+  },
+  "jobStore": {
+    "type": "Quartz.Impl.RAMJobStore, Quartz",
+    "clustered": false,
+    "persistent": false
+  },
+  "statistics": {
+    "version": "1.2.3",
+    "runningSince": "2024-07-01T12:00:00+00:00",
+    "jobsExecuted": 1000000
+  }
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SimpleTriggerBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SimpleTriggerBody.verified.json
@@ -1,0 +1,28 @@
+﻿{
+  "triggerType": "SimpleTrigger",
+  "key": {
+    "name": "SimpleTriggerKey",
+    "group": "SimpleTriggerGroup"
+  },
+  "jobKey": {
+    "name": "SimpleJobKey",
+    "group": "SimpleJobGroup"
+  },
+  "description": "SimpleTrigger description",
+  "calendarName": "SomeOtherCalendar",
+  "jobDataMap": {
+    "TestKey": "150"
+  },
+  "misfireInstruction": 0,
+  "startTimeUtc": "2024-07-01T12:00:00+00:00",
+  "endTimeUtc": "2025-07-01T12:00:00+00:00",
+  "priority": 150000,
+  "nextFireTimeUtc": "2024-08-01T12:30:00+00:00",
+  "previousFireTimeUtc": "2024-08-01T06:30:00+00:00",
+  "executionGroup": null,
+  "preferredNode": null,
+  "preferredNodeAuto": false,
+  "repeatCount": 1000,
+  "repeatIntervalTimeSpan": "120.02:30:59.9990000",
+  "timesTriggered": 0
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_UnknownJobProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_UnknownJobProblemDetailsBody.verified.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.5",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Unknown job DummyGroup.no-such-job"
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_UnknownSchedulerProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_UnknownSchedulerProblemDetailsBody.verified.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.5",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Unknown scheduler no-such-scheduler"
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ValidationProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ValidationProblemDetailsBody.verified.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Request validation failed: Job detail is missing name"
+}


### PR DESCRIPTION
Test-hardening PR 5: the first tests that pin the actual JSON bytes the HTTP API puts on the wire — until now a serializer change could silently break every HttpClient consumer.

## What's pinned (12 snapshots + a 21-row status-code table)

Job detail, one trigger body per family (simple, cron, calendar-interval, daily-time-interval, recurrence), a chained calendar, the PagedResult envelope, the scheduler DTO (locks the `persistent` field), ProblemDetails for 400 and both 404 shapes. All fetched with raw `HttpClient` — never through `HttpScheduler` — via a new fixed-instant `TestData.Wire` fixture (the existing TestData builds from Now/Today/Local, fine for round-trips, fatal for snapshots).

Zero scrubbers: everything is fixed in the data. Two Verify defaults are deliberately disabled because they hid the wire rather than stabilised it: `UseStrictJson` (relaxed rendering made `"150"` and `150` look identical — a job-data value's JSON type is contract) and `DontIgnoreEmptyCollections` (`"jobDataMap": {}` is really emitted).

## Wire oddities recorded for the F5 consolidation (pinned as-is, deliberately not fixed here)

1. Enums render two ways: DTO enums as numbers (`"status": 1`), Quartz's own writers as names (`"repeatIntervalUnit": "Hour"`).
2. JobDataMap keys are not camelCased while every sibling field is.
3. `jobType` (detail) vs `jobTypeName` (listing header) for the same value.
4. `triggerType` is a short logical name; `jobType` is an assembly-qualified .NET name.
5. Trigger detail bodies carry no state — "is this paused?" needs a second call.
6. `preferredNode`/`preferredNodeAuto` ride on every trigger body.
7. The scheduler DTO drops most of SchedulerMetadata; `persistent`/`clustered` are nested under `jobStore`.
8. Empty-body 200s (`AddJob`, `TriggerJob`, `PauseAll`) sit next to one-field-object 200s (`{"applied":…}`).
9. The 400 body shape varies by cause (SchedulerException adds an extension member the validation path doesn't).

When F5 reshapes any of this, these snapshots turn the declared breaking change into a reviewable diff.

All additions; no production code; API baselines untouched. AspNetCore suite green twice (snapshot stability), unit suite green, full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf