### PR TITLE
F6: the shipped jobs are configured by name, and the password leaves the job store

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1747,21 +1747,87 @@ unambiguously, and is what the rest of the API has spoken since 3.0:
 
 | 3.x / earlier 4.x | 4.0 |
 |---|---|
-| `protected void DirectoryScanJob.GetUpdatedOrNewFiles(string, DateTime, DateTime, IReadOnlyCollection<FileInfo>, out List<FileInfo>, out List<FileInfo>, out List<FileInfo>, string, bool)` | `protected DirectoryScanResult GetUpdatedOrNewFiles(string directoryName, DateTimeOffset lastModifiedTime, DateTimeOffset maxAgeTime, IReadOnlyCollection<FileInfo> currentFileList, string searchPattern = "*", bool includeSubDirectories = false)` |
 | `protected virtual DateTime FileScanJob.GetLastModifiedDate(string)`, returning `DateTime.MinValue` for a missing file | `protected virtual DateTimeOffset? GetLastModifiedTime(string fileName)`, returning `null` for a missing file |
+| `protected void DirectoryScanJob.GetUpdatedOrNewFiles(string, DateTime, DateTime, IReadOnlyCollection<FileInfo>, out List<FileInfo>, out List<FileInfo>, out List<FileInfo>, string, bool)` | private, along with the `DirectoryScanResult` it returns |
 
-`DirectoryScanResult` is a `readonly record struct` carrying `All`, `Updated` and `Deleted`. Nine
-parameters, three of them `out`, described one answer; the record is that answer, and the two genuinely
-optional inputs stay optional:
-
-```diff
-- GetUpdatedOrNewFiles(dir, lastModified, maxAge, current, out var all, out var updated, out var deleted);
-+ DirectoryScanResult scanned = GetUpdatedOrNewFiles(dir, lastModified, maxAge, current);
-```
+`GetUpdatedOrNewFiles` was `protected` but never `virtual`, and `DirectoryScanJob.Execute` is not
+virtual either, so no subclass could take part in the scan or do anything with a result it computed.
+`IDirectoryScanListener` is the seam, and it is handed the files themselves.
 
 The `LAST_MODIFIED_TIME` entry these jobs keep in their own job data is written as a `DateTimeOffset`
 now. A `DateTime` written by an earlier version is still read, as the instant it denoted, so an upgraded
 scheduler does not re-report every file it has already seen.
+
+### The shipped jobs are configured by name
+
+Every job in `Quartz.Jobs` was configured by `const string` keys read out of the merged `JobDataMap`,
+which is a configuration model with no compiler in it: the key can be misspelled, the value can be of
+the wrong type, and a setting the job honours can simply be missing from the documentation — as
+`SEARCH_PATTERN` and `INCLUDE_SUB_DIRECTORIES` were, `internal const`s that `DirectoryScanJob` read on
+every fire.
+
+Each job now has an options record that maps onto its keys in one place, and an extension that writes
+it:
+
+| Job | Options | Extension |
+|---|---|---|
+| `DirectoryScanJob` | `DirectoryScanOptions` | `UsingDirectoryScanOptions(…)` |
+| `FileScanJob` | `FileScanOptions` | `UsingFileScanOptions(…)` |
+| `NativeJob` | `NativeJobOptions` | `UsingNativeJobOptions(…)` |
+| `SendMailJob` | `SendMailOptions` | `UsingSendMailOptions(…)` |
+
+```diff
+  IJobDetail job = JobBuilder.Create<DirectoryScanJob>()
+      .WithIdentity("inboxScan")
+-     .UsingJobData(DirectoryScanJob.DirectoryNames, "/var/spool/inbox")
+-     .UsingJobData(DirectoryScanJob.DirectoryScanListenerName, nameof(InboxListener))
+-     .UsingJobData("SEARCH_PATTERN", "*.csv")
+-     .UsingJobData(DirectoryScanJob.MinimumUpdateAge, 30000L)
++     .UsingDirectoryScanOptions(new DirectoryScanOptions
++     {
++         Directories = ["/var/spool/inbox"],
++         ScanListenerName = nameof(InboxListener),
++         SearchPattern = "*.csv",
++         MinimumUpdateAge = TimeSpan.FromSeconds(30),
++     })
+      .Build();
+```
+
+Nothing about what is stored changes. The extensions write the same keys, `FromJobData` reads them
+back, and a job scheduled by 3.x reads identically — including a value a job store in
+`StoreJobDataAsStrings` mode left behind as a string. Configuring key by key still works, and
+`SEARCH_PATTERN` and `INCLUDE_SUB_DIRECTORIES` are `public const`s now, so the literal is no longer
+the only way to reach them. `MinimumUpdateAge` is a `TimeSpan` in the options and a millisecond count
+in the map, as it has always been.
+
+The extensions are generic in the configurator, so both configuration surfaces keep their type: a
+`JobBuilder<TJob>` chain still ends in `Build()`, and the `IJobConfigurator<TJob>` that `AddJob` hands
+you still chains its own members.
+
+### The SMTP password does not belong in job data
+
+`SendMailJob` read its credential from the `smtp_username` and `smtp_password` job data entries. Job
+data is durable: a persistent job store writes it to `QRTZ_JOB_DETAILS`, every node in the cluster
+reads it, the dashboard shows it, and a support-bundle export of that table carries it. `SendMailJob`
+takes the credential from the container instead:
+
+```csharp
+services.AddSingleton<ICredentialsByHost>(new NetworkCredential("mailer", smtpPassword));
+```
+
+`ICredentialsByHost` is what `SmtpClient.Credentials` takes, so a `CredentialCache` covers several
+servers. `SendMailOptions` deliberately has no user name or password on it.
+
+The two keys are still read when nothing is registered, so a job scheduled by an earlier version keeps
+sending; the job logs a warning saying where the credential now lives. A credential from the container
+wins over one in job data.
+
+| 3.x | 4.0 |
+|---|---|
+| `SendMailJob()` | `SendMailJob(ICredentialsByHost? credentials = null)`, which the job factory fills from the container |
+| `MailInfo.SmtpUserName` / `MailInfo.SmtpPassword` | `MailInfo.Credentials`, an `ICredentialsByHost?`. An override of `Send` routing mail through another transport gets whichever credential applied |
+| `protected virtual MailMessage BuildMessageFromParameters(JobDataMap data)` | `protected virtual MailMessage BuildMessage(SendMailOptions options)` — the same override point, reading a value instead of a bag |
+| `protected virtual string GetRequiredParameter(JobDataMap, string)`, `GetOptionalParameter(JobDataMap, string)` | removed; `SendMailOptions.FromJobData` is the one reader, and it reports the same missing key |
 
 ## Logging
 
@@ -6056,7 +6122,8 @@ Parameters and behavior are unchanged:
 | `UsingJobData` takes an `object?` | The nine primitive overloads collapsed into one — see [Nine `UsingJobData` overloads became one](#nine-usingjobdata-overloads-became-one) |
 | `IDirectoryScanListener` is asynchronous | `FilesUpdatedOrAdded` and `FilesDeleted` return `ValueTask` and take a `CancellationToken` |
 | `SendMailJob.Send` is asynchronous | `protected virtual ValueTask Send(MailInfo mailInfo, CancellationToken cancellationToken = default)`. It uses `SmtpClient.SendMailAsync`, so a job fired on the scheduler's thread pool no longer blocks it for the length of an SMTP round trip, and `Execute` forwards its token. An override returns `default` where it used to return nothing |
-| `SendMailJob.MailInfo` is `Quartz.Jobs.MailInfo` | The nested class became a top-level `sealed` type in the same namespace, with `required`/`init` members: `MailMessage` and `SmtpHost` are required, the three SMTP settings are optional. An override of `Send` keeps compiling — `MailInfo` resolves through the `Quartz.Jobs` using — and code that constructed one with an object initializer keeps compiling too. Assigning to a property after construction does not: build the whole value in the initializer |
+| `SendMailJob.MailInfo` is `Quartz.Jobs.MailInfo` | The nested class became a top-level `sealed` type in the same namespace, with `required`/`init` members: `MailMessage` and `SmtpHost` are required, `SmtpPort` and `Credentials` are optional. An override of `Send` keeps compiling — `MailInfo` resolves through the `Quartz.Jobs` using — and code that constructed one with an object initializer keeps compiling too. Assigning to a property after construction does not: build the whole value in the initializer. The two credential strings became one `Credentials`, see [The SMTP password does not belong in job data](#the-smtp-password-does-not-belong-in-job-data) |
+| The jobs in `Quartz.Jobs` have options types | `DirectoryScanOptions`, `FileScanOptions`, `NativeJobOptions` and `SendMailOptions`, written by `Using*Options(…)` on the job's configurator. The job data keys are unchanged and configuring key by key still works — see [The shipped jobs are configured by name](#the-shipped-jobs-are-configured-by-name) |
 | `JobDataMap.GetEnumerator` returns the interface | `IEnumerator<KeyValuePair<string, object?>>` rather than `Dictionary<string, object?>.Enumerator`, matching `SchedulerContext`. `foreach` is unaffected; a variable declared as the concrete struct type needs retyping |
 | `CronTriggerImpl.WillFireOn` is one method | `WillFireOn(DateTimeOffset timeUtc, bool dayOnly = false)`. The two overloads differed only by that default. Both call shapes compile unchanged |
 | `JobExecutionContextImpl.IncrementRefireCount()` and the `JobRunTime` setter are internal | Both record what the scheduler observed while running the job; `JobRunShell` is the only caller, and writing either from a job or a listener reported a fire that never happened |

--- a/docs/documentation/quartz-4.x/packages/quartz-jobs.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-jobs.md
@@ -1,6 +1,6 @@
 ---
 
-title : Jobs
+title: Jobs
 ---
 
 [Quartz.Jobs](https://www.nuget.org/packages/Quartz.Jobs) provides some useful ready-made jobs for your convenience.
@@ -15,34 +15,120 @@ string or a stored `JOB_CLASS_NAME` naming the old spelling still resolves, with
 You need to add NuGet package reference to your project which uses Quartz.
 
 ```shell
-Install-Package Quartz.Jobs
+dotnet add package Quartz.Jobs
 ```
+
+## How these jobs are configured
+
+Each of these jobs reads its settings from its `JobDataMap`, under the keys listed with it below. Those keys
+are the persisted form: they are what a job store writes, what a cluster shares, and what an XML or JSON
+scheduling file names.
+
+Each job also has an options type that maps onto exactly those keys, and an extension that writes it. It is
+the same stored job either way — but the key cannot be misspelled, the value cannot be of the wrong type, and
+every setting the job honours is a named property you can find by typing a dot.
+
+| Job | Options | Extension |
+|---|---|---|
+| `DirectoryScanJob` | `DirectoryScanOptions` | `UsingDirectoryScanOptions(…)` |
+| `FileScanJob` | `FileScanOptions` | `UsingFileScanOptions(…)` |
+| `NativeJob` | `NativeJobOptions` | `UsingNativeJobOptions(…)` |
+| `SendMailJob` | `SendMailOptions` | `UsingSendMailOptions(…)` |
+
+The extensions work on both configuration surfaces — `JobBuilder.Create<TJob>()` and the configurator
+`AddJob<TJob>(…)` hands you — and each leaves you with what you started with, so the chain continues as usual.
+`Options.FromJobData(map)` reads the same settings back out of a job's data.
 
 ## Features
 
 ### DirectoryScanJob
 
-Inspects a directory and compares whether any files' "last modified dates" have changed since the last time it was inspected.
-If one or more files have been updated (or created), the job invokes a "call-back" method on an `IDirectoryScanListener`that can be found in the `SchedulerContext`.
+Inspects a directory and compares whether any files' "last modified dates" have changed since the last time it
+was inspected. If one or more files have been updated, created or deleted, the job invokes a call-back method
+on an `IDirectoryScanListener`.
+
+```csharp
+IJobDetail job = JobBuilder.Create<DirectoryScanJob>()
+    .WithIdentity("inboxScan")
+    .UsingDirectoryScanOptions(new DirectoryScanOptions
+    {
+        Directories = ["/var/spool/inbox"],
+        ScanListenerName = nameof(InboxListener),
+        SearchPattern = "*.csv",
+        IncludeSubDirectories = true,
+        MinimumUpdateAge = TimeSpan.FromSeconds(30),
+    })
+    .Build();
+```
+
+| Setting | Job data key | Default |
+|---|---|---|
+| `Directories` | `DIRECTORY_NAMES` (semicolon-separated), or `DIRECTORY_NAME` for one | — |
+| `DirectoryProviderName` | `DIRECTORY_PROVIDER_NAME` | none; the paths above are used |
+| `ScanListenerName` | `DIRECTORY_SCAN_LISTENER_NAME` | required |
+| `SearchPattern` | `SEARCH_PATTERN` | `*` |
+| `IncludeSubDirectories` | `INCLUDE_SUB_DIRECTORIES` | `false` |
+| `MinimumUpdateAge` | `MINIMUM_UPDATE_AGE`, in milliseconds | 5 seconds |
+
+`MinimumUpdateAge` is how long a file must have been left alone before the job reports it. Without it a file
+another process is still writing would be handed to the listener half-finished.
+
+The listener is found in one of two ways, in this order:
+
+1. **Dependency injection** (recommended): register your `IDirectoryScanListener` implementation in the
+   container, and name its type — `ScanListenerName = nameof(InboxListener)`.
+2. **`SchedulerContext`**: store the instance under a key, and name that key.
+
+```csharp
+scheduler.Context["inboxListener"] = new InboxListener();
+```
+
+Where the directories come from can be decided at run time instead of being listed: implement
+`IDirectoryProvider`, put the instance in the `SchedulerContext`, and name that key as
+`DirectoryProviderName`. It is handed the merged job data and returns the paths to scan.
+
+The job keeps its own bookkeeping — the last modification time it saw and the file list it saw it in — in the
+job detail's data map, which is why it is `[PersistJobDataAfterExecution]`.
 
 ### FileScanJob
 
-Inspects a file and compares whether its "last modified dates" have changed since the last time it was inspected.
-If one or more files have been updated (or created), the job invokes a "call-back" method on an `IFileScanListener`that can be found in the `SchedulerContext`.
+Inspects a single file and compares whether its "last modified date" has changed since the last time it was
+inspected. If it has, the job invokes a call-back method on an `IFileScanListener` found in the
+`SchedulerContext`.
+
+```csharp
+IJobDetail job = JobBuilder.Create<FileScanJob>()
+    .WithIdentity("configWatch")
+    .UsingFileScanOptions(new FileScanOptions
+    {
+        FileName = "/etc/app/settings.json",
+        ScanListenerName = "settingsListener",
+        MinimumUpdateAge = TimeSpan.FromSeconds(5),
+    })
+    .Build();
+```
+
+| Setting | Job data key | Default |
+|---|---|---|
+| `FileName` | `FILE_NAME` | required |
+| `ScanListenerName` | `FILE_SCAN_LISTENER_NAME` | required |
+| `MinimumUpdateAge` | `MINIMUM_UPDATE_AGE`, in milliseconds | 5 seconds |
 
 ### NativeJob
 
-Built in job for executing native executables in a separate process.
-
-**Example**
+Runs a native executable in a separate process.
 
 ```csharp
-var job = JobBuilder.Create<NativeJob>()
+IJobDetail job = JobBuilder.Create<NativeJob>()
     .WithIdentity("dumbJob")
-    .UsingJobData(NativeJob.PropertyCommand, "echo \"hi\" >> foobar.txt")
+    .UsingNativeJobOptions(new NativeJobOptions
+    {
+        Command = "echo",
+        Parameters = "\"hi\" >> foobar.txt",
+    })
     .Build();
 
-var trigger = TriggerBuilder.Create()
+ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("dumbTrigger")
     .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(5)).RepeatForever())
     .Build();
@@ -50,8 +136,97 @@ var trigger = TriggerBuilder.Create()
 await scheduler.ScheduleJob(job, trigger);
 ```
 
-If PropertyWaitForProcess is true, then the integer exit value of the process will be saved as the job execution result in the `JobExecutionContext`.
+| Setting | Job data key | Default |
+|---|---|---|
+| `Command` | `command` | required |
+| `Parameters` | `parameters` | none |
+| `WaitForProcess` | `waitForProcess` | `true` |
+| `ConsumeStreams` | `consumeStreams` | `false` |
+| `WorkingDirectory` | `workingDirectory` | the scheduler's |
+
+When `WaitForProcess` is on, the integer exit code of the process is saved as the job execution result in the
+`IJobExecutionContext`. Turn `ConsumeStreams` on for a chatty process: one that writes more output than its
+pipe holds blocks until someone reads it.
 
 ### SendMailJob
 
-A Job which sends an e-mail with the configured content to the configured recipient.
+Sends an e-mail with the configured content to the configured recipient.
+
+```csharp
+IJobDetail job = JobBuilder.Create<SendMailJob>()
+    .WithIdentity("nightlyDigest")
+    .UsingSendMailOptions(new SendMailOptions
+    {
+        SmtpHost = "smtp.example.com",
+        SmtpPort = 587,
+        Sender = "scheduler@example.com",
+        Recipient = "ops@example.com",
+        Subject = "Nightly digest",
+        Message = "Everything ran.",
+    })
+    .Build();
+```
+
+| Setting | Job data key | Default |
+|---|---|---|
+| `SmtpHost` | `smtp_host` | required |
+| `SmtpPort` | `smtp_port` | the client's default |
+| `Sender` | `sender` | required |
+| `Recipient` | `recipient` | required |
+| `CcRecipient` | `cc_recipient` | none |
+| `ReplyTo` | `reply_to` | the sender |
+| `Subject` | `subject` | required |
+| `Message` | `message` | required |
+| `Encoding` | `encoding` | the default |
+
+Override `Send(MailInfo, CancellationToken)` to route the mail through something other than `SmtpClient`, or
+`BuildMessage(SendMailOptions)` to add to the message — an attachment, a header — before it goes.
+
+#### Keep the SMTP credential out of job data
+
+`SendMailOptions` has no user name or password on purpose. Job data is durable: a persistent job store writes
+it to `QRTZ_JOB_DETAILS`, every node in the cluster reads it, the dashboard shows it, and any export of that
+table carries it. A password put there is a password in all of those places.
+
+Register the credential with the container instead, and the job authenticates with it:
+
+```csharp
+services.AddSingleton<ICredentialsByHost>(new NetworkCredential("mailer", smtpPassword));
+```
+
+`ICredentialsByHost` is what `SmtpClient.Credentials` takes, so a `CredentialCache` covers several servers.
+The password itself belongs wherever the rest of your secrets live — user secrets in development, a key vault
+or an environment variable in production — and reaches this registration through `IConfiguration`.
+
+The `smtp_username` and `smtp_password` job data keys are still read when nothing is registered, so a job
+scheduled by an earlier version keeps sending. The job logs a warning when it uses them, and a credential from
+the container wins.
+
+### NoOpJob
+
+A job that does nothing. Useful as a placeholder, and for triggering listeners on a schedule without any work
+attached.
+
+## Registering these jobs with the container
+
+The jobs take their dependencies — a `TimeProvider`, an `IServiceProvider`, an `ICredentialsByHost` — from the
+container, so register them the same way you register your own:
+
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    q.AddJob<NativeJob>(j => j
+        .WithIdentity("nightlyReport")
+        .StoreDurably()
+        .UsingNativeJobOptions(new NativeJobOptions
+        {
+            Command = "report.exe",
+            Parameters = "--nightly",
+            ConsumeStreams = true,
+        }));
+
+    q.AddTrigger(t => t
+        .ForJob("nightlyReport")
+        .WithCronSchedule("0 0 2 * * ?"));
+});
+```

--- a/src/Quartz.Jobs/Jobs/DefaultDirectoryProvider.cs
+++ b/src/Quartz.Jobs/Jobs/DefaultDirectoryProvider.cs
@@ -9,27 +9,16 @@ internal sealed class DefaultDirectoryProvider : IDirectoryProvider
 {
     public List<string> GetDirectoriesToScan(JobDataMap mergedJobDataMap)
     {
-        List<string> directoriesToScan = new List<string>();
-        var dirName = mergedJobDataMap.GetString(DirectoryScanJob.DirectoryName);
-        var dirNames = mergedJobDataMap.GetString(DirectoryScanJob.DirectoryNames);
-
-        if (dirName is null && dirNames is null)
-        {
-            throw new JobExecutionException($"The parameter '{DirectoryScanJob.DirectoryName}' or '{DirectoryScanJob.DirectoryNames}' " +
-                                            "is required and was not found in merged JobDataMap");
-        }
-
         /*
             If the user supplied both DirectoryScanJob.DirectoryName and DirectoryScanJob.DirectoryNames,
             then just use both. The directory names will be 'distincted' by the caller.
         */
-        if (dirName is not null)
+        List<string> directoriesToScan = DirectoryScanOptions.ReadDirectories(mergedJobDataMap);
+
+        if (directoriesToScan.Count == 0)
         {
-            directoriesToScan.Add(dirName);
-        }
-        if (dirNames is not null)
-        {
-            directoriesToScan.AddRange(dirNames.Split(';', StringSplitOptions.RemoveEmptyEntries));
+            throw new JobExecutionException($"The parameter '{DirectoryScanJob.DirectoryName}' or '{DirectoryScanJob.DirectoryNames}' " +
+                                            "is required and was not found in merged JobDataMap");
         }
 
         return directoriesToScan;

--- a/src/Quartz.Jobs/Jobs/DirectoryScanJob.cs
+++ b/src/Quartz.Jobs/Jobs/DirectoryScanJob.cs
@@ -14,6 +14,13 @@ namespace Quartz.Jobs;
 /// dependency injection or found in the <see cref="SchedulerContext"/>.
 /// </summary>
 /// <remarks>
+/// <para>
+/// What is scanned is configured through the job data keys below.
+/// <see cref="DirectoryScanOptions" /> names them all, and
+/// <see cref="JobConfiguratorExtensions.UsingDirectoryScanOptions{TConfigurator}" /> writes them, so
+/// the settings can be given as a value rather than as string keys; the keys stay the persisted form
+/// either way.
+/// </para>
 /// The listener can be provided in two ways:
 /// <list type="number">
 /// <item>
@@ -61,18 +68,21 @@ public class DirectoryScanJob : IJob
     /// in the middle of writing to the file when the scan occurs, and the
     ///  file may therefore not yet be ready for processing.
     /// <para>If this parameter is not specified, a default value of 5000 (five seconds) will be used.</para>
+    /// <para><see cref="DirectoryScanOptions.MinimumUpdateAge" /> says the same thing as a <see cref="TimeSpan" />.</para>
     public const string MinimumUpdateAge = "MINIMUM_UPDATE_AGE";
 
     internal const string LastModifiedTime = "LAST_MODIFIED_TIME";
 
     /// <summary>
-    /// The search string to match against the names of files.
-    /// Can contain combination of valid literal path and wildcard (* and ?) characters
+    /// <see cref="JobDataMap"/> key with which to specify the search string to match against the
+    /// names of files. Can contain a combination of valid literal path and wildcard (* and ?)
+    /// characters. Defaults to <c>*</c>, every file.
     /// </summary>
-    internal const string SearchPattern = "SEARCH_PATTERN";
+    public const string SearchPattern = "SEARCH_PATTERN";
 
     ///<see cref="JobDataMap"/> Key to specify whether to scan sub directories for file changes.
-    internal const string IncludeSubDirectories = "INCLUDE_SUB_DIRECTORIES";
+    ///<para>Defaults to <see langword="false" />.</para>
+    public const string IncludeSubDirectories = "INCLUDE_SUB_DIRECTORIES";
 
     ///<see cref="JobDataMap"/> key to store the current file list of the scanned directories.
     ///This is required to find out deleted files during next iteration.
@@ -185,7 +195,7 @@ public class DirectoryScanJob : IJob
     /// <param name="currentFileList">What the previous scan saw, which is what a deletion is measured against.</param>
     /// <param name="searchPattern">The pattern file names must match.</param>
     /// <param name="includeSubDirectories">Whether to descend into sub-directories.</param>
-    protected DirectoryScanResult GetUpdatedOrNewFiles(
+    private DirectoryScanResult GetUpdatedOrNewFiles(
         string directoryName,
         DateTimeOffset lastModifiedTime,
         DateTimeOffset maxAgeTime,

--- a/src/Quartz.Jobs/Jobs/DirectoryScanJobModel.cs
+++ b/src/Quartz.Jobs/Jobs/DirectoryScanJobModel.cs
@@ -29,12 +29,12 @@ internal sealed class DirectoryScanJobModel
     internal List<FileInfo> CurrentFileList { get; private set; } = null!;
     internal IDirectoryScanListener DirectoryScanListener { get; private set; } = null!;
     internal DateTimeOffset LastModifiedTime { get; private set; }
-    internal DateTimeOffset MaxAgeTime => TimeProvider.GetUtcNow() - MinUpdateAge;
+    internal DateTimeOffset MaxAgeTime => TimeProvider.GetUtcNow() - Options.MinimumUpdateAge;
     private TimeProvider TimeProvider { get; set; } = null!;
-    private TimeSpan MinUpdateAge { get; set; }
+    private DirectoryScanOptions Options { get; set; } = null!;
     private JobDataMap JobDetailJobDataMap { get; set; } = null!;
-    public string SearchPattern { get; internal set; } = null!;
-    public bool IncludeSubDirectories { get; internal set; }
+    internal string SearchPattern => Options.SearchPattern;
+    internal bool IncludeSubDirectories => Options.IncludeSubDirectories;
 
     /// <summary>
     /// Creates an instance of DirectoryScanJobModel by inspecting the provided IJobExecutionContext <see cref="IJobExecutionContext"/>
@@ -56,24 +56,20 @@ internal sealed class DirectoryScanJobModel
             throw new JobExecutionException("Error obtaining scheduler context.", e);
         }
 
+        DirectoryScanOptions options = DirectoryScanOptions.FromJobData(mergedJobDataMap);
+
         var model = new DirectoryScanJobModel
         {
             TimeProvider = timeProvider,
-            DirectoryScanListener = GetListener(mergedJobDataMap, schedCtxt, serviceProvider),
+            Options = options,
+            DirectoryScanListener = GetListener(options.ScanListenerName, schedCtxt, serviceProvider),
             LastModifiedTime = mergedJobDataMap.ReadTimestamp(DirectoryScanJob.LastModifiedTime) ?? DateTimeOffset.MinValue,
-            MinUpdateAge = mergedJobDataMap.ContainsKey(DirectoryScanJob.MinimumUpdateAge)
-                ? TimeSpan.FromMilliseconds(mergedJobDataMap.GetLong(DirectoryScanJob.MinimumUpdateAge))
-                : TimeSpan.FromSeconds(5), // default of 5 seconds
             JobDetailJobDataMap = context.JobDetail.JobDataMap,
-            DirectoriesToScan = GetDirectoriesToScan(schedCtxt, mergedJobDataMap)
+            DirectoriesToScan = GetDirectoriesToScan(schedCtxt, mergedJobDataMap, options.DirectoryProviderName)
                 .Distinct().ToList(),
             CurrentFileList = mergedJobDataMap.TryGetValue(DirectoryScanJob.CurrentFileList, out object? value)
                 ? (List<FileInfo>) value!
                 : [],
-            SearchPattern = mergedJobDataMap.TryGetString(DirectoryScanJob.SearchPattern, out string? pattern)
-                ? pattern ?? "*"
-                : "*",
-            IncludeSubDirectories = mergedJobDataMap.TryGetBoolean(DirectoryScanJob.IncludeSubDirectories, out bool includeSubDirectories) && includeSubDirectories,
         };
 
         return model;
@@ -104,10 +100,9 @@ internal sealed class DirectoryScanJobModel
     }
 
 
-    private static List<string> GetDirectoriesToScan(SchedulerContext schedCtxt, JobDataMap mergedJobDataMap)
+    private static List<string> GetDirectoriesToScan(SchedulerContext schedCtxt, JobDataMap mergedJobDataMap, string? explicitDirProviderName)
     {
         IDirectoryProvider directoryProvider = new DefaultDirectoryProvider();
-        var explicitDirProviderName = mergedJobDataMap.GetString(DirectoryScanJob.DirectoryProviderName);
 
         if (explicitDirProviderName is not null)
         {
@@ -122,16 +117,8 @@ internal sealed class DirectoryScanJobModel
     }
 
 
-    private static IDirectoryScanListener GetListener(JobDataMap mergedJobDataMap, SchedulerContext schedCtxt, IServiceProvider? serviceProvider)
+    private static IDirectoryScanListener GetListener(string listenerName, SchedulerContext schedCtxt, IServiceProvider? serviceProvider)
     {
-        var listenerName = mergedJobDataMap.GetString(DirectoryScanJob.DirectoryScanListenerName);
-
-        if (listenerName is null)
-        {
-            throw new JobExecutionException("Required parameter '" +
-                                            DirectoryScanJob.DirectoryScanListenerName + "' not found in merged JobDataMap");
-        }
-
         // First, try to resolve from DI if service provider is available
         if (serviceProvider is not null)
         {

--- a/src/Quartz.Jobs/Jobs/DirectoryScanOptions.cs
+++ b/src/Quartz.Jobs/Jobs/DirectoryScanOptions.cs
@@ -1,0 +1,210 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// What <see cref="DirectoryScanJob" /> scans and when it considers a file settled.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The job is configured through its <see cref="JobDataMap" />, and those keys are the persisted
+/// contract — this type is the named way to write and read them.
+/// <see cref="JobConfiguratorExtensions.UsingDirectoryScanOptions{TConfigurator}" /> writes them,
+/// <see cref="FromJobData" /> reads them back, and job data written by hand or by an earlier version
+/// reads the same either way.
+/// </para>
+/// <para>
+/// The directories to scan come either from <see cref="Directories" /> or from an
+/// <see cref="IDirectoryProvider" /> named by <see cref="DirectoryProviderName" />. Naming neither
+/// leaves the job nothing to scan, which it reports when it first fires.
+/// </para>
+/// </remarks>
+public sealed record DirectoryScanOptions
+{
+    /// <summary>
+    /// The directories to monitor; absolute paths are recommended. They are stored semicolon-separated
+    /// under <see cref="DirectoryScanJob.DirectoryNames" />, so a path may not itself contain a
+    /// semicolon.
+    /// </summary>
+    public IReadOnlyList<string> Directories { get; init; } = [];
+
+    /// <summary>
+    /// The <see cref="SchedulerContext" /> key of an <see cref="IDirectoryProvider" /> that supplies
+    /// the directories instead of <see cref="Directories" />, or <see langword="null" /> to use the
+    /// paths in <see cref="Directories" />.
+    /// </summary>
+    public string? DirectoryProviderName { get; init; }
+
+    /// <summary>
+    /// The name of the <see cref="IDirectoryScanListener" /> to notify: either a type registered in
+    /// the container, or a <see cref="SchedulerContext" /> key an instance is stored under.
+    /// </summary>
+    public required string ScanListenerName { get; init; }
+
+    /// <summary>
+    /// The pattern file names must match, which may combine literal path characters with the
+    /// <c>*</c> and <c>?</c> wildcards. Defaults to <c>*</c>, every file.
+    /// </summary>
+    public string SearchPattern { get; init; } = "*";
+
+    /// <summary>
+    /// Whether to descend into sub-directories. Defaults to <see langword="false" />.
+    /// </summary>
+    public bool IncludeSubDirectories { get; init; }
+
+    /// <summary>
+    /// How long a file must have been left alone to count as new or altered rather than as one
+    /// another process is still writing. Defaults to five seconds.
+    /// </summary>
+    /// <remarks>
+    /// Persisted as a whole number of milliseconds under
+    /// <see cref="DirectoryScanJob.MinimumUpdateAge" />, which is what earlier versions wrote.
+    /// </remarks>
+    public TimeSpan MinimumUpdateAge { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Two sets of options are equal when they say the same thing, which for
+    /// <see cref="Directories" /> means the same paths in the same order.
+    /// </summary>
+    /// <remarks>
+    /// Spelled out because the compiler's version would compare the list by reference, and two
+    /// options records read out of the same job data would then differ.
+    /// </remarks>
+    public bool Equals(DirectoryScanOptions? other)
+    {
+        return other is not null
+               && Directories.SequenceEqual(other.Directories, StringComparer.Ordinal)
+               && DirectoryProviderName == other.DirectoryProviderName
+               && ScanListenerName == other.ScanListenerName
+               && SearchPattern == other.SearchPattern
+               && IncludeSubDirectories == other.IncludeSubDirectories
+               && MinimumUpdateAge == other.MinimumUpdateAge;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        HashCode hash = new HashCode();
+        foreach (string directory in Directories)
+        {
+            hash.Add(directory, StringComparer.Ordinal);
+        }
+
+        hash.Add(DirectoryProviderName);
+        hash.Add(ScanListenerName);
+        hash.Add(SearchPattern);
+        hash.Add(IncludeSubDirectories);
+        hash.Add(MinimumUpdateAge);
+        return hash.ToHashCode();
+    }
+
+    /// <summary>
+    /// Reads the options out of a job's data, taking the default for every key it does not carry.
+    /// </summary>
+    /// <param name="data">
+    /// The job data to read, normally <see cref="IJobExecutionContext.MergedJobDataMap" />.
+    /// </param>
+    /// <exception cref="JobExecutionException">
+    /// <see cref="DirectoryScanJob.DirectoryScanListenerName" /> is absent; there is nothing to
+    /// notify, so nothing the job can usefully do.
+    /// </exception>
+    public static DirectoryScanOptions FromJobData(JobDataMap data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        string? listenerName = data.GetString(DirectoryScanJob.DirectoryScanListenerName);
+        if (listenerName is null)
+        {
+            throw new JobExecutionException("Required parameter '" +
+                                            DirectoryScanJob.DirectoryScanListenerName + "' not found in merged JobDataMap");
+        }
+
+        return new DirectoryScanOptions
+        {
+            Directories = ReadDirectories(data),
+            DirectoryProviderName = data.GetString(DirectoryScanJob.DirectoryProviderName),
+            ScanListenerName = listenerName,
+            SearchPattern = data.TryGetString(DirectoryScanJob.SearchPattern, out string? pattern) && !string.IsNullOrEmpty(pattern)
+                ? pattern
+                : "*",
+            IncludeSubDirectories = data.TryGetBoolean(DirectoryScanJob.IncludeSubDirectories, out bool includeSubDirectories) && includeSubDirectories,
+            MinimumUpdateAge = JobDataMapDurations.ReadMilliseconds(data, DirectoryScanJob.MinimumUpdateAge) ?? TimeSpan.FromSeconds(5),
+        };
+    }
+
+    /// <summary>
+    /// Writes the options as the job data keys <see cref="DirectoryScanJob" /> reads.
+    /// </summary>
+    public JobDataMap ToJobData()
+    {
+        JobDataMap data = new JobDataMap();
+
+        if (Directories.Count > 0)
+        {
+            foreach (string directory in Directories)
+            {
+                if (directory.Contains(';', StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Directory '{directory}' contains a semicolon, which is what separates the paths stored under '{DirectoryScanJob.DirectoryNames}'.");
+                }
+            }
+
+            data[DirectoryScanJob.DirectoryNames] = string.Join(';', Directories);
+        }
+
+        if (DirectoryProviderName is not null)
+        {
+            data[DirectoryScanJob.DirectoryProviderName] = DirectoryProviderName;
+        }
+
+        data[DirectoryScanJob.DirectoryScanListenerName] = ScanListenerName;
+        data[DirectoryScanJob.SearchPattern] = SearchPattern;
+        data[DirectoryScanJob.IncludeSubDirectories] = IncludeSubDirectories;
+        data[DirectoryScanJob.MinimumUpdateAge] = (long) MinimumUpdateAge.TotalMilliseconds;
+
+        return data;
+    }
+
+    /// <summary>
+    /// The directory paths spelled out in job data, which is what
+    /// <see cref="DefaultDirectoryProvider" /> serves when no other provider is named.
+    /// </summary>
+    internal static List<string> ReadDirectories(JobDataMap data)
+    {
+        List<string> directories = new List<string>();
+
+        string? directoryName = data.GetString(DirectoryScanJob.DirectoryName);
+        if (directoryName is not null)
+        {
+            directories.Add(directoryName);
+        }
+
+        string? directoryNames = data.GetString(DirectoryScanJob.DirectoryNames);
+        if (directoryNames is not null)
+        {
+            directories.AddRange(directoryNames.Split(';', StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        return directories;
+    }
+}

--- a/src/Quartz.Jobs/Jobs/DirectoryScanResult.cs
+++ b/src/Quartz.Jobs/Jobs/DirectoryScanResult.cs
@@ -24,6 +24,11 @@ namespace Quartz.Jobs;
 /// <summary>
 /// What one pass of <see cref="DirectoryScanJob" /> over a directory found.
 /// </summary>
+/// <remarks>
+/// Internal because the scan is: <see cref="DirectoryScanJob.Execute" /> is not virtual, so the
+/// per-directory pass was never something a subclass could take part in.
+/// <see cref="IDirectoryScanListener" /> is the seam, and it is handed the files themselves.
+/// </remarks>
 /// <param name="All">
 /// Every file the scan matched. This is what the next scan compares against to notice a deletion.
 /// </param>
@@ -33,7 +38,7 @@ namespace Quartz.Jobs;
 /// <param name="Deleted">
 /// The files the previous scan saw and this one did not.
 /// </param>
-public readonly record struct DirectoryScanResult(
+internal readonly record struct DirectoryScanResult(
     IReadOnlyList<FileInfo> All,
     IReadOnlyList<FileInfo> Updated,
     IReadOnlyList<FileInfo> Deleted);

--- a/src/Quartz.Jobs/Jobs/FileScanJob.cs
+++ b/src/Quartz.Jobs/Jobs/FileScanJob.cs
@@ -30,6 +30,12 @@ namespace Quartz.Jobs;
 /// <see cref="IFileScanListener" /> that can be found in the
 /// <see cref="SchedulerContext" />.
 /// </summary>
+/// <remarks>
+/// What is watched is configured through the job data keys below. <see cref="FileScanOptions" />
+/// names them all, and <see cref="JobConfiguratorExtensions.UsingFileScanOptions{TConfigurator}" />
+/// writes them, so the settings can be given as a value rather than as string keys; the keys stay the
+/// persisted form either way.
+/// </remarks>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
 /// <seealso cref="IFileScanListener" />
@@ -58,6 +64,7 @@ public class FileScanJob : IJob
     ///
     /// <para>If this parameter is not specified, a default value of
     /// 5000 (five seconds) will be used.</para>
+    /// <para><see cref="FileScanOptions.MinimumUpdateAge" /> says the same thing as a <see cref="TimeSpan" />.</para>
     /// </summary>
     public const string MinimumUpdateAge = "MINIMUM_UPDATE_AGE";
 
@@ -113,34 +120,19 @@ public class FileScanJob : IJob
             throw new JobExecutionException("Error obtaining scheduler context.", e);
         }
 
-        var fileName = mergedJobDataMap.GetString(FileName);
-        var listenerName = mergedJobDataMap.GetString(FileScanListenerName);
+        FileScanOptions options = FileScanOptions.FromJobData(mergedJobDataMap);
+        string fileName = options.FileName;
 
-        if (fileName is null)
-        {
-            throw new JobExecutionException($"Required parameter '{FileName}' not found in JobDataMap");
-        }
-        if (listenerName is null)
-        {
-            throw new JobExecutionException($"Required parameter '{FileScanListenerName}' not found in JobDataMap");
-        }
-
-        IFileScanListener? listener = (IFileScanListener?) schedCtxt[listenerName];
+        IFileScanListener? listener = (IFileScanListener?) schedCtxt[options.ScanListenerName];
 
         if (listener is null)
         {
-            throw new JobExecutionException($"FileScanListener named '{listenerName}' not found in SchedulerContext");
+            throw new JobExecutionException($"FileScanListener named '{options.ScanListenerName}' not found in SchedulerContext");
         }
 
         DateTimeOffset? lastTime = mergedJobDataMap.ReadTimestamp(LastModifiedTime);
 
-        long minAge = 5000;
-        if (mergedJobDataMap.ContainsKey(MinimumUpdateAge))
-        {
-            minAge = mergedJobDataMap.GetLong(MinimumUpdateAge);
-        }
-
-        DateTimeOffset maxAgeTime = timeProvider.GetUtcNow().AddMilliseconds(minAge);
+        DateTimeOffset maxAgeTime = timeProvider.GetUtcNow() + options.MinimumUpdateAge;
 
         DateTimeOffset? newTime = GetLastModifiedTime(fileName);
 

--- a/src/Quartz.Jobs/Jobs/FileScanOptions.cs
+++ b/src/Quartz.Jobs/Jobs/FileScanOptions.cs
@@ -1,0 +1,102 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// What <see cref="FileScanJob" /> watches and when it considers the file settled.
+/// </summary>
+/// <remarks>
+/// The job is configured through its <see cref="JobDataMap" />, and those keys are the persisted
+/// contract — this type is the named way to write and read them.
+/// <see cref="JobConfiguratorExtensions.UsingFileScanOptions{TConfigurator}" /> writes them,
+/// <see cref="FromJobData" /> reads them back, and job data written by hand or by an earlier version
+/// reads the same either way.
+/// </remarks>
+public sealed record FileScanOptions
+{
+    /// <summary>
+    /// The file to monitor; an absolute path is recommended.
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// The <see cref="SchedulerContext" /> key an <see cref="IFileScanListener" /> is stored under.
+    /// </summary>
+    public required string ScanListenerName { get; init; }
+
+    /// <summary>
+    /// How long the file must have been left alone to count as altered rather than as one another
+    /// process is still writing. Defaults to five seconds.
+    /// </summary>
+    /// <remarks>
+    /// Persisted as a whole number of milliseconds under <see cref="FileScanJob.MinimumUpdateAge" />,
+    /// which is what earlier versions wrote.
+    /// </remarks>
+    public TimeSpan MinimumUpdateAge { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Reads the options out of a job's data, taking the default for every key it does not carry.
+    /// </summary>
+    /// <param name="data">
+    /// The job data to read, normally <see cref="IJobExecutionContext.MergedJobDataMap" />.
+    /// </param>
+    /// <exception cref="JobExecutionException">
+    /// <see cref="FileScanJob.FileName" /> or <see cref="FileScanJob.FileScanListenerName" /> is
+    /// absent; the job has nothing to watch, or nothing to tell.
+    /// </exception>
+    public static FileScanOptions FromJobData(JobDataMap data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        string? fileName = data.GetString(FileScanJob.FileName);
+        if (fileName is null)
+        {
+            throw new JobExecutionException($"Required parameter '{FileScanJob.FileName}' not found in JobDataMap");
+        }
+
+        string? listenerName = data.GetString(FileScanJob.FileScanListenerName);
+        if (listenerName is null)
+        {
+            throw new JobExecutionException($"Required parameter '{FileScanJob.FileScanListenerName}' not found in JobDataMap");
+        }
+
+        return new FileScanOptions
+        {
+            FileName = fileName,
+            ScanListenerName = listenerName,
+            MinimumUpdateAge = JobDataMapDurations.ReadMilliseconds(data, FileScanJob.MinimumUpdateAge) ?? TimeSpan.FromSeconds(5),
+        };
+    }
+
+    /// <summary>
+    /// Writes the options as the job data keys <see cref="FileScanJob" /> reads.
+    /// </summary>
+    public JobDataMap ToJobData()
+    {
+        return new JobDataMap
+        {
+            [FileScanJob.FileName] = FileName,
+            [FileScanJob.FileScanListenerName] = ScanListenerName,
+            [FileScanJob.MinimumUpdateAge] = (long) MinimumUpdateAge.TotalMilliseconds,
+        };
+    }
+}

--- a/src/Quartz.Jobs/Jobs/JobConfiguratorExtensions.cs
+++ b/src/Quartz.Jobs/Jobs/JobConfiguratorExtensions.cs
@@ -1,0 +1,128 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// Configures a job from <c>Quartz.Jobs</c> with named options rather than with its job data keys.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each of these writes the same <see cref="JobDataMap" /> entries the job has always read, so the
+/// stored job is identical to one configured key by key and reads back the same on any version. What
+/// changes is the writing: the key cannot be misspelled, the value cannot be of the wrong type, and
+/// a setting the job supports cannot go missing from the documentation — the options type lists them.
+/// </para>
+/// <para>
+/// They are generic in the configurator so that the call keeps its receiver's type: a
+/// <see cref="JobBuilder{TJob}" /> chain still ends in <c>Build()</c>, and the
+/// <see cref="IJobConfigurator{TJob}" /> handed to <c>AddJob</c> still chains its own members.
+/// </para>
+/// </remarks>
+public static class JobConfiguratorExtensions
+{
+    /// <summary>
+    /// Configures a <see cref="DirectoryScanJob" /> with the directories to scan, the pattern to
+    /// match, whether to recurse, and how long a file must have settled.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// IJobDetail job = JobBuilder.Create&lt;DirectoryScanJob&gt;()
+    ///     .WithIdentity("inboxScan")
+    ///     .UsingDirectoryScanOptions(new DirectoryScanOptions
+    ///     {
+    ///         Directories = ["/var/spool/inbox"],
+    ///         SearchPattern = "*.csv",
+    ///         IncludeSubDirectories = true,
+    ///         ScanListenerName = nameof(InboxListener),
+    ///     })
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public static TConfigurator UsingDirectoryScanOptions<TConfigurator>(this TConfigurator configurator, DirectoryScanOptions options)
+        where TConfigurator : class, IJobConfigurator<DirectoryScanJob>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(options);
+
+        configurator.UsingJobData(options.ToJobData());
+        return configurator;
+    }
+
+    /// <summary>
+    /// Configures a <see cref="FileScanJob" /> with the file to watch, the listener to tell, and how
+    /// long the file must have settled.
+    /// </summary>
+    public static TConfigurator UsingFileScanOptions<TConfigurator>(this TConfigurator configurator, FileScanOptions options)
+        where TConfigurator : class, IJobConfigurator<FileScanJob>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(options);
+
+        configurator.UsingJobData(options.ToJobData());
+        return configurator;
+    }
+
+    /// <summary>
+    /// Configures a <see cref="NativeJob" /> with the command to run and how to run it.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// IJobDetail job = JobBuilder.Create&lt;NativeJob&gt;()
+    ///     .WithIdentity("nightlyReport")
+    ///     .UsingNativeJobOptions(new NativeJobOptions
+    ///     {
+    ///         Command = "report.exe",
+    ///         Parameters = "--nightly",
+    ///         ConsumeStreams = true,
+    ///     })
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public static TConfigurator UsingNativeJobOptions<TConfigurator>(this TConfigurator configurator, NativeJobOptions options)
+        where TConfigurator : class, IJobConfigurator<NativeJob>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(options);
+
+        configurator.UsingJobData(options.ToJobData());
+        return configurator;
+    }
+
+    /// <summary>
+    /// Configures a <see cref="SendMailJob" /> with the message to send and the server to send it
+    /// through.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SendMailOptions" /> has no credentials on purpose; register an
+    /// <see cref="System.Net.ICredentialsByHost" /> with the container instead of putting a password
+    /// in job data.
+    /// </remarks>
+    public static TConfigurator UsingSendMailOptions<TConfigurator>(this TConfigurator configurator, SendMailOptions options)
+        where TConfigurator : class, IJobConfigurator<SendMailJob>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(options);
+
+        configurator.UsingJobData(options.ToJobData());
+        return configurator;
+    }
+}

--- a/src/Quartz.Jobs/Jobs/JobDataMapDurations.cs
+++ b/src/Quartz.Jobs/Jobs/JobDataMapDurations.cs
@@ -1,0 +1,54 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// Reads the durations the scanning jobs keep in job data as a millisecond count.
+/// </summary>
+internal static class JobDataMapDurations
+{
+    /// <summary>
+    /// Reads a duration stored as milliseconds, or <see langword="null" /> when the key is absent or
+    /// holds nothing that can be read as one.
+    /// </summary>
+    /// <remarks>
+    /// Milliseconds is what every version of these jobs has written, so that is what is read — as a
+    /// number, or as the string a store in <c>StoreJobDataAsStrings</c> mode leaves behind. A
+    /// <see cref="TimeSpan" /> someone put there by hand is taken at face value.
+    /// </remarks>
+    internal static TimeSpan? ReadMilliseconds(JobDataMap data, string key)
+    {
+        if (!data.TryGetValue(key, out object? value))
+        {
+            return null;
+        }
+
+        if (value is TimeSpan span)
+        {
+            return span;
+        }
+
+        return data.TryGetLong(key, out long milliseconds)
+            ? TimeSpan.FromMilliseconds(milliseconds)
+            : null;
+    }
+}

--- a/src/Quartz.Jobs/Jobs/MailInfo.cs
+++ b/src/Quartz.Jobs/Jobs/MailInfo.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using System.Net;
 using System.Net.Mail;
 
 namespace Quartz.Jobs;
@@ -49,12 +50,13 @@ public sealed class MailInfo
     public int? SmtpPort { get; init; }
 
     /// <summary>
-    /// The user name to authenticate with, or <see langword="null" /> to send unauthenticated.
+    /// What to authenticate to the SMTP server with, or <see langword="null" /> to send
+    /// unauthenticated.
     /// </summary>
-    public string? SmtpUserName { get; init; }
-
-    /// <summary>
-    /// The password that goes with <see cref="SmtpUserName" />.
-    /// </summary>
-    public string? SmtpPassword { get; init; }
+    /// <remarks>
+    /// The credential registered with the container, or — for a job scheduled before there was one —
+    /// the <c>smtp_username</c> and <c>smtp_password</c> job data entries as a
+    /// <see cref="System.Net.NetworkCredential" />.
+    /// </remarks>
+    public ICredentialsByHost? Credentials { get; init; }
 }

--- a/src/Quartz.Jobs/Jobs/NativeJob.cs
+++ b/src/Quartz.Jobs/Jobs/NativeJob.cs
@@ -32,10 +32,16 @@ namespace Quartz.Jobs;
 /// Built in job for executing native executables in a separate process.
 /// </summary>
 /// <remarks>
+/// <para>
+/// What is run is configured through the job data keys below. <see cref="NativeJobOptions" /> names
+/// them all, and <see cref="JobConfiguratorExtensions.UsingNativeJobOptions{TConfigurator}" /> writes
+/// them, so the settings can be given as a value rather than as string keys; the keys stay the
+/// persisted form either way.
+/// </para>
 /// <example>
 ///     IJobDetail job = JobBuilder.Create&lt;NativeJob&gt;()
 ///         .WithIdentity("dumbJob")
-///         .UsingJobData(NativeJob.PropertyCommand, "echo \"hi\" >> foobar.txt")
+///         .UsingNativeJobOptions(new NativeJobOptions { Command = "echo \"hi\" >> foobar.txt" })
 ///         .Build();
 ///
 ///     ITrigger trigger = TriggerBuilder.Create()
@@ -124,25 +130,15 @@ public class NativeJob : IJob
     /// <param name="cancellationToken">The cancellation instruction.</param>
     public virtual ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
-        JobDataMap data = context.MergedJobDataMap;
+        NativeJobOptions options = NativeJobOptions.FromJobData(context.MergedJobDataMap);
 
-        string command = data.GetString(PropertyCommand) ?? throw new JobExecutionException("command missing");
-        string parameters = data.GetString(PropertyParameters) ?? "";
+        int exitCode = RunNativeCommand(
+            options.Command,
+            options.Parameters ?? "",
+            options.WorkingDirectory,
+            options.WaitForProcess,
+            options.ConsumeStreams);
 
-        bool wait = true;
-        if (data.TryGetBoolean(PropertyWaitForProcess, out bool b))
-        {
-            wait = b;
-        }
-
-        bool consumeStreams = false;
-        if (data.TryGetBoolean(PropertyConsumeStreams, out b))
-        {
-            consumeStreams = b;
-        }
-
-        var workingDirectory = data.GetString(PropertyWorkingDirectory);
-        int exitCode = RunNativeCommand(command, parameters, workingDirectory, wait, consumeStreams);
         context.Result = exitCode;
         return default;
     }

--- a/src/Quartz.Jobs/Jobs/NativeJobOptions.cs
+++ b/src/Quartz.Jobs/Jobs/NativeJobOptions.cs
@@ -1,0 +1,115 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// The command <see cref="NativeJob" /> runs, and how it runs it.
+/// </summary>
+/// <remarks>
+/// The job is configured through its <see cref="JobDataMap" />, and those keys are the persisted
+/// contract — this type is the named way to write and read them.
+/// <see cref="JobConfiguratorExtensions.UsingNativeJobOptions{TConfigurator}" /> writes them,
+/// <see cref="FromJobData" /> reads them back, and job data written by hand or by an earlier version
+/// reads the same either way.
+/// </remarks>
+public sealed record NativeJobOptions
+{
+    /// <summary>
+    /// The executable to run.
+    /// </summary>
+    public required string Command { get; init; }
+
+    /// <summary>
+    /// The parameters to pass to the command, or <see langword="null" /> for none.
+    /// </summary>
+    public string? Parameters { get; init; }
+
+    /// <summary>
+    /// Whether the job waits for the process to exit before it completes, which is also what makes
+    /// the exit code available as <see cref="IJobExecutionContext.Result" />. Defaults to
+    /// <see langword="true" />.
+    /// </summary>
+    public bool WaitForProcess { get; init; } = true;
+
+    /// <summary>
+    /// Whether the spawned process's <c>stdout</c> and <c>stderr</c> are read and logged. A process
+    /// that writes more output than its pipe holds blocks until someone reads it, so leave this on
+    /// for anything chatty. Defaults to <see langword="false" />.
+    /// </summary>
+    public bool ConsumeStreams { get; init; }
+
+    /// <summary>
+    /// The working directory to start the process in, or <see langword="null" /> to inherit the
+    /// scheduler's.
+    /// </summary>
+    public string? WorkingDirectory { get; init; }
+
+    /// <summary>
+    /// Reads the options out of a job's data, taking the default for every key it does not carry.
+    /// </summary>
+    /// <param name="data">
+    /// The job data to read, normally <see cref="IJobExecutionContext.MergedJobDataMap" />.
+    /// </param>
+    /// <exception cref="JobExecutionException">
+    /// <see cref="NativeJob.PropertyCommand" /> is absent; there is nothing to run.
+    /// </exception>
+    public static NativeJobOptions FromJobData(JobDataMap data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        string command = data.GetString(NativeJob.PropertyCommand) ?? throw new JobExecutionException("command missing");
+
+        return new NativeJobOptions
+        {
+            Command = command,
+            Parameters = data.GetString(NativeJob.PropertyParameters),
+            WaitForProcess = !data.TryGetBoolean(NativeJob.PropertyWaitForProcess, out bool wait) || wait,
+            ConsumeStreams = data.TryGetBoolean(NativeJob.PropertyConsumeStreams, out bool consumeStreams) && consumeStreams,
+            WorkingDirectory = data.GetString(NativeJob.PropertyWorkingDirectory),
+        };
+    }
+
+    /// <summary>
+    /// Writes the options as the job data keys <see cref="NativeJob" /> reads.
+    /// </summary>
+    public JobDataMap ToJobData()
+    {
+        JobDataMap data = new JobDataMap
+        {
+            [NativeJob.PropertyCommand] = Command,
+            [NativeJob.PropertyWaitForProcess] = WaitForProcess,
+            [NativeJob.PropertyConsumeStreams] = ConsumeStreams,
+        };
+
+        if (Parameters is not null)
+        {
+            data[NativeJob.PropertyParameters] = Parameters;
+        }
+
+        if (WorkingDirectory is not null)
+        {
+            data[NativeJob.PropertyWorkingDirectory] = WorkingDirectory;
+        }
+
+        return data;
+    }
+}

--- a/src/Quartz.Jobs/Jobs/SendMailJob.cs
+++ b/src/Quartz.Jobs/Jobs/SendMailJob.cs
@@ -33,11 +33,27 @@ namespace Quartz.Jobs;
 /// A Job which sends an e-mail with the configured content to the configured
 /// recipient.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The message is configured through the job data keys below. <see cref="SendMailOptions" /> names
+/// them all, and <see cref="JobConfiguratorExtensions.UsingSendMailOptions{TConfigurator}" /> writes
+/// them, so the settings can be given as a value rather than as string keys; the keys stay the
+/// persisted form either way.
+/// </para>
+/// <para>
+/// The SMTP credential is the exception, and is taken from the container: register an
+/// <see cref="ICredentialsByHost" /> and the job authenticates with it. Job data is durable,
+/// cluster-replicated and visible in the dashboard, which is no place for a password. The
+/// <see cref="PropertyUsername" /> and <see cref="PropertyPassword" /> keys are still read when
+/// nothing is registered, so a job scheduled by an earlier version keeps sending — with a warning.
+/// </para>
+/// </remarks>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
 public class SendMailJob : IJob
 {
     private readonly ILogger<SendMailJob> logger;
+    private readonly ICredentialsByHost? credentials;
 
     /// <summary> The host name of the smtp server. REQUIRED.</summary>
     public const string PropertySmtpHost = "smtp_host";
@@ -45,10 +61,22 @@ public class SendMailJob : IJob
     /// <summary> The port of the smtp server. Optional.</summary>
     public const string PropertySmtpPort = "smtp_port";
 
-    /// <summary> Username for authenticated session. Password must also be set if username is used. Optional.</summary>
+    /// <summary>
+    /// Username for authenticated session. Password must also be set if username is used. Optional.
+    /// <para>
+    /// Legacy. Register an <see cref="ICredentialsByHost" /> with the container instead — job data is
+    /// persisted, replicated to every node and readable from the dashboard.
+    /// </para>
+    /// </summary>
     public const string PropertyUsername = "smtp_username";
 
-    /// <summary> Password for authenticated session. Optional.</summary>
+    /// <summary>
+    /// Password for authenticated session. Optional.
+    /// <para>
+    /// Legacy, and a credential written to <c>QRTZ_JOB_DETAILS</c> in whatever the configured
+    /// serializer emits. Register an <see cref="ICredentialsByHost" /> with the container instead.
+    /// </para>
+    /// </summary>
     public const string PropertyPassword = "smtp_password";
 
     /// <summary> The e-mail address to send the mail to. REQUIRED.</summary>
@@ -72,8 +100,18 @@ public class SendMailJob : IJob
     /// <summary> The message subject and body content type. Optional.</summary>
     public const string PropertyEncoding = "encoding";
 
-    public SendMailJob()
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SendMailJob" /> class.
+    /// </summary>
+    /// <param name="credentials">
+    /// What to authenticate to the SMTP server with, taken from the container. A
+    /// <see cref="NetworkCredential" /> covers one account; a <see cref="CredentialCache" /> covers
+    /// several servers. <see langword="null" /> falls back to the credential in job data, if there is
+    /// one, and otherwise sends unauthenticated.
+    /// </param>
+    public SendMailJob(ICredentialsByHost? credentials = null)
     {
+        this.credentials = credentials;
         logger = LogProvider.CreateLogger<SendMailJob>();
     }
 
@@ -86,24 +124,17 @@ public class SendMailJob : IJob
     {
         JobDataMap data = context.MergedJobDataMap;
 
-        MailMessage message = BuildMessageFromParameters(data);
+        SendMailOptions options = SendMailOptions.FromJobData(data);
+        MailMessage message = BuildMessage(options);
 
         try
         {
-            var portString = GetOptionalParameter(data, PropertySmtpPort);
-            int? port = null;
-            if (!string.IsNullOrEmpty(portString))
-            {
-                port = int.Parse(portString);
-            }
-
             var info = new MailInfo
             {
                 MailMessage = message,
-                SmtpHost = GetRequiredParameter(data, PropertySmtpHost),
-                SmtpPort = port,
-                SmtpUserName = GetOptionalParameter(data, PropertyUsername),
-                SmtpPassword = GetOptionalParameter(data, PropertyPassword)
+                SmtpHost = options.SmtpHost,
+                SmtpPort = options.SmtpPort,
+                Credentials = ResolveCredentials(data)
             };
             await Send(info, cancellationToken).ConfigureAwait(false);
         }
@@ -113,38 +144,35 @@ public class SendMailJob : IJob
         }
     }
 
-    protected virtual MailMessage BuildMessageFromParameters(JobDataMap data)
+    /// <summary>
+    /// Builds the message to send. Override to add to it — an attachment, a header — or to build a
+    /// different one entirely.
+    /// </summary>
+    protected virtual MailMessage BuildMessage(SendMailOptions options)
     {
-        string to = GetRequiredParameter(data, PropertyRecipient);
-        string from = GetRequiredParameter(data, PropertySender);
-        string subject = GetRequiredParameter(data, PropertySubject);
-        string message = GetRequiredParameter(data, PropertyMessage);
-
-        string? cc = GetOptionalParameter(data, PropertyCcRecipient);
-        string? replyTo = GetOptionalParameter(data, PropertyReplyTo);
-
-        string? encoding = GetOptionalParameter(data, PropertyEncoding);
+        ArgumentNullException.ThrowIfNull(options);
 
         MailMessage mailMessage = new MailMessage();
-        mailMessage.To.Add(to);
+        mailMessage.To.Add(options.Recipient);
 
-        if (!string.IsNullOrEmpty(cc))
+        if (options.CcRecipient is not null)
         {
-            mailMessage.CC.Add(cc);
-        }
-        mailMessage.From = new MailAddress(from);
-
-        if (!string.IsNullOrEmpty(replyTo))
-        {
-            mailMessage.ReplyToList.Add(new MailAddress(replyTo));
+            mailMessage.CC.Add(options.CcRecipient);
         }
 
-        mailMessage.Subject = subject;
-        mailMessage.Body = message;
+        mailMessage.From = new MailAddress(options.Sender);
 
-        if (!string.IsNullOrEmpty(encoding))
+        if (options.ReplyTo is not null)
         {
-            var encodingToUse = Encoding.GetEncoding(encoding);
+            mailMessage.ReplyToList.Add(new MailAddress(options.ReplyTo));
+        }
+
+        mailMessage.Subject = options.Subject;
+        mailMessage.Body = options.Message;
+
+        if (options.Encoding is not null)
+        {
+            var encodingToUse = Encoding.GetEncoding(options.Encoding);
             mailMessage.BodyEncoding = encodingToUse;
             mailMessage.SubjectEncoding = encodingToUse;
         }
@@ -152,20 +180,26 @@ public class SendMailJob : IJob
         return mailMessage;
     }
 
-    protected virtual string GetRequiredParameter(JobDataMap data, string propertyName)
+    /// <summary>
+    /// The credential registered with the container, or the one in job data when there is none.
+    /// </summary>
+    private ICredentialsByHost? ResolveCredentials(JobDataMap data)
     {
-        var value = data.GetString(propertyName);
-        if (string.IsNullOrEmpty(value))
+        if (credentials is not null)
         {
-            throw new ArgumentException(propertyName + " not specified.", nameof(propertyName));
+            return credentials;
         }
-        return value!;
-    }
 
-    protected virtual string? GetOptionalParameter(JobDataMap data, string propertyName)
-    {
-        data.TryGetString(propertyName, out string? value);
-        return string.IsNullOrEmpty(value) ? null : value;
+        NetworkCredential? fromJobData = SendMailOptions.ReadJobDataCredentials(data);
+        if (fromJobData is not null)
+        {
+            logger.LogWarning(
+                "SMTP credentials are being read from job data ('{UserNameKey}' / '{PasswordKey}'), which a persistent job store writes to the database and replicates to every node in the cluster. Register an ICredentialsByHost with the container instead.",
+                PropertyUsername,
+                PropertyPassword);
+        }
+
+        return fromJobData;
     }
 
     /// <summary>
@@ -178,9 +212,9 @@ public class SendMailJob : IJob
 
         using (var client = new SmtpClient(mailInfo.SmtpHost))
         {
-            if (mailInfo.SmtpUserName is not null)
+            if (mailInfo.Credentials is not null)
             {
-                client.Credentials = new NetworkCredential(mailInfo.SmtpUserName, mailInfo.SmtpPassword);
+                client.Credentials = mailInfo.Credentials;
             }
 
             if (mailInfo.SmtpPort is not null)

--- a/src/Quartz.Jobs/Jobs/SendMailOptions.cs
+++ b/src/Quartz.Jobs/Jobs/SendMailOptions.cs
@@ -1,0 +1,199 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Net;
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// The message <see cref="SendMailJob" /> sends, and the SMTP server it goes through.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The job is configured through its <see cref="JobDataMap" />, and those keys are the persisted
+/// contract — this type is the named way to write and read them.
+/// <see cref="JobConfiguratorExtensions.UsingSendMailOptions{TConfigurator}" /> writes them,
+/// <see cref="FromJobData" /> reads them back, and job data written by hand or by an earlier version
+/// reads the same either way.
+/// </para>
+/// <para>
+/// There is deliberately no SMTP user name or password here. Job data is durable: a persistent job
+/// store writes it to <c>QRTZ_JOB_DETAILS</c>, every node in a cluster reads it, the dashboard shows
+/// it, and any support-bundle export of that table carries it. Register an
+/// <see cref="ICredentialsByHost" /> — a <see cref="NetworkCredential" /> or a
+/// <see cref="CredentialCache" /> — with the container instead, and the job authenticates with it.
+/// The <c>smtp_username</c> and <c>smtp_password</c> keys still work so that a job scheduled by an
+/// earlier version keeps sending, and the job warns when it uses them.
+/// </para>
+/// </remarks>
+public sealed record SendMailOptions
+{
+    /// <summary>
+    /// The host name of the SMTP server to send through.
+    /// </summary>
+    public required string SmtpHost { get; init; }
+
+    /// <summary>
+    /// The port to reach the SMTP server on, or <see langword="null" /> for the client's default.
+    /// </summary>
+    public int? SmtpPort { get; init; }
+
+    /// <summary>
+    /// The address to send the mail to.
+    /// </summary>
+    public required string Recipient { get; init; }
+
+    /// <summary>
+    /// The address to copy the mail to, or <see langword="null" /> for none.
+    /// </summary>
+    public string? CcRecipient { get; init; }
+
+    /// <summary>
+    /// The address to claim the mail is from.
+    /// </summary>
+    public required string Sender { get; init; }
+
+    /// <summary>
+    /// The address the message asks replies to go to, or <see langword="null" /> to leave it to the
+    /// sender.
+    /// </summary>
+    public string? ReplyTo { get; init; }
+
+    /// <summary>
+    /// The subject line.
+    /// </summary>
+    public required string Subject { get; init; }
+
+    /// <summary>
+    /// The message body.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// The name of the encoding the subject and body are sent in, such as <c>utf-8</c>, or
+    /// <see langword="null" /> for the default.
+    /// </summary>
+    public string? Encoding { get; init; }
+
+    /// <summary>
+    /// Reads the options out of a job's data.
+    /// </summary>
+    /// <param name="data">
+    /// The job data to read, normally <see cref="IJobExecutionContext.MergedJobDataMap" />.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// One of the required keys is absent or empty.
+    /// </exception>
+    public static SendMailOptions FromJobData(JobDataMap data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        return new SendMailOptions
+        {
+            SmtpHost = Required(data, SendMailJob.PropertySmtpHost),
+            SmtpPort = ReadPort(data),
+            Recipient = Required(data, SendMailJob.PropertyRecipient),
+            CcRecipient = Optional(data, SendMailJob.PropertyCcRecipient),
+            Sender = Required(data, SendMailJob.PropertySender),
+            ReplyTo = Optional(data, SendMailJob.PropertyReplyTo),
+            Subject = Required(data, SendMailJob.PropertySubject),
+            Message = Required(data, SendMailJob.PropertyMessage),
+            Encoding = Optional(data, SendMailJob.PropertyEncoding),
+        };
+    }
+
+    /// <summary>
+    /// Writes the options as the job data keys <see cref="SendMailJob" /> reads.
+    /// </summary>
+    public JobDataMap ToJobData()
+    {
+        JobDataMap data = new JobDataMap
+        {
+            [SendMailJob.PropertySmtpHost] = SmtpHost,
+            [SendMailJob.PropertyRecipient] = Recipient,
+            [SendMailJob.PropertySender] = Sender,
+            [SendMailJob.PropertySubject] = Subject,
+            [SendMailJob.PropertyMessage] = Message,
+        };
+
+        if (SmtpPort is not null)
+        {
+            data[SendMailJob.PropertySmtpPort] = SmtpPort.Value;
+        }
+
+        if (CcRecipient is not null)
+        {
+            data[SendMailJob.PropertyCcRecipient] = CcRecipient;
+        }
+
+        if (ReplyTo is not null)
+        {
+            data[SendMailJob.PropertyReplyTo] = ReplyTo;
+        }
+
+        if (Encoding is not null)
+        {
+            data[SendMailJob.PropertyEncoding] = Encoding;
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// The credentials the job data carries, or <see langword="null" /> when it carries none.
+    /// </summary>
+    /// <remarks>
+    /// The legacy path, kept working for job data an earlier version wrote. A credential registered
+    /// with the container wins over this one.
+    /// </remarks>
+    internal static NetworkCredential? ReadJobDataCredentials(JobDataMap data)
+    {
+        string? userName = Optional(data, SendMailJob.PropertyUsername);
+        return userName is null ? null : new NetworkCredential(userName, Optional(data, SendMailJob.PropertyPassword));
+    }
+
+    private static string Required(JobDataMap data, string key)
+    {
+        string? value = data.GetString(key);
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new ArgumentException(key + " not specified.", nameof(data));
+        }
+
+        return value;
+    }
+
+    private static string? Optional(JobDataMap data, string key)
+    {
+        data.TryGetString(key, out string? value);
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private static int? ReadPort(JobDataMap data)
+    {
+        if (!data.TryGetValue(SendMailJob.PropertySmtpPort, out object? raw) || raw is null || (raw is string text && text.Length == 0))
+        {
+            return null;
+        }
+
+        return data.GetInt(SendMailJob.PropertySmtpPort);
+    }
+}

--- a/src/Quartz.Tests.Unit/Jobs/DirectoryScanJobTest.cs
+++ b/src/Quartz.Tests.Unit/Jobs/DirectoryScanJobTest.cs
@@ -117,6 +117,60 @@ public class DirectoryScanJobTest
         }
     }
 
+    [Test]
+    public async Task DirectoryScanJob_ShouldScanWhatTheTypedOptionsSay()
+    {
+        string testDirectory = Path.Combine(Path.GetTempPath(), $"QuartzTest_{Guid.NewGuid()}");
+        string subDirectory = Path.Combine(testDirectory, "nested");
+        Directory.CreateDirectory(subDirectory);
+
+        try
+        {
+            string wanted = Path.Combine(testDirectory, "report.csv");
+            string nested = Path.Combine(subDirectory, "nested.csv");
+            string ignored = Path.Combine(testDirectory, "report.dat");
+            foreach (string path in new[] { wanted, nested, ignored })
+            {
+                await File.WriteAllTextAsync(path, "content");
+                File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddMinutes(-1));
+            }
+
+            var listener = new TestDirectoryScanListener();
+            var schedulerContext = new SchedulerContext { ["listener"] = listener };
+
+            var job = new DirectoryScanJob();
+            var context = TestUtil.NewJobExecutionContextFor(job, schedulerContext);
+
+            // Everything the job needs, said once, in named settings - including the search pattern
+            // and the recursion, which used to be reachable only as hardcoded string literals.
+            JobDataMap data = new DirectoryScanOptions
+            {
+                Directories = [testDirectory],
+                ScanListenerName = "listener",
+                SearchPattern = "*.csv",
+                IncludeSubDirectories = true,
+                MinimumUpdateAge = TimeSpan.FromSeconds(1),
+            }.ToJobData();
+
+            foreach (var pair in data)
+            {
+                context.MergedJobDataMap[pair.Key] = pair.Value;
+            }
+
+            await job.Execute(context);
+
+            TestDirectoryScanListener.UpdatedFileNames.Should().BeEquivalentTo(["report.csv", "nested.csv"],
+                "the pattern chose the CSVs and the recursion reached the nested one");
+        }
+        finally
+        {
+            if (Directory.Exists(testDirectory))
+            {
+                Directory.Delete(testDirectory, true);
+            }
+        }
+    }
+
     private sealed class TestDirectoryScanListener : IDirectoryScanListener
     {
         public static bool FilesUpdatedCalled { get; set; }

--- a/src/Quartz.Tests.Unit/Jobs/FileScanJobTest.cs
+++ b/src/Quartz.Tests.Unit/Jobs/FileScanJobTest.cs
@@ -1,0 +1,91 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Jobs;
+
+namespace Quartz.Tests.Unit.Job;
+
+public class FileScanJobTest
+{
+    [Test]
+    public async Task ShouldNotifyTheListenerNamedByTypedOptions()
+    {
+        string fileName = Path.Combine(Path.GetTempPath(), $"QuartzTest_{Guid.NewGuid()}.txt");
+        await File.WriteAllTextAsync(fileName, "content");
+
+        try
+        {
+            var listener = new TestFileScanListener();
+            var schedulerContext = new SchedulerContext { ["listener"] = listener };
+
+            var job = new FileScanJob();
+            var context = TestUtil.NewJobExecutionContextFor(job, schedulerContext);
+
+            JobDataMap data = new FileScanOptions
+            {
+                FileName = fileName,
+                ScanListenerName = "listener",
+                MinimumUpdateAge = TimeSpan.FromSeconds(1),
+            }.ToJobData();
+
+            foreach (var pair in data)
+            {
+                context.MergedJobDataMap[pair.Key] = pair.Value;
+            }
+
+            // What a previous run of the job would have left behind. The key is the job's own
+            // bookkeeping, not something the options say.
+            context.MergedJobDataMap["LAST_MODIFIED_TIME"] = DateTimeOffset.UtcNow.AddDays(-1);
+
+            await job.Execute(context);
+
+            listener.UpdatedFiles.Should().Equal(fileName);
+            context.JobDetail.JobDataMap.Should().ContainKey("LAST_MODIFIED_TIME",
+                "the job records what it saw so the next run can tell whether the file moved on");
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    [Test]
+    public async Task ShouldSayWhichSettingIsMissing()
+    {
+        var job = new FileScanJob();
+        var context = TestUtil.NewJobExecutionContextFor(job, new SchedulerContext());
+
+        Func<Task> act = async () => await job.Execute(context);
+
+        await act.Should().ThrowAsync<JobExecutionException>().WithMessage($"*{FileScanJob.FileName}*");
+    }
+
+    private sealed class TestFileScanListener : IFileScanListener
+    {
+        public List<string> UpdatedFiles { get; } = new();
+
+        public ValueTask FileUpdated(string fileName, CancellationToken cancellationToken = default)
+        {
+            UpdatedFiles.Add(fileName);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Jobs/JobOptionsTest.cs
+++ b/src/Quartz.Tests.Unit/Jobs/JobOptionsTest.cs
@@ -204,6 +204,22 @@ public class JobOptionsTest
     }
 
     [Test]
+    public void Options_ReachTheJobThroughTheConfiguratorAddJobHandsYou()
+    {
+        // The static type AddJob<T>(j => ...) passes, rather than the builder behind it.
+        JobBuilder<NativeJob> builder = JobBuilder.Create<NativeJob>();
+        IJobConfigurator<NativeJob> configurator = builder;
+
+        IJobConfigurator<NativeJob> returned = configurator
+            .WithIdentity("nightlyReport")
+            .StoreDurably()
+            .UsingNativeJobOptions(new NativeJobOptions { Command = "report.exe" });
+
+        returned.Should().BeSameAs(configurator, "the chain carries on from where it was");
+        builder.Build().JobDataMap[NativeJob.PropertyCommand].Should().Be("report.exe");
+    }
+
+    [Test]
     public void NativeJobOptions_RoundTripThroughJobData()
     {
         NativeJobOptions options = new NativeJobOptions

--- a/src/Quartz.Tests.Unit/Jobs/JobOptionsTest.cs
+++ b/src/Quartz.Tests.Unit/Jobs/JobOptionsTest.cs
@@ -1,0 +1,340 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Jobs;
+
+namespace Quartz.Tests.Unit.Job;
+
+/// <summary>
+/// The typed configuration of the jobs in <c>Quartz.Jobs</c>, which writes and reads the same job
+/// data keys those jobs have always used.
+/// </summary>
+public class JobOptionsTest
+{
+    [Test]
+    public void DirectoryScanOptions_WriteTheJobDataKeysTheJobReads()
+    {
+        JobDataMap data = new DirectoryScanOptions
+        {
+            Directories = ["/inbox", "/outbox"],
+            ScanListenerName = "listener",
+            SearchPattern = "*.csv",
+            IncludeSubDirectories = true,
+            MinimumUpdateAge = TimeSpan.FromSeconds(30),
+        }.ToJobData();
+
+        data[DirectoryScanJob.DirectoryNames].Should().Be("/inbox;/outbox",
+            "the semicolon-separated list is the persisted form every version of the job has read");
+        data[DirectoryScanJob.DirectoryScanListenerName].Should().Be("listener");
+        data[DirectoryScanJob.SearchPattern].Should().Be("*.csv");
+        data[DirectoryScanJob.IncludeSubDirectories].Should().Be(true);
+        data[DirectoryScanJob.MinimumUpdateAge].Should().Be(30000L, "the key holds milliseconds");
+        data.Should().NotContainKey(DirectoryScanJob.DirectoryProviderName, "no provider was named");
+    }
+
+    [Test]
+    public void DirectoryScanOptions_RoundTripThroughJobData()
+    {
+        DirectoryScanOptions options = new DirectoryScanOptions
+        {
+            Directories = ["/inbox"],
+            DirectoryProviderName = "provider",
+            ScanListenerName = "listener",
+            SearchPattern = "*.csv",
+            IncludeSubDirectories = true,
+            MinimumUpdateAge = TimeSpan.FromSeconds(30),
+        };
+
+        DirectoryScanOptions.FromJobData(options.ToJobData()).Should().Be(options);
+    }
+
+    [Test]
+    public void DirectoryScanOptions_ReadTheKeysAnEarlierVersionWrote()
+    {
+        JobDataMap data = new JobDataMap
+        {
+            [DirectoryScanJob.DirectoryName] = "/inbox",
+            [DirectoryScanJob.DirectoryNames] = "/outbox;/archive",
+            [DirectoryScanJob.DirectoryScanListenerName] = "listener",
+            ["SEARCH_PATTERN"] = "*.csv",
+            ["INCLUDE_SUB_DIRECTORIES"] = "true",
+            [DirectoryScanJob.MinimumUpdateAge] = "30000",
+        };
+
+        DirectoryScanOptions options = DirectoryScanOptions.FromJobData(data);
+
+        options.Directories.Should().Equal(new[] { "/inbox", "/outbox", "/archive" },
+            "both the singular and the plural key contribute, as they always have");
+        options.ScanListenerName.Should().Be("listener");
+        options.SearchPattern.Should().Be("*.csv");
+        options.IncludeSubDirectories.Should().BeTrue();
+        options.MinimumUpdateAge.Should().Be(TimeSpan.FromSeconds(30),
+            "a job store in StoreJobDataAsStrings mode leaves the number as a string");
+    }
+
+    [Test]
+    public void DirectoryScanOptions_TakeTheDocumentedDefaults()
+    {
+        DirectoryScanOptions options = DirectoryScanOptions.FromJobData(new JobDataMap
+        {
+            [DirectoryScanJob.DirectoryName] = "/inbox",
+            [DirectoryScanJob.DirectoryScanListenerName] = "listener",
+        });
+
+        options.SearchPattern.Should().Be("*");
+        options.IncludeSubDirectories.Should().BeFalse();
+        options.MinimumUpdateAge.Should().Be(TimeSpan.FromSeconds(5));
+        options.DirectoryProviderName.Should().BeNull();
+    }
+
+    [Test]
+    public void DirectoryScanOptions_RefuseADirectoryHoldingTheSeparator()
+    {
+        Action act = () => new DirectoryScanOptions
+        {
+            Directories = ["/in;box"],
+            ScanListenerName = "listener",
+        }.ToJobData();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*semicolon*",
+                "silently splitting the path into two directories that do not exist is worse than saying so");
+    }
+
+    [Test]
+    public void DirectoryScanOptions_RequireAListener()
+    {
+        Action act = () => DirectoryScanOptions.FromJobData(new JobDataMap { [DirectoryScanJob.DirectoryName] = "/inbox" });
+
+        act.Should().Throw<JobExecutionException>().WithMessage($"*{DirectoryScanJob.DirectoryScanListenerName}*");
+    }
+
+    [Test]
+    public void DirectoryScanOptions_ReachTheJobThroughTheBuilder()
+    {
+        IJobDetail job = JobBuilder.Create<DirectoryScanJob>()
+            .WithIdentity("scan")
+            .UsingDirectoryScanOptions(new DirectoryScanOptions
+            {
+                Directories = ["/inbox"],
+                ScanListenerName = "listener",
+                SearchPattern = "*.csv",
+            })
+            .Build();
+
+        job.JobDataMap[DirectoryScanJob.DirectoryNames].Should().Be("/inbox");
+        job.JobDataMap[DirectoryScanJob.SearchPattern].Should().Be("*.csv");
+        job.Key.Name.Should().Be("scan", "the extension hands the builder back, so the chain keeps its type");
+    }
+
+    [Test]
+    public void FileScanOptions_RoundTripThroughJobData()
+    {
+        FileScanOptions options = new FileScanOptions
+        {
+            FileName = "/var/log/app.log",
+            ScanListenerName = "listener",
+            MinimumUpdateAge = TimeSpan.FromSeconds(15),
+        };
+
+        JobDataMap data = options.ToJobData();
+
+        data[FileScanJob.FileName].Should().Be("/var/log/app.log");
+        data[FileScanJob.FileScanListenerName].Should().Be("listener");
+        data[FileScanJob.MinimumUpdateAge].Should().Be(15000L);
+        FileScanOptions.FromJobData(data).Should().Be(options);
+    }
+
+    [Test]
+    public void FileScanOptions_ReadTheKeysAnEarlierVersionWrote()
+    {
+        FileScanOptions options = FileScanOptions.FromJobData(new JobDataMap
+        {
+            [FileScanJob.FileName] = "/var/log/app.log",
+            [FileScanJob.FileScanListenerName] = "listener",
+            [FileScanJob.MinimumUpdateAge] = 15000L,
+        });
+
+        options.FileName.Should().Be("/var/log/app.log");
+        options.MinimumUpdateAge.Should().Be(TimeSpan.FromSeconds(15));
+    }
+
+    [Test]
+    public void FileScanOptions_RequireAFileAndAListener()
+    {
+        Action noFile = () => FileScanOptions.FromJobData(new JobDataMap { [FileScanJob.FileScanListenerName] = "listener" });
+        noFile.Should().Throw<JobExecutionException>().WithMessage($"*{FileScanJob.FileName}*");
+
+        Action noListener = () => FileScanOptions.FromJobData(new JobDataMap { [FileScanJob.FileName] = "/var/log/app.log" });
+        noListener.Should().Throw<JobExecutionException>().WithMessage($"*{FileScanJob.FileScanListenerName}*");
+    }
+
+    [Test]
+    public void FileScanOptions_ReachTheJobThroughTheBuilder()
+    {
+        IJobDetail job = JobBuilder.Create<FileScanJob>()
+            .WithIdentity("watch")
+            .UsingFileScanOptions(new FileScanOptions
+            {
+                FileName = "/var/log/app.log",
+                ScanListenerName = "listener",
+            })
+            .Build();
+
+        job.JobDataMap[FileScanJob.FileName].Should().Be("/var/log/app.log");
+        job.JobDataMap[FileScanJob.MinimumUpdateAge].Should().Be(5000L, "the default is written out, not left implied");
+    }
+
+    [Test]
+    public void NativeJobOptions_RoundTripThroughJobData()
+    {
+        NativeJobOptions options = new NativeJobOptions
+        {
+            Command = "report.exe",
+            Parameters = "--nightly",
+            WaitForProcess = false,
+            ConsumeStreams = true,
+            WorkingDirectory = "/opt/reports",
+        };
+
+        JobDataMap data = options.ToJobData();
+
+        data[NativeJob.PropertyCommand].Should().Be("report.exe");
+        data[NativeJob.PropertyParameters].Should().Be("--nightly");
+        data[NativeJob.PropertyWaitForProcess].Should().Be(false);
+        data[NativeJob.PropertyConsumeStreams].Should().Be(true);
+        data[NativeJob.PropertyWorkingDirectory].Should().Be("/opt/reports");
+        NativeJobOptions.FromJobData(data).Should().Be(options);
+    }
+
+    [Test]
+    public void NativeJobOptions_ReadTheKeysAnEarlierVersionWrote()
+    {
+        NativeJobOptions options = NativeJobOptions.FromJobData(new JobDataMap
+        {
+            [NativeJob.PropertyCommand] = "report.exe",
+            [NativeJob.PropertyWaitForProcess] = "false",
+            [NativeJob.PropertyConsumeStreams] = "true",
+        });
+
+        options.Command.Should().Be("report.exe");
+        options.WaitForProcess.Should().BeFalse();
+        options.ConsumeStreams.Should().BeTrue();
+        options.Parameters.Should().BeNull();
+    }
+
+    [Test]
+    public void NativeJobOptions_WaitForTheProcessUnlessToldOtherwise()
+    {
+        NativeJobOptions options = NativeJobOptions.FromJobData(new JobDataMap { [NativeJob.PropertyCommand] = "report.exe" });
+
+        options.WaitForProcess.Should().BeTrue("that has always been the default, and it is what makes the exit code the job result");
+        options.ConsumeStreams.Should().BeFalse();
+    }
+
+    [Test]
+    public void NativeJobOptions_RequireACommand()
+    {
+        Action act = () => NativeJobOptions.FromJobData(new JobDataMap { [NativeJob.PropertyParameters] = "--nightly" });
+
+        act.Should().Throw<JobExecutionException>();
+    }
+
+    [Test]
+    public void SendMailOptions_RoundTripThroughJobData()
+    {
+        SendMailOptions options = new SendMailOptions
+        {
+            SmtpHost = "smtp.example.com",
+            SmtpPort = 587,
+            Recipient = "katie@example.com",
+            CcRecipient = "anthony@example.com",
+            Sender = "christian@example.com",
+            ReplyTo = "therese@example.com",
+            Subject = "test mail",
+            Message = "test mail body",
+            Encoding = "utf-8",
+        };
+
+        JobDataMap data = options.ToJobData();
+
+        data[SendMailJob.PropertySmtpHost].Should().Be("smtp.example.com");
+        data[SendMailJob.PropertySmtpPort].Should().Be(587);
+        data[SendMailJob.PropertyRecipient].Should().Be("katie@example.com");
+        data[SendMailJob.PropertySender].Should().Be("christian@example.com");
+        SendMailOptions.FromJobData(data).Should().Be(options);
+    }
+
+    [Test]
+    public void SendMailOptions_ReadTheKeysAnEarlierVersionWrote()
+    {
+        SendMailOptions options = SendMailOptions.FromJobData(new JobDataMap
+        {
+            ["smtp_host"] = "smtp.example.com",
+            ["smtp_port"] = "587",
+            ["recipient"] = "katie@example.com",
+            ["sender"] = "christian@example.com",
+            ["subject"] = "test mail",
+            ["message"] = "test mail body",
+        });
+
+        options.SmtpHost.Should().Be("smtp.example.com");
+        options.SmtpPort.Should().Be(587, "the port was documented as a string and is still read as one");
+        options.CcRecipient.Should().BeNull();
+        options.Encoding.Should().BeNull();
+    }
+
+    [Test]
+    public void SendMailOptions_CarryNoCredential()
+    {
+        typeof(SendMailOptions).GetProperties().Select(x => x.Name)
+            .Should().NotContain(name => name.Contains("Password", StringComparison.OrdinalIgnoreCase) || name.Contains("UserName", StringComparison.OrdinalIgnoreCase),
+                "job data is persisted, cluster-replicated and dashboard-visible, so the credential comes from the container");
+    }
+
+    [Test]
+    public void SendMailOptions_RequireTheAddressesAndTheBody()
+    {
+        Action act = () => SendMailOptions.FromJobData(new JobDataMap { [SendMailJob.PropertySmtpHost] = "smtp.example.com" });
+
+        act.Should().Throw<ArgumentException>().WithMessage($"*{SendMailJob.PropertyRecipient}*");
+    }
+
+    [Test]
+    public void SendMailOptions_ReachTheJobThroughTheBuilder()
+    {
+        IJobDetail job = JobBuilder.Create<SendMailJob>()
+            .WithIdentity("mail")
+            .UsingSendMailOptions(new SendMailOptions
+            {
+                SmtpHost = "smtp.example.com",
+                Recipient = "katie@example.com",
+                Sender = "christian@example.com",
+                Subject = "test mail",
+                Message = "test mail body",
+            })
+            .Build();
+
+        job.JobDataMap[SendMailJob.PropertySmtpHost].Should().Be("smtp.example.com");
+        job.JobDataMap.Should().NotContainKey(SendMailJob.PropertyCcRecipient, "an optional setting nobody set is not written");
+        job.JobDataMap.Should().NotContainKey(SendMailJob.PropertyPassword);
+    }
+}

--- a/src/Quartz.Tests.Unit/Jobs/NativeJobTest.cs
+++ b/src/Quartz.Tests.Unit/Jobs/NativeJobTest.cs
@@ -16,4 +16,28 @@ public class NativeJobTest
 
         act.Should().NotThrow<Exception>();
     }
+
+    [Test]
+    public void ShouldRunWhatTheTypedOptionsSay()
+    {
+        var job = new NativeJob();
+        var context = TestUtil.NewJobExecutionContextFor(job);
+
+        JobDataMap data = new NativeJobOptions
+        {
+            Command = OperatingSystem.IsWindows() ? "cmd.exe" : "echo",
+            Parameters = OperatingSystem.IsWindows() ? "/C exit 0" : "hi",
+            ConsumeStreams = true,
+        }.ToJobData();
+
+        foreach (var pair in data)
+        {
+            context.MergedJobDataMap[pair.Key] = pair.Value;
+        }
+
+        job.Execute(context);
+
+        context.Result.Should().Be(0,
+            "the options waited for the process by default, so its exit code is the job's result");
+    }
 }

--- a/src/Quartz.Tests.Unit/Jobs/SendMailJobTest.cs
+++ b/src/Quartz.Tests.Unit/Jobs/SendMailJobTest.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using System.Net;
 using System.Net.Mail;
 
 using Quartz.Jobs;
@@ -109,13 +110,67 @@ public class SendMailJobTest
         job.Execute(context);
 
         //Then
-        Assert.Multiple(() =>
+        job.actualSmtpHost.Should().Be("someserver");
+        job.actualSmtpPort.Should().Be(123);
+        job.actualCredentials.Should().BeOfType<NetworkCredential>()
+            .Which.Should().Match<NetworkCredential>(x => x.UserName == "user 123" && x.Password == "pass 321",
+                "job data written before the credential moved to the container still authenticates");
+    }
+
+    [Test]
+    public void ShouldTakeItsMessageFromTypedOptions()
+    {
+        var job = new TestSendMailJob();
+        var context = TestUtil.NewJobExecutionContextFor(job);
+
+        JobDataMap data = new SendMailOptions
         {
-            Assert.That(job.actualSmtpHost, Is.EqualTo("someserver"));
-            Assert.That(job.actualSmtpUserName, Is.EqualTo("user 123"));
-            Assert.That(job.actualSmtpPassword, Is.EqualTo("pass 321"));
-            Assert.That(job.actualSmtpPort, Is.EqualTo(123));
-        });
+            SmtpHost = "someserver",
+            SmtpPort = 123,
+            Recipient = "christian@acca.co.uk",
+            CcRecipient = "anthony@acca.co.uk",
+            Sender = "katie@acca.co.uk",
+            ReplyTo = "therese@acca.co.uk",
+            Subject = "test mail",
+            Message = "test mail body",
+        }.ToJobData();
+
+        foreach (var pair in data)
+        {
+            context.MergedJobDataMap[pair.Key] = pair.Value;
+        }
+
+        job.Execute(context);
+
+        job.actualSmtpHost.Should().Be("someserver");
+        job.actualSmtpPort.Should().Be(123);
+        job.actualMailSent.To.Should().ContainSingle().Which.Address.Should().Be("christian@acca.co.uk");
+        job.actualMailSent.CC.Should().ContainSingle().Which.Address.Should().Be("anthony@acca.co.uk");
+        job.actualMailSent.ReplyToList.Should().ContainSingle().Which.Address.Should().Be("therese@acca.co.uk");
+        job.actualMailSent.Subject.Should().Be("test mail");
+        job.actualMailSent.Body.Should().Be("test mail body");
+        job.actualCredentials.Should().BeNull("nothing named a credential, in job data or in the container");
+    }
+
+    [Test]
+    public void ShouldPreferTheCredentialFromTheContainer()
+    {
+        var registered = new NetworkCredential("registered", "secret");
+        var job = new TestSendMailJob(registered);
+        var context = TestUtil.NewJobExecutionContextFor(job);
+
+        context.MergedJobDataMap[SendMailJob.PropertySmtpHost] = "someserver";
+        context.MergedJobDataMap[SendMailJob.PropertyRecipient] = "christian@acca.co.uk";
+        context.MergedJobDataMap[SendMailJob.PropertySender] = "katie@acca.co.uk";
+        context.MergedJobDataMap[SendMailJob.PropertySubject] = "test mail";
+        context.MergedJobDataMap[SendMailJob.PropertyMessage] = "test mail body";
+        context.MergedJobDataMap[SendMailJob.PropertyUsername] = "from job data";
+        context.MergedJobDataMap[SendMailJob.PropertyPassword] = "also from job data";
+
+        job.Execute(context);
+
+        job.actualCredentials.Should().BeSameAs(registered,
+            "a credential the application registered beats one that was left in the job store");
     }
 }
 
@@ -164,16 +219,18 @@ internal sealed class TestSendMailJob : SendMailJob
 {
     public MailMessage actualMailSent = new MailMessage();
     public string actualSmtpHost = "ad";
-    public string actualSmtpUserName;
-    public string actualSmtpPassword;
+    public ICredentialsByHost actualCredentials;
     public int? actualSmtpPort;
+
+    public TestSendMailJob(ICredentialsByHost credentials = null) : base(credentials)
+    {
+    }
 
     protected override ValueTask Send(MailInfo mailInfo, CancellationToken cancellationToken = default)
     {
         actualMailSent = mailInfo.MailMessage;
         actualSmtpHost = mailInfo.SmtpHost;
-        actualSmtpUserName = mailInfo.SmtpUserName;
-        actualSmtpPassword = mailInfo.SmtpPassword;
+        actualCredentials = mailInfo.Credentials;
         actualSmtpPort = mailInfo.SmtpPort;
         return default;
     }

--- a/src/Quartz.Tests.Unit/TestUtil.cs
+++ b/src/Quartz.Tests.Unit/TestUtil.cs
@@ -17,6 +17,8 @@
  */
 #endregion
 
+using FakeItEasy;
+
 using Quartz.Impl;
 using Quartz.Impl.Triggers;
 using Quartz.Jobs;
@@ -80,5 +82,15 @@ public static class TestUtil
     public static IJobExecutionContext NewJobExecutionContextFor(IJob job)
     {
         return new JobExecutionContextImpl(null, NewMinimalTriggerFiredBundle(), job);
+    }
+
+    /// <summary>
+    /// A context whose scheduler carries the given context, for a job that looks a listener up in it.
+    /// </summary>
+    public static IJobExecutionContext NewJobExecutionContextFor(IJob job, SchedulerContext schedulerContext)
+    {
+        IScheduler scheduler = A.Fake<IScheduler>();
+        A.CallTo(() => scheduler.Context).Returns(schedulerContext);
+        return new JobExecutionContextImpl(scheduler, NewMinimalTriggerFiredBundle(), job);
     }
 }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Jobs.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Jobs.verified.txt
@@ -9,18 +9,26 @@ namespace Quartz.Jobs
         public const string DirectoryNames = "DIRECTORY_NAMES";
         public const string DirectoryProviderName = "DIRECTORY_PROVIDER_NAME";
         public const string DirectoryScanListenerName = "DIRECTORY_SCAN_LISTENER_NAME";
+        public const string IncludeSubDirectories = "INCLUDE_SUB_DIRECTORIES";
         public const string MinimumUpdateAge = "MINIMUM_UPDATE_AGE";
+        public const string SearchPattern = "SEARCH_PATTERN";
         public DirectoryScanJob(System.TimeProvider? timeProvider = null) { }
         public DirectoryScanJob(System.IServiceProvider serviceProvider, System.TimeProvider? timeProvider = null) { }
         public System.Threading.Tasks.ValueTask Execute(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        protected Quartz.Jobs.DirectoryScanResult GetUpdatedOrNewFiles(string directoryName, System.DateTimeOffset lastModifiedTime, System.DateTimeOffset maxAgeTime, System.Collections.Generic.IReadOnlyCollection<System.IO.FileInfo> currentFileList, string searchPattern = "*", bool includeSubDirectories = false) { }
     }
-    public readonly struct DirectoryScanResult : System.IEquatable<Quartz.Jobs.DirectoryScanResult>
+    public sealed class DirectoryScanOptions : System.IEquatable<Quartz.Jobs.DirectoryScanOptions>
     {
-        public DirectoryScanResult(System.Collections.Generic.IReadOnlyList<System.IO.FileInfo> All, System.Collections.Generic.IReadOnlyList<System.IO.FileInfo> Updated, System.Collections.Generic.IReadOnlyList<System.IO.FileInfo> Deleted) { }
-        public System.Collections.Generic.IReadOnlyList<System.IO.FileInfo> All { get; init; }
-        public System.Collections.Generic.IReadOnlyList<System.IO.FileInfo> Deleted { get; init; }
-        public System.Collections.Generic.IReadOnlyList<System.IO.FileInfo> Updated { get; init; }
+        public DirectoryScanOptions() { }
+        public System.Collections.Generic.IReadOnlyList<string> Directories { get; init; }
+        public string? DirectoryProviderName { get; init; }
+        public bool IncludeSubDirectories { get; init; }
+        public System.TimeSpan MinimumUpdateAge { get; init; }
+        public required string ScanListenerName { get; init; }
+        public string SearchPattern { get; init; }
+        public bool Equals(Quartz.Jobs.DirectoryScanOptions? other) { }
+        public override int GetHashCode() { }
+        public Quartz.JobDataMap ToJobData() { }
+        public static Quartz.Jobs.DirectoryScanOptions FromJobData(Quartz.JobDataMap data) { }
     }
     [Quartz.DisallowConcurrentExecution]
     [Quartz.PersistJobDataAfterExecution]
@@ -32,6 +40,15 @@ namespace Quartz.Jobs
         public FileScanJob(System.TimeProvider? timeProvider = null) { }
         public virtual System.Threading.Tasks.ValueTask Execute(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual System.DateTimeOffset? GetLastModifiedTime(string fileName) { }
+    }
+    public sealed class FileScanOptions : System.IEquatable<Quartz.Jobs.FileScanOptions>
+    {
+        public FileScanOptions() { }
+        public required string FileName { get; init; }
+        public System.TimeSpan MinimumUpdateAge { get; init; }
+        public required string ScanListenerName { get; init; }
+        public Quartz.JobDataMap ToJobData() { }
+        public static Quartz.Jobs.FileScanOptions FromJobData(Quartz.JobDataMap data) { }
     }
     public interface IDirectoryProvider
     {
@@ -46,14 +63,24 @@ namespace Quartz.Jobs
     {
         System.Threading.Tasks.ValueTask FileUpdated(string fileName, System.Threading.CancellationToken cancellationToken = default);
     }
+    public static class JobConfiguratorExtensions
+    {
+        public static TConfigurator UsingDirectoryScanOptions<TConfigurator>(this TConfigurator configurator, Quartz.Jobs.DirectoryScanOptions options)
+            where TConfigurator :  class, Quartz.IJobConfigurator<Quartz.Jobs.DirectoryScanJob> { }
+        public static TConfigurator UsingFileScanOptions<TConfigurator>(this TConfigurator configurator, Quartz.Jobs.FileScanOptions options)
+            where TConfigurator :  class, Quartz.IJobConfigurator<Quartz.Jobs.FileScanJob> { }
+        public static TConfigurator UsingNativeJobOptions<TConfigurator>(this TConfigurator configurator, Quartz.Jobs.NativeJobOptions options)
+            where TConfigurator :  class, Quartz.IJobConfigurator<Quartz.Jobs.NativeJob> { }
+        public static TConfigurator UsingSendMailOptions<TConfigurator>(this TConfigurator configurator, Quartz.Jobs.SendMailOptions options)
+            where TConfigurator :  class, Quartz.IJobConfigurator<Quartz.Jobs.SendMailJob> { }
+    }
     public sealed class MailInfo
     {
         public MailInfo() { }
+        public System.Net.ICredentialsByHost? Credentials { get; init; }
         public required System.Net.Mail.MailMessage MailMessage { get; init; }
         public required string SmtpHost { get; init; }
-        public string? SmtpPassword { get; init; }
         public int? SmtpPort { get; init; }
-        public string? SmtpUserName { get; init; }
     }
     public class NativeJob : Quartz.IJob
     {
@@ -64,6 +91,17 @@ namespace Quartz.Jobs
         public const string PropertyWorkingDirectory = "workingDirectory";
         public NativeJob() { }
         public virtual System.Threading.Tasks.ValueTask Execute(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public sealed class NativeJobOptions : System.IEquatable<Quartz.Jobs.NativeJobOptions>
+    {
+        public NativeJobOptions() { }
+        public required string Command { get; init; }
+        public bool ConsumeStreams { get; init; }
+        public string? Parameters { get; init; }
+        public bool WaitForProcess { get; init; }
+        public string? WorkingDirectory { get; init; }
+        public Quartz.JobDataMap ToJobData() { }
+        public static Quartz.Jobs.NativeJobOptions FromJobData(Quartz.JobDataMap data) { }
     }
     public sealed class NoOpJob : Quartz.IJob
     {
@@ -83,11 +121,24 @@ namespace Quartz.Jobs
         public const string PropertySmtpPort = "smtp_port";
         public const string PropertySubject = "subject";
         public const string PropertyUsername = "smtp_username";
-        public SendMailJob() { }
-        protected virtual System.Net.Mail.MailMessage BuildMessageFromParameters(Quartz.JobDataMap data) { }
+        public SendMailJob(System.Net.ICredentialsByHost? credentials = null) { }
+        protected virtual System.Net.Mail.MailMessage BuildMessage(Quartz.Jobs.SendMailOptions options) { }
         public virtual System.Threading.Tasks.ValueTask Execute(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        protected virtual string? GetOptionalParameter(Quartz.JobDataMap data, string propertyName) { }
-        protected virtual string GetRequiredParameter(Quartz.JobDataMap data, string propertyName) { }
         protected virtual System.Threading.Tasks.ValueTask Send(Quartz.Jobs.MailInfo mailInfo, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public sealed class SendMailOptions : System.IEquatable<Quartz.Jobs.SendMailOptions>
+    {
+        public SendMailOptions() { }
+        public string? CcRecipient { get; init; }
+        public string? Encoding { get; init; }
+        public required string Message { get; init; }
+        public required string Recipient { get; init; }
+        public string? ReplyTo { get; init; }
+        public required string Sender { get; init; }
+        public required string SmtpHost { get; init; }
+        public int? SmtpPort { get; init; }
+        public required string Subject { get; init; }
+        public Quartz.JobDataMap ToJobData() { }
+        public static Quartz.Jobs.SendMailOptions FromJobData(Quartz.JobDataMap data) { }
     }
 }


### PR DESCRIPTION
Feature F6 from the ratified finalization spec (analyses A8-19 + A6-12).

- **Four typed options records** — `DirectoryScanOptions`, `FileScanOptions`, `NativeJobOptions`, `SendMailOptions` — each with `ToJobData()`/`FromJobData()`, plus `Using*Options(...)` extensions generic in the configurator so builder chains keep their type. The JobDataMap keys remain the persisted contract, byte-identical: 3.x-written data and `StoreJobDataAsStrings` read the same (string-coercing readers, pinned by tests).
- **The SMTP credential comes from the container, never job data**: `SendMailJob(ICredentialsByHost?)` filled by the job factory; `MailInfo`'s username/password pair became one `Credentials`; the legacy keys still work with a warning when nothing is registered, and a registered credential wins. The jobs docs gain a section saying exactly why.
- **A6-12 closed**: the two live internal key constants (`SearchPattern`, `IncludeSubDirectories`) are public; `GetUpdatedOrNewFiles` is private and `DirectoryScanResult` internal with it (walks back part of #3317 to the ledger-ratified form — `Execute` was never an override point, so the record had no public reader).
- Honest fixes en route: `DIRECTORY_NAMES=""` no longer scans nothing silently (the missing-parameter error fires on an EMPTY list, not just absent keys); `SendMailJob`'s untyped parameter helpers deleted rather than left as silent no-op override points.
- The jobs package page is rewritten with per-job setting↔key tables; migration guide gains the two sections plus corrected rows.

Unit 2685, AspNetCore 261, `Compile UnitTest PublishAot` clean. Only the Quartz.Jobs baseline moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf