### PR TITLE
Stop the SQLite 4.0 upgrade claiming it can be re-run

### DIFF
--- a/build/Build.DatabaseMigrations.Scripts.cs
+++ b/build/Build.DatabaseMigrations.Scripts.cs
@@ -356,12 +356,33 @@ partial class Build
 
     static string Build40Script(string dialect)
     {
+        // Every dialect but SQLite guards its ADD COLUMN, so its script can land on a database that
+        // already took some of the optional 3.x migrations. SQLite has no conditional DDL, so saying
+        // the same thing there was a lie -- it fails on the first column that is already present
+        // (#3322). Sections 1-3 are the unguarded ones; section 4 is guarded on every dialect.
+        string[] supersedes = dialect == "sqlite"
+            ?
+            [
+                "This script supersedes the optional per-feature migrations in ../3.17, ../3.18,",
+                "../3.19 and ../3.20 -- it applies everything they do, and it assumes none of them",
+                "were applied. Run it exactly once, against a database that took none of the optional",
+                "3.x column migrations.",
+                "",
+                "On a partially-migrated database take the stepped route instead -- run the",
+                "per-feature files you are still missing -- or check PRAGMA table_info(<table>) and",
+                "apply only the sections whose columns are absent.",
+            ]
+            :
+            [
+                "This script supersedes the optional per-feature migrations in ../3.17, ../3.18,",
+                "../3.19 and ../3.20 -- it applies everything they do. If you already ran some of",
+                "them, run this anyway: every statement checks first, so it is safe on a",
+                "partially-migrated database.",
+            ];
+
         List<string> extra =
         [
-            "This script supersedes the optional per-feature migrations in ../3.17, ../3.18,",
-            "../3.19 and ../3.20 -- it applies everything they do. If you already ran some of",
-            "them, run this anyway: every statement checks first, so it is safe on a",
-            "partially-migrated database.",
+            .. supersedes,
             "",
             "Sections, in order:",
             "  1. MISFIRE_ORIG_FIRE_TIME column                REQUIRED",
@@ -387,7 +408,8 @@ partial class Build
                 "4.x removed those probes and assumes all four exist, so a 3.x database that never",
                 "ran the optional migrations will fail against 4.x until this script has run.",
             ],
-            extra);
+            extra,
+            sqliteNotIdempotent: true);
 
         string[] sections =
         [

--- a/database/migrations/4.0/schema_30_to_40_upgrade_sqlite.sql
+++ b/database/migrations/4.0/schema_30_to_40_upgrade_sqlite.sql
@@ -13,9 +13,13 @@
 --   ran the optional migrations will fail against 4.x until this script has run.
 --
 -- This script supersedes the optional per-feature migrations in ../3.17, ../3.18,
--- ../3.19 and ../3.20 -- it applies everything they do. If you already ran some of
--- them, run this anyway: every statement checks first, so it is safe on a
--- partially-migrated database.
+-- ../3.19 and ../3.20 -- it applies everything they do, and it assumes none of them
+-- were applied. Run it exactly once, against a database that took none of the optional
+-- 3.x column migrations.
+--
+-- On a partially-migrated database take the stepped route instead -- run the
+-- per-feature files you are still missing -- or check PRAGMA table_info(<table>) and
+-- apply only the sections whose columns are absent.
 --
 -- Sections, in order:
 --   1. MISFIRE_ORIG_FIRE_TIME column                REQUIRED
@@ -27,7 +31,8 @@
 -- already succeeded.
 --
 -- Replace 'QRTZ_' with your configured table prefix if different.
--- Every statement checks first, so this script is safe to run more than once.
+-- NOT IDEMPOTENT: SQLite has no conditional DDL, so re-running this fails with a
+-- duplicate-column error. Check PRAGMA table_info(<table>) before applying.
 --
 -- !! FIRST RUN IN TEST ENVIRONMENT AGAINST A COPY OF YOUR PRODUCTION DATABASE !!
 --


### PR DESCRIPTION
Companion to #3325, keeping `database/migrations/` byte-identical across branches per the repo rule: the SQLite 4.0 upgrade header claimed guarded, re-runnable statements while its five `ADD COLUMN`s are unguarded (SQLite has no conditional DDL) — a 3.17+ database fails with `duplicate column name`. The generator now emits the `-- NOT IDEMPOTENT` note the other SQLite files carry plus run-exactly-once guidance. Regenerated output SHA-256-identical to main's (82ff9f8d…).

Generator + `VerifyMigrations` green here; both-TFM unit suites green (net10.0 1761, net472 1750).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf