### PR TITLE
The migration guide is complete, ordered, and telling the truth

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -18,6 +18,14 @@
     "MD046": {
         "style": "fenced"
     },
+    /* MD051 assumes GitHub's heading-slug algorithm. VuePress renders these docs and
+       slugifies with @mdit-vue/shared, which turns punctuation into a hyphen where GitHub
+       deletes it: "Quartz.Core" -> "quartz-core" (not "quartzcore"), "JobDataMap's" ->
+       "jobdatamap-s", "ScheduleBuilder<T>" -> "schedulebuilder-t". Every anchor MD051
+       reports here is one that resolves on the published site, and the anchors it would
+       accept instead are the ones that 404 there — so the rule is measuring the wrong
+       thing for this repo. Anchors are checked against the real slugifier instead. */
+    "MD051": false,
     "MD059": false, /* link text style - existing docs use short links */
     "MD060": false  /* table column style - existing docs use compact style */
 }

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -87,6 +87,112 @@ style `.config` files.
 If you are running on an older .NET version, you will need to upgrade your application to .NET 10
 before upgrading to Quartz 4.x.
 
+## Package Changes
+
+`Quartz.Extensions.DependencyInjection`, `Quartz.Extensions.Hosting`, and `Quartz.Serialization.SystemTextJson` have been merged into the main `Quartz` package. You can remove these package references from your project:
+
+```diff
+- <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.*" />
+- <PackageReference Include="Quartz.Extensions.Hosting" Version="3.*" />
+- <PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.*" />
++ <PackageReference Include="Quartz" Version="4.*" />
+```
+
+If you use Newtonsoft.Json serialization, reference `Quartz.Serialization.Newtonsoft` instead of the old `Quartz.Serialization.Json`.
+
+Configuration that names a type from one of the merged assemblies as a string keeps working: a name that fails to
+resolve is retried against `Quartz`, with a warning naming both spellings.
+
+`Quartz.OpenTracing` is **dropped** and has no 4.x release. It consumed the `DiagnosticSource` events that
+4.x replaced with `System.Diagnostics.Activity`, and the OpenTracing project itself is archived. Remove the
+package reference and the `AddQuartzOpenTracing` call, and instrument with
+[OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz)
+instead — see [OpenTelemetry Integration](packages/opentelemetry-integration.md#coming-from-quartz-opentracing).
+
+```diff
+- <PackageReference Include="Quartz.OpenTracing" Version="3.*" />
++ <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.*" />
+```
+
+## Documentation pages that moved
+
+The documentation was reorganised alongside the API. The old URLs redirect, so an existing bookmark still
+arrives somewhere useful, but if you keep links to these pages in a wiki or a runbook, retarget them:
+
+| Old URL | Where it is now |
+|---|---|
+| `documentation/quartz-4.x/tutorial/crontrigger.html` | [`cron-expressions.html`](cron-expressions.md) — cron syntax is a reference, not a lesson, so it left the tutorial |
+| `documentation/quartz-4.x/how-tos/crontrigger.html` | [`cron-expressions.html`](cron-expressions.md) — a stale second copy of the same material, deleted |
+| `documentation/quartz-4.x/packages/json-configuration.html` | [`configuration/json.html`](configuration/json.md) — it configures a scheduler rather than describing a package |
+| `documentation/quartz-4.x/packages/opentracing-integration.html` | [`packages/opentelemetry-integration.html`](packages/opentelemetry-integration.md) — the package is gone, as above |
+| `documentation/quartz-4.x/tutorial/miscellaneous-features.html` | [`packages/quartz-plugins.html`](packages/quartz-plugins.md) — the grab-bag was split, and plug-ins were the largest part of it |
+
+The two anchors that were linked from outside the site — `#h-hash-for-load-distribution` and
+`#building-cron-expressions-programmatically` — travelled with the cron material and resolve on
+[Cron Expressions](cron-expressions.md).
+
+## Database Schema Migration
+
+Quartz 4.x requires four columns on `QRTZ_TRIGGERS` (and one on `QRTZ_FIRED_TRIGGERS`) that were
+**optional** in 3.x:
+
+| Column | Table(s) | Optional since |
+|---|---|---|
+| `MISFIRE_ORIG_FIRE_TIME` | `QRTZ_TRIGGERS` | 3.17 |
+| `EXECUTION_GROUP` | `QRTZ_TRIGGERS`, `QRTZ_FIRED_TRIGGERS` | 3.18 |
+| `PREFERRED_NODE` | `QRTZ_TRIGGERS` | 3.19 |
+| `PREFERRED_NODE_AUTO` | `QRTZ_TRIGGERS` | 3.19 |
+
+3.x probed for each of these at startup and disabled the corresponding feature when it was
+missing. **4.x removed those probes** and assumes all of them exist, so this migration is
+mandatory even if you never used misfire reporting, execution groups or node affinity.
+
+::: warning
+Always run migration scripts in a test environment against a copy of your production database first.
+:::
+
+Apply the script for your database from
+[database/migrations/4.0/](https://github.com/quartznet/quartznet/tree/main/database/migrations/4.0) —
+`schema_30_to_40_upgrade_sqlServer.sql`, `_postgres`, `_mysql_innodb`, `_oracle`, `_sqlite` or
+`_firebird`. Every statement checks first, so it is safe to run whether or not you already applied
+the optional 3.x migrations, and safe to run twice.
+
+For SQL Server the column additions look like this:
+
+```sql
+IF COL_LENGTH('QRTZ_TRIGGERS','MISFIRE_ORIG_FIRE_TIME') IS NULL
+BEGIN
+  ALTER TABLE [dbo].[QRTZ_TRIGGERS] ADD [MISFIRE_ORIG_FIRE_TIME] bigint NULL;
+END
+```
+
+Replace `QRTZ_` with your configured table prefix if different.
+
+See [Database Schema Changes](../database/schema-changes.md) for the full version-by-version
+history, including what each optional 3.x migration does and what skipping it costs.
+
+### Listing indexes (optional)
+
+The same script aligns the index set with the statements 4.x issues. Two of the additions matter
+most for the [job and trigger listings](#job-store-listings-became-queries):
+
+| Index | Table and columns |
+|---|---|
+| `IDX_QRTZ_J_G_N` | `QRTZ_JOB_DETAILS(SCHED_NAME, JOB_GROUP, JOB_NAME)` |
+| `IDX_QRTZ_T_G_N` | `QRTZ_TRIGGERS(SCHED_NAME, TRIGGER_GROUP, TRIGGER_NAME)` |
+
+Listings page with `ORDER BY JOB_GROUP, JOB_NAME` and `ORDER BY TRIGGER_GROUP, TRIGGER_NAME`, and the primary
+keys are name-before-group, so no existing index serves those ordered scans. **These are optional** — the
+queries work without them, but each page becomes a scan plus a sort. Add them if you list jobs or triggers
+from a large schema. They are in the fresh-install scripts for every dialect already.
+
+The same section drops indexes that are a leftmost prefix of a wider one, or that no 4.x statement
+can drive a scan from. PostgreSQL gets the largest change: several of its indexes omitted
+`SCHED_NAME`, which is the leading column of every predicate Quartz issues, so they could not serve
+a single-scheduler lookup at all.
+
+Full table creation scripts for fresh installations are available in [database/tables/](https://github.com/quartznet/quartznet/tree/main/database/tables).
+
 ## Configuration
 
 This is the largest change in 4.x. Configuration is now strongly typed options and service
@@ -1520,6 +1626,35 @@ services.Configure<QuartzHealthCheckOptions>("Reporting", options => options.Tag
 `QuartzHealthCheckOptions.Name` is nullable, and left unset the check is named after the scheduler it
 reports on. Assigning a name still overrides that.
 
+## `AddQuartzServer` is `AddQuartzHostedService`
+
+`Quartz.AspNetCore.AddQuartzServer` did two unrelated things behind one name: it registered the
+hosted service that starts the scheduler, and — on frameworks that had them — an ASP.NET Core health
+check. Both are separately available, and the hosted service was never specific to ASP.NET Core, so
+the combined method is gone and each half is called by its own name:
+
+```diff
+  services.AddQuartz(q => { /* ... */ });
+
+- services.AddQuartzServer(options => options.WaitForJobsToComplete = true);
++ services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
++ services.AddQuartzHealthChecks();
+```
+
+`AddQuartzHostedService` lives in the core `Quartz` package, so an application that only wants the
+scheduler started with the host no longer needs `Quartz.AspNetCore` at all — see
+[The hosted service starts every scheduler](#the-hosted-service-starts-every-scheduler) for what it
+now starts, and [The ASP.NET Core methods say Quartz once](#the-asp-net-core-methods-say-quartz-once)
+for the rest of that package.
+
+The health-check overload that took `IEnumerable<string> healthCheckTags` is gone with it; tags are
+`QuartzHealthCheckOptions.Tags`, which is added to rather than assigned:
+
+```diff
+- services.AddQuartzServer(configure, healthCheckTags: ["ready", "live"]);
++ services.AddQuartzHealthChecks(options => options.Tags.AddRange(["ready", "live"]));
+```
+
 ## The OpenAPI calendar schema names the properties the payload actually uses
 
 The HTTP API's endpoints handle `ICalendar`, which OpenAPI cannot describe, so the published document has
@@ -1563,95 +1698,6 @@ services.AddQuartzHttpClient("Quartz ASP.NET Core Sample Scheduler", "QuartzHttp
 
 // or serve one over HTTP: AddQuartzHttpApi + MapQuartzHttpApi, from Quartz.AspNetCore
 ```
-
-## Package Changes
-
-`Quartz.Extensions.DependencyInjection`, `Quartz.Extensions.Hosting`, and `Quartz.Serialization.SystemTextJson` have been merged into the main `Quartz` package. You can remove these package references from your project:
-
-```diff
-- <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.*" />
-- <PackageReference Include="Quartz.Extensions.Hosting" Version="3.*" />
-- <PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.*" />
-+ <PackageReference Include="Quartz" Version="4.*" />
-```
-
-If you use Newtonsoft.Json serialization, reference `Quartz.Serialization.Newtonsoft` instead of the old `Quartz.Serialization.Json`.
-
-Configuration that names a type from one of the merged assemblies as a string keeps working: a name that fails to
-resolve is retried against `Quartz`, with a warning naming both spellings.
-
-`Quartz.OpenTracing` is **dropped** and has no 4.x release. It consumed the `DiagnosticSource` events that
-4.x replaced with `System.Diagnostics.Activity`, and the OpenTracing project itself is archived. Remove the
-package reference and the `AddQuartzOpenTracing` call, and instrument with
-[OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz)
-instead — see [OpenTelemetry Integration](packages/opentelemetry-integration.md#coming-from-quartz-opentracing).
-
-```diff
-- <PackageReference Include="Quartz.OpenTracing" Version="3.*" />
-+ <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.*" />
-```
-
-## Database Schema Migration
-
-Quartz 4.x requires four columns on `QRTZ_TRIGGERS` (and one on `QRTZ_FIRED_TRIGGERS`) that were
-**optional** in 3.x:
-
-| Column | Table(s) | Optional since |
-|---|---|---|
-| `MISFIRE_ORIG_FIRE_TIME` | `QRTZ_TRIGGERS` | 3.17 |
-| `EXECUTION_GROUP` | `QRTZ_TRIGGERS`, `QRTZ_FIRED_TRIGGERS` | 3.18 |
-| `PREFERRED_NODE` | `QRTZ_TRIGGERS` | 3.19 |
-| `PREFERRED_NODE_AUTO` | `QRTZ_TRIGGERS` | 3.19 |
-
-3.x probed for each of these at startup and disabled the corresponding feature when it was
-missing. **4.x removed those probes** and assumes all of them exist, so this migration is
-mandatory even if you never used misfire reporting, execution groups or node affinity.
-
-::: warning
-Always run migration scripts in a test environment against a copy of your production database first.
-:::
-
-Apply the script for your database from
-[database/migrations/4.0/](https://github.com/quartznet/quartznet/tree/main/database/migrations/4.0) —
-`schema_30_to_40_upgrade_sqlServer.sql`, `_postgres`, `_mysql_innodb`, `_oracle`, `_sqlite` or
-`_firebird`. Every statement checks first, so it is safe to run whether or not you already applied
-the optional 3.x migrations, and safe to run twice.
-
-For SQL Server the column additions look like this:
-
-```sql
-IF COL_LENGTH('QRTZ_TRIGGERS','MISFIRE_ORIG_FIRE_TIME') IS NULL
-BEGIN
-  ALTER TABLE [dbo].[QRTZ_TRIGGERS] ADD [MISFIRE_ORIG_FIRE_TIME] bigint NULL;
-END
-```
-
-Replace `QRTZ_` with your configured table prefix if different.
-
-See [Database Schema Changes](../database/schema-changes.md) for the full version-by-version
-history, including what each optional 3.x migration does and what skipping it costs.
-
-### Listing indexes (optional)
-
-The same script aligns the index set with the statements 4.x issues. Two of the additions matter
-most for the [job and trigger listings](#job-store-listings-became-queries):
-
-| Index | Table and columns |
-|---|---|
-| `IDX_QRTZ_J_G_N` | `QRTZ_JOB_DETAILS(SCHED_NAME, JOB_GROUP, JOB_NAME)` |
-| `IDX_QRTZ_T_G_N` | `QRTZ_TRIGGERS(SCHED_NAME, TRIGGER_GROUP, TRIGGER_NAME)` |
-
-Listings page with `ORDER BY JOB_GROUP, JOB_NAME` and `ORDER BY TRIGGER_GROUP, TRIGGER_NAME`, and the primary
-keys are name-before-group, so no existing index serves those ordered scans. **These are optional** — the
-queries work without them, but each page becomes a scan plus a sort. Add them if you list jobs or triggers
-from a large schema. They are in the fresh-install scripts for every dialect already.
-
-The same section drops indexes that are a leftmost prefix of a wider one, or that no 4.x statement
-can drive a scan from. PostgreSQL gets the largest change: several of its indexes omitted
-`SCHED_NAME`, which is the leading column of every predicate Quartz issues, so they could not serve
-a single-scheduler lookup at all.
-
-Full table creation scripts for fresh installations are available in [database/tables/](https://github.com/quartznet/quartznet/tree/main/database/tables).
 
 ## Tasks Changed to ValueTask
 
@@ -1868,6 +1914,33 @@ LogProvider.SetLogProvider(host.Services.GetRequiredService<ILoggerFactory>());
 ```
 
 Further information on configuring Microsoft.Logging can be found [at Microsoft docs](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging).
+
+## The ambient logger factory stays ambient
+
+`LogProvider.SetLogProvider(ILoggerFactory)` is the one piece of mutable process-wide state left in
+Quartz, and it is deliberate rather than overlooked.
+
+Almost everything the scheduler is made of is built by a container and is injected an `ILogger` the
+ordinary way. What is left over cannot be: static classes such as `TimeZones`, types a caller
+constructs directly — triggers, calendars, plugins, the jobs in `Quartz.Jobs` — and anything that
+runs while the container is still being built. A type cannot be handed a logger by a container that
+does not exist yet, so those sites read the ambient factory instead of going unlogged.
+
+Nor is it seeded from the container, which would be the obvious convenience. The slot outlives any
+one container: a process that builds a host, disposes it and builds another — every integration test
+suite, and every application that reloads configuration — would be left holding a disposed
+`ILoggerFactory`, and the next logger created anywhere in Quartz would throw
+`ObjectDisposedException` from somewhere unrelated to logging. Whoever sets the factory owns its
+lifetime, and only the application can make that call. The same applies to a hand-written
+`LogProvider.SetLogProvider(host.Services.GetRequiredService<ILoggerFactory>())`: it is correct as
+long as the host outlives the schedulers.
+
+`TimeZones.AddResolver` is ambient for the same reason. `FindById` is reached from
+parsing a `CronExpression` and from deserializing a trigger out of a job store blob, neither of
+which has a scheduler in scope — which is why installing `Quartz.Plugins.TimeZoneConverter` in one
+scheduler changes id resolution for the whole process, and why each registration is undone by
+disposing it rather than by anyone owning the slot — see
+[`TimeZoneUtil` became `Quartz.TimeZones`](#timezoneutil-became-quartz-timezones).
 
 ## Job execution metrics
 
@@ -2477,6 +2550,123 @@ blobs written by 3.x still load — see
 
 `IsReadOnly` is an explicit interface implementation and cannot be accessed directly on the maps. `IsFixedSize`, `SyncRoot` and `IsSynchronized` are gone with the non-generic interfaces — see [`JobDataMap` dropped the non-generic collection interfaces](#jobdatamap-dropped-the-non-generic-collection-interfaces).
 
+## `JobDataMap` dropped the non-generic collection interfaces
+
+`JobDataMap` and `SchedulerContext` (on 3.x, their `DirtyFlagMap<TKey, TValue>` base) no longer
+implement `System.Collections.IDictionary` or `System.Collections.ICollection`. Those duplicated the
+generic interfaces with untyped members that cast at runtime — `Add(object, object)` and the
+`object` indexer threw `InvalidCastException` for a key of the wrong type instead of
+`ArgumentException` (#1417), and `SyncRoot` handed out a lock object the map never took.
+
+| 3.x | 4.x |
+|---|---|
+| `((IDictionary) map).Add(key, value)` | `map.Add(key, value)` |
+| `((IDictionary) map)[key]` | `map[key]` |
+| `((IDictionary) map).Contains(key)` | `map.ContainsKey(key)` |
+| `((IDictionary) map).Remove(key)` | `map.Remove(key)` |
+| `map.CopyTo(array, index)` (`Array`) | `map.CopyTo(KeyValuePair<string, object?>[], index)` |
+| `new JobDataMap(someIDictionary)` | `new JobDataMap(someIDictionaryOfStringToObject)` |
+
+`ISerializable` is untouched, so persisted maps still load. The generic
+`JobDataMap(IDictionary<string, object?>)` constructor also took over what the removed non-generic one did
+with a `QRTZ_FORCE_JOB_DATAMAP_DIRTY` entry: the entry is not copied, and the new map is left flagged dirty.
+
+The accessor set gained `GetDecimal` and `TryGetDecimal`, so a `decimal` in a job data map can now be
+read back the way every other primitive can.
+
+## `JobDataMap`'s typed accessors are extension members
+
+`JobDataMap` declared sixty typed accessors of its own — `GetIntValue`, `TryGetIntValue`,
+`GetIntValueFromString`, `TryGetIntValueFromString`, and the same four for `bool`, `char`, `double`,
+`float`, `long`, `Guid`, `TimeSpan`, `DateTime` and `DateTimeOffset` — while the
+`StringKeyDirtyFlagMap` it derived from declared a second, shorter set doing the same job. Two names
+for one lookup, differing only in a suffix. The `…Value` set is gone; the shorter set survives as
+extension members in the `Quartz` namespace (declared in `DataMapExtensions`, for both `JobDataMap`
+and `SchedulerContext`), so the call sites read the same:
+
+```diff
+- int retries = context.JobDetail.JobDataMap.GetIntValue("retries");
++ int retries = context.JobDetail.JobDataMap.GetInt("retries");
+
+- if (map.TryGetTimeSpanValue("timeout", out TimeSpan timeout)) { }
++ if (map.TryGetTimeSpan("timeout", out TimeSpan timeout)) { }
+```
+
+| 3.x `JobDataMap` | 4.x extension members |
+|---|---|
+| `GetBooleanValue`, `GetBooleanValueFromString` | `GetBoolean` |
+| `GetCharFromString` | `GetChar` |
+| `GetDateTimeValue`, `GetDateTimeValueFromString` | `GetDateTime` |
+| `GetDateTimeOffsetValue`, `GetDateTimeOffsetValueFromString` | `GetDateTimeOffset` |
+| `GetDoubleValue`, `GetDoubleValueFromString` | `GetDouble` |
+| `GetFloatValue`, `GetFloatValueFromString` | `GetFloat` |
+| `GetGuidValue`, `GetGuidValueFromString` | `GetGuid` |
+| `GetIntValue`, `GetIntValueFromString` | `GetInt` |
+| `GetLongValue`, `GetLongValueFromString` | `GetLong` |
+| `GetTimeSpanValue`, `GetTimeSpanValueFromString` | `GetTimeSpan` |
+| every `TryGet…Value` / `TryGet…ValueFromString` | the matching `TryGet…` |
+| `GetNullableGuidValue` | `TryGetGuid`, or read the entry and test it yourself |
+| (none) | `GetString`, `TryGetString`, `GetDecimal`, `TryGetDecimal` |
+
+The `…FromString` half collapses because the retained accessors already convert: a value written as a
+string — which is what `StoreJobDataAsStrings` forces, and what `PutAsString` writes — is parsed on the way
+out, so one accessor covers both. `GetNullableGuidValue` is the only one without a direct
+replacement; it returned `null` both for "absent" and for "present but not a `Guid`", which
+`TryGetGuid` distinguishes.
+
+`PutAsString`'s eleven overloads are one generic `PutAsString<T>(string key, T value) where T :
+IConvertible`, plus the ones the constraint cannot express (`DateTime`, `DateTimeOffset`,
+`DateOnly`, `TimeOnly`, `Guid`, `TimeSpan`). Call sites are unchanged, with two exceptions
+described below.
+
+The accessor set also grew: `GetDateOnly`/`TryGetDateOnly`, `GetTimeOnly`/`TryGetTimeOnly`,
+`GetEnum<TEnum>`/`TryGetEnum<TEnum>` (an enum written through `PutAsString` stores its name, and
+the reader also accepts the underlying number a JSON round trip can produce), and a generic
+`TryGet<T>` that is a pure type test over the stored object — no string parsing.
+
+### `PutAsString` writes round-trip formats now
+
+`PutAsString(key, dateTimeOffset)` used to write the invariant general form — no fractional
+seconds — and a `DateTime` argument bound to the `IConvertible` overload, which erased sub-second
+precision *and* `DateTimeKind`. Both now write the round-trip ("O") format: what you read back is
+what you stored, to the tick, Kind and offset included. Reading is unaffected for existing data —
+the accessors parse both the old general form and "O" — but two edges are observable:
+
+* **Overload rebinding**: `map.PutAsString(key, someDateTime)` used to bind to the generic
+  `IConvertible` overload and store `"01/02/2026 15:04:05"`; it now binds to the dedicated
+  `DateTime` overload and stores `"2026-01-02T15:04:05.0000000"`. Anything *outside* Quartz that
+  reads `JOB_DATA` strings and expects the old shape sees the new one after the value is next
+  written.
+* **`TryGetDateTime` parses with `DateTimeStyles.RoundtripKind`** — its own behavioral change,
+  independent of what was written: a stored string ending in `Z` used to come back shifted to the
+  reader's local time with `Kind=Local`; it now comes back with the UTC clock reading and
+  `Kind=Utc`. That is the correct reading, but a job computing e.g. `DateTime.Now - map.GetDateTime(key)`
+  on such a value shifts by the local UTC offset. Such `Z` strings exist in real stores — the
+  System.Text.Json serializer writes a boxed UTC `DateTime` as `"…Z"` and hands it back as a raw
+  string.
+
+### `PutAsString<T>` is constrained to `IFormattable`
+
+The generic overload asked for `IConvertible`, the legacy conversion interface, and then only ever
+called its formatting member. It asks for `IFormattable` now, which is what it actually uses. The
+practical effect is a wider set of types, not a narrower one: `Int128`, `Half`, `BigInteger`, `Complex`
+and any formattable type of your own were never `IConvertible` and could not be written this way.
+
+`bool` and `char` are `IConvertible` but not `IFormattable` — neither has anything to format for a
+culture — so they gained dedicated overloads and keep writing exactly what they wrote before
+(`"True"` / `"False"`, and the single character). The six round-trip overloads are unchanged.
+
+`string` is the one type that loses the call: `map.PutAsString(key, someString)` no longer compiles.
+Write `map[key] = someString`, which is what it did.
+
+### `PutAsString(string, Guid?)` is gone
+
+Passing `null` stored a present-but-null entry that nothing could read back — `TryGetGuid`
+returned `false`, `GetGuid` threw, and under `StoreJobDataAsStrings = true` the null was coerced to an
+empty string with the same outcome. An unreadable entry is worse than a missing key, so the
+overload is gone rather than fixed: call `PutAsString(key, value.Value)` when there is a value,
+and decide explicitly — usually `map.Remove(key)` — when there is not.
+
 ## Listener API Changes
 
 The three kinds of listener are managed identically now: a listener is registered under a name, registering the
@@ -2768,7 +2958,10 @@ documentation always promised.
 * **[RecurrenceTrigger (RRULE)](tutorial/recurrencetrigger.md)** — schedule jobs using RFC 5545 recurrence rules for complex patterns like "every 2nd Monday of the month" or "last weekday of March each year"
 * **H (hash) token in cron expressions** — deterministic load distribution across triggers using the trigger identity as seed
 * **HTTP API** — optional REST API for managing the scheduler remotely (see [HTTP API](packages/http-api.md))
+* **`Quartz.HttpClient`** — the other end of that API: `HttpScheduler` is an `IScheduler` that speaks to a remote scheduler over HTTP, which is what replaces .NET Remoting (see [Remoting a scheduler is not a Quartz concern](#remoting-a-scheduler-is-not-a-quartz-concern))
 * **Paged, projected job store queries** — list and count jobs, triggers, groups and calendars a page at a time, with the metadata a listing needs already in the row (see [Job store listings became queries](#job-store-listings-became-queries))
+* **Bulk fetch by key** — `GetJobDetails(keys)` and `GetTriggers(keys)` turn a page of keys into one round trip, over ADO.NET and over HTTP alike (see [Job store listings became queries](#job-store-listings-became-queries))
+* **Fire instances are a listing** — `QueryFireInstances` answers what is running as a paged, projected query that a persistent store answers for the whole cluster, where `GetCurrentlyExecutingJobs` could only speak for this process (see [What is running is a listing, not a list of contexts](#what-is-running-is-a-listing-not-a-list-of-contexts))
 * **Job data by property name** — bind job data to the job property it is meant for instead of spelling its key (see [Job data can name the property](#job-data-can-name-the-property))
 * **`TriggerState.Executing`** — tell whether a trigger's job is running, across the whole cluster (see [Executing is a trigger state](#executing-is-a-trigger-state))
 * **`JobInstantiationException`** — a job that could not be built names the trigger, the job and the fire instance instead of only interpolating the job key into a message (see [Instantiation failures name the trigger](#instantiation-failures-name-the-trigger))
@@ -6027,30 +6220,6 @@ Existing calendar blobs load unchanged. Both serializers write the new shapes an
 `ExcludedDays`/`ExcludedDates` array may hold timestamps or dates, and per-day booleans or day numbers or
 day names.
 
-## `JobDataMap` dropped the non-generic collection interfaces
-
-`JobDataMap` and `SchedulerContext` (on 3.x, their `DirtyFlagMap<TKey, TValue>` base) no longer
-implement `System.Collections.IDictionary` or `System.Collections.ICollection`. Those duplicated the
-generic interfaces with untyped members that cast at runtime — `Add(object, object)` and the
-`object` indexer threw `InvalidCastException` for a key of the wrong type instead of
-`ArgumentException` (#1417), and `SyncRoot` handed out a lock object the map never took.
-
-| 3.x | 4.x |
-|---|---|
-| `((IDictionary) map).Add(key, value)` | `map.Add(key, value)` |
-| `((IDictionary) map)[key]` | `map[key]` |
-| `((IDictionary) map).Contains(key)` | `map.ContainsKey(key)` |
-| `((IDictionary) map).Remove(key)` | `map.Remove(key)` |
-| `map.CopyTo(array, index)` (`Array`) | `map.CopyTo(KeyValuePair<string, object?>[], index)` |
-| `new JobDataMap(someIDictionary)` | `new JobDataMap(someIDictionaryOfStringToObject)` |
-
-`ISerializable` is untouched, so persisted maps still load. The generic
-`JobDataMap(IDictionary<string, object?>)` constructor also took over what the removed non-generic one did
-with a `QRTZ_FORCE_JOB_DATAMAP_DIRTY` entry: the entry is not copied, and the new map is left flagged dirty.
-
-The accessor set gained `GetDecimal` and `TryGetDecimal`, so a `decimal` in a job data map can now be
-read back the way every other primitive can.
-
 ## `[Serializable]` survives only where a database blob needs it
 
 `BinaryFormatter` is obsolete on .NET 8 (SYSLIB0051) and throws on .NET 9 and later, and Quartz 4 ships no
@@ -6267,155 +6436,6 @@ any; whether the job honors the token remains the job's business. A `catch
 (UnableToInterruptJobException)` block can simply be deleted; `HttpScheduler`'s error mapping no
 longer resurrects the type either, so a remote scheduler fault on an interrupt call surfaces as the
 `SchedulerException`-derived type the server actually reported.
-
-## `JobDataMap`'s typed accessors are extension members
-
-`JobDataMap` declared sixty typed accessors of its own — `GetIntValue`, `TryGetIntValue`,
-`GetIntValueFromString`, `TryGetIntValueFromString`, and the same four for `bool`, `char`, `double`,
-`float`, `long`, `Guid`, `TimeSpan`, `DateTime` and `DateTimeOffset` — while the
-`StringKeyDirtyFlagMap` it derived from declared a second, shorter set doing the same job. Two names
-for one lookup, differing only in a suffix. The `…Value` set is gone; the shorter set survives as
-extension members in the `Quartz` namespace (declared in `DataMapExtensions`, for both `JobDataMap`
-and `SchedulerContext`), so the call sites read the same:
-
-```diff
-- int retries = context.JobDetail.JobDataMap.GetIntValue("retries");
-+ int retries = context.JobDetail.JobDataMap.GetInt("retries");
-
-- if (map.TryGetTimeSpanValue("timeout", out TimeSpan timeout)) { }
-+ if (map.TryGetTimeSpan("timeout", out TimeSpan timeout)) { }
-```
-
-| 3.x `JobDataMap` | 4.x extension members |
-|---|---|
-| `GetBooleanValue`, `GetBooleanValueFromString` | `GetBoolean` |
-| `GetCharFromString` | `GetChar` |
-| `GetDateTimeValue`, `GetDateTimeValueFromString` | `GetDateTime` |
-| `GetDateTimeOffsetValue`, `GetDateTimeOffsetValueFromString` | `GetDateTimeOffset` |
-| `GetDoubleValue`, `GetDoubleValueFromString` | `GetDouble` |
-| `GetFloatValue`, `GetFloatValueFromString` | `GetFloat` |
-| `GetGuidValue`, `GetGuidValueFromString` | `GetGuid` |
-| `GetIntValue`, `GetIntValueFromString` | `GetInt` |
-| `GetLongValue`, `GetLongValueFromString` | `GetLong` |
-| `GetTimeSpanValue`, `GetTimeSpanValueFromString` | `GetTimeSpan` |
-| every `TryGet…Value` / `TryGet…ValueFromString` | the matching `TryGet…` |
-| `GetNullableGuidValue` | `TryGetGuid`, or read the entry and test it yourself |
-| (none) | `GetString`, `TryGetString`, `GetDecimal`, `TryGetDecimal` |
-
-The `…FromString` half collapses because the retained accessors already convert: a value written as a
-string — which is what `StoreJobDataAsStrings` forces, and what `PutAsString` writes — is parsed on the way
-out, so one accessor covers both. `GetNullableGuidValue` is the only one without a direct
-replacement; it returned `null` both for "absent" and for "present but not a `Guid`", which
-`TryGetGuid` distinguishes.
-
-`PutAsString`'s eleven overloads are one generic `PutAsString<T>(string key, T value) where T :
-IConvertible`, plus the ones the constraint cannot express (`DateTime`, `DateTimeOffset`,
-`DateOnly`, `TimeOnly`, `Guid`, `TimeSpan`). Call sites are unchanged, with two exceptions
-described below.
-
-The accessor set also grew: `GetDateOnly`/`TryGetDateOnly`, `GetTimeOnly`/`TryGetTimeOnly`,
-`GetEnum<TEnum>`/`TryGetEnum<TEnum>` (an enum written through `PutAsString` stores its name, and
-the reader also accepts the underlying number a JSON round trip can produce), and a generic
-`TryGet<T>` that is a pure type test over the stored object — no string parsing.
-
-### `PutAsString` writes round-trip formats now
-
-`PutAsString(key, dateTimeOffset)` used to write the invariant general form — no fractional
-seconds — and a `DateTime` argument bound to the `IConvertible` overload, which erased sub-second
-precision *and* `DateTimeKind`. Both now write the round-trip ("O") format: what you read back is
-what you stored, to the tick, Kind and offset included. Reading is unaffected for existing data —
-the accessors parse both the old general form and "O" — but two edges are observable:
-
-* **Overload rebinding**: `map.PutAsString(key, someDateTime)` used to bind to the generic
-  `IConvertible` overload and store `"01/02/2026 15:04:05"`; it now binds to the dedicated
-  `DateTime` overload and stores `"2026-01-02T15:04:05.0000000"`. Anything *outside* Quartz that
-  reads `JOB_DATA` strings and expects the old shape sees the new one after the value is next
-  written.
-* **`TryGetDateTime` parses with `DateTimeStyles.RoundtripKind`** — its own behavioral change,
-  independent of what was written: a stored string ending in `Z` used to come back shifted to the
-  reader's local time with `Kind=Local`; it now comes back with the UTC clock reading and
-  `Kind=Utc`. That is the correct reading, but a job computing e.g. `DateTime.Now - map.GetDateTime(key)`
-  on such a value shifts by the local UTC offset. Such `Z` strings exist in real stores — the
-  System.Text.Json serializer writes a boxed UTC `DateTime` as `"…Z"` and hands it back as a raw
-  string.
-
-### `PutAsString<T>` is constrained to `IFormattable`
-
-The generic overload asked for `IConvertible`, the legacy conversion interface, and then only ever
-called its formatting member. It asks for `IFormattable` now, which is what it actually uses. The
-practical effect is a wider set of types, not a narrower one: `Int128`, `Half`, `BigInteger`, `Complex`
-and any formattable type of your own were never `IConvertible` and could not be written this way.
-
-`bool` and `char` are `IConvertible` but not `IFormattable` — neither has anything to format for a
-culture — so they gained dedicated overloads and keep writing exactly what they wrote before
-(`"True"` / `"False"`, and the single character). The six round-trip overloads are unchanged.
-
-`string` is the one type that loses the call: `map.PutAsString(key, someString)` no longer compiles.
-Write `map[key] = someString`, which is what it did.
-
-### `PutAsString(string, Guid?)` is gone
-
-Passing `null` stored a present-but-null entry that nothing could read back — `TryGetGuid`
-returned `false`, `GetGuid` threw, and under `StoreJobDataAsStrings = true` the null was coerced to an
-empty string with the same outcome. An unreadable entry is worse than a missing key, so the
-overload is gone rather than fixed: call `PutAsString(key, value.Value)` when there is a value,
-and decide explicitly — usually `map.Remove(key)` — when there is not.
-
-## `AddQuartzServer` is `AddQuartzHostedService`
-
-`Quartz.AspNetCore.AddQuartzServer` did two unrelated things behind one name: it registered the
-hosted service that starts the scheduler, and — on frameworks that had them — an ASP.NET Core health
-check. Both are separately available, and the hosted service was never specific to ASP.NET Core, so
-the combined method is gone and each half is called by its own name:
-
-```diff
-  services.AddQuartz(q => { /* ... */ });
-
-- services.AddQuartzServer(options => options.WaitForJobsToComplete = true);
-+ services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
-+ services.AddQuartzHealthChecks();
-```
-
-`AddQuartzHostedService` lives in the core `Quartz` package, so an application that only wants the
-scheduler started with the host no longer needs `Quartz.AspNetCore` at all — see
-[The hosted service starts every scheduler](#the-hosted-service-starts-every-scheduler) for what it
-now starts, and [The ASP.NET Core methods say Quartz once](#the-asp-net-core-methods-say-quartz-once)
-for the rest of that package.
-
-The health-check overload that took `IEnumerable<string> healthCheckTags` is gone with it; tags are
-`QuartzHealthCheckOptions.Tags`, which is added to rather than assigned:
-
-```diff
-- services.AddQuartzServer(configure, healthCheckTags: ["ready", "live"]);
-+ services.AddQuartzHealthChecks(options => options.Tags.AddRange(["ready", "live"]));
-```
-
-## The ambient logger factory stays ambient
-
-`LogProvider.SetLogProvider(ILoggerFactory)` is the one piece of mutable process-wide state left in
-Quartz, and it is deliberate rather than overlooked.
-
-Almost everything the scheduler is made of is built by a container and is injected an `ILogger` the
-ordinary way. What is left over cannot be: static classes such as `TimeZones`, types a caller
-constructs directly — triggers, calendars, plugins, the jobs in `Quartz.Jobs` — and anything that
-runs while the container is still being built. A type cannot be handed a logger by a container that
-does not exist yet, so those sites read the ambient factory instead of going unlogged.
-
-Nor is it seeded from the container, which would be the obvious convenience. The slot outlives any
-one container: a process that builds a host, disposes it and builds another — every integration test
-suite, and every application that reloads configuration — would be left holding a disposed
-`ILoggerFactory`, and the next logger created anywhere in Quartz would throw
-`ObjectDisposedException` from somewhere unrelated to logging. Whoever sets the factory owns its
-lifetime, and only the application can make that call. The same applies to a hand-written
-`LogProvider.SetLogProvider(host.Services.GetRequiredService<ILoggerFactory>())`: it is correct as
-long as the host outlives the schedulers.
-
-`TimeZones.AddResolver` is ambient for the same reason. `FindById` is reached from
-parsing a `CronExpression` and from deserializing a trigger out of a job store blob, neither of
-which has a scheduler in scope — which is why installing `Quartz.Plugins.TimeZoneConverter` in one
-scheduler changes id resolution for the whole process, and why each registration is undone by
-disposing it rather than by anyone owning the slot — see
-[`TimeZoneUtil` became `Quartz.TimeZones`](#timezoneutil-became-quartz-timezones).
 
 ## `TimeZoneUtil` became `Quartz.TimeZones`
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -239,7 +239,7 @@ A `NameValueCollection` still goes in unchanged, in one call. It is exactly what
 holds — `StdSchedulerFactory` took one — so both `UseProperties` and `AddQuartz` keep an overload for
 it that forwards to the primary shape.
 
-| Member | 3.x / earlier 4.x | Now |
+| Member | 3.x / earlier 4.0 preview | 4.0 |
 |---|---|---|
 | `QuartzSchedulerBuilder.UseProperties` | `UseProperties(NameValueCollection)` | `UseProperties(IEnumerable<KeyValuePair<string, string?>>)`, plus the `NameValueCollection` overload |
 | `AddQuartz(services, properties, …)` | `NameValueCollection` | `IEnumerable<KeyValuePair<string, string?>>`, plus the `NameValueCollection` overload |
@@ -1583,7 +1583,7 @@ updated; the `Starting`/`Started`/`Stopping`/`Stopped` overrides are unchanged. 
 
 ## The ASP.NET Core methods say Quartz once
 
-| Old | New |
+| Before | After |
 |---|---|
 | `IQuartzBuilder.AddHttpApi(…)` | `AddQuartzHttpApi(…)` |
 | `IEndpointRouteBuilder.MapQuartzApi()` | `MapQuartzHttpApi()` |
@@ -1801,7 +1801,7 @@ means `TimeProvider.System`.
 The times they work in are `DateTimeOffset` rather than local `DateTime`, which is the same instant said
 unambiguously, and is what the rest of the API has spoken since 3.0:
 
-| 3.x / earlier 4.x | 4.0 |
+| 3.x / earlier 4.0 preview | 4.0 |
 |---|---|
 | `protected virtual DateTime FileScanJob.GetLastModifiedDate(string)`, returning `DateTime.MinValue` for a missing file | `protected virtual DateTimeOffset? GetLastModifiedTime(string fileName)`, returning `null` for a missing file |
 | `protected void DirectoryScanJob.GetUpdatedOrNewFiles(string, DateTime, DateTime, IReadOnlyCollection<FileInfo>, out List<FileInfo>, out List<FileInfo>, out List<FileInfo>, string, bool)` | private, along with the `DirectoryScanResult` it returns |
@@ -1878,7 +1878,7 @@ The two keys are still read when nothing is registered, so a job scheduled by an
 sending; the job logs a warning saying where the credential now lives. A credential from the container
 wins over one in job data.
 
-| 3.x | 4.0 |
+| 3.x | 4.x |
 |---|---|
 | `SendMailJob()` | `SendMailJob(ICredentialsByHost? credentials = null)`, which the job factory fills from the container |
 | `MailInfo.SmtpUserName` / `MailInfo.SmtpPassword` | `MailInfo.Credentials`, an `ICredentialsByHost?`. An override of `Send` routing mail through another transport gets whichever credential applied |
@@ -1965,7 +1965,7 @@ Every scheduler also now publishes them at all — configuring the meter used to
 
 ### Old and new telemetry names
 
-| 3.x | 4.x | |
+| 3.x | 4.x | Notes |
 |---|---|---|
 | `scheduling.quartz.execute` | *removed* | The histogram's own **count** is the number of executions: `sum(rate(quartz_job_execution_duration_count[5m]))` in Prometheus, or whatever your backend calls a histogram's count |
 | `scheduling.quartz.execute.errors` | *removed* | The **`error.type`-tagged subset** of the same count is the number of failures — and it now says *what* failed, which the counter never did |
@@ -2348,7 +2348,7 @@ from this release, is the processor.
 exactly as they were, and `job_scheduling_data_2_0.xsd` still validates the document before it is
 read. Only two failures report differently:
 
-| Input | 3.x / earlier 4.x | 4.0 |
+| Input | 3.x / earlier 4.0 preview | 4.0 |
 |---|---|---|
 | A file that is not well-formed XML | `InvalidOperationException`, "There is an error in XML document (3, 13)", wrapping an `XmlException` | the `XmlException` itself, naming the line, the position and the unclosed elements |
 | A file whose elements are not in the `http://quartznet.sourceforge.net/JobSchedulingData` namespace | `InvalidOperationException`, "&lt;job-scheduling-data xmlns=''&gt; was not expected" | `SchedulerConfigException` naming the namespace that was expected |
@@ -2955,6 +2955,10 @@ documentation always promised.
 
 ## New Features
 
+Everything 4.x can do that a 3.x application probably is not doing yet. A few of these were backported
+to a late 3.x release after they were written here, so if you are upgrading from the newest 3.x you may
+already have them.
+
 * **[RecurrenceTrigger (RRULE)](tutorial/recurrencetrigger.md)** — schedule jobs using RFC 5545 recurrence rules for complex patterns like "every 2nd Monday of the month" or "last weekday of March each year"
 * **H (hash) token in cron expressions** — deterministic load distribution across triggers using the trigger identity as seed
 * **HTTP API** — optional REST API for managing the scheduler remotely (see [HTTP API](packages/http-api.md))
@@ -3219,7 +3223,7 @@ that this process happened to be holding, so it could only ever answer for one n
 With a persistent job store the answer now covers the whole cluster, because a firing is a row rather
 than a field. `FireInstance` is what a store can say about one firing from anywhere:
 
-| Member | |
+| Member | Meaning |
 |---|---|
 | `FireInstanceId` | identifies this firing; what `InterruptFireInstance` takes |
 | `TriggerKey` | the trigger that fired |
@@ -3557,7 +3561,7 @@ Renamed to say what they return — a custom delegate author reads these names a
 them said `Names` or whole entities where they return keys, while `SelectTriggerGroups` was one name
 overloaded across two unrelated result shapes:
 
-| Was | Is |
+| 3.x | 4.x |
 |---|---|
 | `SelectTriggerNamesForJob` → `List<TriggerKey>` | `SelectTriggerKeysForJob` |
 | `SelectJobsInGroup` → `List<JobKey>` | `SelectJobKeysInGroup` |
@@ -3566,7 +3570,7 @@ overloaded across two unrelated result shapes:
 
 Consolidated into records rather than overload families:
 
-| Was | Is |
+| 3.x | 4.x |
 |---|---|
 | `SelectFiredTriggerRecords`, `SelectFiredTriggerRecordsByJob`, `SelectInstancesFiredTriggerRecords` | `SelectFiredTriggerRecords(conn, FiredTriggerQuery, ct)` |
 | four `DeleteFiredTriggers` overloads | `DeleteFiredTriggers(conn, FiredTriggerQuery, ct)` |
@@ -4970,7 +4974,7 @@ replace it with its own data source. It used to answer in three vocabularies at 
 sixteen methods taking a loose `(schedulerName, group, name)` triplet next to a hub interface that
 already had `JobKeyDto` and `TriggerKeyDto`. Now it says what Quartz says:
 
-| Was | Is |
+| 3.x | 4.x |
 |---|---|
 | `GetTriggerState(…)` → `string` | → `TriggerState` |
 | `TriggerHeaderDto.State` is `string?` | `TriggerState?` |
@@ -5477,7 +5481,7 @@ positional arguments, most of which read as anonymous at the call site.
 Each type now has one no-settings constructor taking an optional `TimeProvider`, and at most one
 convenience constructor. Everything else is an object initializer.
 
-| type | constructors before | constructors now |
+| Type | Constructors before | Constructors now |
 |---|---|---|
 | `SimpleTriggerImpl` | 11 | `(TimeProvider? = null)`, and `(name, group, jobName, jobGroup, startTimeUtc, endTimeUtc, repeatCount, repeatInterval, TimeProvider? = null)` |
 | `CronTriggerImpl` | 9 | `(TimeProvider? = null)`, and `(name, group, cronExpression, TimeProvider? = null)` |
@@ -5771,7 +5775,7 @@ a cron trigger: the number is in range for both families and means a different p
 overload per family, plus a code form for callers that genuinely have a number and no family — a value read
 off the wire, from configuration, or from a trigger.
 
-| 4.0 preview | 4.x |
+| 4.0 preview | 4.0 |
 |---|---|
 | `.WithMisfireInstruction(2)` | `.WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing)` |
 | `.WithMisfireInstruction(MisfireInstruction.CronTrigger.DoNothing)` | `.WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing)` |
@@ -6511,8 +6515,8 @@ fire times it computes and lives in `Quartz.Extensibility` with that contract, r
 root namespace next to `IScheduler`. The type name carries the "fire times" half, so the methods
 stop repeating it:
 
-| 3.x | 4.0 |
-|-----|-----|
+| 3.x | 4.x |
+|---|---|
 | `TriggerUtils.ComputeFireTimes(...)` | `TriggerFireTimes.Compute(...)` |
 | `TriggerUtils.ComputeFireTimesBetween(...)` | `TriggerFireTimes.ComputeBetween(...)` |
 | `TriggerUtils.ComputeEndTimeToAllowParticularNumberOfFirings(...)` | `TriggerFireTimes.ComputeEndTimeForCount(...)` |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2410,13 +2410,14 @@ recommended path anyway; see
 
 The following properties have been removed from `TriggerBase` as they are redundant with the `Key` and `JobKey` properties:
 
-| Removed Property | Replacement |
-|-----------------|-------------|
+| Removed property | Replacement |
+|---|---|
 | `Name` | `Key.Name` |
-| `GroupName` | `Key.Group` |
+| `Group` | `Key.Group` |
 | `JobName` | `JobKey.Name` |
 | `JobGroup` | `JobKey.Group` |
 | `FullName` | `Key.ToString()` |
+| `FullJobName` | `JobKey.ToString()` |
 
 `HasMillisecondPrecision` left `ITrigger` and is `protected abstract` on `TriggerBase`. It is how a
 trigger describes its own schedule to the base class — which rounds the start time down to the second when it
@@ -4000,7 +4001,7 @@ reads the same values from the context:
 + public sealed class ConsulSemaphore : ISemaphore
   {
 -     public string TablePrefix { get; set; } = "";
--     public string? SchedulerName { get; set; }
+-     public string? SchedName { get; set; }
 +     public string? SchedulerName { get; private set; }
 +
 +     public void Initialize(SemaphoreContext context)
@@ -4011,8 +4012,10 @@ reads the same values from the context:
 
 With the setters gone, the configuration keys that reached them by property injection went too:
 `quartz.jobStore.lockHandler.tablePrefix` and `quartz.jobStore.lockHandler.schedulerName` are rejected
-with advice naming this seam. The store hands the handler its own `quartz.jobStore.tablePrefix` value,
-so the lock rows follow the store's table prefix without separate configuration.
+with advice naming this seam. The 3.x property was called `SchedName`, so a configuration carried over
+from 3.x spells the second key `quartz.jobStore.lockHandler.schedName` — delete that one too. The store
+hands the handler its own `quartz.jobStore.tablePrefix` value, so the lock rows follow the store's table
+prefix without separate configuration.
 
 ## A job store of your own can join your transaction
 
@@ -6243,8 +6246,16 @@ readable while you migrate it to JSON — see
 | `BLOB_TRIGGERS.BLOB_DATA` | `TriggerBase`, `SimpleTriggerImpl`, `CronTriggerImpl`, `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` |
 
 A trigger reaches that third row when no trigger persistence delegate handles it — a type of your own, or one
-deriving from a built-in trigger with `HasAdditionalProperties` returning `true`. The store writes the whole
-object into `BLOB_TRIGGERS`, so the trigger class hierarchy is part of the blob graph.
+deriving from `CronTriggerImpl` or `SimpleTriggerImpl` (the two that are still open) with
+`HasAdditionalProperties` returning `true`. The store writes the whole object into `BLOB_TRIGGERS`, so the
+trigger class hierarchy is part of the blob graph.
+
+`RecurrenceTriggerImpl` is the one trigger implementation *not* on that list: it does not carry
+`[Serializable]`, where `TriggerBase` and the other four do. In practice a recurrence trigger is written to
+`SIMPROP_TRIGGERS` by `RecurrenceTriggerPersistenceDelegate` and never takes the blob path — it is `sealed`,
+so `HasAdditionalProperties` cannot be overridden to `true`. It did carry the attribute on 3.x, though, so a
+3.x database that somehow holds a binary recurrence-trigger blob (which takes a delegate list with that
+delegate removed) should have that row migrated to JSON on 3.x before the upgrade.
 
 3.x listed `StringKeyDirtyFlagMap` and `DirtyFlagMap<TKey, TValue>` in the first row; both are
 internal now. That costs nothing for existing blobs: `BinaryFormatter` records an `ISerializable`
@@ -6534,7 +6545,7 @@ Parameters and behavior are unchanged:
 
 | Change | Details |
 |--------|---------|
-| `SimpleTriggerImpl` `endUtc` no longer nullable | The constructor argument is now required |
+| `SimpleTriggerImpl.GetFireTimeBefore(DateTimeOffset? endUtc)` takes a non-nullable `DateTimeOffset` | The nullable parameter was a lie: after the one guard, 3.x dereferenced `endUtc!.Value`, so passing null threw rather than meaning "no bound". A caller holding a nullable end checks it first. `EndTimeUtc` itself is still `DateTimeOffset?` |
 | `QuartzScheduler` and `QuartzSchedulerResources` are internal | Resolve `IScheduler` / `ISchedulerFactory`; scheduler-wide settings are `QuartzSchedulerOptions` |
 | `JobType` introduced | Stores job type info without requiring an actual `Type` instance. A `Type` converts implicitly (validated: it must implement `IJob`); a string converts only explicitly or via the constructor, because resolving the name is deferred and can fail — `Type` throws for a name that does not resolve, `TryResolve` is the non-throwing probe. Equality (`Equals`, `==`/`!=`) is by `FullName`. There is deliberately **no** implicit conversion back to `Type`: `jobDetail.JobType.Type` spells out that assembly probing may happen, and can throw, at that read |
 | `JobBuilder.OfType(JobType)` added | Carries a stored type name and its resolver through a rebuild without forcing the name to resolve; `OfType(string)` constructs an unvalidated `JobType` for the same reason |
@@ -6805,7 +6816,7 @@ namespace, and `Type.Member` for the second one.
 | `Quartz.IServiceCollectionQuartzConfigurator` | Renamed `IQuartzBuilder` | The same members, on one interface shared with the standalone builder — see [The standalone builder is the same builder](#the-standalone-builder-is-the-same-builder) |
 | `Quartz.Spi.ITypeLoadHelper` | Renamed `Quartz.Extensibility.ITypeLoader` | The last `*Helper` left in the public surface; the builder method `UseTypeLoader<T>()` already had the new spelling. `Initialize()` is gone; `LoadType` is the whole interface. `AdoJobStoreBase.TypeLoadHelper` and `DriverDelegateContext.TypeLoadHelper` are `TypeLoader` to match |
 | `Quartz.Impl.JobDetailImpl` | Internal | `JobBuilder.Create<TJob>()`; read an `IJobDetail` |
-| `Quartz.JobFactoryOptions` | Removed | Nothing; both of its properties were already `[Obsolete]` no-ops in 3.x — see [The job factory hands out a scope](#the-job-factory-hands-out-a-scope) |
+| `Quartz.JobFactoryOptions` | Kept, but emptied and refilled | Its two 3.x properties — `AllowDefaultConstructor` and `CreateScope` — were already `[Obsolete]` no-ops and are gone. The type is `sealed` and carries `ConfigureScope`, the per-scheduler hook for a scope Quartz opens — see [The job factory hands out a scope](#the-job-factory-hands-out-a-scope) |
 | `Quartz.Core.JobRunShell` | Internal | No replacement; use `IJobListener` to observe a fire |
 | `Quartz.Impl.AdoJobStore.JobStoreCMT` | Renamed `ExternalTransactionJobStore` | The old spelling still resolves in configuration, with a warning — see [The ADO.NET job stores are named for whose transaction they use](#the-ado-net-job-stores-are-named-for-whose-transaction-they-use) |
 | `Quartz.Impl.AdoJobStore.JobStoreTX` | Renamed `LocalTransactionJobStore` | As above — see [The ADO.NET job stores are named for whose transaction they use](#the-ado-net-job-stores-are-named-for-whose-transaction-they-use) |
@@ -6880,7 +6891,7 @@ removals on types that are still public and still open, which no section above n
 | 3.x member | What happened | What to use instead |
 |---|---|---|
 | `AbstractTrigger.CompareTo(ITrigger)` | Removed; neither `TriggerBase` nor `ITrigger` itself implements `IComparable<ITrigger>` any more | It compared keys — `trigger.Key.CompareTo(other.Key)`. `List<ITrigger>.Sort()` and friends still compile and now throw — see [The trigger family interfaces are read models](#the-trigger-family-interfaces-are-read-models) |
-| `AbstractTrigger.FullJobName` | Removed | `JobKey.ToString()`, alongside the four in [TriggerBase Property Removals](#triggerbase-property-removals) |
+| `AbstractTrigger.FullJobName` | Removed | `JobKey.ToString()`, alongside the rest in [TriggerBase Property Removals](#triggerbase-property-removals) |
 | `CronExpression`'s `protected` constants, fields and parse hooks, and `OnDeserialization` | Gone with the type, which is `sealed` now and no longer implements `IDeserializationCallback` | No replacement; the parsed sets were never a contract — see [The parser is not a subclassing seam](#the-parser-is-not-a-subclassing-seam) |
 | `CronExpression.MaxYear` | Removed (a `public static readonly int`) | No replacement. It was `DateTime.Now.Year + 100`, computed once per process — see [`CronExpression` is immutable](#cronexpression-is-immutable) |
 | `CronTriggerImpl.GetTimeAfter(DateTimeOffset)` | Removed (it was `protected`) | `GetFireTimeAfter(DateTimeOffset?)`, or `CronExpression.GetNextValidTimeAfter` for the expression on its own |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -272,7 +272,10 @@ assignable on a live instance with nothing saying which wins or when. The compon
 | The scheduling-data plugins' `FileNames`, `ScanInterval`, `FailOn*` | `UseXmlSchedulingConfiguration(o => …)` / `UseJsonSchedulingConfiguration(o => …)` |
 | `ShutdownHookPlugin.CleanShutdown` | `UseShutdownHook(o => o.CleanShutdown = …)` |
 
-`SelectForUpdateSemaphore` and `UpdateRowSemaphore` keep their `MaxRetry` and `RetryPeriod` setters.
+The two shipped row-lock handlers keep their retry knobs, but as `init`-only properties rather than
+setters: `SelectForUpdateSemaphore` has `MaxRetry` and `RetryPeriod`, and `UpdateRowSemaphore` has
+`RetryPeriod` — it gained one, having previously hard-coded a second. Set them at construction, or through
+`quartz.jobStore.lockHandler.maxRetry` / `.retryPeriod`, which the binder still writes.
 
 **Flat-key configuration is unaffected.** `quartz.plugin.<name>.<property>` and
 `quartz.jobStore.lockHandler.<property>` write the component directly through reflection, and that
@@ -435,6 +438,7 @@ q.UsePersistentStore(store => store.UseGenericDatabase("MyDatabase", connectionS
 See [the configuration reference](configuration/reference.md#describing-a-driver-quartz-does-not-know) for the
 full description. `DbProvider.RegisterDbMetadata` is gone with the process-wide lookup it wrote into; use
 the callback above, once per driver.
+
 ### `QuartzOptions` is no longer a dictionary
 
 `QuartzOptions` used to derive from `Dictionary<string, string?>`, and to hold a scheduler's jobs and
@@ -503,6 +507,10 @@ reads — so a scheduler name set through it was accepted and then silently igno
 | `SchedulerBuilder` | `QuartzSchedulerBuilder` for standalone use, `AddQuartz` under a host |
 | `DirectSchedulerFactory` | `QuartzSchedulerBuilder`, with `UseThreadPool(IThreadPool)` / `UseJobStore(IJobStore)` for pre-built parts |
 | `IPropertyConfigurer`, `IPropertySetter`, `IPropertyConfigurationRoot`, `PropertiesHolder`, `PropertiesSetter` | typed options |
+| `SchedulerBuilder.UseZeroSizeThreadPool()` | `UseThreadPool<ZeroSizeThreadPool>()` — the pool type is still public, only the shorthand is gone |
+| `SchedulerBuilder.UseDedicatedThreadPool()` | `UseDefaultThreadPool(…)`; `DedicatedThreadPool` is internal, because a dedicated-thread `TaskScheduler` is no longer how a thread pool is written — see [The thread pool is asynchronous](#the-thread-pool-is-asynchronous) |
+| `SchedulerPluginConfigurationExtensions.UsePlugin<T>(name)` | `AddPlugin<T>(name)` on the builder — see [Plugins are registered like listeners](#plugins-are-registered-like-listeners) |
+| `SchedulerPluginConfigurationExtensions.TryRegisterSingleton<TService, TImplementation>()` | `builder.Services.TryAddSingleton<TService, TImplementation>()`; the builder no longer wraps the container's own verbs |
 | `AddQuartz(Action<configurator, IServiceProvider>)` | see below |
 | `quartz.config` file discovery, `StdSchedulerFactory.PropertiesFile` | `IConfiguration`, or properties passed to `QuartzSchedulerBuilder.UseProperties` |
 | `DbProvider.RegisterDbMetadata` | the metadata factory on `UseGenericDatabase` |
@@ -2129,7 +2137,7 @@ which made `UseNewtonsoftJsonSerializer` ambiguous when both were referenced.
 | 3.x | 4.x |
 |---|---|
 | `Quartz.JsonConfigurationExtensions` (Newtonsoft) | `Quartz.NewtonsoftJsonConfigurationExtensions` |
-| `Quartz.Triggers.ITriggerSerializer`, `TriggerSerializer<T>`, the built-in trigger serializers | `Quartz.Serialization.Newtonsoft.Triggers.*` |
+| `Quartz.Serialization.Json.Triggers.ITriggerSerializer`, `TriggerSerializer<T>`, the built-in trigger serializers | `Quartz.Serialization.Newtonsoft.Triggers.*` — this is the namespace a ported file actually names, and in 4.x the *core* package owns the `Quartz.Serialization.SystemTextJson.Triggers` spelling nearest to it |
 | `Quartz.ICalendarSerializer`, `Quartz.CalendarSerializer<T>` | `Quartz.Serialization.Newtonsoft.Calendars.*` — the same namespace shape as the System.Text.Json package's `Quartz.Serialization.SystemTextJson.Calendars` |
 | `Quartz.Converters.NameValueCollectionConverter` | internal — the serializer registers it itself, and the System.Text.Json package's converter of the same name has always been internal |
 
@@ -2288,13 +2296,33 @@ plugin is example code for one.
 
 Two consequences are worth calling out:
 
-- `XmlSchedulingDataProcessorPlugin.TypeLoader` was `protected` and is now private. It was there for a
+* `XmlSchedulingDataProcessorPlugin.TypeLoader` was `protected` and is now private. It was there for a
   subclass to read; the constructor that takes an `ITypeLoader` is how the type loader gets in.
-- `LoggingJobHistoryPlugin` and `LoggingTriggerHistoryPlugin` no longer have the `IsInfoEnabled` /
+* `LoggingJobHistoryPlugin` and `LoggingTriggerHistoryPlugin` no longer have the `IsInfoEnabled` /
   `IsWarnEnabled` / `WriteInfo` / `WriteWarning` protected hooks. They predate
   `Microsoft.Extensions.Logging` and duplicated `ILogger.IsEnabled`: pass an `ILogger` to the
   constructor and route it wherever you want the history to land, which is what the constructor
   taking `(ILogger<T>, TimeProvider)` is for.
+
+### The shipped implementations are sealed
+
+Where the extension point is an interface or an abstract base, the concrete class beside it is closed.
+Each of these was a `public class` with `virtual` members in 3.x:
+
+| Sealed in 4.x | Derive from this instead |
+|---|---|
+| `AnnualCalendar`, `CronCalendar`, `DailyCalendar`, `HolidayCalendar`, `MonthlyCalendar`, `WeeklyCalendar` | `BaseCalendar`, which stays open, or `ICalendar` directly. Every shipped calendar is a short `BaseCalendar` — the `virtual` `IsDayExcluded` / `SetDayExcluded` / `AreAllDaysExcluded` overrides they offered only made sense for that one calendar's day set anyway |
+| `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl`, `RecurrenceTriggerImpl` | `TriggerBase`. `CronTriggerImpl` and `SimpleTriggerImpl` stay open, so a trigger deriving from one of *those* two is still the shortest route to a custom cron or simple trigger. `HasAdditionalProperties` is `virtual` on `TriggerBase`, so it is available either way |
+| `JobExecutionContextImpl`, and its nine `virtual` members with it | `IJobExecutionContext`. A test double implements the interface; a decorator wraps one |
+| `DefaultThreadPool`, `ZeroSizeThreadPool` | `IThreadPool`, or `TaskSchedulingThreadPool`, which stays open — see [The thread pool is asynchronous](#the-thread-pool-is-asynchronous) |
+| `BroadcastJobListener`, `BroadcastSchedulerListener`, `BroadcastTriggerListener`, `JobChainingJobListener` | The three listener interfaces. Every notification member is a default interface member now, so implementing one directly costs a `Name` at most — see [The three `*Support` base classes are gone](#the-three-support-base-classes-are-gone) |
+
+`JobChainingJobListener` also changed base. It derived from `Quartz.Listener.JobListenerSupport`, which is
+gone, and implements `IJobListener` directly, so its `Name` and `JobWasExecuted` are no longer `override`s.
+A chain you customized by deriving from it becomes an `IJobListener` that holds one and forwards.
+
+`RAMJobStore` is sealed too, and has its own section because it comes with a replacement seam — see
+[`RAMJobStore` is sealed](#ramjobstore-is-sealed).
 
 ## TriggerBase Property Removals
 
@@ -2343,7 +2371,7 @@ acquisition, and the column is written back as `NULL` the next time the trigger 
 The normalization and the missing-calendar warning both job stores now log are not 4.x-only: they
 ship on 3.x as well, so upgrading is not what fixes them. One part of #3294 *is* specific to 4.x:
 
-- `IScheduler.RescheduleJob` throws `SchedulerException` when the new trigger names a calendar that
+* `IScheduler.RescheduleJob` throws `SchedulerException` when the new trigger names a calendar that
   does not exist, the way `ScheduleJob` always has. On 3.x it stores the trigger and leaves it
   permanently unfireable, and that was left alone there rather than turning a long-standing silent
   success into a throw on a released branch. If you reschedule onto a calendar you intend to add
@@ -2357,7 +2385,7 @@ the author happened to do. `JobStoreContractTest` runs one set of assertions aga
 closing the disagreements it found changed behaviour a 3.x application could have depended on. Each
 of these is a 3.x behaviour, not a 4.x regression:
 
-- **A prefix `PauseTriggers` pauses every group it matches.** `RAMJobStore` recorded the *matcher's
+* **A prefix `PauseTriggers` pauses every group it matches.** `RAMJobStore` recorded the *matcher's
   text* rather than the group it matched, so `PauseTriggers(GroupMatcher<TriggerKey>.GroupStartsWith("report"))`
   paused the triggers of only the first matching group, returned that one group, and left a phantom
   entry named `report` in the paused-group set — which then paused anything later added to a group
@@ -2370,7 +2398,7 @@ of these is a 3.x behaviour, not a 4.x regression:
   that *would* have matched but did not exist at pause time is not. To pause a group before it
   exists, pause it by exact name — `GroupEquals` deliberately records a group that holds nothing yet.
 
-- **Pausing no longer discards an error.** `RAMJobStore` moved a trigger to `Paused` from every state
+* **Pausing no longer discards an error.** `RAMJobStore` moved a trigger to `Paused` from every state
   but `Complete`, so pausing a trigger — or the group or job it belongs to — silently overwrote
   `TriggerState.Error`: the failure disappeared from listings and `ResetTriggerFromErrorState` found
   nothing left to reset. Only `Normal` (waiting), acquired and blocked triggers are pausable now,
@@ -2382,7 +2410,7 @@ of these is a 3.x behaviour, not a 4.x regression:
   comes out of error into the pause rather than past it. If you have code that pauses a group to
   suppress a failing trigger, pause it and then reset it: the pause no longer does both.
 
-- **`ResumeAll` on the ADO store now resumes groups that hold no triggers.** It walked the groups it
+* **`ResumeAll` on the ADO store now resumes groups that hold no triggers.** It walked the groups it
   found in `QRTZ_TRIGGERS` and cleared only those, plus its own all-groups marker. A group paused
   while empty — `PauseTriggers(GroupEquals("nightly"))` before anything is scheduled into `nightly`,
   which is a supported thing to do — is in no trigger row, so its `QRTZ_PAUSED_TRIGGER_GRPS` row
@@ -2391,7 +2419,7 @@ of these is a 3.x behaviour, not a 4.x regression:
   now, which is what `RAMJobStore` always did. The 3.x row can be removed by hand with
   `DELETE FROM QRTZ_PAUSED_TRIGGER_GRPS WHERE SCHED_NAME = '…'` if a database carries one.
 
-- **The all-groups-paused marker is no longer listed as a group.** The ADO store records `PauseAll`
+* **The all-groups-paused marker is no longer listed as a group.** The ADO store records `PauseAll`
   as a row named `_$_ALL_GROUPS_PAUSED_$_` in the same table it lists paused groups from, so
   `GetPausedTriggerGroups()` — and `QueryTriggerGroups(new TriggerGroupQuery { Paused = true })` —
   handed back a group name no trigger can ever belong to. Code that displayed the list showed it to
@@ -2399,7 +2427,7 @@ of these is a 3.x behaviour, not a 4.x regression:
   listing and its count filter the marker out now; the marker itself is unchanged, so nothing about
   the schema or about how a pause is recorded moves. `RAMJobStore` never had such a row.
 
-- **A duplicate says so on both stores.** `AddCalendar` over an existing name without
+* **A duplicate says so on both stores.** `AddCalendar` over an existing name without
   `Replace = true`, and `AddJob` over an existing key without `replace: true`, raise
   `ObjectAlreadyExistsException` on the ADO store as they always did on `RAMJobStore`. Both calls
   passed through a blanket `catch` that re-wrapped it as a plain `JobPersistenceException` with the
@@ -2421,24 +2449,24 @@ dictionaries implementing `IDictionary<string, object?>` and `IReadOnlyDictionar
 
 Almost nothing changes at a call site:
 
-- The typed read accessors — `GetInt`, `TryGetDateTime`, `GetString` and the rest — are extension
+* The typed read accessors — `GetInt`, `TryGetDateTime`, `GetString` and the rest — are extension
   members in the `Quartz` namespace (declared in `DataMapExtensions`), on both `JobDataMap` and
   `SchedulerContext`. `map.GetInt("retries")` compiles unchanged. They are deliberately declared for
   the two concrete types, not for `IReadOnlyDictionary<string, object?>`, so they do not appear on
   every string-keyed dictionary in scope. A variable typed as the removed base class is the one
   thing that no longer compiles — type it `JobDataMap` (or `IDictionary<string, object?>` when only
   the dictionary surface matters).
-- `Dirty` and `ClearDirtyFlag()` are internal. Calling `ClearDirtyFlag()` from a job made
+* `Dirty` and `ClearDirtyFlag()` are internal. Calling `ClearDirtyFlag()` from a job made
   `[PersistJobDataAfterExecution]` silently skip re-storing the data — nothing else on the type
   could destroy data like that. To force a data blob rewrite, put a
   `SchedulerConstants.ForceJobDataMapDirty` entry in the source dictionary when constructing the
   map, which remains the supported mechanism (the binary-to-JSON migration recipe uses it).
-- The `Get(TKey key)` method 3.x had is gone with the base chain. Use the indexer or `TryGetValue`.
-- `JobDataMap.Equals`/`GetHashCode` compare content now. The inherited comparison looked at key sets
+* The `Get(TKey key)` method 3.x had is gone with the base chain. Use the indexer or `TryGetValue`.
+* `JobDataMap.Equals`/`GetHashCode` compare content now. The inherited comparison looked at key sets
   only, so two maps with the same keys but different values counted as equal — and assigning such a
   map as a nested value did not mark the outer map dirty, silently skipping the job store rewrite.
   Equal maps also hash equally now. `SchedulerContext` compares by reference.
-- `SchedulerContext` is backed by a `ConcurrentDictionary<string, object?>` and is safe to read and
+* `SchedulerContext` is backed by a `ConcurrentDictionary<string, object?>` and is safe to read and
   write concurrently — plugins write to it while jobs read it, and enumerating it during a write no
   longer races.
 
@@ -2640,19 +2668,22 @@ Neither carries a cause. The stores raise these and receive only a `SchedulerIns
 ### The broadcast listeners have one shape
 
 `BroadcastSchedulerListener.GetListeners()` is a `Listeners` property, matching `BroadcastJobListener` and
-`BroadcastTriggerListener`, and all three constructors take an `IReadOnlyCollection<T>`. All three now take the
-same arguments: a name, and optionally the listeners to start with. `BroadcastJobListener` no longer asks for
-an `ILogger` — it resolves its own, as the other two always did — and `BroadcastSchedulerListener` takes a name,
-which it needs now that scheduler listeners are name-identified.
+`BroadcastTriggerListener`, and all three constructors take an `IReadOnlyCollection<T>`. All three now take
+the same two arguments: a name, and optionally the listeners to start with. The odd one out was
+`BroadcastSchedulerListener`, which had no name — it needs one now that scheduler listeners are
+name-identified.
 
 | 3.x | 4.x |
 |---|---|
-| `new BroadcastJobListener(logger, name)` | `new BroadcastJobListener(name)` |
-| `new BroadcastJobListener(logger, name, listeners)` | `new BroadcastJobListener(name, listeners)` |
+| `new BroadcastJobListener(name)` | unchanged |
+| `new BroadcastJobListener(name, List<IJobListener>)` | the parameter is `IReadOnlyCollection<IJobListener>`; a `List<T>` argument still binds |
+| `new BroadcastTriggerListener(name)`, `(name, IReadOnlyCollection<ITriggerListener>)` | unchanged |
 | `new BroadcastSchedulerListener()` | `new BroadcastSchedulerListener(name)` |
-| `new BroadcastSchedulerListener(listeners)` | `new BroadcastSchedulerListener(name, listeners)` |
+| `new BroadcastSchedulerListener(IEnumerable<ISchedulerListener>)` | `new BroadcastSchedulerListener(name, IReadOnlyCollection<ISchedulerListener>)` |
 
 `BroadcastSchedulerListener` also gained `RemoveListener(string)`, which the job and trigger ones already had.
+All three, and `JobChainingJobListener` with them, are `sealed` — see
+[The shipped implementations are sealed](#the-shipped-implementations-are-sealed).
 
 An `IJobStore` that implements `IJobListener` no longer automatically receives all events. Register it explicitly as a job listener using `ListenerManager`:
 
@@ -2768,15 +2799,15 @@ a property of an unrelated job.
 Everything the compiler cannot rule out is rejected where the job data is written, by asking the job
 factory's own lookup whether the key this property's name becomes leads back to this same property:
 
-- a property with no public setter, or a nested path;
-- one reached by casting the lambda parameter to another job;
-- one the factory cannot find — a name starting with a lowercase letter (keys are looked up upper-cased),
+* a property with no public setter, or a nested path;
+* one reached by casting the lambda parameter to another job;
+* one the factory cannot find — a name starting with a lowercase letter (keys are looked up upper-cased),
   or a property that implements an interface explicitly, which is not public on the job class;
-- one whose name resolves to a *different* property of another type, which is what a `new` member that
+* one whose name resolves to a *different* property of another type, which is what a `new` member that
   hides a base property does;
-- a value that will not convert to the property's type, or that would lose information doing so — a
+* a value that will not convert to the property's type, or that would lose information doing so — a
   `double` rounded into an `int`, or saturated into a `float`;
-- `null` for a property that cannot hold one. Type inference widens `TValue` to the nullable form, so
+* `null` for a property that cannot hold one. Type inference widens `TValue` to the nullable form, so
   `int? retries = …; UsingJobData(j => j.RetryCount, retries)` compiles and is rejected here rather than
   quietly becoming `0` when the job runs.
 
@@ -2918,7 +2949,7 @@ fired-triggers table rather than from process-local state.
 A trigger with an execution in flight previously reported `Normal`, `Complete`, or `Blocked` depending on
 its schedule; it now reports `Executing`. States are resolved in this order:
 
-```
+```text
 None > Error > Paused > Executing > Blocked > Complete > Normal
 ```
 
@@ -2970,7 +3001,7 @@ concurrency guarantee — and only cleans them up on a later pass, once the elap
 60-second threshold, expect up to about 90 seconds plus one more check-in cycle before such a trigger
 stops reporting `Executing`.
 
-### If you implement IDriverDelegate
+### If you implement `IDriverDelegate`: the executing state
 
 `IsTriggerCurrentlyExecuting` was replaced by `SelectTriggerStateWithExecuting`, which returns the stored
 state and whether an execution is in flight from a single statement, so reporting a trigger's state stays
@@ -3114,7 +3145,7 @@ owns, so that a listing can say which node is running what.
 The ADO.NET store previously learned a generated id through a special case in the scheduler factory,
 which is gone: every store is told, the same way, at the same moment.
 
-### If you implement `IDriverDelegate`
+### If you implement `IDriverDelegate`: fire instances
 
 `SelectFireInstances(conn, FireInstanceQuery, CancellationToken)` is new. Subclasses of `StdAdoDelegate`
 get it for free. It is a separate member rather than paging on `SelectFiredTriggerRecords`, because every
@@ -3197,7 +3228,7 @@ soften it — if you implement a job store, you implement the query members:
 | `GetCalendarNames` | `QueryCalendarNames` |
 | `IsJobGroupPaused`, `IsTriggerGroupPaused` | the matching `Query*Groups` with `Name` and `Paused = true` |
 | `GetNumberOfJobs`, `GetNumberOfTriggers`, `GetNumberOfCalendars` | the matching query with `Take = 0, IncludeTotalCount = true` |
-| `CalendarExists(name)` | `GetCalendar(name)` returning non-null |
+| `CalendarExists(name)` | `await GetCalendar(name) is not null` — `GetCalendar` returns `ICalendar?` and answers `null` for a name that is not there |
 
 Two members are new on both interfaces: **`GetJobDetails(jobKeys)`** and **`GetTriggers(triggerKeys)`**
 retrieve many by key in one round trip. Keys that do not exist are simply absent, duplicates fold away, and
@@ -3310,7 +3341,7 @@ Console.WriteLine($"{failed.TotalCount} triggers need attention");
   there. This is what `IsJobGroupPaused` always did on that store; the query type just makes it visible.
 * **Two indexes were added** to support the ordered scans — see [Database Schema Migration](#database-schema-migration).
 
-### If you implement `IDriverDelegate`
+### If you implement `IDriverDelegate`: the listing members
 
 Beyond the two batched-misfire members above, the query work adds, removes and consolidates a fair amount.
 New members to implement:
@@ -3623,6 +3654,13 @@ own cluster and misfire machinery reads are internal (`AcceptEnlistedTransaction
 `MisfireHandlerFrequency`, `RetryableActionErrorLogThreshold`). `Clustered`, `SupportsPersistence` and
 `EstimatedTimeToReleaseAndAcquireTrigger` stay public — they are `IJobStore` members.
 
+`EstimatedTimeToReleaseAndAcquireTrigger` did change type, though, on `IJobStore` itself and so on every
+store: it was a `long` holding milliseconds and is a `TimeSpan`. The unit used to live in the member's
+documentation, which is where a wrong answer hides — the scheduler thread subtracts this from the time it
+is prepared to sleep, so a store that meant seconds simply idled wrong. A store returning `70` returns
+`TimeSpan.FromMilliseconds(70)`; the compiler catches the port, so the only way to get it wrong now is to
+reach for `TimeSpan.FromTicks`.
+
 Code that read configuration off the store resolves `IOptions<AdoJobStoreOptions>` instead, and
 configuring goes where it always did in 4.0:
 
@@ -3635,8 +3673,10 @@ configuring goes where it always did in 4.0:
 + })));
 ```
 
-`MisfireThreshold` deliberately keeps its public setter on both `AdoJobStoreBase` and `RAMJobStore`: it
-is read on every misfire pass rather than only at startup.
+`MisfireThreshold` keeps a **public getter** on both `AdoJobStoreBase` and `RAMJobStore` — it is read on
+every misfire pass rather than only at startup, so a store that wraps one needs to see it — but its setter
+is `internal` like the rest. Set it on the options type: `UsePersistentStore(store => store.Configure(o =>
+o.MisfireThreshold = …))`, or `UseInMemoryStore(o => o.MisfireThreshold = …)`.
 
 Two properties that nothing read are gone rather than made read-only: `DriverDelegateType` (the delegate is
 injected, not loaded from a type name here) and `DontSetAutoCommitFalse` (never consulted).
@@ -3816,7 +3856,7 @@ overrides. `Close` stays public.
 
 ## The driver delegate speaks in records
 
-The five types `IDriverDelegate` hands back or takes in were mutable classes with settable properties, loose
+The six types `IDriverDelegate` hands back or takes in were mutable classes with settable properties, loose
 `string` pairs where a key belongs, and — in one case — properties that were non-nullable but unassigned. They
 are records now, and say what they hold.
 
@@ -3827,6 +3867,7 @@ are records now, and say what they hold.
 | `DelegateInitializationArgs` | Renamed `DriverDelegateContext`; `sealed record` with `required` / `init` members, and `InstanceName` is `SchedulerName` — see [The initialization seams are context records](#the-initialization-seams-are-context-records) |
 | `TriggerAcquireResult` | carries a `TriggerKey` instead of `TriggerName` + `TriggerGroup` |
 | `TriggerStatus` | replaced by `StoredTriggerHeader`, returned by `SelectTriggerHeader` |
+| `SchedulerStateRecord` | `sealed record` with a positional constructor `(string SchedulerInstanceId, DateTimeOffset CheckinTimestamp, TimeSpan CheckinInterval)` and `init`-only members; `[Serializable]` dropped, and the three properties are no longer `virtual`. Construction moves from `new SchedulerStateRecord { … }` to the constructor — all three values are read from one row, so none of them is optional |
 
 `FiredTriggerRecord.FireInstanceState` was the last place raw `AdoConstants.State*` string comparisons
 survived after the delegate's states were typed, in stale-acquired recovery and in cluster recovery. Its
@@ -3905,6 +3946,19 @@ ValueTask<int> ValidateSchema(ConnectionAndTransactionHolder conn, CancellationT
 A delegate of your own that derives from `StdAdoDelegate` inherits the implementation and can extend it to
 cover tables of its own. One written against the interface directly has to implement it; returning `0`
 without checking anything restores the old skip.
+
+Three more `StdAdoDelegate` methods moved onto the interface for the same reason — the store called them
+through a type test, so a delegate that was not a `StdAdoDelegate` quietly did not participate:
+
+| Member | What the store does with it |
+|---|---|
+| `RepinTriggersFromDeadNode(conn, oldPreferredNode, newPreferredNode, ct)` | Steals a dead node's pinned triggers during cluster recovery |
+| `UpdateMisfireOriginalFireTime(conn, triggerKey, fireTime, ct)` | Records the fire time a misfire displaced |
+| `ClearMisfireOriginalFireTime(conn, triggerKey, ct)` | Clears it once the trigger fires normally again |
+
+All three are **abstract** on `IDriverDelegate`, not default interface members, because a store that
+silently does nothing for them loses node affinity on failover or reports the wrong original fire time —
+failures that surface far from their cause. A delegate deriving from `StdAdoDelegate` inherits all three.
 
 ## The optional columns are required, so the probes are gone
 
@@ -4077,8 +4131,9 @@ wants the in-memory behaviour plus something of its own wraps it, deriving from 
 `UsePersistentStore<TStore>()` and `quartz.jobStore.type` take the wrapping store exactly as they took the
 derived one; the `Quartz.Examples.AspNetCore` sample's `CustomJobStore` shows the whole shape.
 
-`MisfireThreshold` keeps its setter here as it does on `AdoJobStoreBase`: it is read on every misfire pass
-rather than only at startup.
+`MisfireThreshold` is readable here as it is on `AdoJobStoreBase` — it is read on every misfire pass rather
+than only at startup — but the setter is `internal`. Configure it with
+`UseInMemoryStore(o => o.MisfireThreshold = …)`.
 
 ### `DelegatingJobStore` decorates a store
 
@@ -4363,13 +4418,14 @@ above cover configuration strings.
 | 3.x namespace | 4.x namespace | Notes |
 |---|---|---|
 | `Quartz.Job` | `Quartz.Jobs` | Namespace, assembly and package now agree. A configuration string or a stored `JOB_CLASS_NAME` naming the old spelling still resolves, with a warning |
-| `Quartz.Extensibility.IDirectoryProvider` | `Quartz.Jobs.IDirectoryProvider` | It exists for `DirectoryScanJob` alone, so it lives with it. It is resolved from `SchedulerContext` by key, never by type name |
-| `Quartz.Plugin.History` <br> `Quartz.Plugin.Interrupt` <br> `Quartz.Plugin.Json` <br> `Quartz.Plugin.Management` <br> `Quartz.Plugin.Xml` <br> `Quartz.Plugin.TimeZoneConverter` | `Quartz.Plugins.*` | Same rule as the jobs: the packages are `Quartz.Plugins` and `Quartz.Plugins.TimeZoneConverter`. A `quartz.plugin.<name>.type` naming the old spelling still resolves, with a warning. The **configuration key** prefix is still `quartz.plugin.`, singular — it is not a namespace |
+| `Quartz.Extensibility.IDirectoryProvider` | `Quartz.Jobs.IDirectoryProvider` | It exists for `DirectoryScanJob` alone, so it lives with it. It is resolved from `SchedulerContext` by key, never by type name. Its one member also changed shape: `GetDirectoriesToScan(JobDataMap)` returns `List<string>` rather than `IReadOnlyList<string>`, following the concrete-out convention, so an implementation returning an array or a `ToList()` result needs one edit |
+| `Quartz.Logging`, `Quartz.Logging.LogProviders` | `Quartz.Diagnostics` | `LogProvider`, `DiagnosticHeaders` (now `ActivityTags`) and `OperationName` moved; `ILogProvider`, `LogContext`, `LogLevel`, the `Logger` delegate, `IJobDiagnosticData` and `LogProviders.LibLogException` went with LibLog. A `using Quartz.Logging;` no longer resolves at all, and nothing names these namespaces in configuration, so there is no fallback — see [Logging](#logging) |
+| `Quartz.Plugin.History`, `Quartz.Plugin.Interrupt`, `Quartz.Plugin.Json`, `Quartz.Plugin.Management`, `Quartz.Plugin.Xml`, `Quartz.Plugin.TimeZoneConverter` | `Quartz.Plugins.*` | Same rule as the jobs: the packages are `Quartz.Plugins` and `Quartz.Plugins.TimeZoneConverter`. A `quartz.plugin.<name>.type` naming the old spelling still resolves, with a warning. The **configuration key** prefix is still `quartz.plugin.`, singular — it is not a namespace |
 | `Quartz.Listener` | `Quartz.Listeners` | A `quartz.jobListener.<name>.type` or `quartz.triggerListener.<name>.type` naming the old spelling still resolves, with a warning — but see [The three `*Support` base classes are gone](#the-three-support-base-classes-are-gone): three of the seven types are not there under either name |
 | `Quartz.Impl.Matchers` | `Quartz` | See [Matchers moved to `Quartz`](#matchers-moved-to-quartz). No shim is needed: a matcher is passed as an object and is never named by a configuration string |
-| `Quartz.AspNetCore` <br> `Quartz.AspNetCore.HealthChecks` <br> `Quartz.AspNetCore.HttpApi` | `Quartz` | The package is still `Quartz.AspNetCore`; only the namespaces are gone. `AddQuartzHealthChecks`, `AddQuartzHttpApi` and `MapQuartzHttpApi` are extension methods and resolve through the `Quartz` you already have, so a `using Quartz.AspNetCore;` can simply be deleted. The class that hosts them is `QuartzAspNetCoreConfigurationExtensions`, renamed from `QuartzServiceCollectionExtensions` because the core package now has a class of that name in the same namespace |
+| `Quartz.AspNetCore`, `Quartz.AspNetCore.HealthChecks`, `Quartz.AspNetCore.HttpApi` | `Quartz` | The package is still `Quartz.AspNetCore`; only the namespaces are gone. `AddQuartzHealthChecks`, `AddQuartzHttpApi` and `MapQuartzHttpApi` are extension methods and resolve through the `Quartz` you already have, so a `using Quartz.AspNetCore;` can simply be deleted. The class that hosts them is `QuartzAspNetCoreConfigurationExtensions`, renamed from `QuartzServiceCollectionExtensions` because the core package now has a class of that name in the same namespace |
 | `Quartz.HttpClient` | `Quartz` | `HttpScheduler` and `HttpClientException`; the package is still `Quartz.HttpClient`. The namespace had to go because it shadowed `System.Net.Http.HttpClient` for every file under `Quartz.*`, including Quartz's own. `HttpScheduler` is also `sealed` now |
-| `Quartz.Serialization.Json` <br> `Quartz.Serialization.Json.Calendars` <br> `Quartz.Serialization.Json.Triggers` | `Quartz.Serialization.SystemTextJson[.Calendars\|.Triggers]` | These are the System.Text.Json types, which merged into the core package; the namespace was named after the *retired 3.x Newtonsoft package*. `Quartz.JsonConfigurationExtensions` is `Quartz.SystemTextJsonConfigurationExtensions` to match — the extension methods on it are unaffected. **Read the warning below before changing a `using` on a ported serializer** |
+| `Quartz.Serialization.Json`, `Quartz.Serialization.Json.Calendars`, `Quartz.Serialization.Json.Triggers` | `Quartz.Serialization.SystemTextJson[.Calendars\|.Triggers]` | These are the System.Text.Json types, which merged into the core package; the namespace was named after the *retired 3.x Newtonsoft package*. `Quartz.JsonConfigurationExtensions` is `Quartz.SystemTextJsonConfigurationExtensions` to match — the extension methods on it are unaffected. **Read the warning below before changing a `using` on a ported serializer** |
 | `Quartz.Impl.Redis` | `Quartz.Extensions.Redis` | One type, `RedisSemaphore`, filed under `Impl` as if it were part of the core. Namespace, assembly and package are the same string now; the **package id is unchanged**. A `quartz.jobStore.lockHandler.type` naming the old namespace still resolves, with a warning |
 
 ::: warning Porting a 3.x Newtonsoft serializer
@@ -4729,6 +4785,10 @@ already had `JobKeyDto` and `TriggerKeyDto`. Now it says what Quartz says:
 | `GetJobs(name, string? groupFilter, int page, int pageSize)` → `JobPageDto` | `GetJobs(name, DashboardJobQuery)` → `PagedResult<JobKeyDto>` |
 | `GetTriggers(name, string? groupFilter, TriggerState?, int page, int pageSize)` → `TriggerPageDto` | `GetTriggers(name, DashboardTriggerQuery)` → `PagedResult<TriggerHeaderDto>` |
 | `GetHistory(JobHistoryQueryDto)` → `JobHistoryPageDto` (a `JsonElement`) | `GetHistory(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>?` |
+| `GetCurrentlyExecutingJobs(name)` → `List<CurrentlyExecutingJobDto>` | `GetFireInstances(name, DashboardFireInstanceQuery)` → `PagedResult<FireInstanceDto>`, following `IScheduler` — see [What is running is a listing, not a list of contexts](#what-is-running-is-a-listing-not-a-list-of-contexts) |
+| `CurrentlyExecutingJobDto` | `FireInstanceDto`: `FireInstanceId` is non-null and leads, `JobKey` is nullable (an acquired firing has no job loaded yet), and `SchedulerInstanceId`, `FireInstanceState State` and `ScheduledFireTimeUtc` are new |
+| `IsJobGroupPaused(name, group)` → `bool` | `GetJobGroups(name)` → `List<JobGroupDto>`, each carrying `Name` and `Paused`; one call answers for every group instead of one |
+| `ExecutionLimitsDto(IReadOnlyDictionary<string, int?> Limits)` | `ExecutionLimitsDto(Dictionary<string, int?> Limits)` — concrete out, as everywhere else |
 | `IDashboardHistoryStore.GetPage(name, page, pageSize, jobFilter, triggerFilter)` → `DashboardHistoryPage` | `GetPage(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>` |
 | `…Job(name, string group, string jobName)` — eight members | `…Job(name, JobKeyDto)` |
 | `…Trigger(name, string group, string triggerName)` — seven members | `…Trigger(name, TriggerKeyDto)` |
@@ -4775,7 +4835,7 @@ called out.
 | `SchedulerConstants.FailedJobOriginalTriggerFiretime`, `…ScheduledFiretime` | `…TriggerFireTime`, `…ScheduledFireTime` (the string values are unchanged) |
 | `SchedulingOptions.OverWriteExistingData` | `OverwriteExistingData`. The configuration key is spelled `Quartz:Scheduling:OverwriteExistingData` now; keys are matched case-insensitively, so an existing file keeps binding, but code assigning the property has to change |
 | `RedisSemaphore.LockTtlMilliseconds`, `.LockRetryIntervalMilliseconds` | `LockTimeToLive`, `LockRetryInterval`, both `TimeSpan` — **also the config keys `lockTtlMilliseconds` → `lockTimeToLive` and `lockRetryIntervalMilliseconds` → `lockRetryInterval`** |
-| `IObjectSerializer.DeSerialize` | `Deserialize` |
+| `IObjectSerializer.DeSerialize` | `Deserialize`. `IObjectSerializer.Initialize()` went at the same time: a serializer builds whatever it needs on first use, and nothing was left for a separate initialization call to do |
 | `TriggerFiredBundle.PrevFireTimeUtc` | `PreviousFireTimeUtc`, matching the spelling used everywhere else. The type is a required-init record now: the eight-positional constructor ended in three interchangeable `DateTimeOffset?` values, so transposing `scheduledFireTimeUtc` and `previousFireTimeUtc` compiled cleanly and reported wrong fire times to every listener. A custom job store's `TriggerFired` writes `new TriggerFiredBundle { JobDetail = …, Trigger = …, Recovering = …, FireTimeUtc = …, ScheduledFireTimeUtc = …, PreviousFireTimeUtc = …, NextFireTimeUtc = … }`; only `Calendar` is optional |
 | `Quartz.Plugin.Xml.XMLSchedulingDataProcessorPlugin` | `Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin` — the namespace moved and the casing follows .NET rules. A `quartz.plugin.<name>.type` naming either old spelling still resolves, with a warning. Its nested `JobFile` class and its `JobFiles` property are internal now: they are how the plugin tracks what it has read, not something to call |
 | `Quartz.Xml.ValidationException` | `Quartz.SchedulingDataValidationException`. The old name collided with `System.ComponentModel.DataAnnotations.ValidationException` in any file that used both, and it was never XML-specific — the JSON processor throws it too. Its `ValidationExceptions` is an `IReadOnlyList<Exception>`; it was a `List<Exception>` a caller could add to |
@@ -5032,6 +5092,24 @@ trigger authors write through — is unchanged.
 the built-in calendar serializers assign through the interface while rebuilding a calendar, so they are part
 of its contract in a way the trigger setters never were.
 
+**`ITrigger` no longer implements `IComparable<ITrigger>`**, and neither do the five family interfaces that
+re-declared it. It compared keys, which is what `ITrigger.Key.CompareTo` says out loud; ordering triggers by
+identity is rarely what a caller wants, and where it is, `Key` is a `Key<T>` with the full comparison
+operator set. Two call shapes change:
+
+```diff
+- if (a.CompareTo(b) < 0) { … }
++ if (a.Key.CompareTo(b.Key) < 0) { … }
+
+- triggers.Sort();                       // List<ITrigger>, now throws InvalidOperationException
++ triggers.Sort((x, y) => x.Key.CompareTo(y.Key));
+```
+
+The second one is the one to watch: `List<ITrigger>.Sort()`, `SortedSet<ITrigger>`, `OrderBy(t => t)` and
+anything else that reaches for `Comparer<ITrigger>.Default` still **compile**, and throw at run time.
+Comparing by fire time — which is usually the intent — was never what this gave you; sort on
+`NextFireTimeUtc` explicitly. `TriggerBase.CompareTo(ITrigger)` went with the interface.
+
 If you author an `ITriggerPersistenceDelegate` of your own, `TriggerPropertyBundle` no longer carries the
 parallel `StatePropertyNames` / `StatePropertyValues` arrays that were applied to the trigger by
 reflection. The bundle takes the schedule builder plus an optional applier delegate, checked by the
@@ -5072,9 +5150,10 @@ string is rejected at `AddQuartz` time instead of at store startup.
 
 ## `CronExpression` is immutable
 
-`CronExpression` always looked like a value — sealed, value equality, a get-only expression string — but
-carried one settable property, `TimeZone`. It is now immutable: the time zone arrives through a constructor
-or through `WithTimeZone`, which returns a retimed copy.
+`CronExpression` always read like a value — value equality, a get-only expression string — but it was an
+open class with a settable `TimeZone` and a `protected` parser underneath. It is a **`sealed` immutable
+value** now: the time zone arrives through a constructor or through `WithTimeZone`, which returns a retimed
+copy.
 
 | 3.x | 4.x |
 |---|---|
@@ -5083,6 +5162,7 @@ or through `WithTimeZone`, which returns a retimed copy.
 | `expr.GetTimeAfter(d)` | `expr.GetNextValidTimeAfter(d)` — the two were verbatim aliases; one name remains |
 | `expr.GetFinalFireTime()` | Removed — it was never implemented and always returned `null` |
 | `expr.Clone()` | Removed — the type is sealed and immutable, so reuse the instance |
+| `CronExpression.MaxYear` | Removed — it was `DateTime.Now.Year + 100` evaluated once per process, so its value depended on when the process started. The cap is internal; a schedule that has to stop at a year should say which year |
 
 `null` still means the system's local time zone, and an expression that was never given a zone still
 serializes with the local zone's id, so persisted payloads keep their meaning.
@@ -5109,6 +5189,33 @@ value it always produced through `GetFinalFireTime`.
 `Clone()` went with the setter. A copy of an immutable sealed value is an allocation and nothing else, so
 the two places in Quartz that cloned one — `CronCalendar.Clone` and `CronTriggerImpl.Clone` — share the
 instance instead. If you called it, drop the call.
+
+### The parser is not a subclassing seam
+
+3.x's `CronExpression` was an open `public class` that handed a derived type the whole parser: eleven
+`protected const` field indices (`Second`, `Minute`, `Hour`, `DayOfMonth`, `Month`, `DayOfWeek`, `Year`,
+`AllSpec`, `AllSpecInt`, `NoSpec`, `NoSpecInt`), thirteen `protected` fields holding the parsed sets
+(`seconds`, `minutes`, `hours`, `daysOfMonth`, `months`, `daysOfWeek`, `years`, `lastdayOfWeek`,
+`nthdayOfWeek`, `everyNthWeek`, `calendardayOfWeek`, `calendardayOfMonth`, `expressionParsed`) and twelve
+`protected virtual` parse and arithmetic hooks (`AddToSet`, `BuildExpression`, `CheckNext`,
+`GetExpressionSetSummary`, `GetLastDayOfMonth`, `GetSet`, `GetTime`, `IsLeapYear`, `SkipWhiteSpace`,
+`StoreExpressionVals`, `CreateDateTimeWithoutMillis`, `SetCalendarHour`). Its public members were `virtual`
+for the same reason.
+
+None of it survives. The type is `sealed`, so those fields are private and the `virtual` keywords are gone.
+The lowercase field names give the seam away as an artifact of the Java port rather than a design: it
+exposed the mid-parse state of a value type, and any override that touched it could leave an expression
+that parsed to something its own string does not say. To vary cron syntax, produce a Quartz expression
+string — `CronExpressionBuilder` builds one field by field — or write a trigger type of your own; do not
+reach into the parser.
+
+`CronExpression` also stops implementing `IDeserializationCallback`, so `OnDeserialization(object?)` is
+gone from its surface. It keeps `[Serializable]`, `ISerializable` and `GetObjectData`, because a
+`CronCalendar` inside a 3.x `CALENDARS` blob is made of one — see
+[`[Serializable]` survives only where a database blob needs it](#serializable-survives-only-where-a-database-blob-needs-it).
+The re-parse that `OnDeserialization` used to perform happens in the deserialization constructor now,
+which is where it belongs on a type whose fields are set once. Blobs written by 3.x still read back: the
+payload is the expression string and the time zone id, unchanged.
 
 ### `CronExpression` parses without throwing, and says it is equatable
 
@@ -5139,8 +5246,11 @@ given a zone and one given `TimeZoneInfo.Local` explicitly no longer hash apart 
 `AnnualCalendar`, `CronCalendar`, `DailyCalendar`, `HolidayCalendar`, `MonthlyCalendar` and
 `WeeklyCalendar` each had a `public bool Equals(X obj)` that no interface asked for and that could not be
 handed a `null`. Each declares `IEquatable<X>` now, with the nullable parameter that entails — matching
-`BaseCalendar`, which always did it correctly. Existing calls compile unchanged; an override in a calendar
-of your own needs the `?` on its parameter.
+`BaseCalendar`, which always did it correctly. Existing calls compile unchanged.
+
+All six are also `sealed`, so there is nothing left to override on them; a calendar of your own derives
+from `BaseCalendar`, which stays open and needs the `?` on its `Equals` parameter — see
+[The shipped implementations are sealed](#the-shipped-implementations-are-sealed).
 
 ### `CronExpressionBuilder`'s list fields take a span
 
@@ -5166,7 +5276,7 @@ downcasts the caller's triggers before the store sees them, so a custom store no
 
 ## The trigger implementations construct, then initialize
 
-The four `*TriggerImpl` types carried thirty-two constructors between them, spelling out every combination
+The five `*TriggerImpl` types carried thirty-four constructors between them, spelling out every combination
 of name, group, job name, job group, start time, end time and schedule. Every value they set is a settable
 property, so each combination was a second way to say the same thing — and the longest of them took nine
 positional arguments, most of which read as anonymous at the call site.
@@ -5180,7 +5290,13 @@ convenience constructor. Everything else is an object initializer.
 | `CronTriggerImpl` | 9 | `(TimeProvider? = null)`, and `(name, group, cronExpression, TimeProvider? = null)` |
 | `CalendarIntervalTriggerImpl` | 6 | `(TimeProvider? = null)` |
 | `DailyTimeIntervalTriggerImpl` | 6 | `(TimeProvider? = null)` |
+| `RecurrenceTriggerImpl` | 2 | `(TimeProvider? = null)`, and `(name, group, recurrenceRule, TimeProvider? = null)` |
 | `TriggerBase` (protected) | 5 | `(TimeProvider? = null)` |
+
+Every surviving convenience constructor takes a **non-nullable** `group`. `RecurrenceTriggerImpl` is the
+one that had a `string?` there, so `new RecurrenceTriggerImpl(name, null, rule)` becomes a nullability
+warning — an error under `TreatWarningsAsErrors`. Name the group you meant, or `TriggerKey.DefaultGroup`
+if you had none, or use the object initializer and set `Key`.
 
 The recipe is mechanical: the name and group become `Key`, the job name and group become `JobKey`, and the
 rest keep their property names.
@@ -6210,12 +6326,12 @@ precision *and* `DateTimeKind`. Both now write the round-trip ("O") format: what
 what you stored, to the tick, Kind and offset included. Reading is unaffected for existing data —
 the accessors parse both the old general form and "O" — but two edges are observable:
 
-- **Overload rebinding**: `map.PutAsString(key, someDateTime)` used to bind to the generic
+* **Overload rebinding**: `map.PutAsString(key, someDateTime)` used to bind to the generic
   `IConvertible` overload and store `"01/02/2026 15:04:05"`; it now binds to the dedicated
   `DateTime` overload and stores `"2026-01-02T15:04:05.0000000"`. Anything *outside* Quartz that
   reads `JOB_DATA` strings and expects the old shape sees the new one after the value is next
   written.
-- **`TryGetDateTime` parses with `DateTimeStyles.RoundtripKind`** — its own behavioral change,
+* **`TryGetDateTime` parses with `DateTimeStyles.RoundtripKind`** — its own behavioral change,
   independent of what was written: a stored string ending in `Z` used to come back shifted to the
   reader's local time with `Kind=Local`; it now comes back with the UTC clock reading and
   `Kind=Utc`. That is the correct reading, but a job computing e.g. `DateTime.Now - map.GetDateTime(key)`
@@ -6490,7 +6606,7 @@ Parameters and behavior are unchanged:
 | `StdAdoConstants` group and fired-trigger statements were split | `SqlDeletePausedTriggerGroup`, `SqlSelectTriggerGroupsFiltered`, `SqlUpdateTriggerGroupStateFromState` and `SqlUpdateTriggerGroupStateFromStates` are `…Equals` / `…Like` pairs, and the FIRED_TRIGGERS statements are one `SqlSelectFiredTriggers` / `SqlDeleteFiredTriggers` base plus `SqlFiredTrigger*Predicate` fragments. The type is internal |
 | `IDashboardAuthorizationFilter` and `QuartzDashboardOptions.AuthorizationFilter` removed | Nothing ever invoked the filter, so setting it bought a false sense of security. Use `AuthorizationPolicy`, which is enforced |
 | `IDashboardHistoryStore` is asynchronous | `ValueTask Add`, `ValueTask<PagedResult<DashboardHistoryEntry>> GetPage(DashboardHistoryQuery)`, so a store can talk to a database. `SearchFilter.DebounceMilliseconds` is a `TimeSpan Debounce`, and `QuartzApiClient` / `InProcessQuartzApiClient` are internal — resolve `IQuartzApiClient` |
-| `IQuartzApiClient` speaks Quartz's vocabulary | See [The dashboard's client speaks one currency](#the-dashboards-client-speaks-one-currency) |
+| `IQuartzApiClient` speaks Quartz's vocabulary | See [The dashboard's client speaks one currency](#the-dashboard-s-client-speaks-one-currency) |
 | Serializers outside a scheduler read a container-wide registry | Because the serializer maps are per-serializer, the HTTP API, the dashboard and `Quartz.HttpClient` read a `SystemTextJsonSerializerRegistry` registered in the container. Register it as a singleton to make a custom serializer visible to them |
 | `IDriverDelegate` trigger states are `StoredTriggerState` | Eighteen members took the state as a `string`; the database still stores the same values — see [Trigger states are typed on the driver delegate](#trigger-states-are-typed-on-the-driver-delegate) |
 | The `…FromOtherStates` members take a state collection | Two or three fixed old-state parameters became one `IReadOnlyCollection<StoredTriggerState>` |
@@ -6501,14 +6617,14 @@ Parameters and behavior are unchanged:
 | `TriggerAcquisitionCriteria.LiveNodeCutoff` is a `required DateTimeOffset` | It was an optional `long` of `UtcTicks` beside two required `DateTimeOffset` siblings, and omitting it silently meant "every node is dead". The tick conversion happens in `AddPreferredNodeParameters`, whose parameter is a `DateTimeOffset` too |
 | `StdAdoDelegate.AddPagingParameters(cmd, int skip, int take, bool)` | `skip`/`take` were `long` while `PagedQuery.Skip`/`.Take` are `int`; the dialect override contract now matches the query object it serves |
 | `StdAdoDelegate.ReadBytesFromBlob` takes a `DbDataReader` and is asynchronous | It took a `System.Data.IDataReader` — the last legacy `System.Data.I*` interface anywhere in the public surface — which forced a synchronous, thread-blocking read that ignored the cancellation token it was handed. It is `async ValueTask<byte[]?>` over `IsDBNullAsync` / `GetFieldValueAsync<byte[]>`. **The behaviour contract is unchanged**: a `NULL` column still yields `null`, and an empty blob still yields an empty array, which the only caller (`GetObjectFromBlob`) has always treated the same as `null` by testing `Length > 0`. An override changes its parameter type; every reader the store passes was already a `DbDataReader` |
-| `StdAdoDelegate`'s date/time and time-span conversions are non-virtual | UTC ticks and whole milliseconds are the schema contract the liveness SQL assumes; only the boolean pair remains a dialect seam. A delegate that changes the storage format implements `IDriverDelegate` itself — see [If you implement `IDriverDelegate`](#if-you-implement-idriverdelegate) |
+| `StdAdoDelegate`'s date/time and time-span conversions are non-virtual | UTC ticks and whole milliseconds are the schema contract the liveness SQL assumes; only the boolean pair remains a dialect seam. A delegate that changes the storage format implements `IDriverDelegate` itself — see [If you implement `IDriverDelegate`: the listing members](#if-you-implement-idriverdelegate-the-listing-members) |
 | `JobStoreTX` is `LocalTransactionJobStore`, `JobStoreCMT` is `ExternalTransactionJobStore` | The names now say whose transaction the store uses. `quartz.jobStore.type = Quartz.Impl.AdoJobStore.JobStoreTX, Quartz` and the `JobStoreCMT` spelling still resolve, with a warning — see [The ADO.NET job stores are named for whose transaction they use](#the-ado-net-job-stores-are-named-for-whose-transaction-they-use) |
 | `GetNonManagedTXConnection`, `ExecuteInNonManagedTXLock`, `RetryExecuteInNonManagedTXLock` renamed | `GetLocalTransactionConnection`, `ExecuteInLocalTransactionLock`, `RetryExecuteInLocalTransactionLock`; protected, so only a `AdoJobStoreBase` subclass sees them |
 | `AdoJobStoreBase`'s nine `Execute…Lock` overloads became four members | Optional parameters replace the ladder, and no member returns `object` as a stand-in for `void` any more — see [Nine `Execute…Lock` overloads became four members](#nine-execute-lock-overloads-became-four-members) |
 | `ExternalTransactionJobStore.OpenConnection` moved to `AdoJobStoreOptions.OpenConnection` | The last store setting outside the options system; the store reads it once at construction — see [Nine `Execute…Lock` overloads became four members](#nine-execute-lock-overloads-became-four-members) |
 | `ISemaphore` takes a `SchedulerLock` | The `string lockName` had two legal values. The `LOCK_NAME` column and the Redis keys are unchanged — see [Locks are a `SchedulerLock`, not a string](#locks-are-a-schedulerlock-not-a-string) |
 | `AdoJobStoreBase.LockTriggerAccess` / `.LockStateAccess` removed | `SchedulerLock.TriggerAccess` / `.StateAccess` replace the two protected constants |
-| ~25 `AdoJobStoreBase` configuration properties are read-only and `protected`/internal | They duplicated `AdoJobStoreOptions` / `QuartzSchedulerOptions`; resolve `IOptions<AdoJobStoreOptions>` to read, configure the options to write. `MisfireThreshold` deliberately stays settable, and the `IJobStore` members stay public — see [The job store configuration is read-only](#the-job-store-configuration-is-read-only-and-no-longer-a-public-currency) |
+| ~25 `AdoJobStoreBase` configuration properties are read-only and `protected`/internal | They duplicated `AdoJobStoreOptions` / `QuartzSchedulerOptions`; resolve `IOptions<AdoJobStoreOptions>` to read, configure the options to write. `MisfireThreshold` deliberately stays publicly *readable* (its setter is internal), and the `IJobStore` members stay public — see [The job store configuration is read-only](#the-job-store-configuration-is-read-only-and-no-longer-a-public-currency) |
 | The seven conn-taking `Pause…`/`Resume…`/`RecoverMisfiredJobs` overloads are `protected` | They took a `ConnectionAndTransactionHolder` no caller outside the store can obtain; call the public keyed overloads, which take the lock and the connection themselves |
 | `AdoJobStoreBase`'s virtual surface is a curated seam | Only `Initialize`, `Shutdown`, `GetConnection`, `GetLocalTransactionConnection`, `ExecuteInLock<T>`, `IsTransient`, `AcquireNextTriggers`, `CreateAcquisitionCriteria` and `GetFiredTriggerRecordId` remain overridable; the other ~75 members were virtual by default, not by design, and freezing the store's internal call order as a behavior contract would have made it unrefactorable |
 | `AdoJobStoreBase.DriverDelegateType` and `.DontSetAutoCommitFalse` removed | Nothing read either one; the driver delegate is injected |
@@ -6560,7 +6676,7 @@ Parameters and behavior are unchanged:
 | `IQuartzBuilder.AddHttpApi` / `MapQuartzApi` renamed | `AddQuartzHttpApi` / `MapQuartzHttpApi`; `AddQuartzHealthChecks` gained an `IQuartzBuilder` overload |
 | The health check is added on `IHealthChecksBuilder` | `AddHealthChecks().AddQuartz()` / `.AddQuartz("reporting")`, so it composes with an application's other checks. `AddQuartzHealthChecks()` is shorthand for the first — see [The ASP.NET Core methods say Quartz once](#the-asp-net-core-methods-say-quartz-once) |
 | `QuartzHealthCheckOptions` goes through the options pipeline | It was constructed and read inside the registration call, so `services.Configure<QuartzHealthCheckOptions>(...)` did nothing. `Name` is nullable and defaults to the scheduler's check name |
-| `QuartzHealthCheckOptions.Tags` is a settable `IReadOnlyCollection<string>` | Assign `["ready", "live"]` rather than calling `Add` twice |
+| `QuartzHealthCheckOptions.Tags` is a get-only `List<string>` | It was a settable `IReadOnlyCollection<string>`. Add to it — `options.Tags.AddRange(["ready", "live"])` — rather than assigning; one `configure` callback can no longer discard the tags another added — see [A shipped component is configured through its options type, and only there](#a-shipped-component-is-configured-through-its-options-type-and-only-there) |
 | `QuartzSchedulerBuilder.Build()` returns `StandaloneSchedulerFactory` | It is an `ISchedulerFactory` that is also `IAsyncDisposable` and `IDisposable`, so disposing the container needs no cast |
 | `JobBuilder<TJob>.Key` is public | Reports the identity the builder was given, or `null` when none was set, so a trigger registered alongside a job can agree with it |
 | `ISchedulerProxyFactory` and `HttpSchedulerProxyFactory` removed | Nothing read them — see [Remoting a scheduler is not a Quartz concern](#remoting-a-scheduler-is-not-a-quartz-concern) |
@@ -6672,7 +6788,7 @@ namespace, and `Type.Member` for the second one.
 | `Quartz.Impl.AdoJobStore.JobStoreSupport` | Renamed `AdoJobStoreBase` | Abstract, never a configuration string, so no fallback is needed; a derived store updates its base list — see [The ADO.NET job stores are named for whose transaction they use](#the-ado-net-job-stores-are-named-for-whose-transaction-they-use) |
 | `Quartz.Impl.Triggers.AbstractTrigger` | Renamed `TriggerBase` | Abstract, so never a `$type` value in stored JSON; the five concrete `*TriggerImpl` names are unchanged — see [TriggerBase Property Removals](#triggerbase-property-removals) for the rename and its one binary-blob caveat |
 | `Quartz.Impl.AdoJobStore.SimplePropertiesTriggerPersistenceDelegateSupport` | Renamed `SimplePropertiesTriggerPersistenceDelegateBase` | As above |
-| `Quartz.Simpl.JsonObjectSerializer` | Renamed `Quartz.Serialization.Newtonsoft.NewtonsoftJsonObjectSerializer` | `UseNewtonsoftJsonSerializer()` registers it — see [JSON Serialization](#json-serialization) |
+| `Quartz.Simpl.JsonObjectSerializer` | Renamed `Quartz.Impl.NewtonsoftJsonObjectSerializer`, still in the `Quartz.Serialization.Newtonsoft` package | `UseNewtonsoftJsonSerializer()` registers it. Spelled into `quartz.serializer.type` it is `Quartz.Impl.NewtonsoftJsonObjectSerializer, Quartz.Serialization.Newtonsoft` — see [JSON Serialization](#json-serialization) |
 | `Quartz.JsonSchedulingOptions` | Merged into `FileSchedulingOptions` | It was byte-for-byte identical to `XmlSchedulingOptions` — see [Other Breaking Changes](#other-breaking-changes) |
 | `Quartz.JsonSerializerOptions` | Removed | `UseNewtonsoftJsonSerializer`'s callback hands you the `NewtonsoftJsonSerializerRegistry` itself, with `registerTriggerConverters` as a parameter of the method — see [Custom trigger and calendar serializers are no longer static](#custom-trigger-and-calendar-serializers-are-no-longer-static) |
 | `Quartz.Logging.LogProviders.LibLogException` | Removed with LibLog | No replacement — see [Logging](#logging) |
@@ -6739,9 +6855,10 @@ removals on types that are still public and still open, which no section above n
 
 | 3.x member | What happened | What to use instead |
 |---|---|---|
-| `AbstractTrigger.CompareTo(ITrigger)` | Removed; `TriggerBase` no longer implements `IComparable<ITrigger>` | It compared keys — `trigger.Key.CompareTo(other.Key)` |
+| `AbstractTrigger.CompareTo(ITrigger)` | Removed; neither `TriggerBase` nor `ITrigger` itself implements `IComparable<ITrigger>` any more | It compared keys — `trigger.Key.CompareTo(other.Key)`. `List<ITrigger>.Sort()` and friends still compile and now throw — see [The trigger family interfaces are read models](#the-trigger-family-interfaces-are-read-models) |
 | `AbstractTrigger.FullJobName` | Removed | `JobKey.ToString()`, alongside the four in [TriggerBase Property Removals](#triggerbase-property-removals) |
-| `CronExpression`'s `protected` constants and fields | Gone with the type, which is `sealed` now | No replacement; the parsed sets were never a contract — see [Sealed and Internalized Types](#sealed-and-internalized-types) |
+| `CronExpression`'s `protected` constants, fields and parse hooks, and `OnDeserialization` | Gone with the type, which is `sealed` now and no longer implements `IDeserializationCallback` | No replacement; the parsed sets were never a contract — see [The parser is not a subclassing seam](#the-parser-is-not-a-subclassing-seam) |
+| `CronExpression.MaxYear` | Removed (a `public static readonly int`) | No replacement. It was `DateTime.Now.Year + 100`, computed once per process — see [`CronExpression` is immutable](#cronexpression-is-immutable) |
 | `CronTriggerImpl.GetTimeAfter(DateTimeOffset)` | Removed (it was `protected`) | `GetFireTimeAfter(DateTimeOffset?)`, or `CronExpression.GetNextValidTimeAfter` for the expression on its own |
 | `CronTriggerImpl.YearToGiveupSchedulingAt` | Removed (a `protected const`) | No replacement; where the search stops is the expression's business |
 | `DateBuilder.ValidateDayOfMonth`, `.ValidateHour`, `.ValidateMinute`, `.ValidateMonth`, `.ValidateSecond`, `.ValidateYear` | Removed | No replacement; the builder validates its own arguments, and it is `sealed` — see [`DateBuilder`'s static factories are gone](#datebuilder-s-static-factories-are-gone) |
@@ -6755,6 +6872,8 @@ removals on types that are still public and still open, which no section above n
 | `DirtyFlagMap.Put()`, `.PutAll()` | Removed; both were `[Obsolete]` in 3.x | `map[key] = value`, in a loop for `PutAll` — see [JobDataMap and SchedulerContext stand alone](#jobdatamap-and-schedulercontext-stand-alone) |
 | `DirtyFlagMap.WrappedMap` | Removed | No replacement; the map *is* the dictionary, and handing out the inner one let a caller write past the dirty flag |
 | `IDriverDelegate.UpdateTriggerPreferredNode`, `StdAdoDelegate.UpdateTriggerPreferredNode` | Removed | `UpdateTriggerPreferredNodeConditional`, which is a compare-and-swap, or `IScheduler.UpdateTriggerDetails` from outside the store — see [The preferred node is a value](#the-preferred-node-is-a-value) |
+| `InvalidConfigurationException()` | Removed; the type is `sealed` and keeps only `(string message)` | Say what was invalid — an exception with no message is one nobody can act on |
+| `IObjectSerializer.Initialize()` | Removed | No replacement; a serializer builds what it needs on first use — see [Names that were normalized](#names-that-were-normalized) |
 | `JobBuilder.CreateForAsync<T>()` | Removed | `JobBuilder.Create<T>()`; every job has been asynchronous since 3.0 |
 | `JobStoreSupport.calendarCache`, `.delegateType`, `.firstCheckIn` | Removed (`protected` fields) | No replacement; they are the base class's own bookkeeping |
 | `JobStoreSupport.GetTriggerNames(conn, matcher, ct)` | Removed (`protected`) | The listing members became queries — see [Job store listings became queries](#job-store-listings-became-queries) |


### PR DESCRIPTION
Docs wave PRD4 — the migration-guide close-out against the full 3.x→main baseline delta (9,135 diff lines walked in slices).

- **Sixteen gaps documented** that the per-PR rows missed, from the compiles-but-throws `IComparable` removal on `ITrigger` and the sealed `CronExpression` parse seam, through delegate members promoted to abstract, to the dashboard client's F1 reshape.
- **Twelve wrong claims fixed against source**, several of them CS0200s-in-waiting: "MisfireThreshold keeps its public setter" (it is internal), the settable-Tags claim, retry knobs "keeping setters" (init-only), an invented 3.x `BroadcastJobListener` signature, the wrong namespace for `NewtonsoftJsonObjectSerializer` in the one row people copy `quartz.serializer.type` from.
- **Anchors adjudicated with the real `@mdit-vue/shared` slugify**: one genuinely broken anchor fixed, three duplicate-slug headings de-duplicated — and the 27 remaining MD051 hits proven to be false positives where markdownlint's GitHub-style slugs disagree with what VuePress actually serves (every flagged fragment resolves on the site; every "fix" would 404). **MD051 is disabled in `.markdownlint.jsonc` with that reasoning written in-file** — one-line revert if you'd rather rename 13 headings. The campaign's anchor checker had a mangled character class; the corrected script models the real slugify plus duplicate suffixes.
- **Restructure**: pure relocation (303 lines out, 303 back), the upgrade-first sections (packages, schema) moved to the front, the JobDataMap trio unified, table headers normalized, a documentation-redirects table added, three missing New Features lines added with an honest note that RRULE and the cron `H` token also ship in 3.19.1.

Three findings routed to a follow-up PR (not here): `schema-changes.md`'s 22 `{#id}` anchors that VuePress 2 renders as literal text; `LegacyPropertyKeys` rejecting `lockHandler.schedulerName` when 3.x's real spelling was `schedName`; and the sealed-trigger asymmetry that makes the "supported on all five" serializer claim true for only two.

Guide markdownlint 0 (was 60); 248/248 links; 357 anchors with zero unresolved in the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf