### PR TITLE
Publish test coverage to the SonarCloud analysis

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -124,6 +124,10 @@
             "Release"
           ]
         },
+        "Coverage": {
+          "type": "boolean",
+          "description": "Collect line and branch coverage while running the unit tests, in OpenCover format"
+        },
         "Database": {
           "type": "string",
           "description": "Database to test against (postgres, sqlserver, mysql, oracle, firebird, sqlite, basic, all)"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,89 @@
+# Hand-written rather than generated from build/Build.CI.GitHubActions.cs: an analysis wraps the build
+# ("begin", then compile and test, then "end") and needs a JDK, and the generator emits a fixed
+# checkout / setup / 'dotnet fallout <targets>' shape with no room for either.
+#
+# Two prerequisites live outside this repository, and until both are in place this workflow fails:
+#
+#   - a SONAR_TOKEN repository secret, holding a SonarCloud token with 'Execute Analysis' on
+#     quartznet_quartznet
+#   - Automatic Analysis switched off in the project's Administration -> Analysis Method. SonarCloud
+#     rejects a CI analysis while it is on, and Automatic Analysis cannot import coverage reports at
+#     all, which is the reason this workflow exists.
+name: sonar
+
+on:
+  push:
+    branches:
+      - main
+      - '3.x'
+    paths:
+      - '**/*'
+      - '!docs/**/*'
+      - '!package.json'
+      - '!package-lock.json'
+      - '!readme.md'
+  pull_request:
+    branches:
+      - main
+      - '3.x'
+    paths:
+      - '**/*'
+      - '!docs/**/*'
+      - '!package.json'
+      - '!package-lock.json'
+      - '!readme.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze
+    # A pull request from a fork cannot read SONAR_TOKEN, so the scanner would have nothing to
+    # authenticate with. Those pull requests keep every other check.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The scanner attributes new code through git blame, which a shallow clone cannot answer.
+          fetch-depth: 0
+      - name: 'Setup: JDK'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
+      - name: 'Install: SonarScanner for .NET'
+        run: dotnet tool install --global dotnet-sonarscanner
+      - name: 'Sonar: begin'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          # Without this the scanner reports an empty sonar.token as a format error, which reads
+          # like a typo rather than a missing secret.
+          [ -n "$SONAR_TOKEN" ] || { echo "::error::SONAR_TOKEN is not set — see the header of .github/workflows/sonar.yml"; exit 1; }
+          dotnet-sonarscanner begin \
+            /k:"quartznet_quartznet" \
+            /o:"quartznet" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.token="$SONAR_TOKEN" \
+            /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml"
+      # Has to sit between begin and end: the scanner analyses through MSBuild, so only projects
+      # actually built while it is active are measured.
+      - name: 'Run: Compile, UnitTest'
+        run: dotnet fallout Compile UnitTest --coverage
+      - name: 'Sonar: end'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.8" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="10.3.4" />
     <PackageVersion Include="log4net" Version="3.3.2" />

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -27,10 +27,14 @@ partial class Build : FalloutBuild, ICompile, IPack
     [Parameter("Database to test against (postgres, sqlserver, mysql, oracle, firebird, sqlite, basic, all)")]
     readonly string Database;
 
+    [Parameter("Collect line and branch coverage while running the unit tests, in OpenCover format")]
+    readonly bool Coverage;
+
     [GitRepository] readonly GitRepository GitRepository;
 
     AbsolutePath SourceDirectory => RootDirectory / "src";
     AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
+    AbsolutePath CoverageDirectory => ArtifactsDirectory / "coverage";
 
     // Null when the repository can't be resolved, e.g. in a git worktree, where the local build
     // simply has no tag to version from. CI always checks out a plain clone.
@@ -152,16 +156,33 @@ partial class Build : FalloutBuild, ICompile, IPack
                 Log.Information("Unit tests: {Project} ({Framework})", project.Name, framework);
             }
 
-            DotNetTest(s => s
-                .EnableNoRestore()
-                .EnableNoBuild()
-                .SetConfiguration(configuration)
-                .SetLoggers(GitHubActions.Instance is not null ? ["GitHubActions"] : [])
-                .CombineWith(testRuns, (_, run) => _
+            if (Coverage)
+            {
+                CoverageDirectory.CreateOrCleanDirectory();
+            }
+
+            DotNetTest(s =>
+            {
+                s = s.EnableNoRestore()
+                    .EnableNoBuild()
+                    .SetConfiguration(configuration)
+                    .SetLoggers(GitHubActions.Instance is not null ? ["GitHubActions"] : []);
+
+                if (Coverage)
+                {
+                    // Opt-in, because instrumenting every assembly costs test time that only the Sonar
+                    // analysis has a use for — the other workflows run the same target without it. coverlet
+                    // writes one <guid>/coverage.opencover.xml per run below the results directory, which is
+                    // the layout sonar.cs.opencover.reportsPaths globs for in .github/workflows/sonar.yml.
+                    s = s.SetDataCollector("XPlat Code Coverage;Format=opencover")
+                        .SetResultsDirectory(CoverageDirectory);
+                }
+
+                return s.CombineWith(testRuns, (_, run) => _
                     .SetProjectFile(run.Project)
                     .SetFramework(run.Framework)
-                )
-            );
+                );
+            });
         });
 
     static readonly string[] DatabaseCategories =

--- a/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
+++ b/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
@@ -16,6 +16,10 @@
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="AwesomeAssertions.Analyzers" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -27,6 +27,10 @@
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="AwesomeAssertions.Analyzers" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />


### PR DESCRIPTION
`quartznet_quartznet` carries no coverage data on SonarCloud. Asked anonymously, right now:

```
GET https://sonarcloud.io/api/measures/component
      ?component=quartznet_quartznet
      &metricKeys=coverage,line_coverage,lines_to_cover,uncovered_lines,ncloc

{ "measures": [ { "metric": "ncloc", "value": "120338" } ] }
```

`ncloc` and nothing else. The coverage metrics are not zero, they are *not measured*.

## Why

The check that runs today is SonarCloud's **automatic analysis** — the project reports
`autoscanEnabled: true`, `ciName: "Autoscan for DotNet"`. Per Sonar's own documentation, automatic
analysis *"does not support"* code coverage, alongside branch analysis and external rule engine
reports. No setting on that side can produce a coverage number; a CI-based analysis is the only
route.

This repository has never had one. #3221 established that while removing a
`sonar-project.properties` that nothing was reading.

## What this changes

**`.github/workflows/sonar.yml`** (new). One Ubuntu job, on pushes to `main`/`3.x` and pull requests
to them, running the SonarScanner for .NET around the build that already exists:

```
dotnet-sonarscanner begin /k:"quartznet_quartznet" /o:"quartznet" ... \
    /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml"
dotnet fallout Compile UnitTest --coverage
dotnet-sonarscanner end
```

The scanner analyses *through* MSBuild, so the build has to sit between `begin` and `end` — only
projects compiled while it is active get measured.

It is hand-written rather than generated from `build/Build.CI.GitHubActions.cs`, for the same reason
`docs.yml` is: the generator emits a fixed *checkout → setup → `dotnet fallout <targets>`* shape,
with nowhere to hang a wrapper around the build or the JDK the scanner needs. Path filters,
concurrency group, permissions and step naming follow the generated workflows so it does not read as
a foreign object.

Pull requests **from forks are skipped** by a job-level `if:`. They cannot read `SONAR_TOKEN`, so the
job could only ever fail on them; they keep every other check.

**`build/Build.cs`.** A new `--coverage` parameter. When it is set, `UnitTest` adds
`--collect "XPlat Code Coverage;Format=opencover" --results-directory artifacts/coverage`; when it is
not, the target behaves exactly as it does today. Only the sonar workflow passes it, so
`pr-tests-unit`, `build`, `publish` and the eight `pr-integration-*` workflows keep running the tests
uninstrumented. (`.fallout/build.schema.json` is regenerated by the build, not hand-edited.)

**`coverlet.collector`** added to `Quartz.Tests.Unit` and `Quartz.Tests.AspNetCore`, with the version
in `Directory.Packages.props`. It is a `PrivateAssets="all"` data collector: inert unless `--collect`
asks for it by name.

## Two things have to happen outside this repository first

Until both are done this workflow fails, **including on this pull request's own run** — as you can
see below it. Missing secret first: the job stops at its first step with an annotation naming
`SONAR_TOKEN`, rather than letting the scanner report `The format of the analysis property
sonar.token= is invalid`, which reads like a typo.

1. **A `SONAR_TOKEN` repository secret**, holding a SonarCloud token with *Execute Analysis* on the
   project.
2. **Automatic analysis switched off**, in *Administration → Analysis Method*. Sonar's docs:
   *"If you enable automatic analysis, you must ensure that you do not have any CI-based analyses
   configured. If you do then these CI-based analyses will fail and cause a failure in your build
   process."* The two are mutually exclusive by design, to keep duplicate analyses out of the project
   activity.

There is no way to stage this: coverage requires the CI analysis, and the CI analysis requires
automatic analysis to be gone.

## Consequences of the analysis method changing

Worth reviewing, because they are not all about coverage:

- **`<SonarQubeExclude>` starts working.** #3221's closing note was that the property on
  `build/_build.csproj` (and the four test projects) has never affected the check that actually runs,
  because it is honoured only by the MSBuild scanner. It is now the MSBuild scanner, so the build
  orchestrator and the test projects drop out of analysis on their own.
- **Scope narrows to what the solution builds.** The MSBuild scanner indexes the files of the
  projects it watches compile, so `database/**` and `docs/**` are simply not analysed — the ~34%
  duplication and the 73 `EXECUTE IMMEDIATE` findings from #3219 go away without an exclusion rule.
  That is the outcome #3221 wanted; it now falls out of the analysis method rather than out of
  *Analysis Scope*. **If you would rather keep the SQL analysed, this is the thing to object to** —
  it would have to come back as an explicit `sonar.sources` entry.
- **Expect the issue count to move.** A different analyser configuration on a different file set will
  not reproduce the automatic analysis's 213 issues exactly. The new-code quality gate should be
  watched on the first few pull requests.
- **Branch analysis becomes possible.** Automatic analysis cannot analyse non-`main` branches at all;
  a CI analysis can, which is why `3.x` is in the triggers. It only takes effect once this file is
  forward-ported to that branch.
- **CI time.** One more job, and it will be the slowest: a Release build with the Sonar Roslyn
  analysers injected, plus the instrumented unit tests, plus the upload. Budgeted at 30 minutes
  against the 10 the other jobs use. Nothing that exists today gets slower.

## Validation

Everything except the scanner itself was run locally on Windows against this branch.

`dotnet fallout Compile UnitTest --coverage` — build clean, **2637 + 259 tests passed, 0 failed**, and
the rendered command was the intended one:

```
dotnet test src\Quartz.Tests.Unit\Quartz.Tests.Unit.csproj --no-restore --no-build \
  --configuration Debug --collect "XPlat Code Coverage;Format=opencover" \
  --results-directory ...\artifacts\coverage --framework net10.0
```

Two reports landed at exactly the path the `reportsPaths` glob matches,
`artifacts/coverage/<guid>/coverage.opencover.xml`, carrying real per-line and per-branch data:

| report | sequence points | visited | branch points | visited |
|---|---|---|---|---|
| `Quartz.Tests.Unit` | 32747 | 20786 (63.5%) | 9932 | 6063 (61.0%) |
| `Quartz.Tests.AspNetCore` | 35841 | 8087 (22.6%) | 10928 | 1821 (16.7%) |

The two overlap on `Quartz.dll`, and SonarCloud merges reports, so the project figure will differ
from both — and will be lower than either, since files with no report entry count as uncovered.

`dotnet fallout UnitTest` without the flag was re-run afterwards and behaves as before. Test time
went from roughly 64 s to roughly 78 s locally with instrumentation on; a fair slice of that is
run-to-run noise on a laptop.

The workflow YAML was parsed and its triggers, job `if:`, step list and folded `run:` blocks
inspected. Action major versions were checked against the upstream repositories
(`actions/setup-java@v5` is current at v5.7.0).

**What is unproven:** the scanner invocation itself. It needs `SONAR_TOKEN` and it needs automatic
analysis already off, so `begin`/`end`, the report import and the pull request decoration cannot be
exercised from a workstation. The first run after the two settings above is the real test.

## What to expect after that

- **On this pull request**, once the secret exists and automatic analysis is off: a Sonar analysis of
  the pull request with a coverage figure on new code.
- **On `main`, after merge**: the first push analysis populates `coverage`, `line_coverage`,
  `lines_to_cover`, `uncovered_lines` and per-line hit data for the whole project — so the coverage
  overlay in the SonarCloud file viewer starts showing something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdYCauRPzibzzNxWqfdJkU
