### PR TITLE
The interrupt monitor reads MaxRunTime however it was stored

### DIFF
--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -286,7 +286,7 @@ q.ScheduleJob<SlowJob>(
         .WithIdentity("slowJob")
         .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true)
         // allow only five seconds for this job, overriding the plugin's default.
-        // the value is milliseconds, and the plugin reads it as a string
+        // the value is milliseconds, and either a number or a string holding one works
         .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "5000"));
 ```
 

--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -209,7 +209,7 @@ IJobDetail job = JobBuilder.Create<SlowJob>()
     .WithIdentity("slowJob")
     .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true)
     // allow only five seconds for this job, overriding default configuration.
-    // the value is milliseconds, and the plugin reads it as a string
+    // the value is milliseconds, and either a number or a string holding one works
     .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "5000")
     .Build();
 ```

--- a/src/Quartz.Plugins/Plugins/Interrupt/JobInterruptMonitorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Interrupt/JobInterruptMonitorPlugin.cs
@@ -81,12 +81,18 @@ public sealed class JobInterruptMonitorPlugin : ITriggerListener, ISchedulerPlug
             {
                 var monitorPlugin = (JobInterruptMonitorPlugin) context.Scheduler.Context[JobInterruptMonitorKey]!;
 
-                // Get the MaxRuntime from MergedJobDataMap if NOT available use MaxRunTime from Plugin Configuration
-                var jobDataDelay = DefaultMaxRunTime;
+                // Get the MaxRuntime from MergedJobDataMap if NOT available use MaxRunTime from Plugin Configuration.
+                // TryGetLong coerces a numeric value and a numeric string alike, so the override takes
+                // effect whether the map holds 5000 or "5000".
+                TimeSpan jobDataDelay = DefaultMaxRunTime;
 
-                if (context.MergedJobDataMap.GetString(JobDataMapKeyMaxRunTime) is not null)
+                if (context.MergedJobDataMap.TryGetLong(JobDataMapKeyMaxRunTime, out long maxRunTimeMilliseconds))
                 {
-                    jobDataDelay = TimeSpan.FromMilliseconds(context.MergedJobDataMap.GetLong(JobDataMapKeyMaxRunTime));
+                    jobDataDelay = TimeSpan.FromMilliseconds(maxRunTimeMilliseconds);
+                }
+                else if (context.MergedJobDataMap.ContainsKey(JobDataMapKeyMaxRunTime))
+                {
+                    logger.LogWarning("Job data map value for {Key} is not a number of milliseconds, using the plugin default of {Delay} instead", JobDataMapKeyMaxRunTime, jobDataDelay);
                 }
 
                 monitorPlugin.ScheduleJobInterruptMonitor(context.FireInstanceId, context.JobDetail.Key, jobDataDelay);

--- a/src/Quartz.Tests.Unit/Plugins/Interrupt/JobInterruptMonitorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/Interrupt/JobInterruptMonitorPluginTest.cs
@@ -135,6 +135,68 @@ public class JobInterruptMonitorPluginTest
         }
     }
 
+    [TestCase(500)]
+    [TestCase(500L)]
+    [TestCase("500")]
+    public async Task ShouldHonourMaxRunTimeStoredAsNumberOrString(object maxRunTime)
+    {
+        // the plugin default is deliberately long: only a MaxRunTime the plugin actually read can interrupt in time
+        IScheduler scheduler = await CreateScheduler("MaxRunTimeAs" + maxRunTime.GetType().Name, defaultMaxRunTimeMilliseconds: 60_000);
+        try
+        {
+            IJobDetail job = CreateAutoInterruptableJob();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("t-typed")
+                .ForJob(job)
+                .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, maxRunTime)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("the execution should start");
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue(
+                $"a MaxRunTime of 500 ms stored as {maxRunTime.GetType().Name} should override the plugin's 60 second default");
+
+            interruptedByTrigger["t-typed"].Should().BeTrue(
+                $"the execution exceeded the 500 ms it was allowed by a {maxRunTime.GetType().Name} MaxRunTime");
+        }
+        finally
+        {
+            gate.Release(10); // unblock any execution still gated so shutdown does not wait on it
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    [Test]
+    public async Task ShouldUsePluginDefaultWhenMaxRunTimeIsAbsent()
+    {
+        IScheduler scheduler = await CreateScheduler("NoMaxRunTime", defaultMaxRunTimeMilliseconds: 500);
+        try
+        {
+            IJobDetail job = CreateAutoInterruptableJob();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("t-default")
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("the execution should start");
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue("the plugin's 500 ms default should interrupt a fire that carries no MaxRunTime");
+
+            interruptedByTrigger["t-default"].Should().BeTrue("a fire with no MaxRunTime of its own is bounded by the plugin default");
+        }
+        finally
+        {
+            gate.Release(10); // unblock any execution still gated so shutdown does not wait on it
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
     private static async Task<IScheduler> CreateScheduler(string name, int defaultMaxRunTimeMilliseconds)
     {
         NameValueCollection config = new NameValueCollection


### PR DESCRIPTION
Found during the PRD2 docs verification: `JobInterruptMonitorPlugin` gated its per-job `MaxRunTime` override on strict `GetString` before reading `GetLong` — so a value stored as a perfectly natural `int`/`long` silently fell back to the plugin default (the same silent-degradation family this campaign keeps finding). The gate is now a single `TryGetLong`, which accepts numbers and numeric strings alike.

One deliberate behavior change: a present-but-non-numeric value used to throw `InvalidCastException` out of the trigger listener; it now logs a warning and uses the default — visible instead of fatal.

Tests follow the fixture's real-interrupt pattern and are mutation-verified: with the old gate restored, the int and long cases fail while the string case passes (the regression guard). Docs updated where PRD2 had added the store-it-as-a-string workaround wording.

Unit 2846 green, `Compile UnitTest PublishAot` clean, baselines untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf