### PR TITLE
Wire polish: one applied, one error shape, typed dashboard DTOs, TimeSpan durations

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -79,6 +79,14 @@ jobs:
           # stays in analysis, where the bug and security rules still apply to it; what it is excused
           # from is a coverage figure this workflow is not configured to produce. Its own control is
           # `npm run docs:check-links-test`.
+          #
+          # The dashboard's Razor components are excused for the same reason and no more: this
+          # repository has no component-test harness — no bUnit, no Playwright, and
+          # Quartz.Tests.AspNetCore covers the HTTP API rather than the Blazor UI — so their markup
+          # cannot be covered by construction, and measuring it reports 0% forever rather than
+          # anything a reviewer can act on. The exclusion is the components only, not the package:
+          # everything in src/Quartz.Dashboard that is ordinary C# is measured and expected to be
+          # tested. It is a stopgap, to be narrowed or deleted if #3363 adopts bUnit.
           dotnet-sonarscanner begin \
             /k:"quartznet_quartznet" \
             /o:"quartznet" \
@@ -87,7 +95,7 @@ jobs:
             /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml" \
             /d:sonar.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**" \
             /d:sonar.cpd.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**" \
-            /d:sonar.coverage.exclusions="docs/.vuepress/**"
+            /d:sonar.coverage.exclusions="docs/.vuepress/**,src/Quartz.Dashboard/Components/**/*.razor"
       # Has to sit between begin and end: the scanner analyses through MSBuild, so only projects
       # actually built while it is active are measured.
       - name: 'Run: Compile, UnitTest'

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4971,6 +4971,58 @@ Only these two enums are affected, and the converters are registered per enum ty
 its converters to the application's shared `JsonOptions`, and a host's own endpoints must keep rendering
 their own enums the way they always did.
 
+## Every mutation says `applied`, and every error is one shape
+
+Which body a `200` carries is now a rule rather than a per-endpoint fact: **a `200` carries a body
+exactly when the operation has something to say that the caller could not have worked out for
+itself.** A mutation that always acts — `AddJob`, `TriggerJob`, `PauseAll`, `ScheduleJobs`,
+`AddCalendar`, the scheduler and execution-limit writes — answers with an empty body; a mutation whose
+effect may be a no-op answers `{"applied": …}`; a mutation aimed at a group matcher or a key set
+answers with what it applied to; and a mutation that computed something answers with that value.
+
+The empty-body and `{"applied": …}` halves were already split that way. What was not consistent was
+the *name*: six endpoints spelled the flag their own way, so a caller had to look up the body per
+endpoint instead of predicting it.
+
+| Endpoint | 4.0 preview | 4.0 |
+|---|---|---|
+| `DELETE …/jobs/{group}/{name}` | `{"jobFound": …}` | `{"applied": …}` |
+| `POST …/jobs/delete` | `{"allJobsFound": …}` | `{"applied": …}` |
+| `POST …/jobs/{group}/{name}/interrupt` | `{"interrupted": …}` | `{"applied": …}` |
+| `POST …/jobs/interrupt/{fireInstanceId}` | `{"interrupted": …}` | `{"applied": …}` |
+| `POST …/triggers/{group}/{name}/unschedule` | `{"triggerFound": …}` | `{"applied": …}` |
+| `POST …/triggers/unschedule` | `{"allTriggersFound": …}` | `{"applied": …}` |
+| `DELETE …/calendars/{name}` | `{"calendarFound": …}` | `{"applied": …}` |
+
+`applied` means the operation applied to everything it was aimed at. For a single key that is the one
+key; for the two plural forms it is every key in the body, which is what `allJobsFound` and
+`allTriggersFound` meant — a partial hit is `false`, and the keys that were found are still deleted.
+`HttpScheduler` reads the new spelling, so a client and server upgraded together need no code change;
+a hand-written client reading the old names does.
+
+Errors gained the same treatment. Every problem-details body the API produces now carries the same
+members whichever layer raised it — `type`, `title`, `status`, `detail` and `Quartz-ExceptionType`:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The scheduler has been shut down",
+  "Quartz-ExceptionType": "SchedulerException"
+}
+```
+
+`Quartz-ExceptionType` used to ride only on the `SchedulerException` path, so a `400` from request
+validation and a `400` from the scheduler were two different shapes, and a client could not tell a
+body the member was missing from a body that never carries it. It now names the exception type on
+every error, including the framework's own — `BadHttpRequestException` for a request the endpoint
+rejected, `NotFoundException` for a `404`. Map the Quartz names back to typed exceptions and treat the
+rest as opaque, which is what `HttpScheduler` does.
+
+The one `400` that still has no body is not the API's: a query parameter the framework could not bind
+never reaches an endpoint, so nothing of ours writes the response.
+
 ## The dashboard's client speaks one currency
 
 `IQuartzApiClient` is the dashboard's own projection of the HTTP API — public so that an application can

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5023,6 +5023,25 @@ rest as opaque, which is what `HttpScheduler` does.
 The one `400` that still has no body is not the API's: a query parameter the framework could not bind
 never reaches an endpoint, so nothing of ours writes the response.
 
+## Durations are `TimeSpan`s, wherever they are
+
+A trigger body has always said `"repeatIntervalTimeSpan": "120.02:30:59.9990000"`. Three duration
+members beside it counted whole milliseconds instead, which both disagreed with that and threw away
+everything below a millisecond:
+
+| 4.0 preview | 4.0 |
+|---|---|
+| `POST …/schedulers/{name}/start?delayMilliseconds=30000` | `?delay=00:00:30` |
+| `JobExecutionResultDto.RunTimeMs` (`long`) | `RunTime` (`TimeSpan`) |
+| `DashboardHistoryEntry.DurationMs` (`long`) | `Duration` (`TimeSpan`) |
+
+`HttpScheduler.StartDelayed` sends the new spelling, so a client and server upgraded together need no
+code change. A negative `delay` is now a `400` rather than a delay that runs backwards.
+
+The two dashboard records are the ones the dashboard's SignalR hub and its history store put on the
+wire, so a browser or history store reading `runTimeMs` / `durationMs` as a number reads
+`runTime` / `duration` as an ISO-ish `TimeSpan` string instead.
+
 ## The dashboard's client speaks one currency
 
 `IQuartzApiClient` is the dashboard's own projection of the HTTP API — public so that an application can
@@ -5095,6 +5114,18 @@ Two consequences worth knowing:
   custom trigger type now reaches the detail page as itself.
 * **The HTTP-backed client cannot read a kind no serializer is registered for**, and says so instead
   of rendering an anonymous bag of properties. Register the serializer, as the API itself requires.
+
+`TriggerHeaderDto` was half a positional record and half property-initialised, which read as an
+accident because it was one. It is positional throughout:
+
+```diff
+- new TriggerHeaderDto(group, name, executionGroup) { TriggerType = …, ScheduleSummary = …, State = … }
++ new TriggerHeaderDto(group, name, triggerType, scheduleSummary, state, executionGroup)
+```
+
+A trigger's kind is also named the same way by both clients now — `Cron`, `Simple`, … The HTTP-backed
+one echoed the wire's discriminator, so the same trigger was `CronTrigger` there and `Cron` in
+process.
 
 ## `CheckExists` is `Exists`
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5060,6 +5060,42 @@ because the dashboard's contract needed a name for it. Note that a running sched
 in-process client used to call it `"Started"` while the HTTP-backed client called the same state
 `"Running"`, and code that matched on either string now matches on the enum.
 
+### A trigger is an `ITrigger`, a calendar is an `ICalendar`
+
+Six members of that contract still spoke `System.Text.Json.JsonElement`. They were placeholders from
+the dashboard's build-out, and they made every consumer of `IQuartzApiClient` parse JSON to read
+something Quartz already has a type for:
+
+| 4.0 preview | 4.0 |
+|---|---|
+| `GetTrigger(…)` → `TriggerDetailDto(JsonElement Value)` | → `ITrigger` |
+| `GetCalendar(…)` → `CalendarDetailDto(JsonElement Value)` | → `ICalendar` |
+| `ScheduleJobRequest(JsonElement Trigger, JobDetailDto? Job)` | `ScheduleJobRequest(ITrigger Trigger, JobDetailDto? Job)` |
+| `RescheduleRequest(JsonElement NewTrigger)` | `RescheduleRequest(ITrigger NewTrigger)` |
+| `AddCalendarRequest(string, JsonElement Calendar, bool, bool)` | `AddCalendarRequest(string, ICalendar Calendar, bool, bool)` |
+| `JobDetailDto.JobDataMap` is a `JsonElement` | a `JobDataMap` |
+| `TriggerJobWithData(…, JsonElement jobDataMap, …)` | `TriggerJobWithData(…, JobDataMap jobDataMap, …)` |
+
+`TriggerDetailDto` and `CalendarDetailDto` are gone with them; nothing remains for them to wrap.
+
+The polymorphism a trigger needs is Quartz's own: the serializer registry maps each kind to its own
+serializer, custom kinds an application registered included, and the HTTP API's wire format *is* that
+discriminated shape. A per-kind DTO family in the dashboard would have to grow a member for every
+trigger kind and would still have nothing to say about a kind it had never heard of, so the contract
+speaks `ITrigger` and lets the registry do what it is for. `JobDataMap` is the same argument at the
+other end of the scale: the map holds arbitrary user values, which is exactly what `JobDataMap` is,
+and typing it as one keeps an `int` an `int` where a JSON round trip made it whatever the reader
+guessed.
+
+Two consequences worth knowing:
+
+* **The in-process client no longer serializes anything.** It used to write the trigger to JSON and
+  read it back for no reason but the contract's type, and it fell back to reflecting over the trigger
+  for kinds the registry did not know — which produced a payload that could not be posted back. A
+  custom trigger type now reaches the detail page as itself.
+* **The HTTP-backed client cannot read a kind no serializer is registered for**, and says so instead
+  of rendering an anonymous bag of properties. Register the serializer, as the API itself requires.
+
 ## `CheckExists` is `Exists`
 
 Both overloads, on `IScheduler` and `IJobStore`:

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4971,37 +4971,45 @@ Only these two enums are affected, and the converters are registered per enum ty
 its converters to the application's shared `JsonOptions`, and a host's own endpoints must keep rendering
 their own enums the way they always did.
 
-## Every mutation says `applied`, and every error is one shape
+## One flag per mutation, named for what it reports
 
 Which body a `200` carries is now a rule rather than a per-endpoint fact: **a `200` carries a body
 exactly when the operation has something to say that the caller could not have worked out for
 itself.** A mutation that always acts — `AddJob`, `TriggerJob`, `PauseAll`, `ScheduleJobs`,
 `AddCalendar`, the scheduler and execution-limit writes — answers with an empty body; a mutation whose
-effect may be a no-op answers `{"applied": …}`; a mutation aimed at a group matcher or a key set
+effect may be a no-op answers with one boolean flag; a mutation aimed at a group matcher or a key set
 answers with what it applied to; and a mutation that computed something answers with that value.
 
-The empty-body and `{"applied": …}` halves were already split that way. What was not consistent was
-the *name*: six endpoints spelled the flag their own way, so a caller had to look up the body per
-endpoint instead of predicting it.
+The empty-body and flag-carrying halves were already split that way. What was not consistent was the
+*name*: seven spellings of the same question, so a caller had to look up the body per endpoint instead
+of predicting it.
 
 | Endpoint | 4.0 preview | 4.0 |
 |---|---|---|
 | `DELETE …/jobs/{group}/{name}` | `{"jobFound": …}` | `{"applied": …}` |
-| `POST …/jobs/delete` | `{"allJobsFound": …}` | `{"applied": …}` |
 | `POST …/jobs/{group}/{name}/interrupt` | `{"interrupted": …}` | `{"applied": …}` |
 | `POST …/jobs/interrupt/{fireInstanceId}` | `{"interrupted": …}` | `{"applied": …}` |
 | `POST …/triggers/{group}/{name}/unschedule` | `{"triggerFound": …}` | `{"applied": …}` |
-| `POST …/triggers/unschedule` | `{"allTriggersFound": …}` | `{"applied": …}` |
 | `DELETE …/calendars/{name}` | `{"calendarFound": …}` | `{"applied": …}` |
+| `POST …/jobs/delete` | `{"allJobsFound": …}` | `{"allFound": …}` |
+| `POST …/triggers/unschedule` | `{"allTriggersFound": …}` | `{"allFound": …}` |
 
-`applied` means the operation applied to everything it was aimed at. For a single key that is the one
-key; for the two plural forms it is every key in the body, which is what `allJobsFound` and
-`allTriggersFound` meant — a partial hit is `false`, and the keys that were found are still deleted.
-`HttpScheduler` reads the new spelling, so a client and server upgraded together need no code change;
+`applied` means the entity existed and the operation changed it. The last two rows keep a name of
+their own because they report a different fact: `IScheduler.DeleteJobs` and `UnscheduleJobs` answer
+one `bool` for a whole key set, meaning "every key was found", and a partial hit **still deletes the
+keys it found**. Calling that `"applied": false` would be a false statement about what happened, and
+a caller who retried on it would never learn that most of the work had already succeeded. What is
+uniform is the *shape* — one boolean, on the operations that have something to report; the name still
+has to describe the value. Having those two answer with the applied keys, as the key-set pause and
+resume do, is the better end state and is tracked in
+[#3360](https://github.com/quartznet/quartznet/issues/3360).
+
+`HttpScheduler` reads the new spellings, so a client and server upgraded together need no code change;
 a hand-written client reading the old names does.
 
-Errors gained the same treatment. Every problem-details body the API produces now carries the same
-members whichever layer raised it — `type`, `title`, `status`, `detail` and `Quartz-ExceptionType`:
+Errors gained a rule of their own: **a client-actionable error names the exception type it came from;
+a server fault does not.** Every `400` and every `404` now carries the same members whichever layer
+raised it — `type`, `title`, `status`, `detail` and `Quartz-ExceptionType`:
 
 ```json
 {
@@ -5016,9 +5024,12 @@ members whichever layer raised it — `type`, `title`, `status`, `detail` and `Q
 `Quartz-ExceptionType` used to ride only on the `SchedulerException` path, so a `400` from request
 validation and a `400` from the scheduler were two different shapes, and a client could not tell a
 body the member was missing from a body that never carries it. It now names the exception type on
-every error, including the framework's own — `BadHttpRequestException` for a request the endpoint
-rejected, `NotFoundException` for a `404`. Map the Quartz names back to typed exceptions and treat the
-rest as opaque, which is what `HttpScheduler` does.
+every `400` and `404`, including the framework's own — `BadHttpRequestException` for a request the
+endpoint rejected, `NotFoundException` for a `404`. Map the Quartz names back to typed exceptions and
+treat the rest as opaque, which is what `HttpScheduler` does.
+
+A `500` deliberately does **not** carry it. It is a fault the caller cannot act on, so naming the type
+behind it would say something about the server's internals and nothing a client could use.
 
 The one `400` that still has no body is not the API's: a query parameter the framework could not bind
 never reaches an endpoint, so nothing of ours writes the response.

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -90,23 +90,70 @@ them as numbers needs to read names instead, or parse both.
 
 ## Response-shape conventions
 
-Which shape an operation answers with depends on what it has to say:
+**A `200` carries a body exactly when the operation has something to say that the caller could not
+have worked out for itself** — the value it computed, or whether it applied. The rule is the same for
+every endpoint, so the body follows from what the operation *is* rather than from which endpoint it
+was:
 
 | Operation | Answers |
 |---|---|
 | A read that found its target | `200` with the object |
 | A read whose target does not exist | `404` with RFC 7807 problem details |
-| A write that succeeded and has nothing to report | `200` with an **empty body** — `AddJob`, `TriggerJob`, `PauseAll`, `ScheduleJobs`, … |
-| A write whose outcome the caller needs | `200` with a one-field object — `{ "applied": … }`, `{ "jobFound": … }`, `{ "calendarFound": … }`, `{ "triggerFound": … }`, `{ "interrupted": … }`, `{ "groups": [ … ] }` |
+| A mutation that always acts | `200` with an **empty body** — `AddJob`, `TriggerJob`, `PauseAll`, `ScheduleJobs`, `AddCalendar`, `Start`, `Standby`, `Shutdown`, `Clear`, the execution-limit writes |
+| A mutation whose effect may be a no-op | `200` with `{ "applied": … }` |
+| …the same, aimed at a group matcher or a key set | `200` with what it applied to — `{ "groups": [ … ] }`, `{ "jobs": [ … ] }`, `{ "triggers": [ … ] }` |
+| A mutation that computed something | `200` with that value — `{ "firstFireTimeUtc": … }` from schedule and reschedule |
 
 An unknown scheduler is `404` whatever the operation was.
 
-`400` has two shapes, and the difference is *where* the request was rejected:
+`applied` means **the operation applied to everything it was aimed at**. For a single-key mutation
+that is the one key; for the plural `POST …/jobs/delete` and `POST …/triggers/unschedule` it is every
+key in the body, so a partial hit is `false` even though the keys that were found were still deleted.
 
-- A query parameter that could not be bound at all — `?take=not-a-number`, `?state=not-a-state` — never
-  reaches the endpoint, so the answer is `400` with **no body**.
-- A request the endpoint itself rejected — `?skip=-1`, a job with no name, unparseable JSON — is `400`
-  with problem details carrying a `detail` that says why.
+::: warning Changed in 4.x
+Six endpoints spelled this flag their own way in the 4.0 previews. They all say `applied` now:
+
+| Endpoint | 4.0 preview | 4.0 |
+|---|---|---|
+| `DELETE …/jobs/{group}/{name}` | `{ "jobFound": … }` | `{ "applied": … }` |
+| `POST …/jobs/delete` | `{ "allJobsFound": … }` | `{ "applied": … }` |
+| `POST …/jobs/{group}/{name}/interrupt`, `POST …/jobs/interrupt/{fireInstanceId}` | `{ "interrupted": … }` | `{ "applied": … }` |
+| `POST …/triggers/{group}/{name}/unschedule` | `{ "triggerFound": … }` | `{ "applied": … }` |
+| `POST …/triggers/unschedule` | `{ "allTriggersFound": … }` | `{ "applied": … }` |
+| `DELETE …/calendars/{name}` | `{ "calendarFound": … }` | `{ "applied": … }` |
+:::
+
+### Errors are one shape
+
+Every error the API produces is RFC 7807 problem details with the same members, whichever layer
+raised it: `type`, `title`, `status`, `detail`, and `Quartz-ExceptionType` naming the exception the
+server raised.
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The scheduler has been shut down",
+  "Quartz-ExceptionType": "SchedulerException"
+}
+```
+
+A client maps the Quartz exception names — `SchedulerException`, `JobPersistenceException`,
+`ObjectAlreadyExistsException`, … — back to typed exceptions, and treats any other value as opaque;
+`HttpScheduler` does exactly that. `Quartz-ExceptionStackTrace` joins them only when
+`IncludeStackTraceInProblemDetails` is on.
+
+::: warning Changed in 4.x
+`Quartz-ExceptionType` rode only on the `SchedulerException` path in the 4.0 previews, so a `400`
+raised by request validation and a `400` raised by the scheduler were two different shapes and a
+client could not tell an absent member from one that is never sent.
+:::
+
+There is one case where a `400` has **no** body at all, and it is not the API's doing: a query
+parameter the framework could not bind — `?take=not-a-number`, `?state=not-a-state` — is rejected
+before the request reaches an endpoint. A request the endpoint itself rejected — `?skip=-1`, a job
+with no name, unparseable JSON — always answers with the problem details above.
 
 ## Listing endpoints are paged
 

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -244,12 +244,17 @@ calendar listings. Both shapes are gone; every listing returns the paged envelop
 
 ## Pause and resume report what they did
 
-The single-key mutations that follow the missing-key rule answer `200 OK` with a JSON body telling
-whether anything happened:
+Pause and resume are the mutations most often aimed at a key that has gone, so they are worth spelling
+out — but the rule is the general one above, and every mutation that can be a no-op answers the same
+way:
 
 - `POST …/jobs/{group}/{name}/pause`, `…/resume`
 - `POST …/triggers/{group}/{name}/pause`, `…/resume`
 - `POST …/triggers/{group}/{name}/reset-from-error-state`
+- `POST …/triggers/{group}/{name}/unschedule`, `POST …/triggers/unschedule`
+- `POST …/jobs/{group}/{name}/interrupt`, `POST …/jobs/interrupt/{fireInstanceId}`
+- `DELETE …/jobs/{group}/{name}`, `POST …/jobs/delete`
+- `DELETE …/calendars/{name}`
 
 ```json
 { "applied": true }
@@ -265,9 +270,11 @@ state). The group-matcher forms — `POST …/jobs/pause`, `…/jobs/resume`, `�
 ```
 
 ::: warning Changed in 4.x
-These endpoints previously returned `200 OK` with an empty body. Old clients that ignored the body
-keep working, but a 4.0-final `HttpScheduler` against a 4.0-preview server throws on these calls
-because it expects the body — upgrade the server first.
+The pause, resume and reset-from-error-state endpoints previously returned `200 OK` with an empty
+body. Old clients that ignored the body keep working, but a 4.0-final `HttpScheduler` against a
+4.0-preview server throws on these calls because it expects the body — upgrade the server first. The
+delete, unschedule and interrupt endpoints always answered with a body; only the name of the field
+changed, [as tabulated above](#response-shape-conventions).
 :::
 
 ### A whole set of keys in one call

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -115,34 +115,47 @@ was:
 | A read that found its target | `200` with the object |
 | A read whose target does not exist | `404` with RFC 7807 problem details |
 | A mutation that always acts | `200` with an **empty body** — `AddJob`, `TriggerJob`, `PauseAll`, `ScheduleJobs`, `AddCalendar`, `Start`, `Standby`, `Shutdown`, `Clear`, the execution-limit writes |
-| A mutation whose effect may be a no-op | `200` with `{ "applied": … }` |
+| A mutation whose effect may be a no-op | `200` with one flag, **named for what it reports** — `{ "applied": … }` almost everywhere, `{ "allFound": … }` on the two forms below |
 | …the same, aimed at a group matcher or a key set | `200` with what it applied to — `{ "groups": [ … ] }`, `{ "jobs": [ … ] }`, `{ "triggers": [ … ] }` |
 | A mutation that computed something | `200` with that value — `{ "firstFireTimeUtc": … }` from schedule and reschedule |
 
 An unknown scheduler is `404` whatever the operation was.
 
-`applied` means **the operation applied to everything it was aimed at**. For a single-key mutation
-that is the one key; for the plural `POST …/jobs/delete` and `POST …/triggers/unschedule` it is every
-key in the body, so a partial hit is `false` even though the keys that were found were still deleted.
+The flag is always one boolean, and it is **named for the fact it reports**: `applied` — the entity
+existed and the operation changed it — except where the underlying scheduler API can only answer
+whether *every* key was found, which is `allFound`:
+
+| Endpoint | Flag | Means |
+|---|---|---|
+| every other single-key mutation | `applied` | this key existed and the operation changed it |
+| `POST …/jobs/delete` | `allFound` | every key in the body was found |
+| `POST …/triggers/unschedule` | `allFound` | every key in the body was found |
+
+Those two report `allFound` rather than `applied` because a partial hit **still deletes the keys it
+found** — `IScheduler.DeleteJobs` and `UnscheduleJobs` return one `bool` for the whole set and cannot
+say which. Calling that `"applied": false` would be a false statement about what happened, and a
+caller who retried on it would never learn that most of the work had already succeeded. Answering
+with the applied keys, as the key-set pause and resume do, is the better end state and is tracked in
+[#3360](https://github.com/quartznet/quartznet/issues/3360).
 
 ::: warning Changed in 4.x
-Six endpoints spelled this flag their own way in the 4.0 previews. They all say `applied` now:
+Five endpoints spelled the applied flag their own way in the 4.0 previews:
 
 | Endpoint | 4.0 preview | 4.0 |
 |---|---|---|
 | `DELETE …/jobs/{group}/{name}` | `{ "jobFound": … }` | `{ "applied": … }` |
-| `POST …/jobs/delete` | `{ "allJobsFound": … }` | `{ "applied": … }` |
 | `POST …/jobs/{group}/{name}/interrupt`, `POST …/jobs/interrupt/{fireInstanceId}` | `{ "interrupted": … }` | `{ "applied": … }` |
 | `POST …/triggers/{group}/{name}/unschedule` | `{ "triggerFound": … }` | `{ "applied": … }` |
-| `POST …/triggers/unschedule` | `{ "allTriggersFound": … }` | `{ "applied": … }` |
 | `DELETE …/calendars/{name}` | `{ "calendarFound": … }` | `{ "applied": … }` |
+| `POST …/jobs/delete` | `{ "allJobsFound": … }` | `{ "allFound": … }` |
+| `POST …/triggers/unschedule` | `{ "allTriggersFound": … }` | `{ "allFound": … }` |
 :::
 
-### Errors are one shape
+### Errors are one shape per kind
 
-Every error the API produces is RFC 7807 problem details with the same members, whichever layer
-raised it: `type`, `title`, `status`, `detail`, and `Quartz-ExceptionType` naming the exception the
-server raised.
+Every error the API produces is RFC 7807 problem details. A **client-actionable** error — every `400`
+and every `404` — carries `type`, `title`, `status`, `detail` and `Quartz-ExceptionType` naming the
+exception the server raised, whichever layer raised it:
 
 ```json
 {
@@ -158,6 +171,19 @@ A client maps the Quartz exception names — `SchedulerException`, `JobPersisten
 `ObjectAlreadyExistsException`, … — back to typed exceptions, and treats any other value as opaque;
 `HttpScheduler` does exactly that. `Quartz-ExceptionStackTrace` joins them only when
 `IncludeStackTraceInProblemDetails` is on.
+
+A **`500` deliberately does not carry `Quartz-ExceptionType`.** It is a fault the caller cannot act
+on, so naming the type behind it would say something about the server's internals and nothing a
+client could use:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.6.1",
+  "title": "An error occurred while processing your request.",
+  "status": 500,
+  "detail": "…"
+}
+```
 
 ::: warning Changed in 4.x
 `Quartz-ExceptionType` rode only on the `SchedulerException` path in the 4.0 previews, so a `400`
@@ -245,20 +271,23 @@ calendar listings. Both shapes are gone; every listing returns the paged envelop
 ## Pause and resume report what they did
 
 Pause and resume are the mutations most often aimed at a key that has gone, so they are worth spelling
-out — but the rule is the general one above, and every mutation that can be a no-op answers the same
-way:
+out — but the rule is the general one above, and every single-key mutation that can be a no-op answers
+the same way:
 
 - `POST …/jobs/{group}/{name}/pause`, `…/resume`
 - `POST …/triggers/{group}/{name}/pause`, `…/resume`
 - `POST …/triggers/{group}/{name}/reset-from-error-state`
-- `POST …/triggers/{group}/{name}/unschedule`, `POST …/triggers/unschedule`
+- `POST …/triggers/{group}/{name}/unschedule`
 - `POST …/jobs/{group}/{name}/interrupt`, `POST …/jobs/interrupt/{fireInstanceId}`
-- `DELETE …/jobs/{group}/{name}`, `POST …/jobs/delete`
+- `DELETE …/jobs/{group}/{name}`
 - `DELETE …/calendars/{name}`
 
 ```json
 { "applied": true }
 ```
+
+(`POST …/jobs/delete` and `POST …/triggers/unschedule` take a key set and answer `{ "allFound": … }`
+instead, [for the reason given above](#response-shape-conventions).)
 
 `applied` is `false` when the key does not exist or the operation was a no-op (pausing an already
 paused trigger, resuming a trigger that was not paused, resetting a trigger that is not in the error

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -88,6 +88,21 @@ take a name too: `?state=Paused`.
 them as numbers needs to read names instead, or parse both.
 :::
 
+## Durations travel as `TimeSpan`
+
+Every duration on the wire is a `TimeSpan` in its invariant form, both ways: a trigger body says
+`"repeatIntervalTimeSpan": "120.02:30:59.9990000"`, and the one duration in a query string is spelled
+the same way.
+
+```
+POST {ApiPath}/schedulers/{name}/start?delay=00:00:30
+```
+
+::: warning Changed in 4.x
+That parameter was `?delayMilliseconds=30000` in the 4.0 previews. `TimeSpan` matches every other
+duration the API carries and does not round a sub-millisecond delay away.
+:::
+
 ## Response-shape conventions
 
 **A `200` carries a body exactly when the operation has something to say that the caller could not

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/CalendarEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/CalendarEndpoints.cs
@@ -99,7 +99,7 @@ internal static class CalendarEndpoints
         );
     }
 
-    [ProducesResponseType(typeof(DeleteCalendarResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
     private static Task<IResult> DeleteCalendar(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -110,7 +110,7 @@ internal static class CalendarEndpoints
         return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var calendarFound = await scheduler.DeleteCalendar(calendarName, cancellationToken).ConfigureAwait(false);
-            return new DeleteCalendarResponse(calendarFound);
+            return new OperationAppliedResponse(calendarFound);
         });
     }
 }

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
@@ -376,7 +376,7 @@ internal static class JobEndpoints
         return EndpointHelper.ExecuteWithOkResponse(schedulerName, schedulerRepository, scheduler => scheduler.TriggerJob(new JobKey(jobName, jobGroup), request?.JobData, cancellationToken).AsTask());
     }
 
-    [ProducesResponseType(typeof(InterruptResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
     private static Task<IResult> InterruptJob(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -388,11 +388,11 @@ internal static class JobEndpoints
         return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var interrupted = await scheduler.Interrupt(new JobKey(jobName, jobGroup), cancellationToken).ConfigureAwait(false);
-            return new InterruptResponse(interrupted);
+            return new OperationAppliedResponse(interrupted);
         });
     }
 
-    [ProducesResponseType(typeof(InterruptResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
     private static Task<IResult> InterruptJobInstance(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -403,11 +403,11 @@ internal static class JobEndpoints
         return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var interrupted = await scheduler.InterruptFireInstance(fireInstanceId, cancellationToken).ConfigureAwait(false);
-            return new InterruptResponse(interrupted);
+            return new OperationAppliedResponse(interrupted);
         });
     }
 
-    [ProducesResponseType(typeof(DeleteJobResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
     private static Task<IResult> DeleteJob(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -419,11 +419,11 @@ internal static class JobEndpoints
         return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var jobFound = await scheduler.DeleteJob(new JobKey(jobName, jobGroup), cancellationToken).ConfigureAwait(false);
-            return new DeleteJobResponse(jobFound);
+            return new OperationAppliedResponse(jobFound);
         });
     }
 
-    [ProducesResponseType(typeof(DeleteJobsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
     private static Task<IResult> DeleteJobs(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -436,7 +436,7 @@ internal static class JobEndpoints
         {
             var jobKeys = request.Jobs.Select(x => x.AsJobKey()).ToArray();
             var allJobsFound = await scheduler.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
-            return new DeleteJobsResponse(allJobsFound);
+            return new OperationAppliedResponse(allJobsFound);
         });
     }
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
@@ -423,7 +423,14 @@ internal static class JobEndpoints
         });
     }
 
-    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
+    /// <summary>
+    /// Deletes a set of jobs, answering whether every key given was found.
+    /// </summary>
+    /// <remarks>
+    /// The one mutation body that is not <c>applied</c>: a partial hit deletes the jobs it found, so
+    /// see <see cref="AllKeysFoundResponse" /> for why it may not claim to have applied.
+    /// </remarks>
+    [ProducesResponseType(typeof(AllKeysFoundResponse), StatusCodes.Status200OK)]
     private static Task<IResult> DeleteJobs(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -436,7 +443,7 @@ internal static class JobEndpoints
         {
             var jobKeys = request.Jobs.Select(x => x.AsJobKey()).ToArray();
             var allJobsFound = await scheduler.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
-            return new OperationAppliedResponse(allJobsFound);
+            return new AllKeysFoundResponse(allJobsFound);
         });
     }
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -93,19 +93,29 @@ internal static class SchedulerEndpoints
         });
     }
 
+    /// <summary>
+    /// Starts the scheduler, after <c>delay</c> when one is given — <c>?delay=00:00:30</c>, a
+    /// <see cref="TimeSpan" /> like every other duration on the wire. A request that names none starts
+    /// the scheduler immediately.
+    /// </summary>
     [ProducesResponseType(StatusCodes.Status200OK)]
     private static Task<IResult> Start(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
         string schedulerName,
-        long? delayMilliseconds,
+        TimeSpan? delay,
         CancellationToken cancellationToken = default)
     {
+        if (delay < TimeSpan.Zero)
+        {
+            throw new BadHttpRequestException("delay must not be negative");
+        }
+
         return EndpointHelper.ExecuteWithOkResponse(schedulerName, schedulerRepository, scheduler =>
         {
-            if (delayMilliseconds.HasValue)
+            if (delay.HasValue)
             {
-                return scheduler.StartDelayed(TimeSpan.FromMilliseconds(delayMilliseconds.Value), cancellationToken).AsTask();
+                return scheduler.StartDelayed(delay.Value, cancellationToken).AsTask();
             }
 
             return scheduler.Start(cancellationToken).AsTask();

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
@@ -448,7 +448,14 @@ internal static class TriggerEndpoints
         });
     }
 
-    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
+    /// <summary>
+    /// Unschedules a set of triggers, answering whether every key given was found.
+    /// </summary>
+    /// <remarks>
+    /// The one mutation body that is not <c>applied</c>: a partial hit unschedules the triggers it
+    /// found, so see <see cref="AllKeysFoundResponse" /> for why it may not claim to have applied.
+    /// </remarks>
+    [ProducesResponseType(typeof(AllKeysFoundResponse), StatusCodes.Status200OK)]
     private static Task<IResult> UnscheduleJobs(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -461,7 +468,7 @@ internal static class TriggerEndpoints
         {
             var triggerKeys = request.Triggers.Select(x => x.AsTriggerKey()).ToArray();
             var allTriggersFound = await scheduler.UnscheduleJobs(triggerKeys, cancellationToken).ConfigureAwait(false);
-            return new OperationAppliedResponse(allTriggersFound);
+            return new AllKeysFoundResponse(allTriggersFound);
         });
     }
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
@@ -432,7 +432,7 @@ internal static class TriggerEndpoints
         });
     }
 
-    [ProducesResponseType(typeof(UnscheduleJobResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
     private static Task<IResult> UnscheduleJob(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -444,11 +444,11 @@ internal static class TriggerEndpoints
         return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var triggerFound = await scheduler.UnscheduleJob(new TriggerKey(triggerName, triggerGroup), cancellationToken).ConfigureAwait(false);
-            return new UnscheduleJobResponse(triggerFound);
+            return new OperationAppliedResponse(triggerFound);
         });
     }
 
-    [ProducesResponseType(typeof(UnscheduleJobsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OperationAppliedResponse), StatusCodes.Status200OK)]
     private static Task<IResult> UnscheduleJobs(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -461,7 +461,7 @@ internal static class TriggerEndpoints
         {
             var triggerKeys = request.Triggers.Select(x => x.AsTriggerKey()).ToArray();
             var allTriggersFound = await scheduler.UnscheduleJobs(triggerKeys, cancellationToken).ConfigureAwait(false);
-            return new UnscheduleJobsResponse(allTriggersFound);
+            return new OperationAppliedResponse(allTriggersFound);
         });
     }
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/ExceptionHandler.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/ExceptionHandler.cs
@@ -19,14 +19,22 @@ internal sealed class ExceptionHandler
     }
 
     /// <summary>
-    /// Turns an exception into the one problem-details shape the API answers errors with.
+    /// Turns an exception into the problem details the API answers errors with.
     /// </summary>
     /// <remarks>
-    /// Which layer raised the exception decides the status code and the wording, never the members:
-    /// every error body carries <c>type</c>, <c>title</c>, <c>status</c>, <c>detail</c> and
-    /// <see cref="HttpApiConstants.ProblemDetailsExceptionType" />. The exception type used to ride
-    /// only on the <see cref="SchedulerException" /> path, so a client could not tell a body it was
-    /// missing from a body that never carries it, and a 400 meant two different shapes.
+    /// <para>
+    /// A client-actionable error names the exception type it came from; a server fault does not. A
+    /// <c>400</c> and a <c>404</c> are things the caller can reconstruct and handle — that is what
+    /// <see cref="HttpApiConstants.ProblemDetailsExceptionType" /> is read for — so every one of them
+    /// carries it whichever layer raised it. It used to ride only on the
+    /// <see cref="SchedulerException" /> path, so a <c>400</c> from request validation and a
+    /// <c>400</c> from the scheduler were two different shapes and a client could not tell a body the
+    /// member was missing from one that never carries it.
+    /// </para>
+    /// <para>
+    /// A <c>500</c> is a fault the caller cannot act on, and naming the type that produced it buys
+    /// nothing it does not also leak.
+    /// </para>
     /// </remarks>
     public IResult HandleException(Exception exception, HttpContext context)
     {
@@ -55,20 +63,22 @@ internal sealed class ExceptionHandler
         }
 
         logger.LogError(exception, "Exception thrown when handling api request to url {Url}", context.Request.GetDisplayUrl());
-        return Problem(exception, exception.Message, StatusCodes.Status500InternalServerError);
-
-        static string GetMessageWithInnerExceptionMessage(Exception exception)
-        {
-            return exception.InnerException is not null ? $"{exception.Message} {exception.InnerException.Message}" : exception.Message;
-        }
+        return Problem(exception, exception.Message, StatusCodes.Status500InternalServerError, nameTheExceptionType: false);
     }
 
-    private IResult Problem(Exception exception, string detail, int statusCode)
+    private static string GetMessageWithInnerExceptionMessage(Exception exception)
     {
-        Dictionary<string, object?> extensions = new()
+        return exception.InnerException is not null ? $"{exception.Message} {exception.InnerException.Message}" : exception.Message;
+    }
+
+    private IResult Problem(Exception exception, string detail, int statusCode, bool nameTheExceptionType = true)
+    {
+        Dictionary<string, object?> extensions = new();
+
+        if (nameTheExceptionType)
         {
-            { HttpApiConstants.ProblemDetailsExceptionType, exception.GetType().Name }
-        };
+            extensions.Add(HttpApiConstants.ProblemDetailsExceptionType, exception.GetType().Name);
+        }
 
         if (includeStackTrace)
         {

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/ExceptionHandler.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/ExceptionHandler.cs
@@ -18,57 +18,44 @@ internal sealed class ExceptionHandler
         logger = loggerFactory.CreateLogger("Quartz.HttpApi");
     }
 
+    /// <summary>
+    /// Turns an exception into the one problem-details shape the API answers errors with.
+    /// </summary>
+    /// <remarks>
+    /// Which layer raised the exception decides the status code and the wording, never the members:
+    /// every error body carries <c>type</c>, <c>title</c>, <c>status</c>, <c>detail</c> and
+    /// <see cref="HttpApiConstants.ProblemDetailsExceptionType" />. The exception type used to ride
+    /// only on the <see cref="SchedulerException" /> path, so a client could not tell a body it was
+    /// missing from a body that never carries it, and a 400 meant two different shapes.
+    /// </remarks>
     public IResult HandleException(Exception exception, HttpContext context)
     {
         if (exception is BadHttpRequestException badHttpRequestException)
         {
             logger.LogDebug(exception, "BadHttpRequestException thrown");
-            return Results.Problem(
-                detail: GetMessageWithInnerExceptionMessage(exception),
-                statusCode: badHttpRequestException.StatusCode,
-                extensions: GetCommonExtensions(exception)
-            );
+            return Problem(exception, GetMessageWithInnerExceptionMessage(exception), badHttpRequestException.StatusCode);
         }
 
         if (exception is JsonSerializationException)
         {
             logger.LogDebug(exception, "Failed to deserialize request");
-            return Results.Problem(
-                detail: GetMessageWithInnerExceptionMessage(exception),
-                statusCode: StatusCodes.Status400BadRequest,
-                extensions: GetCommonExtensions(exception)
-            );
+            return Problem(exception, GetMessageWithInnerExceptionMessage(exception), StatusCodes.Status400BadRequest);
         }
 
         if (exception is NotFoundException)
         {
             logger.LogDebug(exception, "NotFoundException thrown");
-            return Results.Problem(
-                detail: GetMessageWithInnerExceptionMessage(exception),
-                statusCode: StatusCodes.Status404NotFound,
-                extensions: GetCommonExtensions(exception)
-            );
+            return Problem(exception, GetMessageWithInnerExceptionMessage(exception), StatusCodes.Status404NotFound);
         }
 
         if (exception is SchedulerException)
         {
-            var schedulerExceptionExtensions = GetCommonExtensions(exception) ?? new Dictionary<string, object?>();
-            schedulerExceptionExtensions.Add(HttpApiConstants.ProblemDetailsExceptionType, exception.GetType().Name);
-
             logger.LogWarning(exception, "SchedulerException thrown when handling api request to url {Url}", context.Request.GetDisplayUrl());
-            return Results.Problem(
-                detail: exception.Message,
-                statusCode: StatusCodes.Status400BadRequest,
-                extensions: schedulerExceptionExtensions
-            );
+            return Problem(exception, exception.Message, StatusCodes.Status400BadRequest);
         }
 
         logger.LogError(exception, "Exception thrown when handling api request to url {Url}", context.Request.GetDisplayUrl());
-        return Results.Problem(
-            detail: exception.Message,
-            statusCode: StatusCodes.Status500InternalServerError,
-            extensions: GetCommonExtensions(exception)
-        );
+        return Problem(exception, exception.Message, StatusCodes.Status500InternalServerError);
 
         static string GetMessageWithInnerExceptionMessage(Exception exception)
         {
@@ -76,16 +63,18 @@ internal sealed class ExceptionHandler
         }
     }
 
-    private Dictionary<string, object?>? GetCommonExtensions(Exception exception)
+    private IResult Problem(Exception exception, string detail, int statusCode)
     {
-        if (!includeStackTrace)
+        Dictionary<string, object?> extensions = new()
         {
-            return null;
+            { HttpApiConstants.ProblemDetailsExceptionType, exception.GetType().Name }
+        };
+
+        if (includeStackTrace)
+        {
+            extensions.Add(HttpApiConstants.ProblemDetailsStackTrace, exception.StackTrace);
         }
 
-        return new Dictionary<string, object?>
-        {
-            { HttpApiConstants.ProblemDetailsStackTrace, exception.StackTrace }
-        };
+        return Results.Problem(detail: detail, statusCode: statusCode, extensions: extensions);
     }
 }

--- a/src/Quartz.Dashboard/Components/Pages/CalendarDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/CalendarDetail.razor
@@ -1,6 +1,5 @@
 @page "/quartz/calendars/{CalendarName}"
 @using System.Reflection
-@using System.Text.Json
 @using Microsoft.Extensions.Options
 @using Quartz.Dashboard.Components.Shared
 @using Quartz.Dashboard.Services
@@ -36,7 +35,7 @@
                 <button type="button" class="qz-button qz-button-danger" @onclick="PromptDelete">Delete calendar</button>
             </div>
         }
-        <p>Type: <strong>@DisplayValueHelper.GetString(_calendar, "CalendarType", "Type")</strong></p>
+        <p>Type: <strong>@_calendar.GetType().Name</strong></p>
 
         <table class="qz-table">
             <tbody>
@@ -61,7 +60,7 @@
 @code {
     private bool _isLoading = true;
     private string? _error;
-    private object? _calendar;
+    private ICalendar? _calendar;
     private readonly List<CalendarProperty> _properties = [];
     private bool _showDeleteConfirm;
 
@@ -103,8 +102,7 @@
                 return;
             }
 
-            CalendarDetailDto detail = await Api.GetCalendar(schedulerName, CalendarName);
-            _calendar = detail.Value;
+            _calendar = await Api.GetCalendar(schedulerName, CalendarName);
             BuildPropertyRows(_calendar);
         }
         catch (Exception ex)
@@ -117,18 +115,8 @@
         }
     }
 
-    private void BuildPropertyRows(object calendar)
+    private void BuildPropertyRows(ICalendar calendar)
     {
-        if (calendar is JsonElement jsonElement && jsonElement.ValueKind == JsonValueKind.Object)
-        {
-            foreach (JsonProperty property in jsonElement.EnumerateObject())
-            {
-                _properties.Add(new CalendarProperty(property.Name, property.Value.ToString()));
-            }
-
-            return;
-        }
-
         Type type = calendar.GetType();
         PropertyInfo[] properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
         foreach (PropertyInfo propertyInfo in properties)

--- a/src/Quartz.Dashboard/Components/Pages/Calendars.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Calendars.razor
@@ -1,8 +1,8 @@
 @page "/quartz/calendars"
-@using System.Text.Json
 @using Microsoft.Extensions.Options
 @using Quartz.Dashboard.Components.Shared
 @using Quartz.Dashboard.Services
+@using Quartz.Impl.Calendar
 @implements IDisposable
 @inject IQuartzApiClient Api
 @inject SchedulerState Scheduler
@@ -86,10 +86,6 @@
                OnCancel="CancelDeleteAsync" />
 
 @code {
-    private static readonly JsonSerializerOptions requestSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
     private readonly List<string> _calendarNames = [];
     private bool _isLoading = true;
     private string? _error;
@@ -167,19 +163,14 @@
             return;
         }
 
-        object calendarPayload = new
-        {
-            type = "CronCalendar",
-            description = string.IsNullOrWhiteSpace(_newCalendarDescription) ? null : _newCalendarDescription.Trim(),
-            timeZoneId = TimeZoneInfo.Utc.Id,
-            baseCalendar = (object?) null,
-            cronExpressionString = cronExpression
-        };
-
         try
         {
-            JsonElement calendarJson = JsonSerializer.SerializeToElement(calendarPayload, requestSerializerOptions);
-            AddCalendarRequest request = new(calendarName, calendarJson, _replaceCalendar, _updateTriggers);
+            CronCalendar calendar = new(baseCalendar: null, cronExpression, TimeZoneInfo.Utc)
+            {
+                Description = string.IsNullOrWhiteSpace(_newCalendarDescription) ? null : _newCalendarDescription.Trim()
+            };
+
+            AddCalendarRequest request = new(calendarName, calendar, _replaceCalendar, _updateTriggers);
             await Api.AddCalendar(schedulerName, request);
             ActionLog.Record(
                 schedulerName,

--- a/src/Quartz.Dashboard/Components/Pages/History.razor
+++ b/src/Quartz.Dashboard/Components/Pages/History.razor
@@ -1,4 +1,5 @@
 @page "/quartz/history"
+@using System.Globalization
 @using Microsoft.Extensions.Options
 @using Quartz.Dashboard.Components.Shared
 @using Quartz.Dashboard.Services
@@ -64,8 +65,8 @@
         <div class="qz-grid qz-grid-4">
             <StatCard Title="Success rate (page)" Value="@GetSuccessRateText()" Icon="✔" Color="success" />
             <StatCard Title="Failures (page)" Value="@_pageFailureCount.ToString()" Icon="⚠" Color="error" />
-            <StatCard Title="Avg duration (page)" Value="@FormatDurationValue(_pageAverageDurationMs)" Icon="⏱️" Color="info" />
-            <StatCard Title="P95 duration (page)" Value="@FormatDurationValue(_pageP95DurationMs)" Icon="📈" Color="info" />
+            <StatCard Title="Avg duration (page)" Value="@FormatDurationValue(_pageAverageDuration)" Icon="⏱️" Color="info" />
+            <StatCard Title="P95 duration (page)" Value="@FormatDurationValue(_pageP95Duration)" Icon="📈" Color="info" />
         </div>
 
         <table class="qz-table">
@@ -86,7 +87,7 @@
                         <td><KeyBadge GroupName="@entry.JobGroup" ItemName="@entry.JobName" /></td>
                         <td><KeyBadge GroupName="@entry.TriggerGroup" ItemName="@entry.TriggerName" /></td>
                         <td>@FormatFiredAt(entry.FiredAtUtc)</td>
-                        <td>@FormatDurationValue(entry.DurationMs)</td>
+                        <td>@FormatDurationValue(entry.Duration)</td>
                         <td><StateIndicator State="@(entry.Succeeded ? "Complete" : "Error")" /></td>
                         <td>@entry.ExceptionMessage</td>
                     </tr>
@@ -113,8 +114,8 @@
     private int _totalPages = 1;
     private int _pageSuccessCount;
     private int _pageFailureCount;
-    private long _pageAverageDurationMs;
-    private long _pageP95DurationMs;
+    private TimeSpan _pageAverageDuration;
+    private TimeSpan _pageP95Duration;
     private string _jobFilter = string.Empty;
     private string _triggerFilter = string.Empty;
     private string _appliedJobFilter = string.Empty;
@@ -226,8 +227,8 @@
         _totalPages = 1;
         _pageSuccessCount = 0;
         _pageFailureCount = 0;
-        _pageAverageDurationMs = 0;
-        _pageP95DurationMs = 0;
+        _pageAverageDuration = TimeSpan.Zero;
+        _pageP95Duration = TimeSpan.Zero;
 
         try
         {
@@ -374,9 +375,28 @@
         return jobPart + " · " + triggerPart;
     }
 
-    private static string FormatDurationValue(long durationMs)
+    /// <summary>
+    /// Shows a duration in the largest unit that keeps it readable: sub-second runs in milliseconds,
+    /// anything longer with its unit spelled out.
+    /// </summary>
+    private static string FormatDurationValue(TimeSpan duration)
     {
-        return durationMs > 0 ? durationMs + " ms" : "n/a";
+        if (duration <= TimeSpan.Zero)
+        {
+            return "n/a";
+        }
+
+        if (duration < TimeSpan.FromSeconds(1))
+        {
+            return duration.TotalMilliseconds.ToString("0.###", CultureInfo.InvariantCulture) + " ms";
+        }
+
+        if (duration < TimeSpan.FromMinutes(1))
+        {
+            return duration.TotalSeconds.ToString("0.##", CultureInfo.InvariantCulture) + " s";
+        }
+
+        return duration.ToString("g", CultureInfo.InvariantCulture);
     }
 
     private string FormatFiredAt(DateTimeOffset? firedAtUtc)
@@ -398,11 +418,11 @@
 
     private void ComputeAnalytics()
     {
-        List<long> durations = [];
+        List<TimeSpan> durations = [];
         _pageSuccessCount = 0;
         _pageFailureCount = 0;
-        _pageAverageDurationMs = 0;
-        _pageP95DurationMs = 0;
+        _pageAverageDuration = TimeSpan.Zero;
+        _pageP95Duration = TimeSpan.Zero;
 
         foreach (DashboardHistoryEntry entry in _entries)
         {
@@ -415,9 +435,9 @@
                 _pageFailureCount++;
             }
 
-            if (entry.DurationMs > 0)
+            if (entry.Duration > TimeSpan.Zero)
             {
-                durations.Add(entry.DurationMs);
+                durations.Add(entry.Duration);
             }
         }
 
@@ -427,10 +447,10 @@
         }
 
         durations.Sort();
-        _pageAverageDurationMs = (long) Math.Round(durations.Average());
+        _pageAverageDuration = TimeSpan.FromTicks((long) Math.Round(durations.Average(x => (double) x.Ticks)));
         int p95Index = (int) Math.Ceiling(durations.Count * 0.95) - 1;
         p95Index = Math.Clamp(p95Index, 0, durations.Count - 1);
-        _pageP95DurationMs = durations[p95Index];
+        _pageP95Duration = durations[p95Index];
     }
 
     public void Dispose()

--- a/src/Quartz.Dashboard/Components/Pages/JobDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/JobDetail.razor
@@ -1,5 +1,4 @@
 @page "/quartz/jobs/{Group}/{Name}"
-@using System.Text.Json
 @using Microsoft.Extensions.Options
 @using Quartz
 @using Quartz.Dashboard.Components.Shared
@@ -45,12 +44,12 @@
 
         <table class="qz-table">
             <tbody>
-                <tr><th>Type</th><td>@DisplayValueHelper.GetString(_job, "JobType")</td></tr>
-                <tr><th>Description</th><td>@DisplayValueHelper.GetString(_job, "Description")</td></tr>
-                <tr><th>Durable</th><td>@DisplayValueHelper.GetString(_job, "Durable")</td></tr>
-                <tr><th>Requests Recovery</th><td>@DisplayValueHelper.GetString(_job, "RequestsRecovery")</td></tr>
-                <tr><th>Disallow Concurrent Execution</th><td>@DisplayValueHelper.GetString(_job, "ConcurrentExecutionDisallowed")</td></tr>
-                <tr><th>Persist JobDataAfterExecution</th><td>@DisplayValueHelper.GetString(_job, "PersistJobDataAfterExecution")</td></tr>
+                <tr><th>Type</th><td>@_job.JobType</td></tr>
+                <tr><th>Description</th><td>@_job.Description</td></tr>
+                <tr><th>Durable</th><td>@_job.Durable</td></tr>
+                <tr><th>Requests Recovery</th><td>@_job.RequestsRecovery</td></tr>
+                <tr><th>Disallow Concurrent Execution</th><td>@_job.ConcurrentExecutionDisallowed</td></tr>
+                <tr><th>Persist JobDataAfterExecution</th><td>@_job.PersistJobDataAfterExecution</td></tr>
             </tbody>
         </table>
 
@@ -115,13 +114,9 @@
                OnCancel="CancelDeleteAsync" />
 
 @code {
-    private static readonly JsonSerializerOptions requestSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
     private bool _isLoading = true;
     private string? _error;
-    private object? _job;
+    private JobDetailDto? _job;
     private readonly List<TriggerHeaderDto> _triggers = [];
     private bool _showDeleteConfirm;
     private JobDataMap _triggerDataMap = new();
@@ -136,7 +131,7 @@
 
     private JobKeyDto JobKey => new(Group, Name);
 
-    private JobDataMap? JobDataMap => DisplayValueHelper.GetJobDataMap(_job, "JobDataMap");
+    private JobDataMap? JobDataMap => _job?.JobDataMap;
 
     protected override async Task OnInitializedAsync()
     {
@@ -227,9 +222,8 @@
 
     private Task TriggerWithDataAsync()
     {
-        JsonElement jobDataMap = JsonSerializer.SerializeToElement(_triggerDataMap, requestSerializerOptions);
         return ExecuteMutatingActionAsync(
-            () => Api.TriggerJobWithData(Scheduler.ActiveSchedulerName!, JobKey, jobDataMap),
+            () => Api.TriggerJobWithData(Scheduler.ActiveSchedulerName!, JobKey, _triggerDataMap),
             "Triggered job " + DisplayValueHelper.FormatKey(Group, Name) + " with overrides.",
             actionName: "TriggerJobWithData",
             target: DisplayValueHelper.FormatKey(Group, Name));

--- a/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
@@ -1,6 +1,4 @@
 @page "/quartz/triggers/{Group}/{Name}"
-@using System.Globalization
-@using System.Text.Json
 @using Microsoft.Extensions.Options
 @using Quartz
 @using Quartz.Dashboard.Components.Shared
@@ -48,12 +46,12 @@
 
         <table class="qz-table">
             <tbody>
-                <tr><th>Type</th><td>@DisplayValueHelper.GetString(_trigger, "TriggerType", "Type")</td></tr>
-                <tr><th>Execution Group</th><td>@(DisplayValueHelper.GetString(_trigger, "ExecutionGroup") is { Length: > 0 } eg ? eg : "\u2014")</td></tr>
-                <tr><th>Description</th><td>@DisplayValueHelper.GetString(_trigger, "Description")</td></tr>
+                <tr><th>Type</th><td>@TriggerDisplay.TypeName(_trigger)</td></tr>
+                <tr><th>Execution Group</th><td>@(_trigger.ExecutionGroup is { Length: > 0 } executionGroup ? executionGroup : "\u2014")</td></tr>
+                <tr><th>Description</th><td>@_trigger.Description</td></tr>
                 <tr><th>Schedule</th><td>@BuildScheduleDescription()</td></tr>
-                <tr><th>Next Fire</th><td>@FormatDate(DisplayValueHelper.GetDateTimeOffset(_trigger, "NextFireTimeUtc", "NextFireTime"))</td></tr>
-                <tr><th>Previous Fire</th><td>@FormatDate(DisplayValueHelper.GetDateTimeOffset(_trigger, "PreviousFireTimeUtc", "PreviousFireTime"))</td></tr>
+                <tr><th>Next Fire</th><td>@FormatDate(_trigger.NextFireTimeUtc)</td></tr>
+                <tr><th>Previous Fire</th><td>@FormatDate(_trigger.PreviousFireTimeUtc)</td></tr>
             </tbody>
         </table>
 
@@ -92,7 +90,7 @@
 @code {
     private bool _isLoading = true;
     private string? _error;
-    private object? _trigger;
+    private ITrigger? _trigger;
     private TriggerState _triggerState = TriggerState.None;
     private bool _showUnscheduleConfirm;
     private string? _cronExpression;
@@ -108,7 +106,7 @@
 
     private TriggerKeyDto TriggerKey => new(Group, Name);
 
-    private JobDataMap? TriggerDataMap => DisplayValueHelper.GetJobDataMap(_trigger, "JobDataMap", "jobDataMap");
+    private JobDataMap? TriggerDataMap => _trigger?.JobDataMap;
 
     protected override async Task OnInitializedAsync()
     {
@@ -142,10 +140,9 @@
                 return;
             }
 
-            TriggerDetailDto detail = await Api.GetTrigger(schedulerName, TriggerKey);
-            _trigger = detail.Value;
+            _trigger = await Api.GetTrigger(schedulerName, TriggerKey);
             _triggerState = await Api.GetTriggerState(schedulerName, TriggerKey);
-            _cronExpression = DisplayValueHelper.GetString(_trigger, "CronExpressionString", "CronExpression");
+            _cronExpression = (_trigger as ICronTrigger)?.CronExpressionString;
             _editedCronExpression = _cronExpression ?? string.Empty;
         }
         catch (Exception ex)
@@ -160,26 +157,12 @@
 
     private string BuildScheduleDescription()
     {
-        string cronExpression = DisplayValueHelper.GetString(_trigger, "CronExpressionString", "CronExpression");
-        if (!string.IsNullOrWhiteSpace(cronExpression))
+        if (_trigger is null)
         {
-            return cronExpression;
+            return string.Empty;
         }
 
-        string repeatInterval = DisplayValueHelper.GetString(_trigger, "RepeatIntervalTimeSpan", "RepeatInterval");
-        if (!string.IsNullOrWhiteSpace(repeatInterval))
-        {
-            string description = "Every " + repeatInterval;
-            string repeatCount = DisplayValueHelper.GetString(_trigger, "RepeatCount");
-            if (int.TryParse(repeatCount, NumberStyles.Integer, CultureInfo.InvariantCulture, out int count))
-            {
-                description += count < 0 ? ", repeat forever" : ", " + count + " time(s)";
-            }
-
-            return description;
-        }
-
-        return DisplayValueHelper.GetString(_trigger, "TriggerType", "Type");
+        return TriggerDisplay.ScheduleSummary(_trigger) ?? TriggerDisplay.TypeName(_trigger);
     }
 
     private string FormatDate(DateTimeOffset? value)
@@ -238,8 +221,7 @@
             return;
         }
 
-        if (_trigger is not JsonElement triggerJson
-            || !TriggerPayloadBuilder.TryWithCronExpression(triggerJson, cronExpression, out JsonElement newTrigger))
+        if (_trigger is null || !TriggerPayloadBuilder.TryWithCronExpression(_trigger, cronExpression, out ITrigger? newTrigger))
         {
             Toasts.Error("This trigger cannot be rescheduled from the dashboard.");
             return;

--- a/src/Quartz.Dashboard/Components/Shared/DisplayValueHelper.cs
+++ b/src/Quartz.Dashboard/Components/Shared/DisplayValueHelper.cs
@@ -17,205 +17,23 @@
  */
 #endregion
 
-using System.Globalization;
-using System.Reflection;
-using System.Text.Json;
-
-using Quartz.Serialization.SystemTextJson;
-
 namespace Quartz.Dashboard.Components.Shared;
 
+/// <summary>
+/// Formatting the dashboard's pages share.
+/// </summary>
+/// <remarks>
+/// This used to read values out of whatever the API client returned by walking JSON properties and
+/// reflecting over properties, because the client's trigger, calendar and job-data members were
+/// untyped. They are <see cref="ITrigger" />, <see cref="ICalendar" /> and <see cref="JobDataMap" />
+/// now, so the pages read them as properties and none of that is needed.
+/// </remarks>
 internal static class DisplayValueHelper
 {
-    /// <summary>
-    /// Options for reading a <see cref="JobDataMap"/> out of an already-serialized payload.
-    /// </summary>
-    /// <remarks>
-    /// The built-in registry is enough here, and deliberately so: this is the only thing these options
-    /// deserialize, and a job data map is read by <c>JobDataMapConverter</c> without ever consulting the
-    /// trigger or calendar converters. A custom trigger or calendar serializer registered in the
-    /// container therefore has nothing to contribute — the places that do need it
-    /// (<c>InProcessQuartzApiClient</c> and the HTTP API) resolve the container's registry instead.
-    /// </remarks>
-    private static readonly JsonSerializerOptions JobDataMapOptions =
-        new JsonSerializerOptions(JsonSerializerDefaults.Web)
-            .AddQuartzConverters(new SystemTextJsonSerializerRegistry(), newtonsoftCompatibilityMode: false);
-
-    public static object? GetObject(object? source, params string[] paths)
-    {
-        if (source is null)
-        {
-            return null;
-        }
-
-        foreach (string path in paths)
-        {
-            if (TryGetPathValue(source, path, out object? value))
-            {
-                return value;
-            }
-        }
-
-        return null;
-    }
-
-    public static JobDataMap? GetJobDataMap(object? source, params string[] paths)
-    {
-        object? value = GetObject(source, paths);
-        if (value is JobDataMap dataMap)
-        {
-            return dataMap;
-        }
-
-        if (value is JsonElement { ValueKind: JsonValueKind.Object } element)
-        {
-            return element.Deserialize<JobDataMap>(JobDataMapOptions);
-        }
-
-        return null;
-    }
-
-    public static string GetString(object? source, params string[] paths)
-    {
-        object? value = GetObject(source, paths);
-        if (value is null)
-        {
-            return string.Empty;
-        }
-
-        if (value is string str)
-        {
-            return str;
-        }
-
-        if (value is JsonElement element)
-        {
-            return element.ToString();
-        }
-
-        if (value is IFormattable formattable)
-        {
-            return formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty;
-        }
-
-        return value.ToString() ?? string.Empty;
-    }
-
-    public static DateTimeOffset? GetDateTimeOffset(object? source, params string[] paths)
-    {
-        object? value = GetObject(source, paths);
-        if (value is null)
-        {
-            return null;
-        }
-
-        if (value is DateTimeOffset dto)
-        {
-            return dto;
-        }
-
-        if (value is DateTime dateTime)
-        {
-            return new DateTimeOffset(dateTime);
-        }
-
-        if (value is string stringValue &&
-            DateTimeOffset.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTimeOffset parsed))
-        {
-            return parsed;
-        }
-
-        if (value is JsonElement jsonElement)
-        {
-            if (jsonElement.ValueKind == JsonValueKind.String &&
-                DateTimeOffset.TryParse(jsonElement.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTimeOffset jsonParsed))
-            {
-                return jsonParsed;
-            }
-        }
-
-        return null;
-    }
-
-    public static IReadOnlyList<object> ToObjectList<T>(IReadOnlyList<T> source)
-    {
-        List<object> result = new(source.Count);
-        foreach (T item in source)
-        {
-            if (item is not null)
-            {
-                result.Add(item);
-            }
-        }
-
-        return result;
-    }
-
     public static string FormatKey(string? group, string? name)
     {
         string safeGroup = string.IsNullOrWhiteSpace(group) ? "DEFAULT" : group;
         string safeName = string.IsNullOrWhiteSpace(name) ? "(unknown)" : name;
         return safeGroup + "." + safeName;
-    }
-
-    private static bool TryGetPathValue(object source, string path, out object? value)
-    {
-        value = source;
-        string[] parts = path.Split('.');
-        foreach (string part in parts)
-        {
-            if (!TryGetMemberValue(value, part, out value))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool TryGetMemberValue(object? source, string memberName, out object? value)
-    {
-        value = null;
-        if (source is null)
-        {
-            return false;
-        }
-
-        if (source is JsonElement jsonElement)
-        {
-            if (jsonElement.ValueKind != JsonValueKind.Object)
-            {
-                return false;
-            }
-
-            if (jsonElement.TryGetProperty(memberName, out JsonElement property))
-            {
-                value = property;
-                return true;
-            }
-
-            foreach (JsonProperty candidate in jsonElement.EnumerateObject())
-            {
-                if (!string.Equals(candidate.Name, memberName, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                value = candidate.Value;
-                return true;
-            }
-
-            return false;
-        }
-
-        Type sourceType = source.GetType();
-        PropertyInfo? propertyInfo = sourceType.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
-        if (propertyInfo is not null)
-        {
-            value = propertyInfo.GetValue(source);
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/Quartz.Dashboard/Components/Shared/TriggerPayloadBuilder.cs
+++ b/src/Quartz.Dashboard/Components/Shared/TriggerPayloadBuilder.cs
@@ -17,101 +17,53 @@
  */
 #endregion
 
-using System.Buffers;
-using System.Text.Json;
+using System.Diagnostics.CodeAnalysis;
+
+using Quartz.Impl.Triggers;
 
 namespace Quartz.Dashboard.Components.Shared;
 
 /// <summary>
-/// Builds the trigger payloads the dashboard posts back to the scheduler by editing the JSON the API
-/// returned, rather than re-assembling a trigger field by field.
+/// Builds the trigger the dashboard posts back when a schedule is edited, by copying the trigger the
+/// API returned and changing only the schedule.
 /// </summary>
 /// <remarks>
-/// Re-assembly silently dropped whatever it did not list. A null calendar name came back as an empty
-/// string, which every job store reads as a calendar it then cannot find, so the trigger stopped
-/// firing (#3294); the node pin was dropped altogether; and the trigger type was hardcoded, so a
-/// custom cron trigger was rewritten as a plain one. Editing the serialized trigger in place keeps
-/// every field the Quartz converters wrote, including ones added later.
+/// Re-assembling the trigger from the fields the page displays silently dropped whatever it did not
+/// list. A null calendar name came back as an empty string, which every job store reads as a calendar
+/// it then cannot find, so the trigger stopped firing (#3294); the node pin was dropped altogether;
+/// and the trigger type was hardcoded, so a custom cron trigger was rewritten as a plain one. Cloning
+/// keeps every field the trigger has, its runtime type included, so a trigger type derived from
+/// <see cref="CronTriggerImpl" /> survives the edit as itself.
 /// </remarks>
 internal static class TriggerPayloadBuilder
 {
-    private const string TriggerTypeProperty = "triggerType";
-    private const string CronExpressionProperty = "cronExpressionString";
-    private const string NextFireTimeProperty = "nextFireTimeUtc";
-
     /// <summary>
-    /// Produces <paramref name="trigger"/> with its cron expression replaced by
-    /// <paramref name="cronExpression"/>, or <see langword="false"/> when the trigger cannot be sent
-    /// back to the scheduler at all.
+    /// Produces <paramref name="trigger" /> with its cron expression replaced by
+    /// <paramref name="cronExpression" />, or <see langword="false" /> when the trigger is not one
+    /// this can faithfully rebuild.
     /// </summary>
-    public static bool TryWithCronExpression(JsonElement trigger, string cronExpression, out JsonElement payload)
+    public static bool TryWithCronExpression(ITrigger trigger, string cronExpression, [NotNullWhen(true)] out ITrigger? payload)
     {
-        if (trigger.ValueKind != JsonValueKind.Object || !HasProperty(trigger, TriggerTypeProperty))
+        ArgumentNullException.ThrowIfNull(trigger);
+
+        // A cron trigger that is not a CronTriggerImpl has a schedule this cannot set without
+        // knowing the type, and guessing means posting back some other trigger than the one on
+        // screen. Refuse it rather than reschedule the wrong thing.
+        if (trigger is not CronTriggerImpl cronTrigger)
         {
-            // A trigger type the Quartz converters do not know is serialized by the API client's
-            // reflection fallback, which omits the discriminator. Such a payload cannot be read
-            // back, so refuse it rather than post something that will not deserialize - or, as the
-            // hand-built payload did, quietly reschedule it as a different trigger type.
-            payload = default;
+            payload = null;
             return false;
         }
 
-        ArrayBufferWriter<byte> buffer = new();
-        using (Utf8JsonWriter writer = new(buffer))
-        {
-            writer.WriteStartObject();
-            bool cronWritten = false;
-            foreach (JsonProperty property in trigger.EnumerateObject())
-            {
-                if (Matches(property.Name, CronExpressionProperty))
-                {
-                    writer.WriteString(property.Name, cronExpression);
-                    cronWritten = true;
-                }
-                else if (Matches(property.Name, NextFireTimeProperty))
-                {
-                    // The schedule just changed, so the stored next fire time belongs to the old
-                    // expression, and RescheduleJob honours a non-null one verbatim. Clearing it
-                    // lets the first fire be computed from the expression the user just entered.
-                    writer.WriteNull(property.Name);
-                }
-                else
-                {
-                    property.WriteTo(writer);
-                }
-            }
+        CronTriggerImpl copy = (CronTriggerImpl) cronTrigger.Clone();
+        copy.CronExpressionString = cronExpression;
 
-            if (!cronWritten)
-            {
-                writer.WriteString(CronExpressionProperty, cronExpression);
-            }
+        // The schedule just changed, so the stored next fire time belongs to the old expression, and
+        // RescheduleJob honours a non-null one verbatim. Clearing it lets the first fire be computed
+        // from the expression the user just entered.
+        copy.NextFireTimeUtc = null;
 
-            writer.WriteEndObject();
-        }
-
-        using JsonDocument document = JsonDocument.Parse(buffer.WrittenMemory);
-        payload = document.RootElement.Clone();
+        payload = copy;
         return true;
     }
-
-    private static bool HasProperty(JsonElement element, string name)
-    {
-        foreach (JsonProperty property in element.EnumerateObject())
-        {
-            if (Matches(property.Name, name))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// The serialized trigger is camelCased today, but the page reads it through
-    /// <see cref="DisplayValueHelper"/>, which tolerates either casing. This does the same so the
-    /// two cannot disagree about which trigger they are looking at.
-    /// </summary>
-    private static bool Matches(string propertyName, string name)
-        => string.Equals(propertyName, name, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Quartz.Dashboard/Hubs/IQuartzDashboardHubClient.cs
+++ b/src/Quartz.Dashboard/Hubs/IQuartzDashboardHubClient.cs
@@ -67,11 +67,16 @@ public sealed record JobEventDto(
     DateTimeOffset FireTimeUtc,
     string? FireInstanceId);
 
+/// <remarks>
+/// <see cref="RunTime" /> is a <see cref="TimeSpan" />, as every other duration on the wire is — it
+/// carries <see cref="IJobExecutionContext.JobRunTime" /> unrounded, where the milliseconds it used to
+/// be threw away everything below one.
+/// </remarks>
 public sealed record JobExecutionResultDto(
     JobKeyDto JobKey,
     TriggerKeyDto TriggerKey,
     DateTimeOffset FireTimeUtc,
-    long RunTimeMs,
+    TimeSpan RunTime,
     bool Vetoed,
     string? ExceptionMessage);
 

--- a/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
@@ -70,7 +70,7 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
                 TriggerGroup: context.Trigger.Key.Group,
                 TriggerName: context.Trigger.Key.Name,
                 FiredAtUtc: context.FireTimeUtc,
-                DurationMs: (long) context.JobRunTime.TotalMilliseconds,
+                Duration: context.JobRunTime,
                 Succeeded: jobException is null,
                 ExceptionMessage: jobException?.Message);
 

--- a/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
@@ -68,7 +68,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
             JobKey: new JobKeyDto(context.JobDetail.Key.Group, context.JobDetail.Key.Name),
             TriggerKey: new TriggerKeyDto(context.Trigger.Key.Group, context.Trigger.Key.Name),
             FireTimeUtc: context.FireTimeUtc,
-            RunTimeMs: (long) context.JobRunTime.TotalMilliseconds,
+            RunTime: context.JobRunTime,
             Vetoed: true,
             ExceptionMessage: null);
 
@@ -81,7 +81,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
             JobKey: new JobKeyDto(context.JobDetail.Key.Group, context.JobDetail.Key.Name),
             TriggerKey: new TriggerKeyDto(context.Trigger.Key.Group, context.Trigger.Key.Name),
             FireTimeUtc: context.FireTimeUtc,
-            RunTimeMs: (long) context.JobRunTime.TotalMilliseconds,
+            RunTime: context.JobRunTime,
             Vetoed: false,
             ExceptionMessage: jobException?.Message);
 

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -77,8 +77,7 @@ public static class QuartzDashboardServiceCollectionExtensions
         services.TryAddScoped<IQuartzApiClient>(static provider => new InProcessQuartzApiClient(
             provider.GetRequiredService<ISchedulerRepository>(),
             provider.GetRequiredService<IOptions<QuartzDashboardOptions>>(),
-            provider.GetRequiredService<IDashboardHistoryStore>(),
-            provider.GetRequiredService<DashboardSerializerOptions>().Deserializer));
+            provider.GetRequiredService<IDashboardHistoryStore>()));
         services.TryAddScoped<SchedulerState>();
         services.TryAddScoped<ToastService>();
         services.TryAddSingleton<IDashboardHistoryStore, DashboardHistoryStore>();

--- a/src/Quartz.Dashboard/Services/DashboardHistoryStore.cs
+++ b/src/Quartz.Dashboard/Services/DashboardHistoryStore.cs
@@ -21,6 +21,10 @@ using System.Collections.Concurrent;
 
 namespace Quartz.Dashboard.Services;
 
+/// <remarks>
+/// <see cref="Duration" /> is a <see cref="TimeSpan" />, as every other duration the dashboard shows
+/// is; it used to be a count of whole milliseconds, which lost every execution shorter than one.
+/// </remarks>
 public sealed record DashboardHistoryEntry(
     string SchedulerName,
     string JobGroup,
@@ -28,7 +32,7 @@ public sealed record DashboardHistoryEntry(
     string TriggerGroup,
     string TriggerName,
     DateTimeOffset FiredAtUtc,
-    long DurationMs,
+    TimeSpan Duration,
     bool Succeeded,
     string? ExceptionMessage);
 

--- a/src/Quartz.Dashboard/Services/DashboardSerializerOptions.cs
+++ b/src/Quartz.Dashboard/Services/DashboardSerializerOptions.cs
@@ -8,11 +8,17 @@ namespace Quartz.Dashboard.Services;
 /// The <see cref="JsonSerializerOptions"/> the dashboard reads and writes Quartz types with, built once.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Only the HTTP-backed client needs these: it is the one that has a wire between it and a scheduler.
+/// The in-process client passes triggers, calendars and job data maps straight through.
+/// </para>
+/// <para>
 /// A singleton because the options are derived purely from the container's
 /// <see cref="SystemTextJsonSerializerRegistry"/>, which is itself a singleton. Building them per request
 /// would allocate a fresh set of converters for every Blazor circuit and, since System.Text.Json caches
 /// type metadata per options instance, re-run converter and metadata resolution for <c>ITrigger</c>,
 /// <c>ICalendar</c> and <c>JobDataMap</c> on the first serialize in each scope.
+/// </para>
 /// </remarks>
 internal sealed class DashboardSerializerOptions
 {

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -17,8 +17,6 @@
  */
 #endregion
 
-using System.Text.Json;
-
 namespace Quartz.Dashboard.Services;
 
 /// <summary>
@@ -26,12 +24,22 @@ namespace Quartz.Dashboard.Services;
 /// API somewhere else.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This is the dashboard's own projection of the HTTP API, not the wire contract itself — it is shaped
 /// for the pages that read it, and it is public so that an application can replace it. It speaks Quartz's
 /// vocabulary throughout: <see cref="TriggerState" /> and <see cref="SchedulerStatus" /> rather than
 /// strings, <see cref="JobKeyDto" /> and <see cref="TriggerKeyDto" /> rather than loose group/name pairs,
-/// and <see cref="PagedQuery" />'s <c>Skip</c>/<c>Take</c> with <see cref="PagedResult{T}" /> rather than
-/// a paging model of its own.
+/// <see cref="PagedQuery" />'s <c>Skip</c>/<c>Take</c> with <see cref="PagedResult{T}" /> rather than
+/// a paging model of its own, and <see cref="ITrigger" />, <see cref="ICalendar" /> and
+/// <see cref="JobDataMap" /> rather than JSON.
+/// </para>
+/// <para>
+/// A trigger and a calendar arrive as themselves because Quartz already owns the polymorphism they
+/// need: the serializer registry maps each kind to its own serializer, custom kinds an application
+/// registered included, and the wire format is that discriminated shape. A DTO family of the
+/// dashboard's own would have to be extended for every trigger kind and would still not describe a
+/// kind it had never heard of.
+/// </para>
 /// </remarks>
 public interface IQuartzApiClient
 {
@@ -84,7 +92,11 @@ public interface IQuartzApiClient
 
     ValueTask TriggerJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
-    ValueTask TriggerJobWithData(string schedulerName, JobKeyDto jobKey, JsonElement jobDataMap, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Triggers the job once, with <paramref name="jobDataMap" /> merged over the job's own data for
+    /// that one firing.
+    /// </summary>
+    ValueTask TriggerJobWithData(string schedulerName, JobKeyDto jobKey, JobDataMap jobDataMap, CancellationToken cancellationToken = default);
 
     ValueTask InterruptJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
@@ -108,7 +120,11 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<PagedResult<TriggerHeaderDto>> GetTriggers(string schedulerName, DashboardTriggerQuery query, CancellationToken cancellationToken = default);
 
-    ValueTask<TriggerDetailDto> GetTrigger(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Returns the trigger itself — a <see cref="ICronTrigger" />, <see cref="ISimpleTrigger" /> or
+    /// whichever kind it is, including one an application registered its own serializer for.
+    /// </summary>
+    ValueTask<ITrigger> GetTrigger(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
 
     ValueTask<TriggerState> GetTriggerState(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
 
@@ -138,7 +154,10 @@ public interface IQuartzApiClient
 
     ValueTask<List<string>> GetCalendarNames(string schedulerName, CancellationToken cancellationToken = default);
 
-    ValueTask<CalendarDetailDto> GetCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Returns the calendar itself, of whichever kind it is.
+    /// </summary>
+    ValueTask<ICalendar> GetCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default);
 
     ValueTask AddCalendar(string schedulerName, AddCalendarRequest request, CancellationToken cancellationToken = default);
 
@@ -220,6 +239,11 @@ public sealed record TriggerHeaderDto(string Group, string Name, string? Executi
     public TriggerState? State { get; init; }
 }
 
+/// <remarks>
+/// <see cref="JobDataMap" /> holds whatever the job was given, of whatever type — but that is exactly
+/// what <see cref="Quartz.JobDataMap" /> is for, and it is what the scheduler hands back, so there is
+/// no honesty to be had from a looser type here.
+/// </remarks>
 public sealed record JobDetailDto(
     string Name,
     string Group,
@@ -229,7 +253,7 @@ public sealed record JobDetailDto(
     bool RequestsRecovery,
     bool ConcurrentExecutionDisallowed,
     bool PersistJobDataAfterExecution,
-    JsonElement JobDataMap);
+    JobDataMap JobDataMap);
 
 /// <summary>
 /// One firing, as the dashboard shows it.
@@ -248,15 +272,17 @@ public sealed record FireInstanceDto(
     DateTimeOffset? ScheduledFireTimeUtc,
     string? ExecutionGroup);
 
-public sealed record TriggerDetailDto(JsonElement Value);
+/// <summary>
+/// A trigger to schedule, and the job it fires when that job is not already stored.
+/// </summary>
+public sealed record ScheduleJobRequest(ITrigger Trigger, JobDetailDto? Job);
 
-public sealed record ScheduleJobRequest(JsonElement Trigger, JobDetailDto? Job);
+/// <summary>
+/// The trigger that replaces the one being rescheduled.
+/// </summary>
+public sealed record RescheduleRequest(ITrigger NewTrigger);
 
-public sealed record RescheduleRequest(JsonElement NewTrigger);
-
-public sealed record CalendarDetailDto(JsonElement Value);
-
-public sealed record AddCalendarRequest(string CalendarName, JsonElement Calendar, bool Replace, bool UpdateTriggers);
+public sealed record AddCalendarRequest(string CalendarName, ICalendar Calendar, bool Replace, bool UpdateTriggers);
 
 public sealed record AddJobRequest(JobDetailDto Job, bool Replace, bool? StoreNonDurableWhileAwaitingScheduling);
 

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -230,14 +230,20 @@ public sealed record JobGroupDto(string Name, bool Paused);
 
 public sealed record TriggerKeyDto(string Group, string Name);
 
-public sealed record TriggerHeaderDto(string Group, string Name, string? ExecutionGroup = null)
-{
-    public string? TriggerType { get; init; }
-
-    public string? ScheduleSummary { get; init; }
-
-    public TriggerState? State { get; init; }
-}
+/// <summary>
+/// One row of a trigger listing: enough to show the trigger without loading it.
+/// </summary>
+/// <remarks>
+/// <see cref="ScheduleSummary" /> is null on the listings that do not load the triggers themselves,
+/// and <see cref="State" /> is null when the listing could not pair the header with a state.
+/// </remarks>
+public sealed record TriggerHeaderDto(
+    string Group,
+    string Name,
+    string? TriggerType,
+    string? ScheduleSummary,
+    TriggerState? State,
+    string? ExecutionGroup);
 
 /// <remarks>
 /// <see cref="JobDataMap" /> holds whatever the job was given, of whatever type — but that is exactly

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -17,52 +17,33 @@
  */
 #endregion
 
-using System.Text.Json;
-
 using Microsoft.Extensions.Options;
 
-using Quartz.Serialization.SystemTextJson;
 using Quartz.Extensibility;
 using Quartz.Util;
 
 namespace Quartz.Dashboard.Services;
 
+/// <remarks>
+/// Nothing here serializes anything. The schedulers are in this process, so a trigger, a calendar and
+/// a job data map travel as themselves; the JSON round trip this client used to make existed only
+/// because the client's contract spoke <c>JsonElement</c>, and it lost every trigger type the
+/// serializer registry did not know.
+/// </remarks>
 internal sealed class InProcessQuartzApiClient : IQuartzApiClient
 {
-    private static readonly JsonSerializerOptions serializerOptions = new()
-    {
-        WriteIndented = false,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-    private readonly JsonSerializerOptions deserializerOptions;
-
     private readonly ISchedulerRepository schedulerRepository;
     private readonly IOptions<QuartzDashboardOptions> options;
     private readonly IDashboardHistoryStore historyStore;
 
-    /// <remarks>
-    /// The dashboard shows every scheduler in the container through one client, so it reads the
-    /// container's <see cref="SystemTextJsonSerializerRegistry"/> rather than any single scheduler's — a
-    /// custom trigger or calendar serializer registered there is what makes a custom type render as
-    /// something other than a reflected blob.
-    /// </remarks>
-    /// <remarks>
-    /// <paramref name="quartzSerializerOptions"/> carries the Quartz converters and is built once from the
-    /// container's registry rather than per scope: this client is scoped, and System.Text.Json caches type
-    /// metadata per options instance.
-    /// </remarks>
     public InProcessQuartzApiClient(
         ISchedulerRepository schedulerRepository,
         IOptions<QuartzDashboardOptions> options,
-        IDashboardHistoryStore historyStore,
-        JsonSerializerOptions quartzSerializerOptions)
+        IDashboardHistoryStore historyStore)
     {
-        ArgumentNullException.ThrowIfNull(quartzSerializerOptions);
-
         this.schedulerRepository = schedulerRepository;
         this.options = options;
         this.historyStore = historyStore;
-        deserializerOptions = quartzSerializerOptions;
     }
 
     public ValueTask<List<SchedulerHeaderDto>> GetSchedulers(CancellationToken cancellationToken = default)
@@ -176,7 +157,6 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
             throw new KeyNotFoundException($"Job '{key.Group}.{key.Name}' was not found in scheduler '{schedulerName}'.");
         }
 
-        JsonElement jobDataMap = JsonSerializer.SerializeToElement(jobDetail.JobDataMap, serializerOptions);
         return new JobDetailDto(
             Name: jobDetail.Key.Name,
             Group: jobDetail.Key.Group,
@@ -186,7 +166,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
             RequestsRecovery: jobDetail.RequestsRecovery,
             ConcurrentExecutionDisallowed: jobDetail.ConcurrentExecutionDisallowed,
             PersistJobDataAfterExecution: jobDetail.PersistJobDataAfterExecution,
-            JobDataMap: jobDataMap);
+            JobDataMap: jobDetail.JobDataMap);
     }
 
     /// <remarks>
@@ -222,8 +202,8 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         {
             result.Add(new TriggerHeaderDto(trigger.Key.Group, trigger.Key.Name, trigger.ExecutionGroup)
             {
-                TriggerType = GetTriggerTypeName(trigger),
-                ScheduleSummary = DescribeSchedule(trigger),
+                TriggerType = TriggerDisplay.TypeName(trigger),
+                ScheduleSummary = TriggerDisplay.ScheduleSummary(trigger),
                 State = states.TryGetValue(trigger.Key, out TriggerState state) ? state : null
             });
         }
@@ -285,12 +265,12 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return scheduler.TriggerJob(AsJobKey(key), cancellationToken: cancellationToken);
     }
 
-    public ValueTask TriggerJobWithData(string schedulerName, JobKeyDto key, JsonElement jobDataMap, CancellationToken cancellationToken = default)
+    public ValueTask TriggerJobWithData(string schedulerName, JobKeyDto key, JobDataMap jobDataMap, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(jobDataMap);
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        JobDataMap triggerDataMap = DeserializeJobDataMap(jobDataMap);
-        return scheduler.TriggerJob(AsJobKey(key), triggerDataMap, cancellationToken);
+        return scheduler.TriggerJob(AsJobKey(key), jobDataMap, cancellationToken);
     }
 
     public async ValueTask InterruptJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
@@ -360,7 +340,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return new PagedResult<TriggerHeaderDto>(items, triggers.HasMore, triggers.TotalCount ?? items.Count);
     }
 
-    public async ValueTask<TriggerDetailDto> GetTrigger(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
+    public async ValueTask<ITrigger> GetTrigger(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
     {
         TriggerKey triggerKey = AsTriggerKey(key);
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
@@ -370,7 +350,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
             throw new KeyNotFoundException($"Trigger '{key.Group}.{key.Name}' was not found in scheduler '{schedulerName}'.");
         }
 
-        return new TriggerDetailDto(SerializeTrigger(trigger));
+        return trigger;
     }
 
     public ValueTask<TriggerState> GetTriggerState(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
@@ -405,14 +385,13 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         ArgumentNullException.ThrowIfNull(request);
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        ITrigger trigger = DeserializeTrigger(request.Trigger);
         if (request.Job is null)
         {
-            return ScheduleTriggerOnly(scheduler, trigger, cancellationToken);
+            return ScheduleTriggerOnly(scheduler, request.Trigger, cancellationToken);
         }
 
         IJobDetail jobDetail = BuildJobDetail(request.Job);
-        return ScheduleJobWithTrigger(scheduler, jobDetail, trigger, cancellationToken);
+        return ScheduleJobWithTrigger(scheduler, jobDetail, request.Trigger, cancellationToken);
     }
 
     public async ValueTask UnscheduleJob(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
@@ -427,8 +406,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         ArgumentNullException.ThrowIfNull(request);
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        ITrigger newTrigger = DeserializeTrigger(request.NewTrigger);
-        return RescheduleTrigger(scheduler, AsTriggerKey(key), newTrigger, cancellationToken);
+        return RescheduleTrigger(scheduler, AsTriggerKey(key), request.NewTrigger, cancellationToken);
     }
 
     public async ValueTask<List<string>> GetCalendarNames(string schedulerName, CancellationToken cancellationToken = default)
@@ -450,7 +428,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         }
     }
 
-    public async ValueTask<CalendarDetailDto> GetCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default)
+    public async ValueTask<ICalendar> GetCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default)
     {
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
         ICalendar? calendar = await scheduler.GetCalendar(calendarName, cancellationToken).ConfigureAwait(false);
@@ -459,8 +437,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
             throw new KeyNotFoundException($"Calendar '{calendarName}' was not found in scheduler '{schedulerName}'.");
         }
 
-        JsonElement calendarJson = JsonSerializer.SerializeToElement<object>(calendar, serializerOptions);
-        return new CalendarDetailDto(calendarJson);
+        return calendar;
     }
 
     public ValueTask AddCalendar(string schedulerName, AddCalendarRequest request, CancellationToken cancellationToken = default)
@@ -468,10 +445,9 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         ArgumentNullException.ThrowIfNull(request);
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        ICalendar calendar = DeserializeCalendar(request.Calendar);
         return scheduler.AddCalendar(
             request.CalendarName,
-            calendar,
+            request.Calendar,
             new AddCalendarOptions { Replace = request.Replace, UpdateTriggers = request.UpdateTriggers },
             cancellationToken);
     }
@@ -488,23 +464,6 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         ArgumentNullException.ThrowIfNull(query);
 
         return await historyStore.GetPage(query, cancellationToken).ConfigureAwait(false);
-    }
-
-    private JsonElement SerializeTrigger(ITrigger trigger)
-    {
-        try
-        {
-            // Use the canonical Quartz converters (same options used for deserialization) so the JSON
-            // exposes TriggerType, schedule fields, JobDataMap and fire times under the property names
-            // the dashboard UI reads. Plain reflection omits most of these.
-            return JsonSerializer.SerializeToElement<object>(trigger, deserializerOptions);
-        }
-        catch (JsonSerializationException)
-        {
-            // Custom trigger types aren't handled by the converter; fall back to a best-effort
-            // reflection serialization so the detail page still renders.
-            return JsonSerializer.SerializeToElement<object>(trigger, serializerOptions);
-        }
     }
 
     private static GroupMatcher<TKey>? BuildGroupMatcher<TKey>(string? groupFilter) where TKey : Key<TKey>
@@ -524,73 +483,14 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return new TriggerKey(key.Name, key.Group);
     }
 
-    private static string GetTriggerTypeName(ITrigger trigger)
-    {
-        return trigger switch
-        {
-            ICronTrigger => "Cron",
-            ISimpleTrigger => "Simple",
-            ICalendarIntervalTrigger => "Calendar interval",
-            IDailyTimeIntervalTrigger => "Daily time interval",
-            _ => trigger.GetType().Name
-        };
-    }
-
-    private static string? DescribeSchedule(ITrigger trigger)
-    {
-        switch (trigger)
-        {
-            case ICronTrigger cron:
-                return cron.CronExpressionString;
-            case ISimpleTrigger simple:
-                string summary = "Every " + simple.RepeatInterval;
-                return summary + (simple.RepeatCount < 0 ? ", repeat forever" : ", " + simple.RepeatCount + " time(s)");
-            default:
-                return null;
-        }
-    }
-
-    private JobDataMap DeserializeJobDataMap(JsonElement element)
-    {
-        if (element.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
-        {
-            return new JobDataMap();
-        }
-
-        JobDataMap? dataMap = element.Deserialize<JobDataMap>(deserializerOptions);
-        return dataMap ?? new JobDataMap();
-    }
-
-    private ITrigger DeserializeTrigger(JsonElement element)
-    {
-        ITrigger? trigger = element.Deserialize<ITrigger>(deserializerOptions);
-        if (trigger is null)
-        {
-            throw new InvalidOperationException("Trigger payload cannot be parsed.");
-        }
-
-        return trigger;
-    }
-
-    private ICalendar DeserializeCalendar(JsonElement element)
-    {
-        ICalendar? calendar = element.Deserialize<ICalendar>(deserializerOptions);
-        if (calendar is null)
-        {
-            throw new InvalidOperationException("Calendar payload cannot be parsed.");
-        }
-
-        return calendar;
-    }
-
-    private IJobDetail BuildJobDetail(JobDetailDto source)
+    private static IJobDetail BuildJobDetail(JobDetailDto source)
     {
         if (string.IsNullOrWhiteSpace(source.JobType))
         {
             throw new InvalidOperationException("Job type is required.");
         }
 
-        JobDataMap jobDataMap = DeserializeJobDataMap(source.JobDataMap);
+        JobDataMap jobDataMap = source.JobDataMap ?? new JobDataMap();
 
         // The type name is stored unresolved on purpose: resolving a name that arrived with the request
         // would have this process probe its assemblies for whatever the caller named. The scheduler

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -200,12 +200,13 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         List<TriggerHeaderDto> result = new(triggers.Count);
         foreach (ITrigger trigger in triggers)
         {
-            result.Add(new TriggerHeaderDto(trigger.Key.Group, trigger.Key.Name, trigger.ExecutionGroup)
-            {
-                TriggerType = TriggerDisplay.TypeName(trigger),
-                ScheduleSummary = TriggerDisplay.ScheduleSummary(trigger),
-                State = states.TryGetValue(trigger.Key, out TriggerState state) ? state : null
-            });
+            result.Add(new TriggerHeaderDto(
+                Group: trigger.Key.Group,
+                Name: trigger.Key.Name,
+                TriggerType: TriggerDisplay.TypeName(trigger),
+                ScheduleSummary: TriggerDisplay.ScheduleSummary(trigger),
+                State: states.TryGetValue(trigger.Key, out TriggerState state) ? state : null,
+                ExecutionGroup: trigger.ExecutionGroup));
         }
 
         return result;
@@ -331,10 +332,16 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         List<TriggerHeaderDto> items = new(triggers.Items.Count);
         foreach (TriggerHeader trigger in triggers.Items)
         {
-            items.Add(new TriggerHeaderDto(trigger.Key.Group, trigger.Key.Name, trigger.ExecutionGroup)
-            {
-                State = trigger.State
-            });
+            // The trigger listing does not load the triggers, so it has no schedule to summarise and
+            // no kind to name: the store's own trigger-type discriminator is not the display name the
+            // associated-triggers table shows, and the two must not disagree.
+            items.Add(new TriggerHeaderDto(
+                Group: trigger.Key.Group,
+                Name: trigger.Key.Name,
+                TriggerType: null,
+                ScheduleSummary: null,
+                State: trigger.State,
+                ExecutionGroup: trigger.ExecutionGroup));
         }
 
         return new PagedResult<TriggerHeaderDto>(items, triggers.HasMore, triggers.TotalCount ?? items.Count);

--- a/src/Quartz.Dashboard/Services/QuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/QuartzApiClient.cs
@@ -36,17 +36,28 @@ internal sealed class QuartzApiClient : IQuartzApiClient
     private readonly IHttpClientFactory httpClientFactory;
     private readonly IHttpContextAccessor httpContextAccessor;
     private readonly IOptions<QuartzDashboardOptions> options;
+    private readonly JsonSerializerOptions quartzSerializerOptions;
     private Uri? cachedBaseAddress;
     private string? cachedCookieHeader;
 
+    /// <remarks>
+    /// <paramref name="serializerOptions"/> carries the Quartz converters, which is what turns the
+    /// wire's discriminated trigger and calendar payloads back into <see cref="ITrigger"/> and
+    /// <see cref="ICalendar"/>. A kind no serializer is registered for cannot be read, and says so
+    /// rather than rendering as an anonymous bag of properties.
+    /// </remarks>
     public QuartzApiClient(
         IHttpClientFactory httpClientFactory,
         IHttpContextAccessor httpContextAccessor,
-        IOptions<QuartzDashboardOptions> options)
+        IOptions<QuartzDashboardOptions> options,
+        DashboardSerializerOptions serializerOptions)
     {
+        ArgumentNullException.ThrowIfNull(serializerOptions);
+
         this.httpClientFactory = httpClientFactory;
         this.httpContextAccessor = httpContextAccessor;
         this.options = options;
+        quartzSerializerOptions = serializerOptions.Deserializer;
     }
 
     public async ValueTask<List<SchedulerHeaderDto>> GetSchedulers(CancellationToken cancellationToken = default)
@@ -166,7 +177,7 @@ internal sealed class QuartzApiClient : IQuartzApiClient
             RequestsRecovery: GetBooleanProperty(json, "requestsRecovery"),
             ConcurrentExecutionDisallowed: GetBooleanProperty(json, "concurrentExecutionDisallowed"),
             PersistJobDataAfterExecution: GetBooleanProperty(json, "persistJobDataAfterExecution"),
-            JobDataMap: GetOptionalProperty(json, "jobDataMap"));
+            JobDataMap: ReadJobDataMap(GetOptionalProperty(json, "jobDataMap")));
     }
 
     /// <remarks>
@@ -288,12 +299,11 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         return Post($"{JobPath(schedulerName, key)}/trigger", body: null, cancellationToken);
     }
 
-    public ValueTask TriggerJobWithData(string schedulerName, JobKeyDto key, JsonElement jobDataMap, CancellationToken cancellationToken = default)
+    public ValueTask TriggerJobWithData(string schedulerName, JobKeyDto key, JobDataMap jobDataMap, CancellationToken cancellationToken = default)
     {
-        object payload = new
-        {
-            JobData = jobDataMap
-        };
+        ArgumentNullException.ThrowIfNull(jobDataMap);
+
+        TriggerJobRequest payload = new(jobDataMap);
         return Post($"{JobPath(schedulerName, key)}/trigger", payload, cancellationToken);
     }
 
@@ -353,10 +363,11 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         return new PagedResult<TriggerHeaderDto>(result, GetBooleanProperty(json, "hasMore"), totalCount);
     }
 
-    public async ValueTask<TriggerDetailDto> GetTrigger(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
+    public async ValueTask<ITrigger> GetTrigger(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
     {
         JsonElement json = await GetJson(TriggerPath(schedulerName, key), cancellationToken).ConfigureAwait(false);
-        return new TriggerDetailDto(json);
+        return json.Deserialize<ITrigger>(quartzSerializerOptions)
+               ?? throw new InvalidOperationException($"Trigger '{key.Group}.{key.Name}' could not be read from the API response.");
     }
 
     public async ValueTask<TriggerState> GetTriggerState(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
@@ -426,10 +437,11 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         }
     }
 
-    public async ValueTask<CalendarDetailDto> GetCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default)
+    public async ValueTask<ICalendar> GetCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default)
     {
         JsonElement json = await GetJson($"{GetSchedulerPath(schedulerName)}/calendars/{Uri.EscapeDataString(calendarName)}", cancellationToken).ConfigureAwait(false);
-        return new CalendarDetailDto(json);
+        return json.Deserialize<ICalendar>(quartzSerializerOptions)
+               ?? throw new InvalidOperationException($"Calendar '{calendarName}' could not be read from the API response.");
     }
 
     public ValueTask AddCalendar(string schedulerName, AddCalendarRequest request, CancellationToken cancellationToken = default)
@@ -575,6 +587,11 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         return await ParseJson(response, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <remarks>
+    /// The body is written with the Quartz converters, because a request carrying a trigger, a
+    /// calendar or a job data map has to travel in the discriminated shape the API reads — reflection
+    /// over the concrete type writes something the server cannot parse back.
+    /// </remarks>
     private async ValueTask Post(string path, object? body = null, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
@@ -587,7 +604,7 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         }
         else
         {
-            response = await client.PostAsJsonAsync(path, body, cancellationToken).ConfigureAwait(false);
+            response = await client.PostAsJsonAsync(path, body, quartzSerializerOptions, cancellationToken).ConfigureAwait(false);
         }
 
         using (response)
@@ -880,6 +897,20 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         }
 
         return value.Clone();
+    }
+
+    /// <summary>
+    /// Reads the <c>jobDataMap</c> member of a job detail body. An absent or null one is an empty map:
+    /// a job with no data is not a job whose data could not be read.
+    /// </summary>
+    private JobDataMap ReadJobDataMap(JsonElement element)
+    {
+        if (element.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+        {
+            return new JobDataMap();
+        }
+
+        return element.Deserialize<JobDataMap>(quartzSerializerOptions) ?? new JobDataMap();
     }
 
     private static string? DescribeSchedule(JsonElement trigger)

--- a/src/Quartz.Dashboard/Services/QuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/QuartzApiClient.cs
@@ -722,32 +722,6 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         };
     }
 
-    private static int GetIntProperty(JsonElement element, string propertyName)
-    {
-        if (element.ValueKind is not JsonValueKind.Object)
-        {
-            return 0;
-        }
-
-        if (!element.TryGetProperty(propertyName, out JsonElement value))
-        {
-            return 0;
-        }
-
-        if (value.ValueKind is JsonValueKind.Number && value.TryGetInt32(out int intValue))
-        {
-            return intValue;
-        }
-
-        if (value.ValueKind is JsonValueKind.String &&
-            int.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedValue))
-        {
-            return parsedValue;
-        }
-
-        return 0;
-    }
-
     private static int? GetNullableIntProperty(JsonElement element, string propertyName)
     {
         if (element.ValueKind is not JsonValueKind.Object)
@@ -919,25 +893,6 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         }
 
         return element.Deserialize<JobDataMap>(quartzSerializerOptions) ?? new JobDataMap();
-    }
-
-    private static string? DescribeSchedule(JsonElement trigger)
-    {
-        string? cron = GetNullableStringProperty(trigger, "cronExpressionString");
-        if (!string.IsNullOrWhiteSpace(cron))
-        {
-            return cron;
-        }
-
-        string? repeatInterval = GetNullableStringProperty(trigger, "repeatIntervalTimeSpan");
-        if (!string.IsNullOrWhiteSpace(repeatInterval))
-        {
-            string summary = "Every " + repeatInterval;
-            int repeatCount = GetIntProperty(trigger, "repeatCount");
-            return summary + (repeatCount < 0 ? ", repeat forever" : ", " + repeatCount + " time(s)");
-        }
-
-        return null;
     }
 
     public async ValueTask<ExecutionLimitsDto?> GetExecutionLimits(string schedulerName, CancellationToken cancellationToken = default)

--- a/src/Quartz.Dashboard/Services/QuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/QuartzApiClient.cs
@@ -182,7 +182,10 @@ internal sealed class QuartzApiClient : IQuartzApiClient
 
     /// <remarks>
     /// The triggers themselves are needed for the schedule summary, and their states come from a single
-    /// trigger listing filtered by job rather than one state request per trigger.
+    /// trigger listing filtered by job rather than one state request per trigger. The kind and the
+    /// summary are read off the trigger by <see cref="TriggerDisplay" />, the same way the in-process
+    /// client reads them — this used to echo the wire's discriminator instead, so the two clients
+    /// called the same trigger <c>CronTrigger</c> and <c>Cron</c>.
     /// </remarks>
     public async ValueTask<List<TriggerHeaderDto>> GetJobTriggers(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
     {
@@ -195,18 +198,21 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         Dictionary<(string Group, string Name), TriggerState?> states = await GetJobTriggerStates(schedulerName, key, cancellationToken).ConfigureAwait(false);
 
         List<TriggerHeaderDto> result = [];
-        foreach (JsonElement trigger in json.EnumerateArray())
+        foreach (JsonElement element in json.EnumerateArray())
         {
-            JsonElement triggerKey = GetOptionalProperty(trigger, "key");
-            string triggerName = GetStringProperty(triggerKey, "name");
-            string triggerGroup = GetStringProperty(triggerKey, "group");
-            string? executionGroup = GetNullableStringProperty(trigger, "executionGroup");
-            result.Add(new TriggerHeaderDto(triggerGroup, triggerName, executionGroup)
+            ITrigger? trigger = element.Deserialize<ITrigger>(quartzSerializerOptions);
+            if (trigger is null)
             {
-                TriggerType = GetNullableStringProperty(trigger, "triggerType"),
-                ScheduleSummary = DescribeSchedule(trigger),
-                State = states.TryGetValue((triggerGroup, triggerName), out TriggerState? state) ? state : null
-            });
+                continue;
+            }
+
+            result.Add(new TriggerHeaderDto(
+                Group: trigger.Key.Group,
+                Name: trigger.Key.Name,
+                TriggerType: TriggerDisplay.TypeName(trigger),
+                ScheduleSummary: TriggerDisplay.ScheduleSummary(trigger),
+                State: states.TryGetValue((trigger.Key.Group, trigger.Key.Name), out TriggerState? state) ? state : null,
+                ExecutionGroup: trigger.ExecutionGroup));
         }
 
         return result;
@@ -349,13 +355,15 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         {
             foreach (JsonElement trigger in items.EnumerateArray())
             {
-                string triggerGroup = GetStringProperty(trigger, "group");
-                string triggerName = GetStringProperty(trigger, "name");
-                string? executionGroup = GetNullableStringProperty(trigger, "executionGroup");
-                result.Add(new TriggerHeaderDto(triggerGroup, triggerName, executionGroup)
-                {
-                    State = GetTriggerStateProperty(trigger, "state")
-                });
+                // A listing does not load the triggers, so there is no schedule to summarise and no
+                // kind to name.
+                result.Add(new TriggerHeaderDto(
+                    Group: GetStringProperty(trigger, "group"),
+                    Name: GetStringProperty(trigger, "name"),
+                    TriggerType: null,
+                    ScheduleSummary: null,
+                    State: GetTriggerStateProperty(trigger, "state"),
+                    ExecutionGroup: GetNullableStringProperty(trigger, "executionGroup")));
             }
         }
 

--- a/src/Quartz.Dashboard/Services/TriggerDisplay.cs
+++ b/src/Quartz.Dashboard/Services/TriggerDisplay.cs
@@ -1,0 +1,59 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz.Dashboard.Services;
+
+/// <summary>
+/// How the dashboard names a trigger's kind and summarises its schedule.
+/// </summary>
+/// <remarks>
+/// One place, so that the listing and the detail page cannot describe the same trigger differently.
+/// </remarks>
+internal static class TriggerDisplay
+{
+    public static string TypeName(ITrigger trigger)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+
+        return trigger switch
+        {
+            ICronTrigger => "Cron",
+            ISimpleTrigger => "Simple",
+            ICalendarIntervalTrigger => "Calendar interval",
+            IDailyTimeIntervalTrigger => "Daily time interval",
+            _ => trigger.GetType().Name
+        };
+    }
+
+    public static string? ScheduleSummary(ITrigger trigger)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+
+        switch (trigger)
+        {
+            case ICronTrigger cron:
+                return cron.CronExpressionString;
+            case ISimpleTrigger simple:
+                string summary = "Every " + simple.RepeatInterval;
+                return summary + (simple.RepeatCount < 0 ? ", repeat forever" : ", " + simple.RepeatCount + " time(s)");
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Quartz.HttpClient/HttpClientExtensions.cs
+++ b/src/Quartz.HttpClient/HttpClientExtensions.cs
@@ -173,12 +173,20 @@ internal static class HttpClientExtensions
             return false;
         }
 
-        // If scheduler throws exception, Web API will return bad request with exception type
-        if (response.StatusCode == HttpStatusCode.BadRequest && (problemDetails.Extensions?.ContainsKey(HttpApiConstants.ProblemDetailsExceptionType) ?? false))
+        // Every error body names the exception type the server raised, whichever layer produced it,
+        // so a bad request a scheduler raised is rethrown here as the same exception. Any other name -
+        // a request the endpoint rejected before it reached the scheduler, or a server that is not
+        // this one - is opaque, and reported as such.
+        if (response.StatusCode == HttpStatusCode.BadRequest)
         {
-            // Might not be the best way to do this...
-            var quartzExceptionName = problemDetails.Extensions[HttpApiConstants.ProblemDetailsExceptionType].GetString();
-            throw quartzExceptionName switch
+            string? exceptionType = null;
+            if (problemDetails.Extensions is not null &&
+                problemDetails.Extensions.TryGetValue(HttpApiConstants.ProblemDetailsExceptionType, out JsonElement exceptionTypeElement))
+            {
+                exceptionType = exceptionTypeElement.GetString();
+            }
+
+            throw exceptionType switch
             {
                 nameof(SchedulerException) => new SchedulerException(problemDetails.Detail),
                 nameof(InvalidConfigurationException) => new InvalidConfigurationException(problemDetails.Detail),
@@ -188,13 +196,8 @@ internal static class HttpClientExtensions
                 nameof(LockException) => new LockException(problemDetails.Detail),
                 nameof(NoSuchDelegateException) => new NoSuchDelegateException(problemDetails.Detail),
                 nameof(ObjectAlreadyExistsException) => new ObjectAlreadyExistsException(problemDetails.Detail),
-                _ => new HttpClientException(problemDetails.Detail)
+                _ => new HttpClientException($"Received response with bad request status code: {problemDetails.Detail}")
             };
-        }
-
-        if (response.StatusCode == HttpStatusCode.BadRequest)
-        {
-            throw new HttpClientException($"Received response with bad request status code: {problemDetails.Detail}");
         }
 
         throw new HttpClientException($"Received response with status code {response.StatusCode}, error details: {problemDetails.Detail}");

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -269,14 +269,14 @@ public sealed class HttpScheduler : IScheduler
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
 
-        var result = await httpClient.PostWithResponse<UnscheduleJobsRequest, OperationAppliedResponse>(
+        var result = await httpClient.PostWithResponse<UnscheduleJobsRequest, AllKeysFoundResponse>(
             $"{TriggerEndpointUrl()}/unschedule",
             new UnscheduleJobsRequest(triggerKeys.Select(KeyDto.Create).ToArray()),
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        return result.Applied;
+        return result.AllFound;
     }
 
     public async ValueTask<DateTimeOffset?> RescheduleJob(TriggerKey triggerKey, ITrigger newTrigger, CancellationToken cancellationToken = default)
@@ -376,14 +376,14 @@ public sealed class HttpScheduler : IScheduler
     {
         ArgumentNullException.ThrowIfNull(jobKeys);
 
-        var result = await httpClient.PostWithResponse<DeleteJobsRequest, OperationAppliedResponse>(
+        var result = await httpClient.PostWithResponse<DeleteJobsRequest, AllKeysFoundResponse>(
             $"{JobEndpointUrl()}/delete",
             new DeleteJobsRequest(jobKeys.Select(KeyDto.Create).ToArray()),
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        return result.Applied;
+        return result.AllFound;
     }
 
     public ValueTask TriggerJob(JobKey jobKey, JobDataMap? data = null, CancellationToken cancellationToken = default)

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -256,27 +256,27 @@ public sealed class HttpScheduler : IScheduler
 
     public async ValueTask<bool> UnscheduleJob(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        var result = await httpClient.PostWithResponse<UnscheduleJobResponse>(
+        var result = await httpClient.PostWithResponse<OperationAppliedResponse>(
             $"{TriggerEndpointUrl(triggerKey)}/unschedule",
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        return result.TriggerFound;
+        return result.Applied;
     }
 
     public async ValueTask<bool> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
 
-        var result = await httpClient.PostWithResponse<UnscheduleJobsRequest, UnscheduleJobsResponse>(
+        var result = await httpClient.PostWithResponse<UnscheduleJobsRequest, OperationAppliedResponse>(
             $"{TriggerEndpointUrl()}/unschedule",
             new UnscheduleJobsRequest(triggerKeys.Select(KeyDto.Create).ToArray()),
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        return result.AllTriggersFound;
+        return result.Applied;
     }
 
     public async ValueTask<DateTimeOffset?> RescheduleJob(TriggerKey triggerKey, ITrigger newTrigger, CancellationToken cancellationToken = default)
@@ -368,22 +368,22 @@ public sealed class HttpScheduler : IScheduler
 
     public async ValueTask<bool> DeleteJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        var result = await httpClient.DeleteWithResponse<DeleteJobResponse>($"{JobEndpointUrl(jobKey)}", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
-        return result.JobFound;
+        var result = await httpClient.DeleteWithResponse<OperationAppliedResponse>($"{JobEndpointUrl(jobKey)}", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+        return result.Applied;
     }
 
     public async ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobKeys);
 
-        var result = await httpClient.PostWithResponse<DeleteJobsRequest, DeleteJobsResponse>(
+        var result = await httpClient.PostWithResponse<DeleteJobsRequest, OperationAppliedResponse>(
             $"{JobEndpointUrl()}/delete",
             new DeleteJobsRequest(jobKeys.Select(KeyDto.Create).ToArray()),
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        return result.AllJobsFound;
+        return result.Applied;
     }
 
     public ValueTask TriggerJob(JobKey jobKey, JobDataMap? data = null, CancellationToken cancellationToken = default)
@@ -711,8 +711,8 @@ public sealed class HttpScheduler : IScheduler
 
     public async ValueTask<bool> DeleteCalendar(string calendarName, CancellationToken cancellationToken = default)
     {
-        var result = await httpClient.DeleteWithResponse<DeleteCalendarResponse>(CalendarEndpointUrl(calendarName), jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
-        return result.CalendarFound;
+        var result = await httpClient.DeleteWithResponse<OperationAppliedResponse>(CalendarEndpointUrl(calendarName), jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+        return result.Applied;
     }
 
     public ValueTask<ICalendar?> GetCalendar(string calendarName, CancellationToken cancellationToken = default)
@@ -722,8 +722,8 @@ public sealed class HttpScheduler : IScheduler
 
     public async ValueTask<bool> Interrupt(JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostWithResponse<InterruptResponse>($"{JobEndpointUrl(jobKey)}/interrupt", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
-        return response.Interrupted;
+        var response = await httpClient.PostWithResponse<OperationAppliedResponse>($"{JobEndpointUrl(jobKey)}/interrupt", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+        return response.Applied;
     }
 
     public async ValueTask<bool> InterruptFireInstance(string fireInstanceId, CancellationToken cancellationToken = default)
@@ -733,13 +733,13 @@ public sealed class HttpScheduler : IScheduler
             throw new ArgumentException("Fire instance id required", nameof(fireInstanceId));
         }
 
-        var response = await httpClient.PostWithResponse<InterruptResponse>(
+        var response = await httpClient.PostWithResponse<OperationAppliedResponse>(
             $"{JobEndpointUrl()}/interrupt/{fireInstanceId}",
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        return response.Interrupted;
+        return response.Applied;
     }
 
     public async ValueTask<bool> Exists(JobKey jobKey, CancellationToken cancellationToken = default)

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -164,8 +164,8 @@ public sealed class HttpScheduler : IScheduler
 
     public ValueTask StartDelayed(TimeSpan delay, CancellationToken cancellationToken = default)
     {
-        var delayMilliseconds = (long) Math.Round(delay.TotalMilliseconds);
-        return httpClient.Post($"{SchedulerEndpointUrl()}/start?delayMilliseconds={delayMilliseconds}", jsonSerializerOptions, cancellationToken);
+        // "c" is the invariant round-trip form, which is what the endpoint parses the parameter with.
+        return httpClient.Post($"{SchedulerEndpointUrl()}/start?delay={delay.ToString("c")}", jsonSerializerOptions, cancellationToken);
     }
 
     public ValueTask Standby(CancellationToken cancellationToken = default)

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardDurationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardDurationTest.cs
@@ -1,0 +1,167 @@
+using FakeItEasy;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Dashboard.Hubs;
+using Quartz.Dashboard.Plugins;
+using Quartz.Dashboard.Services;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// How long a job took, from the execution context to the two places the dashboard reports it.
+/// </summary>
+/// <remarks>
+/// Both used to count whole milliseconds, so an execution shorter than one was recorded as having
+/// taken no time at all. They carry <see cref="IJobExecutionContext.JobRunTime" /> as a
+/// <see cref="TimeSpan" /> now, and these tests are what says the sub-millisecond part survives.
+/// </remarks>
+public class DashboardDurationTest
+{
+    private static readonly TimeSpan SubMillisecond = TimeSpan.FromTicks(4_567);
+
+    [Test]
+    public async Task HistoryPluginRecordsTheRunTimeItWasGiven()
+    {
+        DashboardHistoryStore store = new();
+        IScheduler scheduler = SchedulerWith(store);
+
+        DashboardHistoryPlugin plugin = new();
+        await plugin.Initialize("history", scheduler);
+        await plugin.JobWasExecuted(ExecutionContext(scheduler, SubMillisecond), jobException: null);
+
+        PagedResult<DashboardHistoryEntry> page = await store.GetPage(new DashboardHistoryQuery { SchedulerName = "TestScheduler" });
+
+        DashboardHistoryEntry entry = page.Items.Should().ContainSingle().Subject;
+        entry.Duration.Should().Be(SubMillisecond,
+            "a whole-millisecond count recorded this execution as having taken no time at all");
+        entry.Succeeded.Should().BeTrue();
+        entry.JobName.Should().Be("DummyJob");
+        entry.TriggerGroup.Should().Be("DummyTriggerGroup");
+    }
+
+    [Test]
+    public async Task HistoryPluginRecordsTheFailureAndItsMessage()
+    {
+        DashboardHistoryStore store = new();
+        IScheduler scheduler = SchedulerWith(store);
+
+        DashboardHistoryPlugin plugin = new();
+        await plugin.Initialize("history", scheduler);
+        await plugin.JobWasExecuted(
+            ExecutionContext(scheduler, TimeSpan.FromSeconds(2)),
+            new JobExecutionException("the job threw"));
+
+        DashboardHistoryEntry entry = (await store.GetPage(new DashboardHistoryQuery { SchedulerName = "TestScheduler" }))
+            .Items.Should().ContainSingle().Subject;
+
+        entry.Succeeded.Should().BeFalse();
+        entry.ExceptionMessage.Should().Contain("the job threw");
+        entry.Duration.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    /// <summary>
+    /// The live-events plugin builds its payload before it looks for a hub, so a scheduler with no hub
+    /// registered still exercises the mapping — which is the part that changed.
+    /// </summary>
+    [Test]
+    public async Task LiveEventsPluginSurvivesHavingNoHubToBroadcastTo()
+    {
+        IScheduler scheduler = SchedulerWith(new DashboardHistoryStore());
+
+        DashboardLiveEventsPlugin plugin = new();
+        await plugin.Initialize("live", scheduler);
+
+        Func<Task> executed = async () =>
+            await plugin.JobWasExecuted(ExecutionContext(scheduler, SubMillisecond), jobException: null);
+        Func<Task> vetoed = async () =>
+            await plugin.JobExecutionVetoed(ExecutionContext(scheduler, SubMillisecond));
+
+        await executed.Should().NotThrowAsync("dashboard events are not worth failing a job execution over");
+        await vetoed.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public void JobExecutionResultCarriesTheRunTimeAsATimeSpan()
+    {
+        JobExecutionResultDto result = new(
+            JobKey: new JobKeyDto("group", "job"),
+            TriggerKey: new TriggerKeyDto("group", "trigger"),
+            FireTimeUtc: new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            RunTime: SubMillisecond,
+            Vetoed: false,
+            ExceptionMessage: null);
+
+        result.RunTime.Should().Be(SubMillisecond);
+    }
+
+    [Test]
+    public async Task HistoryPageIsNewestFirstAndCountsTheWholeMatch()
+    {
+        DashboardHistoryStore store = new();
+        for (int i = 0; i < 5; i++)
+        {
+            await store.Add(EntryAt(new DateTimeOffset(2025, 1, 1, 0, 0, i, TimeSpan.Zero), "job" + i));
+        }
+
+        PagedResult<DashboardHistoryEntry> page = await store.GetPage(
+            new DashboardHistoryQuery { SchedulerName = "TestScheduler", Take = 2 });
+
+        page.Items.Select(x => x.JobName).Should().Equal(["job4", "job3"], "history reads newest first");
+        page.HasMore.Should().BeTrue();
+        page.TotalCount.Should().Be(5, "the total counts the whole match, not the page");
+
+        PagedResult<DashboardHistoryEntry> filtered = await store.GetPage(
+            new DashboardHistoryQuery { SchedulerName = "TestScheduler", JobFilter = "job2" });
+
+        filtered.Items.Should().ContainSingle().Which.JobName.Should().Be("job2");
+    }
+
+    private static DashboardHistoryEntry EntryAt(DateTimeOffset firedAt, string jobName) => new(
+        SchedulerName: "TestScheduler",
+        JobGroup: "DummyGroup",
+        JobName: jobName,
+        TriggerGroup: "DummyTriggerGroup",
+        TriggerName: "DummyTrigger",
+        FiredAtUtc: firedAt,
+        Duration: SubMillisecond,
+        Succeeded: true,
+        ExceptionMessage: null);
+
+    /// <remarks>
+    /// The plugins reach their services through the scheduler context, the way the dashboard's own
+    /// registration puts them there.
+    /// </remarks>
+    private static IScheduler SchedulerWith(IDashboardHistoryStore store)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton(store);
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        SchedulerContext context = new() { ["Quartz.ServiceProvider"] = provider };
+
+        IScheduler scheduler = A.Fake<IScheduler>();
+        A.CallTo(() => scheduler.SchedulerName).Returns("TestScheduler");
+        A.CallTo(() => scheduler.Context).Returns(context);
+        A.CallTo(() => scheduler.ListenerManager).Returns(A.Fake<IListenerManager>());
+        return scheduler;
+    }
+
+    private static IJobExecutionContext ExecutionContext(IScheduler scheduler, TimeSpan runTime)
+    {
+        IJobExecutionContext context = A.Fake<IJobExecutionContext>();
+        A.CallTo(() => context.Scheduler).Returns(scheduler);
+        A.CallTo(() => context.JobDetail).Returns(
+            JobBuilder.Create<DummyJob>().WithIdentity("DummyJob", "DummyGroup").Build());
+        A.CallTo(() => context.Trigger).Returns(
+            TriggerBuilder.Create()
+                .WithIdentity("DummyTrigger", "DummyTriggerGroup")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)))
+                .Build());
+        A.CallTo(() => context.FireTimeUtc).Returns(new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        A.CallTo(() => context.JobRunTime).Returns(runTime);
+        A.CallTo(() => context.FireInstanceId).Returns("fire-1");
+        return context;
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -128,6 +128,11 @@ public class InProcessQuartzApiClientTest
             CronCalendar cronCalendar = stored.Should().BeOfType<CronCalendar>().Subject;
             cronCalendar.CronExpression.CronExpressionString.Should().Be("0 0 3 * * ?");
             cronCalendar.Description.Should().Be("maintenance window");
+
+            // and the detail page reads the calendar itself back, not a rendering of one
+            ICalendar readBack = await client.GetCalendar(scheduler.SchedulerName, "maintenance");
+            readBack.Should().BeOfType<CronCalendar>()
+                .Which.CronExpression.CronExpressionString.Should().Be("0 0 3 * * ?");
         }
         finally
         {
@@ -359,6 +364,122 @@ public class InProcessQuartzApiClientTest
             PagedResult<TriggerHeaderDto> errorCount = await client.GetTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Take = 0, State = TriggerState.Error });
             errorCount.Items.Should().BeEmpty();
             errorCount.TotalCount.Should().Be(0, "no trigger has failed, and the error tile reports that exactly");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task ScheduleJobStoresTheJobAndTheTriggerItWasGiven()
+    {
+        IScheduler scheduler = await CreateScheduler("ScheduleJobTest");
+        try
+        {
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            JobDetailDto job = new(
+                Name: "job1",
+                Group: "group1",
+                JobType: typeof(NoOpJob).FullName!,
+                Description: "scheduled from the dashboard",
+                Durable: true,
+                RequestsRecovery: false,
+                ConcurrentExecutionDisallowed: false,
+                PersistJobDataAfterExecution: false,
+                JobDataMap: new JobDataMap { ["colour"] = "green" });
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger1", "group1")
+                .ForJob("job1", "group1")
+                .WithCronSchedule("0 0 1 * * ?")
+                .Build();
+
+            await client.ScheduleJob(scheduler.SchedulerName, new ScheduleJobRequest(trigger, job));
+
+            IJobDetail? stored = await scheduler.GetJobDetail(new JobKey("job1", "group1"));
+            stored.Should().NotBeNull();
+            stored!.Description.Should().Be("scheduled from the dashboard");
+            stored.JobDataMap["colour"].Should().Be("green", "the map travels as a JobDataMap, not as re-parsed JSON");
+            (await scheduler.GetTrigger(new TriggerKey("trigger1", "group1"))).Should().NotBeNull();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task ScheduleJobWithNoJobSchedulesTheTriggerAgainstAStoredJob()
+    {
+        IScheduler scheduler = await CreateScheduler("ScheduleTriggerOnlyTest");
+        try
+        {
+            JobKey jobKey = new("job1", "group1");
+            await scheduler.AddJob(
+                JobBuilder.Create<NoOpJob>().WithIdentity(jobKey).StoreDurably().Build(),
+                new AddJobOptions { Replace = true });
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger1", "group1")
+                .ForJob(jobKey)
+                .WithCronSchedule("0 0 1 * * ?")
+                .Build();
+
+            await client.ScheduleJob(scheduler.SchedulerName, new ScheduleJobRequest(trigger, Job: null));
+
+            (await scheduler.GetTrigger(new TriggerKey("trigger1", "group1"))).Should().NotBeNull(
+                "a request with no job detail schedules against the job already stored");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task TriggerJobWithDataPassesTheOverridesStraightThrough()
+    {
+        IScheduler scheduler = await CreateScheduler("TriggerWithDataTest");
+        try
+        {
+            JobKey jobKey = new("job1", "group1");
+            await scheduler.AddJob(
+                JobBuilder.Create<NoOpJob>().WithIdentity(jobKey).StoreDurably().Build(),
+                new AddJobOptions { Replace = true });
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            // in process there is no serializer between the page and the scheduler, so a value keeps
+            // the type it was given rather than the one a JSON reader would have guessed
+            JobDataMap overrides = new() { ["Count"] = 5 };
+            await client.TriggerJobWithData(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name), overrides);
+
+            PagedResult<TriggerHeader> triggers = await scheduler.QueryTriggers(new TriggerQuery { Job = jobKey });
+            triggers.Items.Should().ContainSingle("triggering a job now schedules the one-off trigger that fires it");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task GetCalendarThrowsForACalendarThatIsNotThere()
+    {
+        IScheduler scheduler = await CreateScheduler("GetMissingCalendarTest");
+        try
+        {
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            Func<Task> act = async () => await client.GetCalendar(scheduler.SchedulerName, "no-such-calendar");
+
+            await act.Should().ThrowAsync<KeyNotFoundException>()
+                .WithMessage("*no-such-calendar*",
+                    "the detail page shows the message, so it has to name what was missing");
         }
         finally
         {

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -1,5 +1,4 @@
 using System.Collections.Specialized;
-using System.Text.Json;
 
 using Microsoft.Extensions.Options;
 
@@ -8,22 +7,16 @@ using Quartz.Dashboard.Services;
 using Quartz.Impl;
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
-using Quartz.Serialization.SystemTextJson;
 
 namespace Quartz.Tests.AspNetCore.Dashboard;
 
 public class InProcessQuartzApiClientTest
 {
-    private static readonly JsonSerializerOptions requestSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     [Test]
-    public async Task RescheduleJobShouldAcceptCronTriggerPayload()
+    public async Task RescheduleJobStoresTheTriggerItWasGiven()
     {
-        // regression test for #3094 - rescheduling from the dashboard failed because the
-        // Quartz JSON converters were never registered and ITrigger could not be deserialized
+        // #3094 was this client failing to parse a trigger out of JSON. In-process there is no JSON:
+        // the request carries the trigger, and the client hands it to the scheduler as it stands.
         IScheduler scheduler = await CreateScheduler("RescheduleJobTest");
         try
         {
@@ -42,27 +35,15 @@ public class InProcessQuartzApiClientTest
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            // a hand-written payload, to pin the shape the HTTP API accepts independently of
-            // whatever TriggerDetail.razor happens to send
-            object payload = new
-            {
-                triggerType = "CronTrigger",
-                key = new { name = triggerKey.Name, group = triggerKey.Group },
-                jobKey = new { name = jobKey.Name, group = jobKey.Group },
-                description = "updated by dashboard",
-                calendarName = (string?) null,
-                jobDataMap = new Dictionary<string, object>(),
-                misfireInstruction = 0,
-                startTimeUtc = DateTimeOffset.UtcNow,
-                endTimeUtc = (DateTimeOffset?) null,
-                priority = 5,
-                timeZone = TimeZoneInfo.Utc.Id,
-                cronExpressionString = "0 0 2 * * ?",
-                executionGroup = "imports"
-            };
-            RescheduleRequest request = new(JsonSerializer.SerializeToElement(payload, requestSerializerOptions));
+            ITrigger replacement = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .WithDescription("updated by dashboard")
+                .WithExecutionGroup("imports")
+                .WithCronSchedule("0 0 2 * * ?")
+                .Build();
 
-            await client.RescheduleJob(scheduler.SchedulerName, new TriggerKeyDto(triggerKey.Group, triggerKey.Name), request);
+            await client.RescheduleJob(scheduler.SchedulerName, new TriggerKeyDto(triggerKey.Group, triggerKey.Name), new RescheduleRequest(replacement));
 
             ITrigger? updated = await scheduler.GetTrigger(triggerKey);
             CronTriggerImpl cronTrigger = updated.Should().BeOfType<CronTriggerImpl>().Subject;
@@ -104,11 +85,11 @@ public class InProcessQuartzApiClientTest
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
             // exactly what TriggerDetail.razor does: read the trigger, then edit its cron expression
-            TriggerDetailDto detail = await client.GetTrigger(scheduler.SchedulerName, new TriggerKeyDto(triggerKey.Group, triggerKey.Name));
-            TriggerPayloadBuilder.TryWithCronExpression(detail.Value, "0 0 2 * * ?", out JsonElement newTrigger)
+            ITrigger detail = await client.GetTrigger(scheduler.SchedulerName, new TriggerKeyDto(triggerKey.Group, triggerKey.Name));
+            TriggerPayloadBuilder.TryWithCronExpression(detail, "0 0 2 * * ?", out ITrigger? newTrigger)
                 .Should().BeTrue();
 
-            await client.RescheduleJob(scheduler.SchedulerName, new TriggerKeyDto(triggerKey.Group, triggerKey.Name), new RescheduleRequest(newTrigger));
+            await client.RescheduleJob(scheduler.SchedulerName, new TriggerKeyDto(triggerKey.Group, triggerKey.Name), new RescheduleRequest(newTrigger!));
 
             ITrigger? updated = await scheduler.GetTrigger(triggerKey);
             CronTriggerImpl cronTrigger = updated.Should().BeOfType<CronTriggerImpl>().Subject;
@@ -127,33 +108,24 @@ public class InProcessQuartzApiClientTest
     }
 
     [Test]
-    public async Task AddCalendarShouldAcceptCronCalendarPayload()
+    public async Task AddCalendarStoresTheCalendarItWasGiven()
     {
-        // the calendar deserialization path was broken the same way as reschedule (#3094)
         IScheduler scheduler = await CreateScheduler("AddCalendarTest");
         try
         {
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            // payload mirrors Calendars.razor calendarPayload
-            object payload = new
+            // the calendar Calendars.razor builds
+            CronCalendar calendar = new(baseCalendar: null, "0 0 3 * * ?", TimeZoneInfo.Utc)
             {
-                type = "CronCalendar",
-                description = "maintenance window",
-                timeZoneId = TimeZoneInfo.Utc.Id,
-                baseCalendar = (object?) null,
-                cronExpressionString = "0 0 3 * * ?"
+                Description = "maintenance window"
             };
-            AddCalendarRequest request = new(
-                "maintenance",
-                JsonSerializer.SerializeToElement(payload, requestSerializerOptions),
-                Replace: false,
-                UpdateTriggers: false);
+            AddCalendarRequest request = new("maintenance", calendar, Replace: false, UpdateTriggers: false);
 
             await client.AddCalendar(scheduler.SchedulerName, request);
 
-            ICalendar? calendar = await scheduler.GetCalendar("maintenance");
-            CronCalendar cronCalendar = calendar.Should().BeOfType<CronCalendar>().Subject;
+            ICalendar? stored = await scheduler.GetCalendar("maintenance");
+            CronCalendar cronCalendar = stored.Should().BeOfType<CronCalendar>().Subject;
             cronCalendar.CronExpression.CronExpressionString.Should().Be("0 0 3 * * ?");
             cronCalendar.Description.Should().Be("maintenance window");
         }
@@ -164,10 +136,11 @@ public class InProcessQuartzApiClientTest
     }
 
     [Test]
-    public async Task GetJobExposesJobDataMapThatConvertsBackToJobDataMap()
+    public async Task GetJobReturnsTheJobDataMapWithItsValuesAsTheyWereStored()
     {
-        // regression test for #3130 - JobDetail.razor cast the JsonElement directly to JobDataMap,
-        // which always produced null. DisplayValueHelper.GetJobDataMap now performs the conversion.
+        // #3130 was the detail page casting a JsonElement to JobDataMap and always getting null. The
+        // map is a JobDataMap on the way out now, so an int is an int and a bool is a bool - reading
+        // it back out of JSON turned every value into whatever the reader guessed.
         IScheduler scheduler = await CreateScheduler("GetJobDataMapTest");
         try
         {
@@ -184,13 +157,9 @@ public class InProcessQuartzApiClientTest
             InProcessQuartzApiClient client = CreateClient(scheduler);
             JobDetailDto dto = await client.GetJob(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name));
 
-            dto.JobDataMap.GetProperty("Name").GetString().Should().Be("abc");
-
-            JobDataMap? map = DisplayValueHelper.GetJobDataMap(dto, "JobDataMap");
-            map.Should().NotBeNull();
-            map!["Name"].Should().Be("abc");
-            map["Count"].Should().Be(5);
-            map["Enabled"].Should().Be(true);
+            dto.JobDataMap["Name"].Should().Be("abc");
+            dto.JobDataMap["Count"].Should().Be(5);
+            dto.JobDataMap["Enabled"].Should().Be(true);
         }
         finally
         {
@@ -199,11 +168,11 @@ public class InProcessQuartzApiClientTest
     }
 
     [Test]
-    public async Task GetTriggerForSimpleTriggerIncludesTypeScheduleAndJobDataMap()
+    public async Task GetTriggerReturnsTheTriggerItself()
     {
-        // regression test for #3130 - simple triggers were serialized via plain reflection, so the
-        // detail page was missing TriggerType / schedule / JobDataMap. GetTrigger now uses the
-        // canonical Quartz converters.
+        // #3130 was the detail page missing type, schedule and job data because the trigger had been
+        // reflected into JSON. There is no JSON in the way now: the page gets the trigger, and reads
+        // the schedule off the interface its kind implements.
         IScheduler scheduler = await CreateScheduler("GetSimpleTriggerTest");
         try
         {
@@ -219,14 +188,13 @@ public class InProcessQuartzApiClientTest
             await scheduler.ScheduleJob(job, trigger);
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
-            TriggerDetailDto detail = await client.GetTrigger(scheduler.SchedulerName, new TriggerKeyDto(triggerKey.Group, triggerKey.Name));
+            ITrigger detail = await client.GetTrigger(scheduler.SchedulerName, new TriggerKeyDto(triggerKey.Group, triggerKey.Name));
 
-            JsonElement value = detail.Value;
-            value.GetProperty("triggerType").GetString().Should().Be("SimpleTrigger");
-            value.GetProperty("jobDataMap").GetProperty("Color").GetString().Should().Be("red");
-            value.TryGetProperty("repeatIntervalTimeSpan", out _).Should().BeTrue();
-
-            DisplayValueHelper.GetJobDataMap(value, "JobDataMap", "jobDataMap")!["Color"].Should().Be("red");
+            ISimpleTrigger simple = detail.Should().BeAssignableTo<ISimpleTrigger>().Subject;
+            simple.RepeatInterval.Should().Be(TimeSpan.FromSeconds(30));
+            simple.RepeatCount.Should().Be(3);
+            detail.JobDataMap["Color"].Should().Be("red");
+            TriggerDisplay.TypeName(detail).Should().Be("Simple");
         }
         finally
         {
@@ -440,8 +408,7 @@ public class InProcessQuartzApiClientTest
         return new InProcessQuartzApiClient(
             repository,
             Options.Create(new QuartzDashboardOptions()),
-            new DashboardHistoryStore(),
-            new DashboardSerializerOptions(new SystemTextJsonSerializerRegistry()).Deserializer);
+            new DashboardHistoryStore());
     }
 
     private sealed class NoOpJob : IJob

--- a/src/Quartz.Tests.AspNetCore/Dashboard/QuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/QuartzApiClientTest.cs
@@ -124,6 +124,121 @@ public class QuartzApiClientTest : WebApiTest
             .MustHaveHappenedOnceExactly();
     }
 
+    [Test]
+    public async Task GetJobReadsAnAbsentJobDataMapAsAnEmptyOne()
+    {
+        IJobDetail withoutData = JobBuilder.Create<DummyJob>()
+            .WithIdentity("no-data", "DummyGroup")
+            .StoreDurably()
+            .Build();
+        A.CallTo(() => FakeScheduler.GetJobDetail(withoutData.Key, A<CancellationToken>._)).Returns(withoutData);
+
+        JobDetailDto job = await CreateClient().GetJob(TestData.SchedulerName, new JobKeyDto("DummyGroup", "no-data"));
+
+        job.JobDataMap.Should().BeEmpty("a job with no data is not a job whose data could not be read");
+    }
+
+    /// <summary>
+    /// The associated-triggers table loads the triggers, so it can name the kind and summarise the
+    /// schedule — and it names them the way the in-process client does.
+    /// </summary>
+    /// <remarks>
+    /// This used to echo the wire's <c>triggerType</c> discriminator, so the same trigger read
+    /// <c>CronTrigger</c> here and <c>Cron</c> in process. Both go through
+    /// <see cref="TriggerDisplay" /> now, and this is the test that says so.
+    /// </remarks>
+    [Test]
+    public async Task GetJobTriggersNamesTheKindTheWayTheInProcessClientDoes()
+    {
+        JobKey jobKey = new("DummyJob", "DummyGroup");
+        ITrigger cron = TriggerBuilder.Create()
+            .WithIdentity("nightly", "reports")
+            .ForJob(jobKey)
+            .WithExecutionGroup("imports")
+            .WithCronSchedule("0 0 1 * * ?")
+            .Build();
+        ITrigger simple = TriggerBuilder.Create()
+            .WithIdentity("often", "reports")
+            .ForJob(jobKey)
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(30)).WithRepeatCount(2))
+            .Build();
+
+        // GetTriggersOfJob is an extension over QueryTriggers + GetTriggers, so those are what a fake
+        // scheduler can be told about
+        A.CallTo(() => FakeScheduler.GetTriggers(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._))
+            .Returns(new List<ITrigger> { cron, simple });
+        A.CallTo(() => FakeScheduler.QueryTriggers(A<TriggerQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<TriggerHeader>(
+                [HeaderFor(cron, TriggerState.Paused), HeaderFor(simple, TriggerState.Normal)],
+                HasMore: false,
+                TotalCount: 2));
+
+        List<TriggerHeaderDto> headers = await CreateClient().GetJobTriggers(
+            TestData.SchedulerName,
+            new JobKeyDto(jobKey.Group, jobKey.Name));
+
+        headers.Should().HaveCount(2);
+
+        TriggerHeaderDto cronHeader = headers.Single(x => x.Name == "nightly");
+        cronHeader.TriggerType.Should().Be("Cron", "not CronTrigger, which is the wire's discriminator");
+        cronHeader.ScheduleSummary.Should().Be("0 0 1 * * ?");
+        cronHeader.Group.Should().Be("reports");
+        cronHeader.ExecutionGroup.Should().Be("imports");
+        cronHeader.State.Should().Be(TriggerState.Paused, "the states come from one listing, not one call per trigger");
+
+        TriggerHeaderDto simpleHeader = headers.Single(x => x.Name == "often");
+        simpleHeader.TriggerType.Should().Be("Simple");
+        simpleHeader.ScheduleSummary.Should().Contain("Every").And.Contain("2 time(s)");
+        simpleHeader.State.Should().Be(TriggerState.Normal);
+    }
+
+    /// <summary>
+    /// The trigger listing does not load the triggers, so it reports no kind and no schedule summary —
+    /// deliberately, because the store's discriminator is not the display name above.
+    /// </summary>
+    [Test]
+    public async Task GetTriggersListsHeadersWithoutNamingTheKind()
+    {
+        ITrigger cron = TriggerBuilder.Create()
+            .WithIdentity("nightly", "reports")
+            .ForJob("DummyJob", "DummyGroup")
+            .WithExecutionGroup("imports")
+            .WithCronSchedule("0 0 1 * * ?")
+            .Build();
+
+        A.CallTo(() => FakeScheduler.QueryTriggers(A<TriggerQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<TriggerHeader>([HeaderFor(cron, TriggerState.Error)], HasMore: true, TotalCount: 7));
+
+        PagedResult<TriggerHeaderDto> page = await CreateClient().GetTriggers(
+            TestData.SchedulerName,
+            new DashboardTriggerQuery { Take = 1, State = TriggerState.Error });
+
+        TriggerHeaderDto header = page.Items.Should().ContainSingle().Subject;
+        header.Group.Should().Be("reports");
+        header.Name.Should().Be("nightly");
+        header.State.Should().Be(TriggerState.Error);
+        header.ExecutionGroup.Should().Be("imports");
+        header.TriggerType.Should().BeNull("a listing has no trigger to read a kind off");
+        header.ScheduleSummary.Should().BeNull("and no schedule to summarise");
+
+        page.HasMore.Should().BeTrue();
+        page.TotalCount.Should().Be(7);
+    }
+
+    private static TriggerHeader HeaderFor(ITrigger trigger, TriggerState state) => new(
+        trigger.Key,
+        trigger.JobKey,
+        Description: trigger.Description,
+        TriggerType: "CRON",
+        State: state,
+        StartTimeUtc: trigger.StartTimeUtc,
+        EndTimeUtc: trigger.EndTimeUtc,
+        NextFireTimeUtc: trigger.NextFireTimeUtc,
+        PreviousFireTimeUtc: trigger.PreviousFireTimeUtc,
+        CalendarName: trigger.CalendarName,
+        Priority: trigger.Priority,
+        ExecutionGroup: trigger.ExecutionGroup);
+
     private QuartzApiClient CreateClient()
     {
         IHttpClientFactory httpClientFactory = A.Fake<IHttpClientFactory>();

--- a/src/Quartz.Tests.AspNetCore/Dashboard/QuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/QuartzApiClientTest.cs
@@ -1,0 +1,143 @@
+using FakeItEasy;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+using Quartz.Dashboard.Services;
+using Quartz.Impl.Calendar;
+using Quartz.Serialization.SystemTextJson;
+using Quartz.Tests.AspNetCore.HttpApi;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// The dashboard's HTTP-backed client, driven against the real HTTP API.
+/// </summary>
+/// <remarks>
+/// This is the half of <see cref="IQuartzApiClient" /> where the contract's types actually have to
+/// survive a serializer: the in-process client hands the objects straight over, while this one has to
+/// write a trigger, a calendar and a job data map in the discriminated shape the API reads, and read
+/// them back out of it.
+/// </remarks>
+public class QuartzApiClientTest : WebApiTest
+{
+    [Test]
+    public async Task GetTriggerReadsTheTriggerBackOffTheWire()
+    {
+        ITrigger expected = TestData.CronTrigger;
+        A.CallTo(() => FakeScheduler.GetTrigger(expected.Key, A<CancellationToken>._)).Returns(expected);
+
+        ITrigger trigger = await CreateClient().GetTrigger(
+            TestData.SchedulerName,
+            new TriggerKeyDto(expected.Key.Group, expected.Key.Name));
+
+        ICronTrigger cron = trigger.Should().BeAssignableTo<ICronTrigger>(
+            "a trigger's kind is on the wire, and the client is the thing that has to read it").Subject;
+        cron.CronExpressionString.Should().Be("0/25 * * * * ?");
+        cron.Key.Should().Be(expected.Key);
+        cron.JobKey.Should().Be(expected.JobKey);
+    }
+
+    [Test]
+    public async Task GetCalendarReadsTheCalendarBackOffTheWire()
+    {
+        A.CallTo(() => FakeScheduler.GetCalendar("holidays", A<CancellationToken>._)).Returns(TestData.CronCalendar);
+
+        ICalendar calendar = await CreateClient().GetCalendar(TestData.SchedulerName, "holidays");
+
+        CronCalendar cron = calendar.Should().BeOfType<CronCalendar>().Subject;
+        cron.CronExpression.CronExpressionString.Should().Be("0 0 * * * ?");
+        cron.Description.Should().Be("Test CronCalendar");
+    }
+
+    [Test]
+    public async Task GetJobReadsTheJobDataMapBackOffTheWire()
+    {
+        A.CallTo(() => FakeScheduler.GetJobDetail(TestData.JobDetail.Key, A<CancellationToken>._)).Returns(TestData.JobDetail);
+
+        JobDetailDto job = await CreateClient().GetJob(
+            TestData.SchedulerName,
+            new JobKeyDto(TestData.JobDetail.Key.Group, TestData.JobDetail.Key.Name));
+
+        job.JobDataMap["TestKey"].Should().Be("TestValue");
+        job.JobType.Should().Be(TestData.JobDetail.JobType.FullName);
+    }
+
+    [Test]
+    public async Task RescheduleJobSendsATriggerTheServerCanRead()
+    {
+        ITrigger replacement = TriggerBuilder.Create()
+            .WithIdentity("CronTriggerKey", "CronTriggerGroup")
+            .ForJob("CronJobKey", "CronJobGroup")
+            .WithExecutionGroup("imports")
+            .WithCronSchedule("0 0 2 * * ?")
+            .Build();
+
+        await CreateClient().RescheduleJob(
+            TestData.SchedulerName,
+            new TriggerKeyDto("CronTriggerGroup", "CronTriggerKey"),
+            new RescheduleRequest(replacement));
+
+        A.CallTo(() => FakeScheduler.RescheduleJob(A<TriggerKey>._, A<ITrigger>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((TriggerKey key, ITrigger trigger, CancellationToken _) =>
+                key == replacement.Key
+                && ((ICronTrigger) trigger).CronExpressionString == "0 0 2 * * ?"
+                && trigger.ExecutionGroup == "imports")
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task AddCalendarSendsACalendarTheServerCanRead()
+    {
+        CronCalendar calendar = new(baseCalendar: null, "0 0 3 * * ?", TimeZoneInfo.Utc)
+        {
+            Description = "maintenance window"
+        };
+
+        await CreateClient().AddCalendar(
+            TestData.SchedulerName,
+            new AddCalendarRequest("maintenance", calendar, Replace: true, UpdateTriggers: false));
+
+        A.CallTo(() => FakeScheduler.AddCalendar(A<string>._, A<ICalendar>._, A<AddCalendarOptions>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((string name, ICalendar received, AddCalendarOptions options, CancellationToken _) =>
+                name == "maintenance"
+                && ((CronCalendar) received).CronExpression.CronExpressionString == "0 0 3 * * ?"
+                && received.Description == "maintenance window"
+                && options.Replace)
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task TriggerJobWithDataSendsTheJobDataMap()
+    {
+        JobDataMap overrides = new() { ["colour"] = "green" };
+
+        await CreateClient().TriggerJobWithData(
+            TestData.SchedulerName,
+            new JobKeyDto("DummyGroup", "DummyJob"),
+            overrides);
+
+        A.CallTo(() => FakeScheduler.TriggerJob(A<JobKey>._, A<JobDataMap>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((JobKey key, JobDataMap? data, CancellationToken _) =>
+                key == new JobKey("DummyJob", "DummyGroup") && data is not null && Equals(data["colour"], "green"))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    private QuartzApiClient CreateClient()
+    {
+        IHttpClientFactory httpClientFactory = A.Fake<IHttpClientFactory>();
+        A.CallTo(() => httpClientFactory.CreateClient(A<string>._)).ReturnsLazily(() => WebApplicationFactory.CreateClient());
+
+        IHttpContextAccessor httpContextAccessor = A.Fake<IHttpContextAccessor>();
+        A.CallTo(() => httpContextAccessor.HttpContext).Returns(null);
+
+        // The test host maps the API at the root, and the client the factory hands out already carries
+        // its base address.
+        return new QuartzApiClient(
+            httpClientFactory,
+            httpContextAccessor,
+            Options.Create(new QuartzDashboardOptions { ApiPath = "/" }),
+            new DashboardSerializerOptions(new SystemTextJsonSerializerRegistry()));
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/TriggerDisplayTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/TriggerDisplayTest.cs
@@ -1,0 +1,80 @@
+using Quartz.Dashboard.Services;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// The one place the dashboard names a trigger's kind and summarises its schedule.
+/// </summary>
+/// <remarks>
+/// Both API clients read it, which is the point: they used to describe the same trigger differently,
+/// the HTTP-backed one echoing the wire's <c>CronTrigger</c> discriminator where the in-process one
+/// said <c>Cron</c>.
+/// </remarks>
+public class TriggerDisplayTest
+{
+    [Test]
+    public void TypeNameNamesEveryShippedKind()
+    {
+        TriggerDisplay.TypeName(Cron()).Should().Be("Cron");
+        TriggerDisplay.TypeName(Simple(TimeSpan.FromSeconds(30), repeatCount: 2)).Should().Be("Simple");
+        TriggerDisplay.TypeName(CalendarInterval()).Should().Be("Calendar interval");
+        TriggerDisplay.TypeName(DailyTimeInterval()).Should().Be("Daily time interval");
+    }
+
+    [Test]
+    public void TypeNameFallsBackToTheTypeItselfForAKindItDoesNotKnow()
+    {
+        ITrigger recurrence = TriggerBuilder.Create()
+            .WithIdentity("recurrence", "group")
+            .WithRecurrenceSchedule("FREQ=DAILY")
+            .Build();
+
+        TriggerDisplay.TypeName(recurrence).Should().Be(recurrence.GetType().Name,
+            "a kind with no display name of its own is better named by its type than by nothing");
+    }
+
+    [Test]
+    public void ScheduleSummaryForACronTriggerIsItsExpression()
+    {
+        TriggerDisplay.ScheduleSummary(Cron()).Should().Be("0 0 1 * * ?");
+    }
+
+    [Test]
+    public void ScheduleSummaryForASimpleTriggerCountsItsRepeats()
+    {
+        TriggerDisplay.ScheduleSummary(Simple(TimeSpan.FromSeconds(30), repeatCount: 2))
+            .Should().Be("Every 00:00:30, 2 time(s)");
+
+        TriggerDisplay.ScheduleSummary(Simple(TimeSpan.FromMinutes(5), repeatCount: -1))
+            .Should().Be("Every 00:05:00, repeat forever",
+                "a negative repeat count is Quartz's spelling of 'forever', not a count to show");
+    }
+
+    [Test]
+    public void ScheduleSummaryIsNullForAKindItCannotSummarise()
+    {
+        TriggerDisplay.ScheduleSummary(CalendarInterval()).Should().BeNull(
+            "the listing shows a dash rather than a half-true summary");
+        TriggerDisplay.ScheduleSummary(DailyTimeInterval()).Should().BeNull();
+    }
+
+    private static ITrigger Cron() => TriggerBuilder.Create()
+        .WithIdentity("cron", "group")
+        .WithCronSchedule("0 0 1 * * ?")
+        .Build();
+
+    private static ITrigger Simple(TimeSpan interval, int repeatCount) => TriggerBuilder.Create()
+        .WithIdentity("simple", "group")
+        .WithSimpleSchedule(x => x.WithInterval(interval).WithRepeatCount(repeatCount))
+        .Build();
+
+    private static ITrigger CalendarInterval() => TriggerBuilder.Create()
+        .WithIdentity("calendar-interval", "group")
+        .WithCalendarIntervalSchedule(x => x.WithInterval(1, IntervalUnit.Day))
+        .Build();
+
+    private static ITrigger DailyTimeInterval() => TriggerBuilder.Create()
+        .WithIdentity("daily-time-interval", "group")
+        .WithDailyTimeIntervalSchedule(x => x.WithInterval(2, IntervalUnit.Hour))
+        .Build();
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/TriggerPayloadBuilderTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/TriggerPayloadBuilderTest.cs
@@ -1,120 +1,106 @@
-using System.Text.Json;
-
 using Quartz.Dashboard.Components.Shared;
+using Quartz.Impl.Triggers;
 
 namespace Quartz.Tests.AspNetCore.Dashboard;
 
 public class TriggerPayloadBuilderTest
 {
-    private static readonly JsonSerializerOptions serializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     /// <summary>
-    /// The shape the Quartz converters write and the dashboard's API client hands the detail page.
-    /// Every property is present; the unset ones are JSON null.
+    /// A trigger as the API client hands the detail page: every field populated, including the ones
+    /// the page never displays.
     /// </summary>
-    private static JsonElement SerializedTrigger(object? description = null, object? calendarName = null)
+    private static ITrigger CronTrigger(string? description = null, string? calendarName = null)
     {
-        return JsonSerializer.SerializeToElement(new
-        {
-            triggerType = "CronTrigger",
-            key = new { name = "trigger1", group = "group1" },
-            jobKey = new { name = "job1", group = "group1" },
-            description,
-            calendarName,
-            jobDataMap = new Dictionary<string, object?> { ["colour"] = "green" },
-            misfireInstruction = 0,
-            startTimeUtc = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            endTimeUtc = (DateTimeOffset?) null,
-            priority = 5,
-            nextFireTimeUtc = new DateTimeOffset(2025, 1, 2, 1, 0, 0, TimeSpan.Zero),
-            previousFireTimeUtc = (DateTimeOffset?) null,
-            executionGroup = "imports",
-            preferredNode = "node-a",
-            preferredNodeAuto = false,
-            cronExpressionString = "0 0 1 * * ?",
-            timeZone = "UTC"
-        }, serializerOptions);
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .ForJob("job1", "group1")
+            .WithDescription(description)
+            .WithCalendarName(calendarName)
+            .UsingJobData("colour", "green")
+            .StartAt(new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
+            .WithPriority(5)
+            .WithExecutionGroup("imports")
+            .WithPreferredNode(PreferredNode.For("node-a"))
+            .WithCronSchedule("0 0 1 * * ?", x => x.InTimeZone(TimeZoneInfo.Utc))
+            .Build();
+
+        ((CronTriggerImpl) trigger).NextFireTimeUtc = new DateTimeOffset(2025, 1, 2, 1, 0, 0, TimeSpan.Zero);
+        return trigger;
     }
 
     [Test(Description = "https://github.com/quartznet/quartznet/issues/3294")]
     public void TryWithCronExpressionLeavesTextTheTriggerDoesNotHaveAsNull()
     {
-        TriggerPayloadBuilder.TryWithCronExpression(SerializedTrigger(), "0 0 2 * * ?", out JsonElement payload)
+        TriggerPayloadBuilder.TryWithCronExpression(CronTrigger(), "0 0 2 * * ?", out ITrigger? payload)
             .Should().BeTrue();
 
-        payload.GetProperty("calendarName").ValueKind.Should().Be(JsonValueKind.Null,
+        payload!.CalendarName.Should().BeNull(
             "an empty calendar name names a calendar that cannot be found, and the trigger then never fires again");
-        payload.GetProperty("description").ValueKind.Should().Be(JsonValueKind.Null);
+        payload.Description.Should().BeNull();
     }
 
     [Test]
     public void TryWithCronExpressionCarriesEverythingElseThroughUntouched()
     {
         TriggerPayloadBuilder.TryWithCronExpression(
-            SerializedTrigger(description: "nightly import", calendarName: "holidays"),
+            CronTrigger(description: "nightly import", calendarName: "holidays"),
             "0 0 2 * * ?",
-            out JsonElement payload).Should().BeTrue();
+            out ITrigger? payload).Should().BeTrue();
 
-        payload.GetProperty("cronExpressionString").GetString().Should().Be("0 0 2 * * ?",
+        payload.Should().BeOfType<CronTriggerImpl>("the edit must not change what kind of trigger this is");
+
+        CronTriggerImpl cron = (CronTriggerImpl) payload!;
+        cron.CronExpressionString.Should().Be("0 0 2 * * ?",
             "the edited expression is the only thing a reschedule is meant to change");
-        payload.GetProperty("calendarName").GetString().Should().Be("holidays");
-        payload.GetProperty("description").GetString().Should().Be("nightly import");
-        payload.GetProperty("executionGroup").GetString().Should().Be("imports");
-        payload.GetProperty("preferredNode").GetString().Should().Be("node-a",
+        cron.TimeZone.Should().Be(TimeZoneInfo.Utc, "the expression is resolved in the zone it was written for");
+        cron.CalendarName.Should().Be("holidays");
+        cron.Description.Should().Be("nightly import");
+        cron.ExecutionGroup.Should().Be("imports");
+        cron.PreferredNode.Node.Should().Be("node-a",
             "the hand-written payload dropped the node pin, which silently unpinned the trigger");
-        payload.GetProperty("preferredNodeAuto").GetBoolean().Should().BeFalse();
-        payload.GetProperty("jobDataMap").GetProperty("colour").GetString().Should().Be("green");
-        payload.GetProperty("key").GetProperty("name").GetString().Should().Be("trigger1");
-        payload.GetProperty("jobKey").GetProperty("group").GetString().Should().Be("group1");
-        payload.GetProperty("priority").GetInt32().Should().Be(5);
-        payload.GetProperty("timeZone").GetString().Should().Be("UTC");
+        cron.PreferredNode.IsAutomatic.Should().BeFalse();
+        cron.JobDataMap["colour"].Should().Be("green");
+        cron.Key.Should().Be(new TriggerKey("trigger1", "group1"));
+        cron.JobKey.Should().Be(new JobKey("job1", "group1"));
+        cron.Priority.Should().Be(5);
+        cron.StartTimeUtc.Should().Be(new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero));
     }
 
     [Test]
     public void TryWithCronExpressionClearsTheStoredNextFireTime()
     {
-        TriggerPayloadBuilder.TryWithCronExpression(SerializedTrigger(), "0 0 2 * * ?", out JsonElement payload)
+        TriggerPayloadBuilder.TryWithCronExpression(CronTrigger(), "0 0 2 * * ?", out ITrigger? payload)
             .Should().BeTrue();
 
-        payload.GetProperty("nextFireTimeUtc").ValueKind.Should().Be(JsonValueKind.Null,
+        payload!.NextFireTimeUtc.Should().BeNull(
             "the stored time was computed from the old expression, and RescheduleJob honours a non-null one verbatim");
     }
 
     [Test]
-    public void TryWithCronExpressionMatchesPropertyNamesWhateverTheirCasing()
+    public void TryWithCronExpressionDoesNotTouchTheTriggerItWasGiven()
     {
-        JsonElement trigger = JsonSerializer.SerializeToElement(new
-        {
-            TriggerType = "CronTrigger",
-            CalendarName = (string?) null,
-            NextFireTimeUtc = new DateTimeOffset(2025, 1, 2, 1, 0, 0, TimeSpan.Zero),
-            CronExpressionString = "0 0 1 * * ?"
-        });
+        ITrigger original = CronTrigger();
 
-        TriggerPayloadBuilder.TryWithCronExpression(trigger, "0 0 2 * * ?", out JsonElement payload)
-            .Should().BeTrue();
+        TriggerPayloadBuilder.TryWithCronExpression(original, "0 0 2 * * ?", out ITrigger? payload).Should().BeTrue();
 
-        payload.GetProperty("CronExpressionString").GetString().Should().Be("0 0 2 * * ?");
-        payload.GetProperty("NextFireTimeUtc").ValueKind.Should().Be(JsonValueKind.Null);
+        ((ICronTrigger) original).CronExpressionString.Should().Be("0 0 1 * * ?",
+            "the page still shows the trigger it loaded until the reschedule comes back");
+        original.NextFireTimeUtc.Should().NotBeNull();
+        payload.Should().NotBeSameAs(original);
     }
 
     [Test]
-    public void TryWithCronExpressionRefusesATriggerItCannotIdentify()
+    public void TryWithCronExpressionRefusesATriggerItCannotRebuild()
     {
-        // The API client falls back to reflection for trigger types the Quartz converters do not
-        // know, and that output carries no discriminator. Posting it back would either fail to
-        // deserialize or, as the hand-written payload did, reschedule it as some other type.
-        JsonElement reflected = JsonSerializer.SerializeToElement(new
-        {
-            key = new { name = "trigger1", group = "group1" },
-            cronExpressionString = "0 0 1 * * ?"
-        }, serializerOptions);
+        // A cron schedule this cannot set without knowing the type. Guessing means posting back some
+        // other trigger than the one on screen, which is how a custom cron trigger used to be
+        // rewritten as a plain one.
+        ITrigger simple = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)))
+            .Build();
 
-        TriggerPayloadBuilder.TryWithCronExpression(reflected, "0 0 2 * * ?", out JsonElement payload)
-            .Should().BeFalse();
-        payload.ValueKind.Should().Be(JsonValueKind.Undefined);
+        TriggerPayloadBuilder.TryWithCronExpression(simple, "0 0 2 * * ?", out ITrigger? payload).Should().BeFalse();
+        payload.Should().BeNull();
     }
 }

--- a/src/Quartz.Tests.AspNetCore/HttpApi/ExceptionHandlerTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/ExceptionHandlerTest.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Quartz.AspNetCore.HttpApi;
+using Quartz.AspNetCore.HttpApi.Util;
+using Quartz.HttpApiContract;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// The members an error body carries, and the one setting that adds another.
+/// </summary>
+/// <remarks>
+/// The wire snapshots pin what these bodies look like with the defaults;
+/// <see cref="QuartzHttpApiOptions.IncludeStackTraceInProblemDetails" /> is off by default and is not
+/// something to discover the behaviour of in production, so it is exercised here.
+/// </remarks>
+public class ExceptionHandlerTest
+{
+    [Test]
+    public async Task AStackTraceIsSentOnlyWhenItIsAskedFor()
+    {
+        SchedulerException thrown = Thrown();
+
+        (await BodyOf(thrown, includeStackTrace: false))
+            .TryGetProperty(HttpApiConstants.ProblemDetailsStackTrace, out _)
+            .Should().BeFalse("a stack trace on every error body is what the option exists to keep off");
+
+        JsonElement withTrace = await BodyOf(thrown, includeStackTrace: true);
+        withTrace.GetProperty(HttpApiConstants.ProblemDetailsStackTrace).GetString()
+            .Should().Contain(nameof(Thrown));
+    }
+
+    [Test]
+    public async Task TheStackTraceJoinsTheExceptionTypeRatherThanReplacingIt()
+    {
+        JsonElement body = await BodyOf(Thrown(), includeStackTrace: true);
+
+        body.GetProperty(HttpApiConstants.ProblemDetailsExceptionType).GetString()
+            .Should().Be(nameof(SchedulerException),
+                "the type is what a client rebuilds the exception from, and the option is about the trace");
+        body.GetProperty("status").GetInt32().Should().Be(400);
+    }
+
+    /// <summary>
+    /// A fault the caller cannot act on names no type, whether or not the trace is on.
+    /// </summary>
+    [Test]
+    public async Task AServerFaultNamesNoExceptionTypeEvenWithStackTracesOn()
+    {
+        InvalidOperationException fault = new("something the API never promised");
+
+        JsonElement body = await BodyOf(fault, includeStackTrace: true);
+
+        body.GetProperty("status").GetInt32().Should().Be(500);
+        body.TryGetProperty(HttpApiConstants.ProblemDetailsExceptionType, out _)
+            .Should().BeFalse("a 500 is a fault, and naming the type behind it tells a caller nothing it can use");
+    }
+
+    private static SchedulerException Thrown()
+    {
+        try
+        {
+            throw new SchedulerException("the scheduler refused");
+        }
+        catch (SchedulerException caught)
+        {
+            return caught;
+        }
+    }
+
+    private static async Task<JsonElement> BodyOf(Exception exception, bool includeStackTrace)
+    {
+        ExceptionHandler handler = new(
+            Options.Create(new QuartzHttpApiOptions { IncludeStackTraceInProblemDetails = includeStackTrace }),
+            NullLoggerFactory.Instance);
+
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddProblemDetails();
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        DefaultHttpContext context = new() { RequestServices = provider };
+        using MemoryStream body = new();
+        context.Response.Body = body;
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("localhost");
+
+        await handler.HandleException(exception, context).ExecuteAsync(context);
+
+        body.Position = 0;
+        using JsonDocument document = await JsonDocument.ParseAsync(body);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 
 using AwesomeAssertions.Execution;
@@ -84,6 +85,37 @@ public class SchedulerEndpointsTest : WebApiTest
 
         await HttpScheduler.StartDelayed(TimeSpan.FromMilliseconds(5_000));
         A.CallTo(() => FakeScheduler.StartDelayed(TimeSpan.FromMilliseconds(5_000), A<CancellationToken>._)).MustHaveHappened(1, Times.Exactly);
+    }
+
+    /// <summary>
+    /// The delay is a <see cref="TimeSpan" /> on the wire, and one with a sub-millisecond part arrives
+    /// as it was sent — <c>?delayMilliseconds=</c> rounded it away.
+    /// </summary>
+    [Test]
+    public async Task StartDelayedSendsTheDelayAsATimeSpan()
+    {
+        using HttpClient httpClient = WebApplicationFactory.CreateClient();
+
+        using HttpResponseMessage response = await httpClient.PostAsync(
+            $"schedulers/{TestData.SchedulerName}/start?delay=01:02:03.0004560",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        A.CallTo(() => FakeScheduler.StartDelayed(new TimeSpan(0, 1, 2, 3, 0, 456), A<CancellationToken>._))
+            .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public async Task StartWithANegativeDelayIsRejected()
+    {
+        using HttpClient httpClient = WebApplicationFactory.CreateClient();
+
+        using HttpResponseMessage response = await httpClient.PostAsync(
+            $"schedulers/{TestData.SchedulerName}/start?delay=-00:00:30",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, "a delay running backwards is not a delay");
+        A.CallTo(() => FakeScheduler.StartDelayed(A<TimeSpan>._, A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
@@ -215,6 +215,24 @@ public class WireFormatSnapshotTest : WebApiTest
         await VerifyBody(body);
     }
 
+    /// <summary>
+    /// A fault the caller cannot act on: the same problem-details members, without the exception type.
+    /// </summary>
+    /// <remarks>
+    /// The client-actionable errors name the type they came from so that a caller can reconstruct and
+    /// handle them. A 500 is not one of those, and naming the type behind it would only say something
+    /// about this server's internals — so the member's absence here is contract, and pinned as such.
+    /// </remarks>
+    [Test]
+    public async Task ServerFaultProblemDetailsBody()
+    {
+        A.CallTo(() => FakeScheduler.PauseAll(A<CancellationToken>._))
+            .Throws(_ => new InvalidOperationException("Something the API never promised"));
+
+        string body = await Post($"{SchedulerUrl}/pause-all", requestJson: "", HttpStatusCode.InternalServerError);
+        await VerifyBody(body);
+    }
+
     [Test]
     public async Task UnknownSchedulerProblemDetailsBody()
     {
@@ -258,6 +276,7 @@ public class WireFormatSnapshotTest : WebApiTest
         A.CallTo(() => FakeScheduler.DeleteJob(existingJob, A<CancellationToken>._)).Returns(true);
         A.CallTo(() => FakeScheduler.DeleteJob(missingJob, A<CancellationToken>._)).Returns(false);
         A.CallTo(() => FakeScheduler.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => FakeScheduler.UnscheduleJobs(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).Returns(true);
         A.CallTo(() => FakeScheduler.DeleteCalendar("existing", A<CancellationToken>._)).Returns(true);
         A.CallTo(() => FakeScheduler.DeleteCalendar("missing", A<CancellationToken>._)).Returns(false);
         A.CallTo(() => FakeScheduler.UnscheduleJob(existingTrigger, A<CancellationToken>._)).Returns(true);
@@ -328,11 +347,15 @@ public class WireFormatSnapshotTest : WebApiTest
             await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/interrupt", HttpStatusCode.OK, expectedBody: """{"applied":true}""");
             await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/missing/interrupt", HttpStatusCode.OK, expectedBody: """{"applied":false}""");
 
-            // the plural delete and unschedule say it of the whole key set: a partial hit is false,
-            // even though the keys that were found were still deleted
+            // the plural delete and unschedule are the exception, and the field is named for what
+            // they can actually report: a partial hit deleted the keys it found, so calling that
+            // "applied": false would be a false statement about what happened
             await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/delete", HttpStatusCode.OK,
                 """{"jobs":[{"name":"existing","group":"group"},{"name":"missing","group":"group"}]}""",
-                expectedBody: """{"applied":false}""");
+                expectedBody: """{"allFound":false}""");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/triggers/unschedule", HttpStatusCode.OK,
+                """{"triggers":[{"name":"existing","group":"group"}]}""",
+                expectedBody: """{"allFound":true}""");
 
             // a malformed request is a 400, never a 404 or a 500
             await Row(HttpMethod.Get, $"{SchedulerUrl}/jobs?skip=-1", HttpStatusCode.BadRequest);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
@@ -197,6 +197,24 @@ public class WireFormatSnapshotTest : WebApiTest
         await VerifyBody(body);
     }
 
+    /// <summary>
+    /// The other way to earn a 400: the request was well formed, and the scheduler refused it.
+    /// </summary>
+    /// <remarks>
+    /// This body had no pin at all, which is how the two 400 shapes came to differ unnoticed. Read it
+    /// beside <see cref="ValidationProblemDetailsBody" />: the members are the same, and only the
+    /// <c>detail</c> and the exception name say which layer rejected the request.
+    /// </remarks>
+    [Test]
+    public async Task SchedulerExceptionProblemDetailsBody()
+    {
+        A.CallTo(() => FakeScheduler.PauseAll(A<CancellationToken>._))
+            .Throws(_ => new SchedulerException("The scheduler has been shut down"));
+
+        string body = await Post($"{SchedulerUrl}/pause-all", requestJson: "", HttpStatusCode.BadRequest);
+        await VerifyBody(body);
+    }
+
     [Test]
     public async Task UnknownSchedulerProblemDetailsBody()
     {
@@ -239,8 +257,13 @@ public class WireFormatSnapshotTest : WebApiTest
             .Returns(new List<JobKey> { existingJob });
         A.CallTo(() => FakeScheduler.DeleteJob(existingJob, A<CancellationToken>._)).Returns(true);
         A.CallTo(() => FakeScheduler.DeleteJob(missingJob, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => FakeScheduler.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).Returns(false);
         A.CallTo(() => FakeScheduler.DeleteCalendar("existing", A<CancellationToken>._)).Returns(true);
         A.CallTo(() => FakeScheduler.DeleteCalendar("missing", A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => FakeScheduler.UnscheduleJob(existingTrigger, A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.UnscheduleJob(missingTrigger, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => FakeScheduler.Interrupt(existingJob, A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.Interrupt(missingJob, A<CancellationToken>._)).Returns(false);
 
         const string addJobJson = """
             {
@@ -294,11 +317,22 @@ public class WireFormatSnapshotTest : WebApiTest
             await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/keys/pause", HttpStatusCode.BadRequest,
                 """{"jobs":[{"group":"group"}]}""");
 
-            // deletes follow the same rule, under a name of their own
-            await Row(HttpMethod.Delete, $"{SchedulerUrl}/jobs/group/existing", HttpStatusCode.OK, expectedBody: """{"jobFound":true}""");
-            await Row(HttpMethod.Delete, $"{SchedulerUrl}/jobs/group/missing", HttpStatusCode.OK, expectedBody: """{"jobFound":false}""");
-            await Row(HttpMethod.Delete, $"{SchedulerUrl}/calendars/existing", HttpStatusCode.OK, expectedBody: """{"calendarFound":true}""");
-            await Row(HttpMethod.Delete, $"{SchedulerUrl}/calendars/missing", HttpStatusCode.OK, expectedBody: """{"calendarFound":false}""");
+            // deletes, unschedules and interrupts say the same word: every mutation that can be a
+            // no-op answers {"applied": …}, whatever it is a mutation of
+            await Row(HttpMethod.Delete, $"{SchedulerUrl}/jobs/group/existing", HttpStatusCode.OK, expectedBody: """{"applied":true}""");
+            await Row(HttpMethod.Delete, $"{SchedulerUrl}/jobs/group/missing", HttpStatusCode.OK, expectedBody: """{"applied":false}""");
+            await Row(HttpMethod.Delete, $"{SchedulerUrl}/calendars/existing", HttpStatusCode.OK, expectedBody: """{"applied":true}""");
+            await Row(HttpMethod.Delete, $"{SchedulerUrl}/calendars/missing", HttpStatusCode.OK, expectedBody: """{"applied":false}""");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/triggers/group/existing/unschedule", HttpStatusCode.OK, expectedBody: """{"applied":true}""");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/triggers/group/missing/unschedule", HttpStatusCode.OK, expectedBody: """{"applied":false}""");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/interrupt", HttpStatusCode.OK, expectedBody: """{"applied":true}""");
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/missing/interrupt", HttpStatusCode.OK, expectedBody: """{"applied":false}""");
+
+            // the plural delete and unschedule say it of the whole key set: a partial hit is false,
+            // even though the keys that were found were still deleted
+            await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/delete", HttpStatusCode.OK,
+                """{"jobs":[{"name":"existing","group":"group"},{"name":"missing","group":"group"}]}""",
+                expectedBody: """{"applied":false}""");
 
             // a malformed request is a 400, never a 404 or a 500
             await Row(HttpMethod.Get, $"{SchedulerUrl}/jobs?skip=-1", HttpStatusCode.BadRequest);

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -25,11 +25,11 @@ namespace Quartz.Dashboard.Hubs
     }
     public sealed class JobExecutionResultDto : System.IEquatable<Quartz.Dashboard.Hubs.JobExecutionResultDto>
     {
-        public JobExecutionResultDto(Quartz.Dashboard.Services.JobKeyDto JobKey, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, System.DateTimeOffset FireTimeUtc, long RunTimeMs, bool Vetoed, string? ExceptionMessage) { }
+        public JobExecutionResultDto(Quartz.Dashboard.Services.JobKeyDto JobKey, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, System.DateTimeOffset FireTimeUtc, System.TimeSpan RunTime, bool Vetoed, string? ExceptionMessage) { }
         public string? ExceptionMessage { get; init; }
         public System.DateTimeOffset FireTimeUtc { get; init; }
         public Quartz.Dashboard.Services.JobKeyDto JobKey { get; init; }
-        public long RunTimeMs { get; init; }
+        public System.TimeSpan RunTime { get; init; }
         public Quartz.Dashboard.Services.TriggerKeyDto TriggerKey { get; init; }
         public bool Vetoed { get; init; }
     }
@@ -129,8 +129,8 @@ namespace Quartz.Dashboard.Services
     }
     public sealed class DashboardHistoryEntry : System.IEquatable<Quartz.Dashboard.Services.DashboardHistoryEntry>
     {
-        public DashboardHistoryEntry(string SchedulerName, string JobGroup, string JobName, string TriggerGroup, string TriggerName, System.DateTimeOffset FiredAtUtc, long DurationMs, bool Succeeded, string? ExceptionMessage) { }
-        public long DurationMs { get; init; }
+        public DashboardHistoryEntry(string SchedulerName, string JobGroup, string JobName, string TriggerGroup, string TriggerName, System.DateTimeOffset FiredAtUtc, System.TimeSpan Duration, bool Succeeded, string? ExceptionMessage) { }
+        public System.TimeSpan Duration { get; init; }
         public string? ExceptionMessage { get; init; }
         public System.DateTimeOffset FiredAtUtc { get; init; }
         public string JobGroup { get; init; }
@@ -270,7 +270,7 @@ namespace Quartz.Dashboard.Services
     }
     public sealed class TriggerHeaderDto : System.IEquatable<Quartz.Dashboard.Services.TriggerHeaderDto>
     {
-        public TriggerHeaderDto(string Group, string Name, string? ExecutionGroup = null) { }
+        public TriggerHeaderDto(string Group, string Name, string? TriggerType, string? ScheduleSummary, Quartz.TriggerState? State, string? ExecutionGroup) { }
         public string? ExecutionGroup { get; init; }
         public string Group { get; init; }
         public string Name { get; init; }

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -108,8 +108,8 @@ namespace Quartz.Dashboard.Services
 {
     public sealed class AddCalendarRequest : System.IEquatable<Quartz.Dashboard.Services.AddCalendarRequest>
     {
-        public AddCalendarRequest(string CalendarName, System.Text.Json.JsonElement Calendar, bool Replace, bool UpdateTriggers) { }
-        public System.Text.Json.JsonElement Calendar { get; init; }
+        public AddCalendarRequest(string CalendarName, Quartz.ICalendar Calendar, bool Replace, bool UpdateTriggers) { }
+        public Quartz.ICalendar Calendar { get; init; }
         public string CalendarName { get; init; }
         public bool Replace { get; init; }
         public bool UpdateTriggers { get; init; }
@@ -120,11 +120,6 @@ namespace Quartz.Dashboard.Services
         public Quartz.Dashboard.Services.JobDetailDto Job { get; init; }
         public bool Replace { get; init; }
         public bool? StoreNonDurableWhileAwaitingScheduling { get; init; }
-    }
-    public sealed class CalendarDetailDto : System.IEquatable<Quartz.Dashboard.Services.CalendarDetailDto>
-    {
-        public CalendarDetailDto(System.Text.Json.JsonElement Value) { }
-        public System.Text.Json.JsonElement Value { get; init; }
     }
     public sealed class DashboardFireInstanceQuery : Quartz.PagedQuery, System.IEquatable<Quartz.Dashboard.Services.DashboardFireInstanceQuery>
     {
@@ -191,7 +186,7 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask AddJob(string schedulerName, Quartz.Dashboard.Services.AddJobRequest request, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask DeleteCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask DeleteJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.CalendarDetailDto> GetCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.ICalendar> GetCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> GetCalendarNames(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.ExecutionLimitsDto?> GetExecutionLimits(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.FireInstanceDto>> GetFireInstances(string schedulerName, Quartz.Dashboard.Services.DashboardFireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default);
@@ -202,7 +197,7 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.JobKeyDto>> GetJobs(string schedulerName, Quartz.Dashboard.Services.DashboardJobQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.SchedulerDetailDto> GetScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.SchedulerHeaderDto>> GetSchedulers(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.TriggerDetailDto> GetTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.ITrigger> GetTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.TriggerState> GetTriggerState(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.TriggerHeaderDto>> GetTriggers(string schedulerName, Quartz.Dashboard.Services.DashboardTriggerQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask InterruptFireInstance(string schedulerName, string fireInstanceId, System.Threading.CancellationToken cancellationToken = default);
@@ -220,17 +215,17 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask StandbyScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask StartScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggerJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggerJobWithData(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Text.Json.JsonElement jobDataMap, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggerJobWithData(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, Quartz.JobDataMap jobDataMap, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask UnscheduleJob(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
     }
     public sealed class JobDetailDto : System.IEquatable<Quartz.Dashboard.Services.JobDetailDto>
     {
-        public JobDetailDto(string Name, string Group, string JobType, string? Description, bool Durable, bool RequestsRecovery, bool ConcurrentExecutionDisallowed, bool PersistJobDataAfterExecution, System.Text.Json.JsonElement JobDataMap) { }
+        public JobDetailDto(string Name, string Group, string JobType, string? Description, bool Durable, bool RequestsRecovery, bool ConcurrentExecutionDisallowed, bool PersistJobDataAfterExecution, Quartz.JobDataMap JobDataMap) { }
         public bool ConcurrentExecutionDisallowed { get; init; }
         public string? Description { get; init; }
         public bool Durable { get; init; }
         public string Group { get; init; }
-        public System.Text.Json.JsonElement JobDataMap { get; init; }
+        public Quartz.JobDataMap JobDataMap { get; init; }
         public string JobType { get; init; }
         public string Name { get; init; }
         public bool PersistJobDataAfterExecution { get; init; }
@@ -250,14 +245,14 @@ namespace Quartz.Dashboard.Services
     }
     public sealed class RescheduleRequest : System.IEquatable<Quartz.Dashboard.Services.RescheduleRequest>
     {
-        public RescheduleRequest(System.Text.Json.JsonElement NewTrigger) { }
-        public System.Text.Json.JsonElement NewTrigger { get; init; }
+        public RescheduleRequest(Quartz.ITrigger NewTrigger) { }
+        public Quartz.ITrigger NewTrigger { get; init; }
     }
     public sealed class ScheduleJobRequest : System.IEquatable<Quartz.Dashboard.Services.ScheduleJobRequest>
     {
-        public ScheduleJobRequest(System.Text.Json.JsonElement Trigger, Quartz.Dashboard.Services.JobDetailDto? Job) { }
+        public ScheduleJobRequest(Quartz.ITrigger Trigger, Quartz.Dashboard.Services.JobDetailDto? Job) { }
         public Quartz.Dashboard.Services.JobDetailDto? Job { get; init; }
-        public System.Text.Json.JsonElement Trigger { get; init; }
+        public Quartz.ITrigger Trigger { get; init; }
     }
     public sealed class SchedulerDetailDto : System.IEquatable<Quartz.Dashboard.Services.SchedulerDetailDto>
     {
@@ -272,11 +267,6 @@ namespace Quartz.Dashboard.Services
         public string SchedulerInstanceId { get; init; }
         public string SchedulerName { get; init; }
         public Quartz.SchedulerStatus Status { get; init; }
-    }
-    public sealed class TriggerDetailDto : System.IEquatable<Quartz.Dashboard.Services.TriggerDetailDto>
-    {
-        public TriggerDetailDto(System.Text.Json.JsonElement Value) { }
-        public System.Text.Json.JsonElement Value { get; init; }
     }
     public sealed class TriggerHeaderDto : System.IEquatable<Quartz.Dashboard.Services.TriggerHeaderDto>
     {

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SchedulerExceptionProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SchedulerExceptionProblemDetailsBody.verified.json
@@ -1,0 +1,7 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The scheduler has been shut down",
+  "Quartz-ExceptionType": "SchedulerException"
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ServerFaultProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ServerFaultProblemDetailsBody.verified.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.6.1",
+  "title": "An error occurred while processing your request.",
+  "status": 500,
+  "detail": "Something the API never promised"
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_UnknownJobProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_UnknownJobProblemDetailsBody.verified.json
@@ -2,5 +2,6 @@
   "type": "https://tools.ietf.org/html/rfc9110#section-15.5.5",
   "title": "Not Found",
   "status": 404,
-  "detail": "Unknown job DummyGroup.no-such-job"
+  "detail": "Unknown job DummyGroup.no-such-job",
+  "Quartz-ExceptionType": "NotFoundException"
 }

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_UnknownSchedulerProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_UnknownSchedulerProblemDetailsBody.verified.json
@@ -2,5 +2,6 @@
   "type": "https://tools.ietf.org/html/rfc9110#section-15.5.5",
   "title": "Not Found",
   "status": 404,
-  "detail": "Unknown scheduler no-such-scheduler"
+  "detail": "Unknown scheduler no-such-scheduler",
+  "Quartz-ExceptionType": "NotFoundException"
 }

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ValidationProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ValidationProblemDetailsBody.verified.json
@@ -2,5 +2,6 @@
   "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
   "title": "Bad Request",
   "status": 400,
-  "detail": "Request validation failed: Job detail is missing name"
+  "detail": "Request validation failed: Job detail is missing name",
+  "Quartz-ExceptionType": "BadHttpRequestException"
 }

--- a/src/Quartz/HttpApiContract/HttpApiConstants.cs
+++ b/src/Quartz/HttpApiContract/HttpApiConstants.cs
@@ -27,9 +27,11 @@ internal static class HttpApiConstants
     /// The problem-details member naming the exception type the server raised.
     /// </summary>
     /// <remarks>
-    /// Present on every error body, whichever layer produced it, so that the shape of an error does
-    /// not depend on its cause. A client maps the Quartz exception names back to typed exceptions and
-    /// treats every other value as opaque — the framework's own names appear here too.
+    /// Present on every client-actionable error — every <c>400</c> and every <c>404</c>, whichever
+    /// layer produced it — so that the shape of such an error does not depend on its cause. A client
+    /// maps the Quartz exception names back to typed exceptions and treats every other value as
+    /// opaque; the framework's own names appear here too. A <c>500</c> deliberately does not carry it:
+    /// a fault the caller cannot act on has nothing to gain from naming the type behind it.
     /// </remarks>
     public const string ProblemDetailsExceptionType = "Quartz-ExceptionType";
 

--- a/src/Quartz/HttpApiContract/HttpApiConstants.cs
+++ b/src/Quartz/HttpApiContract/HttpApiConstants.cs
@@ -23,7 +23,20 @@ namespace Quartz.HttpApiContract;
 
 internal static class HttpApiConstants
 {
+    /// <summary>
+    /// The problem-details member naming the exception type the server raised.
+    /// </summary>
+    /// <remarks>
+    /// Present on every error body, whichever layer produced it, so that the shape of an error does
+    /// not depend on its cause. A client maps the Quartz exception names back to typed exceptions and
+    /// treats every other value as opaque — the framework's own names appear here too.
+    /// </remarks>
     public const string ProblemDetailsExceptionType = "Quartz-ExceptionType";
+
+    /// <summary>
+    /// The problem-details member carrying the exception's stack trace, present only when
+    /// <c>QuartzHttpApiOptions.IncludeStackTraceInProblemDetails</c> asks for it.
+    /// </summary>
     public const string ProblemDetailsStackTrace = "Quartz-ExceptionStackTrace";
 
     /// <summary>

--- a/src/Quartz/HttpApiContract/RequestAndResponses.cs
+++ b/src/Quartz/HttpApiContract/RequestAndResponses.cs
@@ -51,17 +51,30 @@ internal record ExistsResponse(bool Exists);
 internal record GroupPausedResponse(bool Paused);
 
 /// <summary>
-/// The answer of a mutation whose effect may be a no-op: <c>Applied</c> is <see langword="true" />
-/// when the operation applied to everything it was aimed at.
+/// The answer of a mutation aimed at one entity whose effect may be a no-op: <c>Applied</c> is
+/// <see langword="true" /> when the entity existed and the operation changed it.
 /// </summary>
 /// <remarks>
 /// Every such endpoint answers with this one shape, so the body follows from what the operation is
-/// rather than from which endpoint it was. For a single-key mutation it is that one key — the entity
-/// existed and the operation changed it. For the key-set delete and unschedule forms it is every key
-/// given, so a partial hit is <see langword="false" /> even though the keys that were found were
-/// still deleted. A mutation that always acts answers with an empty body instead.
+/// rather than from which endpoint it was. A mutation that always acts answers with an empty body
+/// instead, and one aimed at a key set answers with what it applied to.
 /// </remarks>
 internal record OperationAppliedResponse(bool Applied);
+
+/// <summary>
+/// The answer of a key-set delete or unschedule: <c>AllFound</c> is <see langword="true" /> when every
+/// key given was found.
+/// </summary>
+/// <remarks>
+/// Deliberately not <see cref="OperationAppliedResponse" />, whose shape it shares. A partial hit
+/// deletes the keys it found and reports <see langword="false" />, so calling that "applied" would be
+/// a false statement about what happened, and a caller who retried on it would never learn that most
+/// of the work had already succeeded. <c>IScheduler.DeleteJobs</c> and <c>UnscheduleJobs</c> return
+/// one <see cref="bool" /> for the whole set and cannot say more; until they answer with the keys they
+/// applied to, as the key-set pause and resume do, this field is named for what it can actually
+/// report.
+/// </remarks>
+internal record AllKeysFoundResponse(bool AllFound);
 
 /// <summary>
 /// Answer of a group-matcher pause/resume: the names of the groups the operation affected.

--- a/src/Quartz/HttpApiContract/RequestAndResponses.cs
+++ b/src/Quartz/HttpApiContract/RequestAndResponses.cs
@@ -51,9 +51,16 @@ internal record ExistsResponse(bool Exists);
 internal record GroupPausedResponse(bool Paused);
 
 /// <summary>
-/// Answer of a single-key mutation that follows the missing-key rule: <c>Applied</c> is
-/// <see langword="true" /> when the entity existed and the operation applied to it.
+/// The answer of a mutation whose effect may be a no-op: <c>Applied</c> is <see langword="true" />
+/// when the operation applied to everything it was aimed at.
 /// </summary>
+/// <remarks>
+/// Every such endpoint answers with this one shape, so the body follows from what the operation is
+/// rather than from which endpoint it was. For a single-key mutation it is that one key — the entity
+/// existed and the operation changed it. For the key-set delete and unschedule forms it is every key
+/// given, so a partial hit is <see langword="false" /> even though the keys that were found were
+/// still deleted. A mutation that always acts answers with an empty body instead.
+/// </remarks>
 internal record OperationAppliedResponse(bool Applied);
 
 /// <summary>
@@ -89,18 +96,10 @@ internal record AppliedJobKeysResponse(KeyDto[] Jobs);
 /// </summary>
 internal record AppliedTriggerKeysResponse(KeyDto[] Triggers);
 
-internal record DeleteCalendarResponse(bool CalendarFound);
-
-internal record DeleteJobResponse(bool JobFound);
-
 internal record DeleteJobsRequest(KeyDto[] Jobs) : IValidatable
 {
     public IEnumerable<string> Validate() => Jobs is null ? ["Missing job keys"] : Jobs.SelectMany(x => x.Validate());
 }
-
-internal record DeleteJobsResponse(bool AllJobsFound);
-
-internal record InterruptResponse(bool Interrupted);
 
 // When updating this, make same changes also into Quartz.AspNetCore.HttpApi.OpenApi.ScheduleJobRequest
 internal record ScheduleJobRequest(ITrigger Trigger, JobDetailDto? Job) : IValidatable
@@ -169,14 +168,10 @@ internal record RescheduleJobRequest(ITrigger NewTrigger) : IValidatable
 
 internal record RescheduleJobResponse(DateTimeOffset? FirstFireTimeUtc);
 
-internal record UnscheduleJobResponse(bool TriggerFound);
-
 internal record UnscheduleJobsRequest(KeyDto[] Triggers) : IValidatable
 {
     public IEnumerable<string> Validate() => Triggers is null ? ["Missing trigger keys"] : Triggers.SelectMany(x => x.Validate());
 }
-
-internal record UnscheduleJobsResponse(bool AllTriggersFound);
 
 internal record ExecutionLimitsResponse(Dictionary<string, int?>? Limits, bool UseTriggerGroupWhenUnset = false);
 


### PR DESCRIPTION
The three loose ends recorded when F5 (#3318) landed. Closes #3343.

Six commits, each green on its own: the response-shape rule, the dashboard's untyped DTOs, the
millisecond fields, a cleanup the third made possible, and the review corrections, and the coverage work.

## 1. Response-shape conventions

### The endpoint inventory

The decision is only defensible with the whole set visible, so here it is — grouped by what each
answers with. **Bold** marks what this PR changed.

**Reads → `200` with the thing asked for (21)**

| Endpoint | Answers |
|---|---|
| `GET …/schedulers` | `SchedulerHeaderDto[]` |
| `GET …/schedulers/{n}` | `SchedulerDto` |
| `GET …/schedulers/{n}/context` | `{ "context": … }` |
| `GET …/schedulers/{n}/execution-limits` | `{ "limits": …, "useTriggerGroupWhenUnset": … }` |
| `GET …/jobs` | `PagedResultDto<JobHeaderDto>` |
| `GET …/jobs/{g}/{n}` | `JobDetailDto` |
| `GET …/jobs/{g}/{n}/exists` | `{ "exists": … }` |
| `GET …/jobs/{g}/{n}/triggers` | trigger array |
| `GET …/jobs/fire-instances` | `PagedResultDto<FireInstanceDto>` |
| `GET …/jobs/groups` | `PagedResultDto<JobGroupDto>` |
| `GET …/jobs/groups/{g}/paused` | `{ "paused": … }` |
| `POST …/jobs/fetch` | `JobDetailDto[]` (a read with a body) |
| `GET …/triggers` | `PagedResultDto<TriggerHeaderDto>` |
| `GET …/triggers/{g}/{n}` | trigger |
| `GET …/triggers/{g}/{n}/exists` | `{ "exists": … }` |
| `GET …/triggers/{g}/{n}/state` | `{ "state": … }` |
| `GET …/triggers/groups` | `PagedResultDto<TriggerGroupDto>` |
| `GET …/triggers/groups/{g}/paused` | `{ "paused": … }` |
| `POST …/triggers/fetch` | trigger array (a read with a body) |
| `GET …/calendars` | `PagedResultDto<string>` |
| `GET …/calendars/{n}` | calendar |

**Mutations that always act → `200` with an empty body (12)**

`POST …/start` · `…/standby` · `…/shutdown` · `…/clear` · `…/pause-all` · `…/resume-all` ·
`POST …/execution-limits` · `DELETE …/execution-limits` · `POST …/jobs` (add) ·
`POST …/jobs/{g}/{n}/trigger` · `POST …/triggers/schedule-multiple` · `POST …/calendars` (add)

**Mutations whose effect may be a no-op → `200` with one boolean flag (13)**

| Endpoint | Before | After |
|---|---|---|
| `POST …/jobs/{g}/{n}/pause`, `…/resume` | `{"applied"}` | unchanged |
| `POST …/triggers/{g}/{n}/pause`, `…/resume`, `…/reset-from-error-state` | `{"applied"}` | unchanged |
| **`DELETE …/jobs/{g}/{n}`** | `{"jobFound"}` | `{"applied"}` |
| **`POST …/jobs/{g}/{n}/interrupt`** | `{"interrupted"}` | `{"applied"}` |
| **`POST …/jobs/interrupt/{fireInstanceId}`** | `{"interrupted"}` | `{"applied"}` |
| **`POST …/triggers/{g}/{n}/unschedule`** | `{"triggerFound"}` | `{"applied"}` |
| **`DELETE …/calendars/{n}`** | `{"calendarFound"}` | `{"applied"}` |
| **`POST …/jobs/delete`** | `{"allJobsFound"}` | `{"allFound"}` |
| **`POST …/triggers/unschedule`** | `{"allTriggersFound"}` | `{"allFound"}` |

**Mutations aimed at a group matcher or a key set → `200` with what they applied to (9)**

`POST …/jobs/pause`, `…/jobs/resume`, `…/triggers/pause`, `…/triggers/resume` → `{"groups": […]}` ·
`POST …/jobs/keys/pause`, `…/keys/resume` → `{"jobs": […]}` ·
`POST …/triggers/keys/pause`, `…/keys/resume`, `…/keys/reset-from-error-state` → `{"triggers": […]}`

**Mutations that computed something → `200` with that value (2)**

`POST …/triggers/schedule` and `POST …/triggers/{g}/{n}/reschedule` → `{"firstFireTimeUtc": …}`

### The rule

> **A `200` carries a body exactly when the operation has something to say that the caller could not
> have worked out for itself** — the value it computed, or whether it applied. The flag is always one
> boolean, **named for the fact it reports**.

The empty-body / flag-carrying split was already that; what was not consistent was the **name**. Seven
spellings meant a caller had to look the body up per endpoint.

`applied` means the entity existed and the operation changed it. `POST …/jobs/delete` and
`POST …/triggers/unschedule` keep a name of their own — `allFound` — because they report a different
fact: `IScheduler.DeleteJobs` and `UnscheduleJobs` answer one `bool` for a whole key set, and a partial
hit **still deletes the keys it found**. Calling that `"applied": false` would be a false statement
about what happened. Filed as **#3360** (answer with the applied keys, as the key-set pause and resume
already do); the http-api page links it so the limitation is documented rather than hidden.

### Errors

> **A client-actionable error names the exception type it came from; a server fault does not.**

`Quartz-ExceptionType` rode only on the `SchedulerException` path, so a `400` from request validation
and a `400` from the scheduler were two different shapes — and a client could not tell a body the
member was missing from one that never carries it. Every `400` and `404` now carries it, whichever
layer raised it, including the framework's own names. A `500` deliberately does not: the caller cannot
act on it, so naming the type behind it says something about the server's internals and nothing useful.
`HttpScheduler` reads it in one branch instead of two, with unchanged messages.

The one `400` with no body at all is not ours: a query parameter the framework could not bind never
reaches an endpoint.

## 2. The `JsonElement`-typed DTOs

All seven are typed; none is kept.

| Before | After |
|---|---|
| `GetTrigger(…)` → `TriggerDetailDto(JsonElement Value)` | → `ITrigger` |
| `GetCalendar(…)` → `CalendarDetailDto(JsonElement Value)` | → `ICalendar` |
| `ScheduleJobRequest(JsonElement Trigger, …)` | `ScheduleJobRequest(ITrigger Trigger, …)` |
| `RescheduleRequest(JsonElement NewTrigger)` | `RescheduleRequest(ITrigger NewTrigger)` |
| `AddCalendarRequest(…, JsonElement Calendar, …)` | `AddCalendarRequest(…, ICalendar Calendar, …)` |
| `JobDetailDto.JobDataMap` | `JobDataMap` |
| `TriggerJobWithData(…, JsonElement, …)` | `TriggerJobWithData(…, JobDataMap, …)` |

**Why `ITrigger` rather than a discriminated DTO family.** The polymorphism is already Quartz's: the
serializer registry maps each kind to its own serializer — custom kinds an application registered
included — and the HTTP API's wire format *is* that discriminated shape. A DTO family here would need
a member per trigger kind, would need extending whenever a kind is added, and would still have nothing
to say about a kind it had never heard of. The dashboard's contract is a projection of the API; the API
speaks `ITrigger`, so the projection does too. Same for `ICalendar`.

**Why `JobDataMap` rather than keeping `JsonElement`.** The map does hold arbitrary user values — but
that is what `JobDataMap` is, it is what `IScheduler` hands back, and it is what the wire contract's own
`JobDetailDto` already carries. `JsonElement` was not more honest, it was less: reading a map back out
of JSON turned an `int` into whatever the reader guessed. Nothing narrower exists, and nothing looser is
warranted, so no `JsonElement` survives in this contract.

Fallout worth reading:

- **The in-process client serializes nothing now.** It was writing a trigger to JSON and reading it
  straight back, purely to satisfy the DTO's type — and falling back to reflecting over the trigger for
  kinds the registry did not know, which produced a payload that could not be posted back. That path
  and its `JsonSerializerOptions` dependency are gone.
- **`TriggerPayloadBuilder` clones the trigger instead of rewriting its JSON.** It keeps everything the
  JSON edit kept (that was #3294's fix) *and* the runtime type, so a trigger derived from
  `CronTriggerImpl` survives a schedule edit as itself. It refuses anything it cannot rebuild, as before.
- **`DisplayValueHelper`'s property-walking machinery is deleted** — 200 lines that existed only because
  the members were untyped. `FormatKey` is all that is left.
- **The HTTP-backed client cannot read a trigger kind no serializer is registered for** and says so,
  where it used to render an anonymous bag of properties. This is the API's own requirement.
- **`QuartzApiClient` had no test at all** and is the half where the types must survive a serializer.
  It has six now, driving it against the real HTTP API. That it is registered nowhere is filed as
  **#3361**.

## 3. Unit-typed wire fields

| Before | After |
|---|---|
| `POST …/schedulers/{n}/start?delayMilliseconds=30000` | `?delay=00:00:30` |
| `JobExecutionResultDto.RunTimeMs` (`long`) | `RunTime` (`TimeSpan`) |
| `DashboardHistoryEntry.DurationMs` (`long`) | `Duration` (`TimeSpan`) |

A trigger body has always said `"repeatIntervalTimeSpan": "120.02:30:59.9990000"`. These three
disagreed with it and rounded away everything below a millisecond, which for a job that finishes in
microseconds is the whole measurement. `delayMilliseconds` is in scope because it is the same defect on
the same contract; a negative `delay` is now a `400`.

`TriggerHeaderDto` is positional throughout instead of half-positional. While both dashboard clients
were being touched they stopped disagreeing about a trigger's kind: the HTTP-backed one echoed the
wire's discriminator, so the same trigger was `CronTrigger` there and `Cron` in process. `TriggerDisplay`
is now the one place that names a kind and summarises a schedule.

## Baselines that moved

| Baseline | Why |
|---|---|
| `WireFormatSnapshotTest_ValidationProblemDetailsBody` | gained `"Quartz-ExceptionType": "BadHttpRequestException"` |
| `WireFormatSnapshotTest_UnknownJobProblemDetailsBody` | gained `"Quartz-ExceptionType": "NotFoundException"` |
| `WireFormatSnapshotTest_UnknownSchedulerProblemDetailsBody` | same |
| `WireFormatSnapshotTest_SchedulerExceptionProblemDetailsBody` | **new** — this path had no pin at all, which is how the two 400 shapes came to differ unnoticed |
| `WireFormatSnapshotTest_ServerFaultProblemDetailsBody` | **new** — pins that a `500` carries no exception type, so the absence is contract rather than an omission waiting to drift |
| `PublicApiTest_Quartz.Dashboard` | the DTO retyping, the two `TimeSpan`s and `TriggerHeaderDto` |

The flag renames are pinned as exact bodies in `StatusCodesFollowTheApiConventions` rather than as
Verify files, and that test's expectations moved with them; rows were added for unschedule, interrupt
and both plural forms. `PublicApiTest_Quartz` and `PublicApiTest_Quartz.AspNetCore` are unchanged —
the wire contract is internal.

## Follow-ups filed

- **#3360** — key-set `DeleteJobs`/`UnscheduleJobs` answer a lossy `bool`; they should answer with the
  applied keys, like the key-set pause and resume. Deliberately not done here: it is a scheduler-API
  change with store-contract and migration-guide consequences of its own, and it would have been
  reviewed as a footnote inside a wire-polish PR.
- **#3361** — `QuartzApiClient` is registered nowhere, because `AddQuartzDashboard` always wires the
  in-process one. Either a missing registration or dead code; the issue states both readings without
  guessing.
- **#3363** — the dashboard's Razor components have no test harness, so every dashboard PR contributes
  uncoverable new lines and meets this same gate. Describes what bUnit would take, and owns the
  coverage exclusion added here.

## Found and deliberately left alone

- The trigger *listings* still report no `triggerType` and no `scheduleSummary` on either client — a
  listing does not load the triggers, and the store's discriminator is not the display name. Unchanged
  behaviour, now stated in the code.
- `DashboardSerializerOptions` is consumed only by the unregistered HTTP-backed client. Its
  registration stays, as the extension point for a custom trigger or calendar serializer; see #3361.
- `ExceptionHandler` composes `detail` two ways (`SchedulerException` uses the message alone, the other
  paths append the inner exception's). That is content, not shape, and appending inner messages to a
  `JobPersistenceException` would put database errors on the wire — a call I did not want to make
  unasked.

## Coverage

The Sonar gate failed on new-code coverage alone (51.9%, threshold 80). Reading
`artifacts/coverage/**/coverage.opencover.xml` against this PR's own diff splits the 200 measured new
lines in two:

| | new lines measured | covered | |
|---|---|---|---|
| Razor components (5 files) | 47 | 0 | no test harness exists — see below |
| ordinary C# (19 files) | 153 | **151** | 98.7% |
| together | 200 | 151 | 75.5% |

**The C# half was genuinely under-tested and is now tested**, not excused. 38 uncovered lines became
2. Twenty new tests, aimed at what this PR actually changed:

- `QuartzApiClientTest` — the two listing methods, which is where the HTTP-backed client stopped
  echoing the wire's `CronTrigger` discriminator and started naming kinds through `TriggerDisplay`.
  That was claimed in this PR body and not shown; it is shown now. Plus a job with no data.
- `TriggerDisplayTest` (new) — every arm of both methods, including the fallback for a kind with no
  display name.
- `InProcessQuartzApiClientTest` — schedule-with-job, schedule-trigger-only, trigger-with-data, and
  the calendar round trip through the client rather than around it.
- `DashboardDurationTest` (new) — the history store and both plugins carrying a **sub-millisecond**
  `JobRunTime`, which the old whole-millisecond count recorded as no time at all. That is the defect
  section 3 fixed, and it had no test.
- `ExceptionHandlerTest` (new) — `IncludeStackTraceInProblemDetails`, off by default for a reason and
  not a thing to learn the behaviour of in production. Also pins that a `500` names no exception type
  even with traces on.

The 2 remaining C# lines are defensive branches for a server that is not this one: a trigger element
that deserializes to `null`, and a job detail with no `jobDataMap` member at all (this API always
emits it).

**The Razor half cannot be covered here by construction.** There is no bUnit and no Playwright in
`Directory.Packages.props` or any test project, and `Quartz.Tests.AspNetCore` covers the HTTP API
rather than the Blazor UI, so those 47 lines report 0% no matter what anyone writes. They get a
`sonar.coverage.exclusions` entry beside the `docs/.vuepress/**` one from #3348, for the same stated
reason — analysis keeps applying its bug and security rules; what is excused is a coverage figure the
workflow is not configured to produce. It is scoped to `src/Quartz.Dashboard/Components/**/*.razor`,
**not** to the package, so every ordinary C# file in `Quartz.Dashboard` stays measured. **#3363**
describes what adopting bUnit would involve and is where the exclusion gets revisited; the comment in
`sonar.yml` points at it.

With the components excluded, new-code coverage on this PR is **98.7%**.

## Verification

```
dotnet build Quartz.slnx        Build succeeded. 0 Warning(s) 0 Error(s)
Quartz.Tests.Unit               Passed! - Failed: 0, Passed: 2882, Skipped: 4, Total: 2886
Quartz.Tests.AspNetCore         Passed! - Failed: 0, Passed: 305, Skipped: 0, Total: 305
```

`Quartz.Tests.Integration` was not run — **no Docker daemon is available in this environment**
(`failed to connect to the backend: timed out dialing Hyper-V socket`). Nothing in that project
references the HTTP API contract, `HttpScheduler` or the dashboard, so the change is not exercised
there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3wNU6NFXyZztWp12PGQc
