### PR TITLE
The two job stores answer the same way

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1655,6 +1655,27 @@ ship on 3.x as well, so upgrading is not what fixes them. One part of #3294 *is*
   success into a throw on a released branch. If you reschedule onto a calendar you intend to add
   afterwards, add the calendar first.
 
+## The two job stores answer the same way
+
+`RAMJobStore` and the ADO.NET job store implement one interface, and on 3.x they quietly disagreed
+about a handful of answers — each had its own tests, written against whatever the store in front of
+the author happened to do. `JobStoreContractTest` runs one set of assertions against both stores, and
+closing the disagreements it found changed behaviour a 3.x application could have depended on. Each
+of these is a 3.x behaviour, not a 4.x regression:
+
+- **A prefix `PauseTriggers` pauses every group it matches.** `RAMJobStore` recorded the *matcher's
+  text* rather than the group it matched, so `PauseTriggers(GroupMatcher<TriggerKey>.GroupStartsWith("report"))`
+  paused the triggers of only the first matching group, returned that one group, and left a phantom
+  entry named `report` in the paused-group set — which then paused anything later added to a group
+  literally called `report`. It now records each matched group and pauses all of their triggers, which
+  is what the ADO store always did. `ResumeTriggers` with a non-equality matcher forgets those groups
+  again; it previously only ever cleared an exact-name pause.
+
+  The semantics both stores now share: a pause remembers the **groups the matcher matched**, not the
+  pattern. A trigger added afterwards to a matched group is born paused; a trigger added to a group
+  that *would* have matched but did not exist at pause time is not. To pause a group before it
+  exists, pause it by exact name — `GroupEquals` deliberately records a group that holds nothing yet.
+
 ## JobKey and TriggerKey Null Validation
 
 `JobKey` and `TriggerKey` now throw `ArgumentNullException` when you specify `null` for `name` or `group`. Triggers can no longer be constructed with a null group name. If your code was relying on null group names, switch to an explicit group name.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -49,8 +49,10 @@ returning `PagedResult<T>` of headers; [misfire instructions are enums](#misfire
 [the driver delegate speaks in records](#the-driver-delegate-speaks-in-records);
 [the optional columns are required, so the probes are gone](#the-optional-columns-are-required-so-the-probes-are-gone)
 and the [schema migration](#database-schema-migration) that goes with that is mandatory;
-[`RAMJobStore` is sealed](#ramjobstore-is-sealed); and
-[a job store of your own can join your transaction](#a-job-store-of-your-own-can-join-your-transaction).
+[`RAMJobStore` is sealed](#ramjobstore-is-sealed);
+[a job store of your own can join your transaction](#a-job-store-of-your-own-can-join-your-transaction);
+and the two stores, held to one contract test, now
+[answer the same way](#the-two-job-stores-answer-the-same-way) where they used to disagree.
 
 **5. Configuration and hosting.** The container builds the scheduler:
 [`StdSchedulerFactory` is gone](#stdschedulerfactory-is-gone),
@@ -1696,6 +1698,22 @@ of these is a 3.x behaviour, not a 4.x regression:
   way to see why short of reading the table. `ResumeAll` clears the whole table for the scheduler
   now, which is what `RAMJobStore` always did. The 3.x row can be removed by hand with
   `DELETE FROM QRTZ_PAUSED_TRIGGER_GRPS WHERE SCHED_NAME = '…'` if a database carries one.
+
+- **The all-groups-paused marker is no longer listed as a group.** The ADO store records `PauseAll`
+  as a row named `_$_ALL_GROUPS_PAUSED_$_` in the same table it lists paused groups from, so
+  `GetPausedTriggerGroups()` — and `QueryTriggerGroups(new TriggerGroupQuery { Paused = true })` —
+  handed back a group name no trigger can ever belong to. Code that displayed the list showed it to
+  operators, and code that looped it called `ResumeTriggers` on a group that does not exist. The
+  listing and its count filter the marker out now; the marker itself is unchanged, so nothing about
+  the schema or about how a pause is recorded moves. `RAMJobStore` never had such a row.
+
+- **A duplicate says so on both stores.** `AddCalendar` over an existing name without
+  `Replace = true`, and `AddJob` over an existing key without `replace: true`, raise
+  `ObjectAlreadyExistsException` on the ADO store as they always did on `RAMJobStore`. Both calls
+  passed through a blanket `catch` that re-wrapped it as a plain `JobPersistenceException` with the
+  real exception in `InnerException`, so `catch (ObjectAlreadyExistsException)` worked against one
+  store and not the other. `ObjectAlreadyExistsException` derives from `JobPersistenceException`, so
+  code catching the base type is unaffected.
 
 ## JobKey and TriggerKey Null Validation
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1688,6 +1688,15 @@ of these is a 3.x behaviour, not a 4.x regression:
   comes out of error into the pause rather than past it. If you have code that pauses a group to
   suppress a failing trigger, pause it and then reset it: the pause no longer does both.
 
+- **`ResumeAll` on the ADO store now resumes groups that hold no triggers.** It walked the groups it
+  found in `QRTZ_TRIGGERS` and cleared only those, plus its own all-groups marker. A group paused
+  while empty — `PauseTriggers(GroupEquals("nightly"))` before anything is scheduled into `nightly`,
+  which is a supported thing to do — is in no trigger row, so its `QRTZ_PAUSED_TRIGGER_GRPS` row
+  survived the resume and went on pausing everything scheduled into that group afterwards, with no
+  way to see why short of reading the table. `ResumeAll` clears the whole table for the scheduler
+  now, which is what `RAMJobStore` always did. The 3.x row can be removed by hand with
+  `DELETE FROM QRTZ_PAUSED_TRIGGER_GRPS WHERE SCHED_NAME = '…'` if a database carries one.
+
 ## JobKey and TriggerKey Null Validation
 
 `JobKey` and `TriggerKey` now throw `ArgumentNullException` when you specify `null` for `name` or `group`. Triggers can no longer be constructed with a null group name. If your code was relying on null group names, switch to an explicit group name.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1676,6 +1676,18 @@ of these is a 3.x behaviour, not a 4.x regression:
   that *would* have matched but did not exist at pause time is not. To pause a group before it
   exists, pause it by exact name — `GroupEquals` deliberately records a group that holds nothing yet.
 
+- **Pausing no longer discards an error.** `RAMJobStore` moved a trigger to `Paused` from every state
+  but `Complete`, so pausing a trigger — or the group or job it belongs to — silently overwrote
+  `TriggerState.Error`: the failure disappeared from listings and `ResetTriggerFromErrorState` found
+  nothing left to reset. Only `Normal` (waiting), acquired and blocked triggers are pausable now,
+  matching what the ADO store writes `PAUSED` over. A trigger in error keeps its state, and
+  `PauseTrigger` returns false for it, because nothing moved.
+
+  Resetting such a trigger while its group is paused lands it in `Paused` rather than `Normal` on
+  both stores, which is what the ADO store always did — the group is still paused, so the trigger
+  comes out of error into the pause rather than past it. If you have code that pauses a group to
+  suppress a failing trigger, pause it and then reset it: the pause no longer does both.
+
 ## JobKey and TriggerKey Null Validation
 
 `JobKey` and `TriggerKey` now throw `ArgumentNullException` when you specify `null` for `name` or `group`. Triggers can no longer be constructed with a null group name. If your code was relying on null group names, switch to an explicit group name.

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SQLiteJobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SQLiteJobStoreContractTest.cs
@@ -47,18 +47,6 @@ public sealed class SQLiteJobStoreContractTest : JobStoreContractTest
     /// </summary>
     protected override bool ReportsJobGroupPauseState => false;
 
-    /// <summary>
-    /// Pausing everything is recorded as a row in the same table paused groups are listed from, so
-    /// the marker shows up in the listing as if it were a group.
-    /// </summary>
-    protected override string AllGroupsPausedSentinel => AdoConstants.AllGroupsPaused;
-
-    /// <summary>
-    /// The store's blanket catch re-wraps the specific exception as a plain
-    /// <see cref="JobPersistenceException" />.
-    /// </summary>
-    protected override Type DuplicateCalendarException => typeof(JobPersistenceException);
-
     protected override async ValueTask<IJobStore> CreateStore()
     {
         dbFileName = $"test-store-contract-{Guid.NewGuid():N}.db";

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SQLiteJobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SQLiteJobStoreContractTest.cs
@@ -54,12 +54,6 @@ public sealed class SQLiteJobStoreContractTest : JobStoreContractTest
     protected override string AllGroupsPausedSentinel => AdoConstants.AllGroupsPaused;
 
     /// <summary>
-    /// Resuming everything walks the groups the trigger table knows about, which a paused-but-empty
-    /// group is not one of.
-    /// </summary>
-    protected override bool ResumeAllForgetsPausedButEmptyGroups => false;
-
-    /// <summary>
     /// The store's blanket catch re-wraps the specific exception as a plain
     /// <see cref="JobPersistenceException" />.
     /// </summary>

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -38,8 +38,7 @@ namespace Quartz.Tests.Integration.Impl;
 /// Where the two genuinely disagree the difference is a hook, not a missing assertion: each store says
 /// which way it behaves and both branches are asserted, so the divergence is written down and can be
 /// found by anyone deciding whether to close it. The hooks are
-/// <see cref="ReportsJobGroupPauseState" />, <see cref="AllGroupsPausedSentinel" />,
-/// <see cref="ResumeAllForgetsPausedButEmptyGroups" /> and
+/// <see cref="ReportsJobGroupPauseState" />, <see cref="AllGroupsPausedSentinel" /> and
 /// <see cref="DuplicateCalendarException" />.
 /// </para>
 /// </remarks>
@@ -89,12 +88,6 @@ public abstract class JobStoreContractTest
     /// <see langword="null" /> when it lists only real groups.
     /// </summary>
     protected virtual string AllGroupsPausedSentinel => null;
-
-    /// <summary>
-    /// Whether <see cref="IJobStore.ResumeAll" /> un-pauses a group that is paused but holds no
-    /// triggers.
-    /// </summary>
-    protected virtual bool ResumeAllForgetsPausedButEmptyGroups => true;
 
     /// <summary>
     /// The exception adding a calendar over an existing name raises when replacing was not asked for.
@@ -380,22 +373,11 @@ public abstract class JobStoreContractTest
         IOperableTrigger late = CreateTrigger("late", "empty-group", job.Key);
         await Store.ScheduleJob(job, late);
 
-        if (ResumeAllForgetsPausedButEmptyGroups)
-        {
-            (await Store.QueryTriggerGroups(new TriggerGroupQuery { Paused = true })).Items.Should().BeEmpty();
-            (await Store.GetTriggerState(late.Key)).Should().Be(TriggerState.Normal,
-                "resume-all resumed everything, so there is no pause left to impose");
-        }
-        else
-        {
-            // Pinned, not endorsed. The ADO store's ResumeAll walks the groups it finds in the trigger
-            // table, and a paused-but-empty group is in no trigger row, so its paused marker survives
-            // a resume-all and goes on pausing triggers added to that group afterwards.
-            (await Store.QueryTriggerGroups(new TriggerGroupQuery { Paused = true })).Items
-                .Select(x => x.Name).Should().Contain("empty-group",
-                    "the ADO store's resume-all only visits groups that hold triggers");
-            (await Store.GetTriggerState(late.Key)).Should().Be(TriggerState.Paused);
-        }
+        // A resume-all reaches a group that is paused but holds no triggers, which the group listing
+        // could otherwise never show a caller a way to resume.
+        (await Store.QueryTriggerGroups(new TriggerGroupQuery { Paused = true })).Items.Should().BeEmpty();
+        (await Store.GetTriggerState(late.Key)).Should().Be(TriggerState.Normal,
+            "resume-all resumed everything, so there is no pause left to impose");
     }
 
     [Test]

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -38,10 +38,9 @@ namespace Quartz.Tests.Integration.Impl;
 /// Where the two genuinely disagree the difference is a hook, not a missing assertion: each store says
 /// which way it behaves and both branches are asserted, so the divergence is written down and can be
 /// found by anyone deciding whether to close it. The hooks are
-/// <see cref="ReportsJobGroupPauseState" />, <see cref="PausesEveryTriggerGroupAPrefixMatcherMatches" />,
-/// <see cref="AllGroupsPausedSentinel" />, <see cref="PauseOverwritesTheErrorState" />,
-/// <see cref="ResumeAllForgetsPausedButEmptyGroups" /> and
-/// <see cref="DuplicateCalendarException" />.
+/// <see cref="ReportsJobGroupPauseState" />, <see cref="AllGroupsPausedSentinel" />,
+/// <see cref="PauseOverwritesTheErrorState" />, <see cref="ResumeAllForgetsPausedButEmptyGroups" />
+/// and <see cref="DuplicateCalendarException" />.
 /// </para>
 /// </remarks>
 public abstract class JobStoreContractTest
@@ -84,12 +83,6 @@ public abstract class JobStoreContractTest
     /// <see cref="IJobStore.QueryJobGroups" />.
     /// </summary>
     protected abstract bool ReportsJobGroupPauseState { get; }
-
-    /// <summary>
-    /// Whether <see cref="IJobStore.PauseTriggers" /> with a prefix matcher pauses every group the
-    /// matcher matches rather than only one of them.
-    /// </summary>
-    protected virtual bool PausesEveryTriggerGroupAPrefixMatcherMatches => true;
 
     /// <summary>
     /// The pseudo group name a store lists as paused after <see cref="IJobStore.PauseAll" />, or
@@ -270,35 +263,42 @@ public abstract class JobStoreContractTest
 
         List<string> paused = await Store.PauseTriggers(GroupMatcher<TriggerKey>.GroupStartsWith("tg"));
 
-        if (PausesEveryTriggerGroupAPrefixMatcherMatches)
-        {
-            paused.Should().BeEquivalentTo([TriggerGroupA, TriggerGroupB],
-                "a prefix matcher pauses every group whose name starts with it");
-            (await Store.GetTriggerState(first.Key)).Should().Be(TriggerState.Paused);
-            (await Store.GetTriggerState(second.Key)).Should().Be(TriggerState.Paused);
-        }
-        else
-        {
-            // Pinned, not endorsed. RAMJobStore.PauseTriggersNoLock's prefix branch guards the result
-            // with `pausedTriggerGroups.Add(matcher.CompareToValue)` — the matcher's own text, not the
-            // group it matched — so the set rejects the second matching group and only the first one
-            // is ever paused. The ADO store pauses both. Whichever group comes first is a dictionary
-            // ordering, so the assertion names neither.
-            paused.Should().HaveCount(1,
-                "the in-memory store's prefix branch stops after the first group it matches");
-
-            List<TriggerState> states =
-            [
-                await Store.GetTriggerState(first.Key),
-                await Store.GetTriggerState(second.Key)
-            ];
-
-            states.Should().Contain(TriggerState.Paused).And.Contain(TriggerState.Normal,
-                "exactly one of the two matching groups is actually paused");
-        }
+        paused.Should().BeEquivalentTo([TriggerGroupA, TriggerGroupB],
+            "a prefix matcher pauses every group whose name starts with it");
+        (await Store.GetTriggerState(first.Key)).Should().Be(TriggerState.Paused);
+        (await Store.GetTriggerState(second.Key)).Should().Be(TriggerState.Paused);
 
         (await Store.GetTriggerState(untouched.Key)).Should().Be(TriggerState.Normal,
             "a group the prefix does not match is never touched");
+
+        (await Store.QueryTriggerGroups(new TriggerGroupQuery { Paused = true })).Items
+            .Select(x => x.Name).Should().BeEquivalentTo([TriggerGroupA, TriggerGroupB],
+                "what a prefix pause records is the groups it matched, never the pattern itself");
+
+        // A group that would have matched the pattern but held no triggers when the pause ran was
+        // never one of the matched groups, so nothing imposes the pause on it afterwards. Pausing a
+        // group that does not exist yet is what the equality matcher is for.
+        IJobDetail lateJob = CreateJob("late", JobGroupA);
+        IOperableTrigger late = CreateTrigger("late", "tg-late", lateJob.Key);
+        await Store.ScheduleJob(lateJob, late);
+
+        (await Store.GetTriggerState(late.Key)).Should().Be(TriggerState.Normal,
+            "the prefix pause matched groups, not a pattern the store keeps applying");
+
+        // A trigger joining a group that *was* matched is born paused, because that group is recorded.
+        IJobDetail joiningJob = CreateJob("joining", JobGroupA);
+        IOperableTrigger joining = CreateTrigger("joining", TriggerGroupA, joiningJob.Key);
+        await Store.ScheduleJob(joiningJob, joining);
+
+        (await Store.GetTriggerState(joining.Key)).Should().Be(TriggerState.Paused,
+            "a group the prefix pause matched is a paused group like any other");
+
+        await Store.ResumeTriggers(GroupMatcher<TriggerKey>.GroupStartsWith("tg"));
+
+        (await Store.GetTriggerState(first.Key)).Should().Be(TriggerState.Normal);
+        (await Store.GetTriggerState(second.Key)).Should().Be(TriggerState.Normal);
+        (await Store.QueryTriggerGroups(new TriggerGroupQuery { Paused = true })).Items.Should().BeEmpty(
+            "the same prefix that paused the groups takes the pause off them again");
     }
 
     [Test]

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -39,8 +39,8 @@ namespace Quartz.Tests.Integration.Impl;
 /// which way it behaves and both branches are asserted, so the divergence is written down and can be
 /// found by anyone deciding whether to close it. The hooks are
 /// <see cref="ReportsJobGroupPauseState" />, <see cref="AllGroupsPausedSentinel" />,
-/// <see cref="PauseOverwritesTheErrorState" />, <see cref="ResumeAllForgetsPausedButEmptyGroups" />
-/// and <see cref="DuplicateCalendarException" />.
+/// <see cref="ResumeAllForgetsPausedButEmptyGroups" /> and
+/// <see cref="DuplicateCalendarException" />.
 /// </para>
 /// </remarks>
 public abstract class JobStoreContractTest
@@ -89,11 +89,6 @@ public abstract class JobStoreContractTest
     /// <see langword="null" /> when it lists only real groups.
     /// </summary>
     protected virtual string AllGroupsPausedSentinel => null;
-
-    /// <summary>
-    /// Whether pausing a trigger that is in <see cref="TriggerState.Error" /> overwrites the error.
-    /// </summary>
-    protected virtual bool PauseOverwritesTheErrorState => false;
 
     /// <summary>
     /// Whether <see cref="IJobStore.ResumeAll" /> un-pauses a group that is paused but holds no
@@ -475,26 +470,17 @@ public abstract class JobStoreContractTest
 
         await Store.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals(trigger.Key.Group));
 
-        if (PauseOverwritesTheErrorState)
-        {
-            // Pinned, not endorsed. The in-memory store pauses a trigger from any state but Complete,
-            // Error included, so pausing the group throws the error away: the failure is no longer
-            // visible to a listing, and there is nothing left for ResetTriggerFromErrorState to do.
-            (await Store.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Paused,
-                "the in-memory store overwrites the error with the pause");
-            (await Store.ResetTriggerFromErrorState(trigger.Key)).Should().BeFalse(
-                "the error the operator meant to reset was already overwritten");
-        }
-        else
-        {
-            // The ADO store only writes PAUSED over WAITING, ACQUIRED or BLOCKED, so the error
-            // survives the pause and can still be reset — into the pause, rather than past it.
-            (await Store.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Error,
-                "a trigger in error is not a trigger a group pause may quietly clear");
-            (await Store.ResetTriggerFromErrorState(trigger.Key)).Should().BeTrue();
-            (await Store.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Paused,
-                "the group is paused, so the trigger comes out of error into the pause");
-        }
+        // Only WAITING, ACQUIRED and BLOCKED are pausable, so the error survives the pause and can
+        // still be reset — into the pause, rather than past it.
+        (await Store.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Error,
+            "a trigger in error is not a trigger a group pause may quietly clear");
+
+        (await Store.PauseTrigger(trigger.Key)).Should().BeFalse(
+            "there was no pausable trigger to move, so the pause reports it moved nothing");
+
+        (await Store.ResetTriggerFromErrorState(trigger.Key)).Should().BeTrue();
+        (await Store.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Paused,
+            "the group is paused, so the trigger comes out of error into the pause");
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -37,9 +37,9 @@ namespace Quartz.Tests.Integration.Impl;
 /// <para>
 /// Where the two genuinely disagree the difference is a hook, not a missing assertion: each store says
 /// which way it behaves and both branches are asserted, so the divergence is written down and can be
-/// found by anyone deciding whether to close it. The hooks are
-/// <see cref="ReportsJobGroupPauseState" />, <see cref="AllGroupsPausedSentinel" /> and
-/// <see cref="DuplicateCalendarException" />.
+/// found by anyone deciding whether to close it. One hook is left,
+/// <see cref="ReportsJobGroupPauseState" />: the ADO schema has a paused-groups table for triggers and
+/// none for jobs, so closing it is a schema change rather than a code change.
 /// </para>
 /// </remarks>
 public abstract class JobStoreContractTest
@@ -82,17 +82,6 @@ public abstract class JobStoreContractTest
     /// <see cref="IJobStore.QueryJobGroups" />.
     /// </summary>
     protected abstract bool ReportsJobGroupPauseState { get; }
-
-    /// <summary>
-    /// The pseudo group name a store lists as paused after <see cref="IJobStore.PauseAll" />, or
-    /// <see langword="null" /> when it lists only real groups.
-    /// </summary>
-    protected virtual string AllGroupsPausedSentinel => null;
-
-    /// <summary>
-    /// The exception adding a calendar over an existing name raises when replacing was not asked for.
-    /// </summary>
-    protected virtual Type DuplicateCalendarException => typeof(ObjectAlreadyExistsException);
 
     [SetUp]
     public async Task BuildStoreUnderTest()
@@ -300,23 +289,14 @@ public abstract class JobStoreContractTest
         (await Store.GetTriggerState(first.Key)).Should().Be(TriggerState.Paused);
         (await Store.GetTriggerState(second.Key)).Should().Be(TriggerState.Paused);
 
-        List<string> pausedGroups = (await Store.QueryTriggerGroups(new TriggerGroupQuery { Paused = true }))
-            .Items.Select(x => x.Name).ToList();
+        PagedResult<TriggerGroup> pausedGroups = await Store.QueryTriggerGroups(
+            new TriggerGroupQuery { Paused = true, IncludeTotalCount = true });
 
-        pausedGroups.Should().Contain([TriggerGroupA, TriggerGroupB]);
-
-        if (AllGroupsPausedSentinel is null)
-        {
-            pausedGroups.Should().HaveCount(2, "only real groups are paused");
-        }
-        else
-        {
-            // The ADO store records "everything is paused" as a row in the paused-groups table, and
-            // the listing reads that table without filtering the marker out, so the caller sees a
-            // group name no trigger will ever belong to. The in-memory store has no such row.
-            pausedGroups.Should().Contain(AllGroupsPausedSentinel,
-                "the ADO store keeps its all-groups marker in the same table it lists paused groups from");
-        }
+        // Whatever a store records to mean "everything is paused" stays its own business: a listing
+        // reports groups, and a caller must never be handed a name no trigger can belong to.
+        pausedGroups.Items.Select(x => x.Name).Should().BeEquivalentTo([TriggerGroupA, TriggerGroupB],
+            "only real groups are paused");
+        pausedGroups.TotalCount.Should().Be(2, "the count matches the listing it counts");
 
         await Store.ResumeAll();
 
@@ -466,6 +446,37 @@ public abstract class JobStoreContractTest
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
+    // Storing over something that is already there
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task StoringOverAJobOrTriggerWithoutReplacingRaisesTheSpecificException()
+    {
+        IJobDetail job = CreateJob("taken", JobGroupA);
+        IOperableTrigger trigger = CreateTrigger("taken", TriggerGroupA, job.Key);
+        await Store.ScheduleJob(job, trigger);
+
+        // ObjectAlreadyExistsException derives from JobPersistenceException, so a store that wraps it
+        // still satisfies a catch of the base type — and silently costs the caller the only thing that
+        // told "already there" apart from "the store broke".
+        Func<Task> addingTheJobAgain = async () => await Store.AddJob(CreateJob("taken", JobGroupA), replace: false);
+        await addingTheJobAgain.Should().ThrowAsync<ObjectAlreadyExistsException>(
+            "storing over a job without asking to replace it names the mistake");
+
+        Func<Task> addingTheTriggerAgain = async () => await Store.AddTrigger(
+            CreateTrigger("taken", TriggerGroupA, job.Key), replace: false);
+        await addingTheTriggerAgain.Should().ThrowAsync<ObjectAlreadyExistsException>();
+
+        Func<Task> replacing = async () =>
+        {
+            await Store.AddJob(CreateJob("taken", JobGroupA), replace: true);
+            await Store.AddTrigger(CreateTrigger("taken", TriggerGroupA, job.Key), replace: true);
+        };
+
+        await replacing.Should().NotThrowAsync("replacing is what the flag asks for");
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
     // Calendars
     //////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -489,13 +500,11 @@ public abstract class JobStoreContractTest
         replacement.AddExcludedDay(christmas);
 
         Func<Task> addingAgain = async () => await Store.AddCalendar("holidays", replacement);
-        Exception thrown = (await addingAgain.Should().ThrowAsync<JobPersistenceException>(
-            "adding over a calendar without asking to replace it is a mistake, not an update")).Which;
 
-        // The stores raise different exceptions for the same mistake: the in-memory store throws the
-        // specific ObjectAlreadyExistsException, while the ADO store's blanket catch re-wraps it as a
-        // plain JobPersistenceException. Only the base type is common, so only it can be caught.
-        thrown.Should().BeOfType(DuplicateCalendarException);
+        // The specific type, on every store: "there is already one of those" is an answer a caller
+        // catches by type, and a store that re-wrapped it would make that catch store-dependent.
+        await addingAgain.Should().ThrowAsync<ObjectAlreadyExistsException>(
+            "adding over a calendar without asking to replace it is a mistake, not an update");
 
         await Store.AddCalendar("holidays", replacement, new AddCalendarOptions { Replace = true });
 

--- a/src/Quartz.Tests.Integration/Impl/RAMJobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/RAMJobStoreContractTest.cs
@@ -34,11 +34,6 @@ public sealed class RAMJobStoreContractTest : JobStoreContractTest
     /// </summary>
     protected override bool ReportsJobGroupPauseState => true;
 
-    /// <summary>
-    /// Pausing walks over any state but complete, the error state included.
-    /// </summary>
-    protected override bool PauseOverwritesTheErrorState => true;
-
     protected override async ValueTask<IJobStore> CreateStore()
     {
         IJobStore store = TestJobStores.Ram();

--- a/src/Quartz.Tests.Integration/Impl/RAMJobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/RAMJobStoreContractTest.cs
@@ -35,12 +35,6 @@ public sealed class RAMJobStoreContractTest : JobStoreContractTest
     protected override bool ReportsJobGroupPauseState => true;
 
     /// <summary>
-    /// It cannot: <c>PauseTriggersNoLock</c>'s prefix branch keys its bookkeeping on the matcher's
-    /// text rather than the matched group, and only the first matching group survives that.
-    /// </summary>
-    protected override bool PausesEveryTriggerGroupAPrefixMatcherMatches => false;
-
-    /// <summary>
     /// Pausing walks over any state but complete, the error state included.
     /// </summary>
     protected override bool PauseOverwritesTheErrorState => true;

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -1419,6 +1419,13 @@ public abstract class AdoJobStoreBase : IJobStore
                 throw new JobPersistenceException("Couldn't store job. Insert failed.");
             }
         }
+        catch (ObjectAlreadyExistsException)
+        {
+            // The one exception this method raises on purpose, and the one a caller catches by type
+            // to tell "already there" from "the store broke". Re-wrapping it as a plain
+            // JobPersistenceException would hide the answer inside InnerException.
+            throw;
+        }
         catch (IOException e)
         {
             Throw.JobPersistenceException("Couldn't store job: " + e.Message, e);
@@ -2240,6 +2247,12 @@ public abstract class AdoJobStoreBase : IJobStore
             {
                 calendarCache[calendarName] = calendar; // lazy-cache
             }
+        }
+        catch (ObjectAlreadyExistsException)
+        {
+            // Raised above on purpose, and documented on the member, so it leaves as itself rather
+            // than as a plain JobPersistenceException with the answer buried in InnerException.
+            throw;
         }
         catch (IOException e)
         {

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -3170,7 +3170,10 @@ public abstract class AdoJobStoreBase : IJobStore
 
         try
         {
-            await Delegate.DeletePausedTriggerGroup(conn, GroupMatcher<TriggerKey>.GroupEquals(AdoConstants.AllGroupsPaused), cancellationToken).ConfigureAwait(false);
+            // Every paused group, not just the all-groups marker: the loop above only visits groups the
+            // trigger table knows about, so a group that was paused while empty would keep its row and
+            // go on pausing whatever was added to it after a resume-all resumed everything.
+            await Delegate.DeletePausedTriggerGroup(conn, GroupMatcher<TriggerKey>.AnyGroup(), cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -1029,7 +1029,9 @@ public interface IDriverDelegate
     /// </summary>
     /// <remarks>
     /// A query for paused groups only reads PAUSED_TRIGGER_GRPS, so it reports a paused group that
-    /// currently has no triggers as well.
+    /// currently has no triggers as well. It must not report
+    /// <see cref="AdoConstants.AllGroupsPaused" />: that row records "everything is paused" and is not
+    /// a group any trigger can belong to.
     /// </remarks>
     /// <param name="conn">The DB connection.</param>
     /// <param name="query">What to select and which page of it to return.</param>

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -529,11 +529,20 @@ internal static class StdAdoConstants
     public static readonly string SqlCountTriggerGroups =
         Invariant($"SELECT COUNT(DISTINCT t.{AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @schedulerName");
 
+    /// <summary>
+    /// Excludes the "everything is paused" marker <see cref="AdoConstants.AllGroupsPaused" /> from a
+    /// listing. Only the listings that read PAUSED_TRIGGER_GRPS need it: the marker is a row in that
+    /// table but no trigger belongs to it, so it is not a group and must not be reported as one. The
+    /// other group listings read TRIGGERS, where it cannot appear.
+    /// </summary>
+    private static readonly string ExceptAllGroupsPausedMarker =
+        Invariant($" AND {AdoConstants.ColumnTriggerGroup} <> '{AdoConstants.AllGroupsPaused}'");
+
     public static readonly string SqlSelectPausedTriggerGroups =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName{ExceptAllGroupsPausedMarker}");
 
     public static readonly string SqlCountPausedTriggerGroups =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName{ExceptAllGroupsPausedMarker}");
 
     public static readonly string SqlSelectUnpausedTriggerGroups =
         Invariant($"SELECT DISTINCT t.{AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND NOT EXISTS ({PausedTriggerGroupExists})");

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -1572,6 +1572,16 @@ public sealed class RAMJobStore : IJobStore
         }
     }
 
+    /// <summary>
+    /// Moves one trigger into the paused state, and reports whether it moved.
+    /// </summary>
+    /// <remarks>
+    /// Only a trigger that is waiting, acquired or blocked is pausable, which is the set the ADO
+    /// store writes PAUSED over. Anything else keeps the state it is in: a completed trigger has
+    /// nothing left to pause, a paused one is already there, and a trigger in error is a failure
+    /// somebody has to see — pausing its group must not quietly clear it, or
+    /// <see cref="ResetTriggerFromErrorState" /> finds nothing left to reset.
+    /// </remarks>
     private bool PauseTriggerNoLock(TriggerKey triggerKey)
     {
         // does the trigger exist?
@@ -1580,25 +1590,17 @@ public sealed class RAMJobStore : IJobStore
             return false;
         }
 
-        // if the trigger is "complete" pausing it does not make sense...
-        if (tw.state == StoredTriggerState.Complete)
-        {
-            return false;
-        }
-
-        // already paused, nothing to change
-        if (tw.state is StoredTriggerState.Paused or StoredTriggerState.PausedBlocked)
-        {
-            return false;
-        }
-
         if (tw.state == StoredTriggerState.Blocked)
         {
             tw.state = StoredTriggerState.PausedBlocked;
         }
-        else
+        else if (tw.state is StoredTriggerState.Waiting or StoredTriggerState.Acquired)
         {
             tw.state = StoredTriggerState.Paused;
+        }
+        else
+        {
+            return false;
         }
 
         timeTriggers.Remove(tw);

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -1640,14 +1640,14 @@ public sealed class RAMJobStore : IJobStore
         }
         else
         {
+            // The group that matched is what gets remembered, not the matcher's own text: a pattern is
+            // not a group, and keying the set on it would let the first matching group swallow the
+            // pause for every later one.
             foreach (string group in triggersByGroup.Keys)
             {
-                if (op.Evaluate(group, matcher.CompareToValue))
+                if (op.Evaluate(group, matcher.CompareToValue) && pausedTriggerGroups.Add(group))
                 {
-                    if (pausedTriggerGroups.Add(matcher.CompareToValue))
-                    {
-                        pausedGroups.Add(group);
-                    }
+                    pausedGroups.Add(group);
                 }
             }
         }
@@ -1848,31 +1848,18 @@ public sealed class RAMJobStore : IJobStore
             await ResumeTriggerNoLock(triggerKey).ConfigureAwait(false);
         }
 
-        // Find all matching paused trigger groups, and then remove them.
+        // Forget the pause of every group the matcher selects, whichever operator it carries — the
+        // pause is recorded per matched group, so a resume that only understood equality would leave
+        // the groups a prefix pause recorded paused forever.
         StringOperator op = matcher.CompareWithOperator;
-        var pausedGroups = new List<string>();
-        var matcherGroup = matcher.CompareToValue;
+        string matcherGroup = matcher.CompareToValue;
         if (StringOperator.Equality.Equals(op))
         {
-            if (pausedTriggerGroups.Contains(matcherGroup))
-            {
-                pausedGroups.Add(matcher.CompareToValue);
-            }
-            else
-            {
-                foreach (string group in pausedTriggerGroups)
-                {
-                    if (op.Evaluate(group, matcherGroup))
-                    {
-                        pausedGroups.Add(group);
-                    }
-                }
-            }
-
-            foreach (string pausedGroup in pausedGroups)
-            {
-                pausedTriggerGroups.Remove(pausedGroup);
-            }
+            pausedTriggerGroups.Remove(matcherGroup);
+        }
+        else
+        {
+            pausedTriggerGroups.RemoveWhere(group => op.Evaluate(group, matcherGroup));
         }
 
         return [..groups];


### PR DESCRIPTION
Fixes the four fixable RAM-vs-ADO divergences the store contract fixture (#3305) exposed, flipping each per-store test hook into one unified assertion. All four behaviors are 3.x-inherited (verified against origin/3.x), so each carries a migration-guide row under a new "The two job stores answer the same way" section.

1. **A prefix trigger-group pause remembers the groups, not the pattern.** `RAMJobStore.PauseTriggersNoLock` keyed its bookkeeping on `matcher.CompareToValue` — the matcher's own text — so a `GroupStartsWith` pause stopped after the first matching group. It now records each matched group, matching ADO exactly (matched groups pause; a trigger later added to a matched group is born paused; a group that would match but didn't exist at pause time is unaffected). Also fixes the mirror-image bug this exposed: `ResumeTriggersNoLock` only understood equality, so the groups a prefix pause records could never be resumed by the same matcher.

2. **Pausing a trigger no longer throws its error away.** RAM pause now moves only waiting/acquired/blocked (the set ADO writes PAUSED over); a trigger in `Error` keeps its error through a group pause — a failure somebody has to see — and `ResetTriggerFromErrorState` afterwards lands it in `Paused` on both stores.

3. **`ResumeAll` clears every paused trigger group.** ADO only deleted markers for groups present in `QRTZ_TRIGGERS`, so a paused-but-empty group kept pausing triggers added later. The trailing delete now uses the AnyGroup matcher through the existing LIKE-form delegate statement — no `IDriverDelegate` signature change.

4. **The all-groups marker is not a group, and a duplicate says which one it is.** `QueryTriggerGroups(Paused: true)` no longer surfaces the `_$_ALL_GROUPS_PAUSED_$_` sentinel (filtered in the only two statements that read the table); duplicate `AddCalendar`/`AddJob` on ADO now throw `ObjectAlreadyExistsException` like RAM instead of re-wrapping it into a plain `JobPersistenceException`.

The one deliberate remaining divergence — job-group paused state unqueryable on ADO — keeps its documented hook (schema fix recorded for 4.1).

Baselines untouched. Contract fixtures 82/82 twice, basic leg 108/108 twice, unit suite 2504 twice, `Compile UnitTest PublishAot` clean. The db-\* container legs were scanned for exposure (SmokeTestPerformer's paused-group count holds identically) and run in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf