### PR TITLE
F4: one observability vocabulary, and the strings you subscribe with are constants

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1758,43 +1758,105 @@ Further information on configuring Microsoft.Logging can be found [at Microsoft 
 
 ## Job execution metrics
 
-The `Quartz` meter publishes the same four instruments under the same names, and every scheduler now
-publishes them — configuring the meter used to be wired to `StdSchedulerFactory`, so a scheduler
-registered with `AddQuartz` emitted nothing at all. Two further things changed, and both are visible to
-anything already charting them:
+::: danger EVERY NAME CHANGED
+Every instrument and every attribute Quartz publishes was renamed in 4.0, and two of the four
+instruments were removed. **Dashboards, alerts and recording rules built on the 3.x names all break.**
+The [old → new table](#old-and-new-telemetry-names) below is the complete mapping; nothing in it is emitted
+under both names, because two names for one series doubles the cardinality and settles nothing.
+:::
 
-| Instrument | 4.x type | Tags |
+Three things were wrong at once. The instruments were named `scheduling.quartz.*`, which is neither the
+package's name nor OpenTelemetry's convention; the attributes were unprefixed (`job.name`,
+`trigger.group`), so any other instrumented library in the process could claim the same names; and the
+duration was recorded in milliseconds, into a histogram whose default bucket boundaries assume seconds.
+Every scheduler also now publishes them at all — configuring the meter used to be wired to
+`StdSchedulerFactory`, so a scheduler registered with `AddQuartz` emitted nothing.
+
+| Instrument | Type | Unit | Tags |
+|---|---|---|---|
+| `quartz.job.execution.duration` | `Histogram<double>` | `s` | `quartz.scheduler.name`, `quartz.trigger.group`, `quartz.trigger.name`, `quartz.job.group`, `quartz.job.name`, **+ `error.type`** when the execution failed |
+| `quartz.job.execution.active` | `UpDownCounter<long>` | `{job}` | the five identity attributes |
+
+### Old and new telemetry names
+
+| 3.x | 4.x | |
 |---|---|---|
-| `scheduling.quartz.execute` | `Counter<long>` | **`scheduler.name`**, `trigger.group`, `trigger.name`, `job.group`, `job.name` |
-| `scheduling.quartz.execute.errors` | `Counter<long>` | the five identity tags **+ `error.type`** |
-| `scheduling.quartz.execute.active` | **`UpDownCounter<long>`** (was `Counter<long>`) | the five identity tags |
-| `scheduling.quartz.execute.duration` | `Histogram<double>` | the five identity tags, **+ `error.type`** when the execution failed |
+| `scheduling.quartz.execute` | *removed* | The histogram's own **count** is the number of executions: `sum(rate(quartz_job_execution_duration_count[5m]))` in Prometheus, or whatever your backend calls a histogram's count |
+| `scheduling.quartz.execute.errors` | *removed* | The **`error.type`-tagged subset** of the same count is the number of failures — and it now says *what* failed, which the counter never did |
+| `scheduling.quartz.execute.active` | `quartz.job.execution.active` | Also an `UpDownCounter<long>` now (was `Counter<long>`), unit `{job}` (was `ea`) |
+| `scheduling.quartz.execute.duration` | `quartz.job.execution.duration` | **Unit `s`, not `ms`** — a chart with a hard-coded millisecond axis reads 1000× low until it is changed |
+| `job.name` | `quartz.job.name` | |
+| `job.group` | `quartz.job.group` | |
+| `job.type` | `quartz.job.type` | Span attribute |
+| `trigger.name` | `quartz.trigger.name` | |
+| `trigger.group` | `quartz.trigger.group` | |
+| `scheduler.name` | `quartz.scheduler.name` | |
+| `scheduler.id` | `quartz.scheduler.id` | Span attribute |
+| `fire.instance.id` | `quartz.fire.instance.id` | Span attribute |
+| `jobstore.trigger.count` | `quartz.jobstore.trigger.count` | Job store span attribute |
+| `jobstore.batch.size` | `quartz.jobstore.batch.size` | Job store span attribute |
+| `scheduling.quartz.exception_type` | `error.type` | The one attribute that is *not* namespaced, and its value changed too — see below |
+| `Quartz.Job.Vetoed` | `Quartz.Job.Veto` | Span name for a vetoed fire. `Quartz.Job.Execute` and the 28 `Quartz.JobStore.*` span names are unchanged |
 
-**Every measurement is tagged with `scheduler.name`.** A process can run several schedulers — named
+Renaming a series is not something a backend can do for you: a Prometheus recording rule bridging the
+old name to the new one, or a dashboard variable, is the usual way to keep history readable across the
+upgrade.
+
+**The constants did not move.** `Quartz.Diagnostics.ActivityTags.JobName` is still `ActivityTags.JobName`;
+its *value* changed. Code that reads a tag name through the constants compiles and runs unchanged — it is
+the queries written against the strings that need rewriting.
+
+### The two strings you subscribe with are constants now
+
+`Quartz.Diagnostics.QuartzInstrumentation` publishes the `ActivitySource` and `Meter` names, which used
+to be internal — so wiring Quartz into OpenTelemetry began by typing `"Quartz"` twice from memory:
+
+```csharp
+services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddSource(QuartzInstrumentation.ActivitySourceName))
+    .WithMetrics(metrics => metrics.AddMeter(QuartzInstrumentation.MeterName));
+```
+
+Both are still `"Quartz"`, so an existing `AddSource("Quartz")` keeps working.
+
+### Two instruments, not four
+
+`scheduling.quartz.execute` and `scheduling.quartz.execute.errors` are gone. A histogram already carries
+its own count, so the first was a second instrument write per fire for a number every exporter derives
+from the duration series; and with `error.type` on the histogram, the failures are that count's
+`error.type`-tagged subset, which is what the second reported — less precisely, since a counter cannot
+say what failed.
+
+**The duration is in seconds.** OpenTelemetry records durations in seconds, and a histogram's default
+bucket boundaries are chosen for them: recording milliseconds put every execution longer than ten
+seconds into the top bucket, alongside every other duration series in the application, so "how long do
+jobs take" was unanswerable from the buckets. `quartz.job.execution.active` is `{job}` rather than `ea`,
+which is not a UCUM unit at all.
+
+**Every measurement is tagged with `quartz.scheduler.name`.** A process can run several schedulers — named
 registrations, or a host and a test harness side by side — and their measurements used to arrive as one
 undifferentiated series. Tagging them apart is a cardinality change: a backend stores one series per
 scheduler where it stored one in total, and a query that aggregated across everything now needs to say so
-(`sum without (scheduler_name)` in Prometheus, or the equivalent grouping in whatever reads these). One
-extra series per scheduler is the whole of the increase; the tag's values are the scheduler names an
-application configured, which is a fixed, small set.
+(`sum without (quartz_scheduler_name)` in Prometheus, or the equivalent grouping in whatever reads
+these). One extra series per scheduler is the whole of the increase; the tag's values are the scheduler
+names an application configured, which is a fixed, small set.
 
 The instruments themselves are also created through the container's `IMeterFactory` when it has one,
 which every application on the generic host does. The meter used to be a process-wide static, so two
 containers in one process published to the same instruments; they now publish to their own, which is what
 makes `MetricCollector` — the `Microsoft.Extensions.Diagnostics.Testing` reader that collects one
-factory's instruments — able to see them at all. Nothing about the meter's name, the instrument names or
-what an exporter subscribes to changes, and an application that never calls `AddMetrics()` still gets a
-meter, created directly as before. Quartz does not register an `IMeterFactory` of its own: doing so would
-put Quartz's factory in the way of the application's wherever `AddMetrics()` happened to be called after
-`AddQuartz`.
+factory's instruments — able to see them at all. The meter's name and what an exporter subscribes to are
+unchanged, and an application that never calls `AddMetrics()` still gets a meter, created directly as
+before. Quartz does not register an `IMeterFactory` of its own: doing so would put Quartz's factory in
+the way of the application's wherever `AddMetrics()` happened to be called after `AddQuartz`.
 
-**`scheduling.quartz.execute.active` is an up-down counter.** The number of jobs running goes down as
+**`quartz.job.execution.active` is an up-down counter.** The number of jobs running goes down as
 often as it goes up, and Quartz has always measured the decrement — but a `Counter` is monotonic by
 OpenTelemetry's definition, so an exporter aggregating one is entitled to drop or mis-render a negative
-measurement, leaving a "jobs currently running" chart that only ever climbs. The name, the unit and the
-meaning are unchanged; the instrument type an exporter sees is not, so a dashboard or an alert built on
-the old series has to be rebuilt on a non-monotonic one — a `Sum` with `IsMonotonic = false` in the
-OpenTelemetry SDK, which Prometheus renders as a gauge rather than a counter.
+measurement, leaving a "jobs currently running" chart that only ever climbs. The meaning is unchanged;
+the instrument type an exporter sees is not, so a dashboard or an alert built on the old series has to be
+rebuilt on a non-monotonic one — a `Sum` with `IsMonotonic = false` in the OpenTelemetry SDK, which
+Prometheus renders as a gauge rather than a counter.
 
 **`scheduling.quartz.exception_type` is `error.type`, and it names the exception the job threw.** Two
 things were wrong with it. The tag was added to a copy of the tag list and thrown away, so the errors
@@ -1817,9 +1879,13 @@ emitted alongside it, since two names for one attribute doubles the series and s
 or an alert matching on `scheduling.quartz.exception_type` has to be rewritten**, and one that expected
 the value `JobExecutionException` now sees the type the job threw.
 
-The tag is on the errors counter and on the duration histogram, so a failed run's duration can be told
-apart from a successful one's. It is deliberately *not* on `scheduling.quartz.execute.active`, whose
-increment and decrement have to carry identical attributes or the series never comes back to zero.
+The tag is on `quartz.job.execution.duration`, so a failed run's duration can be told apart from a
+successful one's — and, with the errors counter gone, so that the failures can be counted at all. It is
+deliberately *not* on `quartz.job.execution.active`, whose increment and decrement have to carry
+identical attributes or the series never comes back to zero.
+
+A vetoed fire is not an execution and appears in neither instrument: the job never ran, so there is no
+duration to record. Vetoes are visible in traces, as a `Quartz.Job.Veto` span.
 
 The execution's span carries the same `error.type` with the same value, so one attribute finds a failure
 in a trace and in a metric alike. The span also still records the exception as an event, with the whole
@@ -5900,10 +5966,14 @@ Parameters and behavior are unchanged:
 | `AddDataSourceProvider()` removed | Its other half. It registered `DataSourceDbProvider` in the container for `UseDataSourceConnectionProvider()` to name; `UseRegisteredDataSource` builds the provider itself from the registered `DbDataSource` — see [`AddDataSourceProvider()` went with it](#adddatasourceprovider-went-with-it) |
 | `QuartzOptions.SchedulerName`, `.SchedulerId`, `.MisfireThreshold` removed | Each duplicated a typed option — see [`QuartzOptions` lost its three typed settings](#quartzoptions-lost-its-three-typed-settings) |
 | Job execution metrics are published by every scheduler | The meters were configured only by `StdSchedulerFactory`, so a scheduler registered with `AddQuartz` published none |
-| `scheduling.quartz.execute.active` is an `UpDownCounter<long>` | It was a `Counter<long>` receiving the `-1` that ends an execution, which an exporter aggregating a monotonic sum may drop — see [Job execution metrics](#job-execution-metrics) |
-| Every job execution measurement is tagged with `scheduler.name` | A process can run several schedulers, whose measurements used to arrive as one series. One series per scheduler where there was one in total: a query that aggregated across everything needs to say so — see [Job execution metrics](#job-execution-metrics) |
-| The meter is built from the container's `IMeterFactory` | It was a process-wide static, so two containers in one process shared one set of instruments and `MetricCollector` could not see them. Names and subscriptions are unchanged, and an application that never calls `AddMetrics()` still gets a meter — see [Job execution metrics](#job-execution-metrics) |
-| `scheduling.quartz.exception_type` is `error.type`, naming the exception the job threw | The tag was added to a copy of the tag list and discarded, so the counter said only that something failed — and the type it named was the `JobExecutionException` the run shell wraps everything in. It is OpenTelemetry's conventional name now, it is on the duration histogram and the execution's span too, and a query matching the old name or expecting the old value has to be rewritten — see [Job execution metrics](#job-execution-metrics) |
+| **Every instrument and attribute was renamed, and two instruments were dropped** | `scheduling.quartz.*` became `quartz.job.execution.*`, unprefixed attributes became `quartz.*`, and the two counters gave way to the histogram's own count. Every dashboard, alert and recording rule keyed on the old names breaks — the [old → new table](#old-and-new-telemetry-names) is the complete mapping |
+| `quartz.job.execution.duration` records **seconds**, not milliseconds | A histogram's default bucket boundaries assume seconds, so every execution over ten seconds landed in the top bucket. A chart with a hard-coded millisecond axis reads 1000× low until it is changed — see [Job execution metrics](#job-execution-metrics) |
+| `quartz.job.execution.active` is an `UpDownCounter<long>`, unit `{job}` | It was a `Counter<long>` receiving the `-1` that ends an execution, which an exporter aggregating a monotonic sum may drop; `ea` is not a UCUM unit — see [Job execution metrics](#job-execution-metrics) |
+| Every job execution measurement is tagged with `quartz.scheduler.name` | A process can run several schedulers, whose measurements used to arrive as one series. One series per scheduler where there was one in total: a query that aggregated across everything needs to say so — see [Job execution metrics](#job-execution-metrics) |
+| The meter is built from the container's `IMeterFactory` | It was a process-wide static, so two containers in one process shared one set of instruments and `MetricCollector` could not see them. The meter's name and what an exporter subscribes to are unchanged, and an application that never calls `AddMetrics()` still gets a meter — see [Job execution metrics](#job-execution-metrics) |
+| `scheduling.quartz.exception_type` is `error.type`, naming the exception the job threw | The tag was added to a copy of the tag list and discarded, so the counter said only that something failed — and the type it named was the `JobExecutionException` the run shell wraps everything in. It is OpenTelemetry's conventional name now — the one attribute Quartz does not namespace — it is on the duration histogram and the execution's span, and a query matching the old name or expecting the old value has to be rewritten — see [Job execution metrics](#job-execution-metrics) |
+| `Quartz.Diagnostics.QuartzInstrumentation` publishes the `ActivitySource` and `Meter` names | `AddSource("Quartz")` / `AddMeter("Quartz")` were the only strings on the instrumentation surface with no constant behind them. Both values are still `"Quartz"`, so existing wiring keeps working; `InstrumentationOptions` is gone with the change — see [Job execution metrics](#job-execution-metrics) |
+| The vetoed-fire span is `Quartz.Job.Veto` | `OperationName.Job.Veto` read `"Quartz.Job.Vetoed"` — the constant's name and its value disagreed. `Quartz.Job.Execute` and the `Quartz.JobStore.*` span names are unchanged |
 | `XmlSchedulingOptions` and `JsonSchedulingOptions` merged | They were byte-for-byte identical and are now one type |
 | Constructing a scheduler no longer starts a thread | `QuartzScheduler` starts its scheduler thread from `Start()` rather than its constructor, so resolving the service graph, running a `ValidateOnBuild` pass or asserting on registrations no longer spins one up. The thread always started paused, so this changes when the thread exists, not when jobs run |
 | `IPersistentStoreBuilder.AcceptEnlistedTransactions()` | Never shipped; the setting is `Configure(o => o.AcceptEnlistedTransactions = true)`, like the other nineteen `AdoJobStoreOptions` settings — see [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction) |
@@ -6004,7 +6074,7 @@ Parameters and behavior are unchanged:
 | `TriggerUtils` became `Quartz.Extensibility.TriggerFireTimes` | A fire-time calculator over `IOperableTrigger`, named for what it computes; the three `Compute*` methods shortened with it — see [`TriggerUtils` became `TriggerFireTimes`](#triggerutils-became-triggerfiretimes) |
 | `TimeZoneUtil` became `Quartz.TimeZones` | `FindTimeZoneById` — now `FindById` — and the wall-clock `GetUtcOffset` are scheduling API, not utilities — see [`TimeZoneUtil` became `Quartz.TimeZones`](#timezoneutil-became-quartz-timezones) |
 | `Quartz.Util.ObjectExtensions` is internal | `AssemblyQualifiedNameWithoutVersion()` is how Quartz spells a type name into a blob or onto the wire, not a general-purpose helper |
-| `Quartz.Diagnostics.ActivityOptions` is `ActivityTags` | It holds `Activity` tag names, not options, and `*Options` names an options type everywhere else. It replaced 3.x's `DiagnosticHeaders`; the tag names and values are unchanged |
+| `Quartz.Diagnostics.ActivityOptions` is `ActivityTags` | It holds `Activity` tag names, not options, and `*Options` names an options type everywhere else. It replaced 3.x's `DiagnosticHeaders`; the constant names are unchanged, but their **values** are all `quartz.*` now — see [Job execution metrics](#job-execution-metrics) |
 | `DBSemaphore` is `DbSemaphore` | The last `DB` spelling left in the ADO.NET surface. The type is abstract and is never named in configuration |
 | `StartingDailyAt` / `EndingDailyAt` take a `timeOfDay` | The parameter was `timeOfDayUtc`, and the value is wall-clock in the trigger's time zone rather than UTC — the property it sets, `StartTimeOfDay`, never claimed otherwise. `DailyTimeIntervalTriggerImpl`'s five constructors say `startTimeOfDay` / `endTimeOfDay` for the same reason |
 | `ITriggerSerializer.TriggerTypeForJson` is `TriggerTypeName` | `ICalendarSerializer.CalendarTypeName` names the same concept; both JSON serializers changed |
@@ -6059,7 +6129,7 @@ namespace, and `Type.Member` for the second one.
 | `Quartz.Impl.AdoJobStore.Common.DbMetadataFactory` | Internal | The metadata factory on `UseGenericDatabase` |
 | `Quartz.Impl.AdoJobStore.DBSemaphore` | Renamed `DbSemaphore` | Same abstract base, still public — see [The semaphores were tidied](#the-semaphores-were-tidied) |
 | `Quartz.Simpl.DedicatedThreadPool` | Internal | `IQuartzBuilder.UseThreadPool(IThreadPool)` for a pool of your own — see [The thread pool is asynchronous](#the-thread-pool-is-asynchronous) |
-| `Quartz.Logging.DiagnosticHeaders` | Renamed `Quartz.Diagnostics.ActivityTags` | The tag names and values are unchanged — see [Other Breaking Changes](#other-breaking-changes) |
+| `Quartz.Logging.DiagnosticHeaders` | Renamed `Quartz.Diagnostics.ActivityTags` | The constant names are unchanged; every value is `quartz.*` now — see [Job execution metrics](#job-execution-metrics) |
 | `Quartz.Util.DictionaryExtensions` | Removed | No replacement — see [Other Breaking Changes](#other-breaking-changes) |
 | `Quartz.Impl.DirectSchedulerFactory` | Removed | `QuartzSchedulerBuilder`, with `UseThreadPool(IThreadPool)` / `UseJobStore(IJobStore)` for pre-built parts — see [Removed](#removed) |
 | `Quartz.Impl.AdoJobStore.Common.EmbeddedAssemblyResourceDbMetadataFactory` | Internal | The metadata factory on `UseGenericDatabase` |

--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -15,6 +15,7 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Quartz.Diagnostics;
 using Quartz.Impl.AdoJobStore.Common;
 using Quartz.Impl.Calendar;
 using Quartz.Plugins.History;
@@ -59,10 +60,10 @@ public class Startup
             .WithMetrics(metrics =>
             {
                 metrics.AddRuntimeInstrumentation()
-                    .AddMeter("Quartz", "Microsoft.AspNetCore.Hosting", "Microsoft.AspNetCore.Server.Kestrel", "System.Net.Http");
+                    .AddMeter(QuartzInstrumentation.MeterName, "Microsoft.AspNetCore.Hosting", "Microsoft.AspNetCore.Server.Kestrel", "System.Net.Http");
             })
             .WithTracing(x => x
-                .AddSource("Quartz")
+                .AddSource(QuartzInstrumentation.ActivitySourceName)
                 .AddAspNetCoreInstrumentation()
                 .AddHttpClientInstrumentation()
                 .AddConsoleExporter()

--- a/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
@@ -83,7 +83,7 @@ public sealed class JobExecutionObservabilityTest
         {
             InstrumentPublished = static (instrument, listener) =>
             {
-                if (instrument.Meter.Name == InstrumentationOptions.MeterName)
+                if (instrument.Meter.Name == QuartzInstrumentation.MeterName)
                 {
                     listener.EnableMeasurementEvents(instrument);
                 }
@@ -95,7 +95,7 @@ public sealed class JobExecutionObservabilityTest
 
         activityListener = new ActivityListener
         {
-            ShouldListenTo = static source => source.Name == ActivityTags.DefaultListenerName,
+            ShouldListenTo = static source => source.Name == QuartzInstrumentation.ActivitySourceName,
             Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             ActivityStopped = activity =>
             {
@@ -130,7 +130,7 @@ public sealed class JobExecutionObservabilityTest
             + "of what an application's OpenTelemetry exporter sees, and it saw nothing while configuring "
             + "the meter was wired to one construction path");
 
-        published.Select(m => m.Meter).Should().AllBe(InstrumentationOptions.MeterName,
+        published.Select(m => m.Meter).Should().AllBe(QuartzInstrumentation.MeterName,
             "the meter name is the contract: it is what an exporter is told to subscribe to");
 
         published.Should().ContainSingle(m => m.Instrument == ExecuteCount)
@@ -166,6 +166,16 @@ public sealed class JobExecutionObservabilityTest
     }
 
     /// <summary>
+    /// The two strings an application types to subscribe are published, so nobody has to write "Quartz".
+    /// </summary>
+    [Test]
+    public void SubscriptionNames_ArePublicConstants()
+    {
+        QuartzInstrumentation.ActivitySourceName.Should().Be("Quartz");
+        QuartzInstrumentation.MeterName.Should().Be("Quartz");
+    }
+
+    /// <summary>
     /// The measurements a container's own <c>IMeterFactory</c> publishes, read the way an application's
     /// tests read them.
     /// </summary>
@@ -198,7 +208,7 @@ public sealed class JobExecutionObservabilityTest
 
         using MetricCollector<long> collector = new(
             provider.GetRequiredService<IMeterFactory>(),
-            InstrumentationOptions.MeterName,
+            QuartzInstrumentation.MeterName,
             ExecuteCount);
 
         // The scheduler is injected rather than built from its factory, which is the other half of what
@@ -303,7 +313,7 @@ public sealed class JobExecutionObservabilityTest
         Activity activity = ActivityFor(execution.JobKey);
 
         activity.OperationName.Should().Be(OperationName.Job.Execute);
-        activity.Source.Name.Should().Be(ActivityTags.DefaultListenerName,
+        activity.Source.Name.Should().Be(QuartzInstrumentation.ActivitySourceName,
             "the source name is what a tracer is told to subscribe to");
         activity.Kind.Should().Be(ActivityKind.Internal);
         activity.Status.Should().Be(ActivityStatusCode.Unset, "the job succeeded");

--- a/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
@@ -55,10 +55,23 @@ public sealed class JobExecutionObservabilityTest
     private const string ExecuteErrors = "scheduling.quartz.execute.errors";
     private const string ExecuteActive = "scheduling.quartz.execute.active";
     private const string ExecuteDuration = "scheduling.quartz.execute.duration";
-    // OpenTelemetry's conventional attribute for what an operation failed with, spelled out here rather
-    // than read from Quartz, because the wire name is the contract an exporter and a dashboard are
-    // written against.
+    // Attribute names are spelled out here rather than read from Quartz, because the wire name is the
+    // contract an exporter and a dashboard are written against: reading them from the same constant the
+    // product publishes them from would let a rename pass unnoticed.
+    //
+    // error.type is OpenTelemetry's conventional attribute for what an operation failed with, and the one
+    // attribute Quartz does not namespace, because every instrumented failure in the process spells it
+    // this way.
     private const string ErrorTypeTag = "error.type";
+
+    private const string SchedulerNameTag = "quartz.scheduler.name";
+    private const string SchedulerIdTag = "quartz.scheduler.id";
+    private const string FireInstanceIdTag = "quartz.fire.instance.id";
+    private const string TriggerGroupTag = "quartz.trigger.group";
+    private const string TriggerNameTag = "quartz.trigger.name";
+    private const string JobTypeTag = "quartz.job.type";
+    private const string JobGroupTag = "quartz.job.group";
+    private const string JobNameTag = "quartz.job.name";
 
     private readonly List<RecordedMeasurement> measurements = [];
     private readonly List<Activity> stoppedActivities = [];
@@ -153,16 +166,34 @@ public sealed class JobExecutionObservabilityTest
 
         foreach (RecordedMeasurement measurement in published)
         {
-            measurement.Tags.Should().Contain(new KeyValuePair<string, object>(ActivityTags.SchedulerName, execution.SchedulerName))
-                .And.Contain(new KeyValuePair<string, object>(ActivityTags.TriggerGroup, execution.TriggerKey.Group))
-                .And.Contain(new KeyValuePair<string, object>(ActivityTags.TriggerName, execution.TriggerKey.Name))
-                .And.Contain(new KeyValuePair<string, object>(ActivityTags.JobGroup, execution.JobKey.Group))
-                .And.Contain(new KeyValuePair<string, object>(ActivityTags.JobName, execution.JobKey.Name));
+            measurement.Tags.Should().Contain(new KeyValuePair<string, object>(SchedulerNameTag, execution.SchedulerName))
+                .And.Contain(new KeyValuePair<string, object>(TriggerGroupTag, execution.TriggerKey.Group))
+                .And.Contain(new KeyValuePair<string, object>(TriggerNameTag, execution.TriggerKey.Name))
+                .And.Contain(new KeyValuePair<string, object>(JobGroupTag, execution.JobKey.Group))
+                .And.Contain(new KeyValuePair<string, object>(JobNameTag, execution.JobKey.Name));
 
             measurement.Tags.Should().HaveCount(5,
                 "an execution is identified by the scheduler that ran it, its trigger and its job, and "
                 + "nothing else is added to it");
         }
+    }
+
+    /// <summary>
+    /// Every attribute Quartz defines is spelled under <c>quartz.</c>, and the constants say so.
+    /// </summary>
+    [Test]
+    public void AttributeNames_AreNamespacedUnderQuartz()
+    {
+        ActivityTags.SchedulerName.Should().Be(SchedulerNameTag);
+        ActivityTags.SchedulerId.Should().Be(SchedulerIdTag);
+        ActivityTags.FireInstanceId.Should().Be(FireInstanceIdTag);
+        ActivityTags.TriggerGroup.Should().Be(TriggerGroupTag);
+        ActivityTags.TriggerName.Should().Be(TriggerNameTag);
+        ActivityTags.JobType.Should().Be(JobTypeTag);
+        ActivityTags.JobGroup.Should().Be(JobGroupTag);
+        ActivityTags.JobName.Should().Be(JobNameTag);
+        ActivityTags.TriggerCount.Should().Be("quartz.jobstore.trigger.count");
+        ActivityTags.BatchSize.Should().Be("quartz.jobstore.batch.size");
     }
 
     /// <summary>
@@ -227,7 +258,7 @@ public sealed class JobExecutionObservabilityTest
         CollectedMeasurement<long> measurement = collector.LastMeasurement;
         measurement.Should().NotBeNull("the container's meter factory published this execution");
         measurement.Value.Should().Be(1);
-        measurement.Tags.Should().ContainKey(ActivityTags.SchedulerName)
+        measurement.Tags.Should().ContainKey(SchedulerNameTag)
             .WhoseValue.Should().Be(schedulerName,
                 "a process can run several schedulers, and without the name their measurements are one "
                 + "series a dashboard cannot separate again");
@@ -318,15 +349,15 @@ public sealed class JobExecutionObservabilityTest
         activity.Kind.Should().Be(ActivityKind.Internal);
         activity.Status.Should().Be(ActivityStatusCode.Unset, "the job succeeded");
 
-        activity.GetTagItem(ActivityTags.SchedulerName).Should().Be(execution.SchedulerName);
-        activity.GetTagItem(ActivityTags.SchedulerId).Should().Be(execution.SchedulerInstanceId);
-        activity.GetTagItem(ActivityTags.JobType).Should().Be(new JobType(typeof(SucceedingJob)).FullName,
+        activity.GetTagItem(SchedulerNameTag).Should().Be(execution.SchedulerName);
+        activity.GetTagItem(SchedulerIdTag).Should().Be(execution.SchedulerInstanceId);
+        activity.GetTagItem(JobTypeTag).Should().Be(new JobType(typeof(SucceedingJob)).FullName,
             "the job type is reported the way the scheduler names it — assembly-qualified, without a version");
-        activity.GetTagItem(ActivityTags.FireInstanceId).Should().Be(execution.FireInstanceId);
-        activity.GetTagItem(ActivityTags.TriggerGroup).Should().Be(execution.TriggerKey.Group);
-        activity.GetTagItem(ActivityTags.TriggerName).Should().Be(execution.TriggerKey.Name);
-        activity.GetTagItem(ActivityTags.JobGroup).Should().Be(execution.JobKey.Group);
-        activity.GetTagItem(ActivityTags.JobName).Should().Be(execution.JobKey.Name);
+        activity.GetTagItem(FireInstanceIdTag).Should().Be(execution.FireInstanceId);
+        activity.GetTagItem(TriggerGroupTag).Should().Be(execution.TriggerKey.Group);
+        activity.GetTagItem(TriggerNameTag).Should().Be(execution.TriggerKey.Name);
+        activity.GetTagItem(JobGroupTag).Should().Be(execution.JobKey.Group);
+        activity.GetTagItem(JobNameTag).Should().Be(execution.JobKey.Name);
     }
 
     [Test]
@@ -422,7 +453,7 @@ public sealed class JobExecutionObservabilityTest
         lock (measurements)
         {
             return measurements
-                .Where(m => Equals(m.Tags.GetValueOrDefault(ActivityTags.JobName), jobKey.Name))
+                .Where(m => Equals(m.Tags.GetValueOrDefault(JobNameTag), jobKey.Name))
                 .ToList();
         }
     }
@@ -433,7 +464,7 @@ public sealed class JobExecutionObservabilityTest
         {
             return stoppedActivities.Should().ContainSingle(a =>
                     a.OperationName == OperationName.Job.Execute
-                    && Equals(a.GetTagItem(ActivityTags.JobName), jobKey.Name))
+                    && Equals(a.GetTagItem(JobNameTag), jobKey.Name))
                 .Subject;
         }
     }

--- a/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
@@ -343,7 +343,7 @@ public sealed class JobExecutionObservabilityTest
 
         Activity activity = ActivityFor(execution.JobKey);
 
-        activity.OperationName.Should().Be(OperationName.Job.Execute);
+        activity.OperationName.Should().Be("Quartz.Job.Execute");
         activity.Source.Name.Should().Be(QuartzInstrumentation.ActivitySourceName,
             "the source name is what a tracer is told to subscribe to");
         activity.Kind.Should().Be(ActivityKind.Internal);
@@ -358,6 +358,39 @@ public sealed class JobExecutionObservabilityTest
         activity.GetTagItem(TriggerNameTag).Should().Be(execution.TriggerKey.Name);
         activity.GetTagItem(JobGroupTag).Should().Be(execution.JobKey.Group);
         activity.GetTagItem(JobNameTag).Should().Be(execution.JobKey.Name);
+    }
+
+    /// <summary>
+    /// A vetoed fire is a span of its own, and nothing an execution histogram ever hears about.
+    /// </summary>
+    /// <remarks>
+    /// The span's name was <c>Quartz.Job.Vetoed</c> while the constant naming it was <c>Veto</c>; it is
+    /// <c>Quartz.Job.Veto</c> now, in the present tense the rest of <see cref="OperationName"/> uses.
+    /// </remarks>
+    [Test]
+    public async Task VetoedExecution_EmitsVetoActivityAndNoExecutionMeasurements()
+    {
+        Execution execution = await RunJob<SucceedingJob>(veto: true);
+
+        Activity vetoed = ActivityFor(execution.JobKey, "Quartz.Job.Veto");
+
+        vetoed.Source.Name.Should().Be(QuartzInstrumentation.ActivitySourceName);
+        vetoed.GetTagItem(SchedulerNameTag).Should().Be(execution.SchedulerName);
+        vetoed.GetTagItem(TriggerGroupTag).Should().Be(execution.TriggerKey.Group);
+        vetoed.GetTagItem(TriggerNameTag).Should().Be(execution.TriggerKey.Name);
+        vetoed.GetTagItem(JobGroupTag).Should().Be(execution.JobKey.Group);
+        vetoed.GetTagItem(JobNameTag).Should().Be(execution.JobKey.Name);
+        vetoed.GetTagItem(FireInstanceIdTag).Should().Be(execution.FireInstanceId);
+
+        StoppedActivities().Should().NotContain(a =>
+                a.OperationName == "Quartz.Job.Execute"
+                && Equals(a.GetTagItem(JobNameTag), execution.JobKey.Name),
+            "the job never ran, so there is no execution to trace");
+
+        MeasurementsFor(execution.JobKey).Should().BeEmpty(
+            "the histogram's count is what an exporter reads as the number of executions, and a fire a "
+            + "listener refused is not one — the instruments are started after the veto decision, so a "
+            + "vetoed fire never arrives as a zero-duration success");
     }
 
     [Test]
@@ -385,7 +418,7 @@ public sealed class JobExecutionObservabilityTest
     /// Builds a scheduler the way an application does, runs the job its trigger fires exactly once, and
     /// shuts everything down before returning — so an assertion never races the execution it is about.
     /// </summary>
-    private static async Task<Execution> RunJob<TJob>() where TJob : IJob
+    private static async Task<Execution> RunJob<TJob>(bool veto = false) where TJob : IJob
     {
         string id = Guid.NewGuid().ToString("N");
         JobKey jobKey = new($"job-{id}", $"job-group-{id}");
@@ -400,6 +433,10 @@ public sealed class JobExecutionObservabilityTest
         {
             quartz.ConfigureScheduler(options => options.InstanceName = $"observability-{id}");
             quartz.AddJobListener(completion);
+            if (veto)
+            {
+                quartz.AddTriggerListener(new VetoingTriggerListener());
+            }
             quartz.AddJob<TJob>(job => job.WithIdentity(jobKey));
             quartz.AddTrigger<TJob>(trigger => trigger
                 .ForJob(jobKey)
@@ -415,7 +452,8 @@ public sealed class JobExecutionObservabilityTest
             await scheduler.Start();
 
             Task finished = await Task.WhenAny(completion.Executed, Task.Delay(TimeSpan.FromSeconds(30)));
-            finished.Should().BeSameAs(completion.Executed, "the scheduled job should have run");
+            finished.Should().BeSameAs(completion.Executed,
+                veto ? "the scheduled job should have been vetoed" : "the scheduled job should have run");
 
             return new Execution(
                 jobKey,
@@ -459,14 +497,22 @@ public sealed class JobExecutionObservabilityTest
         }
     }
 
-    private Activity ActivityFor(JobKey jobKey)
+    private Activity ActivityFor(JobKey jobKey, string operationName = "Quartz.Job.Execute")
     {
         lock (stoppedActivities)
         {
             return stoppedActivities.Should().ContainSingle(a =>
-                    a.OperationName == OperationName.Job.Execute
+                    a.OperationName == operationName
                     && Equals(a.GetTagItem(JobNameTag), jobKey.Name))
                 .Subject;
+        }
+    }
+
+    private List<Activity> StoppedActivities()
+    {
+        lock (stoppedActivities)
+        {
+            return [.. stoppedActivities];
         }
     }
 
@@ -487,7 +533,8 @@ public sealed class JobExecutionObservabilityTest
 
     /// <summary>
     /// Signals once the shell has finished with the execution, which is after both the activity and the
-    /// meter measurements have been closed out.
+    /// meter measurements have been closed out — or once a fire has been vetoed, which is the only other
+    /// way a shell reaches an end a listener hears about.
     /// </summary>
     private sealed class ExecutionCompletionListener : IJobListener
     {
@@ -499,12 +546,29 @@ public sealed class JobExecutionObservabilityTest
 
         public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 
-        public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            executed.TrySetResult(context.FireInstanceId);
+            return default;
+        }
 
         public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException jobException, CancellationToken cancellationToken = default)
         {
             executed.TrySetResult(context.FireInstanceId);
             return default;
+        }
+    }
+
+    /// <summary>
+    /// Refuses every fire, so the shell takes the veto path instead of running the job.
+    /// </summary>
+    private sealed class VetoingTriggerListener : ITriggerListener
+    {
+        public string Name => "vetoing";
+
+        public ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<bool>(true);
         }
     }
 

--- a/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
@@ -51,13 +51,12 @@ namespace Quartz.Tests.Unit.Diagnostics;
 [NonParallelizable]
 public sealed class JobExecutionObservabilityTest
 {
-    private const string ExecuteCount = "scheduling.quartz.execute";
-    private const string ExecuteErrors = "scheduling.quartz.execute.errors";
-    private const string ExecuteActive = "scheduling.quartz.execute.active";
-    private const string ExecuteDuration = "scheduling.quartz.execute.duration";
-    // Attribute names are spelled out here rather than read from Quartz, because the wire name is the
-    // contract an exporter and a dashboard are written against: reading them from the same constant the
-    // product publishes them from would let a rename pass unnoticed.
+    private const string ExecuteActive = "quartz.job.execution.active";
+    private const string ExecuteDuration = "quartz.job.execution.duration";
+
+    // Instrument and attribute names are spelled out here rather than read from Quartz, because the wire
+    // name is the contract an exporter and a dashboard are written against: reading them from the same
+    // constant the product publishes them from would let a rename pass unnoticed.
     //
     // error.type is OpenTelemetry's conventional attribute for what an operation failed with, and the one
     // attribute Quartz does not namespace, because every instrumented failure in the process spells it
@@ -146,11 +145,16 @@ public sealed class JobExecutionObservabilityTest
         published.Select(m => m.Meter).Should().AllBe(QuartzInstrumentation.MeterName,
             "the meter name is the contract: it is what an exporter is told to subscribe to");
 
-        published.Should().ContainSingle(m => m.Instrument == ExecuteCount)
-            .Which.Value.Should().Be(1, "one execution counts once");
+        published.Select(m => m.Instrument).Distinct().Should().BeEquivalentTo([ExecuteActive, ExecuteDuration],
+            "an execution is two instruments and no more — the histogram's own count is how many executions "
+            + "there were, and its error.type-tagged subset is how many failed, so the counters that used to "
+            + "report those two numbers were extra writes per fire for something the exporter already had");
 
-        published.Should().ContainSingle(m => m.Instrument == ExecuteDuration)
-            .Which.Value.Should().BeGreaterThanOrEqualTo(0, "the duration is recorded in milliseconds");
+        RecordedMeasurement duration = published.Should().ContainSingle(m => m.Instrument == ExecuteDuration).Subject;
+        duration.Value.Should().BeGreaterThanOrEqualTo(0).And.BeLessThan(30);
+        duration.Unit.Should().Be("s",
+            "OpenTelemetry records a duration in seconds, and a histogram's default bucket boundaries are "
+            + "chosen for seconds — milliseconds piled every execution over ten seconds into the last bucket");
 
         List<RecordedMeasurement> active = published.Where(m => m.Instrument == ExecuteActive).ToList();
 
@@ -160,9 +164,9 @@ public sealed class JobExecutionObservabilityTest
         active.Should().AllSatisfy(m => m.InstrumentType.Should().Be<UpDownCounter<long>>(
             "a count of what is running goes down as often as it goes up, and an exporter aggregates a "
             + "Counter as monotonic — which is what made the decrement something it could drop"));
-
-        published.Should().NotContain(m => m.Instrument == ExecuteErrors,
-            "the job succeeded");
+        active.Should().AllSatisfy(m => m.Unit.Should().Be("{job}",
+            "UCUM's annotation form is how OpenTelemetry spells a dimensionless count of a thing; \"ea\" is "
+            + "not a UCUM unit at all"));
 
         foreach (RecordedMeasurement measurement in published)
         {
@@ -237,10 +241,10 @@ public sealed class JobExecutionObservabilityTest
 
         await using ServiceProvider provider = services.BuildServiceProvider();
 
-        using MetricCollector<long> collector = new(
+        using MetricCollector<double> collector = new(
             provider.GetRequiredService<IMeterFactory>(),
             QuartzInstrumentation.MeterName,
-            ExecuteCount);
+            ExecuteDuration);
 
         // The scheduler is injected rather than built from its factory, which is the other half of what
         // this fixture is for: an application asks the container for both of these.
@@ -255,9 +259,10 @@ public sealed class JobExecutionObservabilityTest
             await scheduler.Shutdown(waitForJobsToComplete: true);
         }
 
-        CollectedMeasurement<long> measurement = collector.LastMeasurement;
+        CollectedMeasurement<double> measurement = collector.LastMeasurement;
         measurement.Should().NotBeNull("the container's meter factory published this execution");
-        measurement.Value.Should().Be(1);
+        measurement.Value.Should().BeGreaterThanOrEqualTo(0);
+        collector.Instrument.Unit.Should().Be("s", "the histogram records seconds");
         measurement.Tags.Should().ContainKey(SchedulerNameTag)
             .WhoseValue.Should().Be(schedulerName,
                 "a process can run several schedulers, and without the name their measurements are one "
@@ -265,17 +270,11 @@ public sealed class JobExecutionObservabilityTest
     }
 
     [Test]
-    public async Task FailingJobExecution_PublishesErrorMetric()
+    public async Task FailingJobExecution_IsCountedByTheDurationHistogramAndTaggedWithTheFailure()
     {
         Execution execution = await RunJob<ThrowingJob>();
 
         List<RecordedMeasurement> published = MeasurementsFor(execution.JobKey);
-
-        published.Should().ContainSingle(m => m.Instrument == ExecuteCount)
-            .Which.Value.Should().Be(1, "a job that throws still executed");
-
-        published.Should().ContainSingle(m => m.Instrument == ExecuteErrors)
-            .Which.Value.Should().Be(1, "a job that throws is one execution error");
 
         List<RecordedMeasurement> active = published.Where(m => m.Instrument == ExecuteActive).ToList();
 
@@ -286,18 +285,19 @@ public sealed class JobExecutionObservabilityTest
             + "tags the increment carried or the series never comes back to zero"));
 
         published.Should().ContainSingle(m => m.Instrument == ExecuteDuration,
-            "how long a job ran is worth knowing whether or not it failed")
+            "a job that throws still executed, and one measurement is what an execution records — a failure "
+            + "is the same measurement wearing error.type, which is how an exporter counts the failures")
             .Which.Tags.Should().ContainKey(ErrorTypeTag,
                 "and a failed run's duration is worth telling apart from a successful one's");
     }
 
     /// <summary>
-    /// The errors counter says what went wrong, not only that something did.
+    /// The failure attribute says what went wrong, not only that something did.
     /// </summary>
     /// <remarks>
     /// The tag used to be added to <c>_tagList.Value</c>, and <see cref="Nullable{T}.Value"/> hands back a
     /// copy of the struct: it went onto a temporary that was thrown away on the next line, where a second
-    /// copy — still the four identity tags — was what the counter was given. Once it did arrive it named
+    /// copy — still the four identity tags — was what the instrument was given. Once it did arrive it named
     /// the <see cref="JobExecutionException"/> the run shell wraps anything a job throws in, which is the
     /// same answer for nearly every failure there is; what it reports now is the exception the job threw,
     /// found by unwrapping that pair of wrappers.
@@ -307,13 +307,13 @@ public sealed class JobExecutionObservabilityTest
     {
         Execution execution = await RunJob<ThrowingJob>();
 
-        RecordedMeasurement error = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteErrors);
+        RecordedMeasurement failed = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteDuration);
 
-        error.Tags.Should().ContainKey(ErrorTypeTag)
+        failed.Tags.Should().ContainKey(ErrorTypeTag)
             .WhoseValue.Should().Be(typeof(InvalidOperationException).FullName,
                 "the run shell wraps what a job throws as JobExecutionException -> "
                 + "JobExecutionProcessException -> the cause, and naming either wrapper would tell an "
-                + "exporter only that Quartz caught something, which it already knew from the counter");
+                + "exporter only that Quartz caught something, which it already knew from the measurement");
     }
 
     /// <summary>
@@ -325,15 +325,15 @@ public sealed class JobExecutionObservabilityTest
     {
         Execution execution = await RunJob<DeliberatelyFailingJob>();
 
-        RecordedMeasurement error = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteErrors);
+        RecordedMeasurement failed = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteDuration);
 
-        error.Tags.Should().ContainKey(ErrorTypeTag)
+        failed.Tags.Should().ContainKey(ErrorTypeTag)
             .WhoseValue.Should().Be(typeof(JobExecutionException).FullName,
                 "a JobExecutionException a job raised itself is not a wrapper the run shell added — there "
                 + "is no JobExecutionProcessException under it — and it is what the job chose to say");
 
         ActivityFor(execution.JobKey).GetTagItem(ErrorTypeTag).Should().Be(typeof(JobExecutionException).FullName,
-            "the span and the errors counter answer the same question the same way");
+            "the span and the duration histogram answer the same question the same way");
     }
 
     [Test]
@@ -372,11 +372,11 @@ public sealed class JobExecutionObservabilityTest
             "the exception the job threw is recorded on the span that failed");
 
         activity.GetTagItem(ErrorTypeTag).Should().Be(typeof(InvalidOperationException).FullName,
-            "the span classifies the failure with the attribute the errors counter is tagged with, so one "
+            "the span classifies the failure with the attribute the measurement is tagged with, so one "
             + "value finds the failed executions in a trace and in a metric alike");
 
-        RecordedMeasurement error = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteErrors);
-        error.Tags[ErrorTypeTag].Should().Be(activity.GetTagItem(ErrorTypeTag),
+        RecordedMeasurement failed = MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteDuration);
+        failed.Tags[ErrorTypeTag].Should().Be(activity.GetTagItem(ErrorTypeTag),
             "the two signals are read together, and disagreeing about what failed is worse than either "
             + "of them being silent");
     }
@@ -443,8 +443,9 @@ public sealed class JobExecutionObservabilityTest
         lock (measurements)
         {
             // The instrument's own type is what an exporter reads to decide how to aggregate the values:
-            // a Counter is a monotonic sum, an UpDownCounter is not.
-            measurements.Add(new RecordedMeasurement(instrument.Meter.Name, instrument.Name, instrument.GetType(), value, copy));
+            // a Counter is a monotonic sum, an UpDownCounter is not. Its unit is read the same way, and it
+            // is what decides whether a duration lands in sensible histogram buckets.
+            measurements.Add(new RecordedMeasurement(instrument.Meter.Name, instrument.Name, instrument.GetType(), instrument.Unit, value, copy));
         }
     }
 
@@ -473,6 +474,7 @@ public sealed class JobExecutionObservabilityTest
         string Meter,
         string Instrument,
         Type InstrumentType,
+        string Unit,
         double Value,
         Dictionary<string, object> Tags);
 

--- a/src/Quartz.Tests.Unit/Diagnostics/JobStoreActivityTracerTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobStoreActivityTracerTest.cs
@@ -36,7 +36,7 @@ public sealed class JobStoreActivityTracerTest : IDisposable
     {
         activityListener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name == ActivityTags.DefaultListenerName,
+            ShouldListenTo = source => source.Name == QuartzInstrumentation.ActivitySourceName,
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             ActivityStarted = activity => startedActivities.Add(activity),
             ActivityStopped = activity => stoppedActivities.Add(activity),

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1558,16 +1558,16 @@ namespace Quartz.Diagnostics
 {
     public static class ActivityTags
     {
-        public const string BatchSize = "jobstore.batch.size";
-        public const string FireInstanceId = "fire.instance.id";
-        public const string JobGroup = "job.group";
-        public const string JobName = "job.name";
-        public const string JobType = "job.type";
-        public const string SchedulerId = "scheduler.id";
-        public const string SchedulerName = "scheduler.name";
-        public const string TriggerCount = "jobstore.trigger.count";
-        public const string TriggerGroup = "trigger.group";
-        public const string TriggerName = "trigger.name";
+        public const string BatchSize = "quartz.jobstore.batch.size";
+        public const string FireInstanceId = "quartz.fire.instance.id";
+        public const string JobGroup = "quartz.job.group";
+        public const string JobName = "quartz.job.name";
+        public const string JobType = "quartz.job.type";
+        public const string SchedulerId = "quartz.scheduler.id";
+        public const string SchedulerName = "quartz.scheduler.name";
+        public const string TriggerCount = "quartz.jobstore.trigger.count";
+        public const string TriggerGroup = "quartz.trigger.group";
+        public const string TriggerName = "quartz.trigger.name";
     }
     public static class LogProvider
     {

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1580,7 +1580,7 @@ namespace Quartz.Diagnostics
         public static class Job
         {
             public const string Execute = "Quartz.Job.Execute";
-            public const string Veto = "Quartz.Job.Vetoed";
+            public const string Veto = "Quartz.Job.Veto";
         }
         public static class JobStore
         {

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1614,6 +1614,11 @@ namespace Quartz.Diagnostics
             public const string UpdateTriggerDetails = "Quartz.JobStore.UpdateTriggerDetails";
         }
     }
+    public static class QuartzInstrumentation
+    {
+        public const string ActivitySourceName = "Quartz";
+        public const string MeterName = "Quartz";
+    }
 }
 namespace Quartz.Extensibility
 {

--- a/src/Quartz/Diagnostics/ActivityTags.cs
+++ b/src/Quartz/Diagnostics/ActivityTags.cs
@@ -1,19 +1,36 @@
 namespace Quartz.Diagnostics;
 
+/// <summary>
+/// The attribute names Quartz puts on its spans and its measurements.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every one of them is spelled under <c>quartz.</c>, which is what OpenTelemetry asks of an attribute a
+/// library defines for itself: <c>job.name</c> is a name any other instrumented library in the same
+/// process could reasonably claim, and once two of them do, a dashboard has one attribute meaning two
+/// things and no way to tell which. The one exception is <see cref="ErrorType.TagName"/> — <c>error.type</c>
+/// is the semantic convention's shared attribute for what an operation failed with, and a Quartz-specific
+/// spelling would only keep these series from lining up with the rest of an application's failures.
+/// </para>
+/// <para>
+/// The values are a telemetry contract rather than a compile-time one, so code reading them by these
+/// constants needs no change while a dashboard, alert or recording rule matching the 3.x spellings does.
+/// </para>
+/// </remarks>
 public static class ActivityTags
 {
-    public const string SchedulerName = "scheduler.name";
-    public const string SchedulerId = "scheduler.id";
-    public const string FireInstanceId = "fire.instance.id";
-    public const string TriggerGroup = "trigger.group";
-    public const string TriggerName = "trigger.name";
-    public const string JobType = "job.type";
-    public const string JobGroup = "job.group";
-    public const string JobName = "job.name";
+    public const string SchedulerName = "quartz.scheduler.name";
+    public const string SchedulerId = "quartz.scheduler.id";
+    public const string FireInstanceId = "quartz.fire.instance.id";
+    public const string TriggerGroup = "quartz.trigger.group";
+    public const string TriggerName = "quartz.trigger.name";
+    public const string JobType = "quartz.job.type";
+    public const string JobGroup = "quartz.job.group";
+    public const string JobName = "quartz.job.name";
 
     // Job store operation tags
-    public const string TriggerCount = "jobstore.trigger.count";
-    public const string BatchSize = "jobstore.batch.size";
+    public const string TriggerCount = "quartz.jobstore.trigger.count";
+    public const string BatchSize = "quartz.jobstore.batch.size";
 }
 
 /// <summary>

--- a/src/Quartz/Diagnostics/ActivityTags.cs
+++ b/src/Quartz/Diagnostics/ActivityTags.cs
@@ -2,9 +2,6 @@ namespace Quartz.Diagnostics;
 
 public static class ActivityTags
 {
-    internal const string DefaultListenerName = "Quartz";
-    internal static readonly string? Version = typeof(ActivityTags).Assembly.GetName().Version?.ToString();
-
     public const string SchedulerName = "scheduler.name";
     public const string SchedulerId = "scheduler.id";
     public const string FireInstanceId = "fire.instance.id";

--- a/src/Quartz/Diagnostics/ActivityTags.cs
+++ b/src/Quartz/Diagnostics/ActivityTags.cs
@@ -35,7 +35,7 @@ public static class ActivityTags
 
 /// <summary>
 /// OpenTelemetry's <c>error.type</c> attribute: what a failed job execution failed with, named the
-/// same way on the span and on the errors counter.
+/// same way on the span and on the duration histogram.
 /// </summary>
 internal static class ErrorType
 {

--- a/src/Quartz/Diagnostics/InstrumentationOptions.cs
+++ b/src/Quartz/Diagnostics/InstrumentationOptions.cs
@@ -1,7 +1,0 @@
-namespace Quartz.Diagnostics;
-
-internal static class InstrumentationOptions
-{
-    public const string MeterName = "Quartz";
-    internal static readonly string? Version = typeof(InstrumentationOptions).Assembly.GetName().Version?.ToString();
-}

--- a/src/Quartz/Diagnostics/Meters.cs
+++ b/src/Quartz/Diagnostics/Meters.cs
@@ -38,7 +38,7 @@ internal sealed class Meters
 
     public Meters(IMeterFactory? meterFactory)
     {
-        MeterOptions options = new(InstrumentationOptions.MeterName) { Version = InstrumentationOptions.Version };
+        MeterOptions options = new(QuartzInstrumentation.MeterName) { Version = QuartzInstrumentation.Version };
 
         meter = meterFactory?.Create(options) ?? new Meter(options);
 

--- a/src/Quartz/Diagnostics/Meters.cs
+++ b/src/Quartz/Diagnostics/Meters.cs
@@ -31,8 +31,6 @@ internal sealed class Meters
     private static readonly Lazy<Meters> shared = new(static () => new Meters(meterFactory: null));
 
     private readonly Meter meter;
-    private readonly Counter<long> jobExecuteTotal;
-    private readonly Counter<long> jobExecuteErrorTotal;
     private readonly UpDownCounter<long> jobExecuteInProgress;
     private readonly Histogram<double> jobExecuteDuration;
 
@@ -42,20 +40,25 @@ internal sealed class Meters
 
         meter = meterFactory?.Create(options) ?? new Meter(options);
 
-        jobExecuteTotal = meter.CreateCounter<long>("scheduling.quartz.execute", "ea", "Number jobs executed");
-        jobExecuteErrorTotal = meter.CreateCounter<long>("scheduling.quartz.execute.errors", "ea", "Number of job execution errors");
         // An up-down counter, not a counter: the number of jobs running goes down as often as it goes up,
         // and a counter is monotonic by definition, so an aggregating exporter is entitled to drop or
-        // mis-render the decrement and show a running count that only ever climbs.
-        jobExecuteInProgress = meter.CreateUpDownCounter<long>("scheduling.quartz.execute.active", "ea", "Number of jobs currently running");
-        jobExecuteDuration = meter.CreateHistogram<double>("scheduling.quartz.execute.duration", "ms", "Elapsed time spent executing a job, in milliseconds");
+        // mis-render the decrement and show a running count that only ever climbs. The unit is UCUM's
+        // annotation form for a dimensionless count of a thing, which is how OpenTelemetry spells one.
+        jobExecuteInProgress = meter.CreateUpDownCounter<long>("quartz.job.execution.active", "{job}", "Number of jobs currently running");
+
+        // Seconds, per OpenTelemetry's duration convention. A histogram's default bucket boundaries assume
+        // a duration is in seconds, so recording milliseconds piled every execution longer than ten
+        // seconds into the last bucket, next to every other duration series in the application.
+        jobExecuteDuration = meter.CreateHistogram<double>("quartz.job.execution.duration", "s", "Elapsed time spent executing a job");
     }
 
     public static Meters Shared => shared.Value;
 
     public Instrumentation StartJobExecute(IJobExecutionContext context)
     {
-        if (!jobExecuteTotal.Enabled)
+        // Nothing is subscribed to either instrument, so the whole tag list is work for a measurement no
+        // one will read. Both are asked: an application is free to configure a view that keeps one.
+        if (!jobExecuteDuration.Enabled && !jobExecuteInProgress.Enabled)
         {
             return default;
         }
@@ -71,7 +74,6 @@ internal sealed class Meters
             { ActivityTags.JobName, context.JobDetail.Key.Name },
         };
 
-        jobExecuteTotal.Add(1, tagList);
         jobExecuteInProgress.Add(1, tagList);
 
         return new Instrumentation(this, tagList);
@@ -92,10 +94,12 @@ internal sealed class Meters
             // The exception the job threw, not the JobExecutionException the run shell wrapped it in —
             // which is also what the execution's span reports, so the two signals name the same failure.
             tags.Add(ErrorType.TagName, ErrorType.Of(exception));
-            jobExecuteErrorTotal.Add(1, tags);
         }
 
-        jobExecuteDuration.Record(duration.TotalMilliseconds, tags);
+        // The one measurement per execution: its count is the number of executions and its error.type
+        // subset is the number of failures, so the two counters that used to report those numbers were
+        // two extra instrument writes per fire for something the exporter already had.
+        jobExecuteDuration.Record(duration.TotalSeconds, tags);
     }
 }
 

--- a/src/Quartz/Diagnostics/OperationName.cs
+++ b/src/Quartz/Diagnostics/OperationName.cs
@@ -5,7 +5,17 @@ public static class OperationName
     public static class Job
     {
         public const string Execute = "Quartz.Job.Execute";
-        public const string Veto = "Quartz.Job.Vetoed";
+
+        /// <summary>
+        /// The span covering a vetoed fire: the trigger listeners said no, and the job listeners are being
+        /// told so instead of the job being run.
+        /// </summary>
+        /// <remarks>
+        /// Its value used to be <c>Quartz.Job.Vetoed</c> while the constant was named <c>Veto</c>, so the
+        /// one name in this class that did not match its value was the one nobody could see. Every other
+        /// operation here is named for the operation, in the present tense, as <see cref="Execute"/> is.
+        /// </remarks>
+        public const string Veto = "Quartz.Job.Veto";
     }
 
     public static class JobStore

--- a/src/Quartz/Diagnostics/QuartzActivitySource.cs
+++ b/src/Quartz/Diagnostics/QuartzActivitySource.cs
@@ -6,7 +6,7 @@ namespace Quartz.Diagnostics;
 
 internal static class QuartzActivitySource
 {
-    internal static readonly ActivitySource Instance = new(ActivityTags.DefaultListenerName, ActivityTags.Version);
+    internal static readonly ActivitySource Instance = new(QuartzInstrumentation.ActivitySourceName, QuartzInstrumentation.Version);
 
     public static StartedActivity StartJobExecute(JobExecutionContextImpl context, DateTimeOffset startTime)
     {

--- a/src/Quartz/Diagnostics/QuartzActivitySource.cs
+++ b/src/Quartz/Diagnostics/QuartzActivitySource.cs
@@ -66,7 +66,7 @@ internal readonly struct StartedActivity
         if (jobExEx != null)
         {
             _activity.SetStatus(ActivityStatusCode.Error, jobExEx.Message);
-            // The same value the errors counter is tagged with, so a failure can be found by the same
+            // The same value the duration measurement is tagged with, so a failure can be found by the same
             // attribute in a trace and in a metric. The exception event below keeps the whole chain,
             // wrappers included, because that is where the stack traces are.
             _activity.SetTag(ErrorType.TagName, ErrorType.Of(jobExEx));

--- a/src/Quartz/Diagnostics/QuartzInstrumentation.cs
+++ b/src/Quartz/Diagnostics/QuartzInstrumentation.cs
@@ -1,0 +1,40 @@
+namespace Quartz.Diagnostics;
+
+/// <summary>
+/// The names an application subscribes to Quartz's telemetry with.
+/// </summary>
+/// <remarks>
+/// Wiring Quartz into OpenTelemetry begins with these two strings, and until 4.0 they were the only part
+/// of the instrumentation surface that was not published: the tag names nobody types by hand were public
+/// constants while the two names everybody types were internal, so every sample in existence spells them
+/// as literals.
+/// <code>
+/// services.AddOpenTelemetry()
+///     .WithTracing(tracing => tracing.AddSource(QuartzInstrumentation.ActivitySourceName))
+///     .WithMetrics(metrics => metrics.AddMeter(QuartzInstrumentation.MeterName));
+/// </code>
+/// </remarks>
+public static class QuartzInstrumentation
+{
+    /// <summary>
+    /// The name of the <see cref="System.Diagnostics.ActivitySource"/> a scheduler emits its spans on —
+    /// what <c>AddSource</c> is given.
+    /// </summary>
+    public const string ActivitySourceName = "Quartz";
+
+    /// <summary>
+    /// The name of the <see cref="System.Diagnostics.Metrics.Meter"/> a scheduler publishes its
+    /// instruments on — what <c>AddMeter</c> is given.
+    /// </summary>
+    /// <remarks>
+    /// It is the same string as <see cref="ActivitySourceName"/>, and deliberately a separate constant:
+    /// traces and metrics are subscribed to independently, and a future divergence should not silently
+    /// re-point whichever call site borrowed the other one.
+    /// </remarks>
+    public const string MeterName = "Quartz";
+
+    /// <summary>
+    /// The Quartz assembly version, reported as the version of both the source and the meter.
+    /// </summary>
+    internal static readonly string? Version = typeof(QuartzInstrumentation).Assembly.GetName().Version?.ToString();
+}


### PR DESCRIPTION
Feature F4 from the ratified finalization spec (analysis: campaign A1-05 — three naming schemes in one observability surface, and the two strings users must type were not public).

- **Every attribute is namespaced `quartz.*`**: `quartz.job.name/.group/.type`, `quartz.trigger.name/.group`, `quartz.scheduler.name/.id`, `quartz.fire.instance.id`, `quartz.jobstore.trigger.count/.batch.size`. `error.type` stays — it is the OTel shared attribute.
- **The duration instrument follows OTel semantic conventions**: `quartz.job.execution.duration`, unit `s` (was ms); `quartz.job.execution.active`, unit `{job}` (was the non-UCUM `ea`).
- **Two counters dropped**: `scheduling.quartz.execute` and `.errors` — the histogram's own count and its `error.type`-tagged subset carry the same information.
- **`QuartzInstrumentation.ActivitySourceName` / `.MeterName`** are public constants — backends subscribe without magic strings (the example now does).
- **`OperationName.Job.Veto`** finally says `"Quartz.Job.Veto"` (was "Vetoed"). Verified along the way: vetoed fires were never miscounted — metrics start after the veto decision — and that property is now pinned by a test, which matters more now that the histogram's count IS the execution count.

The migration guide gains a complete old→new mapping table aimed at telemetry-dashboard owners — this is a breaking change for their queries, and the guide says so plainly. The 28 `Quartz.JobStore.*` span names and `Quartz.Job.Execute` are unchanged.

Tests pin the exact instrument set, names, units, and every attribute against string literals; the veto path has its own coverage, run 10× standalone. Unit 2637, AspNetCore 259, `Compile UnitTest PublishAot` green. Baseline diff is exactly the attribute values, the veto constant, and the new constants type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf