### PR TITLE
Adopt real-slugifier anchor checking into CI

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -22,3 +22,10 @@ jobs:
         run: |
           npm ci
           npm run docs:build
+
+      # markdownlint's MD051 cannot check fragments against a VuePress slugger, so it is off;
+      # this is the replacement. See the note in .markdownlint.jsonc.
+      - name: Check links and anchors
+        run: |
+          npm run docs:check-links-test
+          npm run docs:check-links

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -73,12 +73,21 @@ jobs:
           # Without this the scanner reports an empty sonar.token as a format error, which reads
           # like a typo rather than a missing secret.
           [ -n "$SONAR_TOKEN" ] || { echo "::error::SONAR_TOKEN is not set — see the header of .github/workflows/sonar.yml"; exit 1; }
+          # sonar.coverage.exclusions, not sonar.exclusions: the scanner imports C# coverage only
+          # (sonar.cs.opencover.reportsPaths below), so JavaScript build tooling arrives as new code
+          # carrying no coverage data at all and fails the new-code coverage condition by itself. It
+          # stays in analysis, where the bug and security rules still apply to it; what it is excused
+          # from is a coverage figure this workflow is not configured to produce. Its own control is
+          # `npm run docs:check-links-test`.
           dotnet-sonarscanner begin \
             /k:"quartznet_quartznet" \
             /o:"quartznet" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.token="$SONAR_TOKEN" \
-            /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml"             /d:sonar.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**"             /d:sonar.cpd.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**"
+            /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml" \
+            /d:sonar.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**" \
+            /d:sonar.cpd.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**" \
+            /d:sonar.coverage.exclusions="docs/.vuepress/**"
       # Has to sit between begin and end: the scanner analyses through MSBuild, so only projects
       # actually built while it is active are measured.
       - name: 'Run: Compile, UnitTest'

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -24,7 +24,9 @@
        "jobdatamap-s", "ScheduleBuilder<T>" -> "schedulebuilder-t". Every anchor MD051
        reports here is one that resolves on the published site, and the anchors it would
        accept instead are the ones that 404 there — so the rule is measuring the wrong
-       thing for this repo. Anchors are checked against the real slugifier instead. */
+       thing for this repo. `npm run docs:check-links` checks fragments instead, against
+       the slugger and the router the site is actually built with, and runs on every docs
+       pull request; `npm run docs:check-links-test` is its own control. */
     "MD051": false,
     "MD059": false, /* link text style - existing docs use short links */
     "MD060": false  /* table column style - existing docs use compact style */

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,11 @@ plus a bridge entry on main.
 - **Ported code that fails to build is usually a rename, not a missing feature.** Check the tables
   above and `docs/documentation/quartz-4.x/migration-guide.md`, which explains the reasoning for each.
 - **`docs/documentation/quartz-3.x/` must keep the old names.** Only update `quartz-4.x/`.
+- **Heading fragments are checked with the site's own slugger, not GitHub's.** `npm run docs:check-links`
+  parses the docs with the markdown-it instance VuePress renders them with, so the ids it validates
+  against are the ids the published pages carry — `Quartz.Core` is `#quartz-core`, not `#quartzcore`.
+  It runs on every docs pull request. markdownlint's MD051 is off for exactly this reason; do not
+  take its fragment suggestions, they 404. `npm run docs:check-links-test` is the checker's control.
 - **`src/Quartz.Tests.Unit/Verify/PublicApiTest_*.verified.txt` are the public API baselines.**
   Any change to public API fails those tests; review the diff, and if the change is intended,
   accept the new baseline and carry the same diff into

--- a/docs/.vuepress/check-links.fixtures/broken/README.md
+++ b/docs/.vuepress/check-links.fixtures/broken/README.md
@@ -1,0 +1,28 @@
+---
+title: Broken fixture
+---
+
+# Broken fixture
+
+The negative control. Every link below is dead on a VuePress 2 site, and the checker is asserted
+to say so — a checker nobody has watched go red is worth very little. The first four are the
+anchors markdownlint's MD051 would ask for instead of the ones that work, which is why MD051 is
+off and this runs.
+
+- [GitHub deletes the dot; this site hyphenates it](slugs.md#quartzcore)
+- [GitHub deletes the apostrophe; this site hyphenates it](slugs.md#jobdatamaps-contents)
+- [GitHub deletes the angle brackets; this site hyphenates them](slugs.md#schedulebuildert)
+- [GitHub leaves a leading digit alone; this site prefixes an underscore](slugs.md#40-changes)
+- [one duplicate suffix past the last identical heading](slugs.md#repeated-heading-3)
+- [a page that does not exist](nowhere.md)
+- [a directory the router renames, reached by relative path](_drafts/note.md)
+- [an asset that does not exist](assets/missing.txt)
+- [a fragment this page does not have](#no-such-heading)
+
+Links in a table are checked too, and are reported on their own row rather than on the row the
+table starts at — most of the migration guide is one long table.
+
+| 3.x | 4.x |
+| --- | --- |
+| [one dead anchor](slugs.md#first-dead-anchor-in-a-table) | `Quartz.Core` |
+| [and another](slugs.md#second-dead-anchor-in-a-table) | `Quartz.Core` |

--- a/docs/.vuepress/check-links.fixtures/broken/_drafts/note.md
+++ b/docs/.vuepress/check-links.fixtures/broken/_drafts/note.md
@@ -1,0 +1,3 @@
+# A drafted note
+
+The router serves this at /drafts/note.html: sanitizeFileName strips the leading underscore.

--- a/docs/.vuepress/check-links.fixtures/broken/slugs.md
+++ b/docs/.vuepress/check-links.fixtures/broken/slugs.md
@@ -1,0 +1,15 @@
+# Quartz.Core
+
+GitHub would slug this heading `quartzcore`; @mdit-vue/shared turns the dot into a hyphen.
+
+## JobDataMap's contents
+
+## `ScheduleBuilder<T>`
+
+## 4.0 changes
+
+## Repeated heading
+
+## Repeated heading
+
+## Repeated heading

--- a/docs/.vuepress/check-links.fixtures/clean/README.md
+++ b/docs/.vuepress/check-links.fixtures/clean/README.md
@@ -1,0 +1,30 @@
+---
+title: Clean fixture
+---
+
+# Clean fixture
+
+Every link below resolves on a VuePress 2 site. Several of them are ones markdownlint's MD051
+rejects, because it slugifies headings the way GitHub does rather than the way this site does.
+
+- [a sibling page](slugs.md)
+- [a slug where the punctuation became a hyphen](slugs.md#quartz-core)
+- [a slug where an apostrophe became a hyphen](slugs.md#jobdatamap-s-contents)
+- [a slug taken from a code span](slugs.md#schedulebuilder-t)
+- [a slug prefixed because the heading starts with a digit](slugs.md#_4-0-changes)
+- [the same slug written without the prefix, which VuePress adds for you](slugs.md#4-0-changes)
+- [the second of three identical headings](slugs.md#repeated-heading-1)
+- [the third of three identical headings](slugs.md#repeated-heading-2)
+- [a link written without its extension](slugs)
+- [a directory index](nested/)
+- [the same directory index without its trailing slash](nested)
+- [a site-absolute route](/slugs.html#quartz-core)
+- [a page in a directory whose leading underscore the router strips](/drafts/note.html)
+- [a fragment on this page](#clean-fixture)
+- [an asset](assets/diagram.txt)
+
+Links inside a table are checked too:
+
+| 3.x | 4.x |
+| --- | --- |
+| [a slug from a code span](slugs.md#schedulebuilder-t) | `ScheduleBuilder<T>` |

--- a/docs/.vuepress/check-links.fixtures/clean/_drafts/note.md
+++ b/docs/.vuepress/check-links.fixtures/clean/_drafts/note.md
@@ -1,0 +1,3 @@
+# A drafted note
+
+The router serves this at /drafts/note.html: sanitizeFileName strips the leading underscore.

--- a/docs/.vuepress/check-links.fixtures/clean/assets/diagram.txt
+++ b/docs/.vuepress/check-links.fixtures/clean/assets/diagram.txt
@@ -1,0 +1,1 @@
+A stand-in for an image or a download.

--- a/docs/.vuepress/check-links.fixtures/clean/nested/README.md
+++ b/docs/.vuepress/check-links.fixtures/clean/nested/README.md
@@ -1,0 +1,3 @@
+# Nested index
+
+A directory index, served at the directory route.

--- a/docs/.vuepress/check-links.fixtures/clean/slugs.md
+++ b/docs/.vuepress/check-links.fixtures/clean/slugs.md
@@ -1,0 +1,15 @@
+# Quartz.Core
+
+GitHub would slug this heading `quartzcore`; @mdit-vue/shared turns the dot into a hyphen.
+
+## JobDataMap's contents
+
+## `ScheduleBuilder<T>`
+
+## 4.0 changes
+
+## Repeated heading
+
+## Repeated heading
+
+## Repeated heading

--- a/docs/.vuepress/check-links.mjs
+++ b/docs/.vuepress/check-links.mjs
@@ -1,0 +1,297 @@
+// Link and anchor checker for the VuePress 2 docs tree.
+//
+// markdownlint's MD051 validates fragments with GitHub's heading slugger, which is not the
+// slugger this site uses, so it flags anchors that resolve and suggests anchors that 404.
+// This checker asks VuePress itself instead: it builds the same markdown-it instance the site
+// is rendered with (`createMarkdown` from `vuepress/markdown`, which wires markdown-it-anchor
+// with @mdit-vue/shared's `slugify` and its `-1`/`-2` duplicate suffixes), so the ids it reads
+// off the heading tokens are byte-for-byte the ids the published pages carry. Page routes are
+// computed with VuePress's own `inferRoutePath` and `sanitizeFileName`, which is why
+// `docs/_posts/x.md` is known to be served at `/posts/x.html`.
+//
+// Usage: node docs/.vuepress/check-links.mjs [docsDir]
+//
+// Exit codes: 0 clean, 1 problems found, 2 bad usage.
+
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { createMarkdown } from 'vuepress/markdown'
+import { inferRoutePath, isLinkExternal } from 'vuepress/shared'
+import { fs, path, sanitizeFileName, tinyglobby } from 'vuepress/utils'
+
+// The glob VuePress itself pages the source directory with (`resolveAppOptions`), so the checker
+// covers exactly the files that become pages -- no more, no less.
+const PAGE_PATTERNS = ['**/*.md', '!.vuepress']
+const IGNORE_PATTERNS = ['**/node_modules', '**/.yarn', '**/.git', '**/.svn', '**/.hg']
+
+// Extensions that are pages rather than assets. Everything else is checked as a file on disk.
+const PAGE_EXTENSIONS = new Set(['', '.md', '.html'])
+
+// The shape @vuepress/markdown's links plugin recognises as internal and rewrites into a route.
+// Anything else it leaves as a plain href for the browser to resolve, which changes what the
+// link is relative to -- see `resolveTarget`.
+const VUEPRESS_INTERNAL_LINK = /^[^#?]*?(?:\/|\.md|\.html)(?:[#?].*)?$/
+
+const decode = (value) => {
+  try {
+    return decodeURI(value)
+  } catch {
+    return value
+  }
+}
+
+const decodeFragment = (value) => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+/**
+ * The route VuePress serves a source file at: `resolvePagePath` composed with `inferPagePath`,
+ * with the frontmatter permalink winning when there is one. Routes are kept decoded so they
+ * compare against link targets, which are decoded too.
+ */
+const routeOf = (filePathRelative, frontmatter) => {
+  const permalink = typeof frontmatter?.permalink === 'string' ? frontmatter.permalink : null
+  const pagePath = permalink ?? inferRoutePath(`/${filePathRelative}`)
+  return decode(encodeURI(pagePath.split('/').map(sanitizeFileName).join('/')))
+}
+
+/**
+ * Resolve a link target to a site-absolute path, from whichever base the site resolves it from.
+ *
+ * A link the links plugin recognises is rewritten at build time relative to the *source* file
+ * path; one it does not recognise survives as a plain href and the browser resolves it relative
+ * to the *route*. The two differ wherever `sanitizeFileName` rewrites a directory (`_posts` ->
+ * `posts`) or a permalink moves the page, and a link written the first way into such a directory
+ * is genuinely broken on the site.
+ */
+const resolveTarget = (page, rawPath) => {
+  const from = VUEPRESS_INTERNAL_LINK.test(rawPath) ? `/${page.file}` : page.route
+  return decode(new URL(encodeURI(rawPath), `http://docs${encodeURI(from)}`).pathname)
+}
+
+/** Levenshtein distance, used only to suggest what a dead fragment probably meant. */
+const distance = (a, b) => {
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index)
+  for (let i = 1; i <= a.length; i++) {
+    const current = [i]
+    for (let j = 1; j <= b.length; j++) {
+      current[j] = Math.min(
+        previous[j] + 1,
+        current[j - 1] + 1,
+        previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1))
+    }
+    previous = current
+  }
+  return previous[b.length]
+}
+
+const suggest = (fragment, available) => [...available]
+  .map((candidate) => ({ candidate, score: distance(fragment, candidate) }))
+  .filter(({ candidate, score }) => score <= Math.max(3, Math.ceil(candidate.length / 3)))
+  .sort((left, right) => left.score - right.score)
+  .slice(0, 3)
+  .map(({ candidate }) => `#${candidate}`)
+
+/**
+ * Walk the token stream a page parsed to, collecting the heading ids markdown-it-anchor assigned,
+ * any ids written as raw HTML (VuePress renders that), and every link with the line it sits on.
+ */
+const readPage = (markdown, source, filePathRelative) => {
+  const env = { filePathRelative, base: '/' }
+  const tokens = markdown.parse(source, env)
+  const lines = source.split(/\r?\n/)
+  // The frontmatter plugin parses the body with the frontmatter cut off, so token line numbers
+  // are short by however many lines it removed. Put them back on so reports cite the file.
+  const offset = lines.length - String(env.content ?? source).split(/\r?\n/).length
+
+  const anchors = new Set()
+  const links = []
+
+  const addHtmlIds = (html) => {
+    for (const match of html.matchAll(/<[a-z][^>]*\sid=["']([^"']+)["']/gi)) anchors.add(match[1])
+  }
+
+  // markdown-it hands out a block's line range, not a per-link line, so walk the range for the
+  // href itself and keep a cursor so repeated links on one line are reported where they are.
+  const locate = (block, cursor, href) => {
+    const first = (block?.[0] ?? 0) + offset
+    const last = Math.min((block?.[1] ?? lines.length) + offset, lines.length)
+    for (let line = Math.max(cursor.line, first); line < last; line++) {
+      const column = lines[line].indexOf(href, line === cursor.line ? cursor.column : 0)
+      if (column === -1) continue
+      cursor.line = line
+      cursor.column = column + href.length
+      return line + 1
+    }
+    return first + 1
+  }
+
+  // Tokens arrive in document order, so one cursor over the whole page keeps `locate` monotonic.
+  const cursor = { line: 0, column: 0 }
+
+  const visit = (list, block) => {
+    for (const token of list) {
+      if (token.type === 'heading_open') {
+        const id = token.attrGet('id')
+        if (id) anchors.add(id)
+      } else if (token.type === 'html_block' || token.type === 'html_inline') {
+        addHtmlIds(token.content)
+      } else if (token.type === 'link_open') {
+        const href = token.attrGet('href')
+        if (href) links.push({ href, line: locate(block, cursor, href) })
+      }
+
+      if (token.children?.length) visit(token.children, token.map ?? block)
+    }
+  }
+
+  visit(tokens, null)
+
+  return { anchors, links, frontmatter: env.frontmatter }
+}
+
+export const checkDocs = async (docsDir) => {
+  const root = path.normalize(path.resolve(docsDir))
+  if (!fs.existsSync(root)) throw new Error(`no such directory: ${root}`)
+
+  // The site renders each heading wrapped in its own `#slug` permalink; those self-links are not
+  // content and would drown the counts. Suppressing them leaves the ids untouched.
+  const markdown = createMarkdown({ anchor: { permalink: false } })
+  const files = (await tinyglobby.glob(PAGE_PATTERNS, { cwd: root, ignore: IGNORE_PATTERNS })).sort()
+
+  const pages = new Map()
+  const byRoute = new Map()
+  for (const file of files) {
+    const source = fs.readFileSync(path.join(root, file), 'utf8')
+    const page = { file, ...readPage(markdown, source, file) }
+    page.route = routeOf(file, page.frontmatter)
+    pages.set(file, page)
+    byRoute.set(page.route, page)
+  }
+
+  const problems = []
+  let checkedLinks = 0
+  let checkedFragments = 0
+
+  const report = (page, line, kind, href, note) =>
+    problems.push({ file: page.file, line, kind, href, note })
+
+  for (const page of pages.values()) {
+    for (const { href, line } of page.links) {
+      // Anything with a protocol -- http, mailto, tel, data -- is somebody else's to verify.
+      if (isLinkExternal(href)) continue
+      checkedLinks++
+
+      const hashAt = href.indexOf('#')
+      const rawPath = (hashAt === -1 ? href : href.slice(0, hashAt)).split('?')[0]
+      // VuePress rewrites a fragment that starts with a digit, matching what `slugify` does to
+      // a heading that starts with one.
+      const fragment = hashAt === -1
+        ? ''
+        : decodeFragment(href.slice(hashAt + 1)).replace(/^(\d)/, '_$1')
+
+      let target = page
+      if (rawPath) {
+        const absolute = resolveTarget(page, rawPath)
+        const extension = absolute.endsWith('/') ? '' : path.extname(absolute).toLowerCase()
+
+        if (!PAGE_EXTENSIONS.has(extension)) {
+          // An asset. It is served either from the docs tree or from .vuepress/public.
+          const assets = [path.join(root, absolute), path.join(root, '.vuepress/public', absolute)]
+          if (!assets.some((asset) => fs.existsSync(asset))) {
+            report(page, line, 'no such file', href, absolute === href ? '' : `resolves to ${absolute}`)
+          }
+          continue
+        }
+
+        // A directory link may be written without its trailing slash; the static host redirects.
+        const candidates = [inferRoutePath(absolute)]
+        if (!extension) candidates.push(`${absolute.replace(/\/$/, '')}/`)
+        const routes = [...new Set(candidates)]
+
+        const resolved = routes.map((route) => byRoute.get(route)).find(Boolean)
+        if (!resolved) {
+          const wanted = routes.join(' or ')
+          report(page, line, 'no such page', href, wanted === href ? '' : `resolves to ${wanted}`)
+          continue
+        }
+        target = resolved
+      }
+
+      if (!fragment) continue
+      checkedFragments++
+      if (!target.anchors.has(fragment)) {
+        const closest = suggest(fragment, target.anchors)
+        report(page, line, 'dead anchor', href,
+          `${target.file} has no #${fragment}` +
+          (closest.length > 0 ? `, closest: ${closest.join(', ')}` : ''))
+      }
+    }
+  }
+
+  return {
+    root,
+    files: files.length,
+    checkedLinks,
+    checkedFragments,
+    problems,
+    pages: [...pages.values()].map(({ file, route, anchors }) => ({
+      file,
+      route,
+      anchors: [...anchors],
+    })),
+  }
+}
+
+const run = async (argv) => {
+  const args = argv.filter((argument) => argument !== '--')
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log('Usage: node docs/.vuepress/check-links.mjs [docsDir]')
+    console.log('Checks every internal link and heading fragment in a VuePress docs tree.')
+    return 0
+  }
+  if (args.length > 1) {
+    console.error('error: expected at most one argument, the docs directory')
+    return 2
+  }
+
+  // Default to the tree this script lives in, so the npm script works from anywhere.
+  const docsDir = args[0] ?? path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+
+  let result
+  try {
+    result = await checkDocs(docsDir)
+  } catch (error) {
+    console.error(`error: ${error.message}`)
+    return 2
+  }
+  const { root, files, checkedLinks, checkedFragments, problems } = result
+
+  console.log(`${path.relative(process.cwd(), root) || '.'}: ` +
+    `${files} pages, ${checkedLinks} internal links, ${checkedFragments} fragments`)
+
+  if (problems.length === 0) {
+    console.log('no dead links or anchors')
+    return 0
+  }
+
+  let current = null
+  for (const problem of problems) {
+    if (problem.file !== current) {
+      current = problem.file
+      console.log(`\n${path.relative(process.cwd(), path.join(root, current))}`)
+    }
+    console.log(`  ${String(problem.line).padStart(5)}  ${problem.kind.padEnd(12)}  ${problem.href}`)
+    if (problem.note) console.log(`  ${' '.repeat(21)}${problem.note}`)
+  }
+  console.log(`\n${problems.length} problem${problems.length === 1 ? '' : 's'}`)
+  return 1
+}
+
+if (process.argv[1] && path.normalize(process.argv[1]) === path.normalize(fileURLToPath(import.meta.url))) {
+  process.exitCode = await run(process.argv.slice(2))
+}

--- a/docs/.vuepress/check-links.test.mjs
+++ b/docs/.vuepress/check-links.test.mjs
@@ -1,0 +1,107 @@
+// Controls for the link and anchor checker: a tree that must pass and a tree that must not.
+//
+// Run with: npm run docs:check-links-test
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { execPath } from 'node:process'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { path } from 'vuepress/utils'
+import { checkDocs } from './check-links.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const fixture = (name) => path.join(here, 'check-links.fixtures', name)
+
+test('a tree whose links all resolve is reported clean', async () => {
+  const { problems, files, checkedLinks, checkedFragments } = await checkDocs(fixture('clean'))
+
+  assert.deepEqual(problems, [], 'the clean fixture is the positive control; it must stay clean')
+  assert.equal(files, 4)
+  assert.equal(checkedLinks, 16, 'every link in the fixture is meant to be checked')
+  assert.equal(checkedFragments, 10, 'every fragment in the fixture is meant to be checked')
+})
+
+test('headings are slugified the way the site slugifies them', async () => {
+  const { pages } = await checkDocs(fixture('clean'))
+  const slugs = pages.find((page) => page.file === 'slugs.md')
+
+  // Not one of these is what GitHub's slugger — and so markdownlint's MD051 — would produce:
+  // it deletes the punctuation that @mdit-vue/shared turns into a hyphen, and leaves a leading
+  // digit alone. The last three are markdown-it-anchor's duplicate suffixes.
+  assert.deepEqual(slugs.anchors, [
+    'quartz-core',
+    'jobdatamap-s-contents',
+    'schedulebuilder-t',
+    '_4-0-changes',
+    'repeated-heading',
+    'repeated-heading-1',
+    'repeated-heading-2',
+  ])
+})
+
+test('a page whose directory the router renames is routed the way the router routes it', async () => {
+  const { pages } = await checkDocs(fixture('clean'))
+  const routes = Object.fromEntries(pages.map((page) => [page.file, page.route]))
+
+  assert.equal(routes['README.md'], '/', 'a README is the index of its directory')
+  assert.equal(routes['nested/README.md'], '/nested/')
+  assert.equal(routes['_drafts/note.md'], '/drafts/note.html',
+    'sanitizeFileName strips the leading underscore, which is why docs/_posts is served at /posts')
+})
+
+test('a tree with dead links is rejected, one problem per link', async () => {
+  const { problems } = await checkDocs(fixture('broken'))
+
+  assert.deepEqual(problems.map(({ kind, href }) => `${kind}: ${href}`), [
+    'dead anchor: slugs.md#quartzcore',
+    'dead anchor: slugs.md#jobdatamaps-contents',
+    'dead anchor: slugs.md#schedulebuildert',
+    'dead anchor: slugs.md#40-changes',
+    'dead anchor: slugs.md#repeated-heading-3',
+    'no such page: nowhere.md',
+    'no such page: _drafts/note.md',
+    'no such file: assets/missing.txt',
+    'dead anchor: #no-such-heading',
+    'dead anchor: slugs.md#first-dead-anchor-in-a-table',
+    'dead anchor: slugs.md#second-dead-anchor-in-a-table',
+  ], 'the broken fixture is the negative control; every line of it must be caught')
+})
+
+test('a problem is reported on the line the link is written on', async () => {
+  const { problems } = await checkDocs(fixture('broken'))
+  const lines = Object.fromEntries(problems.map(({ href, line }) => [href, line]))
+
+  assert.equal(lines['slugs.md#quartzcore'], 12)
+  assert.equal(lines['#no-such-heading'], 20)
+  // Two rows of one table: a block's line range is not good enough, the row has to be found.
+  assert.equal(lines['slugs.md#first-dead-anchor-in-a-table'], 27)
+  assert.equal(lines['slugs.md#second-dead-anchor-in-a-table'], 28)
+})
+
+test('a dead anchor is reported with the anchor that was probably meant', async () => {
+  const { problems } = await checkDocs(fixture('broken'))
+  const notes = Object.fromEntries(problems.map(({ href, note }) => [href, note]))
+
+  assert.match(notes['slugs.md#quartzcore'], /closest: #quartz-core/)
+  assert.match(notes['slugs.md#schedulebuildert'], /closest: #schedulebuilder-t/)
+})
+
+test('the command line exits non-zero when it finds problems', () => {
+  const script = path.join(here, 'check-links.mjs')
+
+  const clean = spawnSync(execPath, [script, fixture('clean')], { encoding: 'utf8' })
+  assert.equal(clean.status, 0, clean.stdout + clean.stderr)
+  assert.match(clean.stdout, /no dead links or anchors/)
+
+  const broken = spawnSync(execPath, [script, fixture('broken')], { encoding: 'utf8' })
+  assert.equal(broken.status, 1, 'CI relies on the exit code, not on the report')
+  assert.match(broken.stdout, /11 problems/)
+
+  const misused = spawnSync(execPath, [script, 'one', 'two'], { encoding: 'utf8' })
+  assert.equal(misused.status, 2, 'a usage error is not a docs failure')
+
+  const missing = spawnSync(execPath, [script, fixture('nowhere')], { encoding: 'utf8' })
+  assert.equal(missing.status, 2, 'nor is being pointed at a directory that is not there')
+  assert.match(missing.stderr, /no such directory/)
+})

--- a/docs/_posts/2020-07-14-quartznet-3.1-beta-2-released.md
+++ b/docs/_posts/2020-07-14-quartznet-3.1-beta-2-released.md
@@ -8,7 +8,7 @@ promote: false
 ## Quartz.NET 3.1 beta 2 Released
 
 The wait is almost over, after more than two years of hiatus, Quartz.NET 3.1 beta 2 is here with exciting new features.
-This release builds on top of [beta 1](/2020/07/08/quartznet-3-1-beta-1-released/) adding more fixes and improvements. Read the [beta 1 release notes](/2020/07/08/quartznet-3-1-beta-1-released/) to know more.
+This release builds on top of [beta 1](/posts/2020-07-08-quartznet-3.1-beta-1-released.html) adding more fixes and improvements. Read the [beta 1 release notes](/posts/2020-07-08-quartznet-3.1-beta-1-released.html) to know more.
 
 ### Known Issues
 

--- a/docs/_posts/2020-07-21-quartznet-3.1-beta-3-released.md
+++ b/docs/_posts/2020-07-21-quartznet-3.1-beta-3-released.md
@@ -10,7 +10,7 @@ promote: false
 The wait is almost over, after more than two years of hiatus, Quartz.NET 3.1 beta 2 is here with exciting new features.
 This release builds on top of beta 1 and beta 2 adding more fixes and improvements.
 
-Read the [beta 1 release notes](/2020/07/08/quartznet-3-1-beta-1-released/) and [beta 2 release notes](/2020/07/14/quartznet-3-1-beta-2-released/) to know more.
+Read the [beta 1 release notes](/posts/2020-07-08-quartznet-3.1-beta-1-released.html) and [beta 2 release notes](/posts/2020-07-14-quartznet-3.1-beta-2-released.html) to know more.
 
 ### Known Issues
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "docs:dev-webpack": "DOCS_BUNDLER=webpack pnpm docs:dev",
     "docs:serve": "anywhere -s -h localhost -d .vuepress/dist",
     "docs:publish": "cd docs/.vuepress/dist && git init && git fetch https://github.com/quartznet/quartznet.github.io.git && git checkout 9966bc53c0685311bc9199498ef2338629f6ec4d && git checkout -b master && git add . && git commit -am \"Deploy Documentation\" && git push --force --set-upstream https://github.com/quartznet/quartznet.github.io.git master",
-    "docs:lint": "markdownlint-cli2 docs/**/*.md",
-    "docs:lint-fix": "markdownlint-cli2-fix docs/**/*.md !docs/_posts/**",
+    "docs:check-links": "node docs/.vuepress/check-links.mjs",
+    "docs:check-links-test": "node --test docs/.vuepress/check-links.test.mjs",
+    "docs:lint": "markdownlint-cli2 \"docs/**/*.md\" \"!docs/.vuepress/**\"",
+    "docs:lint-fix": "markdownlint-cli2-fix \"docs/**/*.md\" \"!docs/_posts/**\" \"!docs/.vuepress/**\"",
     "postinstall": "patch-package"
   },
   "repository": {


### PR DESCRIPTION
Closes the first half of #3342: real-slugifier anchor checking, in CI.

## The gap

markdownlint's MD051 validates link fragments with GitHub's heading slugger. This site is VuePress 2,
which slugifies with `@mdit-vue/shared` and de-duplicates with `markdown-it-anchor`'s `-1`/`-2`
suffixes. The two disagree wherever punctuation is involved — `Quartz.Core` is `#quartz-core`, not
`#quartzcore`; `JobDataMap's` is `#jobdatamap-s`; `ScheduleBuilder<T>` is `#schedulebuilder-t`. Every
fragment MD051 flagged during the docs waves resolved on the live site and every replacement it
offered would have 404'd, so MD051 was disabled. Honest, but it left the repo with no anchor checking
at all.

## The replacement

`docs/.vuepress/check-links.mjs` asks VuePress instead of guessing:

- It builds the markdown instance the site is rendered with — `createMarkdown()` from
  `vuepress/markdown`, which is what `@vuepress/core` itself calls — and reads the ids straight off
  the heading tokens. So the ids it validates against are the ids the published pages carry, and the
  duplicate-suffix behaviour is markdown-it-anchor's own rather than a model of it.
- It computes each page's route with VuePress's `inferRoutePath` and `sanitizeFileName`, which is how
  it knows `docs/_posts/x.md` is served at `/posts/x.html`.
- It checks relative and site-absolute links as well as fragments, resolves assets against both the
  docs tree and `.vuepress/public`, and models the two *different* bases the site resolves from: the
  links plugin rewrites `.md`/`.html`/`/` links relative to the **source path**, while everything
  else survives as a plain href the browser resolves relative to the **route**.
- On failure it prints the file, the line the link is written on (including per-row inside tables) and
  the closest existing anchors.

Everything it imports comes from the already-declared `vuepress` dependency (`vuepress/markdown`,
`vuepress/shared`, `vuepress/utils`). No new package, and the checker cannot drift from the renderer.

I validated the ids against the built site as a one-off: across all 209 pages and 1135 heading ids in
`docs/.vuepress/dist`, the checker's ids match the emitted HTML exactly. The single difference is
`<h1 id="main-title">` on the home page, which the theme's hero template emits, not markdown.

## Proof it can fail

`docs/.vuepress/check-links.fixtures/` holds a positive and a negative control, asserted by
`docs/.vuepress/check-links.test.mjs` (`node --test`, no new dependency):

- `clean/` must come back with zero problems. It deliberately contains the anchors MD051 rejects, the
  three duplicate-suffix spellings, a fragment that starts with a digit, a directory index with and
  without its trailing slash, an extensionless link, an asset, a table, and a page in an
  underscore-prefixed directory reached by its real route.
- `broken/` must be caught line for line — 11 problems, including the four GitHub-style anchors MD051
  would have asked for, one duplicate suffix past the last heading, a missing page, a missing asset,
  a dead same-page fragment, two dead anchors inside a table, and the trap that produced the real bug
  below: a relative link into a directory the router renames.

Both fixture trees sit under `.vuepress`, which VuePress excludes from the site (verified: the build
still renders 210 pages) and which markdownlint now excludes too.

Two mutation checks I ran while writing this, since a checker nobody has watched go red is worth
little: swapping GitHub's slugger into the checker fails 6 of the 7 tests, and turns the current docs
tree red with **52 dead anchors** — all of which resolve on the live site. That is the MD051 claim,
measured rather than asserted.

## The documentation bug it flushed out

Three cross-references between the 3.1 beta announcements were written as Jekyll permalinks:

```text
[beta 1](/2020/07/08/quartznet-3-1-beta-1-released/)
```

VuePress routes a post by its file path with `sanitizeFileName` applied, so those pages are served at
`/posts/2020-07-08-quartznet-3.1-beta-1-released.html`. `curl` confirms the Jekyll shape is a 404 on
www.quartz-scheduler.net today and the `/posts/…` shape is a 200. Fixed in its own commit; the built
HTML now renders a real `RouteLink` with a prefetched page chunk.

That was the only breakage in the tree. Four dead links, no dead anchors.

## Wiring

- `npm run docs:check-links` — the checker.
- `npm run docs:check-links-test` — its controls.
- Both run in `.github/workflows/docs-pr.yml`, after the build. **Not** in `docs.yml`: that workflow
  pushes to the live site, and I did not want a dead anchor to be able to block a deploy when the PR
  gate already covers it. Say if you want it there too.
- The MD051 comment in `.markdownlint.jsonc` now points at the replacement, so the disable reads as
  "checked properly elsewhere" rather than "we gave up".
- One line in `AGENTS.md`, so the next agent writing docs does not take MD051's suggestions.

## For a reviewer to decide

1. **`docs:lint` was already failing and still is** — 111 errors on the base commit, spread over all
   four version trees (MD004 ul-style, MD010 hard tabs, MD032, MD040, MD024…). It is not in any
   workflow. My change adds exactly zero: the linted file set and error list are byte-identical to
   the baseline. I deliberately did not fix them or wire `docs:lint` into CI — that is its own PR, and
   several of the offending files belong to docs work in flight.
2. **I quoted the lint globs.** `"docs:lint": "markdownlint-cli2 docs/**/*.md"` is expanded by the
   shell before markdownlint sees it, and POSIX `sh` has no globstar, so on Linux it silently means
   `docs/*/*.md` while on Windows (cmd, no globbing) markdownlint expands it properly. Quoting makes
   it mean the same thing everywhere and is what makes the `!docs/.vuepress/**` exclusion work at all.
   Same file set, same 111 errors, both platforms — but it is a behaviour change on Linux, so it is
   called out rather than buried.
3. **No other markdownlint rule changed.** I looked: nothing is made redundant by this, and nothing
   new is obviously worth enabling while the existing 111 are outstanding.
4. **Not checked, deliberately**: links in the sidebar/navbar TypeScript under `.vuepress/configs`,
   and the destinations in `redirectPlugin`'s config. Both can 404 and neither is markdown. Worth a
   follow-up; I did not want to start parsing `config.ts` here.

Stays out of #3342's second half entirely — no `DocumentedConfigurationTest.cs`, no package-page
samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3wNU6NFXyZztWp12PGQc
