### PR TITLE
Six bug fixes found by the 4.0 campaign, backported

### DIFF
--- a/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Interrupt/JobInterruptMonitorPlugin.cs
@@ -83,12 +83,18 @@ public class JobInterruptMonitorPlugin : TriggerListenerSupport, ISchedulerPlugi
             if (context.MergedJobDataMap.TryGetBoolean(JobDataMapKeyAutoInterruptable, out var value) && value)
             {
                 JobInterruptMonitorPlugin monitorPlugin = (JobInterruptMonitorPlugin) context.Scheduler.Context.Get(JobInterruptMonitorKey);
-                // Get the MaxRuntime from MergedJobDataMap if NOT available use MaxRunTime from Plugin Configuration
+                // Get the MaxRuntime from MergedJobDataMap if NOT available use MaxRunTime from Plugin Configuration.
+                // TryGetLong coerces a numeric value and a numeric string alike, so the override takes
+                // effect whether the map holds 5000 or "5000".
                 var jobDataDelay = DefaultMaxRunTime;
 
-                if (context.MergedJobDataMap.TryGetLongValueFromString(JobDataMapKeyMaxRunTime, out var val))
+                if (context.MergedJobDataMap.TryGetLong(JobDataMapKeyMaxRunTime, out var maxRunTimeMilliseconds))
                 {
-                    jobDataDelay = TimeSpan.FromMilliseconds(val);
+                    jobDataDelay = TimeSpan.FromMilliseconds(maxRunTimeMilliseconds);
+                }
+                else if (context.MergedJobDataMap.ContainsKey(JobDataMapKeyMaxRunTime))
+                {
+                    log.Warn($"Job data map value for {JobDataMapKeyMaxRunTime} is not a number of milliseconds, using the plugin default of {jobDataDelay} instead");
                 }
 
                 monitorPlugin.ScheduleJobInterruptMonitor(context.FireInstanceId, context.JobDetail.Key, jobDataDelay);

--- a/src/Quartz.Serialization.Json/QuartzContractResolver.cs
+++ b/src/Quartz.Serialization.Json/QuartzContractResolver.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Quartz;
+
+/// <summary>
+/// The contract rules Quartz's types need on top of the default resolver's.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A property typed as a read-only collection is replaced, not populated.</b> The default is to
+/// call the getter and add the payload's items to whatever comes back, which is wrong twice over for
+/// a property whose type says its contents cannot be assigned through it: the values it was holding
+/// survive the read, and a getter that hands out a shared or lazily defaulted instance has that
+/// instance mutated. <see cref="IDailyTimeIntervalTrigger.DaysOfWeek" /> is the case that showed it -
+/// its getter defaults to all seven days, so a trigger stored for Monday and Wednesday came back
+/// firing every day.
+/// </para>
+/// <para>
+/// This is a resolver rather than a <see cref="JsonConverter" /> on purpose: a converter registered
+/// on the serializer is not consulted for a value whose type came from a <c>$type</c> property - a
+/// trigger stored as a blob, say - and the rule here applies on every path.
+/// </para>
+/// </remarks>
+internal sealed class QuartzContractResolver : DefaultContractResolver
+{
+    public QuartzContractResolver()
+    {
+        IgnoreSerializableInterface = true;
+    }
+
+    protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+    {
+        JsonProperty property = base.CreateProperty(member, memberSerialization);
+
+        if (property.Writable && IsReadOnlyCollection(property.PropertyType))
+        {
+            property.ObjectCreationHandling = ObjectCreationHandling.Replace;
+        }
+
+        return property;
+    }
+
+    private static bool IsReadOnlyCollection(Type? propertyType)
+    {
+        if (propertyType is null || !propertyType.IsGenericType)
+        {
+            return false;
+        }
+
+        Type definition = propertyType.GetGenericTypeDefinition();
+        return definition == typeof(IReadOnlyCollection<>)
+               || definition == typeof(IReadOnlyList<>)
+               || definition == typeof(IReadOnlyDictionary<,>);
+    }
+}

--- a/src/Quartz.Serialization.Json/Simpl/JsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.Json/Simpl/JsonObjectSerializer.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Text;
 
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Quartz.Converters;
 using Quartz.Serialization.Json.Triggers;
@@ -41,10 +40,7 @@ public class JsonObjectSerializer : IObjectSerializer
             },
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             TypeNameHandling = TypeNameHandling.Auto,
-            ContractResolver = new DefaultContractResolver
-            {
-                IgnoreSerializableInterface = true
-            },
+            ContractResolver = new QuartzContractResolver(),
             NullValueHandling = NullValueHandling.Ignore,
             DateParseHandling = DateParseHandling.DateTimeOffset
         };

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -1064,6 +1065,11 @@ public class JobStoreSupportTest
             }
         }
 
+        internal bool CallIsTransient(Exception ex)
+        {
+            return IsTransient(ex);
+        }
+
         internal Task<bool> CallRemoveTrigger(ConnectionAndTransactionHolder conn, TriggerKey triggerKey)
         {
             return RemoveTrigger(conn, triggerKey, CancellationToken.None);
@@ -1152,6 +1158,117 @@ public class JobStoreSupportTest
         {
         }
     }
+
+    #region IsTransient classification tests
+
+    /// <summary>
+    /// The stand-ins below carry the shapes <see cref="JobStoreSupport.IsTransient"/> reflects over -
+    /// an "IsTransient" property, an "Errors" collection of items with a "Number", a
+    /// "SqliteErrorCode". The real driver exceptions cannot be constructed from outside their
+    /// assemblies, and a property name and a number is all the classification ever reads of them.
+    /// </summary>
+    [Test]
+    public void IsTransient_TrustsADriverThatSaysTransient()
+    {
+        jobStoreSupport.CallIsTransient(new TransientProviderException()).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsTransient_DriverSayingNotTransientIsNotTheEndOfTheEnquiry()
+    {
+        // Since .NET 6 DbException carries IsTransient, and SqlException does not override it - so
+        // returning the driver's verdict unconditionally made the error-number switch below dead
+        // code on every modern host, and deadlocks stopped being retried.
+        SqlServerLikeException deadlock = new SqlServerLikeException(1205);
+
+        PropertyInfo probe = deadlock.GetType().GetProperty("IsTransient");
+        (probe?.GetValue(deadlock) as bool? ?? false).Should().BeFalse(
+            "the stand-in reports what SqlException reports, which on .NET 6+ is DbException's false");
+
+        jobStoreSupport.CallIsTransient(deadlock).Should().BeTrue("1205 is a deadlock, which is worth a retry");
+    }
+
+    [Test]
+    public void IsTransient_SqlServerConstraintViolationIsNotTransient()
+    {
+        // 2627 is a primary key violation: it will fail again on every retry.
+        jobStoreSupport.CallIsTransient(new SqlServerLikeException(2627)).Should().BeFalse();
+    }
+
+    [Test]
+    public void IsTransient_SqliteBusyIsTransient()
+    {
+        jobStoreSupport.CallIsTransient(new SqliteException(5)).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsTransient_TimeoutIsTransient()
+    {
+        jobStoreSupport.CallIsTransient(new TimeoutException()).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsTransient_PlainFailureIsNotTransient()
+    {
+        jobStoreSupport.CallIsTransient(new InvalidOperationException("no")).Should().BeFalse();
+    }
+
+    /// <summary>A driver exception that reports its own verdict and nothing else.</summary>
+    public sealed class TransientProviderException : Exception
+    {
+        public bool IsTransient => true;
+    }
+
+    /// <summary>
+    /// Stands in for <c>Microsoft.Data.SqlClient.SqlException</c>: the numbers sit on an
+    /// <c>Errors</c> collection whose items carry a <c>Number</c>. It derives from
+    /// <see cref="DbException"/> deliberately, so that on .NET it inherits the <c>IsTransient</c>
+    /// that returns false - the property whose answer used to be taken as final.
+    /// </summary>
+    public sealed class SqlServerLikeException : DbException
+    {
+        public SqlServerLikeException(params int[] numbers)
+        {
+            Errors = new SqlServerErrorCollection(numbers);
+        }
+
+        public SqlServerErrorCollection Errors { get; }
+    }
+
+    public sealed class SqlServerErrorCollection : IEnumerable
+    {
+        private readonly int[] numbers;
+
+        public SqlServerErrorCollection(int[] numbers) => this.numbers = numbers;
+
+        public IEnumerator GetEnumerator()
+        {
+            foreach (int number in numbers)
+            {
+                yield return new SqlServerError(number);
+            }
+        }
+    }
+
+    public sealed class SqlServerError
+    {
+        public SqlServerError(int number) => Number = number;
+
+        public int Number { get; }
+    }
+
+    /// <summary>
+    /// Stands in for <c>Microsoft.Data.Sqlite.SqliteException</c>, which is matched by type name and
+    /// read through <c>SqliteErrorCode</c>.
+    /// </summary>
+    public sealed class SqliteException : DbException
+    {
+        public SqliteException(int sqliteErrorCode) => SqliteErrorCode = sqliteErrorCode;
+
+        public int SqliteErrorCode { get; }
+    }
+
+    #endregion
 
     #region TriggersFired transient retry tests
 

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System;
+using System.Threading.Tasks;
 
 using Quartz.Impl.Calendar;
 using Quartz.Simpl;
@@ -68,6 +69,33 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
         };
         var dateTime = new DateTimeOffset(2017, 7, 27, 2, 0, 1, 123, TimeSpan.Zero);
         Assert.That(calendar.IsTimeIncluded(dateTime), Is.False);
+    }
+
+    /// <summary>
+    /// From an instant the calendar EXCLUDES, the next-included search used to walk forward with
+    /// <see cref="CronExpression.GetNextValidTimeAfter" /> - which by definition lands on another
+    /// satisfied, i.e. excluded, instant - so it crawled the excluded run millisecond by millisecond
+    /// and, with no base calendar to leap it forward, never returned at all. The end of the excluded
+    /// range is <see cref="CronExpression.GetNextInvalidTimeAfter" />, which is what Java's
+    /// CronCalendar always used.
+    /// </summary>
+    [Test]
+    public async Task NextIncludedTimeFromAnExcludedInstantIsTheEndOfTheExcludedRange()
+    {
+        CronCalendar calendar = new CronCalendar("* * 9 ? * *")
+        {
+            TimeZone = TimeZoneInfo.Utc
+        };
+        DateTimeOffset insideTheExcludedHour = new DateTimeOffset(2026, 1, 1, 9, 30, 0, TimeSpan.Zero);
+
+        // Through a task with a deadline so a regression fails the test instead of hanging the run.
+        Task<DateTimeOffset> search = Task.Run(() => calendar.GetNextIncludedTimeUtc(insideTheExcludedHour));
+        Task finished = await Task.WhenAny(search, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        finished.Should().BeSameAs(search,
+            "the search must step to the end of the excluded range, not crawl it millisecond by millisecond");
+        (await search).Should().Be(new DateTimeOffset(2026, 1, 1, 10, 0, 0, TimeSpan.Zero),
+            "the first included instant after 09:30 is the top of the next hour, where the expression stops matching");
     }
 
     protected override CronCalendar GetTargetObject()

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -72,6 +72,41 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
     }
 
     /// <summary>
+    /// The three-argument constructor used to hand the zone to <see cref="BaseCalendar" /> and build
+    /// the expression without it, while <see cref="CronCalendar.TimeZone" /> reads the zone back off
+    /// that expression - so the argument was silently dropped and the calendar excluded local hours.
+    /// Only the property setter rebuilt the expression correctly.
+    /// </summary>
+    [Test]
+    public void ConstructorTimeZoneReachesTheExpression()
+    {
+        // America/New_York, which is a plain UTC-5 in January: no DST corner is in play here.
+        TimeZoneInfo eastern = TestTimeZones.Eastern;
+
+        CronCalendar calendar = new CronCalendar(null, "* * 9 ? * *", eastern);
+
+        calendar.TimeZone.Should().Be(eastern,
+            "the constructor's zone is what the calendar reports, not the machine's local zone");
+        calendar.CronExpression.TimeZone.Should().Be(eastern,
+            "TimeZone reads off the expression, so the expression is where the zone has to land");
+
+        DateTimeOffset nineThirtyEastern = new DateTimeOffset(2026, 1, 1, 14, 30, 0, TimeSpan.Zero);
+        DateTimeOffset fourThirtyEastern = new DateTimeOffset(2026, 1, 1, 9, 30, 0, TimeSpan.Zero);
+
+        calendar.IsTimeIncluded(nineThirtyEastern).Should().BeFalse(
+            "14:30Z is 09:30 in New York, the hour the expression excludes");
+        calendar.IsTimeIncluded(fourThirtyEastern).Should().BeTrue(
+            "09:30Z is 04:30 in New York, well outside the excluded hour");
+
+        // The same expression pinned to UTC reads the two instants the other way round, which is
+        // what makes the assertions above about the zone rather than about the expression.
+        CronCalendar utc = new CronCalendar(null, "* * 9 ? * *", TimeZoneInfo.Utc);
+
+        utc.IsTimeIncluded(fourThirtyEastern).Should().BeFalse("09:30Z is inside the excluded hour in UTC");
+        utc.IsTimeIncluded(nineThirtyEastern).Should().BeTrue("14:30Z is outside the excluded hour in UTC");
+    }
+
+    /// <summary>
     /// From an instant the calendar EXCLUDES, the next-included search used to walk forward with
     /// <see cref="CronExpression.GetNextValidTimeAfter" /> - which by definition lands on another
     /// satisfied, i.e. excluded, instant - so it crawled the excluded run millisecond by millisecond

--- a/src/Quartz.Tests.Unit/Plugin/Interrupt/JobInterruptMonitorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/Interrupt/JobInterruptMonitorPluginTest.cs
@@ -139,6 +139,76 @@ public class JobInterruptMonitorPluginTest
         }
     }
 
+    /// <summary>
+    /// MaxRunTime used to be read as a string and nothing else, so a job data map holding the number
+    /// 5000 - which is what UsingJobData("MaxRunTime", 5000L) puts there - was quietly ignored and
+    /// the plugin default applied instead.
+    /// </summary>
+    [TestCase(500)]
+    [TestCase(500L)]
+    [TestCase("500")]
+    public async Task ShouldHonourMaxRunTimeStoredAsNumberOrString(object maxRunTime)
+    {
+        // the plugin default is deliberately long: only a MaxRunTime the plugin actually read can interrupt in time
+        IScheduler scheduler = await CreateScheduler("MaxRunTimeAs" + maxRunTime.GetType().Name, defaultMaxRunTimeMilliseconds: 60_000);
+        try
+        {
+            IJobDetail job = CreateAutoInterruptableJob();
+
+            JobDataMap triggerData = new JobDataMap();
+            triggerData.Put(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, maxRunTime);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("t-typed")
+                .ForJob(job)
+                .UsingJobData(triggerData)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("the execution should start");
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue(
+                $"a MaxRunTime of 500 ms stored as {maxRunTime.GetType().Name} should override the plugin's 60 second default");
+
+            interruptedByTrigger["t-typed"].Should().BeTrue(
+                $"the execution exceeded the 500 ms it was allowed by a {maxRunTime.GetType().Name} MaxRunTime");
+        }
+        finally
+        {
+            gate.Release(10); // unblock any execution still gated so shutdown does not wait on it
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    [Test]
+    public async Task ShouldUsePluginDefaultWhenMaxRunTimeIsAbsent()
+    {
+        IScheduler scheduler = await CreateScheduler("NoMaxRunTime", defaultMaxRunTimeMilliseconds: 500);
+        try
+        {
+            IJobDetail job = CreateAutoInterruptableJob();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("t-default")
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+
+            (await started.WaitAsync(waitTimeout)).Should().BeTrue("the execution should start");
+            (await done.WaitAsync(waitTimeout)).Should().BeTrue("the plugin's 500 ms default should interrupt a fire that carries no MaxRunTime");
+
+            interruptedByTrigger["t-default"].Should().BeTrue("a fire with no MaxRunTime of its own is bounded by the plugin default");
+        }
+        finally
+        {
+            gate.Release(10); // unblock any execution still gated so shutdown does not wait on it
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
     private static async Task<IScheduler> CreateScheduler(string name, int defaultMaxRunTimeMilliseconds)
     {
         NameValueCollection config = new NameValueCollection

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Globalization;
@@ -510,6 +511,71 @@ public class JsonObjectSerializerTest
         }
     }
 
+    /// <summary>
+    /// Newtonsoft populates a readable collection property by calling the getter and adding the
+    /// payload's items to whatever comes back. <see cref="DailyTimeIntervalTriggerImpl.DaysOfWeek" />
+    /// manufactures all seven days on a fresh instance, so a trigger stored for Monday and Wednesday
+    /// read back as firing every day.
+    /// </summary>
+    /// <remarks>
+    /// Driven from a payload rather than a full round trip because 3.x's <see cref="TimeOfDay" /> is
+    /// a class with two constructors and no parameterless one, which the property-populating path
+    /// cannot instantiate at all - so a complete converter-less round trip of this trigger type
+    /// fails for that unrelated reason. Leaving the two time-of-day members out of the payload puts
+    /// exactly the collection property under test.
+    /// </remarks>
+    [Test]
+    public void DeserializeKeepsASubsetOfDaysOfWeek()
+    {
+        // RegisterTriggerConverters is left at its default of false, which is the configuration the
+        // property-populating path runs under.
+        JsonObjectSerializer serializer = new JsonObjectSerializer();
+        serializer.Initialize();
+
+        const string json =
+            """
+            {
+              "$type": "Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl, Quartz",
+              "Name": "SubsetDaysTriggerKey",
+              "Group": "SubsetDaysTriggerGroup",
+              "JobName": "SubsetDaysJobKey",
+              "JobGroup": "SubsetDaysJobGroup",
+              "StartTimeUtc": "2024-07-01T00:00:00+00:00",
+              "RepeatInterval": 30,
+              "RepeatIntervalUnit": 2,
+              "DaysOfWeek": [1, 3]
+            }
+            """;
+
+        var deserialized = (IDailyTimeIntervalTrigger) serializer.DeSerialize<IOperableTrigger>(Encoding.UTF8.GetBytes(json));
+
+        deserialized.DaysOfWeek.Should().BeEquivalentTo(new[] { DayOfWeek.Monday, DayOfWeek.Wednesday },
+            "a trigger stored for two days must not come back firing on all seven");
+    }
+
+    /// <summary>
+    /// The same defect on the path any 3.x application can reach: a value in a job data map is
+    /// written and read as a plain object graph, so a read-only collection property of it was
+    /// appended to whatever its getter handed out instead of being replaced.
+    /// </summary>
+    [Test]
+    public void RoundTripReplacesAReadOnlyCollectionPropertyRatherThanAppendingToIt()
+    {
+        JsonObjectSerializer serializer = new JsonObjectSerializer();
+        serializer.Initialize();
+
+        JobDataMap map = new JobDataMap
+        {
+            { "payload", new DefaultingCollectionHolder { Values = new List<string> { "kept" } } }
+        };
+
+        byte[] bytes = serializer.Serialize(map);
+        JobDataMap deserialized = serializer.DeSerialize<JobDataMap>(bytes);
+
+        ((DefaultingCollectionHolder) deserialized["payload"]).Values.Should().BeEquivalentTo(new[] { "kept" },
+            "the stored collection replaces the getter's default rather than being added to it");
+    }
+
     private void CompareSerialization<T>(
         T original,
         Action<T, T> asserter = null,
@@ -571,6 +637,22 @@ public class JsonObjectSerializerTest
 
         timeProvider = fakeTimeProvider;
         return new DisposableAction(() => SystemTime.UtcNow = original);
+    }
+
+    /// <summary>
+    /// A value of the kind an application puts in a job data map: its collection property is typed
+    /// as read-only and its getter defaults to a mutable instance, which is the combination that
+    /// used to lose data - the payload's items were added to that default rather than replacing it.
+    /// </summary>
+    public class DefaultingCollectionHolder
+    {
+        private IReadOnlyCollection<string> values;
+
+        public IReadOnlyCollection<string> Values
+        {
+            get => values ??= new List<string> { "default" };
+            set => values = value;
+        }
     }
 
     private class IndentingJsonObjectSerializer : JsonObjectSerializer

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -993,6 +993,90 @@ public class RAMJobStoreTest
         Assert.That(updated, Is.InstanceOf<ICronTrigger>(), "Trigger should have been replaced with a CronTrigger");
     }
 
+    /// <summary>
+    /// A non-equality matcher pauses several groups at once, and the store has to remember each of
+    /// them by name. It used to record the matcher's own text instead, so the HashSet accepted it
+    /// once and refused it for every later match: only the first group was really paused, and the
+    /// pattern itself leaked out of GetPausedTriggerGroups as though it were a group.
+    /// </summary>
+    [Test]
+    public async Task PauseTriggers_WithPrefixMatcher_PausesEveryMatchingGroup()
+    {
+        await StoreTriggerInGroup("t-alpha", "reports-daily");
+        await StoreTriggerInGroup("t-beta", "reports-weekly");
+        await StoreTriggerInGroup("t-other", "maintenance");
+
+        var paused = await fJobStore.PauseTriggers(GroupMatcher<TriggerKey>.GroupStartsWith("reports-"));
+
+        paused.Should().BeEquivalentTo(new[] { "reports-daily", "reports-weekly" },
+            "both groups match the prefix, so both are reported paused");
+
+        (await fJobStore.GetTriggerState(new TriggerKey("t-alpha", "reports-daily"))).Should().Be(TriggerState.Paused);
+        (await fJobStore.GetTriggerState(new TriggerKey("t-beta", "reports-weekly"))).Should().Be(TriggerState.Paused,
+            "the second matching group was the one the shared HashSet entry used to swallow");
+        (await fJobStore.GetTriggerState(new TriggerKey("t-other", "maintenance"))).Should().Be(TriggerState.Normal);
+
+        var pausedGroups = await fJobStore.GetPausedTriggerGroups();
+        pausedGroups.Should().BeEquivalentTo(new[] { "reports-daily", "reports-weekly" },
+            "the groups that matched are what is remembered; a pattern is not a group");
+        pausedGroups.Should().NotContain("reports-", "the matcher's text is not the name of any group");
+    }
+
+    /// <summary>
+    /// The whole point of remembering a paused group is that triggers added to it later are born
+    /// paused. That only works for the groups that were actually recorded.
+    /// </summary>
+    [Test]
+    public async Task PauseTriggers_WithPrefixMatcher_TriggerAddedAfterwardsIsBornPaused()
+    {
+        await StoreTriggerInGroup("t-alpha", "reports-daily");
+        await StoreTriggerInGroup("t-beta", "reports-weekly");
+
+        await fJobStore.PauseTriggers(GroupMatcher<TriggerKey>.GroupStartsWith("reports-"));
+
+        await StoreTriggerInGroup("t-late", "reports-weekly");
+
+        (await fJobStore.GetTriggerState(new TriggerKey("t-late", "reports-weekly"))).Should().Be(TriggerState.Paused,
+            "the group is paused, so a trigger stored into it afterwards is paused too");
+    }
+
+    /// <summary>
+    /// The removal of the paused groups sat inside the equality branch, so a prefix pause could
+    /// never be undone by the matcher that made it: the triggers resumed, the group stayed
+    /// remembered as paused, and anything stored into it afterwards came back paused.
+    /// </summary>
+    [Test]
+    public async Task ResumeTriggers_WithPrefixMatcher_ForgetsEveryMatchingGroup()
+    {
+        await StoreTriggerInGroup("t-alpha", "reports-daily");
+        await StoreTriggerInGroup("t-beta", "reports-weekly");
+        await StoreTriggerInGroup("t-other", "maintenance");
+
+        await fJobStore.PauseTriggers(GroupMatcher<TriggerKey>.GroupStartsWith("reports-"));
+        await fJobStore.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals("maintenance"));
+
+        await fJobStore.ResumeTriggers(GroupMatcher<TriggerKey>.GroupStartsWith("reports-"));
+
+        (await fJobStore.GetTriggerState(new TriggerKey("t-alpha", "reports-daily"))).Should().Be(TriggerState.Normal);
+        (await fJobStore.GetTriggerState(new TriggerKey("t-beta", "reports-weekly"))).Should().Be(TriggerState.Normal);
+
+        (await fJobStore.GetPausedTriggerGroups()).Should().BeEquivalentTo(new[] { "maintenance" },
+            "the prefix resume forgets exactly the groups it matches, and leaves the others alone");
+
+        await StoreTriggerInGroup("t-late", "reports-weekly");
+        (await fJobStore.GetTriggerState(new TriggerKey("t-late", "reports-weekly"))).Should().Be(TriggerState.Normal,
+            "the group is no longer paused, so a trigger stored into it now runs");
+    }
+
+    private Task StoreTriggerInGroup(string name, string group)
+    {
+        IOperableTrigger trigger = new SimpleTriggerImpl(
+            name, group, fJobDetail.Name, fJobDetail.Group,
+            DateTimeOffset.UtcNow.AddSeconds(30), null, -1, TimeSpan.FromSeconds(30));
+        trigger.ComputeFirstFireTimeUtc(null);
+        return fJobStore.StoreTrigger(trigger, false);
+    }
+
     [DisallowConcurrentExecution]
     private class DisallowConcurrentNoOpJob : IJob
     {

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -5290,7 +5290,13 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         {
             try
             {
-                return (bool) (isTransientProperty.GetValue(ex) ?? false);
+                // Only a true answer settles it. Since .NET 6 every DbException carries this property
+                // and most providers - SqlException among them - never override it, so returning the
+                // driver's verdict either way would leave every check below unreachable.
+                if ((bool) (isTransientProperty.GetValue(ex) ?? false))
+                {
+                    return true;
+                }
             }
             catch
             {

--- a/src/Quartz/Impl/Calendar/CronCalendar.cs
+++ b/src/Quartz/Impl/Calendar/CronCalendar.cs
@@ -86,10 +86,17 @@ public class CronCalendar : BaseCalendar
     /// calendar functionality
     /// </param>
     /// <param name="expression">a string representation of the desired cron expression</param>
-    /// <param name="timeZone"></param>
+    /// <param name="timeZone">the time zone the expression's times are resolved in;
+    /// <see langword="null" /> means the system's local time zone</param>
     public CronCalendar(ICalendar? baseCalendar, string expression, TimeZoneInfo? timeZone) : base(baseCalendar, timeZone)
     {
         cronExpression = new CronExpression(expression);
+        if (timeZone != null)
+        {
+            // The zone has to reach the expression: TimeZone reads off it, so the base class field
+            // it was just handed is shadowed and the argument would otherwise be dropped.
+            cronExpression.TimeZone = timeZone;
+        }
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Calendar/CronCalendar.cs
+++ b/src/Quartz/Impl/Calendar/CronCalendar.cs
@@ -173,7 +173,10 @@ public class CronCalendar : BaseCalendar
             // testing.
             if (cronExpression.IsSatisfiedBy(nextIncludedTime))
             {
-                nextIncludedTime = cronExpression.GetNextValidTimeAfter(nextIncludedTime)!.Value;
+                // The end of the excluded range is the next time the expression does NOT satisfy.
+                // GetNextValidTimeAfter would land on another satisfied - excluded - time, and the
+                // loop would walk the excluded run millisecond by millisecond forever.
+                nextIncludedTime = cronExpression.GetNextInvalidTimeAfter(nextIncludedTime)!.Value;
             }
             else if (CalendarBase != null &&
                      !CalendarBase.IsTimeIncluded(nextIncludedTime))

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1317,11 +1317,14 @@ public class RAMJobStore : IJobStore, INextVersionJobStore
             }
             else
             {
+                // The group that matched is what gets remembered, not the matcher's own text: a
+                // pattern is not a group, and keying the set on it would let the first matching
+                // group swallow the pause for every later one.
                 foreach (string group in triggersByGroup.Keys)
                 {
                     if (op.Evaluate(group, matcher.CompareToValue))
                     {
-                        if (pausedTriggerGroups.Add(matcher.CompareToValue))
+                        if (pausedTriggerGroups.Add(group))
                         {
                             pausedGroups.Add(group);
                         }
@@ -1503,30 +1506,18 @@ public class RAMJobStore : IJobStore, INextVersionJobStore
                 }
                 ResumeTriggerInternal(triggerKey);
             }
-            // Find all matching paused trigger groups, and then remove them.
+            // Forget the pause of every group the matcher selects, whichever operator it carries -
+            // the pause is recorded per matched group, so a resume that only understood equality
+            // would leave the groups a prefix pause recorded paused forever.
             StringOperator op = matcher.CompareWithOperator;
-            var pausedGroups = new List<string>();
             var matcherGroup = matcher.CompareToValue;
             if (op.Equals(StringOperator.Equality))
             {
-                if (pausedTriggerGroups.Contains(matcherGroup))
-                {
-                    pausedGroups.Add(matcher.CompareToValue);
-                }
-                else
-                {
-                    foreach (string group in pausedTriggerGroups)
-                    {
-                        if (op.Evaluate(group, matcherGroup))
-                        {
-                            pausedGroups.Add(group);
-                        }
-                    }
-                }
-                foreach (string pausedGroup in pausedGroups)
-                {
-                    pausedTriggerGroups.Remove(pausedGroup);
-                }
+                pausedTriggerGroups.Remove(matcherGroup);
+            }
+            else
+            {
+                pausedTriggerGroups.RemoveWhere(group => op.Evaluate(group, matcherGroup));
             }
             return groups;
         }


### PR DESCRIPTION
The 4.0 pre-alpha campaign's test waves surfaced several defects that predate the 4.x work; a verification pass confirmed six of them on 3.x with exact locations, and this backports the fixes — minimal, 3.x-idiomatic diffs, each mutation-verified (failing before, passing after) on both test TFMs.

1. **`CronCalendar.GetNextIncludedTimeUtc` never terminates from an excluded instant** — it advanced with `GetNextValidTimeAfter`, which lands on another satisfied (= excluded) time; now `GetNextInvalidTimeAfter`, the end of the excluded range. Deadline-guarded regression test.
2. **`CronCalendar`'s 3-arg constructor dropped its `timeZone`** — the base writes a private field the `TimeZone` override shadows, so the calendar evaluated its exclusion cron in machine-local time. The zone now reaches the expression.
3. **Transient-error classification short-circuited on `DbException.IsTransient`** — on any .NET 6+ host the reflective probe matches every driver exception, and `SqlException` does not override the property, so the deadlock-1205 list, the SQLite busy/locked check and the timeout fallback were all dead code; retryable failures were classified permanent. The probe now only trusts `true` and falls through otherwise; .NET Framework hosts unchanged.
4. **A prefix trigger-group pause paused only the first matching group** (the bookkeeping added the matcher's own text, which also leaked out of `GetPausedTriggerGroups` and mis-drove born-paused checks), **and a prefix resume could never clear what a prefix pause recorded** (removal was nested in the equality branch). `PauseJobs`/`ResumeJobs` were already correct and are untouched.
5. **`JobInterruptMonitorPlugin` silently ignored a numeric `MaxRunTime`** — the value was read only as a string; `UsingJobData("MaxRunTime", 5000L)` fell back to the 5-minute default with no log. Numbers and numeric strings now both work; garbage warns; absent stays silent.
6. **Newtonsoft deserialization populated read-only collections through their getters** — on the DEFAULT configuration (`RegisterTriggerConverters` is false), a `DaysOfWeek` subset came back as all seven days wherever a trigger travels through the plain serializer (blob-fallback subclassed triggers, direct use, POCOs in job data). A contract resolver now replaces rather than populates read-only collection properties. (The full-trigger round-trip test is driven from a payload omitting `TimeOfDay` — that class has no parameterless constructor on 3.x, an independent pre-existing limitation noted in the test.)

Deliberately NOT backported: the 4.x store-parity semantic alignments (pause-over-Error, ResumeAll marker clearing, sentinel visibility, exception re-wrap types) — those change observable maintenance-branch behavior.

Verification: unit suites green on net10.0 (1782) and net472 (1771); `Compile UnitTest` across all six TFMs under warnings-as-errors; public API baselines byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf