### PR TITLE
Documentation samples are compiled code injected into the pages

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -28,6 +28,7 @@
         "Clean",
         "Compile",
         "DocsBuild",
+        "DocsSnippets",
         "GenerateMigrations",
         "IntegrationTest",
         "Pack",
@@ -36,6 +37,7 @@
         "PublishAot",
         "Restore",
         "UnitTest",
+        "VerifyDocsSnippets",
         "VerifyMigrations"
       ]
     },

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -36,8 +36,14 @@ jobs:
       - name: Verify documentation snippets
         run: dotnet fallout VerifyDocsSnippets
 
+      # --ignore-scripts blocks the lifecycle scripts of every dependency. patch-package is ours, and
+      # package.json's postinstall is the only one this repository actually wants, so it is run as its
+      # own step rather than trusting the whole tree to behave.
       - name: Install
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Apply dependency patches
+        run: npx patch-package
 
       - name: Build
         run: npm run docs:build

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -38,12 +38,15 @@ jobs:
 
       # --ignore-scripts blocks the lifecycle scripts of every dependency. patch-package is ours, and
       # package.json's postinstall is the only one this repository actually wants, so it is run as its
-      # own step rather than trusting the whole tree to behave.
+      # own step. `npm run apply-patches`, not npx: npm run executes the copy npm ci just installed at
+      # the version package-lock.json pins, where npx is free to fetch an unpinned one from the registry
+      # and run its lifecycle scripts. package.json keeps postinstall as well, for contributors who run a
+      # plain npm ci and should not have to know about this step at all.
       - name: Install
         run: npm ci --ignore-scripts
 
       - name: Apply dependency patches
-        run: npx patch-package
+        run: npm run apply-patches
 
       - name: Build
         run: npm run docs:build

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -8,6 +8,9 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '**/docs*.yml'
+      # the compiled samples the documentation shows, and the target that injects them
+      - 'src/Quartz.Documentation.Samples/**'
+      - 'build/**'
 permissions:
   contents: read
 jobs:
@@ -18,14 +21,31 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
+
+      # Its own step, and its own line, so the target's exit code is the step's result. It fails when a
+      # page names a snippet that no longer exists, when a marker was left empty, and when the committed
+      # markdown no longer matches the samples — the last of which the author fixes with
+      # 'dotnet fallout DocsSnippets'. Nothing regenerates the documentation behind the author's back.
+      - name: Verify documentation snippets
+        run: dotnet fallout VerifyDocsSnippets
+
+      - name: Install
+        run: npm ci
+
       - name: Build
-        run: |
-          npm ci
-          npm run docs:build
+        run: npm run docs:build
 
       # markdownlint's MD051 cannot check fragments against a VuePress slugger, so it is off;
       # this is the replacement. See the note in .markdownlint.jsonc.
+      - name: Test the link checker
+        run: npm run docs:check-links-test
+
       - name: Check links and anchors
-        run: |
-          npm run docs:check-links-test
-          npm run docs:check-links
+        run: npm run docs:check-links

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,12 +35,15 @@ jobs:
 
       # --ignore-scripts blocks the lifecycle scripts of every dependency. patch-package is ours, and
       # package.json's postinstall is the only one this repository actually wants, so it is run as its
-      # own step rather than trusting the whole tree to behave.
+      # own step. `npm run apply-patches`, not npx: npm run executes the copy npm ci just installed at
+      # the version package-lock.json pins, where npx is free to fetch an unpinned one from the registry
+      # and run its lifecycle scripts. package.json keeps postinstall as well, for contributors who run a
+      # plain npm ci and should not have to know about this step at all.
       - name: Install
         run: npm ci --ignore-scripts
 
       - name: Apply dependency patches
-        run: npx patch-package
+        run: npm run apply-patches
 
       - name: Build
         run: npm run docs:build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '**/docs*.yml'
+      # the compiled samples the documentation shows, and the target that injects them
+      - 'src/Quartz.Documentation.Samples/**'
+      - 'build/**'
 permissions:
   contents: read
 jobs:
@@ -18,10 +21,23 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
+
+      # The site is never published from markdown that disagrees with the samples it shows.
+      - name: Verify documentation snippets
+        run: dotnet fallout VerifyDocsSnippets
+
+      - name: Install
+        run: npm ci
+
       - name: Build
-        run: |
-          npm ci
-          npm run docs:build
+        run: npm run docs:build
 
       - name: Deploy
         working-directory: ./docs/.vuepress/dist

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,8 +33,14 @@ jobs:
       - name: Verify documentation snippets
         run: dotnet fallout VerifyDocsSnippets
 
+      # --ignore-scripts blocks the lifecycle scripts of every dependency. patch-package is ours, and
+      # package.json's postinstall is the only one this repository actually wants, so it is run as its
+      # own step rather than trusting the whole tree to behave.
       - name: Install
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Apply dependency patches
+        run: npx patch-package
 
       - name: Build
         run: npm run docs:build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,14 @@ plus a bridge entry on main.
   against are the ids the published pages carry — `Quartz.Core` is `#quartz-core`, not `#quartzcore`.
   It runs on every docs pull request. markdownlint's MD051 is off for exactly this reason; do not
   take its fragment suggestions, they 404. `npm run docs:check-links-test` is the checker's control.
+- **C# in a documentation page is generated, not typed.** Samples live as `#region sample_*` blocks in
+  `src/Quartz.Documentation.Samples` — an ordinary project in the solution, so a rotted sample fails
+  `Compile` — and a page carries `<!-- snippet: name -->` / `<!-- endSnippet -->` markers that
+  `dotnet fallout DocsSnippets` fills in. `VerifyDocsSnippets` fails a pull request whose markdown is
+  stale, whose marker names nothing, or whose marker came out empty. The convention, and the handful of
+  blocks deliberately left as plain fences, are written up in `CONTRIBUTING.md` under "Code samples in
+  the documentation". Pages outside `docs/documentation/quartz-4.x/packages/` still carry hand-written
+  fences; converting one is welcome, converting it halfway is not.
 - **`src/Quartz.Tests.Unit/Verify/PublicApiTest_*.verified.txt` are the public API baselines.**
   Any change to public API fails those tests; review the diff, and if the change is intended,
   accept the new baseline and carry the same diff into

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,59 @@ The documentation website is built and published from this **`main`** branch. Al
 
 The published Quartz 3.x package pages under `docs/documentation/quartz-3.x/packages/` are mirrored, in compact NuGet-rendered form, by the per-package `src/<Project>/README.md` files on the `3.x` branch (which are packed into the NuGet packages). When you change one, update the other in a companion PR so the published page and the shipped package README stay consistent.
 
+### Code samples in the documentation
+
+**Do not type C# into a markdown file.** Write it as ordinary code in
+[`src/Quartz.Documentation.Samples`](src/Quartz.Documentation.Samples), which is a project in the
+solution, and let the build inject it into the page. A sample that stops compiling then fails the
+build like any other code, and the page cannot drift from it, because the page is generated from it.
+
+Wrap the lines the page should show in a `#region`, named `sample_` followed by something unique:
+
+```csharp
+public static void ShutdownHook(IServiceCollection services)
+{
+    #region sample_plugins_shutdown_hook
+
+    services.AddQuartz(q => q.UseShutdownHook(options => options.CleanShutdown = true));
+
+    #endregion
+}
+```
+
+Then put a marker pair where the fenced block would have gone:
+
+```markdown
+<!-- snippet: sample_plugins_shutdown_hook -->
+<!-- endSnippet -->
+```
+
+and run `npm run docs:snippets` (or `dotnet fallout DocsSnippets`) to fill it in. Commit the filled-in
+markdown: it is what GitHub and the published site both render, and reviewing the generated code is
+half the point.
+
+A few things worth knowing:
+
+- **Names must be unique across the whole samples project.** Two regions with one name are not an error
+  upstream — both are emitted, one after the other — so `DocsSnippets` treats a duplicate as an error.
+- **The region's indentation is removed**, so a fragment can live inside whatever scaffolding makes it
+  compile: put the region inside an `AddQuartz(q => { … })` body and the page shows just the `q.…` lines.
+- **Two samples can show a type of the same name** by living in different namespaces or in different
+  nested classes; the region never includes the enclosing declaration.
+- **A page that must show `using` directives** needs its region to start at the top of a file, which
+  means that file has no namespace of its own — see `CustomCalendarSample.cs`.
+- **Sample code still has to satisfy the compiler.** The samples project turns the *style* analyzers
+  down so a sample reads like a documentation page rather than like library code, but it is built with
+  the same `TreatWarningsAsErrors` as everything else.
+- Some blocks are deliberately left as plain fences: those calling a package this repository does not
+  reference, and the `BinaryFormatter` migration sample, which would drag in an unsupported
+  compatibility package. Adding a NuGet dependency purely to compile a sample is not worth it.
+
+`dotnet fallout VerifyDocsSnippets` is what CI runs. It fails when a page names a snippet that does not
+exist, when a marker was left empty, and when the committed markdown no longer matches the samples.
+Nothing regenerates the documentation behind your back — a stale page is your pull request's problem,
+not a bot's.
+
 ## Bugs and feature requests?
 
 Please log a new issue in the GitHub repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,17 @@ The documentation website is built and published from this **`main`** branch. Al
 
 The published Quartz 3.x package pages under `docs/documentation/quartz-3.x/packages/` are mirrored, in compact NuGet-rendered form, by the per-package `src/<Project>/README.md` files on the `3.x` branch (which are packed into the NuGet packages). When you change one, update the other in a companion PR so the published page and the shipped package README stay consistent.
 
+### Building the site
+
+`npm ci` then `npm run docs:build`. `npm ci` runs `postinstall`, which is `patch-package`, which applies
+the files in `patches/` — VuePress needs the `gray-matter` patch to parse front matter, so a build from an
+unpatched tree fails in a way that does not name the cause.
+
+CI installs with `npm ci --ignore-scripts`, so that no dependency's lifecycle script runs on a machine
+holding a deploy secret, and then calls `npm run apply-patches` explicitly. The two entries in
+`package.json` are the same command for different callers: `postinstall` is for you, `apply-patches` is for
+CI. Keep both.
+
 ### Code samples in the documentation
 
 **Do not type C# into a markdown file.** Write it as ordinary code in
@@ -62,18 +73,18 @@ half the point.
 
 A few things worth knowing:
 
-- **Names must be unique across the whole samples project.** Two regions with one name are not an error
+* **Names must be unique across the whole samples project.** Two regions with one name are not an error
   upstream — both are emitted, one after the other — so `DocsSnippets` treats a duplicate as an error.
-- **The region's indentation is removed**, so a fragment can live inside whatever scaffolding makes it
+* **The region's indentation is removed**, so a fragment can live inside whatever scaffolding makes it
   compile: put the region inside an `AddQuartz(q => { … })` body and the page shows just the `q.…` lines.
-- **Two samples can show a type of the same name** by living in different namespaces or in different
+* **Two samples can show a type of the same name** by living in different namespaces or in different
   nested classes; the region never includes the enclosing declaration.
-- **A page that must show `using` directives** needs its region to start at the top of a file, which
+* **A page that must show `using` directives** needs its region to start at the top of a file, which
   means that file has no namespace of its own — see `CustomCalendarSample.cs`.
-- **Sample code still has to satisfy the compiler.** The samples project turns the *style* analyzers
+* **Sample code still has to satisfy the compiler.** The samples project turns the *style* analyzers
   down so a sample reads like a documentation page rather than like library code, but it is built with
   the same `TreatWarningsAsErrors` as everything else.
-- Some blocks are deliberately left as plain fences: those calling a package this repository does not
+* Some blocks are deliberately left as plain fences: those calling a package this repository does not
   reference, and the `BinaryFormatter` migration sample, which would drag in an unsupported
   compatibility package. Adding a NuGet dependency purely to compile a sample is not worth it.
 

--- a/Quartz.slnx
+++ b/Quartz.slnx
@@ -38,6 +38,7 @@
   </Project>
   <Project Path="src/Quartz.AspNetCore/Quartz.AspNetCore.csproj" />
   <Project Path="src/Quartz.Dashboard/Quartz.Dashboard.csproj" />
+  <Project Path="src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj" />
   <Project Path="src/Quartz.Benchmark/Quartz.Benchmark.csproj" />
   <Project Path="src/Quartz.HttpClient/Quartz.HttpClient.csproj" />
   <Project Path="src/Quartz.Jobs/Quartz.Jobs.csproj" />

--- a/build/Build.Docs.Snippets.cs
+++ b/build/Build.Docs.Snippets.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Fallout.Common;
+using Fallout.Common.IO;
+
+using MarkdownSnippets;
+
+using Serilog;
+
+/// <summary>
+/// Injects the compiled documentation samples into the markdown that references them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Samples live as <c>#region sample_*</c> blocks in <c>src/Quartz.Documentation.Samples</c>, which is an
+/// ordinary project in the solution — so a sample that stops compiling fails the normal build. A docs page
+/// carries a <c>&lt;!-- snippet: name --&gt;</c> / <c>&lt;!-- endSnippet --&gt;</c> marker pair, and this
+/// target fills it in.
+/// </para>
+/// <para>
+/// The engine is <see href="https://github.com/SimonCropp/MarkdownSnippets">MarkdownSnippets</see>, used
+/// through its library rather than its <c>mdsnippets</c> command line tool. The tool would be the obvious
+/// choice, but its directory filter hard-codes a list of names that are never scanned, and
+/// <c>packages</c> — the name of the directory holding the fifteen package pages this convention exists
+/// for — is on it (<c>DefaultDirectoryExclusions.ShouldExcludeDirectory</c>). The tool skips the whole
+/// directory and exits 0, which is the silent degradation the convention is meant to remove. The library
+/// takes the directory predicates as parameters, so they are spelled out below instead.
+/// </para>
+/// <para>
+/// Three things fail rather than warn: a marker naming a snippet that does not exist, a marker that came
+/// out empty (which is how a skipped directory would show up), and markdown that does not match what the
+/// samples currently say. The last one is why <see cref="VerifyDocsSnippets" /> exists — the upstream tool
+/// has no check mode, and the pattern most of its users adopt regenerates and auto-commits, which would let
+/// a pull request merge green while the reviewed diff and the published page disagreed.
+/// </para>
+/// </remarks>
+public partial class Build
+{
+    AbsolutePath DocsDirectory => RootDirectory / "docs";
+
+    AbsolutePath DocumentationSamplesDirectory => SourceDirectory / "Quartz.Documentation.Samples";
+
+    /// <summary>
+    /// Markdown trees that are frozen at the names their release shipped with, or are not documentation.
+    /// </summary>
+    static readonly string[] MarkdownDirectoryExclusions =
+    [
+        "docs/documentation/quartz-1.x",
+        "docs/documentation/quartz-2.x",
+        "docs/documentation/quartz-3.x",
+        "docs/_posts",
+        "docs/.vuepress"
+    ];
+
+    static readonly string[] TraversalExclusions =
+    [
+        ".git", ".vs", ".vscode", ".idea", "node_modules", "bin", "obj", "artifacts", "dist"
+    ];
+
+    static readonly Regex EmptySnippetMarker = new(
+        @"<!--\s*snippet:\s*(?<key>[^\s>]+)\s*-->\s*(\r?\n)\s*<!--\s*endSnippet\s*-->",
+        RegexOptions.None,
+        TimeSpan.FromSeconds(5));
+
+    static readonly Regex SnippetMarker = new(
+        @"<!--\s*snippet:\s*(?<key>[^\s>]+)\s*-->",
+        RegexOptions.None,
+        TimeSpan.FromSeconds(5));
+
+    Target DocsSnippets => _ => _
+        .Description("Injects the compiled documentation samples into the markdown that references them")
+        .Executes(() => ProcessDocumentationSnippets(verifyOnly: false));
+
+    Target VerifyDocsSnippets => _ => _
+        .Description("Fails when a documented snippet is missing, empty, or out of step with the samples")
+        .Executes(() => ProcessDocumentationSnippets(verifyOnly: true));
+
+    void ProcessDocumentationSnippets(bool verifyOnly)
+    {
+        var markdownFiles = DocsDirectory
+            .GlobFiles("**/*.md")
+            .Where(x => !IsExcludedMarkdown(x))
+            .ToList();
+
+        var before = markdownFiles.ToDictionary(x => x.ToString(), x => File.ReadAllText(x), StringComparer.Ordinal);
+
+        var processor = new DirectoryMarkdownProcessor(
+            RootDirectory,
+            appendSnippets: AppendSnippet,
+            directoryIncludes: ShouldTraverse,
+            markdownDirectoryIncludes: IsDocumentationDirectory,
+            snippetDirectoryIncludes: IsSampleDirectory,
+            convention: DocumentConvention.InPlaceOverwrite,
+            log: x => Log.Debug("{Message}", x),
+            treatMissingAsWarning: false);
+
+        AssertSnippetKeysAreUnique(processor.Snippets);
+
+        List<AbsolutePath> changed;
+
+        try
+        {
+            processor.Run();
+
+            changed = markdownFiles
+                .Where(x => !string.Equals(before[x], File.ReadAllText(x), StringComparison.Ordinal))
+                .ToList();
+        }
+        finally
+        {
+            // Even a failing run may have written the pages it got through before the one that threw, and
+            // a verification must leave the working tree exactly as it found it.
+            if (verifyOnly)
+            {
+                foreach (var file in markdownFiles)
+                {
+                    File.WriteAllText(file, before[file]);
+                }
+            }
+        }
+
+        AssertNoEmptySnippets(markdownFiles);
+        ReportUnreferencedSamples(processor.Snippets, markdownFiles);
+
+        if (changed.Count == 0)
+        {
+            Log.Information("Documentation snippets are up to date ({Count} markdown files checked)", markdownFiles.Count);
+            return;
+        }
+
+        if (!verifyOnly)
+        {
+            foreach (var file in changed)
+            {
+                Log.Information("Updated {File}", RootDirectory.GetRelativePathTo(file));
+            }
+
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"""
+             {changed.Count} documentation page(s) no longer match the samples they show:
+             {string.Join(Environment.NewLine, changed.Select(x => "  " + RootDirectory.GetRelativePathTo(x)))}
+
+             Run 'dotnet fallout DocsSnippets' (or 'npm run docs:snippets') and commit the result.
+             """);
+    }
+
+    /// <summary>
+    /// Writes the snippet as a plain fenced block, with no source link.
+    /// </summary>
+    /// <remarks>
+    /// MarkdownSnippets' own writer emits an <c>&lt;a id&gt;</c> anchor and a <c>&lt;sup&gt;</c> line
+    /// carrying a line-numbered permalink. Both are dropped here. The raw HTML would need the repository's
+    /// markdownlint MD033 allow-list widened, and the permalink carries the sample's line numbers — so
+    /// moving a sample within its own file would dirty every page that shows it, and a pull request that
+    /// touched no documentation would fail the staleness gate. Without the link the generated markdown
+    /// depends only on the sample's text. The fence language is spelled the way the rest of the
+    /// documentation spells it.
+    /// </remarks>
+    static void AppendSnippet(string key, IEnumerable<Snippet> snippets, Action<string> appendLine)
+    {
+        foreach (var snippet in snippets)
+        {
+            appendLine($"```{FenceLanguage(snippet.Language)}");
+            appendLine(snippet.Value);
+            appendLine("```");
+        }
+    }
+
+    static string FenceLanguage(string language) => language switch
+    {
+        "cs" => "csharp",
+        _ => language
+    };
+
+    static bool ShouldTraverse(string path) =>
+        !TraversalExclusions.Contains(Path.GetFileName(path), StringComparer.OrdinalIgnoreCase);
+
+    bool IsDocumentationDirectory(string path) =>
+        IsUnder(path, DocsDirectory) && !IsExcludedMarkdown(path);
+
+    bool IsSampleDirectory(string path) => IsUnder(path, DocumentationSamplesDirectory);
+
+    static bool IsUnder(string path, AbsolutePath root) =>
+        NormalizePath(path).StartsWith(NormalizePath(root), StringComparison.OrdinalIgnoreCase);
+
+    bool IsExcludedMarkdown(string path) =>
+        MarkdownDirectoryExclusions.Any(x => NormalizePath(path).StartsWith(NormalizePath(RootDirectory / x), StringComparison.OrdinalIgnoreCase));
+
+    static string NormalizePath(string path) => path.Replace('\\', '/').TrimEnd('/');
+
+    /// <summary>
+    /// Two regions sharing a name are not an error upstream — both are emitted, stacked, one after the
+    /// other. That is never what a page wants, so it is an error here.
+    /// </summary>
+    static void AssertSnippetKeysAreUnique(IReadOnlyList<Snippet> snippets)
+    {
+        var duplicates = snippets
+            .GroupBy(x => x.Key, StringComparer.Ordinal)
+            .Where(x => x.Count() > 1)
+            .ToList();
+
+        if (duplicates.Count == 0)
+        {
+            return;
+        }
+
+        var detail = duplicates.Select(x => $"  {x.Key}: {string.Join(", ", x.Select(y => $"{Path.GetFileName(y.Path)}:{y.StartLine}"))}");
+        throw new InvalidOperationException(
+            "Documentation sample names must be unique, and these are not:" + Environment.NewLine + string.Join(Environment.NewLine, detail));
+    }
+
+    /// <summary>
+    /// A marker with nothing between it and its <c>endSnippet</c> means the page was never processed —
+    /// which is how a directory silently dropped from the scan announces itself.
+    /// </summary>
+    static void AssertNoEmptySnippets(IEnumerable<AbsolutePath> markdownFiles)
+    {
+        var empty = new List<string>();
+
+        foreach (var file in markdownFiles)
+        {
+            foreach (Match match in EmptySnippetMarker.Matches(File.ReadAllText(file)))
+            {
+                empty.Add($"  {file}: {match.Groups["key"].Value}");
+            }
+        }
+
+        if (empty.Count != 0)
+        {
+            throw new InvalidOperationException(
+                "These snippet markers were left empty, so the page was never processed:" + Environment.NewLine + string.Join(Environment.NewLine, empty));
+        }
+    }
+
+    static void ReportUnreferencedSamples(IReadOnlyList<Snippet> snippets, IEnumerable<AbsolutePath> markdownFiles)
+    {
+        var referenced = markdownFiles
+            .SelectMany(x => SnippetMarker.Matches(File.ReadAllText(x)).Select(y => y.Groups["key"].Value))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var unreferenced = snippets
+            .Select(x => x.Key)
+            .Where(x => !referenced.Contains(x))
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        if (unreferenced.Count != 0)
+        {
+            // A warning rather than an error: a sample may legitimately land before the page that shows it.
+            Log.Warning("Documentation samples nothing references: {Samples}", string.Join(", ", unreferenced));
+        }
+    }
+}

--- a/build/Build.Docs.Snippets.cs
+++ b/build/Build.Docs.Snippets.cs
@@ -187,11 +187,21 @@ public partial class Build
 
     bool IsSampleDirectory(string path) => IsUnder(path, DocumentationSamplesDirectory);
 
-    static bool IsUnder(string path, AbsolutePath root) =>
-        NormalizePath(path).StartsWith(NormalizePath(root), StringComparison.OrdinalIgnoreCase);
-
     bool IsExcludedMarkdown(string path) =>
-        MarkdownDirectoryExclusions.Any(x => NormalizePath(path).StartsWith(NormalizePath(RootDirectory / x), StringComparison.OrdinalIgnoreCase));
+        MarkdownDirectoryExclusions.Any(x => IsUnder(path, RootDirectory / x));
+
+    /// <summary>
+    /// Whether <paramref name="path" /> is <paramref name="root" /> or sits below it. The comparison
+    /// stops at a separator, so a sibling whose name merely starts the same way is not swept in.
+    /// </summary>
+    static bool IsUnder(string path, AbsolutePath root)
+    {
+        var normalized = NormalizePath(path);
+        var prefix = NormalizePath(root);
+
+        return normalized.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith(prefix + '/', StringComparison.OrdinalIgnoreCase);
+    }
 
     static string NormalizePath(string path) => path.Replace('\\', '/').TrimEnd('/');
 

--- a/build/Build.Docs.cs
+++ b/build/Build.Docs.cs
@@ -15,6 +15,7 @@ using static Fallout.Common.Tools.Npm.NpmTasks;
 public partial class Build
 {
     Target DocsBuild => _ => _
+        .DependsOn(DocsSnippets)
         .Executes(() =>
         {
             if (IsServerBuild)

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -20,6 +20,13 @@
     <PackageReference Include="Fallout.Components" Version="10.4.0" />
 
     <!--
+      The engine behind the DocsSnippets targets. The library, not the mdsnippets command line tool:
+      the tool's directory filter never scans a directory named 'packages', which is where the package
+      pages live. See build/Build.Docs.Snippets.cs.
+    -->
+    <PackageReference Include="MarkdownSnippets" Version="28.4.2" />
+
+    <!--
       SDK 10.0.400 ships NuGet.Frameworks 7.9.0.0 and its targets bind that assembly by strong
       name. Fallout.Components resolves 6.14.3 transitively through NuGet.Packaging, and an
       app-local assembly wins over the one MSBuildLocator registers, so the older copy shadows the

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -590,8 +590,8 @@ case the options callback used to be needed for:
 -     });
 + services.AddQuartz(q =>
 + {
-+     q.AddJob<ExampleJob>(new JobKey("job", "group"));
-+     q.AddTrigger((provider, t) => t
++     q.AddJob<ExampleJob>(j => j.WithIdentity("job", "group"));
++     q.AddTrigger<IJob>((provider, t) => t
 +         .ForJob("job", "group")
 +         .WithCronSchedule(provider.GetRequiredService<IOptions<SampleOptions>>().Value.CronSchedule));
 + });

--- a/docs/documentation/quartz-4.x/packages/aspnet-core-integration.md
+++ b/docs/documentation/quartz-4.x/packages/aspnet-core-integration.md
@@ -34,6 +34,7 @@ See [Quartz documentation](microsoft-di-integration) to learn more about configu
 
 **Example Program.cs configuration**
 
+<!-- snippet: sample_aspnetcore_registration -->
 ```csharp
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -51,6 +52,7 @@ builder.AddQuartzHostedService(options =>
 
 WebApplication app = builder.Build();
 ```
+<!-- endSnippet -->
 
 ## A practical example of the setup
 
@@ -65,6 +67,7 @@ The class should extend the `IJob` interface and implement the `Execute` method.
 
 **Example SendEmailJob.cs configuration**
 
+<!-- snippet: sample_aspnetcore_job -->
 ```csharp
 public sealed class SendEmailJob : IJob
 {
@@ -82,6 +85,7 @@ public sealed class SendEmailJob : IJob
     }
 }
 ```
+<!-- endSnippet -->
 
 A job whose work is asynchronous is written `async ValueTask` as usual. One that only forwards a call, like
 this one, can return it directly and skip the state machine; one with nothing to await at all returns
@@ -92,6 +96,7 @@ After that, you just need to build Quartz trigger in `Program.cs`, which guarant
 
 **Example Program.cs configuration**
 
+<!-- snippet: sample_aspnetcore_schedule_job -->
 ```csharp
 builder.AddQuartz(q =>
 {
@@ -108,6 +113,7 @@ builder.AddQuartz(q =>
 
 builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 ```
+<!-- endSnippet -->
 
 For more on cron triggers see the [CronTriggers lesson](../tutorial/crontriggers.md), and for the expression
 syntax itself the [Cron Expression Reference](../cron-expressions.md).
@@ -131,6 +137,7 @@ compose with.
 The registration can be customized via the optional configuration callback, for example to attach
 tags so the check can be filtered into separate liveness and readiness probes:
 
+<!-- snippet: sample_aspnetcore_health_check_options -->
 ```csharp
 builder.Services.AddHealthChecks().AddQuartz(options =>
 {
@@ -139,6 +146,7 @@ builder.Services.AddHealthChecks().AddQuartz(options =>
     options.FailureStatus = HealthStatus.Unhealthy;
 });
 ```
+<!-- endSnippet -->
 
 The callback is one source of `QuartzHealthCheckOptions` among several: the settings go through the
 options pipeline, so `services.Configure<QuartzHealthCheckOptions>(...)` and a bound configuration
@@ -147,22 +155,28 @@ section mean the same thing, whichever order they are written in.
 A named scheduler has a check of its own, reporting on *its* scheduler. Name it on the health checks
 builder, or ask for one from inside `AddQuartz`:
 
+<!-- snippet: sample_aspnetcore_named_health_check -->
 ```csharp
 builder.Services.AddHealthChecks().AddQuartz("reporting", options => options.Tags.Add("ready"));
 
 // or, where the scheduler is configured
 builder.Services.AddQuartz("reporting", q => q.AddQuartzHealthChecks());
 ```
+<!-- endSnippet -->
 
 Its options are that scheduler's, so they are configured under its name:
 
+<!-- snippet: sample_aspnetcore_named_health_check_options -->
 ```csharp
 builder.Services.Configure<QuartzHealthCheckOptions>("reporting", options => options.Tags.Add("ready"));
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_aspnetcore_map_health_checks -->
 ```csharp
 app.MapHealthChecks("/healthz/ready", new HealthCheckOptions
 {
     Predicate = registration => registration.Tags.Contains("ready")
 });
 ```
+<!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -22,6 +22,7 @@ dotnet add package Quartz.Dashboard
 
 Configure Quartz, enable the HTTP API, and add the dashboard services.
 
+<!-- snippet: sample_dashboard_registration -->
 ```csharp
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -36,9 +37,11 @@ builder.AddQuartz(q =>
 builder.Services.AddQuartzDashboard();
 builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 ```
+<!-- endSnippet -->
 
 Map endpoints:
 
+<!-- snippet: sample_dashboard_pipeline -->
 ```csharp
 WebApplication app = builder.Build();
 
@@ -49,6 +52,7 @@ app.UseAntiforgery();
 app.MapQuartzHttpApi().RequireAuthorization();
 app.MapQuartzDashboard();
 ```
+<!-- endSnippet -->
 
 By default, dashboard UI is available at `/quartz`.
 
@@ -56,18 +60,22 @@ By default, dashboard UI is available at `/quartz`.
 
 When the dashboard hosts its own Blazor root, it can be served from a custom base path. Name it where the endpoints are mapped, the way the rest of ASP.NET Core reads (`MapHealthChecks("/health")`):
 
+<!-- snippet: sample_dashboard_map_path -->
 ```csharp
 app.MapQuartzDashboard("/my-api/quartz");
 ```
+<!-- endSnippet -->
 
 Or configure it at registration, which is the shape to use when the path comes from configuration:
 
+<!-- snippet: sample_dashboard_options_path -->
 ```csharp
 services.AddQuartzDashboard(options =>
 {
     options.DashboardPath = "/my-api/quartz";
 });
 ```
+<!-- endSnippet -->
 
 If both are given, **the pattern passed to `MapQuartzDashboard` wins**; the parameterless overload uses whatever `DashboardPath` says. A pattern given at the map site is held to the same rule as the option: a plain URL path starting with `/`, with no `{`, `}`, `?`, `#`, `.` or `..` segments and no empty ones.
 
@@ -77,10 +85,12 @@ This makes the dashboard work behind a reverse proxy that forwards only a path p
 
 Alternatively, when the whole application is rebased with `UsePathBase()` (or the proxy sets the request path base), the configured `DashboardPath` is interpreted relative to the path base — the default `/quartz` then works as-is under the prefix. With minimal hosting (`WebApplication`), call `app.UseRouting()` explicitly **after** `app.UsePathBase(...)` — otherwise the implicit routing step matches against the un-stripped path and every dashboard route returns 404:
 
+<!-- snippet: sample_dashboard_path_base -->
 ```csharp
 app.UsePathBase("/my-api");
 app.UseRouting();
 ```
+<!-- endSnippet -->
 
 ::: warning Upgrading existing custom-path deployments
 In earlier releases the Blazor circuit stayed at the site root; with a custom `DashboardPath` it now connects at `{DashboardPath}/_blazor`. Reverse-proxy rules scoped to `/_blazor` (for example a WebSocket-upgrade location) must be updated accordingly.
@@ -95,6 +105,7 @@ A custom dashboard path is **not** supported when integrating into an existing B
 To populate execution history and make related views useful, add the Quartz history plugins to the
 scheduler:
 
+<!-- snippet: sample_dashboard_history_plugins -->
 ```csharp
 builder.AddQuartz(q =>
 {
@@ -102,6 +113,7 @@ builder.AddQuartz(q =>
     q.UseTriggerHistoryLogging();
 });
 ```
+<!-- endSnippet -->
 
 ## Production hardening
 
@@ -109,6 +121,7 @@ builder.AddQuartz(q =>
 
 Use an explicit policy for dashboard access, and secure API endpoints separately:
 
+<!-- snippet: sample_dashboard_authorization_policy -->
 ```csharp
 builder.Services.AddAuthorization(options =>
 {
@@ -124,11 +137,14 @@ builder.Services.AddQuartzDashboard(options =>
     options.AuthorizationPolicy = "QuartzDashboardOps";
 });
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_dashboard_require_authorization -->
 ```csharp
 app.MapQuartzHttpApi().RequireAuthorization("QuartzDashboardOps");
 app.MapQuartzDashboard();
 ```
+<!-- endSnippet -->
 
 When `AuthorizationPolicy` is set, the policy is applied to the dashboard pages, the SignalR hub, the Blazor circuit (`/_blazor`) and the dashboard static asset endpoint, so the whole dashboard is gated consistently — including under a fail-closed `FallbackPolicy`.
 
@@ -174,11 +190,14 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
 
 If your host application already uses Blazor Server (i.e., it calls `MapRazorComponents<App>().AddInteractiveServerRenderMode()`), you must use the `MapQuartzDashboard` overload that accepts the existing `RazorComponentsEndpointConventionBuilder`. This avoids registering a second `/_blazor` SignalR endpoint, which would cause routing conflicts.
 
+<!-- snippet: sample_dashboard_host_app_registration -->
 ```csharp
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 builder.Services.AddQuartzDashboard();
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_dashboard_host_app_pipeline -->
 ```csharp
 app.UseAntiforgery();
 
@@ -188,6 +207,7 @@ RazorComponentsEndpointConventionBuilder blazor = app.MapRazorComponents<App>()
 app.MapQuartzHttpApi().RequireAuthorization();
 app.MapQuartzDashboard(blazor);
 ```
+<!-- endSnippet -->
 
 The dashboard pages, layout, CSS, and JavaScript interop are automatically registered into the host's Blazor setup via `AddAdditionalAssemblies`. No additional `<link>` or `<script>` tags are needed in your `App.razor`.
 

--- a/docs/documentation/quartz-4.x/packages/hosted-services-integration.md
+++ b/docs/documentation/quartz-4.x/packages/hosted-services-integration.md
@@ -30,6 +30,7 @@ service was asked for, so something was meant to run. Register a scheduler with 
 
 **Example program utilizing hosted services configuration**
 
+<!-- snippet: sample_hosted_program -->
 ```csharp
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
@@ -48,6 +49,7 @@ builder.AddQuartzHostedService(options =>
 
 await builder.Build().RunAsync();
 ```
+<!-- endSnippet -->
 
 ## Options
 
@@ -63,18 +65,22 @@ To take part in the lifecycle itself — a warm-up before the scheduler starts, 
 from `QuartzHostedService` and register the subclass; its `StartingAsync`, `StartedAsync`, `StoppingAsync` and
 `StoppedAsync` are virtual, and `Schedulers` gives it the schedulers it is running:
 
+<!-- snippet: sample_hosted_derived_service -->
 ```csharp
 builder.AddQuartzHostedService<WarmUpBeforeSchedulingService>(options => options.WaitForJobsToComplete = true);
 ```
+<!-- endSnippet -->
 
 `builder.AddQuartz(...)` is `builder.Services.AddQuartz(...)` with the application's configuration
 already found: it reads the `Quartz` section, so anything described in `appsettings.json` is applied
 before your callback. The `IServiceCollection` overloads are unchanged, and are what to use for a
 configuration section under a different name:
 
+<!-- snippet: sample_hosted_configuration_section -->
 ```csharp
 builder.Services.AddQuartz(builder.Configuration.GetSection("Scheduling"), q => { });
 ```
+<!-- endSnippet -->
 
 A string names a scheduler, here as everywhere else in Quartz — `builder.AddQuartz("reporting", …)`
 registers a scheduler called `reporting`, reading its settings from `Quartz:Schedulers:reporting` when

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -19,6 +19,7 @@ dotnet add package Quartz.AspNetCore
 
 Configure Quartz and enable the HTTP API:
 
+<!-- snippet: sample_httpapi_registration -->
 ```csharp
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -27,6 +28,7 @@ builder.Services.AddQuartzHttpApi();
 builder.AddQuartz(q => { });
 builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 ```
+<!-- endSnippet -->
 
 The API serves every scheduler in the container through one set of endpoints — a request names the
 scheduler it is for — so it is added to the container rather than to a scheduler. The same call can be
@@ -35,6 +37,7 @@ scheduler and one place that configures it.
 
 Map endpoints:
 
+<!-- snippet: sample_httpapi_pipeline -->
 ```csharp
 WebApplication app = builder.Build();
 
@@ -43,11 +46,13 @@ app.UseAuthorization();
 
 app.MapQuartzHttpApi("/quartz-api").RequireAuthorization();
 ```
+<!-- endSnippet -->
 
 ### Where the API is served
 
 `/quartz-api` is the default, and there are two ways to say something else:
 
+<!-- snippet: sample_httpapi_path -->
 ```csharp
 // at the map site, beside the application's other routes
 app.MapQuartzHttpApi("/ops/api");
@@ -55,6 +60,7 @@ app.MapQuartzHttpApi("/ops/api");
 // or at registration
 builder.Services.AddQuartzHttpApi(options => options.ApiPath = "/ops/api");
 ```
+<!-- endSnippet -->
 
 Naming the path where the endpoints are mapped is how the rest of ASP.NET Core reads —
 `MapHealthChecks("/health")` — and it keeps the route with the application's other routes. If both are
@@ -255,18 +261,22 @@ against a local one:
 dotnet add package Quartz.HttpClient
 ```
 
+<!-- snippet: sample_httpapi_client -->
 ```csharp
 IScheduler scheduler = new HttpScheduler("MyScheduler", httpClient);
 await scheduler.TriggerJob(new JobKey("nightly-report"));
 ```
+<!-- endSnippet -->
 
 In an application with a container, register it instead and inject `IScheduler` as usual — naming the
 `IHttpClientFactory` client that carries the base address and the authentication:
 
+<!-- snippet: sample_httpapi_client_registration -->
 ```csharp
 builder.Services.AddHttpClient("quartz", client => client.BaseAddress = new Uri("https://scheduler.example.com/"));
 builder.Services.AddQuartzHttpClient(schedulerName: "MyScheduler", httpClientName: "quartz");
 ```
+<!-- endSnippet -->
 
 The wire format is the one documented on this page, so any HTTP client speaks it; the package is the
 convenience of not writing that yourself. [HTTP Client](http-client.md) covers registration,

--- a/docs/documentation/quartz-4.x/packages/http-client.md
+++ b/docs/documentation/quartz-4.x/packages/http-client.md
@@ -15,11 +15,13 @@ dotnet add package Quartz.HttpClient
 
 The server has to be running the Quartz HTTP API, from `Quartz.AspNetCore`:
 
+<!-- snippet: sample_httpclient_server_side -->
 ```csharp
 builder.Services.AddQuartzHttpApi();
 // ...
 app.MapQuartzHttpApi("/quartz-api");
 ```
+<!-- endSnippet -->
 
 Two things must line up:
 
@@ -36,6 +38,7 @@ paths would otherwise resolve against the wrong segment.
 
 The recommended shape names an `IHttpClientFactory` client, so the handler is pooled and recycled:
 
+<!-- snippet: sample_httpclient_registration -->
 ```csharp
 builder.Services.AddHttpClient("quartz", client =>
 {
@@ -45,6 +48,7 @@ builder.Services.AddHttpClient("quartz", client =>
 
 builder.Services.AddQuartzHttpClient(schedulerName: "MyScheduler", httpClientName: "quartz");
 ```
+<!-- endSnippet -->
 
 There are three overloads:
 
@@ -69,15 +73,25 @@ live client sitting in one has no owner.
 A remote scheduler is registered exactly like a local one: **keyed by its name**, and unkeyed as well
 while it is the only scheduler in the container.
 
+<!-- snippet: sample_httpclient_controller -->
 ```csharp
 public sealed class OpsController(IScheduler scheduler);                          // one scheduler
+```
+<!-- endSnippet -->
 
+Once a second scheduler joins the container, name the one you meant:
+
+<!-- snippet: sample_httpclient_keyed_controller -->
+```csharp
 public sealed class OpsController([FromKeyedServices("MyScheduler")] IScheduler scheduler);
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_httpclient_resolve_keyed -->
 ```csharp
 IScheduler reporting = provider.GetRequiredKeyedService<IScheduler>("reporting");
 ```
+<!-- endSnippet -->
 
 The unkeyed registration is `TryAdd`, so a second remote scheduler does not quietly take over what
 "the scheduler" means — with two of them, inject by key.
@@ -96,12 +110,14 @@ startup rather than on first injection; a container with no host stays exactly a
 
 No container needed:
 
+<!-- snippet: sample_httpclient_without_container -->
 ```csharp
 using HttpClient http = new() { BaseAddress = new Uri("https://scheduler.example.com/quartz-api/") };
 IScheduler scheduler = new HttpScheduler("MyScheduler", http);
 
 await scheduler.TriggerJob(new JobKey("nightly-report", "reports"));
 ```
+<!-- endSnippet -->
 
 ## Authentication
 
@@ -130,12 +146,14 @@ leaves your instance untouched — so sharing one `JsonSerializerOptions` across
 Custom trigger and calendar types need their serializers registered **on both sides**. The remote
 scheduler's registrations are invisible from this process, so the client cannot discover them:
 
+<!-- snippet: sample_httpclient_custom_serializers -->
 ```csharp
 SystemTextJsonSerializerRegistry registry = new();
 registry.AddTriggerSerializer<MyTrigger>(new MyTriggerSerializer());
 
 IScheduler scheduler = new HttpScheduler("MyScheduler", http, jsonSerializerOptions: null, registry);
 ```
+<!-- endSnippet -->
 
 Registering through the container instead — the same `AddQuartz`-side serializer registration the
 server uses — is picked up automatically, because `AddQuartzHttpClient` resolves the container-wide
@@ -180,9 +198,11 @@ only one that is free — the client already knows it.
 Do not touch them on a request path. `GetMetadata()` is the async member that answers most of the same
 questions in one call:
 
+<!-- snippet: sample_httpclient_metadata -->
 ```csharp
 SchedulerMetadata metadata = await scheduler.GetMetadata(cancellationToken);
 ```
+<!-- endSnippet -->
 
 Its `IsProxy` is `true` for an HTTP scheduler, and the three type properties — `SchedulerTypeName`,
 `JobStoreTypeName`, `ThreadPoolTypeName` — are **strings**, not `System.Type`. That is what lets the
@@ -192,6 +212,7 @@ metadata describe a remote scheduler whose types do not exist in this process.
 
 The query family maps straight onto query-string parameters:
 
+<!-- snippet: sample_httpclient_query_triggers -->
 ```csharp
 PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
 {
@@ -202,6 +223,7 @@ PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
     IncludeTotalCount = true,
 }, cancellationToken);
 ```
+<!-- endSnippet -->
 
 `Skip`, `Take` and `IncludeTotalCount` become `skip`, `take` and `includeTotalCount`; matchers become
 `groupStartsWith`, `nameEquals` and their siblings. `take` defaults to 250 at both ends, so a client
@@ -212,9 +234,11 @@ whole cluster, since the listing is store-backed.
 
 Bulk fetch posts the keys back:
 
+<!-- snippet: sample_httpclient_bulk_fetch -->
 ```csharp
 List<IJobDetail> details = await scheduler.GetJobDetails(keys, cancellationToken);
 ```
+<!-- endSnippet -->
 
 The endpoint accepts **at most 1000 keys per call**; page the keys if you have more.
 

--- a/docs/documentation/quartz-4.x/packages/json-serialization.md
+++ b/docs/documentation/quartz-4.x/packages/json-serialization.md
@@ -31,6 +31,7 @@ dotnet add package Quartz.Serialization.Newtonsoft
 
 **Configuring the store**
 
+<!-- snippet: sample_newtonsoft_registration -->
 ```csharp
 builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
 {
@@ -43,9 +44,11 @@ builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
     store.UseNewtonsoftJsonSerializer();
 }));
 ```
+<!-- endSnippet -->
 
 Without a host, the same calls hang off `QuartzSchedulerBuilder`:
 
+<!-- snippet: sample_newtonsoft_standalone -->
 ```csharp
 await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
     .UsePersistentStore(store =>
@@ -56,6 +59,7 @@ await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder
     })
     .Build();
 ```
+<!-- endSnippet -->
 
 `Build()` returns a `StandaloneSchedulerFactory`, which owns the container it built: dispose it — with
 `await using`, as above — and the scheduler shuts down with it.
@@ -64,6 +68,7 @@ await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder
 
 The flat keys 3.x used still work, and mean the same thing:
 
+<!-- snippet: sample_newtonsoft_properties -->
 ```csharp
 NameValueCollection properties = new()
 {
@@ -75,6 +80,7 @@ await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder
     .UseProperties(properties)
     .Build();
 ```
+<!-- endSnippet -->
 
 `UseGenericDatabase` is the right method only for a database Quartz has no specific support for; use
 `UseSqlServer`, `UsePostgres` and the rest otherwise. If Quartz ships no description of your ADO.NET
@@ -174,6 +180,7 @@ public sealed class MigratorSerializer : IObjectSerializer
 
 If you need to customize JSON.NET settings, you need to inherit custom implementation and override `CreateSerializerSettings`.
 
+<!-- snippet: sample_newtonsoft_custom_serializer -->
 ```csharp
 class CustomJsonSerializer : NewtonsoftJsonObjectSerializer
 {
@@ -185,12 +192,15 @@ class CustomJsonSerializer : NewtonsoftJsonObjectSerializer
     }
 }
 ```
+<!-- endSnippet -->
 
 **And then configure it to use**
 
+<!-- snippet: sample_newtonsoft_use_custom_serializer -->
 ```csharp
 store.UseSerializer<CustomJsonSerializer>();
 ```
+<!-- endSnippet -->
 
 or, as a flat property key:
 
@@ -205,6 +215,7 @@ There's a convenience base class `CalendarSerializer` that you can use the get s
 
 **Custom calendar and serializer**
 
+<!-- snippet: sample_newtonsoft_custom_calendar -->
 ```csharp
 [Serializable]
 class CustomCalendar : BaseCalendar
@@ -249,6 +260,7 @@ class CustomCalendarSerializer : CalendarSerializer<CustomCalendar>
     }
 }
 ```
+<!-- endSnippet -->
 
 A serializer can optionally override `CalendarTypeName` to give the calendar a serializer-neutral
 name — the same discriminator the System.Text.Json package would use for it. The registry then finds
@@ -258,6 +270,7 @@ assembly-qualified name, which is what payloads written by 3.x carry.
 
 **Configuring custom calendar serializer**
 
+<!-- snippet: sample_newtonsoft_register_calendar_serializer -->
 ```csharp
 builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
 {
@@ -267,6 +280,7 @@ builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
     });
 }));
 ```
+<!-- endSnippet -->
 
 ::: warning Changed in 4.0
 `NewtonsoftJsonObjectSerializer.AddCalendarSerializer` and `AddTriggerSerializer` were static in 3.x, so
@@ -280,6 +294,7 @@ If you build a serializer yourself rather than through the store builder, hand i
 `NewtonsoftJsonSerializerRegistry`. A new registry already knows every built-in trigger and calendar type,
 so registering a custom one adds to that set:
 
+<!-- snippet: sample_newtonsoft_registry_directly -->
 ```csharp
 NewtonsoftJsonSerializerRegistry registry = new NewtonsoftJsonSerializerRegistry()
     .AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer())
@@ -287,3 +302,4 @@ NewtonsoftJsonSerializerRegistry registry = new NewtonsoftJsonSerializerRegistry
 
 NewtonsoftJsonObjectSerializer serializer = new(registry);
 ```
+<!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -19,6 +19,7 @@ Need several independent schedulers in one application? See [Multiple Schedulers
 
 ## Registering a scheduler
 
+<!-- snippet: sample_di_registering_a_scheduler -->
 ```csharp
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
@@ -31,6 +32,7 @@ builder.AddQuartz(q =>
 
 builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 ```
+<!-- endSnippet -->
 
 `AddQuartz` and `AddQuartzHostedService` hang off `IHostApplicationBuilder`, so the same two calls work in a
 web application built with `WebApplication.CreateBuilder(args)`. Both are also available on
@@ -59,6 +61,7 @@ name:
 The `Quartz` section is bound automatically when the scheduler is registered through `IHostApplicationBuilder`.
 On `IServiceCollection`, where there is no configuration to hand, pass the section:
 
+<!-- snippet: sample_di_configuration_section -->
 ```csharp
 services.AddQuartz(configuration.GetSection("Quartz"), q =>
 {
@@ -66,6 +69,7 @@ services.AddQuartz(configuration.GetSection("Quartz"), q =>
     q.ConfigureScheduler(options => options.InstanceId = "Scheduler-Core");
 });
 ```
+<!-- endSnippet -->
 
 The section names, the options under each and the whole schedule-in-configuration format are in
 [Configuration Reference](../configuration/reference.md) and
@@ -84,6 +88,7 @@ work. A job should have only one public constructor.
 
 The registration is a `TryAdd`, so your own registration always wins:
 
+<!-- snippet: sample_di_registration_wins -->
 ```csharp
 // your lifetime, your factory, your implementation type - kept
 services.AddSingleton<SendReportsJob>(_ => SendReportsJob.ForTenant("acme"));
@@ -93,6 +98,7 @@ services.AddQuartz(q =>
     q.AddJob<SendReportsJob>(j => j.WithIdentity("send-reports"));
 });
 ```
+<!-- endSnippet -->
 
 ::: warning
 A singleton job serves every fire from one instance, so it must be thread-safe and it cannot take
@@ -109,11 +115,13 @@ Development environment — sees it and checks that its constructor can be satis
 something nobody registered therefore fails when the container is built, naming the job and the
 dependency:
 
+<!-- snippet: sample_di_validate_on_build -->
 ```csharp
 services.AddQuartz(q => q.AddJob<SendReportsJob>(j => j.WithIdentity("send-reports")));
 
 // throws: Unable to resolve service for type 'IReportStore' while attempting to activate 'SendReportsJob'
 ```
+<!-- endSnippet -->
 
 Before 4.0 the job type was not registered, so validation never saw it and the failure arrived at fire
 time instead: the trigger had already fired, the job never ran, and every trigger of that job was
@@ -125,8 +133,9 @@ your own — can still fail that way. If you need to react to such a failure at 
 prevent it — to fail whatever scheduled the work, for instance — `ISchedulerListener.SchedulerError`
 receives a `JobInstantiationException` naming the trigger, the job and the fire instance:
 
+<!-- snippet: sample_di_instantiation_failure_listener -->
 ```csharp
-public sealed class InstantiationFailureListener : ISchedulerListener
+public sealed class InstantiationFailureListener(ILogger<InstantiationFailureListener> logger) : ISchedulerListener
 {
     public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
     {
@@ -140,6 +149,7 @@ public sealed class InstantiationFailureListener : ISchedulerListener
     }
 }
 ```
+<!-- endSnippet -->
 
 `ISchedulerListener.TriggersInError` is raised alongside it, and reports the same thing from the job
 store's side: every trigger of that job is now in the error state.
@@ -160,6 +170,7 @@ schedule accumulates duplicates. Naming only the job and the trigger is enough �
 the same value every time.
 :::
 
+<!-- snippet: sample_di_persistent_store -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -183,11 +194,13 @@ builder.Services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 Settings of the store itself go through `store.Configure(...)`, which configures `AdoJobStoreOptions`; the
 database call and the clustering call are the ones that hang off the builder. How duplicate scheduling data is
 treated is a setting of its own:
 
+<!-- snippet: sample_di_duplicate_scheduling_data -->
 ```csharp
 services.Configure<QuartzOptions>(options =>
 {
@@ -195,6 +208,7 @@ services.Configure<QuartzOptions>(options =>
     options.Scheduling.IgnoreDuplicates = false;     // default: false
 });
 ```
+<!-- endSnippet -->
 
 ## A worked configuration
 
@@ -203,6 +217,7 @@ The rest of this page is one registration, broken into the things you might want
 **Jobs and triggers.** `ScheduleJob<T>` is a job and its one trigger; `AddJob` plus `AddTrigger` is a job that
 several triggers share, each able to carry its own data.
 
+<!-- snippet: sample_di_jobs_and_triggers -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -242,9 +257,11 @@ builder.Services.AddQuartz(q =>
         .WithDescription("fires once per minute at a hash-derived second"));
 });
 ```
+<!-- endSnippet -->
 
 **Calendars**, to exclude days from a schedule:
 
+<!-- snippet: sample_di_calendars -->
 ```csharp
 const string calendarName = "myHolidayCalendar";
 
@@ -259,9 +276,11 @@ q.AddTrigger<ExampleJob>(t => t
     .WithDailyTimeIntervalSchedule(x => x.WithInterval(10, IntervalUnit.Second))
     .WithCalendarName(calendarName));
 ```
+<!-- endSnippet -->
 
 **Plugins**, including a schedule kept in a file and watched for changes:
 
+<!-- snippet: sample_di_plugins -->
 ```csharp
 q.UseXmlSchedulingConfiguration(x =>
 {
@@ -289,22 +308,26 @@ q.ScheduleJob<SlowJob>(
         // the value is milliseconds, and either a number or a string holding one works
         .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "5000"));
 ```
+<!-- endSnippet -->
 
 Every plugin Quartz ships has an extension like these; they are listed in
 [Plugins](quartz-plugins.md).
 
 **Listeners**, constructed from the container and in place before the scheduler starts:
 
+<!-- snippet: sample_di_listeners -->
 ```csharp
 q.AddSchedulerListener<SampleSchedulerListener>();
 q.AddJobListener<SampleJobListener>(GroupMatcher<JobKey>.GroupEquals("awesome group"));
 q.AddTriggerListener<SampleTriggerListener>();
 ```
+<!-- endSnippet -->
 
 **Registration that depends on your own configuration.** Whether something is scheduled at all is decided
 here, in ordinary code; a value needed to build the trigger is read from the container when the trigger is
 built:
 
+<!-- snippet: sample_di_registration_from_options -->
 ```csharp
 services.Configure<SampleOptions>(configuration.GetSection("Sample"));
 
@@ -323,3 +346,4 @@ services.AddQuartz(q =>
     }
 });
 ```
+<!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
+++ b/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
@@ -21,6 +21,7 @@ If you are not using Microsoft DI, you can create multiple schedulers from separ
 
 Register each scheduler with a unique name using the `AddQuartz(string name, ...)` overload:
 
+<!-- snippet: sample_multiple_two_schedulers -->
 ```csharp
 var builder = Host.CreateApplicationBuilder(args);
 
@@ -60,11 +61,13 @@ builder.Services.AddQuartzHostedService(options =>
 
 builder.Build().Run();
 ```
+<!-- endSnippet -->
 
 ## Per-Scheduler Listeners and Calendars
 
 Listeners and calendars registered within a named `AddQuartz` call are scoped to that scheduler only:
 
+<!-- snippet: sample_multiple_per_scheduler_listeners -->
 ```csharp
 builder.Services.AddQuartz("Scheduler1", q =>
 {
@@ -82,12 +85,14 @@ builder.Services.AddQuartz("Scheduler2", q =>
     // Scheduler2 has no listeners or calendars unless explicitly added here
 });
 ```
+<!-- endSnippet -->
 
 ## Injecting a Named Scheduler
 
 A scheduler's name is the service key it is registered under, so a named scheduler is injected the way
 any other keyed service is:
 
+<!-- snippet: sample_multiple_keyed_service -->
 ```csharp
 public class MyService
 {
@@ -104,13 +109,16 @@ public class MyService
     }
 }
 ```
+<!-- endSnippet -->
 
 Resolved directly, it is the same thing:
 
+<!-- snippet: sample_multiple_resolving -->
 ```csharp
 var fast = provider.GetRequiredKeyedService<IScheduler>("FastScheduler");
 var standard = provider.GetRequiredService<IScheduler>();   // the default scheduler, if one is registered
 ```
+<!-- endSnippet -->
 
 Everything a named scheduler is built from is registered under that key, so `ISchedulerFactory` and the
 rest are reachable the same way — `GetRequiredKeyedService<ISchedulerFactory>("FastScheduler")` — while
@@ -131,6 +139,7 @@ before the application runs. `SchedulerName` never builds anything.
 Where the name is not known until runtime — a dashboard listing what is running, a request naming the
 scheduler it is for — the container's `ISchedulerRepository` holds every scheduler that has been built:
 
+<!-- snippet: sample_multiple_scheduler_repository -->
 ```csharp
 public class MyService
 {
@@ -154,6 +163,7 @@ public class MyService
     }
 }
 ```
+<!-- endSnippet -->
 
 ::: warning
 The repository holds schedulers that have been *built*, so during application startup it may not yet
@@ -169,6 +179,7 @@ The repository is scoped to the container, not the process. A scheduler built by
 
 You can combine the traditional unnamed `AddQuartz()` with named schedulers:
 
+<!-- snippet: sample_multiple_default_and_named -->
 ```csharp
 // Default scheduler (traditional single-scheduler usage)
 builder.Services.AddQuartz(q =>
@@ -189,6 +200,7 @@ builder.Services.AddQuartz("Auxiliary", q =>
 // Starts both the default and the named scheduler
 builder.Services.AddQuartzHostedService();
 ```
+<!-- endSnippet -->
 
 ::: tip
 The order of the calls does not matter. The hosted service resolves the schedulers when the host
@@ -202,20 +214,24 @@ nothing silently.
 A named scheduler's configuration can come from a section. Pass the root `Quartz` section and the
 scheduler's own settings are resolved out of `Schedulers:{name}`:
 
+<!-- snippet: sample_multiple_named_from_configuration -->
 ```csharp
 builder.AddQuartz("DurableScheduler");
 // or, naming the section yourself:
 builder.Services.AddQuartz("DurableScheduler", builder.Configuration.GetSection("Quartz"));
 ```
+<!-- endSnippet -->
 
 To register every scheduler the section describes rather than one of them, call
 `AddQuartzSchedulers`, which registers one named scheduler per child of `Schedulers`:
 
+<!-- snippet: sample_multiple_all_from_configuration -->
 ```csharp
 builder.AddQuartzSchedulers();
 // or:
 builder.Services.AddQuartzSchedulers(builder.Configuration.GetSection("Quartz"));
 ```
+<!-- endSnippet -->
 
 ```json
 {
@@ -237,10 +253,12 @@ builder.Services.AddQuartzSchedulers(builder.Configuration.GetSection("Quartz"))
 Individual flat keys that no typed option covers can still be set on the named options directly, through
 the `Properties` dictionary:
 
+<!-- snippet: sample_multiple_named_options -->
 ```csharp
 builder.Services.Configure<QuartzOptions>("DurableScheduler",
     options => options.Properties["quartz.jobStore.someThirdPartySetting"] = "value");
 ```
+<!-- endSnippet -->
 
 ## Per-Scheduler Startup and Shutdown
 
@@ -248,6 +266,7 @@ builder.Services.Configure<QuartzOptions>("DurableScheduler",
 scheduler that has to differ says so by name, and its settings refine the shared ones whichever order
 the two calls are made in:
 
+<!-- snippet: sample_multiple_hosted_services -->
 ```csharp
 // shared by every scheduler
 builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
@@ -258,6 +277,7 @@ builder.Services.AddQuartzHostedService("DurableScheduler", options =>
     options.StartDelay = TimeSpan.FromMinutes(2);
 });
 ```
+<!-- endSnippet -->
 
 ## Limitations
 

--- a/docs/documentation/quartz-4.x/packages/opentelemetry-integration.md
+++ b/docs/documentation/quartz-4.x/packages/opentelemetry-integration.md
@@ -11,6 +11,7 @@ whatever collects them.
 
 The two names are public constants, so they can be subscribed to without typing a string twice:
 
+<!-- snippet: sample_opentelemetry_subscribe -->
 ```csharp
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
@@ -20,6 +21,7 @@ builder.Services.AddOpenTelemetry()
         .AddMeter(QuartzInstrumentation.MeterName)
         .AddOtlpExporter());
 ```
+<!-- endSnippet -->
 
 `QuartzInstrumentation` is in the `Quartz.Diagnostics` namespace, and both constants are `"Quartz"`, so an
 existing `AddSource("Quartz")` keeps working.

--- a/docs/documentation/quartz-4.x/packages/quartz-jobs.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-jobs.md
@@ -47,6 +47,7 @@ Inspects a directory and compares whether any files' "last modified dates" have 
 was inspected. If one or more files have been updated, created or deleted, the job invokes a call-back method
 on an `IDirectoryScanListener`.
 
+<!-- snippet: sample_jobs_directory_scan -->
 ```csharp
 IJobDetail job = JobBuilder.Create<DirectoryScanJob>()
     .WithIdentity("inboxScan")
@@ -60,6 +61,7 @@ IJobDetail job = JobBuilder.Create<DirectoryScanJob>()
     })
     .Build();
 ```
+<!-- endSnippet -->
 
 | Setting | Job data key | Default |
 |---|---|---|
@@ -79,9 +81,11 @@ The listener is found in one of two ways, in this order:
    container, and name its type — `ScanListenerName = nameof(InboxListener)`.
 2. **`SchedulerContext`**: store the instance under a key, and name that key.
 
+<!-- snippet: sample_jobs_scan_listener_context -->
 ```csharp
 scheduler.Context["inboxListener"] = new InboxListener();
 ```
+<!-- endSnippet -->
 
 Where the directories come from can be decided at run time instead of being listed: implement
 `IDirectoryProvider`, put the instance in the `SchedulerContext`, and name that key as
@@ -96,6 +100,7 @@ Inspects a single file and compares whether its "last modified date" has changed
 inspected. If it has, the job invokes a call-back method on an `IFileScanListener` found in the
 `SchedulerContext`.
 
+<!-- snippet: sample_jobs_file_scan -->
 ```csharp
 IJobDetail job = JobBuilder.Create<FileScanJob>()
     .WithIdentity("configWatch")
@@ -107,6 +112,7 @@ IJobDetail job = JobBuilder.Create<FileScanJob>()
     })
     .Build();
 ```
+<!-- endSnippet -->
 
 | Setting | Job data key | Default |
 |---|---|---|
@@ -118,6 +124,7 @@ IJobDetail job = JobBuilder.Create<FileScanJob>()
 
 Runs a native executable in a separate process.
 
+<!-- snippet: sample_jobs_native -->
 ```csharp
 IJobDetail job = JobBuilder.Create<NativeJob>()
     .WithIdentity("dumbJob")
@@ -135,6 +142,7 @@ ITrigger trigger = TriggerBuilder.Create()
 
 await scheduler.ScheduleJob(job, trigger);
 ```
+<!-- endSnippet -->
 
 | Setting | Job data key | Default |
 |---|---|---|
@@ -152,6 +160,7 @@ pipe holds blocks until someone reads it.
 
 Sends an e-mail with the configured content to the configured recipient.
 
+<!-- snippet: sample_jobs_send_mail -->
 ```csharp
 IJobDetail job = JobBuilder.Create<SendMailJob>()
     .WithIdentity("nightlyDigest")
@@ -166,6 +175,7 @@ IJobDetail job = JobBuilder.Create<SendMailJob>()
     })
     .Build();
 ```
+<!-- endSnippet -->
 
 | Setting | Job data key | Default |
 |---|---|---|
@@ -190,9 +200,11 @@ table carries it. A password put there is a password in all of those places.
 
 Register the credential with the container instead, and the job authenticates with it:
 
+<!-- snippet: sample_jobs_smtp_credentials -->
 ```csharp
 services.AddSingleton<ICredentialsByHost>(new NetworkCredential("mailer", smtpPassword));
 ```
+<!-- endSnippet -->
 
 `ICredentialsByHost` is what `SmtpClient.Credentials` takes, so a `CredentialCache` covers several servers.
 The password itself belongs wherever the rest of your secrets live — user secrets in development, a key vault
@@ -212,6 +224,7 @@ attached.
 The jobs take their dependencies — a `TimeProvider`, an `IServiceProvider`, an `ICredentialsByHost` — from the
 container, so register them the same way you register your own:
 
+<!-- snippet: sample_jobs_native_under_di -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -230,3 +243,4 @@ builder.Services.AddQuartz(q =>
         .WithCronSchedule("0 0 2 * * ?"));
 });
 ```
+<!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -51,6 +51,7 @@ is registered and named.
 Logs a history of all job executions (and execution vetoes) and writes the entries to configured logging
 infrastructure. `LoggingTriggerHistoryPlugin` does the same for trigger firings, misfires and completions.
 
+<!-- snippet: sample_plugins_history_logging -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -63,6 +64,7 @@ services.AddQuartz(q =>
     q.UseTriggerHistoryLogging();
 });
 ```
+<!-- endSnippet -->
 
 Both use index-based placeholders in their messages. Prefer the structured plugins below unless you have
 existing message templates to keep.
@@ -84,6 +86,7 @@ Available template properties:
 
 **DI configuration:**
 
+<!-- snippet: sample_plugins_structured_job_logging -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -94,6 +97,7 @@ services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 ::: tip
 Recommended over `LoggingJobHistoryPlugin` when using structured logging providers (Serilog, NLog, etc.).
@@ -115,6 +119,7 @@ Available template properties:
 
 **DI configuration:**
 
+<!-- snippet: sample_plugins_structured_trigger_logging -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -125,6 +130,7 @@ services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 ::: tip
 Recommended over `LoggingTriggerHistoryPlugin` when using structured logging providers (Serilog, NLog, etc.).
@@ -135,9 +141,11 @@ Recommended over `LoggingTriggerHistoryPlugin` when using structured logging pro
 This plugin catches the event of the process terminating (such as upon a Ctrl-C) and tells the scheduler to
 shut down.
 
+<!-- snippet: sample_plugins_shutdown_hook -->
 ```csharp
 services.AddQuartz(q => q.UseShutdownHook(options => options.CleanShutdown = true));
 ```
+<!-- endSnippet -->
 
 `CleanShutdown` decides whether the shutdown waits for jobs that are still running. Under a host,
 [the hosted service](hosted-services-integration.md) already stops the scheduler with the application, so
@@ -147,6 +155,7 @@ this plugin is for a scheduler that has no host to stop it.
 
 This plugin loads XML file(s) to add jobs and schedule them with triggers as the scheduler is initialized, and can optionally periodically scan the file for changes.
 
+<!-- snippet: sample_plugins_xml_scheduling -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -159,6 +168,7 @@ services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 ::: warning
 The periodically scanning of files for changes is not currently supported in a clustered environment.
@@ -174,6 +184,7 @@ The periodically scanning of files for changes is not currently supported in a c
 
 **DI configuration:**
 
+<!-- snippet: sample_plugins_json_scheduling -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -186,6 +197,7 @@ services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 See [JSON Configuration](../configuration/json.md) for the full JSON file format and trigger type reference.
 
@@ -193,6 +205,7 @@ See [JSON Configuration](../configuration/json.md) for the full JSON file format
 
 This plugin catches the event of job running for a long time (more than the configured max time) and tells the scheduler to "try" interrupting it if enabled.
 
+<!-- snippet: sample_plugins_job_auto_interrupt -->
 ```csharp
 services.AddQuartz(q => q.UseJobAutoInterrupt(options =>
 {
@@ -200,10 +213,12 @@ services.AddQuartz(q => q.UseJobAutoInterrupt(options =>
     options.DefaultMaxRunTime = TimeSpan.FromMinutes(5);
 }));
 ```
+<!-- endSnippet -->
 
 Each job configuration needs to have `JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable` key's value set to true in order for plugin to monitor the execution timeout.
 Jobs can also define custom timeout value instead of global default by using key `JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime`.
 
+<!-- snippet: sample_plugins_job_auto_interrupt_job_data -->
 ```csharp
 IJobDetail job = JobBuilder.Create<SlowJob>()
     .WithIdentity("slowJob")
@@ -213,6 +228,7 @@ IJobDetail job = JobBuilder.Create<SlowJob>()
     .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "5000")
     .Build();
 ```
+<!-- endSnippet -->
 
 Both `AutoInterruptable` and `MaxRunTime` are read from the merged job data map, so a trigger's data map can also enable interruption or override the timeout for its own fires.
 
@@ -223,6 +239,7 @@ Only the execution that exceeded its allowed run time is interrupted — the plu
 `AddPlugin` comes in the same three shapes as the listener registrations: the container builds the
 plugin, you build it, or you configure options it is given.
 
+<!-- snippet: sample_plugins_add_plugin -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -236,14 +253,17 @@ services.AddQuartz(q =>
     q.AddPlugin<MyPlugin, MyPluginOptions>(options => options.SomeSetting = "value");
 });
 ```
+<!-- endSnippet -->
 
 Every shape takes an optional name as its last argument:
 
+<!-- snippet: sample_plugins_add_plugin_names -->
 ```csharp
 q.AddPlugin<MyPlugin>("myPlugin");
 q.AddPlugin(provider => new MyPlugin(), "myPlugin");
 q.AddPlugin<MyPlugin, MyPluginOptions>(options => options.SomeSetting = "value", "myPlugin");
 ```
+<!-- endSnippet -->
 
 The name is how the scheduler refers to the plugin, and some plugins derive persisted job and trigger
 keys from it — so it is part of the deployment's identity rather than a label. It is also the name a
@@ -268,6 +288,7 @@ When you write your own `ISchedulerPlugin`, offer the same experience as the bui
 extension method on `IQuartzBuilder`. Take an options object of your own, apply it to the plugin, and
 register the plugin under its conventional name:
 
+<!-- snippet: sample_plugins_authoring_extension -->
 ```csharp
 public static class MyPluginConfigurationExtensions
 {
@@ -299,9 +320,11 @@ public sealed class MyPluginOptions
     public string? SomeSetting { get; set; }
 }
 ```
+<!-- endSnippet -->
 
 The same extension method works wherever an `IQuartzBuilder` does, which is both configuration styles:
 
+<!-- snippet: sample_plugins_using_the_extension -->
 ```csharp
 // under a host
 services.AddQuartz(q => q.UseMyPlugin(options => options.SomeSetting = "value"));
@@ -312,6 +335,7 @@ builder.UseMyPlugin(options => options.SomeSetting = "value");
 
 var scheduler = await builder.BuildScheduler();
 ```
+<!-- endSnippet -->
 
 Configuration written this way and configuration written as `quartz.plugin.myPlugin.someSetting`
 reach the same plugin instance, because they agree on its name: the properties are applied to the

--- a/docs/documentation/quartz-4.x/packages/redis.md
+++ b/docs/documentation/quartz-4.x/packages/redis.md
@@ -32,6 +32,7 @@ The Redis lock handler replaces these database locks with Redis `SET NX PX` dist
 
 ### Using the builder (recommended)
 
+<!-- snippet: sample_redis_lock_handler -->
 ```csharp
 builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
 {
@@ -44,6 +45,7 @@ builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
     });
 }));
 ```
+<!-- endSnippet -->
 
 The same `UseRedisLockHandler` call works without a host, on `QuartzSchedulerBuilder.Create()`.
 
@@ -58,6 +60,7 @@ The same `UseRedisLockHandler` call works without a host, on `QuartzSchedulerBui
 | `LockTimeToLive` | 30 seconds | Lock TTL &mdash; the lock auto-expires after this duration |
 | `LockRetryInterval` | 100 milliseconds | Polling interval between `SET NX` retry attempts |
 
+<!-- snippet: sample_redis_lock_handler_options -->
 ```csharp
 store.UseRedisLockHandler(redis =>
 {
@@ -66,6 +69,7 @@ store.UseRedisLockHandler(redis =>
     redis.LockRetryInterval = TimeSpan.FromMilliseconds(100);
 });
 ```
+<!-- endSnippet -->
 
 The scheduler name that namespaces the lock keys is not configured here: the job store tells the handler
 which scheduler it locks for, through `ISemaphore.Initialize(SemaphoreContext)`, before the handler is used.
@@ -75,6 +79,7 @@ which scheduler it locks for, through `ISemaphore.Initialize(SemaphoreContext)`,
 The same handler chosen with flat keys, under `quartz.jobStore.lockHandler.*`. A bare number in one of the
 two time settings is read as milliseconds:
 
+<!-- snippet: sample_redis_properties -->
 ```csharp
 NameValueCollection properties = new()
 {
@@ -89,6 +94,7 @@ await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder
     .UseProperties(properties)
     .Build();
 ```
+<!-- endSnippet -->
 
 ## How It Works
 

--- a/docs/documentation/quartz-4.x/packages/system-text-json.md
+++ b/docs/documentation/quartz-4.x/packages/system-text-json.md
@@ -16,6 +16,7 @@ persistent store gets when nothing else is configured.
 
 **Code-first configuration**
 
+<!-- snippet: sample_stj_registration -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -31,9 +32,11 @@ services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 **Classic property-based configuration**
 
+<!-- snippet: sample_stj_properties -->
 ```csharp
 var properties = new NameValueCollection
 {
@@ -44,6 +47,7 @@ ISchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
     .UseProperties(properties)
     .Build();
 ```
+<!-- endSnippet -->
 
 ## Migrating from binary serialization
 
@@ -56,6 +60,7 @@ it applies to System.Text.Json the same way.
 If you need to customize serialization, inherit a custom implementation and override
 `CreateSerializerOptions`.
 
+<!-- snippet: sample_stj_custom_serializer -->
 ```csharp
 class CustomJsonSerializer : SystemTextJsonObjectSerializer
 {
@@ -73,12 +78,15 @@ class CustomJsonSerializer : SystemTextJsonObjectSerializer
     }
 }
 ```
+<!-- endSnippet -->
 
 **And then configure it to use**
 
+<!-- snippet: sample_stj_use_custom_serializer -->
 ```csharp
 store.UseSerializer<CustomJsonSerializer>();
 ```
+<!-- endSnippet -->
 
 or, as a flat property key:
 
@@ -96,6 +104,7 @@ There's a convenience base class `CalendarSerializer` that gives you a strongly-
 
 **Custom calendar and serializer**
 
+<!-- snippet: sample_stj_custom_calendar -->
 ```csharp
 using System.Text.Json;
 
@@ -128,6 +137,7 @@ public sealed class CustomCalendarSerializer : CalendarSerializer<CustomCalendar
     }
 }
 ```
+<!-- endSnippet -->
 
 ## Customizing trigger serialization
 
@@ -139,6 +149,7 @@ blob, which can be read back only by the exact same type.
 
 Both kinds are registered through the `UseSystemTextJsonSerializer` callback:
 
+<!-- snippet: sample_stj_register_custom_serializers -->
 ```csharp
 services.AddQuartz(q => q.UsePersistentStore(store =>
 {
@@ -150,6 +161,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
     });
 }));
 ```
+<!-- endSnippet -->
 
 ::: warning Changed in 4.0
 `SystemTextJsonObjectSerializer.AddCalendarSerializer` and `AddTriggerSerializer` were static in 3.x, so
@@ -160,6 +172,7 @@ decided which one won. They have been removed - use the callback above.
 **What the callback registers belongs to that scheduler alone.** This is the point of the change: two
 schedulers in one container can now serialize different custom types.
 
+<!-- snippet: sample_stj_per_scheduler_serializers -->
 ```csharp
 services.AddQuartz("reporting", q => q.UsePersistentStore(store =>
 {
@@ -173,6 +186,7 @@ services.AddQuartz("ingest", q => q.UsePersistentStore(store =>
     store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<IngestTrigger>(new IngestTriggerSerializer()));
 }));
 ```
+<!-- endSnippet -->
 
 ### Making custom serializers visible outside the job store
 
@@ -182,6 +196,7 @@ a single scheduler. They read the container-wide registry instead, so a serializ
 scheduler's callback knows about is invisible to them. Register it on the container to make it visible
 everywhere:
 
+<!-- snippet: sample_stj_container_registry -->
 ```csharp
 services.AddSingleton(new SystemTextJsonSerializerRegistry()
     .AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer())
@@ -195,6 +210,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
     store.UseSystemTextJsonSerializer();
 }));
 ```
+<!-- endSnippet -->
 
 `SystemTextJsonSerializerRegistry` lives in the `Quartz.Serialization.SystemTextJson` namespace. It always starts
 out knowing every built-in trigger and calendar type, so registering a custom one adds to that set rather
@@ -203,10 +219,12 @@ than replacing it. Both `Add*` methods return the registry, so registrations cha
 A single scheduler can also be given its own registry directly, which is the same thing the callback does
 under the hood:
 
+<!-- snippet: sample_stj_keyed_registry -->
 ```csharp
 services.AddKeyedSingleton("reporting", new SystemTextJsonSerializerRegistry()
     .AddTriggerSerializer<ReportTrigger>(new ReportTriggerSerializer()));
 ```
+<!-- endSnippet -->
 
 `Quartz.HttpClient` resolves the container's registry when the scheduler is registered with
 `AddQuartzHttpClient`; when a `HttpScheduler` is constructed by hand, pass one to its `serializerRegistry`

--- a/docs/documentation/quartz-4.x/packages/timezoneconverter-integration.md
+++ b/docs/documentation/quartz-4.x/packages/timezoneconverter-integration.md
@@ -29,21 +29,27 @@ dotnet add package Quartz.Plugins.TimeZoneConverter
 
 ## Using
 
+<!-- snippet: sample_timezoneconverter_host -->
 ```csharp
 builder.Services.AddQuartz(q => q.UseTimeZoneConverter());
 ```
+<!-- endSnippet -->
 
 `UseTimeZoneConverter` hangs off `IQuartzBuilder`, so the same call configures a scheduler built without a
 host:
 
+<!-- snippet: sample_timezoneconverter_standalone -->
 ```csharp
-await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
-    .UseTimeZoneConverter()
-    .Build();
+QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create();
+builder.UseTimeZoneConverter();
+
+await using StandaloneSchedulerFactory schedulerFactory = builder.Build();
 ```
+<!-- endSnippet -->
 
 **Classic property-based configuration**
 
+<!-- snippet: sample_timezoneconverter_properties -->
 ```csharp
 NameValueCollection properties = new()
 {
@@ -54,3 +60,4 @@ await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder
     .UseProperties(properties)
     .Build();
 ```
+<!-- endSnippet -->

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docs:snippets": "dotnet fallout DocsSnippets",
     "docs:lint": "markdownlint-cli2 \"docs/**/*.md\" \"!docs/.vuepress/**\"",
     "docs:lint-fix": "markdownlint-cli2-fix \"docs/**/*.md\" \"!docs/_posts/**\" \"!docs/.vuepress/**\"",
+    "apply-patches": "patch-package",
     "postinstall": "patch-package"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docs:publish": "cd docs/.vuepress/dist && git init && git fetch https://github.com/quartznet/quartznet.github.io.git && git checkout 9966bc53c0685311bc9199498ef2338629f6ec4d && git checkout -b master && git add . && git commit -am \"Deploy Documentation\" && git push --force --set-upstream https://github.com/quartznet/quartznet.github.io.git master",
     "docs:check-links": "node docs/.vuepress/check-links.mjs",
     "docs:check-links-test": "node --test docs/.vuepress/check-links.test.mjs",
+    "docs:snippets": "dotnet fallout DocsSnippets",
     "docs:lint": "markdownlint-cli2 \"docs/**/*.md\" \"!docs/.vuepress/**\"",
     "docs:lint-fix": "markdownlint-cli2-fix \"docs/**/*.md\" \"!docs/_posts/**\" \"!docs/.vuepress/**\"",
     "postinstall": "patch-package"

--- a/src/Quartz.Documentation.Samples/CustomCalendarSample.cs
+++ b/src/Quartz.Documentation.Samples/CustomCalendarSample.cs
@@ -1,0 +1,38 @@
+// The system-text-json page shows this sample with its using directives, so the region has to start at
+// the top of a file — which is why these two types sit in the global namespace rather than in
+// Quartz.Documentation.Samples with everything else.
+
+#region sample_stj_custom_calendar
+
+using System.Text.Json;
+
+using Quartz.Impl.Calendar;
+using Quartz.Serialization.SystemTextJson.Calendars;
+
+public sealed class CustomCalendar : BaseCalendar
+{
+    public bool SomeCustomProperty { get; set; } = true;
+}
+
+// JSON serialization support
+public sealed class CustomCalendarSerializer : CalendarSerializer<CustomCalendar>
+{
+    public override string CalendarTypeName => "CustomCalendar";
+
+    protected override CustomCalendar Create(JsonElement jsonElement, JsonSerializerOptions options)
+    {
+        return new CustomCalendar();
+    }
+
+    protected override void SerializeFields(Utf8JsonWriter writer, CustomCalendar calendar, JsonSerializerOptions options)
+    {
+        writer.WriteBoolean("SomeCustomProperty", calendar.SomeCustomProperty);
+    }
+
+    protected override void DeserializeFields(CustomCalendar calendar, JsonElement jsonElement, JsonSerializerOptions options)
+    {
+        calendar.SomeCustomProperty = jsonElement.GetProperty("SomeCustomProperty").GetBoolean();
+    }
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Packages/AspNetCoreSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/AspNetCoreSamples.cs
@@ -1,0 +1,124 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/aspnet-core-integration.md.
+/// </summary>
+public static class AspNetCoreSamples
+{
+    public static void Registration(string[] args)
+    {
+        #region sample_aspnetcore_registration
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+        builder.AddQuartz(q =>
+        {
+            // base Quartz scheduler, job and trigger configuration
+        });
+
+        // ASP.NET Core hosting
+        builder.AddQuartzHostedService(options =>
+        {
+            // when shutting down we want jobs to complete gracefully
+            options.WaitForJobsToComplete = true;
+        });
+
+        WebApplication app = builder.Build();
+
+        #endregion
+    }
+
+    #region sample_aspnetcore_job
+
+    public sealed class SendEmailJob : IJob
+    {
+        private readonly IEmailSender sender;
+
+        public SendEmailJob(IEmailSender sender)
+        {
+            this.sender = sender;
+        }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            // Code that sends a periodic email to the user (for example)
+            return sender.SendDigest(cancellationToken);
+        }
+    }
+
+    #endregion
+
+    public static void ScheduleTheJob(WebApplicationBuilder builder)
+    {
+        #region sample_aspnetcore_schedule_job
+
+        builder.AddQuartz(q =>
+        {
+            // Just use the name of your job that you created in the Jobs folder.
+            JobKey jobKey = new("SendEmailJob");
+            q.AddJob<SendEmailJob>(opts => opts.WithIdentity(jobKey));
+
+            q.AddTrigger<SendEmailJob>(opts => opts
+                .ForJob(jobKey)
+                .WithIdentity("SendEmailJob-trigger")
+                // This Cron interval can be described as "run every minute" (when second is zero)
+                .WithCronSchedule("0 * * ? * *"));
+        });
+
+        builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    public static void HealthCheckOptionsSample(WebApplicationBuilder builder)
+    {
+        #region sample_aspnetcore_health_check_options
+
+        builder.Services.AddHealthChecks().AddQuartz(options =>
+        {
+            options.Name = "quartz-scheduler";   // the default, or quartz-scheduler-<name> for a named scheduler
+            options.Tags.AddRange(["ready", "live"]);
+            options.FailureStatus = HealthStatus.Unhealthy;
+        });
+
+        #endregion
+    }
+
+    public static void NamedSchedulerHealthCheck(WebApplicationBuilder builder)
+    {
+        #region sample_aspnetcore_named_health_check
+
+        builder.Services.AddHealthChecks().AddQuartz("reporting", options => options.Tags.Add("ready"));
+
+        // or, where the scheduler is configured
+        builder.Services.AddQuartz("reporting", q => q.AddQuartzHealthChecks());
+
+        #endregion
+    }
+
+    public static void NamedHealthCheckOptions(WebApplicationBuilder builder)
+    {
+        #region sample_aspnetcore_named_health_check_options
+
+        builder.Services.Configure<QuartzHealthCheckOptions>("reporting", options => options.Tags.Add("ready"));
+
+        #endregion
+    }
+
+    public static void MapHealthChecks(WebApplication app)
+    {
+        #region sample_aspnetcore_map_health_checks
+
+        app.MapHealthChecks("/healthz/ready", new HealthCheckOptions
+        {
+            Predicate = registration => registration.Tags.Contains("ready")
+        });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/DashboardSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/DashboardSamples.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/dashboard.md.
+/// </summary>
+public static class DashboardSamples
+{
+    public static void Registration(string[] args)
+    {
+        #region sample_dashboard_registration
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+        builder.AddQuartz(q =>
+        {
+            q.AddQuartzHttpApi(options =>
+            {
+                options.ApiPath = "/quartz-api";
+            });
+        });
+
+        builder.Services.AddQuartzDashboard();
+        builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    public static void Pipeline(WebApplicationBuilder builder)
+    {
+        #region sample_dashboard_pipeline
+
+        WebApplication app = builder.Build();
+
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseAntiforgery();
+
+        app.MapQuartzHttpApi().RequireAuthorization();
+        app.MapQuartzDashboard();
+
+        #endregion
+    }
+
+    public static void MapAtAPath(WebApplication app)
+    {
+        #region sample_dashboard_map_path
+
+        app.MapQuartzDashboard("/my-api/quartz");
+
+        #endregion
+    }
+
+    public static void PathFromOptions(IServiceCollection services)
+    {
+        #region sample_dashboard_options_path
+
+        services.AddQuartzDashboard(options =>
+        {
+            options.DashboardPath = "/my-api/quartz";
+        });
+
+        #endregion
+    }
+
+    public static void PathBase(WebApplication app)
+    {
+        #region sample_dashboard_path_base
+
+        app.UsePathBase("/my-api");
+        app.UseRouting();
+
+        #endregion
+    }
+
+    public static void HistoryPlugins(WebApplicationBuilder builder)
+    {
+        #region sample_dashboard_history_plugins
+
+        builder.AddQuartz(q =>
+        {
+            q.UseJobHistoryLogging();
+            q.UseTriggerHistoryLogging();
+        });
+
+        #endregion
+    }
+
+    public static void AuthorizationPolicy(WebApplicationBuilder builder)
+    {
+        #region sample_dashboard_authorization_policy
+
+        builder.Services.AddAuthorization(options =>
+        {
+            options.AddPolicy("QuartzDashboardOps", policy =>
+            {
+                policy.RequireAuthenticatedUser();
+                policy.RequireRole("Operations", "SchedulerAdmin");
+            });
+        });
+
+        builder.Services.AddQuartzDashboard(options =>
+        {
+            options.AuthorizationPolicy = "QuartzDashboardOps";
+        });
+
+        #endregion
+    }
+
+    public static void RequireAuthorization(WebApplication app)
+    {
+        #region sample_dashboard_require_authorization
+
+        app.MapQuartzHttpApi().RequireAuthorization("QuartzDashboardOps");
+        app.MapQuartzDashboard();
+
+        #endregion
+    }
+
+    public static void HostAppRegistration(WebApplicationBuilder builder)
+    {
+        #region sample_dashboard_host_app_registration
+
+        builder.Services.AddRazorComponents().AddInteractiveServerComponents();
+        builder.Services.AddQuartzDashboard();
+
+        #endregion
+    }
+
+    public static void HostAppPipeline(WebApplication app)
+    {
+        #region sample_dashboard_host_app_pipeline
+
+        app.UseAntiforgery();
+
+        RazorComponentsEndpointConventionBuilder blazor = app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+
+        app.MapQuartzHttpApi().RequireAuthorization();
+        app.MapQuartzDashboard(blazor);
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/HostedServicesSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/HostedServicesSamples.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/hosted-services-integration.md.
+/// </summary>
+public static class HostedServicesSamples
+{
+    public static async ValueTask TheWholeProgram(string[] args)
+    {
+        #region sample_hosted_program
+
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+        // see Quartz documentation about how to configure different configuration aspects
+        builder.AddQuartz(q =>
+        {
+            // your configuration here
+        });
+
+        // Quartz hosting
+        builder.AddQuartzHostedService(options =>
+        {
+            // when shutting down we want jobs to complete gracefully
+            options.WaitForJobsToComplete = true;
+        });
+
+        await builder.Build().RunAsync();
+
+        #endregion
+    }
+
+    public static void DerivedHostedService(IHostApplicationBuilder builder)
+    {
+        #region sample_hosted_derived_service
+
+        builder.AddQuartzHostedService<WarmUpBeforeSchedulingService>(options => options.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    public static void SchedulingFromConfiguration(HostApplicationBuilder builder)
+    {
+        #region sample_hosted_configuration_section
+
+        builder.Services.AddQuartz(builder.Configuration.GetSection("Scheduling"), q => { });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/HttpApiSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/HttpApiSamples.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/http-api.md.
+/// </summary>
+public static class HttpApiSamples
+{
+    public static void Registration(string[] args)
+    {
+        #region sample_httpapi_registration
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddQuartzHttpApi();
+
+        builder.AddQuartz(q => { });
+        builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    public static void Pipeline(WebApplicationBuilder builder)
+    {
+        #region sample_httpapi_pipeline
+
+        WebApplication app = builder.Build();
+
+        app.UseAuthentication();
+        app.UseAuthorization();
+
+        app.MapQuartzHttpApi("/quartz-api").RequireAuthorization();
+
+        #endregion
+    }
+
+    public static void ApiPath(WebApplicationBuilder builder, WebApplication app)
+    {
+        #region sample_httpapi_path
+
+        // at the map site, beside the application's other routes
+        app.MapQuartzHttpApi("/ops/api");
+
+        // or at registration
+        builder.Services.AddQuartzHttpApi(options => options.ApiPath = "/ops/api");
+
+        #endregion
+    }
+
+    public static async ValueTask ClientAgainstTheApi(System.Net.Http.HttpClient httpClient)
+    {
+        #region sample_httpapi_client
+
+        IScheduler scheduler = new HttpScheduler("MyScheduler", httpClient);
+        await scheduler.TriggerJob(new JobKey("nightly-report"));
+
+        #endregion
+    }
+
+    public static void ClientRegistration(WebApplicationBuilder builder)
+    {
+        #region sample_httpapi_client_registration
+
+        builder.Services.AddHttpClient("quartz", client => client.BaseAddress = new Uri("https://scheduler.example.com/"));
+        builder.Services.AddQuartzHttpClient(schedulerName: "MyScheduler", httpClientName: "quartz");
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/HttpClientSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/HttpClientSamples.cs
@@ -1,0 +1,129 @@
+using System.Net.Http;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Serialization.SystemTextJson;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/http-client.md.
+/// </summary>
+public static class HttpClientSamples
+{
+    public static void ServerSide(WebApplicationBuilder builder, WebApplication app)
+    {
+        #region sample_httpclient_server_side
+
+        builder.Services.AddQuartzHttpApi();
+        // ...
+        app.MapQuartzHttpApi("/quartz-api");
+
+        #endregion
+    }
+
+    public static void Registration(WebApplicationBuilder builder)
+    {
+        #region sample_httpclient_registration
+
+        builder.Services.AddHttpClient("quartz", client =>
+        {
+            client.BaseAddress = new Uri("https://scheduler.example.com/quartz-api/");
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
+
+        builder.Services.AddQuartzHttpClient(schedulerName: "MyScheduler", httpClientName: "quartz");
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Two containers so the page can show one controller name twice, which is how it contrasts the
+    /// single-scheduler and keyed shapes.
+    /// </summary>
+    public static class Controllers
+    {
+        #region sample_httpclient_controller
+
+        public sealed class OpsController(IScheduler scheduler);                          // one scheduler
+
+        #endregion
+    }
+
+    public static class KeyedControllers
+    {
+        #region sample_httpclient_keyed_controller
+
+        public sealed class OpsController([FromKeyedServices("MyScheduler")] IScheduler scheduler);
+
+        #endregion
+    }
+
+    public static void ResolveKeyed(IServiceProvider provider)
+    {
+        #region sample_httpclient_resolve_keyed
+
+        IScheduler reporting = provider.GetRequiredKeyedService<IScheduler>("reporting");
+
+        #endregion
+    }
+
+    public static async ValueTask WithoutTheContainer()
+    {
+        #region sample_httpclient_without_container
+
+        using HttpClient http = new() { BaseAddress = new Uri("https://scheduler.example.com/quartz-api/") };
+        IScheduler scheduler = new HttpScheduler("MyScheduler", http);
+
+        await scheduler.TriggerJob(new JobKey("nightly-report", "reports"));
+
+        #endregion
+    }
+
+    public static void CustomTriggerSerializers(HttpClient http)
+    {
+        #region sample_httpclient_custom_serializers
+
+        SystemTextJsonSerializerRegistry registry = new();
+        registry.AddTriggerSerializer<MyTrigger>(new MyTriggerSerializer());
+
+        IScheduler scheduler = new HttpScheduler("MyScheduler", http, jsonSerializerOptions: null, registry);
+
+        #endregion
+    }
+
+    public static async ValueTask Metadata(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        #region sample_httpclient_metadata
+
+        SchedulerMetadata metadata = await scheduler.GetMetadata(cancellationToken);
+
+        #endregion
+    }
+
+    public static async ValueTask QueryTriggers(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        #region sample_httpclient_query_triggers
+
+        PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
+        {
+            Group = GroupMatcher<TriggerKey>.GroupStartsWith("reporting-"),
+            State = TriggerState.Error,
+            Skip = 0,
+            Take = 100,
+            IncludeTotalCount = true,
+        }, cancellationToken);
+
+        #endregion
+    }
+
+    public static async ValueTask BulkFetch(IScheduler scheduler, IReadOnlyCollection<JobKey> keys, CancellationToken cancellationToken)
+    {
+        #region sample_httpclient_bulk_fetch
+
+        List<IJobDetail> details = await scheduler.GetJobDetails(keys, cancellationToken);
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
@@ -1,0 +1,265 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Quartz.Impl.Calendar;
+using Quartz.Plugins.Interrupt;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/microsoft-di-integration.md.
+/// </summary>
+public static class MicrosoftDiIntegrationSamples
+{
+    public static void RegisteringAScheduler(string[] args)
+    {
+        #region sample_di_registering_a_scheduler
+
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+        builder.AddQuartz(q =>
+        {
+            q.ScheduleJob<ExampleJob>(trigger => trigger
+                .WithIdentity("example")
+                .WithCronSchedule("0 0/5 * * * ?"));
+        });
+
+        builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    public static void BindingAConfigurationSection(IServiceCollection services, IConfiguration configuration)
+    {
+        #region sample_di_configuration_section
+
+        services.AddQuartz(configuration.GetSection("Quartz"), q =>
+        {
+            // code configuration on top of what the file says; code wins
+            q.ConfigureScheduler(options => options.InstanceId = "Scheduler-Core");
+        });
+
+        #endregion
+    }
+
+    public static void YourOwnRegistrationWins(IServiceCollection services)
+    {
+        #region sample_di_registration_wins
+
+        // your lifetime, your factory, your implementation type - kept
+        services.AddSingleton<SendReportsJob>(_ => SendReportsJob.ForTenant("acme"));
+
+        services.AddQuartz(q =>
+        {
+            q.AddJob<SendReportsJob>(j => j.WithIdentity("send-reports"));
+        });
+
+        #endregion
+    }
+
+    public static void ValidateOnBuildSeesTheJob(IServiceCollection services)
+    {
+        #region sample_di_validate_on_build
+
+        services.AddQuartz(q => q.AddJob<SendReportsJob>(j => j.WithIdentity("send-reports")));
+
+        // throws: Unable to resolve service for type 'IReportStore' while attempting to activate 'SendReportsJob'
+
+        #endregion
+    }
+
+    #region sample_di_instantiation_failure_listener
+
+    public sealed class InstantiationFailureListener(ILogger<InstantiationFailureListener> logger) : ISchedulerListener
+    {
+        public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+        {
+            if (exception is JobInstantiationException failure)
+            {
+                logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}",
+                    failure.JobDetail.Key, failure.Trigger.Key, failure.FireInstanceId);
+            }
+
+            return default;
+        }
+    }
+
+    #endregion
+
+    public static void PersistentStore(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_di_persistent_store
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer(connectionString);
+                store.UseSystemTextJsonSerializer();
+
+                store.Configure(options =>
+                {
+                    options.TablePrefix = "QRTZ_";        // the default
+                    options.StoreJobDataAsStrings = true; // preferred, but not the default
+                    options.PerformSchemaValidation = true;
+                });
+
+                store.UseClustering(cluster =>
+                {
+                    cluster.CheckinInterval = TimeSpan.FromSeconds(10);
+                    cluster.CheckinMisfireThreshold = TimeSpan.FromSeconds(20);
+                });
+            });
+        });
+
+        #endregion
+    }
+
+    public static void DuplicateSchedulingData(IServiceCollection services)
+    {
+        #region sample_di_duplicate_scheduling_data
+
+        services.Configure<QuartzOptions>(options =>
+        {
+            options.Scheduling.OverwriteExistingData = true; // default: true
+            options.Scheduling.IgnoreDuplicates = false;     // default: false
+        });
+
+        #endregion
+    }
+
+    public static void JobsAndTriggers(IHostApplicationBuilder builder)
+    {
+        #region sample_di_jobs_and_triggers
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.ScheduleJob<ExampleJob>(trigger => trigger
+                .WithIdentity("Combined Configuration Trigger")
+                .StartAt(DateTimeOffset.UtcNow.AddSeconds(7))
+                .WithDailyTimeIntervalSchedule(x => x.WithInterval(10, IntervalUnit.Second))
+                .WithDescription("my awesome trigger configured for a job with single call"));
+
+            JobKey jobKey = new("awesome job", "awesome group");
+
+            q.AddJob<ExampleJob>(j => j
+                .WithIdentity(jobKey)
+                .WithDescription("my awesome job")
+                // job data can name the job property it is meant for instead of spelling its key,
+                // which makes a mistyped key or a wrong-typed value a compile error
+                .UsingJobData(x => x.InjectedString, "Hello")
+                .UsingJobData(x => x.InjectedBool, true));
+
+            q.AddTrigger<ExampleJob>(t => t
+                .WithIdentity("Simple Trigger")
+                .ForJob(jobKey)
+                .StartNow()
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever()));
+
+            q.AddTrigger<ExampleJob>(t => t
+                .WithIdentity("Cron Trigger")
+                .ForJob(jobKey)
+                .StartAt(DateTimeOffset.UtcNow.AddSeconds(3))
+                .WithCronSchedule("0/3 * * * * ?"));
+
+            // use H (hash) to spread trigger fire times based on trigger identity
+            q.AddTrigger<ExampleJob>(t => t
+                .WithIdentity("Spread Cron Trigger")
+                .ForJob(jobKey)
+                .WithCronSchedule("H * * * * ?")
+                .WithDescription("fires once per minute at a hash-derived second"));
+        });
+
+        #endregion
+    }
+
+    public static void TheRestOfTheWorkedConfiguration(IHostApplicationBuilder builder)
+    {
+        builder.Services.AddQuartz(q =>
+        {
+            JobKey jobKey = new("awesome job", "awesome group");
+
+            #region sample_di_calendars
+
+            const string calendarName = "myHolidayCalendar";
+
+            q.AddCalendar<HolidayCalendar>(
+                name: calendarName,
+                options: new AddCalendarOptions { Replace = true, UpdateTriggers = true },
+                configure: calendar => calendar.AddExcludedDay(new DateOnly(2026, 5, 15)));
+
+            q.AddTrigger<ExampleJob>(t => t
+                .WithIdentity("Daily Trigger")
+                .ForJob(jobKey)
+                .WithDailyTimeIntervalSchedule(x => x.WithInterval(10, IntervalUnit.Second))
+                .WithCalendarName(calendarName));
+
+            #endregion
+
+            #region sample_di_plugins
+
+            q.UseXmlSchedulingConfiguration(x =>
+            {
+                x.Files.Add("~/quartz_jobs.config");
+                x.ScanInterval = TimeSpan.FromSeconds(2);
+                x.FailOnFileNotFound = true;
+                x.FailOnSchedulingError = true;
+            });
+
+            // resolve Windows and IANA time zone ids on either operating system
+            q.UseTimeZoneConverter();
+
+            // interrupt a job that runs longer than it should
+            q.UseJobAutoInterrupt(options => options.DefaultMaxRunTime = TimeSpan.FromMinutes(5));
+
+            q.ScheduleJob<SlowJob>(
+                trigger => trigger
+                    .WithIdentity("slowJobTrigger")
+                    .StartNow()
+                    .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(5)).RepeatForever()),
+                job => job
+                    .WithIdentity("slowJob")
+                    .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true)
+                    // allow only five seconds for this job, overriding the plugin's default.
+                    // the value is milliseconds, and either a number or a string holding one works
+                    .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "5000"));
+
+            #endregion
+
+            #region sample_di_listeners
+
+            q.AddSchedulerListener<SampleSchedulerListener>();
+            q.AddJobListener<SampleJobListener>(GroupMatcher<JobKey>.GroupEquals("awesome group"));
+            q.AddTriggerListener<SampleTriggerListener>();
+
+            #endregion
+        });
+    }
+
+    public static void RegistrationThatDependsOnConfiguration(IServiceCollection services, IConfiguration configuration)
+    {
+        #region sample_di_registration_from_options
+
+        services.Configure<SampleOptions>(configuration.GetSection("Sample"));
+
+        services.AddQuartz(q =>
+        {
+            if (!string.IsNullOrWhiteSpace(configuration.GetSection("Sample")["CronSchedule"]))
+            {
+                JobKey customJobKey = new("options-custom-job", "custom");
+
+                q.AddJob<ExampleJob>(j => j.WithIdentity(customJobKey));
+
+                q.AddTrigger<ExampleJob>((serviceProvider, trigger) => trigger
+                    .WithIdentity("options-custom-trigger", "custom")
+                    .ForJob(customJobKey)
+                    .WithCronSchedule(serviceProvider.GetRequiredService<IOptions<SampleOptions>>().Value.CronSchedule));
+            }
+        });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/MultipleSchedulersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MultipleSchedulersSamples.cs
@@ -1,0 +1,221 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Extensibility;
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/multiple-schedulers.md.
+/// </summary>
+public static class MultipleSchedulersSamples
+{
+    public static void TwoSchedulers(string[] args)
+    {
+        #region sample_multiple_two_schedulers
+
+        var builder = Host.CreateApplicationBuilder(args);
+
+        // First scheduler: fast in-memory jobs
+        builder.Services.AddQuartz("FastScheduler", q =>
+        {
+            q.UseInMemoryStore();
+            q.UseDefaultThreadPool(tp => tp.MaxConcurrency = 5);
+
+            q.ScheduleJob<NotificationJob>(trigger => trigger
+                .WithIdentity("notify-trigger")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(30)).RepeatForever()));
+        });
+
+        // Second scheduler: persistent database jobs
+        builder.Services.AddQuartz("DurableScheduler", q =>
+        {
+            q.UsePersistentStore(s =>
+            {
+                s.UseSqlServer(sqlServer =>
+                {
+                    sqlServer.ConnectionString = "your connection string";
+                });
+                s.UseSystemTextJsonSerializer();
+            });
+
+            q.ScheduleJob<ReportJob>(trigger => trigger
+                .WithIdentity("report-trigger")
+                .WithCronSchedule("0 0 2 * * ?"));
+        });
+
+        // Single call starts all named schedulers
+        builder.Services.AddQuartzHostedService(options =>
+        {
+            options.WaitForJobsToComplete = true;
+        });
+
+        builder.Build().Run();
+
+        #endregion
+    }
+
+    public static void PerSchedulerListenersAndCalendars(IHostApplicationBuilder builder)
+    {
+        #region sample_multiple_per_scheduler_listeners
+
+        builder.Services.AddQuartz("Scheduler1", q =>
+        {
+            q.AddSchedulerListener<AuditSchedulerListener>();
+            q.AddJobListener<LoggingJobListener>();
+            q.AddTriggerListener<MetricsTriggerListener>();
+
+            q.AddCalendar<HolidayCalendar>("holidays", new AddCalendarOptions { Replace = true, UpdateTriggers = true },
+                cal => cal.AddExcludedDay(new DateOnly(2025, 12, 25)));
+            // These listeners and calendars only apply to Scheduler1
+        });
+
+        builder.Services.AddQuartz("Scheduler2", q =>
+        {
+            // Scheduler2 has no listeners or calendars unless explicitly added here
+        });
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Container for the keyed-service sample, so that the repository sample below can show a class of
+    /// the same name — as the page does.
+    /// </summary>
+    public static class KeyedService
+    {
+        #region sample_multiple_keyed_service
+
+        public class MyService
+        {
+            private readonly IScheduler scheduler;
+
+            public MyService([FromKeyedServices("FastScheduler")] IScheduler scheduler)
+            {
+                this.scheduler = scheduler;
+            }
+
+            public async Task DoWork()
+            {
+                await scheduler.TriggerJob(new JobKey("my-job"));
+            }
+        }
+
+        #endregion
+    }
+
+    public static void ResolvingSchedulers(IServiceProvider provider)
+    {
+        #region sample_multiple_resolving
+
+        var fast = provider.GetRequiredKeyedService<IScheduler>("FastScheduler");
+        var standard = provider.GetRequiredService<IScheduler>();   // the default scheduler, if one is registered
+
+        #endregion
+    }
+
+    public static class Repository
+    {
+        #region sample_multiple_scheduler_repository
+
+        public class MyService
+        {
+            private readonly ISchedulerRepository schedulerRepository;
+
+            public MyService(ISchedulerRepository schedulerRepository)
+            {
+                this.schedulerRepository = schedulerRepository;
+            }
+
+            public async Task DoWork()
+            {
+                var scheduler = schedulerRepository.Lookup("FastScheduler");
+                if (scheduler != null)
+                {
+                    await scheduler.TriggerJob(new JobKey("my-job"));
+                }
+
+                // Or every scheduler this container has built
+                var all = schedulerRepository.LookupAll();
+            }
+        }
+
+        #endregion
+    }
+
+    public static void DefaultAndNamed(IHostApplicationBuilder builder)
+    {
+        #region sample_multiple_default_and_named
+
+        // Default scheduler (traditional single-scheduler usage)
+        builder.Services.AddQuartz(q =>
+        {
+            q.ScheduleJob<MainJob>(trigger => trigger
+                .WithIdentity("main-trigger")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever()));
+        });
+
+        // Additional named scheduler
+        builder.Services.AddQuartz("Auxiliary", q =>
+        {
+            q.ScheduleJob<CleanupJob>(trigger => trigger
+                .WithIdentity("cleanup-trigger")
+                .WithCronSchedule("0 0 3 * * ?"));
+        });
+
+        // Starts both the default and the named scheduler
+        builder.Services.AddQuartzHostedService();
+
+        #endregion
+    }
+
+    public static void NamedSchedulerFromConfiguration(HostApplicationBuilder builder)
+    {
+        #region sample_multiple_named_from_configuration
+
+        builder.AddQuartz("DurableScheduler");
+        // or, naming the section yourself:
+        builder.Services.AddQuartz("DurableScheduler", builder.Configuration.GetSection("Quartz"));
+
+        #endregion
+    }
+
+    public static void EverySchedulerFromConfiguration(HostApplicationBuilder builder)
+    {
+        #region sample_multiple_all_from_configuration
+
+        builder.AddQuartzSchedulers();
+        // or:
+        builder.Services.AddQuartzSchedulers(builder.Configuration.GetSection("Quartz"));
+
+        #endregion
+    }
+
+    public static void NamedOptions(IHostApplicationBuilder builder)
+    {
+        #region sample_multiple_named_options
+
+        builder.Services.Configure<QuartzOptions>("DurableScheduler",
+            options => options.Properties["quartz.jobStore.someThirdPartySetting"] = "value");
+
+        #endregion
+    }
+
+    public static void PerSchedulerHostedService(IHostApplicationBuilder builder)
+    {
+        #region sample_multiple_hosted_services
+
+        // shared by every scheduler
+        builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        // ...except this one, which waits longer before its first fire
+        builder.Services.AddQuartzHostedService("DurableScheduler", options =>
+        {
+            options.StartDelay = TimeSpan.FromMinutes(2);
+        });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/NewtonsoftJsonSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/NewtonsoftJsonSamples.cs
@@ -1,0 +1,205 @@
+using System.Collections.Specialized;
+using System.Runtime.Serialization;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using Quartz.Impl;
+using Quartz.Impl.Calendar;
+using Quartz.Impl.Triggers;
+using Quartz.Serialization.Newtonsoft;
+using Quartz.Serialization.Newtonsoft.Calendars;
+using Quartz.Serialization.Newtonsoft.Triggers;
+
+// A namespace of its own: this page and the System.Text.Json page both name their custom types
+// CustomCalendar and CustomTrigger, and each sample has to compile against its own flavour.
+namespace Quartz.Documentation.Samples.Packages.NewtonsoftJson;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/json-serialization.md.
+/// </summary>
+public static class NewtonsoftJsonSamples
+{
+    public static void Registration(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_newtonsoft_registration
+
+        builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(connectionString);
+
+            // it's generally recommended to stick with
+            // string property keys and values when serializing
+            store.Configure(options => options.StoreJobDataAsStrings = true);
+
+            store.UseNewtonsoftJsonSerializer();
+        }));
+
+        #endregion
+    }
+
+    public static async ValueTask Standalone()
+    {
+        #region sample_newtonsoft_standalone
+
+        await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
+            .UsePersistentStore(store =>
+            {
+                store.UseGenericDatabase("MyProvider", "my connection string");
+                store.Configure(options => options.StoreJobDataAsStrings = true);
+                store.UseNewtonsoftJsonSerializer();
+            })
+            .Build();
+
+        #endregion
+    }
+
+    public static async ValueTask FromProperties()
+    {
+        #region sample_newtonsoft_properties
+
+        NameValueCollection properties = new()
+        {
+            ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.LocalTransactionJobStore, Quartz",
+            ["quartz.serializer.type"] = "newtonsoft"
+        };
+
+        await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
+            .UseProperties(properties)
+            .Build();
+
+        #endregion
+    }
+
+    #region sample_newtonsoft_custom_serializer
+
+    class CustomJsonSerializer : NewtonsoftJsonObjectSerializer
+    {
+        protected override JsonSerializerSettings CreateSerializerSettings()
+        {
+            var settings = base.CreateSerializerSettings();
+            settings.Converters.Add(new MyCustomConverter());
+            return settings;
+        }
+    }
+
+    #endregion
+
+    public static void UseCustomSerializer(IServiceCollection services)
+    {
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            #region sample_newtonsoft_use_custom_serializer
+
+            store.UseSerializer<CustomJsonSerializer>();
+
+            #endregion
+        }));
+    }
+
+    public static void RegisterCalendarSerializer(IHostApplicationBuilder builder)
+    {
+        #region sample_newtonsoft_register_calendar_serializer
+
+        builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseNewtonsoftJsonSerializer(json =>
+            {
+                json.AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer());
+            });
+        }));
+
+        #endregion
+    }
+
+    public static void BuildARegistryDirectly()
+    {
+        #region sample_newtonsoft_registry_directly
+
+        NewtonsoftJsonSerializerRegistry registry = new NewtonsoftJsonSerializerRegistry()
+            .AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer())
+            .AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer());
+
+        NewtonsoftJsonObjectSerializer serializer = new(registry);
+
+        #endregion
+    }
+}
+
+#region sample_newtonsoft_custom_calendar
+
+[Serializable]
+class CustomCalendar : BaseCalendar
+{
+    public CustomCalendar()
+    {
+    }
+
+    // binary serialization support
+    protected CustomCalendar(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        SomeCustomProperty = info?.GetBoolean("SomeCustomProperty") ?? true;
+    }
+
+    public bool SomeCustomProperty { get; set; } = true;
+
+    // binary serialization support
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        base.GetObjectData(info, context);
+        info?.AddValue("SomeCustomProperty", SomeCustomProperty);
+    }
+}
+
+// JSON serialization support
+class CustomCalendarSerializer : CalendarSerializer<CustomCalendar>
+{
+    protected override CustomCalendar Create(JObject source)
+    {
+        return new CustomCalendar();
+    }
+
+    protected override void SerializeFields(JsonWriter writer, CustomCalendar calendar)
+    {
+        writer.WritePropertyName("SomeCustomProperty");
+        writer.WriteValue(calendar.SomeCustomProperty);
+    }
+
+    protected override void DeserializeFields(CustomCalendar calendar, JObject source)
+    {
+        calendar.SomeCustomProperty = source["SomeCustomProperty"]!.Value<bool>();
+    }
+}
+
+#endregion
+
+/// <summary>
+/// The Newtonsoft flavour of the custom trigger the registry sample registers.
+/// </summary>
+class CustomTrigger : SimpleTriggerImpl;
+
+class CustomTriggerSerializer : TriggerSerializer<CustomTrigger>
+{
+    public override string TriggerTypeName => "CustomTrigger";
+
+    public override IScheduleBuilder CreateScheduleBuilder(JObject source) => SimpleScheduleBuilder.Create();
+
+    protected override void SerializeFields(JsonWriter writer, CustomTrigger trigger)
+    {
+    }
+}
+
+/// <summary>
+/// A converter of the reader's own, standing in for whatever the application needs.
+/// </summary>
+class MyCustomConverter : JsonConverter<Uri>
+{
+    public override Uri? ReadJson(JsonReader reader, Type objectType, Uri? existingValue, bool hasExistingValue, JsonSerializer serializer) =>
+        reader.Value is string value ? new Uri(value) : existingValue;
+
+    public override void WriteJson(JsonWriter writer, Uri? value, JsonSerializer serializer) =>
+        writer.WriteValue(value?.ToString());
+}

--- a/src/Quartz.Documentation.Samples/Packages/OpenTelemetrySamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/OpenTelemetrySamples.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+using Quartz.Diagnostics;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/opentelemetry-integration.md.
+/// </summary>
+public static class OpenTelemetrySamples
+{
+    public static void SubscribeToQuartzSignals(IHostApplicationBuilder builder)
+    {
+        #region sample_opentelemetry_subscribe
+
+        builder.Services.AddOpenTelemetry()
+            .WithTracing(tracing => tracing
+                .AddSource(QuartzInstrumentation.ActivitySourceName)
+                .AddOtlpExporter())
+            .WithMetrics(metrics => metrics
+                .AddMeter(QuartzInstrumentation.MeterName)
+                .AddOtlpExporter());
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/QuartzJobsSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/QuartzJobsSamples.cs
@@ -1,0 +1,135 @@
+using System.Net;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Jobs;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/quartz-jobs.md.
+/// </summary>
+public static class QuartzJobsSamples
+{
+    public static void DirectoryScanJobSample()
+    {
+        #region sample_jobs_directory_scan
+
+        IJobDetail job = JobBuilder.Create<DirectoryScanJob>()
+            .WithIdentity("inboxScan")
+            .UsingDirectoryScanOptions(new DirectoryScanOptions
+            {
+                Directories = ["/var/spool/inbox"],
+                ScanListenerName = nameof(InboxListener),
+                SearchPattern = "*.csv",
+                IncludeSubDirectories = true,
+                MinimumUpdateAge = TimeSpan.FromSeconds(30),
+            })
+            .Build();
+
+        #endregion
+    }
+
+    public static void ScanListenerInSchedulerContext(IScheduler scheduler)
+    {
+        #region sample_jobs_scan_listener_context
+
+        scheduler.Context["inboxListener"] = new InboxListener();
+
+        #endregion
+    }
+
+    public static void FileScanJobSample()
+    {
+        #region sample_jobs_file_scan
+
+        IJobDetail job = JobBuilder.Create<FileScanJob>()
+            .WithIdentity("configWatch")
+            .UsingFileScanOptions(new FileScanOptions
+            {
+                FileName = "/etc/app/settings.json",
+                ScanListenerName = "settingsListener",
+                MinimumUpdateAge = TimeSpan.FromSeconds(5),
+            })
+            .Build();
+
+        #endregion
+    }
+
+    public static async ValueTask NativeJobSample(IScheduler scheduler)
+    {
+        #region sample_jobs_native
+
+        IJobDetail job = JobBuilder.Create<NativeJob>()
+            .WithIdentity("dumbJob")
+            .UsingNativeJobOptions(new NativeJobOptions
+            {
+                Command = "echo",
+                Parameters = "\"hi\" >> foobar.txt",
+            })
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("dumbTrigger")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(5)).RepeatForever())
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+
+        #endregion
+    }
+
+    public static void SendMailJobSample()
+    {
+        #region sample_jobs_send_mail
+
+        IJobDetail job = JobBuilder.Create<SendMailJob>()
+            .WithIdentity("nightlyDigest")
+            .UsingSendMailOptions(new SendMailOptions
+            {
+                SmtpHost = "smtp.example.com",
+                SmtpPort = 587,
+                Sender = "scheduler@example.com",
+                Recipient = "ops@example.com",
+                Subject = "Nightly digest",
+                Message = "Everything ran.",
+            })
+            .Build();
+
+        #endregion
+    }
+
+    public static void SmtpCredentials(IServiceCollection services, string smtpPassword)
+    {
+        #region sample_jobs_smtp_credentials
+
+        services.AddSingleton<ICredentialsByHost>(new NetworkCredential("mailer", smtpPassword));
+
+        #endregion
+    }
+
+    public static void NativeJobUnderDependencyInjection(IHostApplicationBuilder builder)
+    {
+        #region sample_jobs_native_under_di
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.AddJob<NativeJob>(j => j
+                .WithIdentity("nightlyReport")
+                .StoreDurably()
+                .UsingNativeJobOptions(new NativeJobOptions
+                {
+                    Command = "report.exe",
+                    Parameters = "--nightly",
+                    ConsumeStreams = true,
+                }));
+
+            q.AddTrigger<NativeJob>(t => t
+                .ForJob("nightlyReport")
+                .WithCronSchedule("0 0 2 * * ?"));
+        });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/QuartzPluginsSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/QuartzPluginsSamples.cs
@@ -1,0 +1,217 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using Quartz.Plugins.Interrupt;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/quartz-plugins.md.
+/// </summary>
+public static class QuartzPluginsSamples
+{
+    public static void JobAndTriggerHistoryLogging(IServiceCollection services)
+    {
+        #region sample_plugins_history_logging
+
+        services.AddQuartz(q =>
+        {
+            q.UseJobHistoryLogging(options =>
+            {
+                // each message left unset keeps the plugin's own default
+                options.JobSuccessMessage = "Job {1}.{0} completed";
+            });
+
+            q.UseTriggerHistoryLogging();
+        });
+
+        #endregion
+    }
+
+    public static void StructuredJobLogging(IServiceCollection services)
+    {
+        #region sample_plugins_structured_job_logging
+
+        services.AddQuartz(q =>
+        {
+            q.UseStructuredJobLogging(options =>
+            {
+                // Optional; each template left unset keeps the plugin's own default.
+                options.JobFailedMessage = "Job {JobGroup}.{JobName} failed: {ExceptionMessage}";
+            });
+        });
+
+        #endregion
+    }
+
+    public static void StructuredTriggerLogging(IServiceCollection services)
+    {
+        #region sample_plugins_structured_trigger_logging
+
+        services.AddQuartz(q =>
+        {
+            q.UseStructuredTriggerLogging(options =>
+            {
+                // Optional; each template left unset keeps the plugin's own default.
+                options.TriggerMisfiredMessage = "Trigger {TriggerGroup}.{TriggerName} misfired at {FireTime}";
+            });
+        });
+
+        #endregion
+    }
+
+    public static void ShutdownHook(IServiceCollection services)
+    {
+        #region sample_plugins_shutdown_hook
+
+        services.AddQuartz(q => q.UseShutdownHook(options => options.CleanShutdown = true));
+
+        #endregion
+    }
+
+    public static void XmlSchedulingConfiguration(IServiceCollection services)
+    {
+        #region sample_plugins_xml_scheduling
+
+        services.AddQuartz(q =>
+        {
+            q.UseXmlSchedulingConfiguration(x =>
+            {
+                x.Files.Add("~/quartz_jobs.config");
+                x.ScanInterval = TimeSpan.FromMinutes(1);
+                x.FailOnFileNotFound = true;
+                x.FailOnSchedulingError = true;
+            });
+        });
+
+        #endregion
+    }
+
+    public static void JsonSchedulingConfiguration(IServiceCollection services)
+    {
+        #region sample_plugins_json_scheduling
+
+        services.AddQuartz(q =>
+        {
+            q.UseJsonSchedulingConfiguration(x =>
+            {
+                x.Files.Add("quartz_jobs.json");
+                x.ScanInterval = TimeSpan.FromMinutes(1);
+                x.FailOnFileNotFound = true;
+                x.FailOnSchedulingError = true;
+            });
+        });
+
+        #endregion
+    }
+
+    public static void JobAutoInterrupt(IServiceCollection services)
+    {
+        #region sample_plugins_job_auto_interrupt
+
+        services.AddQuartz(q => q.UseJobAutoInterrupt(options =>
+        {
+            // the default, applied to every job that opts in
+            options.DefaultMaxRunTime = TimeSpan.FromMinutes(5);
+        }));
+
+        #endregion
+    }
+
+    public static void JobAutoInterruptJobData()
+    {
+        #region sample_plugins_job_auto_interrupt_job_data
+
+        IJobDetail job = JobBuilder.Create<SlowJob>()
+            .WithIdentity("slowJob")
+            .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true)
+            // allow only five seconds for this job, overriding default configuration.
+            // the value is milliseconds, and either a number or a string holding one works
+            .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyMaxRunTime, "5000")
+            .Build();
+
+        #endregion
+    }
+
+    public static void AddPluginShapes(IServiceCollection services)
+    {
+        #region sample_plugins_add_plugin
+
+        services.AddQuartz(q =>
+        {
+            // the container constructs it, so it gets constructor injection
+            q.AddPlugin<MyPlugin>();
+
+            // you construct it
+            q.AddPlugin(provider => new MyPlugin(provider.GetRequiredService<IMyPluginDependency>()));
+
+            // it takes an IOptions<MyPluginOptions> of its own
+            q.AddPlugin<MyPlugin, MyPluginOptions>(options => options.SomeSetting = "value");
+        });
+
+        #endregion
+    }
+
+    public static void AddPluginNames(IQuartzBuilder q)
+    {
+        #region sample_plugins_add_plugin_names
+
+        q.AddPlugin<MyPlugin>("myPlugin");
+        q.AddPlugin(provider => new MyPlugin(), "myPlugin");
+        q.AddPlugin<MyPlugin, MyPluginOptions>(options => options.SomeSetting = "value", "myPlugin");
+
+        #endregion
+    }
+
+    public static async ValueTask UsingTheExtension(IServiceCollection services)
+    {
+        #region sample_plugins_using_the_extension
+
+        // under a host
+        services.AddQuartz(q => q.UseMyPlugin(options => options.SomeSetting = "value"));
+
+        // standalone, without an application container
+        var builder = QuartzSchedulerBuilder.Create();
+        builder.UseMyPlugin(options => options.SomeSetting = "value");
+
+        var scheduler = await builder.BuildScheduler();
+
+        #endregion
+
+        await scheduler.Shutdown();
+    }
+}
+
+#region sample_plugins_authoring_extension
+
+public static class MyPluginConfigurationExtensions
+{
+    public static IQuartzBuilder UseMyPlugin(
+        this IQuartzBuilder builder,
+        Action<MyPluginOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var options = new MyPluginOptions();
+        configure?.Invoke(options);
+
+        // companion services your plugin needs injected
+        builder.Services.TryAddSingleton<IMyPluginDependency, MyPluginDependency>();
+
+        return builder.AddPlugin<MyPlugin>(
+            provider =>
+            {
+                var plugin = ActivatorUtilities.CreateInstance<MyPlugin>(provider);
+                plugin.SomeSetting = options.SomeSetting;
+                return plugin;
+            },
+            name: "myPlugin");
+    }
+}
+
+public sealed class MyPluginOptions
+{
+    public string? SomeSetting { get; set; }
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Packages/RedisSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/RedisSamples.cs
@@ -1,0 +1,67 @@
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/redis.md.
+/// </summary>
+public static class RedisSamples
+{
+    public static void RedisLockHandler(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_redis_lock_handler
+
+        builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(connectionString);
+            store.UseSystemTextJsonSerializer();
+            store.UseClustering();
+            store.UseRedisLockHandler(redis =>
+            {
+                redis.RedisConfiguration = "redis-server:6379";
+            });
+        }));
+
+        #endregion
+    }
+
+    public static void RedisLockHandlerOptions(IServiceCollection services)
+    {
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            #region sample_redis_lock_handler_options
+
+            store.UseRedisLockHandler(redis =>
+            {
+                redis.RedisConfiguration = "redis-server:6379";
+                redis.LockTimeToLive = TimeSpan.FromSeconds(30);
+                redis.LockRetryInterval = TimeSpan.FromMilliseconds(100);
+            });
+
+            #endregion
+        }));
+    }
+
+    public static async ValueTask RedisFromProperties()
+    {
+        #region sample_redis_properties
+
+        NameValueCollection properties = new()
+        {
+            ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.LocalTransactionJobStore, Quartz",
+            ["quartz.jobStore.clustered"] = "true",
+            ["quartz.jobStore.lockHandler.type"] = "Quartz.Extensions.Redis.RedisSemaphore, Quartz.Extensions.Redis",
+            ["quartz.jobStore.lockHandler.redisConfiguration"] = "redis-server:6379",
+            ["quartz.jobStore.lockHandler.lockTimeToLive"] = "30000"
+        };
+
+        await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
+            .UseProperties(properties)
+            .Build();
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/SystemTextJsonSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/SystemTextJsonSamples.cs
@@ -1,0 +1,149 @@
+using System.Collections.Specialized;
+using System.Text.Json;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl;
+using Quartz.Serialization.SystemTextJson;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/system-text-json.md.
+/// </summary>
+public static class SystemTextJsonSamples
+{
+    public static void Registration(IServiceCollection services)
+    {
+        #region sample_stj_registration
+
+        services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer("my connection string");
+
+                // it's generally recommended to stick with
+                // string property keys and values when serializing
+                store.Configure(options => options.StoreJobDataAsStrings = true);
+
+                store.UseSystemTextJsonSerializer();
+            });
+        });
+
+        #endregion
+    }
+
+    public static void FromProperties()
+    {
+        #region sample_stj_properties
+
+        var properties = new NameValueCollection
+        {
+         ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.LocalTransactionJobStore, Quartz",
+         ["quartz.serializer.type"] = "stj"
+        };
+        ISchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
+            .UseProperties(properties)
+            .Build();
+
+        #endregion
+    }
+
+    #region sample_stj_custom_serializer
+
+    class CustomJsonSerializer : SystemTextJsonObjectSerializer
+    {
+        // Declaring this constructor is what lets the container hand the serializer the registered custom
+        // trigger and calendar serializers; without it only the built-in types are known.
+        public CustomJsonSerializer(SystemTextJsonSerializerRegistry registry) : base(registry)
+        {
+        }
+
+        protected override JsonSerializerOptions CreateSerializerOptions()
+        {
+            var options = base.CreateSerializerOptions();
+            options.Converters.Add(new MyCustomConverter());
+            return options;
+        }
+    }
+
+    #endregion
+
+    public static void UseCustomSerializer(IServiceCollection services)
+    {
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            #region sample_stj_use_custom_serializer
+
+            store.UseSerializer<CustomJsonSerializer>();
+
+            #endregion
+        }));
+    }
+
+    public static void RegisterCustomSerializers(IServiceCollection services)
+    {
+        #region sample_stj_register_custom_serializers
+
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer("my connection string");
+            store.UseSystemTextJsonSerializer(json =>
+            {
+                json.AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer());
+                json.AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer());
+            });
+        }));
+
+        #endregion
+    }
+
+    public static void PerSchedulerSerializers(IServiceCollection services, string reportingDb, string ingestDb)
+    {
+        #region sample_stj_per_scheduler_serializers
+
+        services.AddQuartz("reporting", q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(reportingDb);
+            store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<ReportTrigger>(new ReportTriggerSerializer()));
+        }));
+
+        services.AddQuartz("ingest", q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(ingestDb);
+            store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<IngestTrigger>(new IngestTriggerSerializer()));
+        }));
+
+        #endregion
+    }
+
+    public static void ContainerWideRegistry(IServiceCollection services)
+    {
+        #region sample_stj_container_registry
+
+        services.AddSingleton(new SystemTextJsonSerializerRegistry()
+            .AddTriggerSerializer<CustomTrigger>(new CustomTriggerSerializer())
+            .AddCalendarSerializer<CustomCalendar>(new CustomCalendarSerializer()));
+
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer("my connection string");
+            // no callback: the store's serializer reads the container's registry, so the same custom
+            // serializers apply to the job store, the HTTP API and the dashboard
+            store.UseSystemTextJsonSerializer();
+        }));
+
+        #endregion
+    }
+
+    public static void KeyedRegistry(IServiceCollection services)
+    {
+        #region sample_stj_keyed_registry
+
+        services.AddKeyedSingleton("reporting", new SystemTextJsonSerializerRegistry()
+            .AddTriggerSerializer<ReportTrigger>(new ReportTriggerSerializer()));
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Packages/TimeZoneConverterSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/TimeZoneConverterSamples.cs
@@ -1,0 +1,49 @@
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples.Packages;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/packages/timezoneconverter-integration.md.
+/// </summary>
+public static class TimeZoneConverterSamples
+{
+    public static void UnderAHost(IHostApplicationBuilder builder)
+    {
+        #region sample_timezoneconverter_host
+
+        builder.Services.AddQuartz(q => q.UseTimeZoneConverter());
+
+        #endregion
+    }
+
+    public static async ValueTask Standalone()
+    {
+        #region sample_timezoneconverter_standalone
+
+        QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create();
+        builder.UseTimeZoneConverter();
+
+        await using StandaloneSchedulerFactory schedulerFactory = builder.Build();
+
+        #endregion
+    }
+
+    public static async ValueTask FromProperties()
+    {
+        #region sample_timezoneconverter_properties
+
+        NameValueCollection properties = new()
+        {
+            ["quartz.plugin.timeZoneConverter.type"] = "Quartz.Plugins.TimeZoneConverter.TimeZoneConverterPlugin, Quartz.Plugins.TimeZoneConverter"
+        };
+
+        await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
+            .UseProperties(properties)
+            .Build();
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj
+++ b/src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj
@@ -1,0 +1,67 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The code the documentation shows.
+
+    Every fenced sample on a converted docs page is a #region in this project, injected into the
+    markdown by MarkdownSnippets (see mdsnippets.json). Nothing here ships, and nothing here runs:
+    the point is that `dotnet build` refuses a sample that no longer compiles, so a documented call
+    cannot outlive the API it names. See CONTRIBUTING.md, "Code samples in the documentation".
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <SonarQubeExclude>true</SonarQubeExclude>
+
+    <!--
+      Sample code is written to read well on a documentation page. The compiler still has to accept
+      it — that is the whole guarantee — but the style analyzers are turned down to what a reader
+      would recognise as idiomatic: a page shows `await scheduler.Start()`, not
+      `await scheduler.Start().ConfigureAwait(false)`, and it names a job `ExampleJob` without an
+      XML documentation comment. The same relaxations the test projects take.
+    -->
+    <AnalysisLevel>none</AnalysisLevel>
+
+    <!--
+      CS1998: a sample method may be async purely to show `await` at the call site.
+      CS9113: a sample may show a constructor signature — `OpsController(IScheduler scheduler)` — without
+              a body that uses the parameter, because the injection is the point being made.
+      CS0219, CS0168, IDE0059: a sample often ends by naming its result (`IJobDetail job = …`), which is
+              what makes the type visible on the page, and then does nothing with it.
+    -->
+    <NoWarn>$(NoWarn);CS1998;CS9113;CS0219;CS0168;IDE0059</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- ASP.NET Core types for the hosting, health-check, HTTP API and dashboard pages. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+    <ProjectReference Include="..\Quartz.AspNetCore\Quartz.AspNetCore.csproj" />
+    <ProjectReference Include="..\Quartz.Dashboard\Quartz.Dashboard.csproj" />
+    <ProjectReference Include="..\Quartz.Extensions.Redis\Quartz.Extensions.Redis.csproj" />
+    <ProjectReference Include="..\Quartz.HttpClient\Quartz.HttpClient.csproj" />
+    <ProjectReference Include="..\Quartz.Jobs\Quartz.Jobs.csproj" />
+    <ProjectReference Include="..\Quartz.Plugins\Quartz.Plugins.csproj" />
+    <ProjectReference Include="..\Quartz.Plugins.TimeZoneConverter\Quartz.Plugins.TimeZoneConverter.csproj" />
+    <ProjectReference Include="..\Quartz.Serialization.Newtonsoft\Quartz.Serialization.Newtonsoft.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Microsoft.Extensions.Hosting, Options and Configuration arrive with the ASP.NET Core framework
+      reference above; referencing them again is NU1510.
+    -->
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <GlobalPackageReference Remove="Meziantou.Analyzer" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz.Documentation.Samples/SampleSerializationTypes.cs
+++ b/src/Quartz.Documentation.Samples/SampleSerializationTypes.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Quartz.Impl.Triggers;
+using Quartz.Serialization.SystemTextJson.Triggers;
+
+namespace Quartz.Documentation.Samples;
+
+/// <summary>
+/// The custom trigger types and converters the serialization pages name.
+/// </summary>
+/// <remarks>
+/// A page showing how to register a serializer is showing the registration, not the serializer, so these
+/// are the smallest thing that satisfies the registration's type constraints. Each derives from an
+/// existing trigger implementation rather than from <c>AbstractTrigger</c>, because a full custom trigger
+/// would be a page of its own.
+/// </remarks>
+public sealed class MyCustomConverter : JsonConverter<Uri>
+{
+    public override Uri Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        new(reader.GetString()!);
+
+    public override void Write(Utf8JsonWriter writer, Uri value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString());
+}
+
+public class CustomTrigger : SimpleTriggerImpl;
+
+public sealed class ReportTrigger : CustomTrigger;
+
+public sealed class IngestTrigger : CustomTrigger;
+
+public sealed class MyTrigger : CustomTrigger;
+
+public class CustomTriggerSerializer : TriggerSerializer<CustomTrigger>
+{
+    public override string TriggerTypeName => "CustomTrigger";
+
+    public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options) =>
+        SimpleScheduleBuilder.Create();
+
+    protected override void SerializeFields(Utf8JsonWriter writer, CustomTrigger trigger, JsonSerializerOptions options)
+    {
+    }
+}
+
+public sealed class ReportTriggerSerializer : CustomTriggerSerializer;
+
+public sealed class IngestTriggerSerializer : CustomTriggerSerializer;
+
+public sealed class MyTriggerSerializer : CustomTriggerSerializer;

--- a/src/Quartz.Documentation.Samples/SampleTypes.cs
+++ b/src/Quartz.Documentation.Samples/SampleTypes.cs
@@ -1,0 +1,135 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+using Quartz.Extensibility;
+using Quartz.Jobs;
+
+namespace Quartz.Documentation.Samples;
+
+/// <summary>
+/// The jobs, listeners and option classes the documentation samples refer to.
+/// </summary>
+/// <remarks>
+/// A page that shows one of these in full wraps it in its own region; the rest are here only so the
+/// samples that name them compile.
+/// </remarks>
+public sealed class ExampleJob : IJob
+{
+    public string InjectedString { get; set; } = "";
+
+    public bool InjectedBool { get; set; }
+
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class SlowJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public interface IReportStore;
+
+public interface IEmailSender
+{
+    ValueTask SendDigest(CancellationToken cancellationToken = default);
+}
+
+public sealed class SendReportsJob : IJob
+{
+    public SendReportsJob(IReportStore store)
+    {
+    }
+
+    public static SendReportsJob ForTenant(string tenant) => new(null!);
+
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class SampleOptions
+{
+    public string CronSchedule { get; set; } = "";
+}
+
+public sealed class NotificationJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class ReportJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class MainJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class CleanupJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class AuditSchedulerListener : ISchedulerListener;
+
+public sealed class LoggingJobListener : IJobListener;
+
+public sealed class MetricsTriggerListener : ITriggerListener;
+
+public sealed class SampleSchedulerListener : ISchedulerListener;
+
+public sealed class SampleJobListener : IJobListener;
+
+public sealed class SampleTriggerListener : ITriggerListener;
+
+public sealed class InboxListener : IDirectoryScanListener
+{
+    public ValueTask FilesUpdatedOrAdded(IReadOnlyCollection<FileInfo> updatedFiles, CancellationToken cancellationToken = default) => default;
+
+    public ValueTask FilesDeleted(IReadOnlyCollection<FileInfo> deletedFiles, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class WarmUpBeforeSchedulingService(
+    IHostApplicationLifetime applicationLifetime,
+    IServiceProvider serviceProvider,
+    IOptionsMonitor<QuartzHostedServiceOptions> options)
+    : QuartzHostedService(applicationLifetime, serviceProvider, options);
+
+/// <summary>
+/// Stands in for the Blazor root component an application hosting the dashboard alongside its own
+/// Razor components would have. Written in C# rather than as a .razor file so that the samples project
+/// does not need the Razor SDK.
+/// </summary>
+public sealed class App : IComponent
+{
+    public void Attach(RenderHandle renderHandle)
+    {
+    }
+
+    public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+}
+
+public interface IMyPluginDependency;
+
+public sealed class MyPluginDependency : IMyPluginDependency;
+
+public sealed class MyPlugin : ISchedulerPlugin
+{
+    public MyPlugin()
+    {
+    }
+
+    public MyPlugin(IMyPluginDependency dependency)
+    {
+    }
+
+    public string? SomeSetting { get; set; }
+
+    public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+
+    public ValueTask Start(CancellationToken cancellationToken = default) => default;
+
+    public ValueTask Shutdown(CancellationToken cancellationToken = default) => default;
+}
+

--- a/src/Quartz.Tests.Unit/Configuration/DocumentedConfigurationTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/DocumentedConfigurationTest.cs
@@ -1,39 +1,66 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Documentation.Samples.Packages;
 
 namespace Quartz.Tests.Unit.Configuration;
 
 /// <summary>
-/// The configuration snippets the documentation shows, compiled.
+/// Runs the configuration samples the documentation shows.
 /// </summary>
 /// <remarks>
-/// The DI configurator and the concrete trigger builder carry two parallel families of schedule
-/// extensions, and a gap in either one makes documented code stop compiling without any test noticing.
+/// <para>
+/// This test used to hold its own transcription of the pages' snippets, which is the arrangement that let
+/// a page ship a call that did not exist: the page and the test were two copies of the same code and
+/// nothing compared them. The samples now live in <c>src/Quartz.Documentation.Samples</c> and the pages
+/// are generated from them, so compiling that project is what keeps the documentation honest.
+/// </para>
+/// <para>
+/// What is left here is the part compilation cannot check — that the registration the DI page shows
+/// really does produce the schedule it claims to.
+/// </para>
 /// </remarks>
 public class DocumentedConfigurationTest
 {
-    public class ExampleJob : IJob
+    [Test]
+    public void TheWorkedConfigurationSchedulesEveryTriggerItShows()
     {
-        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings());
+        builder.Services.AddLogging();
+
+        MicrosoftDiIntegrationSamples.JobsAndTriggers(builder);
+        MicrosoftDiIntegrationSamples.TheRestOfTheWorkedConfiguration(builder);
+
+        using ServiceProvider provider = builder.Services.BuildServiceProvider();
+
+        provider.ScheduledTriggers().Select(x => x.Key.Name).Should().BeEquivalentTo(
+            [
+                "Combined Configuration Trigger",
+                "Simple Trigger",
+                "Cron Trigger",
+                "Spread Cron Trigger",
+                "Daily Trigger",
+                "slowJobTrigger"
+            ],
+            "every trigger the worked configuration on the Microsoft DI page shows should be scheduled");
     }
 
     [Test]
-    public void TheDiIntegrationSnippetsCompile()
+    public void TheScheduleJobSampleRegistersItsJobAndTrigger()
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddQuartz(q =>
-        {
-            q.ScheduleJob<ExampleJob>(trigger => trigger
-                .WithIdentity("Combined Configuration Trigger")
-                .WithDailyTimeIntervalSchedule(x => x.WithInterval(10, IntervalUnit.Second)));
+        services.AddQuartz(q => q.ScheduleJob<ExampleJob>(trigger => trigger
+            .WithIdentity("example")
+            .WithCronSchedule("0 0/5 * * * ?")));
 
-            var jobKey = new JobKey("awesome job", "awesome group");
-            q.AddJob<ExampleJob>(j => j.WithIdentity(jobKey).WithDescription("my awesome job"));
-            q.AddTrigger<IJob>(t => t.WithIdentity("t2").ForJob(jobKey)
-                .WithDailyTimeIntervalSchedule(x => x.WithInterval(10, IntervalUnit.Second)));
-        });
+        using ServiceProvider provider = services.BuildServiceProvider();
 
-        using var provider = services.BuildServiceProvider();
-        provider.ScheduledTriggers().Should().HaveCount(2);
+        provider.ScheduledTriggers().Should().ContainSingle().Which.Key.Name.Should().Be("example");
+    }
+
+    public class ExampleJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
     }
 }

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -51,6 +51,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
+    <!--
+      The documentation samples. DocumentedConfigurationTest runs the ones the Microsoft DI page shows,
+      so the page's registration is checked for what it does and not only for whether it compiles.
+    -->
+    <ProjectReference Include="..\Quartz.Documentation.Samples\Quartz.Documentation.Samples.csproj" />
     <ProjectReference Include="..\Quartz.HttpClient\Quartz.HttpClient.csproj" />
     <ProjectReference Include="..\Quartz.Jobs\Quartz.Jobs.csproj" />
     <ProjectReference Include="..\Quartz.Plugins\Quartz.Plugins.csproj" />


### PR DESCRIPTION
Closes #3342 (its second half — the snippet-coverage gap).

`DocumentedConfigurationTest` was a 38-line test holding configuration snippets hand-transcribed out of
the documentation. Nothing read the markdown, so the page and the test were two copies that drift — which
is how a freshly written package page shipped a DI sample calling a non-generic `AddTrigger` overload that
does not exist.

This inverts it. Samples are ordinary compiled code and the prose is generated from them, so the normal
build is the guarantee and drift is not possible.

## The mechanism

Samples live as `#region sample_*` blocks in **`src/Quartz.Documentation.Samples`**, a new project in
`Quartz.slnx`. It is built by `Compile`, so a sample that stops compiling fails a pull request exactly
like any other code — the more reliably red of the two safety nets, and the same shape Polly
(`src/Snippets`) and Swashbuckle (`DocumentationSnippets.csproj`) use.

Pages carry `<!-- snippet: name -->` / `<!-- endSnippet -->` markers. `dotnet fallout DocsSnippets`
(also `npm run docs:snippets`) fills them in; the filled-in markdown is committed, so GitHub and the
published site both render it and the generated code is part of the reviewed diff.

`dotnet fallout VerifyDocsSnippets` is the gate, and it runs as its own step in `docs-pr.yml` and
`docs.yml`, whose `paths` now also cover `src/Quartz.Documentation.Samples/**` and `build/**`. **There is
no self-healing.** The dominant real-world integration of this tool regenerates post-merge and
auto-commits — Polly, Swashbuckle, and the upstream project's own recommended action all do — which would
let a pull request merge green while the reviewed diff and the published page disagreed. That is a quieter
version of the bug being fixed here, so the target fails and the author regenerates.

## Which mechanism, and the evidence

| | Missing sample fails? | Stale sample fails? | Renders on GitHub? |
|---|---|---|---|
| VuePress 2 native import | **no** | **no** | no |
| DocFX `[!code-csharp[](f#region)]` | no (silent empty block) | no | no |
| MarkdownSnippets CLI | yes, exit 1 | only via `git diff --exit-code` | yes |
| MarkdownSnippets library, as adopted here | yes | yes, `VerifyDocsSnippets` | yes |

**VuePress's native code import loses on the evidence, and it is not the syntax one would assume.**
`<<< @/path` is VitePress and VuePress 1; it does not exist in VuePress 2 and renders as literal
paragraph text. VuePress 2's form is `@[code](path)`, and `2.0.0-rc.28` — the exact pin — was probed in
an isolated site:

- **missing file**: prints `error Import file ... not found` to *stderr*, **exits 0**, and emits a normal
  syntax-highlighted code block containing the literal text `File not found`
- **line range past EOF**: no message at all, exit 0, empty code block
- **`#region` is not supported** — line numbers only; the three plausible spellings fail three different
  ways, two of them silently degrading to an ordinary markdown link
- **source drift is invisible**: renaming a region and inserting three lines shifted every excerpt and
  produced no output whatsoever
- no source link, no strict mode, one config option (`handleImportPath`)

The authority is this repository's own `node_modules/@vuepress/markdown/dist/index.js`:

```js
if (!fs.existsSync(importFilePath)) {
    logger.error(`Import file ${colors.magenta(importPath)} not found`);
    return { importFilePath, importCode: "File not found" };
}
```

It logs and returns a placeholder; it never throws, and nothing downstream inspects the result. The
same file's `SYNTAX_RE` starts `/^@\[code` and `<<<` appears nowhere in it. Making the import fatal takes
hand-written config, and even then covers only the missing-file case, not staleness or regions.

**DocFX is worse than its reputation:** the classic `[!code-csharp[](file#region)]` renders a silent empty
block when a region is renamed, so `--warningsAsErrors` cannot catch it. Akka.NET, which puts its snippets
in `[Fact]` methods so they compile *and run*, has a live example of exactly this rot in `schedulers.md`.

**Everything in the inverse direction is dead**: `dotnet try` retired December 2025,
`dotnet/interactive` archived April 2026, `MdCompile` untouched for eleven years.

### Why the library and not the `mdsnippets` tool

This is the decision I would most like reviewed rather than accepted.

`MarkdownSnippets.Tool` never scans a directory named `packages`. It is hard-coded, not configurable —
`DefaultDirectoryExclusions.ShouldExcludeDirectory` lists `.git`, `.vs`, `.vscode`, `.idea`, **`packages`**,
`node_modules`, `dist`, `.angular`, `bin`, `obj` — and `ExcludeMarkdownDirectories` can only add to it. This
was found by running the tool against this repository: it processed `docs/documentation/`, skipped
`docs/documentation/quartz-4.x/packages/` entirely, and **exited 0**. That is precisely the silent
degradation this change exists to remove, on precisely the beachhead directory.

That left two ways out: rename `docs/documentation/quartz-4.x/packages/` (URL-breaking for published
pages, ~80 link edits, 15 new redirects, and it would leave 3.x and 4.x with different URL shapes), or
drive the same library from the build project. `DefaultDirectoryExclusions` lives in the tool's
`ExcludeToFilterBuilder`, not in the engine — `DirectoryMarkdownProcessor` takes the three directory
predicates as parameters — so the library route is the tool minus its landmine.

`build/Build.Docs.Snippets.cs` supplies those predicates and adds what the tool lacks:

- **a real check mode.** Upstream has none; `ValidateContent` is a *prose linter* that bans the words
  "you", "your", "we" and "simply", and would reject nearly every page here. `VerifyDocsSnippets`
  regenerates into memory, compares, and restores the tree in a `finally` so a failing run leaves nothing
  behind.
- **duplicate snippet names are an error.** Upstream emits both, stacked. This matters here: 393 files
  under `src/` contain `#region License`, and a page referencing `License` would silently inline 393
  Apache headers. Snippet scanning is also scoped to the samples project, so those regions are not even
  in the namespace.
- **an empty marker is an error** — which is how a silently skipped directory announces itself.
- **plain fenced output, no raw HTML.** Upstream emits `<a id>` and `<sup>`, which needs the MD033
  allow-list widened and trips MD031. More importantly its permalink carries the sample's *line numbers*,
  so moving a sample within its own file would dirty every page showing it and fail the staleness gate on
  a pull request that touched no documentation. Without the link the generated markdown depends only on
  the sample's text. Polly drops the links for the same reason (`OmitSnippetLinks: true`).
- the fence says `csharp`, as the rest of the documentation does, rather than the extension-derived `cs`.

The cost is that `dotnet fallout DocsSnippets` replaces `dotnet mdsnippets` as the command. That fits a
repository that already generates and verifies artifacts this way (`GenerateMigrations` /
`VerifyMigrations`).

## What was converted

All fifteen package pages: **100 of 104 `csharp` blocks**. The four left as plain fences, and why, are in
#3357.

`DocumentedConfigurationTest` no longer holds a transcription. `Quartz.Tests.Unit` references the samples
project and the test now *runs* the Microsoft DI page's worked configuration, asserting it schedules the
six triggers it shows — so the page is checked for what it does, not only for whether it compiles.

## Documentation bugs conversion flushed out

Every one of these is a block that did not compile:

1. **`timezoneconverter-integration.md`** — `QuartzSchedulerBuilder.Create().UseTimeZoneConverter().Build()`.
   `UseTimeZoneConverter` is an extension on `IQuartzBuilder`, which has no `Build()`; `Build()` is on the
   concrete `QuartzSchedulerBuilder`. Fixed by splitting into two statements — the shape
   `quartz-plugins.md` already used correctly two sections away.
2. **`microsoft-di-integration.md`** — `InstantiationFailureListener` called `logger.LogError(...)` with no
   `logger` anywhere in the sample. Fixed with a primary constructor taking
   `ILogger<InstantiationFailureListener>`.
3. **`http-client.md`** — one fenced block declared `OpsController` twice (CS0101). Split into two blocks
   with a sentence between them.
4. **`migration-guide.md`** (found beside the others, in a page this change does not otherwise convert) —
   the *"after"* half of a `diff` block showed `q.AddJob<ExampleJob>(new JobKey("job", "group"))` and a
   non-generic `q.AddTrigger((provider, t) => …)`. Both overloads were removed in 4.0, by the table
   directly above the block. This is the same bug class #3342 reported, and it is in the one page shaped
   so that the new mechanism cannot reach it — see #3357.

## Analyzer friction, and how it was resolved

`TreatWarningsAsErrors` applies to the samples like anything else, and it should. The samples project
turns the *style* analyzers down (`AnalysisLevel none`, no Meziantou — what the test projects already do)
so a sample reads like a documentation page rather than like library code, and suppresses four
diagnostics that punish documentation-shaped code specifically: `CS9113` (a sample showing a constructor
signature whose parameter has no body to use it), `CS1998` (async purely to show `await` at the call
site), and `CS0219`/`IDE0059` (a sample ending by naming its result, which is what makes the type visible
on the page). Nothing that would let genuinely wrong code through is suppressed. Only one sample needed
its *shape* changed to compile: the two `OpsController` declarations above.

## Verification

Run locally, output as seen:

- `dotnet build Quartz.slnx` — succeeded, 0 warnings, 0 errors
- `dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj` — **2883 passed**, 0 failed, 4 skipped
- `dotnet fallout VerifyDocsSnippets` — `Documentation snippets are up to date (80 markdown files checked)`, exit 0
- `npm run docs:build` — `Rendering 212 pages`, `VuePress build completed`, exit 0
- `npm run docs:check-links` — `678 internal links, 374 fragments`, `no dead links or anchors`, exit 0
- `npx markdownlint-cli2 "docs/documentation/quartz-4.x/packages/*.md"` — `Linting: 15 file(s)`, **0 errors**

Because the conversion is byte-for-byte, `git diff` on thirteen of the fifteen pages contains **nothing
but marker lines** — the samples reproduce the prose exactly. The two exceptions are documentation bugs 1
and 2 above.

### The guards, watched going red

Each break was made deliberately, the failure observed, then reverted.

**1. A sample stops compiling** — `options.CleanShutdown` changed to `options.CleanShutdownn`:

```text
BUILD EXIT=1
QuartzPluginsSamples.cs(67,70): error CS1061: 'ShutdownHookOptions' does not contain a definition
for 'CleanShutdownn'
```

**2. A referenced snippet disappears** — region renamed to `sample_plugins_shutdown_hook_renamed`:

```text
VERIFY EXIT=127
Missing snippets:
  docs\documentation\quartz-4.x\packages\quartz-plugins.md: sample_plugins_shutdown_hook
```

and `md5sum -c` over all fifteen pages afterwards: **15 OK** — a failing verification leaves the tree
untouched.

**3. The committed markdown is edited by hand** — `CleanShutdown = true` changed to `false` in the .md only:

```text
VERIFY EXIT=127
System.InvalidOperationException: 1 documentation page(s) no longer match the samples they show:
  docs\documentation\quartz-4.x\packages\quartz-plugins.md
Run 'dotnet fallout DocsSnippets' (or 'npm run docs:snippets') and commit the result.
```

**4. The `packages` trap itself** — the guard that motivated the design. One page's snippet bodies were
blanked, as a freshly written page would look, and the markdown predicate was made to use
MarkdownSnippets' own `DefaultDirectoryExclusions` — i.e. behave exactly as the `mdsnippets` tool does:

```text
GENERATE EXIT=127
System.InvalidOperationException: These snippet markers were left empty, so the page was never processed:
  ...quartz-plugins.md: sample_plugins_history_logging
  ...quartz-plugins.md: sample_plugins_structured_job_logging
  [... all twelve ...]
```

Under the tool this is exit 0 and an untouched page. Reverted, `DocsSnippets` and `VerifyDocsSnippets`
both return to exit 0.

On exit codes: `dotnet fallout <target>` returns **127** on a failed target and 0 on success. Every gate
sits on its own `run:` line in its own step, so the exit code is the step's result — no `&&` chain to
swallow it, and no PowerShell (`$ErrorActionPreference = "Stop"` does not propagate a native exit code,
which is why some repositories' snippet steps stay green).

## Rebased onto the anchor-checking half of #3342

`355c7e88` landed while this was being written, so the branch is rebased on it rather than merged.
`docs-pr.yml` and `package.json` both wanted editing by both halves; the resolution keeps both, with the
snippet verification running before the site is built and the link and anchor checks after it — each on
its own step so no exit code is swallowed.

`npm run docs:lint` still fails, on `docs/README.md`, `quartz-2.x/`, `quartz-3.x/` and
`quartz-4.x/tutorial/execution-groups.md` — all pre-existing on `main`, none of them files this change
touches, and it is not a CI gate. The fifteen converted pages lint clean.

## One thing this change had to fix that it did not cause

Splitting `npm ci` out of the old multi-line `run:` block turned it into *new code*, and Sonar rated both
docs workflows **C for security**. It took two passes to get right, and the first attempt is worth
recording because it moved the problem rather than removing it.

**`githubactions:S6505` — a bare `npm ci` runs every dependency's lifecycle scripts.** Adding
`--ignore-scripts` alone would have broken the build silently: `package.json`'s `postinstall` is
`patch-package`, and it applies `patches/gray-matter+4.0.3.patch`, which VuePress needs to parse front
matter. So the dependency scripts are blocked and the patch is applied as its own step. Those two
findings are now `status CLOSED` in Sonar's API.

**The first version of that step used `npx patch-package`, and opened two new findings** — `S6505` again,
because `npx` fetches and runs a package's lifecycle scripts when it is not already present, and
`githubactions:S8543`, because a bare name pins no version. That is the same exposure as the bare
`npm ci`, one step to the right, on a workflow that holds a deploy secret.

The fix is that nothing needs resolving at all: `npm ci` has already installed `patch-package` at the
version `package-lock.json` pins. A new `apply-patches` script runs that copy.

```yaml
- name: Install
  run: npm ci --ignore-scripts

- name: Apply dependency patches
  run: npm run apply-patches
```

`postinstall` stays alongside it. The two `package.json` entries are the same command for different
callers — a contributor running a plain `npm ci` still gets the patch without knowing the step exists,
and only CI opts out of dependency scripts and applies it itself. `package.json` cannot carry a comment
saying so, so `CONTRIBUTING.md` does, under a new **Building the site** heading.

Verified locally each time: `npm ci --ignore-scripts` exit 0, `npm run apply-patches` reporting
`gray-matter@4.0.3` applied, `npm run docs:build` rendering 212 pages. Both workflows were re-read end to
end afterwards; each contains exactly one package-manager install, and both carry `--ignore-scripts`.

Net effect: both docs workflows are more locked down than they are on `main`, where the bare `npm ci` was
simply old enough that Sonar's new-code analysis never looked at it.

## Left for follow-up

#3357: the ~300 remaining `csharp` blocks elsewhere under `quartz-4.x/`, the four deliberate plain fences,
and the question of what to do about `diff`-fenced before/after blocks, which no snippet mechanism reaches
and which is where bug 4 was hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3wNU6NFXyZztWp12PGQc
