### PR TITLE
Three calendar and migration follow-ups from the test waves

### DIFF
--- a/build/Build.DatabaseMigrations.Scripts.cs
+++ b/build/Build.DatabaseMigrations.Scripts.cs
@@ -356,12 +356,33 @@ partial class Build
 
     static string Build40Script(string dialect)
     {
+        // Every dialect but SQLite guards its ADD COLUMN, so its script can land on a database that
+        // already took some of the optional 3.x migrations. SQLite has no conditional DDL, so saying
+        // the same thing there was a lie -- it fails on the first column that is already present
+        // (#3322). Sections 1-3 are the unguarded ones; section 4 is guarded on every dialect.
+        string[] supersedes = dialect == "sqlite"
+            ?
+            [
+                "This script supersedes the optional per-feature migrations in ../3.17, ../3.18,",
+                "../3.19 and ../3.20 -- it applies everything they do, and it assumes none of them",
+                "were applied. Run it exactly once, against a database that took none of the optional",
+                "3.x column migrations.",
+                "",
+                "On a partially-migrated database take the stepped route instead -- run the",
+                "per-feature files you are still missing -- or check PRAGMA table_info(<table>) and",
+                "apply only the sections whose columns are absent.",
+            ]
+            :
+            [
+                "This script supersedes the optional per-feature migrations in ../3.17, ../3.18,",
+                "../3.19 and ../3.20 -- it applies everything they do. If you already ran some of",
+                "them, run this anyway: every statement checks first, so it is safe on a",
+                "partially-migrated database.",
+            ];
+
         List<string> extra =
         [
-            "This script supersedes the optional per-feature migrations in ../3.17, ../3.18,",
-            "../3.19 and ../3.20 -- it applies everything they do. If you already ran some of",
-            "them, run this anyway: every statement checks first, so it is safe on a",
-            "partially-migrated database.",
+            .. supersedes,
             "",
             "Sections, in order:",
             "  1. MISFIRE_ORIG_FIRE_TIME column                REQUIRED",
@@ -387,7 +408,8 @@ partial class Build
                 "4.x removed those probes and assumes all four exist, so a 3.x database that never",
                 "ran the optional migrations will fail against 4.x until this script has run.",
             ],
-            extra);
+            extra,
+            sqliteNotIdempotent: true);
 
         string[] sections =
         [

--- a/database/migrations/4.0/schema_30_to_40_upgrade_sqlite.sql
+++ b/database/migrations/4.0/schema_30_to_40_upgrade_sqlite.sql
@@ -13,9 +13,13 @@
 --   ran the optional migrations will fail against 4.x until this script has run.
 --
 -- This script supersedes the optional per-feature migrations in ../3.17, ../3.18,
--- ../3.19 and ../3.20 -- it applies everything they do. If you already ran some of
--- them, run this anyway: every statement checks first, so it is safe on a
--- partially-migrated database.
+-- ../3.19 and ../3.20 -- it applies everything they do, and it assumes none of them
+-- were applied. Run it exactly once, against a database that took none of the optional
+-- 3.x column migrations.
+--
+-- On a partially-migrated database take the stepped route instead -- run the
+-- per-feature files you are still missing -- or check PRAGMA table_info(<table>) and
+-- apply only the sections whose columns are absent.
 --
 -- Sections, in order:
 --   1. MISFIRE_ORIG_FIRE_TIME column                REQUIRED
@@ -27,7 +31,8 @@
 -- already succeeded.
 --
 -- Replace 'QRTZ_' with your configured table prefix if different.
--- Every statement checks first, so this script is safe to run more than once.
+-- NOT IDEMPOTENT: SQLite has no conditional DDL, so re-running this fails with a
+-- duplicate-column error. Check PRAGMA table_info(<table>) before applying.
 --
 -- !! FIRST RUN IN TEST ENVIRONMENT AGAINST A COPY OF YOUR PRODUCTION DATABASE !!
 --

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4933,6 +4933,16 @@ triggers that were already built — and writing `TimeZone` on an expression you
 retimed the builder behind your back. Both are now impossible: the builder reshapes its own copy, and
 already-built triggers keep the zone they were built with.
 
+`CronCalendar` had a defect of its own in the same plumbing:
+`new CronCalendar(baseCalendar, expression, timeZone)` handed the zone to `BaseCalendar` but built the
+expression without it, and `CronCalendar.TimeZone` reads off that expression — so the argument was
+dropped and the calendar excluded the *local* machine's hours while reporting the local zone back
+([#3321](https://github.com/quartznet/quartznet/issues/3321)). The constructor now builds the
+expression with the zone. Assigning `TimeZone` after construction always worked and still does, and
+the stored form is unchanged — the zone has always been persisted with the nested expression, so
+**no migration is needed**. What changes is which times such a calendar excludes: code that passed a
+zone and quietly got local-time exclusions now gets what it asked for.
+
 `CronTriggerImpl.FinalFireTimeUtc` now returns `null` directly for a trigger with no end time, which is the
 value it always produced through `GetFinalFireTime`.
 

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MigrationScriptTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MigrationScriptTest.cs
@@ -46,11 +46,14 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// configured table prefix" instruction each script carries actually works.
 /// </para>
 /// <para>
-/// Two upgrade routes reach 4.0 and both are covered, because the 4.0 script claims to serve both:
-/// <c>QRTZM_</c> takes the stepped route, applying the optional 3.17-3.20 migrations first, so the
-/// 4.0 script lands on a partially-migrated database; <c>QRTZD_</c> takes the direct route, applying
-/// nothing but the mandatory 4.0 script to an untouched 3.16 database. Either way the end state has
-/// to be table-for-table, column-for-column and index-for-index what a fresh install produces.
+/// Two upgrade routes reach 4.0 and both are covered: <c>QRTZM_</c> takes the stepped route,
+/// applying the optional 3.17-3.20 migrations first, so the 4.0 script lands on a partially-migrated
+/// database; <c>QRTZD_</c> takes the direct route, applying nothing but the mandatory 4.0 script to
+/// an untouched 3.16 database. Either way the end state has to be table-for-table, column-for-column
+/// and index-for-index what a fresh install produces. Every dialect but SQLite says in its header
+/// that it serves both routes; SQLite's says the opposite, and the stepped route only reaches 4.0
+/// there because <see cref="SqliteAddColumnAlreadyApplied" /> does by hand what that header tells a
+/// reader to do.
 /// </para>
 /// <para>
 /// Re-runnability is asserted on the stepped route, where every migration is applied twice. SQLite is
@@ -442,9 +445,13 @@ public class MigrationScriptTest
     /// Every other dialect guards its own <c>ADD COLUMN</c>, which is what lets the same migration
     /// run twice, and what lets the 4.0 script land on a database that already took some of the
     /// optional 3.17-3.19 ones. SQLite has no conditional DDL for it, so both of those raise
-    /// "duplicate column name" — a limitation <c>database/README.md</c> records, and the only reason
-    /// this shim exists. It deliberately does nothing else: an unguarded <c>CREATE INDEX</c> would
-    /// still fail the re-run, which is what the second pass is there to catch.
+    /// "duplicate column name" — a limitation <c>database/README.md</c> records and every SQLite
+    /// script's header repeats, the 4.0 upgrade included: it is NOT IDEMPOTENT, and it tells a
+    /// reader whose database is partially migrated to consult <c>PRAGMA table_info</c> and apply
+    /// only the sections whose columns are absent. This shim is that instruction, executed, and it
+    /// is the only reason the stepped and re-run passes get through. It deliberately does nothing
+    /// else: an unguarded <c>CREATE INDEX</c> would still fail the re-run, which is what the second
+    /// pass is there to catch.
     /// </para>
     /// </remarks>
     private static async Task<bool> SqliteAddColumnAlreadyApplied(DbConnection connection, string batch)

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CalendarBinarySerializationContractTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CalendarBinarySerializationContractTest.cs
@@ -540,9 +540,9 @@ public class CalendarBinarySerializationContractTest
     [Test]
     public void CronCalendarRoundTripsThroughItsOwnSerializationPlumbing()
     {
-        // The zone goes on through the property rather than the constructor: CronCalendar reads its
-        // zone off the nested expression, and only the setter rebuilds the expression with it.
-        CronCalendar original = new CronCalendar(null, "* * 0-7,18-23 ? * *") { TimeZone = TimeZoneInfo.Utc };
+        // The zone rides in the nested expression, which is where both the constructor and the
+        // property setter put it — CronCalendar reads TimeZone back off that expression.
+        CronCalendar original = new CronCalendar(null, "* * 0-7,18-23 ? * *", TimeZoneInfo.Utc);
 
         CronCalendar deserialized = RoundTrip(original);
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -105,6 +105,30 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
             "and the New York calendar says the same of the instant it includes");
     }
 
+    /// <summary>
+    /// From an instant the calendar EXCLUDES, the next-included search used to walk forward with
+    /// <see cref="CronExpression.GetNextValidTimeAfter" /> - which by definition lands on another
+    /// satisfied, i.e. excluded, instant - so it crawled the excluded run millisecond by millisecond
+    /// and, with no base calendar to leap it forward, never returned at all. The end of the excluded
+    /// range is <see cref="CronExpression.GetNextInvalidTimeAfter" />, which is what Java's
+    /// CronCalendar always used.
+    /// </summary>
+    [Test]
+    public async Task NextIncludedTimeFromAnExcludedInstantIsTheEndOfTheExcludedRange()
+    {
+        CronCalendar calendar = new CronCalendar(null, "* * 9 ? * *", TimeZoneInfo.Utc);
+        DateTimeOffset insideTheExcludedHour = new DateTimeOffset(2026, 1, 1, 9, 30, 0, TimeSpan.Zero);
+
+        // Through a task with a deadline so a regression fails the test instead of hanging the run.
+        Task<DateTimeOffset> search = Task.Run(() => calendar.GetNextIncludedTimeUtc(insideTheExcludedHour));
+        Task finished = await Task.WhenAny(search, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        finished.Should().BeSameAs(search,
+            "the search must step to the end of the excluded range, not crawl it millisecond by millisecond");
+        (await search).Should().Be(new DateTimeOffset(2026, 1, 1, 10, 0, 0, TimeSpan.Zero),
+            "the first included instant after 09:30 is the top of the next hour, where the expression stops matching");
+    }
+
     protected override CronCalendar GetTargetObject()
     {
         return new CronCalendar("* * 1-3 ? * *")

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -67,6 +67,44 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
         Assert.That(calendar.IsTimeIncluded(dateTime), Is.False);
     }
 
+    /// <summary>
+    /// The three-argument constructor used to hand the zone to <see cref="BaseCalendar" /> and build
+    /// the expression without it, while <see cref="CronCalendar.TimeZone" /> reads the zone back off
+    /// that expression — so the argument was silently dropped and the calendar excluded local hours
+    /// (#3321). Only the property setter rebuilt the expression correctly.
+    /// </summary>
+    [Test]
+    public void ConstructorTimeZoneReachesTheExpression()
+    {
+        // America/New_York, which is a plain UTC-5 in January: no DST corner is in play here.
+        TimeZoneInfo eastern = TestTimeZones.Eastern;
+
+        CronCalendar calendar = new CronCalendar(null, "* * 9 ? * *", eastern);
+
+        calendar.TimeZone.Should().Be(eastern,
+            "the constructor's zone is what the calendar reports, not the machine's local zone");
+        calendar.CronExpression.TimeZone.Should().Be(eastern,
+            "TimeZone reads off the expression, so the expression is where the zone has to land");
+
+        DateTimeOffset nineThirtyEastern = new DateTimeOffset(2026, 1, 1, 14, 30, 0, TimeSpan.Zero);
+        DateTimeOffset fourThirtyEastern = new DateTimeOffset(2026, 1, 1, 9, 30, 0, TimeSpan.Zero);
+
+        calendar.IsTimeIncluded(nineThirtyEastern).Should().BeFalse(
+            "14:30Z is 09:30 in New York, the hour the expression excludes");
+        calendar.IsTimeIncluded(fourThirtyEastern).Should().BeTrue(
+            "09:30Z is 04:30 in New York, well outside the excluded hour");
+
+        // The same expression pinned to UTC reads the two instants the other way round, which is
+        // what makes the assertions above about the zone rather than about the expression.
+        CronCalendar utc = new CronCalendar(null, "* * 9 ? * *", TimeZoneInfo.Utc);
+
+        utc.IsTimeIncluded(fourThirtyEastern).Should().BeFalse("09:30Z is inside the excluded hour in UTC");
+        utc.GetNextIncludedTimeUtc(nineThirtyEastern).Should().Be(nineThirtyEastern.AddMilliseconds(1),
+            "14:30Z is outside the excluded hour in UTC, so the very next instant is included");
+        calendar.GetNextIncludedTimeUtc(fourThirtyEastern).Should().Be(fourThirtyEastern.AddMilliseconds(1),
+            "and the New York calendar says the same of the instant it includes");
+    }
+
     protected override CronCalendar GetTargetObject()
     {
         return new CronCalendar("* * 1-3 ? * *")

--- a/src/Quartz/Impl/Calendar/CronCalendar.cs
+++ b/src/Quartz/Impl/Calendar/CronCalendar.cs
@@ -177,7 +177,10 @@ public sealed class CronCalendar : BaseCalendar, IEquatable<CronCalendar>
             // testing.
             if (cronExpression.IsSatisfiedBy(nextIncludedTime))
             {
-                nextIncludedTime = cronExpression.GetNextValidTimeAfter(nextIncludedTime)!.Value;
+                // The end of the excluded range is the next time the expression does NOT satisfy.
+                // GetNextValidTimeAfter would land on another satisfied - excluded - time, and the
+                // loop would walk the excluded run millisecond by millisecond forever.
+                nextIncludedTime = cronExpression.GetNextInvalidTimeAfter(nextIncludedTime)!.Value;
             }
             else if (CalendarBase is not null &&
                      !CalendarBase.IsTimeIncluded(nextIncludedTime))

--- a/src/Quartz/Impl/Calendar/CronCalendar.cs
+++ b/src/Quartz/Impl/Calendar/CronCalendar.cs
@@ -85,10 +85,13 @@ public sealed class CronCalendar : BaseCalendar, IEquatable<CronCalendar>
     /// calendar functionality
     /// </param>
     /// <param name="expression">a string representation of the desired cron expression</param>
-    /// <param name="timeZone"></param>
+    /// <param name="timeZone">the time zone the expression's times are resolved in;
+    /// <see langword="null" /> means the system's local time zone</param>
     public CronCalendar(ICalendar? baseCalendar, string expression, TimeZoneInfo? timeZone) : base(baseCalendar, timeZone)
     {
-        cronExpression = new CronExpression(expression);
+        // The zone has to reach the expression: TimeZone reads off it, so building the expression
+        // without the zone would drop the argument on the floor.
+        cronExpression = new CronExpression(expression, timeZone);
     }
 
     /// <summary>


### PR DESCRIPTION
The recorded follow-ups from #3321/#3322, plus one more real bug the fix work surfaced.

1. **The SQLite 4.0 migration header stops lying** (found by #3322): it claimed every statement checks first and the script is re-runnable — its five `ADD COLUMN`s are unguarded, and a 3.17+ database fails with `duplicate column name`. The generator now emits the same `-- NOT IDEMPOTENT` voice the other five SQLite files carry, plus honest run-exactly-once guidance with the stepped-route/PRAGMA alternatives. Only the SQLite file changed (`VerifyMigrations` green); the other five dialects guard their DDL and their headers are true. **Companion 3.x PR keeps `database/migrations/` byte-identical** (SHA-256 verified equal on both branches).
2. **`CronCalendar`'s constructor timezone reaches the expression** (found by #3321): the three-argument constructor handed the zone to `BaseCalendar` but built the expression without it, and `TimeZone` reads off the expression — so the argument was silently dropped. Serialized forms are untouched (the blob always carried the id; 94 serialization tests green, snapshots unchanged).
3. **`GetNextIncludedTimeUtc` steps past the excluded range, not through it** (surfaced writing fix 2's test): it advanced with `GetNextValidTimeAfter`, which by definition lands on another satisfied — excluded — instant, so from an excluded start it crawled millisecond by millisecond and never returned (reproduced: a 15-second non-return). The end of the range is `GetNextInvalidTimeAfter`, which is what Java's CronCalendar always used and what the method's own comment already described. Regression test runs the search under a deadline so a regression fails instead of hanging the suite.

Unit 2842 green, SQLite migration leg 7/7, `VerifyMigrations` + `Compile UnitTest PublishAot` clean on main; 3.x branch verified with its own generator + both-TFM unit suites (1761 + 1750 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf