### PR TITLE
Contract guards: binary layouts, options conventions, and the key gate

### DIFF
--- a/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
@@ -1,0 +1,425 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using System.Collections.Specialized;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// The completeness property behind "a misspelled key throws".
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="LegacyPropertyKeys.Validate" /> rejects any <c>quartz.*</c> key it does not recognise,
+/// which is only a kindness while the recognised list is exhaustive. If a reader consults a key the
+/// list has never heard of, the guard turns a working configuration into a startup failure — and it
+/// does so for exactly the 3.x-migration shape the guard was written for. The other tests around
+/// here check that the guard fires; this one checks that it fires only on real mistakes.
+/// </para>
+/// <para>
+/// The key inventory is extracted mechanically rather than curated, by walking the IL of every type
+/// in the <c>Quartz.Configuration</c> namespace and collecting the <c>ldstr</c> literals that begin
+/// with <c>quartz.</c>. That is where every reader of the flat format lives — the bridge, the plugin
+/// and listener factories, the execution-limit parser, the scheduler content initializer — and
+/// because <c>const</c> strings are inlined at their use sites, a key named through
+/// <see cref="LegacyPropertyKeys" /> shows up at the reader just as a literal one does.
+/// <see cref="LegacyPropertyKeys" /> itself is skipped: it declares the lists rather than reading
+/// them, and it is the thing under test.
+/// </para>
+/// <para>
+/// A curated list of the keys the documentation promises backs the scan up, because a key the
+/// documentation teaches and no reader consults is a different bug with the same symptom.
+/// </para>
+/// </remarks>
+public class LegacyPropertyKeyExhaustivenessTest
+{
+    private const string Prefix = "quartz.";
+    private const string ConfigurationNamespace = "Quartz.Configuration";
+
+    private static readonly Assembly quartzAssembly = typeof(IScheduler).Assembly;
+
+    // Declared before the scan: static field initializers run in textual order, and the walk needs
+    // these tables to know how long each instruction is.
+    private static readonly OpCode?[] singleByteOpCodes = BuildOpCodeTable(twoByte: false);
+    private static readonly OpCode?[] twoByteOpCodes = BuildOpCodeTable(twoByte: true);
+
+    /// <summary>
+    /// Every <c>quartz.*</c> key or key prefix the flat-format readers name, as found in their IL.
+    /// </summary>
+    private static readonly IReadOnlyList<string> keysTheReadersConsult = ScanConfigurationReaders();
+
+    /// <summary>
+    /// Keys the 4.x documentation tells a reader to write. Placeholders in the documentation
+    /// (<c>NAME</c>) are filled in with a plausible name, because these keys are matched by prefix.
+    /// </summary>
+    private static readonly string[] documentedKeys =
+    [
+        // configuration/reference.md
+        "quartz.checkConfiguration",
+        "quartz.context.key.environment",
+        "quartz.dataSource.myDs.provider",
+        "quartz.dataSource.myDs.connectionString",
+        "quartz.dataSource.myDs.connectionStringName",
+        "quartz.dataSource.myDs.connectionProvider.type",
+        "quartz.dbprovider.MyDatabase.productName",
+        "quartz.jobListener.myListener.type",
+        "quartz.jobStore.acceptEnlistedTransactions",
+        "quartz.jobStore.clusterCheckinInterval",
+        "quartz.jobStore.clusterCheckinMisfireThreshold",
+        "quartz.jobStore.clustered",
+        "quartz.jobStore.dataSource",
+        "quartz.jobStore.driverDelegateInitString",
+        "quartz.jobStore.lockHandler.type",
+        "quartz.jobStore.makeThreadsDaemons",
+        "quartz.jobStore.misfireThreshold",
+        "quartz.jobStore.tablePrefix",
+        "quartz.jobStore.type",
+        "quartz.jobStore.useProperties",
+        "quartz.plugin.myPlugin.type",
+        "quartz.scheduler.batchTriggerAcquisitionFireAheadTimeWindow",
+        "quartz.scheduler.batchTriggerAcquisitionMaxCount",
+        "quartz.scheduler.idleWaitTime",
+        "quartz.scheduler.instanceId",
+        "quartz.scheduler.instanceName",
+        "quartz.scheduler.interruptJobsOnShutdown",
+        "quartz.scheduler.interruptJobsOnShutdownWithWait",
+        "quartz.scheduler.jobFactory.type",
+        "quartz.scheduler.typeLoadHelper.type",
+        "quartz.serializer.type",
+        "quartz.threadExecutor",
+        "quartz.threadPool.maxConcurrency",
+        "quartz.threadPool.type",
+        "quartz.triggerListener.myListener.type",
+
+        // tutorial/job-stores.md
+        "quartz.jobStore.driverDelegateType",
+
+        // tutorial/execution-groups.md
+        "quartz.executionLimit.batch-jobs",
+
+        // migration-guide.md
+        "quartz.timeProvider.type"
+    ];
+
+    /// <summary>
+    /// Keys the 4.x documentation says are rejected, and the section that says so.
+    /// </summary>
+    private static readonly string[] documentedRemovals =
+    [
+        // configuration/reference.md, "Removed in 4.x"
+        "quartz.scheduler.proxy",
+        "quartz.scheduler.exporter",
+        "quartz.scheduler.threadName",
+        "quartz.scheduler.makeSchedulerThreadDaemon",
+
+        // migration-guide.md
+        "quartz.jobStore.lockHandler.tablePrefix",
+        "quartz.jobStore.lockHandler.schedulerName"
+    ];
+
+    [Test]
+    public void TheScanFoundTheKeysTheReadersConsult()
+    {
+        // Guards the guard: a scanner that silently found nothing would make every assertion below
+        // vacuous, and IL walking is exactly the kind of code that fails that way.
+        keysTheReadersConsult.Should().HaveCountGreaterThan(30);
+
+        keysTheReadersConsult.Should().Contain(
+            [
+                "quartz.jobStore.type",
+                "quartz.jobStore.driverDelegateType",
+                "quartz.threadPool.threadCount",
+                "quartz.serializer.type",
+                "quartz.scheduler.instanceName",
+                "quartz.dbprovider"
+            ],
+            "a mix of inline literals and LegacyPropertyKeys constants, so the scan has to see both "
+            + "spellings — a constant reaches the reader's IL inlined, exactly like a literal");
+    }
+
+    [Test]
+    public void EveryKeyTheReadersConsultIsOneTheValidatorAccepts()
+    {
+        List<string> rejected = [];
+        foreach (string key in keysTheReadersConsult)
+        {
+            if (Rejection(key) is { } message)
+            {
+                rejected.Add($"{key}: {message}");
+            }
+        }
+
+        rejected.Should().BeEmpty(
+            "a key some reader consults is by definition not a misspelling, so rejecting it would break "
+            + "a configuration that works — this is the property that makes the unknown-key guard safe "
+            + "to have at all");
+    }
+
+    [Test]
+    public void NoKeyTheReadersConsultIsAlsoListedAsRemoved()
+    {
+        List<string> overlaps = [];
+        foreach (string key in keysTheReadersConsult)
+        {
+            foreach ((string prefix, string _) in LegacyPropertyKeys.removedKeys)
+            {
+                if (key.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    overlaps.Add($"{key} is read but '{prefix}' is advertised as removed");
+                }
+            }
+        }
+
+        overlaps.Should().BeEmpty(
+            "the removed list is checked before the supported list, so a key on both is rejected with "
+            + "advice telling the reader to remove a key Quartz still reads");
+    }
+
+    [Test]
+    public void EveryRemovedKeyIsRejectedByNameAndWithItsAdvice()
+    {
+        LegacyPropertyKeys.removedKeys.Should().NotBeEmpty();
+
+        foreach ((string prefix, string advice) in LegacyPropertyKeys.removedKeys)
+        {
+            string? message = Rejection(prefix);
+
+            message.Should().NotBeNull($"'{prefix}' is advertised as removed, so it must be rejected");
+            message.Should().Contain(prefix, "the reader has to be told which key in their file is the problem");
+            message.Should().Contain(advice,
+                "'unknown property' reads like a typo; a key that was configuring something real earns "
+                + "an explanation of what to do instead");
+        }
+    }
+
+    [Test]
+    public void TheSupportedListIsInternallyConsistent()
+    {
+        string[] supported = LegacyPropertyKeys.supportedKeys;
+
+        supported.Should().NotBeEmpty();
+        supported.Should().OnlyHaveUniqueItems("a key listed twice is a merge accident, not a policy");
+        supported.Should().OnlyContain(key => key.StartsWith(Prefix, StringComparison.Ordinal) && key.Length > Prefix.Length,
+            "the validator only ever looks at keys under the quartz. prefix, so an entry outside it can never match");
+        supported.Should().OnlyContain(key => !key.StartsWith("quartz.server", StringComparison.Ordinal),
+            "quartz.server.* belongs to Quartz.Server's own settings and is skipped before this list is consulted");
+    }
+
+    [Test]
+    public void EveryDocumentedKeyIsOneTheValidatorAccepts()
+    {
+        List<string> rejected = [];
+        foreach (string key in documentedKeys)
+        {
+            if (Rejection(key) is { } message)
+            {
+                rejected.Add($"{key}: {message}");
+            }
+        }
+
+        rejected.Should().BeEmpty(
+            "the documentation is the other half of the contract: a key it teaches and the validator "
+            + "rejects fails a reader who did exactly what they were told");
+    }
+
+    [Test]
+    public void EveryDocumentedRemovalIsRejected()
+    {
+        List<string> accepted = documentedRemovals.Where(key => Rejection(key) is null).ToList();
+
+        accepted.Should().BeEmpty(
+            "the documentation promises these are rejected rather than ignored, which is the whole point "
+            + "of listing them by name");
+    }
+
+    [Test]
+    public void QuartzServerKeysAreNotSchedulerKeys()
+    {
+        Rejection("quartz.server.scheduler.instanceName").Should().BeNull(
+            "Quartz.Server reads its own settings out of the same file, and they are not misspelled "
+            + "scheduler keys");
+    }
+
+    /// <summary>
+    /// Runs the validator over a bag holding just this key, and returns the complaint or
+    /// <see langword="null" /> when the key is accepted.
+    /// </summary>
+    private static string? Rejection(string key)
+    {
+        NameValueCollection properties = new NameValueCollection { [key] = "value" };
+
+        try
+        {
+            LegacyPropertyKeys.Validate(properties);
+            return null;
+        }
+        catch (SchedulerConfigException exception)
+        {
+            return exception.Message;
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Reading the keys back out of the readers
+    // ---------------------------------------------------------------------------------------------
+
+    private static IReadOnlyList<string> ScanConfigurationReaders()
+    {
+        SortedSet<string> keys = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (Type type in quartzAssembly.GetTypes())
+        {
+            // Nested display classes carry the lambdas, and they report their declaring type's namespace.
+            if (!string.Equals(type.Namespace, ConfigurationNamespace, StringComparison.Ordinal)
+                || type == typeof(LegacyPropertyKeys))
+            {
+                continue;
+            }
+
+            foreach (MethodBase method in DeclaredMethods(type))
+            {
+                foreach (string literal in StringLiterals(method))
+                {
+                    // The bare prefix is manufactured by QuartzConfigurationHelper rather than read.
+                    if (literal.Length > Prefix.Length && literal.StartsWith(Prefix, StringComparison.Ordinal))
+                    {
+                        keys.Add(literal);
+                    }
+                }
+            }
+        }
+
+        return keys.ToList();
+    }
+
+    private static IEnumerable<MethodBase> DeclaredMethods(Type type)
+    {
+        const BindingFlags Declared = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
+                                      | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        return type.GetMethods(Declared).Cast<MethodBase>().Concat(type.GetConstructors(Declared));
+    }
+
+    /// <summary>
+    /// The IL opcode table, read off <see cref="OpCodes" /> rather than transcribed, so that the
+    /// operand sizes the walk relies on come from the runtime's own definitions.
+    /// </summary>
+    private static OpCode?[] BuildOpCodeTable(bool twoByte)
+    {
+        OpCode?[] table = new OpCode?[0x100];
+        foreach (FieldInfo field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.GetValue(null) is not OpCode opCode)
+            {
+                continue;
+            }
+
+            ushort value = unchecked((ushort) opCode.Value);
+            if (twoByte && (value & 0xFF00) == 0xFE00)
+            {
+                table[value & 0xFF] = opCode;
+            }
+            else if (!twoByte && value < 0x100)
+            {
+                table[value] = opCode;
+            }
+        }
+
+        return table;
+    }
+
+    /// <summary>
+    /// Walks a method body instruction by instruction, resolving every <c>ldstr</c> against the
+    /// module's string heap. Stepping over operands properly is what keeps an operand byte from being
+    /// misread as an opcode and inventing keys that are not there.
+    /// </summary>
+    private static List<string> StringLiterals(MethodBase method)
+    {
+        List<string> literals = [];
+
+        byte[]? il;
+        try
+        {
+            il = method.GetMethodBody()?.GetILAsByteArray();
+        }
+        catch (Exception)
+        {
+            // abstract, extern or otherwise bodiless
+            return literals;
+        }
+
+        if (il is null)
+        {
+            return literals;
+        }
+
+        Module module = method.Module;
+        int position = 0;
+        while (position < il.Length)
+        {
+            if (ReadOpCode(il, ref position) is not { } instruction)
+            {
+                // An opcode this table does not know means the walk has lost the instruction boundary;
+                // stopping is honest, and TheScanFoundTheKeysTheReadersConsult notices if it happens often.
+                break;
+            }
+
+            if (instruction.OperandType == OperandType.InlineString && position + 4 <= il.Length)
+            {
+                literals.Add(module.ResolveString(BitConverter.ToInt32(il, position)));
+            }
+
+            position += OperandSize(instruction, il, position);
+        }
+
+        return literals;
+    }
+
+    private static OpCode? ReadOpCode(byte[] il, ref int position)
+    {
+        byte first = il[position++];
+        if (first != 0xFE)
+        {
+            return singleByteOpCodes[first];
+        }
+
+        return position < il.Length ? twoByteOpCodes[il[position++]] : null;
+    }
+
+    private static int OperandSize(OpCode opCode, byte[] il, int position) => opCode.OperandType switch
+    {
+        OperandType.InlineNone => 0,
+        OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+        OperandType.InlineVar => 2,
+        OperandType.InlineBrTarget or OperandType.InlineField or OperandType.InlineI or OperandType.InlineMethod
+            or OperandType.InlineSig or OperandType.InlineString or OperandType.InlineTok
+            or OperandType.InlineType or OperandType.ShortInlineR => 4,
+        OperandType.InlineI8 or OperandType.InlineR => 8,
+        OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, position),
+        _ => 0
+    };
+}

--- a/src/Quartz.Tests.Unit/Configuration/OptionsConventionTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/OptionsConventionTest.cs
@@ -1,0 +1,517 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using System.Collections;
+using System.Reflection;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// The mechanical half of the S6 options rule, which the 4.0 API finalization ratified as a
+/// principle and asked to be enforced "by a reflection test beside the API baselines".
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rule asks one question — <em>who calls <c>new</c>?</em> — and every other clause follows
+/// from the answer.
+/// </para>
+/// <para>
+/// <strong>Group A, container-bound options.</strong> Quartz calls <c>new</c>: the instance is
+/// created by <c>Microsoft.Extensions.Options</c>, or by a registration helper immediately before it
+/// invokes the caller's <c>Action&lt;T&gt;</c>, and is then mutated by that delegate or bound from
+/// <c>IConfiguration</c>. So: a sealed class with a public parameterless constructor; every scalar
+/// member <c>{ get; set; }</c> carrying the recommended value as its initialiser; every collection
+/// or nested-options member <c>{ get; }</c> initialised in place, because the binder binds
+/// <em>into</em> the existing instance and a setter lets one <c>Configure</c> callback silently
+/// discard another's edits; never a record, never <c>init</c>, never <c>required</c>, never a
+/// struct — <c>required</c> cannot be honoured when the application never runs a constructor.
+/// </para>
+/// <para>
+/// <strong>Group B, call-site arguments.</strong> The application calls <c>new</c>, writes an object
+/// initialiser and passes the value to a Quartz method; the type is never in the container. So: a
+/// <c>readonly record struct</c> with every member <c>init</c>, and defaults chosen so that
+/// <c>default</c> <em>is</em> the conservative behaviour — which is what lets the parameter be
+/// <c>T options = default</c> rather than <c>T? options = null</c>, and is what removed four
+/// null-normalising sites when the shape landed.
+/// </para>
+/// <para>
+/// Two clauses of the rule are deliberately not encoded here, because encoding them would mean
+/// inventing policy rather than enforcing it. "Defaults encode recommended usage" is a judgement
+/// about values, not shapes; the closest mechanical statement — that a fresh instance is readable
+/// and its complex members are already there — <em>is</em> checked. And "validated by an
+/// <c>IValidateOptions&lt;T&gt;</c>" is not yet true of the whole set: four of the container-bound
+/// types have nothing to validate, and <c>ClusteringStaysEnabledValidator</c> is registered at its
+/// own use site rather than centrally.
+/// </para>
+/// <para>
+/// Scope is the <c>Quartz</c> assembly's exported types. The satellite packages carry options of
+/// their own — including <c>QuartzHealthCheckOptions</c>, whose <c>Tags</c> setter the finalization
+/// campaign flagged for an S6 re-check — and they are not covered here.
+/// </para>
+/// </remarks>
+public class OptionsConventionTest
+{
+    private static readonly Assembly quartzAssembly = typeof(IScheduler).Assembly;
+
+    /// <summary>
+    /// Members the referenced-type rule cannot express, each with the reason it is out of reach.
+    /// A new entry needs a reason of the same kind: a contract imposed from outside Quartz.
+    /// </summary>
+    private static readonly Dictionary<string, string> referencedTypeExceptions = new(StringComparer.Ordinal)
+    {
+        // Ratified by A5's S6 audit, which lists DataSourceOptions among the fully conforming types:
+        // a keyed-service key is typed 'object' by Microsoft.Extensions.DependencyInjection's own
+        // contract (ServiceDescriptor.ServiceKey, [FromKeyedServices(object)]), so an option that
+        // carries one to the container cannot be narrower than the container itself.
+        ["Quartz.DataSourceOptions.DataSourceServiceKey"] = "a DI service key is typed 'object' by the container's contract"
+    };
+
+    /// <summary>
+    /// Types a scalar member may be: assigned wholesale, carrying no state Quartz binds into.
+    /// </summary>
+    private static readonly HashSet<Type> scalarTypes =
+    [
+        typeof(string), typeof(decimal), typeof(TimeSpan), typeof(DateTime), typeof(DateTimeOffset),
+        typeof(TimeOnly), typeof(DateOnly), typeof(Guid), typeof(Uri), typeof(Type), typeof(Version)
+    ];
+
+    /// <summary>
+    /// The options types the application constructs itself, discovered the way the rule defines them:
+    /// they appear as a parameter of a public Quartz member. Members declared on an options type are
+    /// skipped so that a record's own generated <c>Equals(T)</c> cannot classify its declaring type.
+    /// </summary>
+    private static readonly HashSet<Type> callSiteArgumentOptions = FindCallSiteArgumentOptions();
+
+    public static IEnumerable<Type> AllOptions() => quartzAssembly.GetExportedTypes()
+        .Where(IsOptionsType)
+        .OrderBy(type => type.FullName, StringComparer.Ordinal);
+
+    public static IEnumerable<Type> ContainerBoundOptions() => AllOptions().Where(type => !callSiteArgumentOptions.Contains(type));
+
+    public static IEnumerable<Type> CallSiteArgumentOptions() => AllOptions().Where(callSiteArgumentOptions.Contains);
+
+    [Test]
+    public void TheAssemblyHasOptionsTypesOfBothKinds()
+    {
+        // Guards the guards: a classification that silently found nothing would make every test below
+        // pass without checking anything.
+        ContainerBoundOptions().Should().NotBeEmpty();
+        CallSiteArgumentOptions().Should().NotBeEmpty();
+    }
+
+    [TestCaseSource(nameof(AllOptions))]
+    public void EveryOptionsTypeIsSealed(Type optionsType)
+    {
+        optionsType.IsSealed.Should().BeTrue(
+            "an options type is data, and nothing in Quartz calls a virtual member on one — subclassing "
+            + "it would only produce an instance the binder cannot fill");
+    }
+
+    [TestCaseSource(nameof(AllOptions))]
+    public void NoOptionsTypeExposesAnInstanceField(Type optionsType)
+    {
+        FieldInfo[] fields = optionsType.GetFields(BindingFlags.Public | BindingFlags.Instance);
+
+        fields.Select(field => field.Name).Should().BeEmpty(
+            "the configuration binder writes properties, so a public field is a setting that binds from "
+            + "nowhere; constants and statics are fine and are not instance state");
+    }
+
+    [Test]
+    public void EveryReferencedTypeExceptionIsStillEarningItsPlace()
+    {
+        List<PropertyInfo> properties = AllOptions().SelectMany(PublicProperties).ToList();
+
+        foreach (string member in referencedTypeExceptions.Keys)
+        {
+            PropertyInfo? property = properties.SingleOrDefault(candidate => Describe(candidate) == member);
+
+            property.Should().NotBeNull($"the allow-list names {member}, which no longer exists");
+            ShapeOf(Unwrap(property!.PropertyType)).Should().Be(MemberShape.Unknown,
+                $"{member} would pass the rule on its own now, so its exception is stale and should go");
+        }
+    }
+
+    [TestCaseSource(nameof(AllOptions))]
+    public void EveryOptionsMemberIsTypedAsAnOptionsTypeAnEnumOrABclType(Type optionsType)
+    {
+        List<string> violations = [];
+        foreach (PropertyInfo property in PublicProperties(optionsType))
+        {
+            if (ShapeOf(property) == MemberShape.Unknown)
+            {
+                violations.Add($"{Describe(property)} is a {property.PropertyType.Name}");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "an options graph is reachable from configuration, so it may only name other options types, "
+            + "enums, delegates and BCL types — a Quartz component reached through an option is a "
+            + "service that belongs in the container instead");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Group A — Quartz calls new
+    // ---------------------------------------------------------------------------------------------
+
+    [TestCaseSource(nameof(ContainerBoundOptions))]
+    public void ContainerBoundOptionsAreClassesTheBinderCanConstruct(Type optionsType)
+    {
+        optionsType.IsValueType.Should().BeFalse("the container hands the same instance to every Configure callback");
+        IsRecord(optionsType).Should().BeFalse(
+            "a record's value semantics say the instance is replaced, and a container-bound instance is mutated in place");
+
+        ConstructorInfo[] constructors = optionsType.GetConstructors();
+        constructors.Should().ContainSingle("the binder picks a constructor by having only one to pick")
+            .Which.GetParameters().Should().BeEmpty(
+                "nothing supplies constructor arguments: Microsoft.Extensions.Options creates the instance");
+    }
+
+    [TestCaseSource(nameof(ContainerBoundOptions))]
+    public void ContainerBoundOptionsHaveNoInitOnlyOrRequiredMembers(Type optionsType)
+    {
+        List<string> violations = [];
+        foreach (PropertyInfo property in PublicProperties(optionsType))
+        {
+            if (IsInitOnly(property))
+            {
+                violations.Add($"{Describe(property)} is init-only");
+            }
+
+            if (IsRequired(property))
+            {
+                violations.Add($"{Describe(property)} is required");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "the application never runs a constructor or an object initialiser for these, so init-only "
+            + "shuts the Configure callback out and required can never be satisfied — a mandatory value "
+            + "is a non-nullable property plus an IValidateOptions");
+    }
+
+    [TestCaseSource(nameof(ContainerBoundOptions))]
+    public void ContainerBoundScalarsAreSettableAndComplexMembersAreGetOnly(Type optionsType)
+    {
+        List<string> violations = [];
+        foreach (PropertyInfo property in PublicProperties(optionsType))
+        {
+            bool readable = property.GetMethod is { IsPublic: true };
+            bool writable = property.SetMethod is { IsPublic: true };
+
+            if (!readable)
+            {
+                violations.Add($"{Describe(property)} has no public getter");
+                continue;
+            }
+
+            switch (ShapeOf(property))
+            {
+                case MemberShape.Scalar when !writable:
+                    violations.Add($"{Describe(property)} is a scalar with no setter");
+                    break;
+                case MemberShape.Complex when writable:
+                    violations.Add($"{Describe(property)} is a collection or nested options object with a setter");
+                    break;
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "a scalar is assigned wholesale, so it is get/set; a collection or nested options object is "
+            + "bound into, so it is get-only — a setter there lets one Configure callback replace the "
+            + "instance another one had already written to");
+    }
+
+    [TestCaseSource(nameof(ContainerBoundOptions))]
+    public void ContainerBoundComplexMembersAreInitialisedInPlace(Type optionsType)
+    {
+        object instance = Activator.CreateInstance(optionsType)!;
+
+        List<string> violations = [];
+        foreach (PropertyInfo property in PublicProperties(optionsType).Where(p => ShapeOf(p) == MemberShape.Complex))
+        {
+            object? value = property.GetValue(instance);
+            if (value is null)
+            {
+                violations.Add($"{Describe(property)} is null on a fresh instance");
+                continue;
+            }
+
+            bool frozen = value switch
+            {
+                IDictionary dictionary => dictionary.IsReadOnly,
+                IList list => list.IsReadOnly,
+                _ => false
+            };
+
+            if (frozen)
+            {
+                violations.Add($"{Describe(property)} is read-only on a fresh instance");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "the binder and every Configure callback write into whatever is already there, so a get-only "
+            + "member that starts out null or frozen silently swallows the configuration aimed at it");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Group B — the application calls new
+    // ---------------------------------------------------------------------------------------------
+
+    [TestCaseSource(nameof(CallSiteArgumentOptions))]
+    public void CallSiteArgumentOptionsAreReadonlyRecordStructs(Type optionsType)
+    {
+        optionsType.IsValueType.Should().BeTrue(
+            "a value passed to a method should not make the caller allocate, and should not be aliased "
+            + "by the callee afterwards");
+
+        optionsType.GetCustomAttributesData().Should().Contain(
+            attribute => attribute.AttributeType.Name == "IsReadOnlyAttribute",
+            "readonly is what stops a member mutating a copy nobody reads back");
+
+        IsRecord(optionsType).Should().BeTrue(
+            "value equality and a printable ToString are free, and a call-site argument is compared and "
+            + "logged far more often than it is mutated");
+    }
+
+    [TestCaseSource(nameof(CallSiteArgumentOptions))]
+    public void CallSiteArgumentOptionMembersAreInitOnly(Type optionsType)
+    {
+        List<string> violations = [];
+        foreach (PropertyInfo property in PublicProperties(optionsType))
+        {
+            if (property.GetMethod is not { IsPublic: true })
+            {
+                violations.Add($"{Describe(property)} has no public getter");
+            }
+
+            if (property.SetMethod is not { IsPublic: true })
+            {
+                violations.Add($"{Describe(property)} has no initialiser");
+            }
+            else if (!IsInitOnly(property))
+            {
+                violations.Add($"{Describe(property)} has a plain setter");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "the whole value is written in one object initialiser at the call site and read by Quartz "
+            + "afterwards; a plain setter suggests a lifetime the value does not have");
+    }
+
+    [Test]
+    public void CallSiteArgumentOptionsAreNeverBoundThroughTheOptionsPattern()
+    {
+        List<string> violations = [];
+        foreach (Type type in ConsumingTypes())
+        {
+            foreach (MethodBase member in PublicMembers(type))
+            {
+                foreach (ParameterInfo parameter in member.GetParameters())
+                {
+                    foreach (Type argument in OptionsPatternArguments(parameter.ParameterType))
+                    {
+                        if (callSiteArgumentOptions.Contains(argument))
+                        {
+                            violations.Add($"{type.Name}.{member.Name} binds {argument.Name} as {parameter.ParameterType.Name}");
+                        }
+                    }
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "a call-site argument is never registered in a container: the corollary of the rule is that "
+            + "the two groups do not overlap, and a type configured through Action<T> is group A");
+    }
+
+    [Test]
+    public void CallSiteArgumentParametersDefaultToTheConservativeValue()
+    {
+        List<string> violations = [];
+        foreach (Type type in ConsumingTypes())
+        {
+            foreach (MethodBase member in PublicMembers(type))
+            {
+                ParameterInfo[] parameters = member.GetParameters();
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    ParameterInfo parameter = parameters[i];
+                    Type parameterType = Unwrap(parameter.ParameterType);
+                    if (!callSiteArgumentOptions.Contains(parameterType))
+                    {
+                        continue;
+                    }
+
+                    if (Nullable.GetUnderlyingType(parameter.ParameterType) is not null)
+                    {
+                        violations.Add($"{type.Name}.{member.Name} takes {parameterType.Name}? — the absent value has a spelling of its own");
+                        continue;
+                    }
+
+                    // A parameter cannot be optional while something after it is required, which is the
+                    // one reason the rule tolerates a mandatory options argument.
+                    bool couldBeOptional = parameters.Skip(i + 1).All(later => later.IsOptional);
+                    if (couldBeOptional && !parameter.IsOptional)
+                    {
+                        violations.Add($"{type.Name}.{member.Name} takes a mandatory {parameterType.Name}");
+                    }
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "'default' is the conservative behaviour by construction, so the parameter is 'T options = "
+            + "default'; 'T? options = null' would put the same meaning in two spellings and make every "
+            + "callee normalise it");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    private enum MemberShape
+    {
+        /// <summary>Assigned wholesale by a Configure callback.</summary>
+        Scalar,
+
+        /// <summary>A collection or a nested options object, which the binder writes into.</summary>
+        Complex,
+
+        /// <summary>Something the rule does not allow an options type to name at all.</summary>
+        Unknown
+    }
+
+    private static MemberShape ShapeOf(PropertyInfo property) =>
+        referencedTypeExceptions.ContainsKey(Describe(property))
+            ? MemberShape.Scalar
+            : ShapeOf(Unwrap(property.PropertyType));
+
+    private static MemberShape ShapeOf(Type type)
+    {
+        if (type.IsPrimitive || type.IsEnum || scalarTypes.Contains(type))
+        {
+            return MemberShape.Scalar;
+        }
+
+        if (typeof(Delegate).IsAssignableFrom(type))
+        {
+            // A delegate has no state to bind into; it is replaced, never edited.
+            return MemberShape.Scalar;
+        }
+
+        if (IsOptionsType(type) || typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            return MemberShape.Complex;
+        }
+
+        return MemberShape.Unknown;
+    }
+
+    private static HashSet<Type> FindCallSiteArgumentOptions()
+    {
+        HashSet<Type> found = [];
+        foreach (Type type in ConsumingTypes())
+        {
+            foreach (MethodBase member in PublicMembers(type))
+            {
+                foreach (ParameterInfo parameter in member.GetParameters())
+                {
+                    Type parameterType = Unwrap(parameter.ParameterType);
+                    if (IsOptionsType(parameterType))
+                    {
+                        found.Add(parameterType);
+                    }
+                }
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// The options types a parameter carries into the container: <c>Action&lt;T&gt;</c> and the
+    /// <c>Microsoft.Extensions.Options</c> family are how a group-A type is configured.
+    /// </summary>
+    private static IEnumerable<Type> OptionsPatternArguments(Type parameterType)
+    {
+        Type type = Unwrap(parameterType);
+        if (!type.IsGenericType)
+        {
+            yield break;
+        }
+
+        Type definition = type.GetGenericTypeDefinition();
+        bool optionsPattern = definition == typeof(Action<>)
+            || string.Equals(definition.Namespace, "Microsoft.Extensions.Options", StringComparison.Ordinal);
+
+        if (!optionsPattern)
+        {
+            yield break;
+        }
+
+        foreach (Type argument in type.GetGenericArguments())
+        {
+            yield return argument;
+        }
+    }
+
+    /// <summary>
+    /// The exported types that <em>use</em> options rather than being one. An options type's own
+    /// generated equality members take it as a parameter, which would classify every record as a
+    /// call-site argument if they were counted.
+    /// </summary>
+    private static IEnumerable<Type> ConsumingTypes() => quartzAssembly.GetExportedTypes().Where(type => !IsOptionsType(type));
+
+    private static IEnumerable<MethodBase> PublicMembers(Type type) => type
+        .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+        .Cast<MethodBase>()
+        .Concat(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+
+    private static IEnumerable<PropertyInfo> PublicProperties(Type type) => type
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .OrderBy(property => property.Name, StringComparer.Ordinal);
+
+    private static bool IsOptionsType(Type type) =>
+        type.Assembly == quartzAssembly && type.IsPublic && type.Name.EndsWith("Options", StringComparison.Ordinal);
+
+    private static Type Unwrap(Type type)
+    {
+        Type unwrapped = type.IsByRef ? type.GetElementType()! : type;
+        return Nullable.GetUnderlyingType(unwrapped) ?? unwrapped;
+    }
+
+    /// <summary>
+    /// Records — class and struct alike — get a compiler-generated <c>PrintMembers</c>; nothing else does.
+    /// </summary>
+    private static bool IsRecord(Type type) =>
+        type.GetMethod("PrintMembers", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) is not null;
+
+    private static bool IsInitOnly(PropertyInfo property) => property.SetMethod is { } setter
+        && setter.ReturnParameter.GetRequiredCustomModifiers().Any(modifier => modifier.Name == "IsExternalInit");
+
+    private static bool IsRequired(PropertyInfo property) => property.GetCustomAttributesData()
+        .Any(attribute => attribute.AttributeType.Name == "RequiredMemberAttribute");
+
+    private static string Describe(PropertyInfo property) => $"{property.DeclaringType!.FullName}.{property.Name}";
+}

--- a/src/Quartz.Tests.Unit/CronExpressionBinarySerializationContractTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBinarySerializationContractTest.cs
@@ -1,0 +1,239 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Pins the ISerializable shape of <see cref="CronExpression" /> — the binary contract for the
+/// cron expression inside a 3.x <c>BLOB_TRIGGERS</c> or <c>CALENDARS</c> blob, which the
+/// binary-to-JSON migration path reads. BinaryFormatter itself is gone from net10, so these tests
+/// drive the plumbing directly with hand-built <see cref="SerializationInfo" /> and the private
+/// serialization constructor; a change that breaks them breaks the ability to load 3.x blobs.
+/// </summary>
+/// <remarks>
+/// The historical layouts are reconstructed here rather than read from stored <c>.ser</c> fixtures:
+/// the repository keeps none, and a hand-built <see cref="SerializationInfo" /> states the field
+/// names and payload types a formatter would have written far more legibly than an opaque blob.
+/// The current-format fixture is generated from the current code by
+/// <see cref="RoundTripsThroughItsOwnSerializationPlumbing" />.
+/// </remarks>
+#pragma warning disable SYSLIB0050 // SerializationInfo/FormatterConverter are obsolete, which is the point: this exercises the legacy contract
+public class CronExpressionBinarySerializationContractTest
+{
+    [Test]
+    public void CronExpressionCarriesSerializableAttributeAndPrivateSerializationConstructor()
+    {
+        typeof(CronExpression).IsSerializable.Should().BeTrue("BinaryFormatter-written blobs record the type as serializable");
+
+        SerializationConstructor().Should().NotBeNull(
+            "the (SerializationInfo, StreamingContext) constructor is what a formatter-style reader invokes");
+    }
+
+    [Test]
+    public void GetObjectDataWritesTheThreeEntriesTheBlobFormatHasAlwaysHad()
+    {
+        CronExpression expression = new CronExpression("0 15 10 * * ?", TimeZoneInfo.Utc);
+
+        SerializationInfo info = CreateInfo();
+        ((ISerializable) expression).GetObjectData(info, default);
+
+        Dictionary<string, object?> entries = ToDictionary(info);
+        entries.Keys.Should().BeEquivalentTo(["version", "cronExpression", "timeZoneId"],
+            "3.x readers look these entries up by exactly these names");
+
+        entries["version"].Should().Be(1);
+        entries["cronExpression"].Should().Be("0 15 10 * * ?",
+            "the expression string is the whole of the persisted state; everything else is re-parsed");
+        entries["timeZoneId"].Should().Be("UTC",
+            "the zone travels as its id, never as a TimeZoneInfo — Windows and IANA ids differ and a "
+            + "serialized TimeZoneInfo does not survive the crossing");
+    }
+
+    [Test]
+    public void GetObjectDataUpperCasesTheExpressionTheSameWayTheConstructorDid()
+    {
+        CronExpression expression = new CronExpression("0 0 12 ? * mon-fri", TimeZoneInfo.Utc);
+
+        SerializationInfo info = CreateInfo();
+        ((ISerializable) expression).GetObjectData(info, default);
+
+        ToDictionary(info)["cronExpression"].Should().Be("0 0 12 ? * MON-FRI",
+            "the stored string is the normalized one, so re-parsing it on the way back cannot change meaning");
+    }
+
+    [Test]
+    public void GetObjectDataResolvesTheLocalZoneRatherThanWritingNothing()
+    {
+        CronExpression expression = new CronExpression("0 15 10 * * ?");
+
+        SerializationInfo info = CreateInfo();
+        ((ISerializable) expression).GetObjectData(info, default);
+
+        ToDictionary(info)["timeZoneId"].Should().Be(TimeZoneInfo.Local.Id,
+            "an expression with no explicit zone runs in the local one, and the writer pins that "
+            + "rather than leaving the reader to pick the reading machine's zone");
+    }
+
+    [Test]
+    public void RoundTripsThroughItsOwnSerializationPlumbing()
+    {
+        CronExpression original = new CronExpression("0 15 10 * * ?", TimeZoneInfo.Utc);
+
+        SerializationInfo info = CreateInfo();
+        ((ISerializable) original).GetObjectData(info, default);
+        CronExpression deserialized = InvokeSerializationConstructor(info);
+
+        deserialized.CronExpressionString.Should().Be(original.CronExpressionString);
+        deserialized.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        deserialized.Should().Be(original);
+    }
+
+    [Test]
+    public void ReadsTheVersion1FormatEveryVersionSince20Wrote()
+    {
+        SerializationInfo info = CreateInfo();
+        info.AddValue("version", 1);
+        info.AddValue("cronExpression", "0 15 10 * * ?");
+        info.AddValue("timeZoneId", "Eastern Standard Time");
+
+        CronExpression deserialized = InvokeSerializationConstructor(info);
+
+        deserialized.CronExpressionString.Should().Be("0 15 10 * * ?");
+        deserialized.TimeZone.Should().Be(TimeZones.FindById("Eastern Standard Time"),
+            "the id is resolved through TimeZones.FindById, which is what makes a blob written on "
+            + "Windows readable on Linux");
+    }
+
+    [Test]
+    public void Version1WithAnEmptyTimeZoneIdFallsBackToTheLocalZone()
+    {
+        SerializationInfo info = CreateInfo();
+        info.AddValue("version", 1);
+        info.AddValue("cronExpression", "0 15 10 * * ?");
+        info.AddValue("timeZoneId", "");
+
+        InvokeSerializationConstructor(info).TimeZone.Should().Be(TimeZoneInfo.Local);
+    }
+
+    [Test]
+    public void ReadsTheVersion0FormatWithTheTimeZoneAsAnObject()
+    {
+        // The 1.x-era shape: no version entry, the expression under its field name, and the zone as
+        // a serialized TimeZoneInfo rather than an id.
+        SerializationInfo info = CreateInfo();
+        info.AddValue("cronExpressionString", "0 15 10 * * ?");
+        info.AddValue("timeZone", TimeZoneInfo.Utc);
+
+        CronExpression deserialized = InvokeSerializationConstructor(info);
+
+        deserialized.CronExpressionString.Should().Be("0 15 10 * * ?");
+        deserialized.TimeZone.Should().Be(TimeZoneInfo.Utc);
+    }
+
+    [Test]
+    public void RejectsAnUnknownVersion()
+    {
+        SerializationInfo info = CreateInfo();
+        info.AddValue("version", 2);
+        info.AddValue("cronExpression", "0 15 10 * * ?");
+        info.AddValue("timeZoneId", "UTC");
+
+        Action act = () => InvokeSerializationConstructor(info);
+
+        act.Should().Throw<TargetInvocationException>()
+            .WithInnerException<NotSupportedException>()
+            .WithMessage("*Unknown serialization version*");
+    }
+
+    /// <summary>
+    /// Everything but the expression string and the zone is <c>[NonSerialized]</c> parse state, so the
+    /// blob is only as good as the re-parse. These are the modifiers whose state lives outside the
+    /// bitmask fields — an 'L' or 'W' or 'nth' that failed to come back would silently reschedule a job.
+    /// </summary>
+    [TestCase("0 15 10 * * ?")]
+    [TestCase("0 0/5 14,18 * * ?")]
+    [TestCase("0 0 12 L * ?")]
+    [TestCase("0 0 12 LW * ?")]
+    [TestCase("0 0 12 L-3 * ?")]
+    [TestCase("0 0 12 15W * ?")]
+    [TestCase("0 0 12 ? * 6#3")]
+    [TestCase("0 0 12 ? * 6L")]
+    [TestCase("0 0 12 ? * MON-FRI")]
+    [TestCase("0 0 12 1/2 * ? 2026-2030")]
+    public void ParseStateRebuiltFromTheExpressionStringSurvivesTheRoundTrip(string expressionString)
+    {
+        CronExpression original = new CronExpression(expressionString, TimeZoneInfo.Utc);
+
+        SerializationInfo info = CreateInfo();
+        ((ISerializable) original).GetObjectData(info, default);
+        CronExpression deserialized = InvokeSerializationConstructor(info);
+
+        DateTimeOffset cursor = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        for (int i = 0; i < 25; i++)
+        {
+            DateTimeOffset? expected = original.GetNextValidTimeAfter(cursor);
+            deserialized.GetNextValidTimeAfter(cursor).Should().Be(expected,
+                $"fire time {i} after {cursor:O} must not move when '{expressionString}' comes back out of a blob");
+
+            if (expected is null)
+            {
+                break;
+            }
+
+            cursor = expected.Value;
+        }
+    }
+
+    private static SerializationInfo CreateInfo()
+    {
+        return new SerializationInfo(typeof(CronExpression), new FormatterConverter());
+    }
+
+    private static Dictionary<string, object?> ToDictionary(SerializationInfo info)
+    {
+        Dictionary<string, object?> entries = new Dictionary<string, object?>();
+        SerializationInfoEnumerator enumerator = info.GetEnumerator();
+        while (enumerator.MoveNext())
+        {
+            entries[enumerator.Name] = enumerator.Value;
+        }
+
+        return entries;
+    }
+
+    private static ConstructorInfo SerializationConstructor()
+    {
+        return typeof(CronExpression).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            [typeof(SerializationInfo), typeof(StreamingContext)])!;
+    }
+
+    private static CronExpression InvokeSerializationConstructor(SerializationInfo info)
+    {
+        return (CronExpression) SerializationConstructor().Invoke([info, default(StreamingContext)]);
+    }
+}
+#pragma warning restore SYSLIB0050

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CalendarBinarySerializationContractTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CalendarBinarySerializationContractTest.cs
@@ -1,0 +1,608 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using System.Collections;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Tests.Unit.Impl.Calendar;
+
+/// <summary>
+/// Pins the ISerializable shape of the calendar family — the binary contract for <c>CALENDARS</c>
+/// blobs written by 1.x, 2.x and 3.x, which the binary-to-JSON migration path reads. BinaryFormatter
+/// itself is gone from net10, so these tests drive the plumbing directly with hand-built
+/// <see cref="SerializationInfo" /> and the non-public serialization constructors; a change that
+/// breaks them breaks the ability to load stored calendars.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The historical layouts are reconstructed here rather than read from stored <c>.ser</c> fixtures:
+/// the repository keeps none, and a hand-built <see cref="SerializationInfo" /> states the entry
+/// names and payload types a formatter would have written far more legibly than an opaque blob. The
+/// current-format fixtures are generated from the current code by the round-trip tests, each of
+/// which writes with <c>GetObjectData</c> and reads the result back through the serialization
+/// constructor.
+/// </para>
+/// <para>
+/// Two version numbers are in play in every payload. <c>baseCalendarVersion</c> belongs to
+/// <see cref="BaseCalendar" /> and <c>version</c> to the subclass, and they moved independently —
+/// which is why each subclass writes a version of its own even when the base did not change.
+/// </para>
+/// </remarks>
+#pragma warning disable SYSLIB0050 // SerializationInfo/FormatterConverter are obsolete, which is the point: this exercises the legacy contract
+public class CalendarBinarySerializationContractTest
+{
+    private static readonly Type[] calendarFamily =
+    [
+        typeof(BaseCalendar),
+        typeof(AnnualCalendar),
+        typeof(CronCalendar),
+        typeof(DailyCalendar),
+        typeof(HolidayCalendar),
+        typeof(MonthlyCalendar),
+        typeof(WeeklyCalendar)
+    ];
+
+    [TestCaseSource(nameof(calendarFamily))]
+    public void EveryCalendarCarriesSerializableAttributeAndASerializationConstructor(Type calendarType)
+    {
+        calendarType.IsSerializable.Should().BeTrue("BinaryFormatter-written blobs record the type as serializable");
+
+        SerializationConstructor(calendarType).Should().NotBeNull(
+            "the (SerializationInfo, StreamingContext) constructor is what a formatter-style reader invokes");
+
+        typeof(ISerializable).IsAssignableFrom(calendarType).Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // BaseCalendar — the entries every calendar in the family carries
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public void BaseCalendarWritesTheFourEntriesTheBlobFormatHasAlwaysHad()
+    {
+        BaseCalendar calendar = new BaseCalendar(TimeZoneInfo.Utc) { Description = "business hours" };
+
+        Dictionary<string, object?> entries = Write(calendar);
+
+        entries.Keys.Should().BeEquivalentTo(["baseCalendarVersion", "baseCalendar", "description", "timeZoneId"],
+            "readers of stored calendars look these entries up by exactly these names");
+
+        entries["baseCalendarVersion"].Should().Be(1);
+        entries["baseCalendar"].Should().BeNull();
+        entries["description"].Should().Be("business hours");
+        entries["timeZoneId"].Should().Be("UTC",
+            "the zone travels as its id, never as a TimeZoneInfo — Windows and IANA ids differ and a "
+            + "serialized TimeZoneInfo does not survive the crossing");
+    }
+
+    [Test]
+    public void BaseCalendarWritesNoTimeZoneIdWhenNoZoneWasChosen()
+    {
+        Dictionary<string, object?> entries = Write(new BaseCalendar());
+
+        entries["timeZoneId"].Should().BeNull(
+            "unlike CronExpression, a calendar does not pin the writing machine's local zone; it stays "
+            + "unset and resolves to the reading machine's local zone");
+    }
+
+    [Test]
+    public void BaseCalendarRoundTripsThroughItsOwnSerializationPlumbing()
+    {
+        BaseCalendar chained = new BaseCalendar(TimeZoneInfo.Utc) { Description = "weekends" };
+        BaseCalendar original = new BaseCalendar(chained, TimeZoneInfo.Utc) { Description = "holidays" };
+
+        BaseCalendar deserialized = RoundTrip(original);
+
+        deserialized.Description.Should().Be("holidays");
+        deserialized.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        deserialized.CalendarBase.Should().BeOfType<BaseCalendar>()
+            .Which.Description.Should().Be("weekends", "a chained calendar travels inside its parent's payload");
+    }
+
+    [Test]
+    public void BaseCalendarReadsTheVersion0LayoutWithTheTimeZoneAsAnObject()
+    {
+        // The 1.x-era shape: no baseCalendarVersion entry, and the zone as a serialized TimeZoneInfo.
+        SerializationInfo info = CreateInfo(typeof(BaseCalendar));
+        info.AddValue("timeZone", TimeZoneInfo.Utc);
+        info.AddValue("baseCalendar", null, typeof(ICalendar));
+        info.AddValue("description", "legacy");
+
+        BaseCalendar deserialized = (BaseCalendar) Read(typeof(BaseCalendar), info);
+
+        deserialized.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        deserialized.Description.Should().Be("legacy");
+    }
+
+    [Test]
+    public void BaseCalendarReadsThePre20LayoutWithBaseClassQualifiedEntryNames()
+    {
+        // The oldest shape: the base class's fields were serialized under a 'BaseCalendar+' prefix by
+        // field-based serialization of the subclass, so nothing is present under the bare names.
+        SerializationInfo info = CreateInfo(typeof(BaseCalendar));
+        info.AddValue("BaseCalendar+timeZone", TimeZoneInfo.Utc);
+        info.AddValue("BaseCalendar+baseCalendar", null, typeof(ICalendar));
+        info.AddValue("BaseCalendar+description", "prefixed");
+
+        BaseCalendar deserialized = (BaseCalendar) Read(typeof(BaseCalendar), info);
+
+        deserialized.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        deserialized.Description.Should().Be("prefixed",
+            "the absence of an unqualified 'description' entry is what selects the prefixed layout");
+    }
+
+    [Test]
+    public void BaseCalendarReadsTheVersion1LayoutByTimeZoneId()
+    {
+        SerializationInfo info = BaseEntries(timeZoneId: "Eastern Standard Time", description: "stored");
+
+        BaseCalendar deserialized = (BaseCalendar) Read(typeof(BaseCalendar), info);
+
+        deserialized.TimeZone.Should().Be(TimeZones.FindById("Eastern Standard Time"),
+            "the id is resolved through TimeZones.FindById, which is what makes a blob written on "
+            + "Windows readable on Linux");
+        deserialized.Description.Should().Be("stored");
+    }
+
+    [Test]
+    public void BaseCalendarRejectsAnUnknownVersion()
+    {
+        SerializationInfo info = CreateInfo(typeof(BaseCalendar));
+        info.AddValue("baseCalendarVersion", 2);
+        info.AddValue("timeZoneId", "UTC");
+        info.AddValue("baseCalendar", null, typeof(ICalendar));
+        info.AddValue("description", null, typeof(string));
+
+        Action act = () => Read(typeof(BaseCalendar), info);
+
+        act.Should().Throw<TargetInvocationException>()
+            .WithInnerException<NotSupportedException>()
+            .WithMessage("*Unknown serialization version*");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // AnnualCalendar — three payload shapes for the excluded days
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public void AnnualCalendarWritesTheVersion2LayoutPinnedToALeapYear()
+    {
+        AnnualCalendar calendar = new AnnualCalendar();
+        calendar.AddExcludedDay(new MonthDay(2, 29));
+        calendar.AddExcludedDay(new MonthDay(12, 25));
+
+        Dictionary<string, object?> entries = Write(calendar);
+
+        entries["version"].Should().Be(2);
+        entries["excludeDays"].Should().BeOfType<SortedSet<DateTime>>(
+            "the payload entry must serialize as SortedSet<DateTime>; a different backing type emits a "
+            + "type record older readers reject");
+
+        ((SortedSet<DateTime>) entries["excludeDays"]!).Should().BeEquivalentTo(
+            [new DateTime(2000, 2, 29), new DateTime(2000, 12, 25)],
+            "the dates are pinned to a leap year so that February 29th survives the round-trip");
+    }
+
+    [Test]
+    public void AnnualCalendarRoundTripsThroughItsOwnSerializationPlumbing()
+    {
+        AnnualCalendar original = new AnnualCalendar();
+        original.AddExcludedDay(new MonthDay(2, 29));
+        original.AddExcludedDay(new MonthDay(7, 4));
+
+        RoundTrip(original).DaysExcluded.Should().BeEquivalentTo([new MonthDay(2, 29), new MonthDay(7, 4)]);
+    }
+
+    [Test]
+    public void AnnualCalendarReadsTheVersion0ArrayListLayout()
+    {
+        // The 1.x shape: no version entry and an ArrayList of DateTime.
+        SerializationInfo info = BaseEntries();
+        info.AddValue("excludeDays", new ArrayList { new DateTime(2005, 7, 4), new DateTime(2005, 12, 25) });
+
+        AnnualCalendar deserialized = (AnnualCalendar) Read(typeof(AnnualCalendar), info);
+
+        deserialized.DaysExcluded.Should().BeEquivalentTo([new MonthDay(7, 4), new MonthDay(12, 25)],
+            "only the month and day were ever meaningful, whatever year the stored value carried");
+    }
+
+    [Test]
+    public void AnnualCalendarReadsTheVersion0DateTimeOffsetLayout()
+    {
+        // The same version number covered a second shape, written after the list became generic.
+        SerializationInfo info = BaseEntries();
+        info.AddValue(
+            "excludeDays",
+            new List<DateTimeOffset> { new DateTimeOffset(2005, 7, 4, 0, 0, 0, TimeSpan.Zero) },
+            typeof(object));
+
+        AnnualCalendar deserialized = (AnnualCalendar) Read(typeof(AnnualCalendar), info);
+
+        deserialized.DaysExcluded.Should().BeEquivalentTo([new MonthDay(7, 4)]);
+    }
+
+    [Test]
+    public void AnnualCalendarReadsTheVersion1DateTimeOffsetLayout()
+    {
+        SerializationInfo info = BaseEntries();
+        info.AddValue("version", 1);
+        info.AddValue("excludeDays", new List<DateTimeOffset> { new DateTimeOffset(2005, 12, 25, 0, 0, 0, TimeSpan.Zero) });
+
+        AnnualCalendar deserialized = (AnnualCalendar) Read(typeof(AnnualCalendar), info);
+
+        deserialized.DaysExcluded.Should().BeEquivalentTo([new MonthDay(12, 25)]);
+    }
+
+    [Test]
+    public void AnnualCalendarReadsTheVersion2SortedSetLayout()
+    {
+        SerializationInfo info = BaseEntries();
+        info.AddValue("version", 2);
+        info.AddValue("excludeDays", new SortedSet<DateTime> { new DateTime(2000, 2, 29) });
+
+        AnnualCalendar deserialized = (AnnualCalendar) Read(typeof(AnnualCalendar), info);
+
+        deserialized.DaysExcluded.Should().BeEquivalentTo([new MonthDay(2, 29)]);
+    }
+
+    [Test]
+    public void AnnualCalendarRejectsAnUnknownVersion()
+    {
+        SerializationInfo info = BaseEntries();
+        info.AddValue("version", 3);
+        info.AddValue("excludeDays", new SortedSet<DateTime>());
+
+        Action act = () => Read(typeof(AnnualCalendar), info);
+
+        act.Should().Throw<TargetInvocationException>()
+            .WithInnerException<NotSupportedException>()
+            .WithMessage("*Unknown serialization version*");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // DailyCalendar — the eight-integer time range
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public void DailyCalendarWritesTheEightIntegerRangeLayout()
+    {
+        DailyCalendar calendar = new DailyCalendar(new TimeOnly(1, 20, 1, 456), new TimeOnly(14, 50, 15, 2))
+        {
+            InvertTimeRange = true
+        };
+
+        Dictionary<string, object?> entries = Write(calendar);
+
+        entries["version"].Should().Be(1);
+        entries.Should().Contain(new Dictionary<string, object?>
+        {
+            ["rangeStartingHourOfDay"] = 1,
+            ["rangeStartingMinute"] = 20,
+            ["rangeStartingSecond"] = 1,
+            ["rangeStartingMillis"] = 456,
+            ["rangeEndingHourOfDay"] = 14,
+            ["rangeEndingMinute"] = 50,
+            ["rangeEndingSecond"] = 15,
+            ["rangeEndingMillis"] = 2,
+            ["invertTimeRange"] = true
+        }, "the range has always been eight separate integers, not a TimeOnly pair");
+    }
+
+    [Test]
+    public void DailyCalendarRoundTripsThroughItsOwnSerializationPlumbing()
+    {
+        DailyCalendar original = new DailyCalendar(new TimeOnly(8, 0, 0, 500), new TimeOnly(17, 30, 15, 250))
+        {
+            InvertTimeRange = true
+        };
+
+        DailyCalendar deserialized = RoundTrip(original);
+
+        deserialized.TimeRange.Should().Be(new TimeRange(new TimeOnly(8, 0, 0, 500), new TimeOnly(17, 30, 15, 250)),
+            "the millisecond is the finest resolution the serialized form carries, and it must survive");
+        deserialized.InvertTimeRange.Should().BeTrue();
+    }
+
+    [TestCase(null, TestName = "DailyCalendarReadsTheEightIntegerLayout(version 0)")]
+    [TestCase(1, TestName = "DailyCalendarReadsTheEightIntegerLayout(version 1)")]
+    public void DailyCalendarReadsTheEightIntegerLayout(int? version)
+    {
+        SerializationInfo info = BaseEntries();
+        if (version is not null)
+        {
+            info.AddValue("version", version.Value);
+        }
+
+        info.AddValue("rangeStartingHourOfDay", 8);
+        info.AddValue("rangeStartingMinute", 15);
+        info.AddValue("rangeStartingSecond", 30);
+        info.AddValue("rangeStartingMillis", 125);
+        info.AddValue("rangeEndingHourOfDay", 17);
+        info.AddValue("rangeEndingMinute", 45);
+        info.AddValue("rangeEndingSecond", 0);
+        info.AddValue("rangeEndingMillis", 0);
+        info.AddValue("invertTimeRange", false);
+
+        DailyCalendar deserialized = (DailyCalendar) Read(typeof(DailyCalendar), info);
+
+        deserialized.TimeRange.Should().Be(new TimeRange(new TimeOnly(8, 15, 30, 125), new TimeOnly(17, 45)));
+        deserialized.InvertTimeRange.Should().BeFalse();
+    }
+
+    [Test]
+    public void DailyCalendarRejectsAnUnknownVersion()
+    {
+        SerializationInfo info = BaseEntries();
+        info.AddValue("version", 2);
+
+        Action act = () => Read(typeof(DailyCalendar), info);
+
+        act.Should().Throw<TargetInvocationException>()
+            .WithInnerException<NotSupportedException>()
+            .WithMessage("*Unknown serialization version*");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // HolidayCalendar — the one calendar that refuses its own oldest payloads
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public void HolidayCalendarWritesTheVersion2DateTimeArrayLayout()
+    {
+        HolidayCalendar calendar = new HolidayCalendar();
+        calendar.AddExcludedDay(new DateOnly(2026, 12, 25));
+
+        Dictionary<string, object?> entries = Write(calendar);
+
+        entries["version"].Should().Be(2);
+        entries["dates"].Should().BeOfType<DateTime[]>(
+            "the payload entry must serialize as DateTime[]; a different backing type emits a type "
+            + "record older readers reject");
+
+        ((DateTime[]) entries["dates"]!).Should().Equal([new DateTime(2026, 12, 25)]);
+    }
+
+    [Test]
+    public void HolidayCalendarRoundTripsThroughItsOwnSerializationPlumbing()
+    {
+        HolidayCalendar original = new HolidayCalendar();
+        original.AddExcludedDay(new DateOnly(2026, 12, 25));
+        original.AddExcludedDay(new DateOnly(2027, 1, 1));
+
+        RoundTrip(original).DaysExcluded.Should().BeEquivalentTo(
+            [new DateOnly(2026, 12, 25), new DateOnly(2027, 1, 1)]);
+    }
+
+    [Test]
+    public void HolidayCalendarReadsTheVersion2DateTimeArrayLayout()
+    {
+        SerializationInfo info = BaseEntries();
+        info.AddValue("version", 2);
+        info.AddValue("dates", new[] { new DateTime(2026, 12, 25) });
+
+        HolidayCalendar deserialized = (HolidayCalendar) Read(typeof(HolidayCalendar), info);
+
+        deserialized.DaysExcluded.Should().BeEquivalentTo([new DateOnly(2026, 12, 25)]);
+    }
+
+    [TestCase(null, TestName = "HolidayCalendarRefusesItsPre2xPayloads(version 0)")]
+    [TestCase(1, TestName = "HolidayCalendarRefusesItsPre2xPayloads(version 1)")]
+    public void HolidayCalendarRefusesItsPre2xPayloads(int? version)
+    {
+        SerializationInfo info = BaseEntries();
+        if (version is not null)
+        {
+            info.AddValue("version", version.Value);
+        }
+
+        Action act = () => Read(typeof(HolidayCalendar), info);
+
+        act.Should().Throw<TargetInvocationException>()
+            .WithInnerException<NotSupportedException>()
+            .WithMessage("*use latest Quartz 2.x version to re-serialize*",
+                "the advice names the way out, because the payload genuinely cannot be read here");
+    }
+
+    [Test]
+    public void HolidayCalendarRejectsAnUnknownVersion()
+    {
+        SerializationInfo info = BaseEntries();
+        info.AddValue("version", 3);
+        info.AddValue("dates", Array.Empty<DateTime>());
+
+        Action act = () => Read(typeof(HolidayCalendar), info);
+
+        act.Should().Throw<TargetInvocationException>()
+            .WithInnerException<NotSupportedException>()
+            .WithMessage("*Unknown serialization version*");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // The remaining family members: bool-array day masks, and a nested CronExpression
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public void MonthlyCalendarWritesTheBoolArrayDayMask()
+    {
+        MonthlyCalendar calendar = new MonthlyCalendar();
+        calendar.AddExcludedDay(1);
+        calendar.AddExcludedDay(31);
+
+        Dictionary<string, object?> entries = Write(calendar);
+
+        entries["version"].Should().Be(1);
+        entries["excludeAll"].Should().Be(false);
+
+        bool[] mask = entries["excludeDays"].Should().BeOfType<bool[]>().Subject;
+        mask.Should().HaveCount(31, "the mask is indexed by day-of-month minus one and always covers 31 days");
+        mask[0].Should().BeTrue();
+        mask[30].Should().BeTrue();
+        mask[15].Should().BeFalse();
+    }
+
+    [TestCase(null, TestName = "MonthlyCalendarReadsTheBoolArrayDayMask(version 0)")]
+    [TestCase(1, TestName = "MonthlyCalendarReadsTheBoolArrayDayMask(version 1)")]
+    public void MonthlyCalendarReadsTheBoolArrayDayMask(int? version)
+    {
+        bool[] mask = new bool[31];
+        mask[0] = true;
+        mask[30] = true;
+
+        SerializationInfo info = BaseEntries();
+        if (version is not null)
+        {
+            info.AddValue("version", version.Value);
+        }
+
+        info.AddValue("excludeDays", mask);
+        info.AddValue("excludeAll", false);
+
+        MonthlyCalendar deserialized = (MonthlyCalendar) Read(typeof(MonthlyCalendar), info);
+
+        deserialized.DaysExcluded.Should().BeEquivalentTo([1, 31]);
+    }
+
+    [Test]
+    public void WeeklyCalendarWritesTheBoolArrayDayMask()
+    {
+        WeeklyCalendar calendar = new WeeklyCalendar();
+
+        Dictionary<string, object?> entries = Write(calendar);
+
+        entries["version"].Should().Be(1);
+        entries["excludeAll"].Should().Be(false);
+
+        bool[] mask = entries["excludeDays"].Should().BeOfType<bool[]>().Subject;
+        mask.Should().HaveCount(7, "the mask is indexed by DayOfWeek, Sunday first");
+        mask[(int) DayOfWeek.Saturday].Should().BeTrue("a new WeeklyCalendar excludes the weekend");
+        mask[(int) DayOfWeek.Sunday].Should().BeTrue();
+        mask[(int) DayOfWeek.Wednesday].Should().BeFalse();
+    }
+
+    [TestCase(null, TestName = "WeeklyCalendarReadsTheBoolArrayDayMask(version 0)")]
+    [TestCase(1, TestName = "WeeklyCalendarReadsTheBoolArrayDayMask(version 1)")]
+    public void WeeklyCalendarReadsTheBoolArrayDayMask(int? version)
+    {
+        bool[] mask = new bool[7];
+        mask[(int) DayOfWeek.Monday] = true;
+
+        SerializationInfo info = BaseEntries();
+        if (version is not null)
+        {
+            info.AddValue("version", version.Value);
+        }
+
+        info.AddValue("excludeDays", mask);
+        info.AddValue("excludeAll", false);
+
+        WeeklyCalendar deserialized = (WeeklyCalendar) Read(typeof(WeeklyCalendar), info);
+
+        deserialized.DaysExcluded.Should().BeEquivalentTo([DayOfWeek.Monday],
+            "the stored mask replaces the weekend default rather than adding to it");
+    }
+
+    [Test]
+    public void CronCalendarWritesTheNestedCronExpression()
+    {
+        CronCalendar calendar = new CronCalendar(null, "* * 0-7,18-23 ? * *") { TimeZone = TimeZoneInfo.Utc };
+
+        Dictionary<string, object?> entries = Write(calendar);
+
+        entries["version"].Should().Be(1);
+        entries["cronExpression"].Should().BeOfType<CronExpression>(
+            "the expression is nested as an object, so CronExpression's own ISerializable contract is "
+            + "part of this calendar's blob format");
+    }
+
+    [Test]
+    public void CronCalendarRoundTripsThroughItsOwnSerializationPlumbing()
+    {
+        // The zone goes on through the property rather than the constructor: CronCalendar reads its
+        // zone off the nested expression, and only the setter rebuilds the expression with it.
+        CronCalendar original = new CronCalendar(null, "* * 0-7,18-23 ? * *") { TimeZone = TimeZoneInfo.Utc };
+
+        CronCalendar deserialized = RoundTrip(original);
+
+        deserialized.CronExpression.CronExpressionString.Should().Be("* * 0-7,18-23 ? * *");
+        deserialized.TimeZone.Should().Be(TimeZoneInfo.Utc);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The <see cref="BaseCalendar" /> half of a payload, in the version 1 layout every subclass
+    /// test builds on. Subclass entries are added on top by the caller.
+    /// </summary>
+    private static SerializationInfo BaseEntries(string? timeZoneId = "UTC", string? description = null)
+    {
+        SerializationInfo info = CreateInfo(typeof(BaseCalendar));
+        info.AddValue("baseCalendarVersion", 1);
+        info.AddValue("timeZoneId", timeZoneId, typeof(string));
+        info.AddValue("baseCalendar", null, typeof(ICalendar));
+        info.AddValue("description", description, typeof(string));
+        return info;
+    }
+
+    private static SerializationInfo CreateInfo(Type type)
+    {
+        return new SerializationInfo(type, new FormatterConverter());
+    }
+
+    private static Dictionary<string, object?> Write(BaseCalendar calendar)
+    {
+        SerializationInfo info = CreateInfo(calendar.GetType());
+        ((ISerializable) calendar).GetObjectData(info, default);
+
+        Dictionary<string, object?> entries = new Dictionary<string, object?>();
+        SerializationInfoEnumerator enumerator = info.GetEnumerator();
+        while (enumerator.MoveNext())
+        {
+            entries[enumerator.Name] = enumerator.Value;
+        }
+
+        return entries;
+    }
+
+    private static T RoundTrip<T>(T calendar) where T : BaseCalendar
+    {
+        SerializationInfo info = CreateInfo(typeof(T));
+        ((ISerializable) calendar).GetObjectData(info, default);
+        return (T) Read(typeof(T), info);
+    }
+
+    private static ConstructorInfo SerializationConstructor(Type calendarType)
+    {
+        return calendarType.GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            [typeof(SerializationInfo), typeof(StreamingContext)])!;
+    }
+
+    private static object Read(Type calendarType, SerializationInfo info)
+    {
+        return SerializationConstructor(calendarType).Invoke([info, default(StreamingContext)]);
+    }
+}
+#pragma warning restore SYSLIB0050

--- a/src/Quartz.Tests.Unit/SerializationTestSupport.cs
+++ b/src/Quartz.Tests.Unit/SerializationTestSupport.cs
@@ -68,10 +68,17 @@ public abstract class SerializationTestSupport<T, TInterface> where T : class wh
     }
 
     /// <summary>
-    /// Use this method in the future to generate other versions of
-    /// of the serialized object file.
+    /// Writes a <c>.ser</c> file holding the current serialized form of the target object, for use as
+    /// a fixture by a future version reading it back.
     /// </summary>
+    /// <remarks>
+    /// Explicit because it is a tool, not a test: it asserts nothing, and left runnable it wrote a file
+    /// into the test working directory on every build — once per fixture per serializer — while
+    /// reporting a pass whatever it produced. Run it on purpose (by name, or with
+    /// <c>--filter "Name=WriteJobDataFile"</c>) when a baseline is actually wanted.
+    /// </remarks>
     [Test]
+    [Explicit("baseline generator")]
     public void WriteJobDataFile()
     {
         Assembly asm = GetType().Assembly;

--- a/src/Quartz/Configuration/LegacyPropertyKeys.cs
+++ b/src/Quartz/Configuration/LegacyPropertyKeys.cs
@@ -94,7 +94,12 @@ internal static class LegacyPropertyKeys
     /// <summary>
     /// The key prefixes a scheduler understands, used to reject a misspelled one.
     /// </summary>
-    private static readonly string[] supportedKeys =
+    /// <remarks>
+    /// Internal rather than private so that the completeness test can read it: rejecting an unknown key
+    /// is only safe while this list covers every key some reader still consults, and that is a property
+    /// of the pair rather than of either list on its own.
+    /// </remarks>
+    internal static readonly string[] supportedKeys =
     [
         SchedulerInstanceName,
         SchedulerInstanceId,
@@ -125,10 +130,16 @@ internal static class LegacyPropertyKeys
     /// Keys Quartz used to read, and what to do instead.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Reported by name rather than as merely unknown: a configuration that still carries one of these
     /// was configuring something real, and "unknown property" reads like a typo.
+    /// </para>
+    /// <para>
+    /// Internal rather than private for the same reason as <see cref="supportedKeys" />: no key listed
+    /// here may still be one a reader consults, and only a test that sees both lists can say so.
+    /// </para>
     /// </remarks>
-    private static readonly (string Prefix, string Advice)[] removedKeys =
+    internal static readonly (string Prefix, string Advice)[] removedKeys =
     [
         ("quartz.scheduler.proxy",
             "Remoting a scheduler is not supported on modern .NET. Talk to a remote scheduler over HTTP "


### PR DESCRIPTION
Test-hardening PRs 9 and 10 from the funded workstream, as one branch.

## Binary serialization contracts (+59 tests)

The repo kept ZERO .ser fixtures — `SerializationTestSupport.WriteJobDataFile` wrote them but nothing ever committed or read one (it is now `[Explicit("baseline generator")]`, retiring 20 assertion-free "tests"). Following the JobDataMap contract-test model, historical layouts are reconstructed as hand-built `SerializationInfo` with the entry names in the open:

- **CronExpression**: the three written entries, both historical read paths (v0 serialized-TimeZoneInfo and v1 id-based), unknown-version rejection — and a 10-expression × 25-fire-time behavioral comparison across the round trip, because all parse state is `[NonSerialized]` and only re-parsing rebuilds it.
- **All seven calendars**: BaseCalendar's three read layouts including the pre-2.0 nested-class-qualified one; AnnualCalendar's three payload generations (`ArrayList`, `List<DateTimeOffset>`, `SortedSet<DateTime>`) with the leap-year pin; DailyCalendar's eight-integer range; HolidayCalendar's deliberate refusal of pre-2.x payloads; the day-mask arrays; CronCalendar's nested expression.

## The convention guards the spec promised (+97 tests)

- **OptionsConventionTest**: reflects over all 13 exported `*Options` types and encodes the S6 rules — group membership discovered the way S6 defines it (parameter-of-a-public-member ⇒ call-site group), sealed everywhere, group A binder-shaped (no init/required, get-only initialized collections), group B `readonly record struct` init-only never options-bound. Exactly ONE allow-list entry (`DataSourceOptions.DataSourceServiceKey : object` — keyed-service keys are `object` in MS.DI's own contract), with a test that fails the entry the moment it stops being needed. The two S6 clauses that are judgement rather than shape are declared un-encoded in the docs rather than faked.
- **LegacyPropertyKeyExhaustivenessTest**: the key inventory is mechanically extracted by walking the IL of every Quartz.Configuration type (opcode table read off `OpCodes`, `ldstr` resolved against the string heap — consts inline at use sites, so readers are the truth). Proves: every key any reader consults is accepted by `Validate` (what makes "misspelled key throws" safe for 3.x migrations, not a trap), removed keys never overlap live ones and reject WITH their advice, and the 38 documented keys accept / 6 documented-gone keys refuse. Negative-control verified: commenting one key out fails two named tests; a scan-sanity test stops a broken walker from passing vacuously.

Production delta: two `LegacyPropertyKeys` collections `private`→`internal` for the gate; baselines untouched.

Incidental finding recorded, not acted on: `CronCalendar(baseCalendar, expression, timeZone)`'s zone argument never reaches the expression the `TimeZone` property reads — follow-up filed in the campaign notes.

Unit suite 2828 green (net +136), `Compile UnitTest PublishAot` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf