### PR TITLE
A release tag is read off the ref and parsed as semver

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
+using Semver;
+
 using Fallout.Common;
 using Fallout.Common.CI;
 using Fallout.Common.CI.GitHubActions;
@@ -36,11 +38,25 @@ partial class Build : FalloutBuild, ICompile, IPack
     AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
     AbsolutePath CoverageDirectory => ArtifactsDirectory / "coverage";
 
-    // Null when the repository can't be resolved, e.g. in a git worktree, where the local build
-    // simply has no tag to version from. CI always checks out a plain clone.
-    string TagVersion => GitRepository?.Tags.SingleOrDefault(x => x.StartsWith('v'))?[1..];
+    // On GitHub Actions the ref itself is the authority: the host's RefName carries the tag name
+    // for both lightweight and annotated tags, where GitRepository.Tags only ever sees lightweight
+    // ones (it matches the ref's stored object id against the commit, and an annotated tag's ref
+    // points at the tag object). Locally GitRepository is the fallback -- and null in a git
+    // worktree, where the local build simply has no tag to version from.
+    string TagName =>
+        GitHubActions.Instance is { RefType: "tag" } actions
+            ? actions.RefName
+            : GitRepository?.Tags.FirstOrDefault(x => x.StartsWith('v'));
 
-    bool IsTaggedBuild => !string.IsNullOrWhiteSpace(TagVersion);
+    // The parsed release version, null when this is not a tagged build. A v-tag that is not valid
+    // semantic versioning fails the build in OnBuildInitialized rather than packing a garbage
+    // version string.
+    SemVersion TagSemVersion =>
+        TagName is { } name && name.StartsWith('v')
+            ? SemVersion.TryParse(name[1..], SemVersionStyles.Strict, out var parsed) ? parsed : null
+            : null;
+
+    bool IsTaggedBuild => TagName is { } name && name.StartsWith('v');
 
     string VersionPrefix;
     string VersionSuffix;
@@ -60,16 +76,23 @@ partial class Build : FalloutBuild, ICompile, IPack
         // untagged preview builds carry — a stale value there cannot affect a release.
         if (IsTaggedBuild)
         {
-            var separator = TagVersion.IndexOf('-');
-            VersionPrefix = separator < 0 ? TagVersion : TagVersion[..separator];
-            VersionSuffix = separator < 0 ? null : TagVersion[(separator + 1)..];
+            var version = TagSemVersion;
+            if (version is null)
+            {
+                throw new InvalidOperationException(
+                    $"Tag '{TagName}' is not valid semantic versioning after the 'v'. " +
+                    "A release tag looks like v4.0.0 or v4.0.0-alpha.1; fix the tag rather than the build.");
+            }
+
+            VersionPrefix = $"{version.Major}.{version.Minor}.{version.Patch}";
+            VersionSuffix = version.IsPrerelease ? version.Prerelease : null;
 
             if (VersionPrefix != PropsVersionPrefix)
             {
                 // Not fatal — the tag wins by design. Surfaced (as a ::warning:: annotation on CI, via
                 // Fallout's Serilog sink) so the props file gets caught up after the release.
-                Log.Warning("Releasing {FullVersion:l} from tag v{TagVersion:l}, but {File:l} still says {PropsVersion:l} — bump it after the release",
-                    FullVersion, TagVersion, VersionPropsFile.Name, PropsVersionPrefix);
+                Log.Warning("Releasing {FullVersion:l} from tag {TagName:l}, but {File:l} still says {PropsVersion:l} — bump it after the release",
+                    FullVersion, TagName, VersionPropsFile.Name, PropsVersionPrefix);
             }
         }
         else

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -29,6 +29,7 @@
       (Fallout-build/Fallout#638).
     -->
     <PackageReference Include="NuGet.Frameworks" Version="7.9.0" />
+    <PackageReference Include="Semver" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The v4.0.0-alpha.1 publish run skipped Publish (`Tagged build: False`). Root cause: the tag was ANNOTATED — its ref points at the tag object — and Fallout's `GetTagsFromCommit` matches ref contents against the commit SHA, so only lightweight tags were ever visible (every historical release tag is one; this tag was the deviation).

Two-layer fix in our Build.cs, per review:

1. **The ref is the authority on Actions**: `GITHUB_REF_TYPE=tag` → `GITHUB_REF_NAME` carries the name for annotated and lightweight tags alike; `GitRepository.Tags` remains the local fallback.
2. **Real semver parsing** via the [Semver](https://www.nuget.org/packages/Semver) package (3.0.0, strict styles) instead of splitting on the first hyphen: prefix = Major.Minor.Patch, suffix = the prerelease identifiers — and a v-tag that is not valid semver **fails the build loudly** ("fix the tag rather than the build") instead of packing whatever followed the v. Also retires the `SingleOrDefault` throw-on-two-tags.

Verified empirically on all three paths: `GITHUB_REF_NAME=v4.0.0-alpha.1` → Tagged build True, prefix 4.0.0; `vNext` → the loud failure; untagged → preview as before.

After merge: the annotated tag gets replaced by a lightweight one on the fixed head, which reruns publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9KNtGpkNuNL1udgBwDXf