### PR TITLE
F2: give IJobDetail the member a store needs, take away the one nobody could write

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -22,7 +22,9 @@ every asynchronous member returns [`ValueTask`](#tasks-changed-to-valuetask) and
 [job factory hands out a scope](#the-job-factory-hands-out-a-scope) instead of an instance; the
 [thread pool is asynchronous](#the-thread-pool-is-asynchronous); and
 [trigger fire times are properties](#trigger-fire-times-are-properties) rather than getter/setter
-pairs. Start here: everything else assumes these signatures.
+pairs; and [a job detail of your own](#an-ijobdetail-of-your-own) is finally implementable, because
+the one member no implementation could write is gone from `IJobDetail`. Start here: everything else
+assumes these signatures.
 
 **2. The vocabulary and the surface.** One word per concept, and nothing public that was never a
 contract. [Names that were normalized](#names-that-were-normalized),
@@ -2676,6 +2678,7 @@ documentation always promised.
 * **`ISchedulerListener.TriggerInError` / `TriggersInError`** — observe a trigger being moved to `TriggerState.Error`, including two ADO store transitions that reached nothing at all before (see [Triggers entering the error state are reported](#triggers-entering-the-error-state-are-reported))
 * **Joining a transaction the application owns** — the ADO job store can take part in a transaction you started, so saving your own data and scheduling the job that acts on it commit together or not at all. Turn it on with `store.Configure(o => o.AcceptEnlistedTransactions = true)`, `JobStore:AcceptEnlistedTransactions`, or `quartz.jobStore.acceptEnlistedTransactions`, then hand the store a connection for the duration of a scope with `IScheduler.EnlistTransaction` / `EnlistConnection`. Handing over a connection is the only way to take part: a connection the job store opens for itself is deliberately kept out of any ambient `TransactionScope`, since a second connection in that transaction would require promoting it to a distributed one. See [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction)
 * **Builder methods for three more plugins** — `UseJobHistoryLogging()`, `UseTriggerHistoryLogging()` and `UseShutdownHook()`. Only the structured-logging variants had one, so the classic history plugins and the shutdown hook could previously be reached only through `quartz.plugin.*` property keys
+* **An `IJobDetail` of your own** — the interface no longer declares a member only Quartz can implement, so an application can supply its own job detail type and have `RAMJobStore` hand it back rather than quietly swapping it for Quartz's (see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own))
 * **`TriggerDetailsUpdate.WithExecutionGroup`** — move a stored trigger into an execution group, or out of every group, without rescheduling it. `QRTZ_TRIGGERS.EXECUTION_GROUP` was already written by the generic trigger update, and `RAMJobStore` applies it in place the same way it applies a preferred node, so both stores behave alike
 
 ## Job data can name the property
@@ -2726,7 +2729,7 @@ the builder itself is `JobBuilder<TJob>` / `TriggerBuilder<TJob>`:
 | `TriggerBuilder` | `TriggerBuilder<TJob>`, from `TriggerBuilder.Create<TJob>()` — `TriggerBuilder.Create()` gives `TriggerBuilder<IJob>` |
 | `IJobConfigurator` | `IJobConfigurator<TJob>` |
 | `ITriggerConfigurator` | `ITriggerConfigurator<TJob>` — the 4.x `ITriggerConfigurator` is a new, much smaller base holding only `WithSchedule`, see [One family of `WithXSchedule` extensions](#one-family-of-withxschedule-extensions) |
-| `IJobDetail.GetJobBuilder()` | returns `JobBuilder<IJob>` |
+| `IJobDetail.GetJobBuilder()` | an extension method returning `JobBuilder<IJob>` — see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own) |
 | `ITrigger.GetTriggerBuilder()` | returns `TriggerBuilder<IJob>` |
 
 Chained code is unaffected — `JobBuilder.Create<MyJob>().WithIdentity("x").Build()` reads the same, and so
@@ -2772,6 +2775,50 @@ Three runtime checks come with the type parameter, all only on a builder whose `
 * `TriggerBuilder.Create<TJob>().ForJob(jobDetail)` throws `ArgumentException` when the detail is not for a
   `TJob`. `ForJob(JobKey)` carries no type, and a detail whose type name does not resolve in this process
   cannot be checked either — both are accepted.
+
+## An `IJobDetail` of your own
+
+`IJobDetail` declared `GetJobBuilder()`, which nobody outside Quartz could implement.
+`JobBuilder<TJob>` is sealed with an internal constructor and builds Quartz's own detail, so an
+implementation of the interface had to return a builder that produces somebody else's type
+([#1143](https://github.com/quartznet/quartznet/issues/1143)). That was not only awkward to write
+around: `RAMJobStore` called the member to re-store the job data of a
+`[PersistJobDataAfterExecution]` job, so the first completion of such a job silently replaced the
+caller's detail with Quartz's.
+
+The unimplementable member is gone from the interface, and the one a job store actually needs
+replaces it:
+
+| 4.0 preview | 4.0 |
+|---|---|
+| `IJobDetail.GetJobBuilder()` | `JobDetailExtensions.GetJobBuilder(this IJobDetail)`, in the `Quartz` namespace |
+| — | `IJobDetail.WithJobData(JobDataMap)` — a copy of the detail carrying the given data |
+
+**Calling code changes nothing.** `detail.GetJobBuilder()` still compiles, still resolves without a
+new `using`, and still returns `JobBuilder<IJob>`; it is now filled in from the detail's public state
+rather than by the detail itself. It carries the detail's `JobType` across as it is, so a detail read
+from a job store whose stored type name names nothing in this process rebuilds, and keeps the stored
+spelling, rather than throwing.
+
+**An implementation writes `WithJobData` instead of `GetJobBuilder`.** It returns a copy of the
+detail carrying the given map, leaving the instance it was called on alone; the map is taken as
+given, not copied.
+
+```diff
+- public JobBuilder<IJob> GetJobBuilder() => /* nothing you can write */;
++ public IJobDetail WithJobData(JobDataMap jobDataMap) => new MyJobDetail(Key, JobType, …, jobDataMap);
+```
+
+How far your own detail travels depends on what holds it:
+
+* `RAMJobStore` keeps the instances it is given and hands back `Clone()`s of them, so a detail of
+  your own round-trips as itself — including across the re-store of a `[PersistJobDataAfterExecution]`
+  job, which is what `WithJobData` is for.
+* Anything that keeps a detail as data does not. The ADO.NET job store writes the columns of
+  `QRTZ_JOB_DETAILS` and rebuilds every detail it reads through `JobBuilder`, so what comes back is
+  Quartz's own implementation; `HttpScheduler` rebuilds one the same way from its wire payload.
+  Whatever your type carries beyond the interface's members is gone by then, so anything that has to
+  survive a persistent store belongs in the `JobDataMap`.
 
 ## Trimming annotations
 
@@ -6046,6 +6093,8 @@ Parameters and behavior are unchanged:
 | `QuartzScheduler` and `QuartzSchedulerResources` are internal | Resolve `IScheduler` / `ISchedulerFactory`; scheduler-wide settings are `QuartzSchedulerOptions` |
 | `JobType` introduced | Stores job type info without requiring an actual `Type` instance. A `Type` converts implicitly (validated: it must implement `IJob`); a string converts only explicitly or via the constructor, because resolving the name is deferred and can fail — `Type` throws for a name that does not resolve, `TryResolve` is the non-throwing probe. Equality (`Equals`, `==`/`!=`) is by `FullName`. There is deliberately **no** implicit conversion back to `Type`: `jobDetail.JobType.Type` spells out that assembly probing may happen, and can throw, at that read |
 | `JobBuilder.OfType(JobType)` added | Carries a stored type name and its resolver through a rebuild without forcing the name to resolve; `OfType(string)` constructs an unvalidated `JobType` for the same reason |
+| `IJobDetail.GetJobBuilder()` removed from the interface | The same call still compiles: it is an extension method on `IJobDetail` in the `Quartz` namespace, built from the detail's public state. Only an implementation of the interface has to change — see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own) |
+| `IJobDetail.WithJobData(JobDataMap)` added | The one member a job store needs of a detail it cannot construct: a copy of it carrying the given data. `RAMJobStore` calls it where it used to rebuild the detail through `JobBuilder`, so a custom `IJobDetail` survives its first `[PersistJobDataAfterExecution]` completion — see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own) |
 | `RecoveringTriggerKey` behavior | `IJobExecutionContext.RecoveringTriggerKey` now returns `null` when not recovering instead of throwing |
 | `DictionaryExtensions` removed | `Quartz.Util.DictionaryExtensions` type was removed |
 | `AdoJobStoreBase` connection methods | `GetLocalTransactionConnection` (was `GetNonManagedTXConnection`) and `GetConnection` now return `ValueTask<ConnectionAndTransactionHolder>` |

--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -328,6 +328,11 @@ concurrency requirements - trigger acquisition has to be atomic against other sc
 handling has to be idempotent - so start from the semantics `RAMJobStore` and `AdoJobStoreBase` document rather
 than from the method signatures alone.
 
+A store that keeps job details as objects rather than as rows should re-store the data of a
+`[PersistJobDataAfterExecution]` job with `jobDetail.WithJobData(newData)`, not by rebuilding the detail through
+`JobBuilder`. An application may have supplied an [`IJobDetail` of its own](more-about-jobs.md#a-jobdetail-of-your-own),
+and rebuilding one silently swaps it for Quartz's implementation on the job's first completion.
+
 Either kind is registered the same way, by type:
 
 ```csharp

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -319,6 +319,58 @@ In other words, non-durable jobs have a life span bounded by the existence of it
 (i.e. the process it is running within crashes, or the machine is shut off), then it is re-executed when the scheduler is started again.
 In this case, the `JobExecutionContext.Recovering` property will return true.
 
+## A JobDetail of your own
+
+`JobBuilder` builds Quartz's own `IJobDetail`, and that is what almost every application wants. If you need a
+job definition that carries something of yours alongside the ones above — a tenant, a correlation id, whatever
+the rest of your system keys on — you can implement `IJobDetail` yourself. Everything Quartz asks of a detail is
+declared on the interface:
+
+```csharp
+public sealed class TenantJobDetail : IJobDetail
+{
+    public TenantJobDetail(JobKey key, JobType jobType, string tenant, JobDataMap jobDataMap = null)
+    {
+        Key = key;
+        JobType = jobType;
+        Tenant = tenant;
+        JobDataMap = jobDataMap ?? new JobDataMap();
+    }
+
+    public string Tenant { get; }
+
+    public JobKey Key { get; }
+    public string Description => $"jobs for {Tenant}";
+    public JobType JobType { get; }
+    public JobDataMap JobDataMap { get; }
+    public bool Durable => true;
+    public bool PersistJobDataAfterExecution => true;
+    public bool ConcurrentExecutionDisallowed => true;
+    public bool RequestsRecovery => false;
+
+    // How a job store re-stores the data a [PersistJobDataAfterExecution] job left behind: it asks the
+    // detail for a copy of itself rather than building one, which it could only do as Quartz's own type.
+    public IJobDetail WithJobData(JobDataMap jobDataMap)
+        => new TenantJobDetail(Key, JobType, Tenant, jobDataMap);
+
+    public IJobDetail Clone()
+        => new TenantJobDetail(Key, JobType, Tenant, new JobDataMap(JobDataMap));
+}
+```
+
+::: warning How far it travels
+A detail of your own round-trips through `RAMJobStore`, which holds the instances it is given and hands back
+clones of them. It does not survive a store or a transport that keeps a detail as data: the ADO.NET job store
+writes the columns of `QRTZ_JOB_DETAILS` and rebuilds every detail it reads through `JobBuilder`, so what comes
+back is Quartz's own implementation, and the HTTP client rebuilds one the same way from its wire payload.
+Anything your type carries beyond the members above is gone by then — put it in the `JobDataMap` if it has to
+come back.
+:::
+
+`detail.GetJobBuilder()` is an extension method over the interface, so it works on a detail of your own too. It
+describes the detail rather than preserving it: what it builds is Quartz's `IJobDetail`. Use `WithJobData` to
+vary the data of a detail of your own, and `Clone()` to copy one.
+
 ## JobExecutionException
 
 Finally, we need to inform you of a few details of the `IJob.Execute(..)` method. The only type of exception

--- a/src/Quartz.Tests.Unit/CustomJobDetailTest.cs
+++ b/src/Quartz.Tests.Unit/CustomJobDetailTest.cs
@@ -1,0 +1,259 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Specialized;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// An <see cref="IJobDetail" /> of somebody else's making, from end to end (#1143).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The interface used to declare <c>GetJobBuilder()</c>, which nobody outside Quartz could implement:
+/// <see cref="JobBuilder{TJob}" /> is sealed and builds Quartz's own detail, so an implementation had
+/// to hand back a builder that produces somebody else's type. It was not a cosmetic problem —
+/// <see cref="RAMJobStore" /> called it to re-store the data of a
+/// <see cref="PersistJobDataAfterExecutionAttribute" /> job, so the first completion of such a job
+/// silently swapped the caller's detail for Quartz's.
+/// </para>
+/// <para>
+/// The member the store needs is <see cref="IJobDetail.WithJobData" />, and the builder accessor is an
+/// extension over the interface's public state. These tests hold both ends of that: a detail of our own
+/// survives a firing in the in-memory store, and the extension describes it without needing to know
+/// what it is.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public class CustomJobDetailTest
+{
+    private static TaskCompletionSource<SecondFiring> secondFiring = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        secondFiring = new TaskCompletionSource<SecondFiring>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    /// <summary>
+    /// What the job saw the second time it ran, which is what the store held after the first firing
+    /// completed: the detail's type, and the data the first firing left in it.
+    /// </summary>
+    private sealed record SecondFiring(Type DetailType, string Tenant, int RunsSeen);
+
+    [Test]
+    public async Task RamStoreKeepsTheDetailsTypeWhenItRestoresTheDataOfAFinishedJob()
+    {
+        RAMJobStore store = TestJobStores.Ram();
+        TenantJobDetail job = new(new JobKey("job", "custom"), new JobType(typeof(CountingJob)), "acme");
+        IOperableTrigger trigger = CreateTrigger("trigger", job.Key);
+
+        await store.ScheduleJob(job, trigger);
+
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddMinutes(1),
+            MaxCount = 1,
+        });
+        List<TriggerFiredResult> fired = await store.TriggersFired(acquired);
+
+        IJobDetail firing = fired.Should().ContainSingle().Which.TriggerFiredBundle!.JobDetail;
+        firing.Should().BeOfType<TenantJobDetail>("the store hands the scheduler the detail it was given");
+
+        // What the job would have done: leave something behind in its own data map.
+        firing.JobDataMap["runs"] = 1;
+
+        await store.TriggeredJobComplete(acquired[0], firing, SchedulerInstruction.NoInstruction);
+
+        IJobDetail stored = (await store.GetJob(job.Key))!;
+        stored.Should().BeOfType<TenantJobDetail>(
+            "re-storing job data must ask the detail for a copy of itself rather than rebuild one");
+        stored.As<TenantJobDetail>().Tenant.Should().Be("acme", "state only this implementation has survives with it");
+        stored.JobDataMap.GetInt("runs").Should().Be(1, "the point of the copy is that it carries the new data");
+        stored.Should().NotBeSameAs(firing, "the store hands out copies, never the instance it holds");
+    }
+
+    /// <summary>
+    /// The same thing through a running scheduler rather than through the store's own contract. The
+    /// second firing is what proves the first one landed: its detail is a copy of what the store holds
+    /// after completing the first.
+    /// </summary>
+    [Test]
+    public async Task ASchedulerRunsAndReStoresADetailOfOurOwn()
+    {
+        NameValueCollection properties = new()
+        {
+            ["quartz.scheduler.instanceName"] = nameof(ASchedulerRunsAndReStoresADetailOfOurOwn),
+            ["quartz.scheduler.idleWaitTime"] = "1000",
+            ["quartz.threadPool.threadCount"] = "2",
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+        };
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create().UseProperties(properties).BuildScheduler();
+        try
+        {
+            TenantJobDetail job = new(new JobKey("job", "custom"), new JobType(typeof(CountingJob)), "acme");
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger", "custom")
+                .ForJob(job.Key)
+                .StartNow()
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMilliseconds(200)).RepeatForever())
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            SecondFiring observed = await secondFiring.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+            observed.DetailType.Should().Be<TenantJobDetail>(
+                "the scheduler fires with a copy of what the store holds, and the first completion must not have replaced it");
+            observed.Tenant.Should().Be("acme");
+            observed.RunsSeen.Should().Be(1, "the data the first firing left behind is what the second one starts from");
+
+            IJobDetail stored = (await scheduler.GetJobDetail(job.Key))!;
+            stored.Should().BeOfType<TenantJobDetail>("what the scheduler hands back is what the store holds");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    [Test]
+    public void GetJobBuilderDescribesADetailItKnowsNothingAbout()
+    {
+        JobDataMap data = new() { ["greeting"] = "hello" };
+        TenantJobDetail job = new(new JobKey("job", "custom"), new JobType(typeof(CountingJob)), "acme", data);
+
+        IJobDetail rebuilt = job.GetJobBuilder().Build();
+
+        rebuilt.Key.Should().Be(job.Key);
+        rebuilt.Description.Should().Be(job.Description);
+        rebuilt.JobType.Should().Be(job.JobType);
+        rebuilt.Durable.Should().Be(job.Durable);
+        rebuilt.RequestsRecovery.Should().Be(job.RequestsRecovery);
+        rebuilt.ConcurrentExecutionDisallowed.Should().Be(job.ConcurrentExecutionDisallowed);
+        rebuilt.PersistJobDataAfterExecution.Should().Be(job.PersistJobDataAfterExecution);
+        rebuilt.JobDataMap.GetString("greeting").Should().Be("hello");
+
+        rebuilt.Should().NotBeOfType<TenantJobDetail>(
+            "a builder describes a detail, it does not preserve one - WithJobData and Clone are what keep the type");
+    }
+
+    /// <summary>
+    /// A job store loads details without resolving their job type, so the accessor must not force the
+    /// stored name to resolve either. It reads <see cref="IJobDetail.JobType" /> and hands it on as it
+    /// is, which is also how the stored spelling survives being read.
+    /// </summary>
+    [Test]
+    public void GetJobBuilderDoesNotResolveTheJobTypeName()
+    {
+        TenantJobDetail job = new(new JobKey("job", "custom"), new JobType("Library.UnknownType"), "acme");
+
+        IJobDetail rebuilt = job.GetJobBuilder().Build();
+
+        rebuilt.JobType.FullName.Should().Be("Library.UnknownType");
+        rebuilt.JobType.TryResolve(out _).Should().BeFalse("nothing along the way may have settled the type");
+        rebuilt.Key.Should().Be(job.Key);
+    }
+
+    private static IOperableTrigger CreateTrigger(string name, JobKey jobKey)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity(name, "custom")
+            .ForJob(jobKey)
+            .StartAt(DateTimeOffset.UtcNow)
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+
+        trigger.ComputeFirstFireTimeUtc(calendar: null);
+        return trigger;
+    }
+
+    /// <summary>
+    /// Counts its firings in its own job data, and reports the second one - by then the store has
+    /// completed the first, so the detail the job is handed says what survived that.
+    /// </summary>
+    public sealed class CountingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            JobDataMap data = context.JobDetail.JobDataMap;
+            int runsSeen = data.ContainsKey("runs") ? data.GetInt("runs") : 0;
+            data["runs"] = runsSeen + 1;
+
+            if (runsSeen == 1)
+            {
+                secondFiring.TrySetResult(new SecondFiring(
+                    context.JobDetail.GetType(),
+                    (context.JobDetail as TenantJobDetail)?.Tenant ?? "",
+                    runsSeen));
+            }
+
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IJobDetail" /> written the way an application would write one: immutable, carrying
+    /// a field of its own that Quartz knows nothing about, and copying itself for the two members that
+    /// hand a detail back.
+    /// </summary>
+    private sealed class TenantJobDetail : IJobDetail
+    {
+        public TenantJobDetail(JobKey key, JobType jobType, string tenant, JobDataMap jobDataMap = null)
+        {
+            Key = key;
+            JobType = jobType;
+            Tenant = tenant;
+            JobDataMap = jobDataMap ?? new JobDataMap();
+        }
+
+        /// <summary>The reason for having an implementation of one's own at all.</summary>
+        public string Tenant { get; }
+
+        public JobKey Key { get; }
+
+        public string Description => $"jobs for {Tenant}";
+
+        public JobType JobType { get; }
+
+        public JobDataMap JobDataMap { get; }
+
+        public bool Durable => true;
+
+        public bool PersistJobDataAfterExecution => true;
+
+        public bool ConcurrentExecutionDisallowed => true;
+
+        public bool RequestsRecovery => false;
+
+        public IJobDetail WithJobData(JobDataMap jobDataMap) => new TenantJobDetail(Key, JobType, Tenant, jobDataMap);
+
+        // JobDataMap's copy constructor is the public way to copy one; the map itself is mutable, so a
+        // clone that shared it would not be one.
+        public IJobDetail Clone() => new TenantJobDetail(Key, JobType, Tenant, new JobDataMap(JobDataMap));
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -402,6 +402,66 @@ public class StdAdoDelegateTest
             "a job class name stored before the jobs moved to their own assembly has to resolve through the type loader");
     }
 
+    /// <summary>
+    /// An ADO store keeps a job as the columns of QRTZ_JOB_DETAILS and rebuilds every detail it reads
+    /// through <see cref="JobBuilder" />, so an implementation of <see cref="IJobDetail" /> other than
+    /// Quartz's own does not survive the round trip the way it does through <c>RAMJobStore</c> (#1143).
+    /// That is the promise <see cref="IJobDetail" />'s documentation makes to anyone implementing it,
+    /// and this is where it is decided.
+    /// </summary>
+    [Test]
+    public async Task SelectJobDetailRebuildsTheDetailAsQuartzsOwnImplementation()
+    {
+        var connection = A.Fake<DbConnection>();
+        var transaction = A.Fake<DbTransaction>();
+        var conn = new ConnectionAndTransactionHolder(connection, transaction);
+
+        var dataReader = A.Fake<DbDataReader>();
+        A.CallTo(() => dataReader.ReadAsync(CancellationToken.None))
+            .Returns(true)
+            .Once();
+
+        A.CallTo(() => dataReader[AdoConstants.ColumnJobName]).Returns("job");
+        A.CallTo(() => dataReader[AdoConstants.ColumnJobGroup]).Returns("group");
+        A.CallTo(() => dataReader[AdoConstants.ColumnDescription]).Returns("description");
+        A.CallTo(() => dataReader[AdoConstants.ColumnJobClass]).Returns(typeof(TestJob).AssemblyQualifiedNameWithoutVersion());
+        A.CallTo(() => dataReader[AdoConstants.ColumnRequestsRecovery]).Returns(false);
+        A.CallTo(() => dataReader[AdoConstants.ColumnIsDurable]).Returns(true);
+        A.CallTo(() => dataReader[AdoConstants.ColumnIsNonConcurrent]).Returns(false);
+        A.CallTo(() => dataReader[AdoConstants.ColumnIsUpdateData]).Returns(true);
+
+        var command = A.Fake<StubCommand>();
+        A.CallTo(command)
+            .Where(x => x.Method.Name == "ExecuteDbDataReaderAsync")
+            .WithReturnType<Task<DbDataReader>>()
+            .Returns(Task.FromResult(dataReader));
+
+        var dbProvider = A.Fake<IDbProvider>();
+        A.CallTo(() => dbProvider.CreateCommand()).Returns(command);
+        A.CallTo(() => dbProvider.Metadata).Returns(new DbMetadata { BindByName = true, ParameterNamePrefix = "@" });
+
+        var adoDelegate = new StdAdoDelegate();
+        adoDelegate.Initialize(new DriverDelegateContext
+        {
+            TablePrefix = "QRTZ_",
+            InstanceId = "TESTSCHED",
+            SchedulerName = "INSTANCE",
+            TypeLoader = new SimpleTypeLoader(),
+            UseProperties = false,
+            DbProvider = dbProvider,
+            ObjectSerializer = serializer
+        });
+
+        IJobDetail jobDetail = await adoDelegate.SelectJobDetail(
+            conn,
+            new JobKey("job", "group"),
+            new SimpleTypeLoader(),
+            CancellationToken.None);
+
+        jobDetail.Should().BeOfType<JobDetailImpl>(
+            "the row says what the job is, not what type described it when it was stored");
+    }
+
     private sealed class TestJob : IJob
     {
         public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/Quartz.Tests.Unit/JobDetailTest.cs
+++ b/src/Quartz.Tests.Unit/JobDetailTest.cs
@@ -96,6 +96,42 @@ public class JobDetailTest
         }
     }
 
+    /// <summary>
+    /// A job store re-stores the data of a finished job by asking its detail for a copy of itself, so
+    /// the copy has to carry everything else across and the detail the store already handed out has to
+    /// be left as it was.
+    /// </summary>
+    [Test]
+    public void WithJobDataCopiesTheDetailAndLeavesTheOriginalAlone()
+    {
+        IJobDetail original = JobBuilder.Create<NoOpJob>()
+            .WithIdentity("job", "group")
+            .WithDescription("description")
+            .StoreDurably()
+            .RequestRecovery()
+            .UsingJobData("key", "original")
+            .Build();
+
+        JobDataMap replacement = new() { ["key"] = "replacement" };
+
+        IJobDetail updated = original.WithJobData(replacement);
+
+        using (new AssertionScope())
+        {
+            updated.Should().NotBeSameAs(original);
+            updated.JobDataMap.Should().BeSameAs(replacement, "the caller hands over a map it does not keep");
+            updated.Key.Should().Be(original.Key);
+            updated.Description.Should().Be(original.Description);
+            updated.JobType.Should().Be(original.JobType);
+            updated.Durable.Should().Be(original.Durable);
+            updated.RequestsRecovery.Should().Be(original.RequestsRecovery);
+            updated.PersistJobDataAfterExecution.Should().Be(original.PersistJobDataAfterExecution);
+            updated.ConcurrentExecutionDisallowed.Should().Be(original.ConcurrentExecutionDisallowed);
+            original.JobDataMap.GetString("key").Should().Be("original",
+                "a detail the store handed out earlier must not change under whoever holds it");
+        }
+    }
+
     public class GenericJob<T> : IJob
     {
         public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -426,7 +426,7 @@ namespace Quartz
         bool PersistJobDataAfterExecution { get; }
         bool RequestsRecovery { get; }
         Quartz.IJobDetail Clone();
-        Quartz.JobBuilder<Quartz.IJob> GetJobBuilder();
+        Quartz.IJobDetail WithJobData(Quartz.JobDataMap jobDataMap);
     }
     public interface IJobExecutionContext
     {
@@ -812,6 +812,10 @@ namespace Quartz
             where T : System.IFormattable { }
         public bool Remove(string key) { }
         public bool TryGetValue(string key, out object? value) { }
+    }
+    public static class JobDetailExtensions
+    {
+        public static Quartz.JobBuilder<Quartz.IJob> GetJobBuilder(this Quartz.IJobDetail jobDetail) { }
     }
     public sealed class JobExecutionException : Quartz.SchedulerException
     {

--- a/src/Quartz/IJobDetail.cs
+++ b/src/Quartz/IJobDetail.cs
@@ -38,6 +38,30 @@ namespace Quartz;
 /// are scheduled. Many <see cref="ITrigger" /> s can point to the same <see cref="IJob" />,
 /// but a single <see cref="ITrigger" /> can only point to one <see cref="IJob" />.
 /// </para>
+/// <para>
+/// The interface is implementable. Everything Quartz asks of a detail is declared here, including
+/// <see cref="WithJobData" />, which is how a job store re-stores the data of a
+/// <see cref="PersistJobDataAfterExecutionAttribute" /> job without having to rebuild the detail
+/// itself — a store cannot know how to construct an implementation it has never seen. How far such
+/// an implementation travels depends on the store:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <see cref="RAMJobStore" /> holds the instances it is given and hands back copies of them, so a
+/// detail of your own round-trips as itself.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// Anything that keeps a detail as data does not. The ADO.NET job store writes the columns of
+/// <c>QRTZ_JOB_DETAILS</c> and rebuilds every detail it loads through <see cref="JobBuilder" />, so
+/// what comes back is Quartz's own implementation; the HTTP client rebuilds one the same way from
+/// its wire payload. Whatever your type carries beyond the members declared here is gone by then,
+/// so anything that has to survive belongs in the <see cref="JobDataMap" />.
+/// </description>
+/// </item>
+/// </list>
 /// </remarks>
 /// <seealso cref="IJob" />
 /// <seealso cref="DisallowConcurrentExecutionAttribute"/>
@@ -105,10 +129,23 @@ public interface IJobDetail
     bool RequestsRecovery { get; }
 
     /// <summary>
-    /// Get a <see cref="JobBuilder" /> that is configured to produce a 
-    /// <see cref="IJobDetail" /> identical to this one.
+    /// Return a detail like this one but carrying <paramref name="jobDataMap" /> as its
+    /// <see cref="JobDataMap" />, leaving this instance untouched.
     /// </summary>
-    JobBuilder<IJob> GetJobBuilder();
+    /// <remarks>
+    /// <para>
+    /// A job store calls this when a <see cref="PersistJobDataAfterExecutionAttribute" /> job finishes
+    /// and the data it left behind has to become the data the next firing sees. It is the one
+    /// mutation-shaped member on the interface, and it exists so that a store re-storing job data does
+    /// not have to construct a detail itself — which it could only do as Quartz's own implementation,
+    /// silently swapping out yours.
+    /// </para>
+    /// <para>
+    /// The map is taken as given rather than copied: the caller hands over a map it does not keep.
+    /// </para>
+    /// </remarks>
+    /// <param name="jobDataMap">The job data the returned detail carries.</param>
+    IJobDetail WithJobData(JobDataMap jobDataMap);
 
     IJobDetail Clone();
 }

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -414,6 +414,25 @@ internal sealed class JobDetailImpl : IJobDetail
     }
 
     /// <summary>
+    /// Returns a copy of this detail carrying the given job data.
+    /// </summary>
+    /// <remarks>
+    /// The map is taken as given, not copied: a store re-storing the data a job left behind has already
+    /// made a copy of its own, and copying again would only cost.
+    /// </remarks>
+    public IJobDetail WithJobData(JobDataMap jobDataMap)
+    {
+        if (jobDataMap is null)
+        {
+            Throw.ArgumentNullException(nameof(jobDataMap));
+        }
+
+        var copy = (JobDetailImpl) MemberwiseClone();
+        copy.JobDataMap = jobDataMap;
+        return copy;
+    }
+
+    /// <summary>
     /// Determines whether the specified detail is equal to this instance.
     /// </summary>
     /// <param name="detail">The detail to examine.</param>
@@ -465,18 +484,5 @@ internal sealed class JobDetailImpl : IJobDetail
     public override int GetHashCode()
     {
         return FullName.GetHashCode();
-    }
-
-    public JobBuilder<IJob> GetJobBuilder()
-    {
-        return JobBuilder.Create()
-            .OfType(JobType)
-            .RequestRecovery(RequestsRecovery)
-            .StoreDurably(Durable)
-            .UsingJobData(JobDataMap)
-            .DisallowConcurrentExecution(ConcurrentExecutionDisallowed)
-            .PersistJobDataAfterExecution(PersistJobDataAfterExecution)
-            .WithDescription(description)
-            .WithIdentity(Key);
     }
 }

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -2432,7 +2432,11 @@ public sealed class RAMJobStore : IJobStore
                     JobDataMap newData = jobDetail.JobDataMap;
                     newData = newData.Clone();
                     newData.ClearDirtyFlag();
-                    jd = jd.GetJobBuilder().ReplaceJobData(newData).Build();
+
+                    // Asking the detail for a copy of itself, rather than rebuilding one through the
+                    // builder, is what lets an implementation of the interface other than our own
+                    // survive its first completion of a job that persists its data.
+                    jd = jd.WithJobData(newData);
                     jw.JobDetail = jd;
                 }
 

--- a/src/Quartz/JobDetailExtensions.cs
+++ b/src/Quartz/JobDetailExtensions.cs
@@ -1,0 +1,65 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// Conveniences over <see cref="IJobDetail" /> that need nothing but the interface.
+/// </summary>
+public static class JobDetailExtensions
+{
+    /// <summary>
+    /// Get a <see cref="JobBuilder{TJob}" /> configured to produce a detail equivalent to this one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An extension rather than an interface member, because a builder can be filled in from the
+    /// detail's public state alone, and <see cref="JobBuilder{TJob}" /> is sealed: an implementation
+    /// of <see cref="IJobDetail" /> other than Quartz's own could only have satisfied such a member by
+    /// returning a builder that produces somebody else's type.
+    /// </para>
+    /// <para>
+    /// The result builds Quartz's own implementation, whatever it was called on — a builder is how a
+    /// detail is described, not how a type is preserved. Use <see cref="IJobDetail.WithJobData" /> to
+    /// vary the job data of a detail of your own, and <see cref="IJobDetail.Clone" /> to copy one.
+    /// </para>
+    /// <para>
+    /// The job type is carried over as the <see cref="JobType" /> the detail holds, so a detail loaded
+    /// from a job store whose stored type name does not resolve in this process rebuilds, and keeps
+    /// the name as it was stored, rather than throwing here.
+    /// </para>
+    /// </remarks>
+    /// <param name="jobDetail">The detail to describe.</param>
+    public static JobBuilder<IJob> GetJobBuilder(this IJobDetail jobDetail)
+    {
+        ArgumentNullException.ThrowIfNull(jobDetail);
+
+        return JobBuilder.Create()
+            .OfType(jobDetail.JobType)
+            .RequestRecovery(jobDetail.RequestsRecovery)
+            .StoreDurably(jobDetail.Durable)
+            .UsingJobData(jobDetail.JobDataMap)
+            .DisallowConcurrentExecution(jobDetail.ConcurrentExecutionDisallowed)
+            .PersistJobDataAfterExecution(jobDetail.PersistJobDataAfterExecution)
+            .WithDescription(jobDetail.Description)
+            .WithIdentity(jobDetail.Key);
+    }
+}


### PR DESCRIPTION
Feature F2 from the ratified finalization spec. Closes #1143.

- **`IJobDetail.WithJobData(JobDataMap)` added** — the one mutation-shaped member a custom implementation needs: stores hand back an updated-data copy of the caller's OWN type. RAMJobStore's completion path now uses it, so a custom `IJobDetail` round-trips through the RAM store as itself (proven by a tenant-typed fixture through a running scheduler's fire→complete→re-store cycle).
- **`GetJobBuilder()` leaves the interface** — implementers could never write it faithfully. It returns as an extension method with the SAME name and namespace, built purely from public state via `OfType(JobType)`, so every existing consumer call site compiles untouched (verified: the six AspNetCore test call sites bind to the extension with zero edits) and an unresolvable stored type name keeps its spelling instead of throwing.
- **The travel contract is documented everywhere it matters**: RAM round-trips the custom type; ADO and HTTP rebuild as Quartz's own implementation (pinned by a faked-reader delegate test under both serializer fixtures). Tutorial gains "A JobDetail of your own" with the honest how-far-it-travels warning; the job-store authoring page tells store authors to prefer `WithJobData` over rebuilding.

Baseline delta is exactly the interface swap plus the extension class. Unit 2665, AspNetCore 259, basic-leg integration 108, `Compile UnitTest PublishAot` clean, 21 projects 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf