### PR TITLE
The vendored schema baselines are history, not code to analyse

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -78,7 +78,7 @@ jobs:
             /o:"quartznet" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.token="$SONAR_TOKEN" \
-            /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml"
+            /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml"             /d:sonar.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**"             /d:sonar.cpd.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**"
       # Has to sit between begin and end: the scanner analyses through MSBuild, so only projects
       # actually built while it is active are measured.
       - name: 'Run: Compile, UnitTest'


### PR DESCRIPTION
Companion to #3322: its `SchemaBaselines/3.16/` files are byte-identical copies of v3.16.1's table scripts — the migration chain's starting point — and must never be edited, so Sonar's PL/SQL rules (VARCHAR2 advice against Firebird DDL) and the duplication check (six dialects of one schema) have nothing true to say about them. Excludes the path from analysis and duplication in the new CI-based scanner workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf