### PR TITLE
The retry-test clock advances cede real time to the handler

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/DbSemaphoreRetryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/DbSemaphoreRetryTest.cs
@@ -103,7 +103,12 @@ public class DbSemaphoreRetryTest
         for (int i = 0; i < 500 && !task.IsCompleted; i++)
         {
             clock.Advance(step);
-            await Task.Yield();
+
+            // Real time, not Task.Yield(): the handler's continuation between the failed statement and
+            // its next Task.Delay registration runs on a thread-pool thread, and on a busy runner five
+            // hundred yields can pass in microseconds without that thread ever being scheduled - the
+            // advance then lands before the timer exists and releases nothing.
+            await Task.Delay(TimeSpan.FromMilliseconds(2));
         }
 
         // Asserted rather than left to hang: a handler that went back to waiting on wall time would
@@ -116,7 +121,7 @@ public class DbSemaphoreRetryTest
     {
         for (int i = 0; i < 500 && !condition() && !running.IsCompleted; i++)
         {
-            await Task.Yield();
+            await Task.Delay(TimeSpan.FromMilliseconds(2));
         }
 
         condition().Should().BeTrue("the handler was expected to have issued its first statement by now");


### PR DESCRIPTION
Fixes the flake #3313 introduced (failed its macos/ubuntu legs; merged on a raced check read — my process error, now corrected to a fresh zero-fail zero-pending check before every merge).

`AdvanceUntilComplete` looped `Advance` + `Task.Yield()`, but a FakeTimeProvider advance releases only timers that already exist, and the handler registers its next `Task.Delay` on a thread-pool continuation — on a busy runner the 500 yields pass in microseconds without that thread ever being scheduled (the CI failure ran 53 ms). Each step now cedes 2 real milliseconds, which converges every time the code is right and still fails loudly and bounded when it is not. Both helpers hardened; fixture run 5× locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf