### PR TITLE
Docs: a tenancy patterns page, and 3.x multi-tenancy mechanics

### DIFF
--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -30,8 +30,10 @@ export const sidebarEn: SidebarConfig = [
       },
       "/documentation/quartz-3.x/configuration/reference",
       "/documentation/quartz-3.x/packages/json-configuration",
+      "/documentation/quartz-3.x/multi-tenancy",
       "/documentation/faq",
       "/documentation/best-practices",
+      "/documentation/tenancy-patterns",
       "/documentation/troubleshooting",
       {
         text: "API Documentation",
@@ -123,6 +125,7 @@ export const sidebarEn: SidebarConfig = [
           "/documentation/quartz-4.x/multi-tenancy",
           "/documentation/faq",
           "/documentation/best-practices",
+          "/documentation/tenancy-patterns",
           "/documentation/quartz-4.x/db/",
           "/documentation/database/schema-changes",
           "/documentation/quartz-4.x/migration-guide",

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -5,12 +5,14 @@ title: Documentation
 
 * [Frequently Asked Questions](faq.html)
 * [Best Practices](best-practices.html)
+* [Tenancy Patterns](tenancy-patterns.html)
 
 ## Available Documents (Quartz 4.x)
 
 * [Quick Start Guide](quartz-4.x/quick-start.html)
 * [Tutorials for Developing with Quartz](quartz-4.x/tutorial/index.html)
 * [Cron Expression Reference](quartz-4.x/cron-expressions.html)
+* [Multi-Tenancy](quartz-4.x/multi-tenancy.html)
 * [Migration Guide](quartz-4.x/migration-guide.html)
 
 ## Available Documents (Quartz 3.x)
@@ -18,6 +20,7 @@ title: Documentation
 * [Quick Start Guide](quartz-3.x/quick-start.html)
 * [Tutorials for Developing with Quartz](quartz-3.x/tutorial/index.html)
 * [CronTrigger Tutorial](quartz-3.x/tutorial/crontrigger.html)
+* [Multi-Tenancy](quartz-3.x/multi-tenancy.html)
 * [Migration Guide](quartz-3.x/migration-guide.html)
 
 ## Available Documents (Quartz 2.x)

--- a/docs/documentation/quartz-3.x/multi-tenancy.md
+++ b/docs/documentation/quartz-3.x/multi-tenancy.md
@@ -1,0 +1,601 @@
+---
+title: 'Multi-Tenancy'
+---
+
+# Multi-Tenancy
+
+Quartz has no `Tenant` concept. What it has are three separations you can build one out of — a
+scheduler, a group, and a `SCHED_NAME` — and this page is about picking the right one and knowing
+exactly what it does and does not isolate.
+
+If you have not yet chosen a model, read [Tenancy Patterns](../tenancy-patterns.md) first: it surveys
+how other schedulers partition tenants and names the axes that decide. This page is the 3.x
+mechanics.
+
+## Choosing a model
+
+| | Scheduler per tenant | Group per tenant | Database or prefix per tenant |
+|---|---|---|---|
+| **Isolation** | strongest: separate job store, thread pool, listeners, plugins, calendars | logical only — one scheduler, one pool | strongest at rest; one process still runs them all |
+| **Tenants known at** | startup, or runtime outside the container | any time | startup |
+| **Add a tenant at runtime** | yes, but you own its lifetime | yes | no |
+| **Per-tenant concurrency limits** | yes, naturally | yes, via execution groups | yes |
+| **Cost per tenant** | a scheduling loop, a connection pool, a thread pool | ~nothing | a schema |
+| **Fits** | tens of tenants, strong isolation needs | hundreds or thousands of tenants | regulatory separation of data |
+
+They compose. The common shape for a SaaS with many small tenants is *one* scheduler, groups per
+tenant, one database — and a second scheduler for the handful of tenants that bought isolation.
+
+## Scheduler per tenant
+
+`AddQuartz(name, …)` registers a named scheduler. The name becomes that scheduler's
+`quartz.scheduler.instanceName`, the name of its `QuartzOptions`, and — with a persistent store — its
+`SCHED_NAME`, so its configuration and its rows always agree.
+
+```csharp
+foreach (string tenant in tenants)
+{
+    builder.Services.AddQuartz(tenant, q =>
+    {
+        q.UsePersistentStore(s =>
+        {
+            s.UseSqlServer(sqlServer => sqlServer.ConnectionString = connectionStrings[tenant]);
+            s.UseSystemTextJsonSerializer();
+            s.UseClustering();
+        });
+        q.UseDefaultThreadPool(tp => tp.MaxConcurrency = 5);
+        q.ScheduleJob<NightlyReportJob>(trigger => trigger
+            .WithIdentity("nightly", tenant)
+            .WithCronSchedule("0 30 2 * * ?"));
+    });
+}
+
+builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+```
+
+One `AddQuartzHostedService` starts them all. Behind that single call sit up to two hosted services:
+one that enumerates every named scheduler, always registered, and one for the default scheduler,
+registered only when an unnamed `AddQuartz()` has already put `ISchedulerFactory` in the container.
+
+::: warning
+Order matters. `AddQuartz()` must be called **before** `AddQuartzHostedService()` for the *default*
+scheduler, because the default hosted service is only registered when `ISchedulerFactory` is already
+in the service collection. Named schedulers are unaffected by the ordering.
+:::
+
+Setting `SchedulerName` inside a named `AddQuartz(name, …)` block throws — the name is the
+registration key and cannot drift from it.
+
+### Getting one back
+
+There is no keyed `IScheduler` on 3.x. Named schedulers are not registered in the container at all;
+they are created by the hosted service and bound into the repository. Inject
+`Quartz.Spi.ISchedulerRepository`:
+
+```csharp
+public class TenantOpsService
+{
+    private readonly ISchedulerRepository schedulerRepository;
+
+    public TenantOpsService(ISchedulerRepository schedulerRepository)
+    {
+        this.schedulerRepository = schedulerRepository;
+    }
+
+    public async Task TriggerNightly(string tenant)
+    {
+        IScheduler? scheduler = schedulerRepository.Lookup(tenant);
+        if (scheduler is not null)
+        {
+            await scheduler.TriggerJob(new JobKey("nightly", tenant));
+        }
+    }
+}
+```
+
+::: warning
+`ISchedulerFactory` is only registered when an unnamed `AddQuartz()` call has been made. In a
+container holding only named schedulers there is no `ISchedulerFactory` to inject — use
+`ISchedulerRepository`.
+
+Named schedulers appear in the repository only once the hosted service has created and started them,
+so they are not there during application startup.
+:::
+
+There are **two** repositories, and mixing them up is the most common 3.x multi-scheduler mistake.
+`SchedulerRepository.Instance` is a process-wide static that `StdSchedulerFactory` and
+`DirectSchedulerFactory` bind into by default. The DI integration registers its *own*
+`ISchedulerRepository` singleton in the container, and the named-scheduler factory binds there
+instead. A scheduler created through DI is therefore **not** in `SchedulerRepository.Instance`, and a
+scheduler created by a bare `StdSchedulerFactory` is **not** in the container's repository — nor,
+consequently, in the Dashboard's scheduler list. Always inject `ISchedulerRepository` in a DI
+application; never reach for the static.
+
+### What is per scheduler
+
+Each named scheduler gets its own job store, thread pool, listeners, plugins, calendars, jobs and
+triggers. Listeners and calendars registered inside a named `AddQuartz(name, …)` block are attached to
+that scheduler only. Plugins configured by `quartz.plugin.*` properties are instantiated once per
+scheduler, from that scheduler's own property bag, so `q.UseXmlSchedulingConfiguration(...)`,
+`q.UseJobAutoInterrupt(...)` and the rest all work inside a named block.
+
+`QuartzOptions` are *named options* whose name is the scheduler's name, which is what
+`builder.Services.Configure<QuartzOptions>("DurableScheduler", …)` binds to. Note that unlike 4.x,
+3.x does not have per-scheduler `ThreadPoolOptions` or `AdoJobStoreOptions` — a named scheduler's
+components are configured through `quartz.*` properties on its own builder.
+
+### What is not
+
+- **`QuartzHostedServiceOptions` is global.** `WaitForJobsToComplete`, `StartDelay` and
+  `AwaitApplicationStarted` apply to every scheduler uniformly; there is no
+  `AddQuartzHostedService(name, …)` overload on 3.x.
+- **Job types are shared.** See [per-tenant services inside a job](#per-tenant-services-inside-a-job).
+- **`scheduler.Context["Quartz.ServiceProvider"]` is set only for the default scheduler.** A plugin
+  that reaches for the container through the scheduler context works on the default scheduler and
+  silently does not on a named one.
+- **The health check covers the default scheduler only.** See
+  [health checks](#health-checks-and-observability).
+
+A named scheduler colliding with a default scheduler renamed to the same string is not caught at
+registration; it surfaces at host start as a `SchedulerException` reading
+`Scheduler with name 'X' already exists.` from the repository. Two named schedulers with the same name
+*are* caught at registration — but only when the names match exactly. The registration check compares
+ordinally while the repository compares case-insensitively, so `AddQuartz("Acme")` beside
+`AddQuartz("acme")` passes registration and fails at start. Derive tenant scheduler names from a
+single normalised source.
+
+## Group per tenant
+
+One scheduler; the tenant is the group half of every key.
+
+```csharp
+JobKey job = new("nightly-report", tenantId);
+TriggerKey trigger = new("nightly", tenantId);
+```
+
+Everything that takes a `GroupMatcher` then becomes tenant-scoped:
+
+```csharp
+// everything this tenant has scheduled
+IReadOnlyCollection<TriggerKey> theirs =
+    await scheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals(tenantId));
+
+// suspend a tenant
+await scheduler.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals(tenantId));
+
+// is a tenant suspended?
+IReadOnlyCollection<string> paused = await scheduler.GetPausedTriggerGroups();
+bool suspended = paused.Contains(tenantId);
+
+// or, directly
+bool alsoSuspended = await scheduler.IsTriggerGroupPaused(tenantId);
+
+// offboard a tenant
+IReadOnlyCollection<JobKey> jobs =
+    await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(tenantId));
+await scheduler.DeleteJobs(jobs.ToList());
+```
+
+`GroupMatcher<TKey>` also offers `GroupStartsWith`, `GroupEndsWith`, `GroupContains` and `AnyGroup`,
+and `AndMatcher` / `OrMatcher` / `NotMatcher` compose them.
+
+::: warning
+Pause tenants by **trigger** group. The ADO.NET job store does not persist paused *job* group state —
+`IsJobGroupPaused` always returns `false` there, because `PauseJobs` pauses the individual triggers of
+the jobs in the group without recording the group itself. `RAMJobStore` does track it, so the two
+stores differ; write against the persistent behaviour.
+:::
+
+Listeners take matchers too, so a per-tenant listener is one registration:
+
+```csharp
+q.AddJobListener<AuditListener>(GroupMatcher<JobKey>.GroupEquals(tenantId));
+```
+
+Several matchers on one listener are OR-ed. Matchers can be added and removed at runtime through
+`IListenerManager.AddJobListenerMatcher` / `RemoveJobListenerMatcher` / `SetJobListenerMatchers`.
+Scheduler listeners are not matchable — a tenant-scoped `ISchedulerListener` is not expressible.
+
+`DeleteJobs`, `UnscheduleJobs` and `ScheduleJobs` take key collections rather than matchers on 3.x,
+which is why offboarding is the two-step above. `Clear()` takes no matcher at all: it empties the
+whole scheduler, never one tenant.
+
+Calendars are a flat namespace within a scheduler — there is no calendar group. Under group-per-tenant,
+tenants share it and must namespace the names themselves (`"acme:holidays"`).
+
+### Per-tenant concurrency quotas
+
+Execution groups cap how many threads a category of work may use on a node. Give each tenant an
+execution group and a limit:
+
+```csharp
+services.AddQuartz(q =>
+{
+    q.UseExecutionLimits(limits => limits
+        .ForGroup("acme", maxConcurrent: 8)      // a big tenant
+        .ForGroup("initech", maxConcurrent: 2)
+        .ForOtherGroups(maxConcurrent: 1));      // everyone else gets one thread each
+});
+```
+
+or as properties:
+
+```text
+quartz.executionLimit.acme = 8
+quartz.executionLimit.initech = 2
+quartz.executionLimit.* = 1
+```
+
+::: warning
+On 3.x the execution group is a **separate tag on the trigger**; it is not derived from the trigger
+group. Every trigger for a tenant must carry it explicitly:
+
+```csharp
+ITrigger trigger = TriggerBuilder.Create()
+    .WithIdentity("nightly", tenantId)
+    .ForJob(job)
+    .WithExecutionGroup(tenantId)      // <- required; the key group is not consulted
+    .WithCronSchedule("0 30 2 * * ?")
+    .Build();
+```
+
+Quartz 4.x adds `UseTriggerGroupWhenUnset()`, which lets the trigger group stand in for the execution
+group so that no trigger has to repeat it. There is no 3.x equivalent — forget the tag on one trigger
+and that trigger runs unlimited, or falls into whatever `ForOtherGroups` allows.
+:::
+
+::: warning
+`WithExecutionGroup` is on `TriggerBuilder`, **not** on the DI `ITriggerConfigurator`. So
+`q.AddTrigger(t => t.WithExecutionGroup("acme"))` does not compile, and neither does the
+`q.ScheduleJob<T>(trigger => …)` form. Triggers that need an execution group must be built with
+`TriggerBuilder` and passed to `scheduler.ScheduleJob(...)` at runtime, or declared through
+[JSON scheduling](packages/json-configuration.md), where `ExecutionGroup` is a recognised property on
+a trigger definition.
+
+Reading it back has the same asymmetry: `ITrigger` does not declare `ExecutionGroup` on 3.x, so
+`(await scheduler.GetTrigger(key)).ExecutionGroup` does not compile either — cast to
+`Quartz.Impl.Triggers.AbstractTrigger`.
+:::
+
+Limits can also be changed at runtime, per node:
+
+```csharp
+await scheduler.SetExecutionLimits(new ExecutionLimits()
+    .ForGroup("acme", 8)
+    .ForOtherGroups(1));
+```
+
+`SetExecutionLimits` and `GetExecutionLimits` are **extension methods** on `IScheduler`, not interface
+members, and they require the scheduler to be a `StdScheduler`. Against a `RemoteScheduler` or a
+custom `IScheduler` they throw a `SchedulerException`. Limits take effect on the next acquisition
+cycle; pass `null` to clear them.
+
+With an ADO.NET job store, persisting a trigger's execution group needs an `EXECUTION_GROUP` column on
+`QRTZ_TRIGGERS`. The column is optional on 3.x — the store probes for it at startup and logs at Debug
+level when it is missing — but without it nothing is persisted and every trigger looks ungrouped after
+a restart. See [Execution Groups](tutorial/execution-groups.md) for the DDL.
+
+::: warning
+Execution limits are **per node**, held in memory, and nothing about them is persisted or coordinated.
+On a three-node cluster, a limit of 8 for `acme` means up to 24 concurrent Acme jobs. See
+[honest limits](#honest-limits).
+:::
+
+### Pinning a tenant to hardware
+
+[Node affinity](tutorial/node-affinity.md) is the other per-tenant cluster control, and unlike
+execution limits it *is* persisted. `TriggerBuilder.WithPreferredNode(instanceId)` records which node
+should pick a trigger up, with failover to another node if the preferred one is down. Where execution
+limits say "how much of this node may this tenant use", node affinity says "which nodes are this
+tenant's" — which is usually the more useful question when tenants have bought dedicated capacity.
+
+Node affinity needs a stable `quartz.scheduler.instanceId`. `AUTO` generates a fresh id on every
+restart, and the store logs a warning when it detects one.
+
+## Shared database
+
+Every Quartz table has `SCHED_NAME` as the first column of its primary key, and every statement
+filters on it. Two schedulers with different names therefore share tables without seeing each other's
+rows, and that is a property of the schema rather than of the code paths — there is no query that
+forgets. `SCHED_NAME` is bound to `quartz.scheduler.instanceName`; the only statements that do not
+carry it are the schema probes, which select no rows.
+
+Table prefix is the other axis. `quartz.jobStore.tablePrefix` (default `QRTZ_`) is a per-scheduler
+setting, so two tenants can have entirely separate table *sets* in one database:
+
+```csharp
+builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s =>
+{
+    s.UseSqlServer(sqlServer =>
+    {
+        sqlServer.ConnectionString = sharedConnectionString;
+        sqlServer.TablePrefix = "ACME_QRTZ_";
+    });
+    s.UseSystemTextJsonSerializer();
+}));
+```
+
+Three rules:
+
+- **Different scheduler name is enough.** Prefixes are for keeping tenants in separate *tables*, which
+  is a backup-and-restore or a permissions decision, not an isolation one.
+- **The prefix has to match the DDL.** Nothing derives one from the other; you run the DDL with the
+  prefix substituted.
+- **A wrong prefix is caught at startup.** `PerformSchemaValidation` is on by default, so a missing or
+  mis-prefixed table is reported at startup rather than surfacing as the first failing operation an
+  hour later.
+
+::: warning
+Two schedulers sharing a database with the **same** `SCHED_NAME` are, by construction, indistinguishable
+from two nodes of one cluster — because that is exactly what they look like to the schema. Schema
+validation will not catch it, and they will steal each other's triggers. The duplicate-name check
+protects you only within one container; across processes, the name is a contract you keep.
+
+`instanceName` identifies the *logical* scheduler and is what tenants differ by. `instanceId`
+identifies a *node* of one logical scheduler, and is what cluster members differ by. Getting these the
+wrong way round is what produces the failure above.
+:::
+
+Also worth knowing: with a persistent store, `[DisallowConcurrentExecution]` is enforced cluster-wide
+by counting rows in `QRTZ_FIRED_TRIGGERS` — but that count is filtered by `SCHED_NAME`, so it does not
+reach across tenants. That is the intended behaviour, and it means two tenants can each run their own
+copy of the same job type concurrently.
+
+If you use the Redis lock handler, its keys already include the scheduler name, so a shared Redis is
+safe across tenants that differ by `SCHED_NAME`.
+
+## Per-tenant services inside a job
+
+A job needs to reach *its* tenant's database, its tenant's configuration, its tenant's feature flags.
+`MicrosoftDependencyInjectionJobFactory` creates a DI scope for every job execution — unconditionally
+on 3.x, the older `CreateScope` and `AllowDefaultConstructor` options are obsolete and ignored — and
+the scope is prepared before the job and everything it injects are constructed.
+
+The hook is `protected virtual void ConfigureScope(IServiceScope, TriggerFiredBundle, IScheduler)`,
+reached by subclassing:
+
+```csharp
+public sealed class TenantJobFactory : MicrosoftDependencyInjectionJobFactory
+{
+    public TenantJobFactory(IServiceProvider serviceProvider, IOptions<QuartzOptions> options)
+        : base(serviceProvider, options)
+    {
+    }
+
+    protected override void ConfigureScope(
+        IServiceScope scope,
+        TriggerFiredBundle bundle,
+        IScheduler scheduler)
+    {
+        scope.ServiceProvider.GetRequiredService<TenantHolder>().TenantId = bundle.Trigger.Key.Group;
+    }
+}
+```
+
+```csharp
+services.AddScoped<TenantHolder>();
+services.AddQuartz(q => q.UseJobFactory<TenantJobFactory>());
+```
+
+::: tip Quartz 4.x
+Quartz 4.x adds `q.ConfigureJobScope((scope, bundle, scheduler) => …)`, a delegate registration that
+needs no subclass and whose callbacks combine. There is no 3.x equivalent; subclassing is the way.
+:::
+
+Two things make this work, and both are worth knowing:
+
+- **The hook is synchronous.** An asynchronous hook would be awaited, and the `ExecutionContext`
+  restored on the way back would discard exactly the `AsyncLocal<T>` values it exists to set. Both the
+  scoped-holder pattern above and an `AsyncLocal<T>` work; the holder is easier to test and does not
+  depend on execution context flow.
+- **The job is created on the execution path**, not during initialization, so values set here flow into
+  `Execute`.
+
+The `TriggerFiredBundle` gives you the whole firing to derive the tenant from — `Trigger.Key.Group`,
+`JobDetail.Key.Group`, or a value out of `Trigger.JobDataMap` — plus the `IScheduler` that fired it,
+which is the tenant itself under the scheduler-per-tenant model. Inside `Execute`, the same identity is
+available from `context.Trigger.Key.Group` or `context.MergedJobDataMap`.
+
+Alternatively, read the tenant inside the job and resolve per-tenant services by key. Quartz 3.x makes
+no keyed registrations of its own, but keyed lookups pass through the job's scope, so your own keyed
+services resolve:
+
+```csharp
+public class ReportJob : IJob
+{
+    private readonly IServiceProvider services;
+
+    public ReportJob(IServiceProvider services) => this.services = services;
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        string tenant = context.Trigger.Key.Group;
+        ITenantStore store = services.GetRequiredKeyedService<ITenantStore>(tenant);
+        await store.WriteReport(context.CancellationToken);
+    }
+}
+```
+
+Keyed services require `Microsoft.Extensions.DependencyInjection` 8.0 or later, so this pattern needs
+an application on `net8.0` or newer — Quartz 3.x itself still supports `netstandard2.0` and .NET
+Framework, where it is unavailable.
+
+::: warning
+Registering a job type keyed does **not** work. The job factory resolves the job type unkeyed from the
+scope and falls back to direct activation when nothing is registered, so a keyed job-type registration
+is silently never consulted. Key the job's *dependencies*, not the job.
+:::
+
+For anything more involved — resolving jobs from a tenant-owned container, say — implement
+`Quartz.Spi.IJobFactory` directly (`IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler)` plus
+`void ReturnJob(IJob job)`) and register it with `q.UseJobFactory<T>()`. On Quartz 4.x that interface
+is in `Quartz.Extensibility` and returns a `ValueTask<JobScope>`, so a custom factory does not port
+across unchanged.
+
+::: warning
+On a **named** scheduler, `UseJobFactory<T>()` configures the factory by property and deliberately
+does not replace the container's global singleton, so the type is constructed by the named scheduler's
+own factory rather than resolved as a registered service. Make sure its constructor dependencies are
+registered in the container.
+:::
+
+## Health checks and observability
+
+**Health checks are not per tenant on 3.x.** `AddQuartzServer` registers a single health check named
+`quartz-scheduler`, which resolves the **default** scheduler from `ISchedulerFactory`, checks that it
+is started and performs one store round-trip. Named schedulers are not covered, the check type is
+internal so it cannot be registered again by hand, and on `netstandard2.0` there is no health check at
+all.
+
+Note the consequence for a scheduler-per-tenant container: the check is registered unconditionally,
+but it resolves `ISchedulerFactory`, which a container holding **only** named schedulers never
+registers. If you use `AddQuartzServer` without a default scheduler, either register a default one or
+use `AddQuartzHostedService` and write your own check.
+
+Tags are the only knob on the built-in one:
+
+```csharp
+services.AddQuartzServer(
+    options => options.WaitForJobsToComplete = true,
+    healthCheckTags: new[] { "ready" });
+```
+
+For per-tenant health, write your own `IHealthCheck` that injects `ISchedulerRepository` and walks the
+schedulers you care about.
+
+::: tip Quartz 4.x
+Quartz 4.x adds `AddQuartzHealthChecks` on a scheduler's own builder, defaulting the check name to
+`quartz-scheduler-<scheduler name>` so several can be registered side by side.
+:::
+
+**Traces** come from `DiagnosticListener` and `Activity`, under the listener name `Quartz`. The tag
+names are public constants on `Quartz.Logging.DiagnosticHeaders`:
+
+| Constant | Tag |
+|---|---|
+| `DiagnosticHeaders.SchedulerName` | `scheduler.name` |
+| `DiagnosticHeaders.SchedulerId` | `scheduler.id` |
+| `DiagnosticHeaders.FireInstanceId` | `fire.instance.id` |
+| `DiagnosticHeaders.TriggerGroup` | `trigger.group` |
+| `DiagnosticHeaders.TriggerName` | `trigger.name` |
+| `DiagnosticHeaders.JobGroup` | `job.group` |
+| `DiagnosticHeaders.JobName` | `job.name` |
+| `DiagnosticHeaders.JobType` | `job.type` |
+
+Under scheduler-per-tenant the tenant is `scheduler.name`; under group-per-tenant it is `job.group`
+and `trigger.group`. That is a good reason to make the group the raw tenant id rather than a decorated
+string.
+
+::: warning Cardinality
+`job.name` and `trigger.name` are per job and per trigger. Multiply that by a tenant dimension and a
+backend can find itself with a series per tenant per trigger. Drop the name tags before they reach the
+backend unless you know you need them.
+:::
+
+Two gaps to plan around:
+
+- **There are no metrics on 3.x.** Quartz 3.x publishes no `Meter` and no counters or histograms; the
+  4.x `quartz.job.execution.*` instruments have no 3.x counterpart. Traces, and your own
+  instrumentation, are what you have.
+- **Nothing puts the tenant into a logging scope.** If you want every log line a job writes to carry
+  its tenant, open an `ILogger.BeginScope` yourself — in `Execute`, in a job base class, or in a custom
+  job factory. `q.UseStructuredJobLogging()` and `q.UseStructuredTriggerLogging()` emit Quartz's own
+  history entries with named parameters, which helps, but they do not scope your job's logging.
+
+## Honest limits
+
+Things multi-tenant deployments ask Quartz for and do not get.
+
+**Execution limits are per node, not cluster-wide.** The running count for each execution group lives
+in a dictionary in memory on the scheduler thread. Nothing is persisted and nodes do not coordinate. A
+cluster-wide cap is not available; the closest approximation is dividing the cap by the node count,
+which is wrong whenever a node is down. For a cluster-aware per-tenant control, use
+[node affinity](tutorial/node-affinity.md) instead — it is persisted.
+
+**There is no rate limiting.** Execution limits cap *concurrency*, not throughput. "This tenant may
+run 100 jobs an hour" is not something Quartz can express; build it in the job, or in the thing the job
+calls.
+
+**A starved group's triggers misfire; they do not queue.** When a group is at its limit its triggers
+are skipped during acquisition and left as they are, keeping their original next fire time. If the
+starvation outlasts the misfire threshold, the ordinary misfire machinery claims them and the
+trigger's misfire instruction decides whether the occurrence is skipped or rescheduled. Choose misfire
+instructions deliberately for triggers in limited groups.
+
+**Job types are shared across schedulers.** Job classes are resolved unkeyed from the one container, so
+two schedulers cannot register different implementations for the same job type. Give each tenant its
+own job type, or — far better — one job type that reads its tenant from the firing.
+
+**Nothing stops a job reaching another tenant's data.** `IJobExecutionContext.Scheduler` hands the
+running job the whole scheduler, with `DeleteJob`, `PauseTriggers` and `Clear` on it. There is no
+group-scoped scheduler façade and no authorization hook. Group-per-tenant is a naming convention with
+tooling support, not an enforcement boundary. If tenant code must not be able to reach across, that is
+a process boundary, not a group.
+
+**Dashboard authorization is per process, all or nothing.** The Dashboard has one
+`AuthorizationPolicy`, one `IDashboardAuthorizationFilter` and one `ReadOnly` flag; there is no
+per-scheduler policy and no scheduler-name claim check, even though its scheduler selector lists every
+scheduler in the repository. If tenants must reach their own scheduler and not each other's, enforce
+that outside Quartz.
+
+**A shut-down scheduler cannot be restarted.** `Start()` on a shut-down scheduler throws
+`The Scheduler cannot be restarted after Shutdown() has been called.`, and every other operation throws
+`The Scheduler has been Shutdown.`. `Standby()` / `Start()` is the pause-and-resume pair. Shutdown does
+remove the scheduler from the repository, so a subsequent `StdSchedulerFactory.GetScheduler()` builds a
+fresh one rather than handing back the corpse — but it is a new scheduler, not a revived one.
+
+**A per-tenant thread pool is a real cost.** Under the scheduler-per-tenant model each tenant gets a
+scheduling loop that wakes on its own idle timer, a thread pool, and — with a persistent store — a
+connection pool and a cluster check-in. That is fine for tens of tenants and not for thousands.
+
+## Onboarding a tenant while the process runs
+
+Under the group-per-tenant model this is a non-question: scheduling a job for a new group is an
+ordinary API call.
+
+Under the scheduler-per-tenant model it is still possible, because on 3.x scheduler construction is not
+bound to the DI container. `AddQuartz` mutates `IServiceCollection`, which is closed once the container
+is built — but `StdSchedulerFactory` will build a scheduler from a `NameValueCollection` at any time:
+
+```csharp
+NameValueCollection props = new()
+{
+    ["quartz.scheduler.instanceName"] = tenantId,
+    ["quartz.threadPool.maxConcurrency"] = "5",
+    ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.JobStoreTX, Quartz",
+    ["quartz.jobStore.tablePrefix"] = "QRTZ_",
+    ["quartz.jobStore.dataSource"] = "default",
+    ["quartz.dataSource.default.connectionString"] = connectionStrings[tenantId],
+    ["quartz.dataSource.default.provider"] = "SqlServer",
+};
+
+IScheduler scheduler = await new StdSchedulerFactory(props).GetScheduler();
+await scheduler.Start();
+```
+
+`DirectSchedulerFactory.Instance.CreateScheduler(name, instanceId, threadPool, jobStore)` does the same
+with hand-built parts and no property strings.
+
+Three things you take on by doing this:
+
+- **The repository split.** Both routes bind into the static `SchedulerRepository.Instance`, not the
+  container's `ISchedulerRepository` — so the new scheduler will not appear in
+  `ISchedulerRepository.LookupAll()` or in the Dashboard. To join them, subclass `StdSchedulerFactory`
+  and override `protected virtual ISchedulerRepository GetSchedulerRepository()` to return the
+  container's instance.
+- **Its lifetime is yours.** The hosted service enumerates named schedulers once at start; a scheduler
+  created afterwards is not started, stopped or shut down by the host. Register an
+  `IHostApplicationLifetime.ApplicationStopping` callback, or an `IHostedService` of your own.
+- **Job resolution.** A bare `StdSchedulerFactory` uses `PropertySettingJobFactory`, which activates
+  job types directly and needs a public parameterless constructor. For container-resolved jobs, set
+  `scheduler.JobFactory = new MicrosoftDependencyInjectionJobFactory(serviceProvider, options)` before
+  starting it.
+
+## See also
+
+- [Tenancy Patterns](../tenancy-patterns.md) — prior art, the deciding axes, and the anti-patterns
+- [Multiple Schedulers](packages/multiple-schedulers.md) — the mechanics of naming and keying schedulers
+- [Execution Groups](tutorial/execution-groups.md) — per-node thread limits in full
+- [Node Affinity](tutorial/node-affinity.md) — pinning triggers to nodes, persisted and cluster-aware
+- [Clustering](tutorial/advanced-enterprise-features.md) — what a shared database gives you
+- [Microsoft DI Integration](packages/microsoft-di-integration.md) — job factories and scopes

--- a/docs/documentation/quartz-3.x/packages/multiple-schedulers.md
+++ b/docs/documentation/quartz-3.x/packages/multiple-schedulers.md
@@ -85,7 +85,7 @@ builder.Services.AddQuartz("Scheduler2", q =>
 
 ## Accessing Named Schedulers Programmatically
 
-All schedulers -- whether created via DI or directly -- are registered in the shared `ISchedulerRepository`. You can retrieve any scheduler by name using the repository:
+Schedulers created through DI are registered in the container's `ISchedulerRepository`. You can retrieve any of them by name using the repository:
 
 ```csharp
 public class MyService
@@ -135,6 +135,13 @@ public class MyService
 Named schedulers are only available after the hosted service has created and started them. During application startup, they may not yet be in the repository.
 
 `ISchedulerFactory` is only available from DI when a default (unnamed) `AddQuartz()` call has been made. If you only use named schedulers, inject `ISchedulerRepository` instead.
+
+There are **two** repositories, and they are not the same object. The DI integration registers its own
+`ISchedulerRepository` singleton in the container, while a bare `StdSchedulerFactory` or
+`DirectSchedulerFactory` binds into the process-wide static `SchedulerRepository.Instance`. A
+scheduler created outside the container therefore does not appear in the injected repository — nor in
+the Dashboard, which reads that one. To join them, subclass `StdSchedulerFactory` and override
+`GetSchedulerRepository()` to return the container's instance.
 :::
 
 ## Mixing Default and Named Schedulers
@@ -192,3 +199,10 @@ builder.Services.Configure<QuartzOptions>("DurableScheduler",
 - **Hosted service options are global** -- `QuartzHostedServiceOptions` (such as `WaitForJobsToComplete`, `StartDelay`, `AwaitApplicationStarted`) apply to all schedulers uniformly.
 - **Job types are shared** -- job classes are resolved from the shared DI container. The same job type can be used across multiple schedulers.
 - **Scheduler names must be unique** -- each call to `AddQuartz(name, ...)` must use a distinct name.
+
+## See Also
+
+A scheduler per tenant is one of three ways to partition tenants, and not always the right one.
+
+- [Multi-Tenancy](../multi-tenancy.md) -- the three separations 3.x offers, and their honest limits
+- [Tenancy Patterns](../../tenancy-patterns.md) -- how other schedulers partition tenants, and the axes that decide

--- a/docs/documentation/quartz-3.x/tutorial/execution-groups.md
+++ b/docs/documentation/quartz-3.x/tutorial/execution-groups.md
@@ -120,8 +120,15 @@ quartz.executionLimit.* = 10
 
 ## Interaction with DisallowConcurrentExecution
 
-The `[DisallowConcurrentExecution]` attribute is checked **before** execution group limits during trigger acquisition.
-This means `[DisallowConcurrentExecution]` is always respected regardless of execution group configuration.
+`[DisallowConcurrentExecution]` is always respected regardless of execution group configuration. Both
+constraints are applied — a trigger must satisfy both to be acquired.
+
+The order in which they are applied differs by store, which matters only in that a slot can be spent on
+a trigger that is then dropped. `RAMJobStore` checks `[DisallowConcurrentExecution]` first and the
+execution group limit second. In the ADO job store neither is a SQL predicate: the candidate select
+projects each trigger's execution group and the delegate counts slots down as it reads the rows, and
+`[DisallowConcurrentExecution]` is checked afterwards in the acquisition loop. Either way the trigger
+stays where it is and is reconsidered on the next cycle.
 
 ## Database migration
 
@@ -190,3 +197,11 @@ limits.ForGroup("tenant-a", maxConcurrent: 5);
 limits.ForGroup("tenant-b", maxConcurrent: 5);
 limits.ForGroup("tenant-c", maxConcurrent: 5);
 ```
+
+Every trigger belonging to a tenant must carry `.WithExecutionGroup("tenant-a")`; the execution group
+is a separate tag and is not derived from the trigger's key group. Remember also that these limits are
+per node, so a three-node cluster running the configuration above allows fifteen concurrent jobs per
+tenant, not five.
+
+For the wider picture — the other two separations Quartz offers, and how to choose between them —
+see [Multi-Tenancy](../multi-tenancy.md) and [Tenancy Patterns](../../tenancy-patterns.md).

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -8,6 +8,10 @@ Quartz has no `Tenant` concept, and it is not going to get one. What it has inst
 separations you can build one out of — a scheduler, a group, and a `SCHED_NAME` — and this page is
 about picking the right one and knowing exactly what it does and does not isolate.
 
+If you have not yet chosen a model, read [Tenancy Patterns](../tenancy-patterns.md) first: it surveys
+how other schedulers partition tenants and names the axes that decide. This page is the 4.x
+mechanics.
+
 ## Choosing a model
 
 | | Scheduler per tenant | Group per tenant | Database or prefix per tenant |
@@ -309,13 +313,34 @@ per-scheduler policy and no scheduler-name claim check. If tenants must reach th
 not each other's, enforce that **outside** Quartz — a process per tenant, or a proxy or middleware that
 authorizes on the `{schedulerName}` route segment.
 
-**Tenants cannot be onboarded at runtime under the scheduler-per-tenant model.** Schedulers are
-registered against `IServiceCollection`, which is closed once the container is built, and the hosted
-service enumerates them once at start. Nor can a scheduler be restarted after `Shutdown()`: the
-container owns its parts' lifetimes, and `GetScheduler()` throws rather than resurrecting a thread pool
-and a job store underneath a scheduler that can never run again. `Standby()` / `Start()` is the
-pause-and-resume pair; a genuinely new tenant needs a new host, or the group-per-tenant model, which has
-no such limit.
+**Tenants cannot be onboarded at runtime *through the DI path*.** Schedulers are registered against
+`IServiceCollection`, which is closed once the container is built, and the hosted service enumerates
+them once at start. Nor can a scheduler be restarted after `Shutdown()`: the container owns its parts'
+lifetimes, and `GetScheduler()` throws rather than resurrecting a thread pool and a job store
+underneath a scheduler that can never run again. `Standby()` / `Start()` is the pause-and-resume pair.
+
+That is a limit of the DI path, not of the library. `QuartzSchedulerBuilder` builds a scheduler from a
+container of its own, at any point in the process's life, and `ISchedulerRepository.Bind` makes the
+result visible to `GetAllSchedulers`, the dashboard and the HTTP API:
+
+```csharp
+IScheduler tenant = await QuartzSchedulerBuilder.Create()
+    .ConfigureScheduler(o => o.InstanceName = tenantId)
+    .UsePersistentStore(s => s.UseSqlServer(connectionStrings[tenantId]))
+    .BuildScheduler();
+
+await tenant.Start();
+app.Services.GetRequiredService<ISchedulerRepository>().Bind(tenant);
+```
+
+What you take on by doing this: the returned `StandaloneSchedulerFactory` owns the container, so *you*
+start the scheduler and dispose the factory — the hosted service will not; the scheduler's jobs resolve
+from its own container rather than the application's unless you give it an `IJobFactory` that bridges;
+and health checks registered at startup do not cover it. `Bind` throws on a duplicate name, and
+offboarding is `Remove` plus disposing the factory.
+
+Weigh that against the group-per-tenant model, where onboarding is a `ScheduleJob` call and none of
+the above applies.
 
 **A per-tenant thread pool is a real cost.** Under the scheduler-per-tenant model each tenant gets a
 scheduling loop that wakes on its own idle timer, a thread pool, and — with a persistent store — a

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -1,0 +1,593 @@
+---
+title: Tenancy Patterns
+---
+
+# Tenancy Patterns
+
+Quartz.NET has no `Tenant` type and is not going to get one. What it has are three separations you
+can build one out of — a scheduler, a group, and a `SCHED_NAME` — and the hard part is not wiring
+any of them up. It is deciding which one you need before you have twelve tenants in production and
+a migration to write.
+
+This page is about that decision. It surveys how other schedulers and job systems partition
+tenants, names the axes that actually decide the model, and maps those axes onto the mechanisms
+Quartz.NET really has. The mechanics live in the per-version guides:
+
+- [Multi-Tenancy (Quartz 4.x)](quartz-4.x/multi-tenancy.md)
+- [Multi-Tenancy (Quartz 3.x)](quartz-3.x/multi-tenancy.md)
+
+## Isolation is not authorization, and partitioning is not isolation
+
+Three points decide most arguments about tenancy, and all are worth getting straight before looking
+at any mechanism.
+
+The first is that **tenant isolation is not the same thing as authentication and authorization**.
+AWS's SaaS guidance is unusually blunt about it: "the fact that a tenant user is authenticated does
+not mean that your system has achieved isolation … a user could be authenticated and authorized, and
+still access the resources of another tenant." Isolation is the separate, enforced use of tenant
+context to bound which resources a request can reach at all.
+
+The second is that **partitioning is not isolation**. Putting a tenant id in a column, a key prefix
+or a group name arranges your data by tenant. It does not by itself stop code from reading across
+the boundary. Every system in the survey below distinguishes a partition it merely *names* from a
+boundary it actually *enforces*, and the ones that blur the two are the ones whose users get hurt.
+
+The third thing worth internalising is that isolation is not one choice. Microsoft's guidance says
+to treat it as a spectrum rather than a discrete property, and that "you can use different levels of
+isolation for each tier". AWS says the same thing from the other direction: under its bridge model,
+"your view of silo and pool will be much more granular for environments that are decomposed into a
+collection of services that have varying isolation requirements", and you should be "thinking about
+the tradeoffs of silo and pool models for each resource or layer of your architecture."
+
+For a scheduler that means the interesting question is rarely "siloed or pooled?" It is "which of
+the scheduling loop, the thread pool, the job store and the database is siloed, and which is
+pooled?" Those four can be answered differently, and usually should be.
+
+### Two vocabularies for the same thing
+
+The two most-cited bodies of guidance use different words. They line up well enough to translate,
+and knowing both is useful because the literature you find will use one or the other.
+
+| AWS | Microsoft | Meaning |
+|---|---|---|
+| Silo | Automated single-tenant deployments | Each tenant gets a dedicated stack |
+| Pool | Fully multitenant deployments | Every tenant shares one set of infrastructure |
+| Bridge | Vertically partitioned deployments | Some tenants siloed, some pooled — usually a premium tier |
+| Bridge (applied per layer) | Horizontally partitioned deployments | Shared compute, dedicated data store per tenant |
+| Cell | Deployment stamp | A whole copy of the system serving a bounded set of tenants |
+
+The last row is the one people conflate with silo. A cell or stamp is **not** one tenant — it holds
+many. Microsoft says a stamp is "sometimes a *service unit*, *scale unit*, or *cell*", and that "each
+stamp serves a predefined number of tenants". AWS frames cells through the bulkhead metaphor: "If a
+workload uses 10 cells to service 100 requests, when a failure occurs in one cell, 90% of the overall
+requests would be unaffected." Silo bounds *access*; a cell bounds *blast radius*. You can want one
+without the other.
+
+## How other systems partition tenants
+
+The pattern across the field is consistent enough to state up front: **almost every system's tenancy
+primitive is a naming, configuration and access boundary, and almost none of them make it a fairness
+boundary.** Quotas and rate limits usually attach one level up — to the account, the cluster or the
+process — and where a system does give per-tenant fairness, it is frequently the paid tier.
+
+| System | Primitive | Enforced by | Quota attaches to | Tenant added at runtime? |
+|---|---|---|---|---|
+| Temporal | Namespace | Server | Namespace *and* cluster | Yes, `RegisterNamespace` |
+| Cadence | Domain | Server | Domain and task list | Yes |
+| Kubernetes `CronJob` | Namespace | API server + RBAC | Namespace, via `ResourceQuota` | Yes, one API call |
+| AWS EventBridge Scheduler | Schedule group | IAM, via the ARN | **Account and Region, never the group** | Yes, `CreateScheduleGroup` |
+| Azure Durable Functions | Task hub | Storage naming, or RBAC on the managed provider | Scheduler resource, not the hub | Yes, implicitly |
+| HashiCorp Nomad | Namespace | Server + ACL | Namespace — but quotas are Enterprise-only | Yes |
+| Google Cloud Scheduler | Project | IAM | Project | Only by creating a project |
+| Hangfire | Queue, server, storage | Convention | Server process | Storage yes, queue set no |
+| Celery | Queue, broker vhost | Broker | **Worker process, not the cluster** | Yes, `add_consumer` |
+| Sidekiq | Queue, Redis instance | Convention | Process, or capsule | Queue set fixed at start |
+| Airflow | Team, pool, queue | Pools: the metadata database. Teams: the API layer | Pool, cluster-wide | A pool yes; a team needs new processes |
+| Quartz (Java) | `instanceName`, group | `SCHED_NAME` in every statement | Scheduler, not the group | Yes, `DirectSchedulerFactory` |
+
+A few of these repay a closer look, because each teaches something the table cannot.
+
+### Temporal ranks namespace-per-tenant last
+
+Temporal's Namespace is the textbook tenancy primitive: "A Namespace is a unit of isolation within
+the Temporal Platform." Workflow id uniqueness is scoped to it, task queues belong to it, and
+retention, archival, replication and rate limits are configured on it. It is genuinely
+server-enforced, and a tenant is one `RegisterNamespace` call away.
+
+Temporal nevertheless tells you not to use it that way. Its own multi-tenant patterns guidance ranks
+four approaches and puts namespace-per-tenant **fourth**, describing it as "Only practical for a
+smaller number of high-value tenants", manageable "for fewer than 50 tenants", and "not a good fit if
+you expect a very large number of tenants (10,000+)". The recommended pattern is **task queue per
+tenant** — that is, a client-side naming convention — scaling to "thousands of tenants per Namespace",
+with a `TenantId` search attribute for querying. Their own summary: "For most SaaS use cases, a shared
+Namespace with per-tenant Task Queues is simpler and more scalable."
+
+The reason is the part the marketing does not cover. Namespaces share the persistence store and the
+history shard set; the shard is chosen by hashing workflow id *and* namespace, so namespaces are an
+input to the hash rather than a partition of it. The shard count "cannot be changed" after the
+database is integrated. And in the open-source server there is no built-in RBAC at all: without an
+`Authorizer` of your own, Temporal "allows every API request, with no authentication or access
+control", which means namespace-per-tenant in OSS is a security boundary only if you write the
+enforcement yourself.
+
+Cadence, from which Temporal forked, reaches the same conclusion from the other side: its engineering
+blog states plainly that "Shards are shared across the different domains in a Cadence cluster", and it
+added per-workflow-id rate limits precisely because the domain was not a fine enough unit.
+
+### Kubernetes documents what its namespace does not isolate
+
+The Kubernetes multi-tenancy documentation is the model for the register this page tries to hit. It
+recommends namespaces and then immediately lists what they fail to cover: namespace isolation
+"doesn't apply to Kubernetes resources that can't be namespaced, such as Custom Resource
+Definitions, Storage Classes, and Webhooks"; a `PersistentVolume` "is a cluster-wide resource and has
+a lifecycle independent of workloads and namespaces"; "By default, the Kubernetes DNS service allows
+lookups across all namespaces"; and "Quotas cannot protect against all kinds of resource sharing,
+such as network traffic."
+
+Two of those leaks have direct analogues in a scheduler. The control plane is shared, so there is one
+`CronJob` controller for every tenant in the cluster; and `PriorityClass` is cluster-scoped, so a
+paying tenant's pods can preempt a free tenant's across the namespace boundary. Kubernetes is also
+explicit that `CronJob` delivery is not exactly-once — "the Jobs that you define should be
+*idempotent*" — which is the same advice Quartz.NET's [best practices](best-practices.md) give about
+recoverable jobs, and for the same reason.
+
+Where namespaces are not enough, the escalation ladder Kubernetes describes is a virtual control
+plane per tenant, and past that a dedicated cluster. That ladder — shared partition, then per-tenant
+quota, then per-tenant control plane, then separate deployment — is the same one this page ends on.
+
+### EventBridge Scheduler's group is a billing boundary, not a fairness one
+
+AWS EventBridge Scheduler has an explicit *schedule group* primitive, and the group is embedded in
+every schedule's ARN, which makes it a natural IAM boundary. It is also the only thing you can tag:
+"With EventBridge Scheduler, you organize schedule **groups**, instead of individual schedules, by
+applying tags." So it is the unit of cost allocation and the only dimension on the service's
+CloudWatch metrics.
+
+What it is not is a quota. Every published quota — 10,000,000 schedules, 500 schedule groups, the
+1,000 TPS invocation throttle — is per account and Region. A tenant that floods its own group
+consumes the same invocation budget as every other tenant. The group names and authorizes; it does
+not ration.
+
+### Azure's task hub is a `SCHED_NAME` by another name
+
+Azure Durable Functions partitions by *task hub*, and on the SQL backend the implementation is
+strikingly close to Quartz's: "each table includes a `TaskHub` column as part of its primary key."
+On the Azure Storage backend the hub name is a prefix on queue, table and blob names in a shared
+storage account, which means RBAC granularity is the storage account and not the hub.
+
+Microsoft's warning about sharing one is the sharpest statement any vendor in this survey makes:
+"If multiple apps use the same task hub, they compete for messages, which can result in undefined
+behavior — including orchestrations getting unexpectedly stuck." Quartz.NET users will recognise the
+failure mode; it is exactly what happens when two unrelated schedulers are given the same
+`SCHED_NAME`. Microsoft's mitigation is to make the safe thing the default: the hub name is derived
+from the app name so that "accidental sharing doesn't happen."
+
+### Airflow spent a decade discovering where the boundary belongs
+
+Airflow is the field's longest-running attempt to retrofit tenancy onto a scheduler, and the outcome
+is the single best argument for the position this page takes.
+
+AIP-1 proposed multi-tenancy in 2016, diagnosing that "every task has full access to the Airflow
+database including connection details like usernames, passwords etc". It was eventually marked
+superseded by four successors. AIP-43 shipped in Airflow 2.4, separating DAG-file parsing from the
+scheduler. AIP-44 aimed to keep workers off the metadata database behind an internal API, shipped
+experimentally in 2.10 — and was then deleted wholesale, in favour of AIP-72's Task SDK, which landed
+in Airflow 3.0 and finally established that "in Airflow 3 direct DB access from workers will not be
+allowed at all".
+
+What shipped after all that is called **multi-team**, not multi-tenant, and its own documentation is
+careful about the difference: it "provides *logical isolation* for a secure perimeter around teams, not
+complete isolation. All teams share the same metadata database and common Airflow infrastructure. For
+absolutely strict security requirements, consider separate Airflow deployments." The giveaway detail
+is that "Dag IDs, Variable keys, and Connection IDs must be unique across the entire Airflow
+deployment, regardless of which team owns them" — a single flat namespace, which is a naming
+convention by definition.
+
+The two halves are worth separating, because Airflow got one of them right and it is the half
+Quartz.NET users ask about. **Pools are real.** A pool's concurrency bound is enforced in the metadata
+database, with a row lock over the pool table, so it holds across multiple schedulers — genuinely
+cluster-wide. **Identity is not.** Airflow's security model states that "All Dag authors have access
+to all Dags in the Airflow deployment" and that DAG authors "should be trusted".
+
+Note also the trap in the neighbouring setting: a *pool* binds cluster-wide, while `[core] parallelism`
+binds "per scheduler". Two knobs that read as siblings, at different scopes. That is exactly the
+confusion Quartz.NET's execution limits invite, which is why this page states their scope in the first
+sentence that mentions them.
+
+### Where the limit binds: Celery, Hangfire, and the per-worker trap
+
+The single most transferable lesson in this survey concerns *where* a concurrency or rate limit is
+counted, because it is the one everybody gets wrong.
+
+Celery's documentation is admirably direct about it: "Note that this is a *per worker instance* rate
+limit, and not a global rate limit. To enforce a global rate limit … you must restrict to a given
+queue." A `rate_limit` of 10/s across four workers is 40/s.
+
+Quartz.NET's execution limits have exactly this property, for exactly this reason: the running count
+lives in memory in the scheduler. See [what Quartz.NET does not give you](#what-quartz-net-does-not-give-you).
+
+The contrast is Hangfire. Its free tier has no per-queue or per-tenant cap either — worker count is
+per server — but `Hangfire.Throttling`, part of the paid **Hangfire Ace** set, adds mutexes,
+semaphores and fixed/sliding/dynamic window rate limiters, throttling by rescheduling a job rather
+than blocking a worker. A throttler's scope is its *storage's* scope: on SQL Server or Redis the limit
+therefore holds across every server sharing that storage, and on the in-memory storage it collapses
+back to one process. Even so the docs are careful — "Everything works on a best-effort basis," because
+"it's very hard to achieve it due to the complexity of distributed processing."
+
+Hangfire's own documentation pitches one of these at tenancy explicitly, and it is worth noting that
+it is the paid one: dynamic window counters give "some kind of fair processing, where one participant
+can't capture all the available resources that's especially useful for multi-tenant applications."
+
+Hangfire also shows what happens when the queue is pressed into service as the tenant boundary. A
+server's queue list is fixed when it starts, so a tenant that gets its own queue costs a restart — the
+request to make that dynamic has been open since 2017, filed by someone describing exactly this
+scenario. And on SQL Server the fetch statement has no `ORDER BY` at all; ordering falls out of an
+index on the queue name, so tenants are served alphabetically and a busy `acme` can starve `zeta`.
+Ordering that emerges from an index is not a fairness policy.
+
+BullMQ splits the same way, and its history is instructive. The open-source limiter is genuinely
+global — "The rate limiter is global, so if you have for example 10 workers for one queue with the
+above settings, still only 10 jobs will be processed by second" — but per-*group* limiting was
+removed: "From BullMQ 3.0 and onwards, group keys support is removed to improve global rate limit."
+Per-tenant fairness came back as **Groups** in the paid BullMQ Pro, motivated by precisely the SaaS
+case: "one user could fill the queue with jobs and the rest of the users will need to wait."
+
+### Upstream Quartz has no tenancy guidance, and that is informative
+
+Java Quartz — the project Quartz.NET is a port of — has the same three separations, and says nothing
+about tenancy at all. There is no page, no cookbook entry and no FAQ answer; the only issue asking how
+to handle a database per tenant was closed by a stale bot without an answer. `instanceName` is
+documented as a way "to distinguish schedulers when multiple instances are used within the same
+program", and `tablePrefix` as a way to "have multiple sets of Quartz's tables within the same
+database". Neither mentions a tenant.
+
+Groups are documented as categorisation and nothing more — "useful for organizing your jobs and
+triggers into categories such as 'reporting jobs' and 'maintenance jobs'". There is no per-group
+concurrency limit anywhere in Java Quartz; the thread pool is scheduler-wide and
+`@DisallowConcurrentExecution` is scoped to a job key. Upstream's answer to "different concurrency for
+different sets of jobs" is a second scheduler.
+
+The one place upstream does recommend partitioning, it is for a reason that has nothing to do with
+tenants and everything to do with the shared lock: "If you need to scale out to support thousands of
+short-running (e.g 1 second) jobs, consider partitioning the set of jobs by using multiple distinct
+schedulers … The scheduler makes use of a cluster-wide lock, a pattern that degrades performance as
+you add more nodes (when going beyond about three nodes …)." That is a throughput argument, and it
+happens to point the same way as the tenancy one.
+
+Also worth knowing if you lean on group matchers: Java Quartz warns that
+`pauseTriggers(GroupMatcher)` has "a limitation that only exactly matched groups can be remembered as
+paused", so pausing by prefix does not keep newly-added triggers paused. Quartz.NET's group pause
+state has its own caveat — job group pause state is not persisted by the ADO store — which is why both
+per-version guides tell you to suspend a tenant by *trigger* group.
+
+### Sidekiq removed its namespaces on purpose
+
+Sidekiq supported Redis key namespacing through the `redis-namespace` gem and removed it in 7.0.
+The upgrade guide is terse — "Support for `redis-namespace` has been removed", "I have advised
+against its usage for many years now" — and the reasoning is on the maintainer's blog: namespacing
+"increases the size of every key by the size of the prefix", and it means "you don't get to tune
+Redis for the individual needs of 'cache' and 'transactional'." His verdict on the practice was that
+it suits "hobbyists only who only want to pay for a single Redis database from a SaaS; you do not
+want to build a business on top of this hack." The Sidekiq wiki's current line: "Redis namespaces do
+not allow for this configuration and come with many other problems, so using discrete Redis instances
+is always preferred."
+
+The transferable point is not "prefixes are bad". It is that a prefix bought naming and nothing else
+— no separate tuning, no separate durability policy, no separate failure domain — while adding cost
+to every operation. A partition that gives you no new *capability* is usually not worth its
+complexity. This is worth holding in mind when reaching for a per-tenant table prefix, which has the
+same shape.
+
+## The axes that decide
+
+Walk your own situation down these. They are ordered roughly by how often they turn out to be the
+deciding one.
+
+| Axis | Ask yourself | Pushes toward shared | Pushes toward dedicated |
+|---|---|---|---|
+| Onboarding cadence | Does a tenant appear while the process runs? | Runtime arrival | Tenants known at deploy time |
+| Tenant count | How many, and how skewed? | Hundreds or thousands | Tens, or a few whales |
+| Blast radius | What is the cost of one bad tenant taking everything down? | Tolerable | Unacceptable |
+| Noisy neighbours | Can one tenant's work starve another's? | Workloads are small and similar | Workloads are bursty or heavy |
+| Per-tenant quotas and SLAs | Do you sell tiers with different guarantees? | One tier | Contractual per-tenant limits |
+| Data residency | Must a tenant's data live somewhere specific, or under its own key? | No constraint | Regulated or sovereign data |
+| Cost per idle tenant | What does a tenant cost when it schedules nothing? | Must be ~zero | Amortised by the contract |
+| Customisation | Do tenants differ in configuration, calendars, or schema? | Uniform | Divergent |
+| Observability | Must you answer "what is tenant X doing right now?" | Group dimension is enough | Needs its own dashboards |
+
+### Onboarding cadence decides more than anything else
+
+This is the axis to evaluate first, because on most platforms it eliminates an option outright rather
+than trading off against one.
+
+Runtime tenant arrival is cheap where the primitive is a row or an API call and expensive where it is
+a deployment. Temporal registers a namespace over gRPC, though registration "takes up to 10 seconds
+to complete" and the API is itself rate-limited. Kubernetes creates a namespace instantly — but a
+*usable* tenant is a namespace plus RBAC plus a `ResourceQuota` plus a `LimitRange` plus a
+`NetworkPolicy`, and the docs concede that this "requires configuration of several other Kubernetes
+resources". Celery can tell a running worker to consume a new queue with `add_consumer`; Hangfire and
+Sidekiq fix a server's queue set when it starts.
+
+AWS's silo model is where the cost shows: onboarding a siloed tenant "will require the provisioning
+of new infrastructure and, potentially, the configuration of new account limits", which makes what
+was one database insert into a deployment.
+
+In Quartz.NET the same split appears between the group-per-tenant model, where onboarding is writing
+a trigger, and the scheduler-per-tenant model, where it is closer to a deployment. It need not be a
+*redeploy* on either version — see
+[onboarding a tenant while the process runs](#onboarding-a-tenant-while-the-process-runs) — but it is
+still several orders of magnitude more work than a `ScheduleJob` call.
+
+### Tenant count, and the shape of the distribution
+
+Nobody in this literature will give you a threshold, because the real limit is operational rather
+than technical — but two sources come close enough to be useful.
+
+AWS on silo: "If you have 20 siloed accounts for each of your tenants, for example, that may be
+manageable. However, if you have a thousand tenants, that would likely begin to impact operational
+efficiency and agility." Temporal on namespace-per-tenant: "most teams find this manageable for fewer
+than 50 tenants."
+
+Both numbers describe the same thing — the point at which a per-tenant *deployment artefact* stops
+being something a human can reason about. For Quartz.NET, where a per-tenant scheduler costs a
+scheduling loop, a thread pool and (with a persistent store) a connection pool and a cluster check-in,
+the same order of magnitude applies. Tens of schedulers in a process is ordinary; thousands is a
+different program.
+
+The distribution matters as much as the count, and this is where the bridge model earns its keep.
+Microsoft's vertically partitioned model exists for exactly the common SaaS shape: most tenants on
+shared infrastructure, "single-tenant infrastructures for customers who require higher performance or
+data isolation", with the option to "charge customers a higher rate to use a single-tenant
+deployment". A long tail on one shared scheduler and a handful of whales on their own is not a
+compromise; it is the recommended answer.
+
+### Blast radius and noisy neighbours are different problems
+
+They are easy to conflate and have different remedies. Noisy neighbours are a *capacity* problem —
+one tenant consuming a disproportionate share — and the fix is resource governance: quotas,
+throttling, priorities. Blast radius is a *failure* problem, and the fix is partitioning into
+independent failure domains: cells, stamps, separate deployments.
+
+Microsoft's Noisy Neighbor guidance is that this is "a resource governance problem" to be met with
+"usage quotas, throttling, and governance controls" — plus one piece of scheduling advice worth
+lifting wholesale: "Consider whether you have background processes or resource-intensive workloads
+that aren't time-sensitive. Run these workloads asynchronously at off-peak times to preserve your
+resource capacity for time-sensitive workloads." For a scheduler, that is a cron expression, and it is
+often cheaper than any isolation mechanism.
+
+Blast radius is what cells and stamps address, and it is the reason the deployment-stamp guidance
+insists you "deploy at least two stamps of your solution. If you deploy only a single stamp, you can
+easily hard-code assumptions into your code or configuration that don't apply when you scale out."
+The Quartz.NET equivalent: if you intend ever to run more than one scheduler, run two from the start.
+
+### Cost per idle tenant
+
+Worth checking explicitly, because scheduling workloads are unusually sparse — a tenant with one
+nightly job is idle 99.9% of the time, and a model that charges for existence rather than execution
+scales badly against that shape.
+
+The managed services divide cleanly. EventBridge Scheduler charges per invocation, so a dormant
+schedule is free. Google Cloud Scheduler charges "$0.10 per job per month" for the job's existence,
+and "A paused job is counted as a job" — with a free tier of three jobs *per billing account*, not per
+project, so it does not scale with tenant count. Azure's Durable Task Scheduler is free when idle on
+Consumption and charges per capacity unit on Dedicated.
+
+Quartz.NET has no billing model, but it has the same asymmetry in resources. A tenant that is a group
+costs a row. A tenant that is a scheduler costs a scheduling loop that wakes on its own idle timer
+whether or not it has work, plus its pools. Multiply by the number of dormant tenants before choosing.
+
+### Observability
+
+Ask whether you can answer "what is tenant X doing right now?" without a deployment, and whether
+doing so will bankrupt your metrics backend.
+
+Under a group-per-tenant model the tenant is a dimension you already have, which is a strong argument
+for making the group the raw tenant id rather than a decorated string. Under a scheduler-per-tenant
+model the scheduler name is that dimension.
+
+The trap is cardinality. Job and trigger names are per job and per trigger; multiplying them by a
+tenant dimension produces a series per tenant per trigger. Drop the name tags in a view before they
+reach the backend unless you know you need them.
+
+The group is also not automatically everywhere you might assume. It is a tag on Quartz.NET's execution
+traces on both versions, and on metrics on 4.x — 3.x publishes no metrics at all — but neither version
+puts it into a logging scope, so per-tenant log correlation is something you add.
+
+## Mapping the axes onto Quartz.NET
+
+Quartz.NET gives you three separations. They compose, and the useful designs use more than one.
+
+**The scheduler** is the strongest boundary in the process. Each one owns its job store, thread pool,
+listeners, plugins, calendars and — with a persistent store — its own connection pool and cluster
+check-in. In silo/pool terms, a scheduler per tenant is siloed compute.
+
+**The group** is the group half of every `JobKey` and `TriggerKey`. It is a logical partition, not an
+enforced one: nothing stops a job in group `acme` from touching group `initech`. What it buys is that
+every matcher-taking API becomes tenant-scoped — listing, pausing, resuming, deleting — and that the
+group is already a tag on the execution traces. In silo/pool terms, a group per tenant is pooled
+compute with a tenant discriminator, which is the same trade Temporal recommends when it steers you
+to task queues over namespaces.
+
+**`SCHED_NAME`** is the database-level separation. Every Quartz table has it as the first column of
+its primary key and every statement filters on it, so two schedulers with different names share
+tables without seeing each other's rows. That is a property of the schema rather than of the code
+paths — the same design Azure's SQL backend uses for task hubs. The table prefix is a second, coarser
+axis: separate table *sets* in one database, which is a backup, restore and permissions decision
+rather than an isolation one.
+
+### Which mechanism exists on which version
+
+| Mechanism | 3.x | 4.x |
+|---|---|---|
+| Multiple schedulers in one process | Yes | Yes |
+| Named schedulers through Microsoft DI | Yes, `AddQuartz(name, …)` | Yes, `AddQuartz(name, …)` |
+| Resolving one by name | `ISchedulerRepository` | Keyed `IScheduler`, or `ISchedulerRepository` |
+| Groups and group matchers | Yes, `GroupMatcher<T>` | Yes, plus the paged query API |
+| `SCHED_NAME` row separation | Yes | Yes |
+| Per-scheduler table prefix | Yes | Yes |
+| Startup schema validation | Yes, `PerformSchemaValidation` on by default | Yes, `PerformSchemaValidation` on by default |
+| Execution groups and per-node limits | Yes | Yes |
+| Trigger group as the execution group | No — tag every trigger explicitly | Yes, `UseTriggerGroupWhenUnset()` |
+| Cluster-wide quotas or rate limiting | No | No |
+| Node affinity (persisted, cluster-aware) | Yes, `WithPreferredNode` | Yes, `WithPreferredNode` |
+| Preparing the job's DI scope | Subclass and override `ConfigureScope` | `ConfigureJobScope(…)` delegate |
+| Per-scheduler health check | No — one check, on the default scheduler | Yes, `AddQuartzHealthChecks` per scheduler |
+| Metrics | No | Yes |
+| Runtime tenant onboarding without a container | Yes, `StdSchedulerFactory` / `DirectSchedulerFactory` | Yes, `QuartzSchedulerBuilder` |
+
+Both trees carry the mechanics in full:
+
+- [Multi-Tenancy (Quartz 4.x)](quartz-4.x/multi-tenancy.md)
+- [Multi-Tenancy (Quartz 3.x)](quartz-3.x/multi-tenancy.md)
+
+### Choosing
+
+Work down this list and stop at the first that applies.
+
+1. **Tenants' data must be physically separate, or must live in a particular place.** A database per
+   tenant, and therefore a scheduler per tenant, because a job store binds to one data source. This is
+   the silo, with the silo's onboarding cost.
+2. **A few tenants need isolation and the rest do not.** The bridge: one shared scheduler with a group
+   per tenant for the long tail, and a dedicated scheduler for each tenant that bought isolation. This
+   is the most common shape for a SaaS and the one to reach for by default when the answer is not
+   obviously 3 or 4.
+3. **Tenants arrive while the process is running, and there are many of them.** Group per tenant.
+   Onboarding is a `ScheduleJob` call; there is no registration, no restart, and no per-tenant
+   resource cost beyond the rows.
+4. **Tenants are few, known at deployment, and differ in configuration.** Scheduler per tenant, named,
+   with per-scheduler options and health checks.
+
+Then, whichever you chose, decide the database question separately: one `SCHED_NAME` per tenant is
+usually enough, a table prefix per tenant if backup or permissions demand separate tables, and a
+separate database only if the data must not sit beside another tenant's.
+
+## What Quartz.NET does not give you
+
+A recommendation that oversells is worse than none, so these are the things multi-tenant deployments
+ask Quartz.NET for and do not get. They apply to both 3.x and 4.x unless noted.
+
+**Concurrency limits are per node, not cluster-wide.** Execution groups cap how many threads a
+category of work may use, and the running count lives in a dictionary in memory on the scheduler
+thread. Nothing is persisted and nodes do not coordinate, so a group limited to 3 can run up to 3×N
+across an N-node cluster. This is the same trap Celery documents for `rate_limit`, and the same one
+Hangfire only escapes in a paid add-on that coordinates through storage. The closest approximation is
+dividing the cap by the node count, which is wrong whenever a node is down.
+
+**There is no rate limiting.** Execution limits cap *concurrency*, not throughput. "This tenant may
+run 100 jobs an hour" is not something Quartz.NET can express; build it in the job, or in the thing
+the job calls.
+
+**A starved group misfires; it does not queue.** When a group is at its limit its triggers are
+skipped during acquisition and left where they are. They keep their original next fire time, so if
+the starvation lasts longer than the misfire threshold the ordinary misfire machinery claims them,
+and the trigger's misfire instruction — not the limit — decides whether the occurrence is skipped or
+rescheduled. Set per-tenant limits with that in mind, and pick misfire instructions deliberately for
+triggers in limited groups.
+
+**Job types are not keyed by scheduler.** Jobs are resolved from the one container by type, with no
+scheduler key, so two schedulers in one container cannot have different implementations of the same
+job type. On 4.x, `AddJob<T>` registers the type with `TryAdd` semantics and the first registration
+wins, silently and without a warning; on 3.x nothing is registered for you at all and whatever the
+application registered is what every scheduler gets. Keying the *job type* does not help either — the
+factory looks it up unkeyed and silently falls back to direct activation. Give each tenant its own job
+type, or — far better — use one job type that reads its tenant from the firing and resolves what it
+needs, by key if you like, inside `Execute`.
+
+**Nothing stops a job reaching another tenant's data.** Groups are a naming partition. In AWS's terms
+Quartz.NET gives you partitioning, and isolation is your application's job — a tenant id read from
+the firing and threaded through every query, not a boundary the scheduler enforces.
+
+**Dashboard and HTTP API authorization is per process, all or nothing.** The dashboard has a single
+authorization policy and a single read-only flag on both versions, and 4.x's HTTP API serves every
+scheduler in the container behind one uniformly-applied policy, with the scheduler named in the route.
+There is no per-scheduler policy and no scheduler-name claim check. If tenants must reach their own
+scheduler and not each other's, enforce that outside Quartz.NET — a process per tenant, or middleware
+that authorizes on the scheduler-name route segment.
+
+**A shut-down scheduler cannot be restarted.** `Standby()` / `Start()` is the pause-and-resume pair.
+Shutdown is terminal: the scheduler refuses to start again and every other operation throws. You can
+build a *new* scheduler with the same name, but it is a new one, not a revived one.
+
+**The tenant does not reach your logs by itself.** The job and trigger group are tags on the execution
+traces, and on 4.x's metrics, but neither version puts them into a logging scope; if you want
+per-tenant log correlation you add it. Note also that a tenant carried only in an *execution* group is
+invisible to those signals — one more reason to make the trigger group the tenant.
+
+### Onboarding a tenant while the process runs
+
+Under the group-per-tenant model this is a non-question: scheduling a job for a new group is an
+ordinary API call.
+
+Under the scheduler-per-tenant model, the DI path is closed once the container is built —
+`AddQuartz` mutates `IServiceCollection`, and the hosted service enumerates schedulers once at
+start. But that is a limit of the DI path, not of the library. Both versions can build a scheduler at
+runtime outside the container: 3.x through `StdSchedulerFactory` or `DirectSchedulerFactory`, and 4.x
+through `QuartzSchedulerBuilder`, which creates and owns a container of its own.
+
+What that costs you is worth knowing before you build on it: a scheduler created this way gets no
+hosted-service lifetime (you start and dispose it), its jobs resolve from its own container rather
+than the application's unless you give it a job factory that bridges, and it is not covered by health
+checks registered at startup. The per-version guides spell out the API and the trade-offs.
+
+## Anti-patterns
+
+**Smuggling the tenant into a job name and parsing it back out.** `JobKey("nightly-report-acme")`
+looks harmless until something needs every job for a tenant, and the only way to get it is to fetch
+every key and split strings. The group half of the key exists for this; use it, and keep the name for
+what the job *is*. This is the same mistake as encoding a tenant in a Redis key when the system offers
+a database — and Sidekiq's history is what happens next.
+
+**One scheduler per tenant at thousands of tenants.** Each scheduler is a scheduling loop that wakes
+on its own timer, a thread pool, a connection pool and a cluster check-in, whether or not that tenant
+has anything to run. This is AWS's silo scaling problem in miniature, and their guidance holds: fine
+at twenty, a serious operational burden at a thousand. Groups scale where schedulers do not.
+
+**A shared database with a mismatched table prefix.** Nothing derives the prefix from the DDL or the
+DDL from the prefix; you run the scripts with the prefix substituted. A prefix pointing at tables
+that do not exist is caught at startup — `PerformSchemaValidation` is on by default on both versions,
+and it names the missing table rather than letting the first failing operation surface an hour later.
+What validation cannot catch is a prefix pointing at tables that *do* exist and belong to another
+tenant: that configuration is indistinguishable from a correct one, and it will run happily on the
+wrong data. Derive the prefix from the tenant id in code rather than pasting it into per-environment
+configuration.
+
+**Two unrelated schedulers sharing a database with the same `SCHED_NAME`.** By construction they are
+indistinguishable from two nodes of one cluster, because that is exactly what they look like to the
+schema. They will steal each other's triggers. Duplicate-name checks protect you only within one
+container; across processes the name is a contract you keep. Microsoft hit the same problem with task
+hubs and solved it by deriving the default name from the app name — a good idea to copy, by deriving
+the scheduler name from the tenant id rather than from a configuration file someone can copy-paste.
+
+**Assuming a per-node limit is a per-cluster limit.** Covered above, and repeated here because it is
+the failure that only shows up in production, after the second node is added.
+
+**Letting per-tenant metrics multiply without a view.** A tenant dimension times a trigger-name
+dimension is a series per tenant per trigger. Aggregate before the data leaves the process.
+
+## See also
+
+- [Multi-Tenancy (Quartz 4.x)](quartz-4.x/multi-tenancy.md) — the 4.x mechanics in full
+- [Multi-Tenancy (Quartz 3.x)](quartz-3.x/multi-tenancy.md) — the 3.x mechanics in full
+- [Best Practices](best-practices.md) — including why never to point two non-clustered schedulers at one database
+- [Troubleshooting](troubleshooting.md)
+
+## Sources
+
+The prior-art survey above is drawn from these primary sources, read in August 2026.
+
+- AWS, [SaaS Architecture Fundamentals: Tenant isolation](https://docs.aws.amazon.com/whitepapers/latest/saas-architecture-fundamentals/tenant-isolation.html) and [SaaS Lens: Silo, Pool, and Bridge Models](https://docs.aws.amazon.com/wellarchitected/latest/saas-lens/silo-pool-and-bridge-models.html)
+- AWS, [SaaS Tenant Isolation Strategies](https://docs.aws.amazon.com/whitepapers/latest/saas-tenant-isolation-strategies/silo-isolation.html) — silo, pool and bridge pros and cons
+- AWS, [Reducing the Scope of Impact with Cell-Based Architecture](https://docs.aws.amazon.com/wellarchitected/latest/reducing-scope-of-impact-with-cell-based-architecture/what-is-a-cell-based-architecture.html)
+- Microsoft, [Tenancy models to consider for a multitenant solution](https://learn.microsoft.com/azure/architecture/guide/multitenant/considerations/tenancy-models), [Architectural approaches for compute](https://learn.microsoft.com/azure/architecture/guide/multitenant/approaches/compute), [Deployment Stamps pattern](https://learn.microsoft.com/azure/architecture/patterns/deployment-stamp) and the [Noisy Neighbor antipattern](https://learn.microsoft.com/azure/architecture/antipatterns/noisy-neighbor/noisy-neighbor)
+- Temporal, [Multi-tenant patterns](https://docs.temporal.io/production-deployment/multi-tenant-patterns), [Namespaces](https://docs.temporal.io/namespaces) and [Managing namespaces](https://docs.temporal.io/best-practices/managing-namespace)
+- Cadence, [Workflow ID-based rate limits](https://cadenceworkflow.io/blog/2024/09/05/workflow-specific-rate-limits)
+- Kubernetes, [Multi-tenancy](https://kubernetes.io/docs/concepts/security/multi-tenancy/) and [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
+- Apache Airflow, [Security model](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html), [Multi-team](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/multi-team.html), [Pools](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/pools.html) and [AIP-1](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=89066609), [AIP-44](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-44+Airflow+Internal+API), [AIP-72](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-72+Task+Execution+Interface+aka+Task+SDK)
+- AWS, [EventBridge Scheduler quotas](https://docs.aws.amazon.com/scheduler/latest/UserGuide/scheduler-quotas.html) and [schedule groups](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-schedule-group.html)
+- Microsoft, [Durable task hubs](https://learn.microsoft.com/azure/durable-task/common/durable-task-hubs)
+- Celery, [Tasks: `Task.rate_limit`](https://docs.celeryq.dev/en/stable/userguide/tasks.html)
+- Hangfire, [Concurrency and rate limiting](https://docs.hangfire.io/en/latest/background-processing/throttling.html), [Configuring queues](https://docs.hangfire.io/en/latest/background-processing/configuring-queues.html), [Using the dashboard](https://docs.hangfire.io/en/latest/configuration/using-dashboard.html) and issue [#879](https://github.com/HangfireIO/Hangfire/issues/879)
+- Quartz (Java), [Multiple schedulers cookbook](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/cookbook/MultipleSchedulers.html), [JDBC-JobStore clustering](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/configuration/ConfigJDBCJobStoreClustering.html) and [tutorial lesson 2](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-02.html)
+- BullMQ, [Rate limiting](https://docs.bullmq.io/guide/rate-limiting) and [Pro: Groups](https://docs.bullmq.io/bullmq-pro/groups)
+- Sidekiq, [7.0 upgrade notes](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md) and [Storing data with Redis](https://www.mikeperham.com/2015/09/24/storing-data-with-redis/)
+- Quartz (Java), [Configuration reference](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/configuration/ConfigMain.html)


### PR DESCRIPTION
Closes #3346.

Two new pages and three corrections to existing ones.

## `docs/documentation/tenancy-patterns.md` (version-neutral)

Sits beside `best-practices.md` and `troubleshooting.md`, because none of prior art, isolation vocabulary, deciding axes or anti-patterns is version-specific. Where a Quartz mechanism differs between versions it says so inline and links into the right tree rather than forking.

Structure: what isolation *is* (and is not) → the two vocabularies and their translation table → how twelve other systems partition tenants → the axes that decide → mapping those onto Quartz.NET → what Quartz.NET does not give you → anti-patterns.

The thesis the research converged on, and the reason the page is worth shipping: **almost every system's tenancy primitive is a naming and access boundary, and almost none of them make it a fairness boundary.** Celery documents `rate_limit` as "a *per worker instance* rate limit, and not a global rate limit". Hangfire's free tier has no per-tenant cap and its storage-coordinated throttling is paid Hangfire Ace. BullMQ removed per-group rate limiting from the OSS line in 3.0 and sells it back as Pro Groups. EventBridge Scheduler's schedule group carries tags and IAM but every quota is per account. Quartz.NET's per-node execution limits sit squarely in that tradition, so the page says so where a reader will see it rather than in a footnote.

Two systems that were more instructive than expected:

- **Temporal ranks namespace-per-tenant last of four patterns**, caps it at "fewer than 50 tenants", and recommends task-queue-per-tenant — a client-side naming convention — chosen deliberately over its own server-enforced boundary.
- **Upstream Java Quartz has no tenancy guidance at all.** No page, no cookbook entry, no FAQ answer; the one issue asking about a database per tenant was closed by a stale bot. Its only partitioning recommendation is about cluster-lock contention. That absence is itself citable, and it is why this page exists.

## `docs/documentation/quartz-3.x/multi-tenancy.md`

Written against `origin/3.x`, not transposed from the 4.x page. The trees diverge more than the shape suggests: 3.x has no keyed `IScheduler` (inject `ISchedulerRepository`), no `UseTriggerGroupWhenUnset`, no `ConfigureJobScope`, no per-scheduler health check, and no metrics at all; its trace tags are `trigger.group`, not `quartz.trigger.group`. It is also the *more* flexible tree for runtime onboarding, since `StdSchedulerFactory` needs no container.

## Corrections to existing pages

| Page | Was | Verified behaviour |
|---|---|---|
| `quartz-4.x/multi-tenancy.md` | "Tenants cannot be onboarded at runtime" | True of the DI path only. `QuartzSchedulerBuilder` + `ISchedulerRepository.Bind` works; the page now states it and what it costs. |
| `quartz-3.x/packages/multiple-schedulers.md` | "All schedulers — whether created via DI or directly — are registered in the shared `ISchedulerRepository`" | They are not. DI registers its own; `StdSchedulerFactory`/`DirectSchedulerFactory` bind the static `SchedulerRepository.Instance`. This is why a hand-built scheduler is missing from the dashboard. |
| `quartz-3.x/tutorial/execution-groups.md` | "`[DisallowConcurrentExecution]` is checked **before** execution group limits" | True for `RAMJobStore`, inverted for the ADO store. The 4.x page already described it correctly. |

## Honesty constraints — all three checked, two refined

- **#3337 (per-node limits) — confirmed, refined.** Ledger is `QuartzSchedulerThread.runningExecutionGroupCounts`, a `ConcurrentDictionary<string,int>` per `QuartzScheduler`. `ExecutionSlots` is a per-acquisition-pass tally, not the ledger. `EXECUTION_GROUP` on `QRTZ_FIRED_TRIGGERS` is never written on 3.x, so there is no latent cluster ledger. Also documented, and previously undocumented: **a group held at its limit past the misfire threshold misfires rather than queueing**, and the misfire instruction — not the limit — decides what happens.
- **#3338 (no runtime onboarding) — refined; the brief was too strong.** Shutdown is genuinely terminal. But the DI path being closed is not the library being closed, on either version. Reported here because it changed what the 4.x page says.
- **#3340 (unkeyed job types) — confirmed for job types, too strong for plugins.** `TryAddScoped`, first wins silently: confirmed. Plugins are *not* unkeyed — a `quartz.plugin.*` entry is instantiated per scheduler from that scheduler's own property bag; the only hole is the container probe preceding activation. The pages say the narrower, true thing.

## Where helper agents disagreed, and how it was settled

Eight agents, blind to each other. Two ran the same 3.x slice with opposite lenses (enumerate capabilities vs. hunt for claims that would be wrong).

1. **3.x schema validation.** My draft asserted 3.x had none. Both 3.x auditors said it does. Settled from source: `JobStoreSupport.PerformSchemaValidation` defaults to `true`. The auditors were right and my draft was wrong; the anti-pattern paragraph was rewritten around what validation *cannot* catch — a prefix pointing at another tenant's real tables.
2. **DisallowConcurrentExecution ordering.** One auditor said the existing 3.x doc is inverted for the ADO store; the other declined to verify. Settled by reading both stores: `RAMJobStore` checks DCE then limits; the ADO path filters limits in the delegate and checks DCE afterwards in `JobStoreSupport`. The minority-confident agent was right, and the page is corrected rather than averaged.
3. **`WithExecutionGroup` in DI.** Only the adversarial auditor raised it. Confirmed against the 3.x public API baseline: `ITriggerConfigurator` has no such method, so `q.AddTrigger(t => t.WithExecutionGroup(...))` does not compile. Kept, with the JSON-scheduling alternative — this would have been a broken code sample.
4. **Hangfire.Throttling edition and scope.** One fetch said "Pro", another "Ace"; on scope, one asserted storage-coordination outright while the dedicated agent found *no sentence in the corpus states it*. Settled on the narrower claim the evidence supports: Ace, and "a throttler's scope is its storage's scope" — which also captures the trap that in-memory storage collapses it to one process.
5. **Runtime onboarding on 4.x.** Contradicted the brief, so I read `QuartzSchedulerBuilder`, `StandaloneSchedulerFactory` and `SchedulerRepository.Bind` myself rather than take it on report.

## Claims I could not verify, and what I did about them

- Whether `AddQuartzServer` in a named-only 3.x container actually throws when the health check is probed. Both registration sites read as I describe, but I did not run it, so the page states the mechanism (the check resolves `ISchedulerFactory`, which such a container lacks) rather than the symptom.
- Deliberately left out: Cadence's "2,000 domains with total isolation" (vendor comparison page, contradicted by their own engineering blog); a claim that Java Quartz's `tablePrefix` docs mention tenant isolation (one summarizer produced that sentence; it is not in the docs); Dagster and Prefect, which are researched but were cut for length as the least scheduler-shaped of the survey.
- All quoted figures are dated in the page ("read in August 2026") because cloud quotas move.

## Verification

- `npm run docs:build` — clean, 212 pages.
- `npm run docs:lint` — 111 problems before and after, identical rule-code distribution; the only diff is two pre-existing errors whose line numbers shifted. No new violations.
- Links and anchors checked with the real `@mdit-vue/shared` slugifier: 670 links, 366 fragments, only the four pre-existing `_posts` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3wNU6NFXyZztWp12PGQc
