### PR TITLE
An execution limit says whether it is counted per node or per cluster

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/rescheduling-jobs.md
+++ b/docs/documentation/quartz-4.x/how-tos/rescheduling-jobs.md
@@ -87,9 +87,9 @@ existing association in place.
 The return value is `true` when the trigger was found and updated, `false` when the key names nothing.
 
 Two of these do affect firing, just not the fire *times*: the misfire instruction changes what happens
-the next time the trigger is late, and the execution group changes which per-node limit the job counts
-against — from the next acquisition cycle, so a job already running keeps counting against the group it
-was acquired under.
+the next time the trigger is late, and the execution group changes which limit the job counts against —
+from the next acquisition cycle, so a job already running keeps counting against the group it was
+acquired under.
 
 ### Misfire instructions are validated against the trigger's family
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3369,6 +3369,61 @@ job store of your own cannot silently opt out of the derivation by not passing i
 + if (!slots.TryTake(candidate.ExecutionGroup, candidate.Key.Group))
 ```
 
+## An execution limit can be cluster-wide
+
+An execution limit now says what it is counted against. `ExecutionLimitScope.Node`, the default and the
+only behaviour 3.x and earlier 4.0 previews had, is what *this* node may run — so an N-node cluster runs
+up to N times the number. `ExecutionLimitScope.Cluster` is what every node sharing the job store may run
+between them, which is what a per-tenant quota actually means:
+
+```csharp
+q.UseExecutionLimits(limits => limits
+    .ForGroup("high-cpu", 2)                                  // per node, as before
+    .ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster)  // per cluster
+    .ForOtherGroups(1));
+```
+
+Nothing changes for a configuration that does not ask for it, and both scopes can appear in one set of
+limits. `quartz.clusterExecutionLimit.<group>` is the property spelling, taking the same group keys and
+values as `quartz.executionLimit.<group>`.
+
+**No schema change.** The count is an aggregate over `QRTZ_FIRED_TRIGGERS.EXECUTION_GROUP`, which has
+shipped on every dialect since 3.18 and has been written since the fired-trigger insert started carrying
+it. A row there already has a reservation's lifetime — inserted on acquisition, updated when the trigger
+fires, deleted on completion or by cluster recovery — so there is no new table, no new column, and no
+migration on either branch.
+
+Read [Execution Groups](/documentation/quartz-4.x/tutorial/execution-groups.html#clustering-considerations)
+before relying on it: the ceiling is **approximate with a bounded overshoot** unless
+`AcquireTriggersWithinLock` is on, it **fails closed** (a node that cannot reach the store fires nothing
+rather than firing unmetered), and work held at a ceiling for longer than `MisfireThreshold` goes to
+misfire handling.
+
+### What moved
+
+| Before | 4.0 |
+|---|---|
+| `ExecutionGroupLimit(ExecutionGroupScope Scope, int? MaxConcurrent)` | `ExecutionGroupLimit(ExecutionGroupScope Group, int? MaxConcurrent, ExecutionLimitScope Scope = Node)` |
+| `ExecutionLimits.TryGetLimit(ExecutionGroupScope scope, out int?)` | `TryGetLimit(ExecutionGroupScope group, out int?)` — parameter renamed; the number is still all it returns |
+| `ExecutionLimits.CreateSlots()` | `CreateSlots(IReadOnlyCollection<ExecutionGroupInFlight>? clusterInFlight = null)` |
+| — | `ExecutionLimits.HasClusterScopedLimits` |
+| — | `ExecutionGroupInFlight(string? ExecutionGroup, string TriggerGroup, int Count)` |
+| — | `TriggerAcquisitionCriteria.ClusterInFlight` |
+| — | `IDriverDelegate.SelectExecutionGroupsInFlight(conn, cancellationToken)` |
+| `ExecutionLimitsResponse` / `SetExecutionLimitsRequest` carrying `Dictionary<string, int?>` | carrying `Dictionary<string, ExecutionLimitDto>`, where the DTO is `(int? MaxConcurrent, ExecutionLimitScope Scope)` |
+| `ExecutionLimitsDto(Dictionary<string, int?> Limits)` (dashboard) | `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits)` |
+
+If you implement `IDriverDelegate` from scratch rather than deriving from `StdAdoDelegate`, the new
+member is a compile break — deliberately, because returning "nothing in flight" from a stub would fail
+the ceiling open. `StdAdoDelegate` implements it for every dialect with one statement and no overrides.
+
+If you implement `IJobStore`, nothing is required: a store that reports `Clustered == false` has one
+node, so a cluster-scoped limit and a node-scoped one are the same number, and the limits it is handed
+already say what that number is. A store that *is* clustered honours the scope by passing its own
+in-flight counts to `CreateSlots`, and must **not** expect the scheduler thread to have subtracted this
+node's running work from a cluster-scoped limit — those firings are already reservations in its own
+ledger, and subtracting them twice halves the quota.
+
 ## Batched Misfire Recovery
 
 Misfire recovery now handles a whole batch of misfired triggers with a handful of statements instead of a
@@ -5072,7 +5127,7 @@ already had `JobKeyDto` and `TriggerKeyDto`. Now it says what Quartz says:
 | `GetCurrentlyExecutingJobs(name)` → `List<CurrentlyExecutingJobDto>` | `GetFireInstances(name, DashboardFireInstanceQuery)` → `PagedResult<FireInstanceDto>`, following `IScheduler` — see [What is running is a listing, not a list of contexts](#what-is-running-is-a-listing-not-a-list-of-contexts) |
 | `CurrentlyExecutingJobDto` | `FireInstanceDto`: `FireInstanceId` is non-null and leads, `JobKey` is nullable (an acquired firing has no job loaded yet), and `SchedulerInstanceId`, `FireInstanceState State` and `ScheduledFireTimeUtc` are new |
 | `IsJobGroupPaused(name, group)` → `bool` | `GetJobGroups(name)` → `List<JobGroupDto>`, each carrying `Name` and `Paused`; one call answers for every group instead of one |
-| `ExecutionLimitsDto(IReadOnlyDictionary<string, int?> Limits)` | `ExecutionLimitsDto(Dictionary<string, int?> Limits)` — concrete out, as everywhere else |
+| `ExecutionLimitsDto(IReadOnlyDictionary<string, int?> Limits)` | `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits)` — concrete out, as everywhere else, and each entry carries the limit's [scope](#an-execution-limit-can-be-cluster-wide) as well as its number |
 | `IDashboardHistoryStore.GetPage(name, page, pageSize, jobFilter, triggerFilter)` → `DashboardHistoryPage` | `GetPage(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>` |
 | `…Job(name, string group, string jobName)` — eight members | `…Job(name, JobKeyDto)` |
 | `…Trigger(name, string group, string triggerName)` — seven members | `…Trigger(name, TriggerKeyDto)` |
@@ -6499,17 +6554,21 @@ the type was a dictionary, and it is the reason the lookup is a `TryGet` rather 
 The read side is typed instead of spelled. `ExecutionGroupScope` is a readonly record struct with exactly the
 three cases the builder can write — `Default` (triggers with no execution group), `OtherGroups` (the catch-all)
 and `Named(name)` — mirroring how `PreferredNode` models none/auto/named rather than using a nullable string
-with a sentinel. `ExecutionGroupLimit.Scope` replaces `ExecutionGroupLimit.Group`, so enumerating `Groups` no
-longer requires knowing that `null` meant the default bucket and `"*"` meant the catch-all:
+with a sentinel. `ExecutionGroupLimit.Group` is that value, so enumerating `Groups` no longer requires knowing
+that `null` meant the default bucket and `"*"` meant the catch-all:
 
 ```csharp
 foreach (ExecutionGroupLimit limit in limits.Groups)
 {
-    string label = limit.Scope.IsDefault ? "(default)"
-        : limit.Scope.IsOtherGroups ? "(other groups)"
-        : limit.Scope.Name!;
+    string label = limit.Group.IsDefault ? "(default)"
+        : limit.Group.IsOtherGroups ? "(other groups)"
+        : limit.Group.Name!;
 }
 ```
+
+`ExecutionGroupLimit.Scope` is a different thing — `ExecutionLimitScope.Node` or `.Cluster`, added by
+[cluster-wide ceilings](#an-execution-limit-can-be-cluster-wide). The two words sit side by side on
+purpose: `Group` says *which* bucket the limit is for, `Scope` says *what it is counted against*.
 
 The configuration spellings are unchanged: `quartz.executionLimit.*` keys and the HTTP API still say `*` for the
 catch-all and `_` or `null` for the default bucket (neither a property key nor a JSON object key can be empty).
@@ -6548,6 +6607,9 @@ public override async ValueTask<List<IOperableTrigger>> AcquireNextTriggers(
 Create the ledger per acquisition attempt, not per store: it is mutable and not thread-safe by design, and a
 retried acquisition has to start from the limits again rather than from what the failed attempt had counted down.
 `CreateSlots()` leaves the snapshot untouched, so the same `ExecutionLimits` can produce as many as you need.
+
+A clustered store of your own has one more thing to do — see
+[cluster-wide ceilings](#an-execution-limit-can-be-cluster-wide).
 
 ## Interruption has two names, not three
 

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -171,17 +171,24 @@ q.AddJobListener<AuditListener>(Matchers.Group<JobKey>(StringOperator.Equality, 
 
 ### Per-tenant concurrency quotas
 
-Execution groups cap how many threads a category of work may use on a node. When the schedule already
-partitions work by trigger group — a tenant per group — the trigger group can stand in for the
-execution group, so a quota is one line per tenant and no change to any trigger:
+Execution groups cap how many threads a category of work may use. When the schedule already partitions
+work by trigger group — a tenant per group — the trigger group can stand in for the execution group, so
+a quota is one line per tenant and no change to any trigger:
 
 ```csharp
 q.UseExecutionLimits(limits => limits
     .UseTriggerGroupWhenUnset()
-    .ForGroup("acme", 8)          // a big tenant
-    .ForGroup("initech", 2)
-    .ForOtherGroups(1));          // everyone else gets one thread each
+    .ForGroup("acme", 8, ExecutionLimitScope.Cluster)          // a big tenant
+    .ForGroup("initech", 2, ExecutionLimitScope.Cluster)
+    .ForOtherGroups(1, ExecutionLimitScope.Cluster));          // everyone else gets one thread each
 ```
+
+`ExecutionLimitScope.Cluster` is what makes these quotas rather than capacity settings: the number is
+what every node sharing the job store may run **between them**, counted from the reservations the store
+itself is holding. Leave the scope off and each limit is per node instead, which on a three-node cluster
+means `ForGroup("acme", 8)` allows 24 concurrent Acme jobs. Both scopes are legitimate — node-scoped for
+"this machine can stand eight", cluster-scoped for "this tenant is entitled to eight" — and one set of
+limits can hold both.
 
 `UseTriggerGroupWhenUnset()` changes nothing about the data — the trigger still carries no execution
 group, and the store still persists none. It changes only how a limit is looked up. Three consequences:
@@ -195,13 +202,25 @@ group, and the store still persists none. It changes only how a limit is looked 
 `Unlimited(group)` is not the same as leaving a group out: an unlisted group falls back to
 `ForOtherGroups`, an explicitly unlimited one does not.
 
-Limits can also be changed at runtime, per node, with `SetExecutionLimits` / `GetExecutionLimits` — they
-take effect on the next acquisition cycle, and `null` clears them.
+Limits can also be changed at runtime with `SetExecutionLimits` / `GetExecutionLimits` — they take
+effect on the next acquisition cycle, and `null` clears them. The call is per node whichever scope the
+limits use: it replaces what *this* scheduler enforces, so a cluster-scoped quota you mean every node to
+honour has to be set on every node, or configured rather than set.
 
-::: warning
-Execution limits are **per node**, held in memory, and nothing about them is persisted. On a
-three-node cluster, `ForGroup("acme", 8)` means up to 24 concurrent Acme jobs. See
-[honest limits](#honest-limits).
+::: warning What a cluster-scoped quota does and does not promise
+The ceiling holds **within one acquisition round**, and by default acquisition takes no cluster lock, so
+a brief overshoot is possible while several nodes acquire at once — at most
+`limit + (nodes − 1) × batchSize`, until the losers notice. `AcquireTriggersWithinLock = true` makes it
+exact and serializes acquisition cluster-wide.
+
+It **fails closed**: the quota ledger and the work queue are the same database, so a node that cannot
+reach the store fires nothing at all rather than firing unmetered. Plan for a database outage stopping
+work, not for it removing the ceiling.
+
+A group held at its ceiling for longer than `MisfireThreshold` (one minute by default) feeds its backlog
+into misfire handling. Pair a tight quota with `MisfireInstruction.IgnoreMisfirePolicy` or a larger
+threshold. See [Execution Groups](tutorial/execution-groups.md#clustering-considerations) for the
+full statement.
 :::
 
 ## Shared database
@@ -296,14 +315,19 @@ not once at startup, if tenants can be reconfigured while the process runs.
 
 Things multi-tenant deployments ask Quartz for and do not get:
 
-**Execution limits are per node, not cluster-wide.** They live in a field on the in-process scheduler
-and count against an in-memory dictionary of what is running here. Nothing is persisted and nodes do not
-coordinate. A cluster-wide cap is not available; the closest approximation is dividing the cap by the
-node count, which is wrong whenever a node is down.
+**A cluster-wide concurrency ceiling is approximate, not exact, unless you pay for exactness.**
+`ExecutionLimitScope.Cluster` counts a group's in-flight work from `QRTZ_FIRED_TRIGGERS`, which is
+transactional and cluster-wide, but the default acquisition path takes no cluster lock — so the ceiling
+holds within one acquisition round and can transiently overshoot by up to
+`(nodes − 1) × batchSize` while several nodes acquire at once. `AcquireTriggersWithinLock = true` removes
+the overshoot and serializes acquisition for every group, limited or not. There is no third setting that
+gives you both.
 
 **There is no rate limiting.** Execution limits cap *concurrency*, not throughput. "This tenant may run
 100 jobs an hour" is not something Quartz can express; build it in the job, or in the thing the job
-calls.
+calls. It is worth asking whether concurrency is what you actually meant: "at most four of this tenant's
+jobs at once" is usually the real requirement behind "100 an hour", and it is the one Quartz can enforce
+honestly.
 
 **HTTP API and dashboard authorization is per process, all or nothing.** One `MapQuartzHttpApi` serves
 every scheduler in the container, with the scheduler named in the route
@@ -374,7 +398,7 @@ rest — so a view or a filter can reference them rather than repeat the strings
 ## See also
 
 - [Multiple Schedulers](packages/multiple-schedulers.md) — the mechanics of naming and keying schedulers
-- [Execution Groups](tutorial/execution-groups.md) — per-node thread limits in full
+- [Execution Groups](tutorial/execution-groups.md) — per-node and cluster-wide thread limits in full
 - [Querying Jobs and Triggers](tutorial/querying-jobs-and-triggers.md) — group-filtered listings
 - [Clustering](tutorial/advanced-enterprise-features.md) — what a shared database gives you
 - [Migration Guide](migration-guide.md) — including why a shut-down scheduler cannot be restarted

--- a/docs/documentation/quartz-4.x/tutorial/execution-groups.md
+++ b/docs/documentation/quartz-4.x/tutorial/execution-groups.md
@@ -2,7 +2,7 @@
 title: 'Execution Groups'
 ---
 
-Execution groups allow you to limit how many threads a category of job can use concurrently on a given scheduler node.
+Execution groups allow you to limit how many threads a category of job can use concurrently.
 This prevents resource-intensive jobs from starving lightweight jobs of available threads.
 
 ## Concepts
@@ -10,14 +10,21 @@ This prevents resource-intensive jobs from starving lightweight jobs of availabl
 An **execution group** is an optional tag on a trigger that characterizes the resource requirements of its associated job.
 Examples might be `"batch-jobs"`, `"high-cpu"`, `"large-ram"`, or `"reports"`.
 
-**Execution limits** are configured per node, declaring how many threads each group may consume:
+**Execution limits** declare how many threads each group may consume:
 
 - A positive integer (e.g. `5`) limits the group to that many concurrent executions.
-- `0` forbids the group from running on this node entirely.
+- `0` forbids the group from running entirely.
 - No limit configured means unlimited (no restriction).
 
-Each scheduler node can declare its own independent limits, making this ideal for heterogeneous clusters
-where some nodes are tuned for heavy batch work and others for lightweight, latency-sensitive jobs.
+Every limit also says **what it is counted against**, its `ExecutionLimitScope`:
+
+| Scope | The number is | Use it for |
+| -- | -- | -- |
+| `Node` (the default) | what *this* node may run at once. Each node enforces its own copy, so an N-node cluster can be running N times the number. | heterogeneous hardware — a batch node and an API node want different numbers |
+| `Cluster` | what *every node sharing the job store* may run between them | quotas — "this tenant gets eight threads", however many nodes are up |
+
+The two coexist in one set of limits, and one deployment often wants both. A limit that says nothing is
+node-scoped, which is what execution limits have always meant.
 
 ## Setting execution groups on triggers
 
@@ -67,18 +74,27 @@ quartz.executionLimit.batch-jobs = 2
 quartz.executionLimit.high-cpu = 3
 quartz.executionLimit._ = 10
 quartz.executionLimit.* = 5
+
+quartz.clusterExecutionLimit.tenant-acme = 8
 ```
 
 | Key | Meaning |
 |-----|---------|
-| `batch-jobs` | At most 2 concurrent "batch-jobs" triggers |
-| `high-cpu` | At most 3 concurrent "high-cpu" triggers |
-| `_` (underscore) | At most 10 concurrent triggers with no execution group |
-| `*` (asterisk) | Default limit of 5 for any group not explicitly listed |
+| `quartz.executionLimit.batch-jobs` | At most 2 concurrent "batch-jobs" triggers **on this node** |
+| `quartz.executionLimit.high-cpu` | At most 3 concurrent "high-cpu" triggers on this node |
+| `quartz.executionLimit._` (underscore) | At most 10 concurrent triggers with no execution group, on this node |
+| `quartz.executionLimit.*` (asterisk) | Default limit of 5 for any group not explicitly listed |
+| `quartz.clusterExecutionLimit.tenant-acme` | At most 8 concurrent "tenant-acme" triggers **across the whole cluster** |
+
+`quartz.clusterExecutionLimit.*` takes the same group keys — including `_` and `*` — and the same
+values as `quartz.executionLimit.*`; the only difference is the scope. It is a prefix of its own rather
+than a magic value under the existing one, because every key under `quartz.executionLimit` is a group
+name and every value is a count, so neither half had a spelling to spare.
 
 Special values for the limit:
-- `unlimited`, `none`, or `null` — no restriction (same as not listing the group)
-- `0` — completely forbidden on this node
+- `unlimited`, `none`, or `null` — no restriction (same as not listing the group); it takes no scope,
+  since unlimited on a node and unlimited across the cluster are the same permission
+- `0` — completely forbidden
 
 ### Via dependency injection
 
@@ -87,13 +103,17 @@ services.AddQuartz(q =>
 {
     q.UseExecutionLimits(limits =>
     {
-        limits.ForGroup("batch-jobs", maxConcurrent: 2);
-        limits.ForGroup("high-cpu", maxConcurrent: 3);
+        limits.ForGroup("batch-jobs", maxConcurrent: 2);                        // per node
+        limits.ForGroup("high-cpu", maxConcurrent: 3);                          // per node
+        limits.ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster);         // per cluster
         limits.ForDefaultGroup(maxConcurrent: 10);
         limits.ForOtherGroups(maxConcurrent: 5);
     });
 });
 ```
+
+`ForGroup`, `ForDefaultGroup` and `ForOtherGroups` all take an optional trailing
+`ExecutionLimitScope`, defaulting to `Node`.
 
 ### Via scheduler API at runtime
 
@@ -141,18 +161,19 @@ With the option on, a trigger that carries no execution group is limited as thou
 The option is a code-level one. There is no `quartz.executionLimit.*` property for it, because every key
 under that prefix is a group name and a magic one would collide with a group that happened to share the
 spelling.
-Read one back with `TryGetLimit(scope, out int? maxConcurrent)`, or enumerate `Groups`. Each entry's
-`ExecutionGroupScope` is one of exactly three cases — `Default` (triggers with no execution group),
-`OtherGroups` (the catch-all) and `Named(name)` — so reading limits never involves sentinel strings:
+Read one back with `TryGetLimit(group, out int? maxConcurrent)`, or enumerate `Groups`. Each entry's
+`Group` is an `ExecutionGroupScope`, one of exactly three cases — `Default` (triggers with no execution
+group), `OtherGroups` (the catch-all) and `Named(name)` — so reading limits never involves sentinel
+strings, and its `Scope` says which scope the number is counted in:
 
 ```csharp
 ExecutionLimits? limits = await scheduler.GetExecutionLimits();
 foreach (ExecutionGroupLimit limit in limits?.Groups ?? [])
 {
-    string scope = limit.Scope.IsDefault ? "(no group)"
-        : limit.Scope.IsOtherGroups ? "(other groups)"
-        : limit.Scope.Name!;
-    Console.WriteLine($"{scope}: {limit.MaxConcurrent?.ToString() ?? "unlimited"}");
+    string group = limit.Group.IsDefault ? "(no group)"
+        : limit.Group.IsOtherGroups ? "(other groups)"
+        : limit.Group.Name!;
+    Console.WriteLine($"{group}: {limit.MaxConcurrent?.ToString() ?? "unlimited"} per {limit.Scope}");
 }
 
 limits?.TryGetLimit(ExecutionGroupScope.Named("batch-jobs"), out int? batchLimit);
@@ -172,7 +193,7 @@ different things — the table below puts them side by side so neither is read a
 
 | Where it appears | What `*` means there | Typed reading |
 |---|---|---|
-| `quartz.executionLimit.*` key / execution-limits HTTP body | The catch-all limit applied to any *named* group without a limit of its own (never to ungrouped triggers) | `ExecutionGroupScope.OtherGroups` |
+| `quartz.executionLimit.*` or `quartz.clusterExecutionLimit.*` key / execution-limits HTTP body | The catch-all limit applied to any *named* group without a limit of its own (never to ungrouped triggers) | `ExecutionGroupScope.OtherGroups` |
 | A trigger row's preferred-node column | An automatic pin no node has claimed yet — the trigger runs anywhere until one node fires it first and keeps it | `PreferredNode.Auto` |
 
 In both places `*` is reserved vocabulary, not a name: a trigger cannot have `*` as its execution group, and
@@ -182,9 +203,13 @@ a node cannot have `*` as its scheduler instance id.
 
 On each trigger acquisition cycle, the scheduler thread:
 
-1. Computes the available slots per execution group by subtracting currently running counts from configured limits.
+1. Computes the available slots per execution group by subtracting currently running counts from the
+   configured **node-scoped** limits. Cluster-scoped limits are deliberately left as configured here —
+   this node's firings are already reservations the store is holding, and subtracting them twice would
+   halve the quota on the busiest node.
 2. Passes these available limits to the job store during trigger acquisition.
-3. The job store skips triggers whose execution group has no available slots.
+3. The job store lowers each **cluster-scoped** limit by what the cluster holds in flight, then skips
+   triggers whose execution group has no available slots.
 4. When a job starts, the running count for its group is incremented; when it completes, the count is decremented.
 
 This means:
@@ -194,8 +219,10 @@ This means:
 
 ## Clustering considerations
 
-Execution limits are **per-node** configuration. Each scheduler node independently declares and enforces its own limits.
-This is intentional — different nodes in a cluster may have different hardware capabilities.
+### Node-scoped limits
+
+A node-scoped limit is configuration each node declares and enforces for itself. This is intentional —
+different nodes in a cluster may have different hardware capabilities.
 
 Example: in a cluster with dedicated batch nodes and API nodes:
 ```
@@ -207,6 +234,73 @@ quartz.executionLimit.* = 2
 quartz.executionLimit.batch-jobs = 0
 quartz.executionLimit.* = 10
 ```
+
+Because each node enforces its own copy, three nodes each configured `batch-jobs = 8` can be running 24
+batch jobs. That is the right answer for hardware capacity and the wrong one for a quota.
+
+### Cluster-scoped limits
+
+A cluster-scoped limit is one number for the whole cluster, and every node enforces the same one:
+
+```csharp
+q.UseExecutionLimits(limits => limits
+    .ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster));
+```
+
+**Where the count comes from.** `QRTZ_FIRED_TRIGGERS` already is the cluster's reservation ledger — a
+row appears when any node acquires a trigger, becomes the running execution, and is deleted when the job
+completes or when cluster recovery cleans up after the node that owned it. Acquisition aggregates that
+table by execution group, so the ceiling needs no new table, no new column and no migration; the
+`EXECUTION_GROUP` column on `QRTZ_FIRED_TRIGGERS` has been part of the 4.x schema since it was written.
+
+Four things about the guarantee are worth knowing before you rely on it.
+
+**1. It is approximate by default, with a bounded overshoot.** By default the ADO.NET store acquires
+triggers *without* taking the cluster's `TRIGGER_ACCESS` lock (`AcquireTriggersWithinLock` is `false` and
+`MaxBatchSize` is `1`), so two nodes can read "2 of 3 in flight" in the same instant and each take one.
+
+> The ceiling holds within one acquisition round. Transient overshoot is bounded by the number of nodes
+> acquiring concurrently — at most `limit + (nodes − 1) × batchSize`, for as long as it takes the losers
+> to notice. Setting `AcquireTriggersWithinLock = true` makes it exact, at the cost of serializing
+> acquisition cluster-wide for *every* group rather than only the limited ones.
+
+That is a real improvement on `limit × nodes`, and it is what a tenant quota actually needs: "8,
+occasionally 9 for a moment" is fine, "8 became 24" is not. If you need exactness more than you need
+acquisition throughput, turn the lock on deliberately.
+
+::: tip SQLite is exact, and nothing else is by default
+`AcquireTriggersWithinLock` is forced to `true` for SQLite at startup (it has to be, for locking
+reasons), so the ceiling is exact there and approximate on every other database until you say otherwise.
+Do not read a SQLite test as evidence about SQL Server or PostgreSQL.
+:::
+
+**2. It fails closed, structurally.** The ledger and the work queue are the same database, so there is
+nothing to fail open *to*. If the store is unreachable or a node is partitioned away from it, that node's
+`AcquireNextTriggers` throws, the scheduler thread raises `SchedulerError` and backs off, and the node
+fires **nothing at all** — the quota is not bypassed, the node is out of service. A database outage
+therefore stops firing rather than removing the ceiling. That is the safe direction for a quota and the
+one to plan for.
+
+**3. A dead node's slots are held until recovery.** `ClusterRecover` deletes a failed node's fired-trigger
+rows on the ordinary check-in cadence (`CheckinInterval` + `CheckinMisfireThreshold`). Until it does, the
+dead node's reservations still count, so the quota is briefly **under**-served, never over-served. The
+count is deliberately *not* narrowed to nodes that are currently checking in: a node that has missed one
+check-in but is still running jobs would stop counting, and that would let the cluster exceed the ceiling.
+
+**4. Held-back work can misfire.** A trigger a ceiling holds back stays `WAITING`, and acquisition
+excludes anything older than `MisfireThreshold` — one minute by default. A group parked at its ceiling
+for longer than that feeds its backlog into `RecoverMisfiredJobs`, with whatever each trigger's misfire
+instruction says. This is more likely with a cluster-scoped limit than a node-scoped one, because a
+saturated node simply loses the trigger to a peer while a saturated *cluster* has no peer to lose it to.
+Pair a tightly limited group with `MisfireInstruction.IgnoreMisfirePolicy`, or raise
+`MisfireThreshold`, if the backlog matters.
+
+**Cost.** One extra aggregate per acquisition attempt — not per trigger — emitted only when at least one
+limit is cluster-scoped. A configuration with none pays nothing.
+
+**RAMJobStore.** `RAMJobStore` is never clustered, so its cluster is the one process: it counts its own
+reservations and running executions, and a cluster-scoped limit comes out as the same number a
+node-scoped one would. Both stores are held to the same assertions in `JobStoreContractTest`.
 
 ## Interaction with DisallowConcurrentExecution
 
@@ -236,10 +330,10 @@ ALTER TABLE QRTZ_TRIGGERS ADD (EXECUTION_GROUP VARCHAR2(200) NULL);
 ```
 
 The standard 4.x schema also includes an `EXECUTION_GROUP` column on `QRTZ_FIRED_TRIGGERS`. It records
-the execution group a firing belongs to, so that `IScheduler.QueryFireInstances` can report it from any
-node in the cluster. Acquisition still reads limits from `QRTZ_TRIGGERS`; this column is what the listing
-reads. Rows written by a 4.0 preview before it went live hold `NULL`. If upgrading from 3.x, add it
-alongside the `QRTZ_TRIGGERS` column:
+the execution group a firing belongs to, which two things read: `IScheduler.QueryFireInstances` reports
+it from any node in the cluster, and a **cluster-scoped** limit is counted by aggregating over it. Which
+triggers are candidates is still decided from `QRTZ_TRIGGERS`. Rows written by a 4.0 preview before it
+went live hold `NULL`. If upgrading from 3.x, add it alongside the `QRTZ_TRIGGERS` column:
 
 ```sql
 ALTER TABLE QRTZ_FIRED_TRIGGERS ADD EXECUTION_GROUP NVARCHAR(200) NULL;  -- SQL Server
@@ -278,8 +372,14 @@ quartz.executionLimit.* = 0
 
 ### Multi-tenant isolation
 
+A tenant quota is a property of the tenant, not of the machine, so it is cluster-scoped:
+
 ```csharp
-limits.ForGroup("tenant-a", maxConcurrent: 5);
-limits.ForGroup("tenant-b", maxConcurrent: 5);
-limits.ForGroup("tenant-c", maxConcurrent: 5);
+limits.ForGroup("tenant-a", 5, ExecutionLimitScope.Cluster);
+limits.ForGroup("tenant-b", 5, ExecutionLimitScope.Cluster);
+limits.ForGroup("tenant-c", 5, ExecutionLimitScope.Cluster);
 ```
+
+Node-scoped instead (`limits.ForGroup("tenant-a", 5)`) would give each tenant five threads *per node*,
+which on a three-node cluster is fifteen. See [Multi-tenancy](../multi-tenancy.md) for the rest of the
+per-tenant story.

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -203,8 +203,11 @@ Celery's documentation is admirably direct about it: "Note that this is a *per w
 limit, and not a global rate limit. To enforce a global rate limit … you must restrict to a given
 queue." A `rate_limit` of 10/s across four workers is 40/s.
 
-Quartz.NET's execution limits have exactly this property, for exactly this reason: the running count
-lives in memory in the scheduler. See [what Quartz.NET does not give you](#what-quartz-net-does-not-give-you).
+Quartz.NET's execution limits have exactly this property by default, for exactly this reason: the
+running count lives in memory in the scheduler. On 4.x a limit can opt out of it — declared
+`ExecutionLimitScope.Cluster`, it is counted from the fired-triggers table instead, which is the same
+move Airflow's pools make and the one Hangfire charges for. See
+[what Quartz.NET does not give you](#what-quartz-net-does-not-give-you).
 
 The contrast is Hangfire. Its free tier has no per-queue or per-tenant cap either — worker count is
 per server — but `Hangfire.Throttling`, part of the paid **Hangfire Ace** set, adds mutexes,
@@ -428,7 +431,8 @@ rather than an isolation one.
 | Startup schema validation | Yes, `PerformSchemaValidation` on by default | Yes, `PerformSchemaValidation` on by default |
 | Execution groups and per-node limits | Yes | Yes |
 | Trigger group as the execution group | No — tag every trigger explicitly | Yes, `UseTriggerGroupWhenUnset()` |
-| Cluster-wide quotas or rate limiting | No | No |
+| Cluster-wide concurrency quota | No | Yes, `ExecutionLimitScope.Cluster` — approximate unless `AcquireTriggersWithinLock` |
+| Rate limiting (N per window) | No | No |
 | Node affinity (persisted, cluster-aware) | Yes, `WithPreferredNode` | Yes, `WithPreferredNode` |
 | Preparing the job's DI scope | Subclass and override `ConfigureScope` | `ConfigureJobScope(…)` delegate |
 | Per-scheduler health check | No — one check, on the default scheduler | Yes, `AddQuartzHealthChecks` per scheduler |
@@ -466,12 +470,19 @@ separate database only if the data must not sit beside another tenant's.
 A recommendation that oversells is worse than none, so these are the things multi-tenant deployments
 ask Quartz.NET for and do not get. They apply to both 3.x and 4.x unless noted.
 
-**Concurrency limits are per node, not cluster-wide.** Execution groups cap how many threads a
-category of work may use, and the running count lives in a dictionary in memory on the scheduler
-thread. Nothing is persisted and nodes do not coordinate, so a group limited to 3 can run up to 3×N
-across an N-node cluster. This is the same trap Celery documents for `rate_limit`, and the same one
-Hangfire only escapes in a paid add-on that coordinates through storage. The closest approximation is
-dividing the cap by the node count, which is wrong whenever a node is down.
+**Concurrency limits are per node unless you say otherwise, and on 3.x that is the only option.**
+Execution groups cap how many threads a category of work may use, and by default the running count
+lives in a dictionary in memory on the scheduler thread: nothing is persisted, nodes do not coordinate,
+and a group limited to 3 can run up to 3×N across an N-node cluster. This is the same trap Celery
+documents for `rate_limit`, and the same one Hangfire only escapes in a paid add-on that coordinates
+through storage. On 3.x the closest approximation is dividing the cap by the node count, which is wrong
+whenever a node is down.
+
+4.x adds the real thing: `ForGroup("acme", 8, ExecutionLimitScope.Cluster)` is counted from
+`QRTZ_FIRED_TRIGGERS`, which is already the cluster's reservation ledger. Read what it promises before
+relying on it — the ceiling holds within one acquisition round and can transiently overshoot by
+`(nodes − 1) × batchSize` unless `AcquireTriggersWithinLock` is on, and it fails closed, so a node that
+cannot reach the store fires nothing rather than firing unmetered.
 
 **There is no rate limiting.** Execution limits cap *concurrency*, not throughput. "This tenant may
 run 100 jobs an hour" is not something Quartz.NET can express; build it in the job, or in the thing
@@ -559,7 +570,8 @@ hubs and solved it by deriving the default name from the app name — a good ide
 the scheduler name from the tenant id rather than from a configuration file someone can copy-paste.
 
 **Assuming a per-node limit is a per-cluster limit.** Covered above, and repeated here because it is
-the failure that only shows up in production, after the second node is added.
+the failure that only shows up in production, after the second node is added. It is still the default
+on 4.x — a limit is cluster-wide only when it says `ExecutionLimitScope.Cluster`.
 
 **Letting per-tenant metrics multiply without a view.** A tenant dimension times a trigger-name
 dimension is a series per tenant per trigger. Aggregate before the data leaves the process.

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -183,13 +183,13 @@ internal static class SchedulerEndpoints
         return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             ExecutionLimits? limits = await scheduler.GetExecutionLimits(cancellationToken).ConfigureAwait(false);
-            Dictionary<string, int?>? dict = null;
+            Dictionary<string, ExecutionLimitDto>? dict = null;
             if (limits is not null && !limits.IsEmpty)
             {
-                dict = new Dictionary<string, int?>();
+                dict = new Dictionary<string, ExecutionLimitDto>();
                 foreach (ExecutionGroupLimit limit in limits.Groups)
                 {
-                    dict[limit.Scope.ToConfigurationKey()] = limit.MaxConcurrent;
+                    dict[limit.Group.ToConfigurationKey()] = new ExecutionLimitDto(limit.MaxConcurrent, limit.Scope);
                 }
             }
             return new ExecutionLimitsResponse(dict, limits?.UsesTriggerGroupWhenUnset ?? false);
@@ -212,20 +212,23 @@ internal static class SchedulerEndpoints
             if (request.Limits is { Count: > 0 })
             {
                 ExecutionLimitsBuilder builder = ExecutionLimitsBuilder.Create();
-                foreach (KeyValuePair<string, int?> kvp in request.Limits)
+                foreach (KeyValuePair<string, ExecutionLimitDto> kvp in request.Limits)
                 {
                     string key = kvp.Key.Trim();
+                    int? maxConcurrent = kvp.Value.MaxConcurrent;
+                    ExecutionLimitScope scope = kvp.Value.Scope;
+
                     if (key == ExecutionLimits.OtherGroups)
                     {
-                        if (kvp.Value.HasValue) builder.ForOtherGroups(kvp.Value.Value);
+                        if (maxConcurrent.HasValue) builder.ForOtherGroups(maxConcurrent.Value, scope);
                     }
                     else if (ExecutionLimits.IsDefaultGroupAlias(key))
                     {
-                        if (kvp.Value.HasValue) builder.ForDefaultGroup(kvp.Value.Value);
+                        if (maxConcurrent.HasValue) builder.ForDefaultGroup(maxConcurrent.Value, scope);
                     }
                     else
                     {
-                        if (kvp.Value.HasValue) builder.ForGroup(key, kvp.Value.Value);
+                        if (maxConcurrent.HasValue) builder.ForGroup(key, maxConcurrent.Value, scope);
                         else builder.Unlimited(key);
                     }
                 }

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -292,4 +292,17 @@ public sealed record AddCalendarRequest(string CalendarName, ICalendar Calendar,
 
 public sealed record AddJobRequest(JobDetailDto Job, bool Replace, bool? StoreNonDurableWhileAwaitingScheduling);
 
-public sealed record ExecutionLimitsDto(Dictionary<string, int?> Limits);
+/// <summary>
+/// The execution limits a scheduler is running with, keyed by a display-friendly group name.
+/// </summary>
+/// <param name="Limits">Each group's limit, with the scope it is counted in.</param>
+public sealed record ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits);
+
+/// <summary>
+/// One group's limit as the dashboard reads it.
+/// </summary>
+/// <param name="MaxConcurrent">The limit, or <see langword="null" /> when the group is explicitly
+/// unlimited.</param>
+/// <param name="Scope">Whether the number is what one node may run or what the cluster may run.</param>
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+public readonly record struct DashboardExecutionLimit(int? MaxConcurrent, ExecutionLimitScope Scope);

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -560,12 +560,12 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
                 return null;
             }
 
-            Dictionary<string, int?> dict = new();
+            Dictionary<string, DashboardExecutionLimit> dict = new();
             foreach (ExecutionGroupLimit limit in limits.Groups)
             {
                 // Use display-friendly keys
-                string key = limit.Scope.IsDefault ? "(default)" : limit.Scope.ToConfigurationKey();
-                dict[key] = limit.MaxConcurrent;
+                string key = limit.Group.IsDefault ? "(default)" : limit.Group.ToConfigurationKey();
+                dict[key] = new DashboardExecutionLimit(limit.MaxConcurrent, limit.Scope);
             }
 
             return new ExecutionLimitsDto(dict);

--- a/src/Quartz.Dashboard/Services/QuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/QuartzApiClient.cs
@@ -912,13 +912,43 @@ internal sealed class QuartzApiClient : IQuartzApiClient
             return null;
         }
 
-        Dictionary<string, int?> dict = new();
+        Dictionary<string, DashboardExecutionLimit> dict = new();
         foreach (JsonProperty prop in limitsElement.EnumerateObject())
         {
             string key = prop.Name is "" or "_" ? "(default)" : prop.Name;
-            dict[key] = prop.Value.ValueKind == JsonValueKind.Null ? null : prop.Value.GetInt32();
+            dict[key] = ReadExecutionLimit(prop.Value);
         }
 
         return dict.Count > 0 ? new ExecutionLimitsDto(dict) : null;
+    }
+
+    /// <summary>
+    /// Reads one group's limit out of the execution-limits body.
+    /// </summary>
+    /// <remarks>
+    /// A payload that carries no scope reads as <see cref="ExecutionLimitScope.Node" />, which is what
+    /// an execution limit meant before scopes existed and what a bare number on the wire still means.
+    /// The dashboard talks to whatever API it was pointed at, so this degrades rather than throws.
+    /// </remarks>
+    private static DashboardExecutionLimit ReadExecutionLimit(JsonElement value)
+    {
+        if (value.ValueKind != JsonValueKind.Object)
+        {
+            return new DashboardExecutionLimit(
+                value.ValueKind == JsonValueKind.Number ? value.GetInt32() : null,
+                ExecutionLimitScope.Node);
+        }
+
+        int? maxConcurrent = value.TryGetProperty("maxConcurrent", out JsonElement max) && max.ValueKind == JsonValueKind.Number
+            ? max.GetInt32()
+            : null;
+
+        ExecutionLimitScope scope = value.TryGetProperty("scope", out JsonElement scopeElement)
+                                    && scopeElement.ValueKind == JsonValueKind.String
+                                    && Enum.TryParse(scopeElement.GetString(), ignoreCase: true, out ExecutionLimitScope parsed)
+            ? parsed
+            : ExecutionLimitScope.Node;
+
+        return new DashboardExecutionLimit(maxConcurrent, scope);
     }
 }

--- a/src/Quartz.Dashboard/Services/QuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/QuartzApiClient.cs
@@ -21,6 +21,7 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
@@ -32,6 +33,15 @@ namespace Quartz.Dashboard.Services;
 internal sealed class QuartzApiClient : IQuartzApiClient
 {
     private static readonly JsonSerializerOptions historySerializerOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// How an execution limit comes off the wire: web casing, and the scope by name rather than by
+    /// ordinal, which is how <c>HttpApiJson.ConfigureWireFormat</c> writes it on the server.
+    /// </summary>
+    private static readonly JsonSerializerOptions executionLimitSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter<ExecutionLimitScope>() }
+    };
 
     private readonly IHttpClientFactory httpClientFactory;
     private readonly IHttpContextAccessor httpContextAccessor;
@@ -915,40 +925,16 @@ internal sealed class QuartzApiClient : IQuartzApiClient
         Dictionary<string, DashboardExecutionLimit> dict = new();
         foreach (JsonProperty prop in limitsElement.EnumerateObject())
         {
-            string key = prop.Name is "" or "_" ? "(default)" : prop.Name;
-            dict[key] = ReadExecutionLimit(prop.Value);
+            // Deserialized through the wire contract's own DTO rather than read property by property,
+            // so the body's shape has one definition and the scope cannot be dropped here by omission.
+            ExecutionLimitDto? limit = prop.Value.Deserialize<ExecutionLimitDto>(executionLimitSerializerOptions);
+            if (limit is not null)
+            {
+                string key = prop.Name is "" or "_" ? "(default)" : prop.Name;
+                dict[key] = new DashboardExecutionLimit(limit.MaxConcurrent, limit.Scope);
+            }
         }
 
         return dict.Count > 0 ? new ExecutionLimitsDto(dict) : null;
-    }
-
-    /// <summary>
-    /// Reads one group's limit out of the execution-limits body.
-    /// </summary>
-    /// <remarks>
-    /// A payload that carries no scope reads as <see cref="ExecutionLimitScope.Node" />, which is what
-    /// an execution limit meant before scopes existed and what a bare number on the wire still means.
-    /// The dashboard talks to whatever API it was pointed at, so this degrades rather than throws.
-    /// </remarks>
-    private static DashboardExecutionLimit ReadExecutionLimit(JsonElement value)
-    {
-        if (value.ValueKind != JsonValueKind.Object)
-        {
-            return new DashboardExecutionLimit(
-                value.ValueKind == JsonValueKind.Number ? value.GetInt32() : null,
-                ExecutionLimitScope.Node);
-        }
-
-        int? maxConcurrent = value.TryGetProperty("maxConcurrent", out JsonElement max) && max.ValueKind == JsonValueKind.Number
-            ? max.GetInt32()
-            : null;
-
-        ExecutionLimitScope scope = value.TryGetProperty("scope", out JsonElement scopeElement)
-                                    && scopeElement.ValueKind == JsonValueKind.String
-                                    && Enum.TryParse(scopeElement.GetString(), ignoreCase: true, out ExecutionLimitScope parsed)
-            ? parsed
-            : ExecutionLimitScope.Node;
-
-        return new DashboardExecutionLimit(maxConcurrent, scope);
     }
 }

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -307,10 +307,10 @@ public sealed class HttpScheduler : IScheduler
         }
         else
         {
-            Dictionary<string, int?> dict = new();
+            Dictionary<string, ExecutionLimitDto> dict = new();
             foreach (ExecutionGroupLimit limit in limits.Groups)
             {
-                dict[limit.Scope.ToConfigurationKey()] = limit.MaxConcurrent;
+                dict[limit.Group.ToConfigurationKey()] = new ExecutionLimitDto(limit.MaxConcurrent, limit.Scope);
             }
             await httpClient.Post(
                 $"{SchedulerEndpointUrl()}/execution-limits",
@@ -329,20 +329,23 @@ public sealed class HttpScheduler : IScheduler
         }
 
         ExecutionLimitsBuilder builder = ExecutionLimitsBuilder.Create();
-        foreach (KeyValuePair<string, int?> kvp in response.Limits)
+        foreach (KeyValuePair<string, ExecutionLimitDto> kvp in response.Limits)
         {
+            int? maxConcurrent = kvp.Value.MaxConcurrent;
+            ExecutionLimitScope scope = kvp.Value.Scope;
+
             if (kvp.Key == ExecutionLimits.OtherGroups)
             {
-                if (kvp.Value.HasValue) builder.ForOtherGroups(kvp.Value.Value);
+                if (maxConcurrent.HasValue) builder.ForOtherGroups(maxConcurrent.Value, scope);
             }
             else if (ExecutionLimits.IsDefaultGroupAlias(kvp.Key))
             {
-                if (kvp.Value.HasValue) builder.ForDefaultGroup(kvp.Value.Value);
+                if (maxConcurrent.HasValue) builder.ForDefaultGroup(maxConcurrent.Value, scope);
                 // null value = unlimited, nothing to set
             }
             else
             {
-                if (kvp.Value.HasValue) builder.ForGroup(kvp.Key, kvp.Value.Value);
+                if (maxConcurrent.HasValue) builder.ForGroup(kvp.Key, maxConcurrent.Value, scope);
                 else builder.Unlimited(kvp.Key);
             }
         }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -511,6 +511,57 @@ public class InProcessQuartzApiClientTest
         }
     }
 
+    /// <summary>
+    /// The dashboard reads a limit's scope as well as its number, so a cluster-wide quota is not shown
+    /// as a per-node one.
+    /// </summary>
+    [Test]
+    public async Task GetExecutionLimitsShouldReportEachLimitsScope()
+    {
+        IScheduler scheduler = await CreateScheduler("GetExecutionLimitsTest");
+        try
+        {
+            await scheduler.SetExecutionLimits(ExecutionLimitsBuilder.Create()
+                .ForGroup("batch", 2)
+                .ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster)
+                .ForDefaultGroup(3)
+                .Build());
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            ExecutionLimitsDto? limits = await client.GetExecutionLimits(scheduler.SchedulerName);
+
+            limits.Should().NotBeNull();
+            limits.Limits.Should().BeEquivalentTo(new Dictionary<string, DashboardExecutionLimit>
+            {
+                ["batch"] = new(2, ExecutionLimitScope.Node),
+                ["tenant-acme"] = new(8, ExecutionLimitScope.Cluster),
+                ["(default)"] = new(3, ExecutionLimitScope.Node),
+            });
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task GetExecutionLimitsShouldBeNullWhenNothingIsLimited()
+    {
+        IScheduler scheduler = await CreateScheduler("GetExecutionLimitsEmptyTest");
+        try
+        {
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            (await client.GetExecutionLimits(scheduler.SchedulerName)).Should().BeNull(
+                "a scheduler with no limits has nothing to show, which is not the same as showing zeros");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
     private static async Task<IScheduler> CreateScheduler(string testName)
     {
         NameValueCollection properties = new()

--- a/src/Quartz.Tests.AspNetCore/Dashboard/QuartzApiClientExecutionLimitsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/QuartzApiClientExecutionLimitsTest.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Text;
+
+using FakeItEasy;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+using Quartz.Dashboard;
+using Quartz.Dashboard.Services;
+using Quartz.Serialization.SystemTextJson;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// How the dashboard's remote API client reads the execution-limits body.
+/// </summary>
+/// <remarks>
+/// This client talks to whatever HTTP API it was pointed at, which need not be the same build, so the
+/// body's shape is a contract rather than an implementation detail. The scope is the part worth
+/// pinning: a limit that lost it in transit would be shown as a per-node one, which reads as a quota
+/// silently multiplied by the node count.
+/// </remarks>
+public class QuartzApiClientExecutionLimitsTest
+{
+    [Test]
+    public async Task GetExecutionLimitsShouldReadTheScopeOfEachLimit()
+    {
+        QuartzApiClient client = CreateClient("""
+            {
+              "limits": {
+                "batch": { "maxConcurrent": 2, "scope": "Node" },
+                "tenant-acme": { "maxConcurrent": 8, "scope": "Cluster" },
+                "_": { "maxConcurrent": 3, "scope": "Node" },
+                "free": { "maxConcurrent": null, "scope": "Node" }
+              },
+              "useTriggerGroupWhenUnset": false
+            }
+            """);
+
+        ExecutionLimitsDto? limits = await client.GetExecutionLimits("core");
+
+        limits.Should().NotBeNull();
+        limits.Limits.Should().BeEquivalentTo(new Dictionary<string, DashboardExecutionLimit>
+        {
+            ["batch"] = new(2, ExecutionLimitScope.Node),
+            ["tenant-acme"] = new(8, ExecutionLimitScope.Cluster),
+            ["(default)"] = new(3, ExecutionLimitScope.Node),
+            ["free"] = new(null, ExecutionLimitScope.Node),
+        }, "the scope travels with the number, and the default bucket's wire spelling becomes a label a reader can understand");
+    }
+
+    [Test]
+    public async Task GetExecutionLimitsShouldReadALimitThatOmitsItsScopeAsPerNode()
+    {
+        QuartzApiClient client = CreateClient("""{"limits":{"batch":{"maxConcurrent":2}}}""");
+
+        ExecutionLimitsDto? limits = await client.GetExecutionLimits("core");
+
+        limits.Should().NotBeNull();
+        limits.Limits["batch"].Scope.Should().Be(ExecutionLimitScope.Node,
+            "an omitted scope is what an execution limit has always meant, so it degrades to the safe reading rather than failing");
+    }
+
+    [Test]
+    public async Task GetExecutionLimitsShouldBeNullWhenTheSchedulerLimitsNothing()
+    {
+        QuartzApiClient client = CreateClient("""{"limits":null}""");
+
+        (await client.GetExecutionLimits("core")).Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetExecutionLimitsShouldBeNullWhenTheApiRefuses()
+    {
+        QuartzApiClient client = CreateClient("", HttpStatusCode.NotFound);
+
+        (await client.GetExecutionLimits("core")).Should().BeNull(
+            "a dashboard pointed at an API that does not answer shows nothing, rather than throwing on a page load");
+    }
+
+    private static QuartzApiClient CreateClient(string body, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        IHttpClientFactory factory = A.Fake<IHttpClientFactory>();
+        A.CallTo(() => factory.CreateClient(A<string>._))
+            .ReturnsLazily(() => new HttpClient(new CannedResponseHandler(body, status)));
+
+        return new QuartzApiClient(
+            factory,
+            A.Fake<IHttpContextAccessor>(),
+            Options.Create(new QuartzDashboardOptions { BaseUrl = new Uri("http://quartz.test/") }),
+            new DashboardSerializerOptions(new SystemTextJsonSerializerRegistry()));
+    }
+
+    /// <summary>
+    /// Answers every request with one prepared body, so the client's reading is what the test is about
+    /// rather than any part of the transport.
+    /// </summary>
+    private sealed class CannedResponseHandler : HttpMessageHandler
+    {
+        private readonly string body;
+        private readonly HttpStatusCode status;
+
+        public CannedResponseHandler(string body, HttpStatusCode status)
+        {
+            this.body = body;
+            this.status = status;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
@@ -39,6 +39,40 @@ public class SchedulerEndpointsTest : WebApiTest
         }
     }
 
+    /// <summary>
+    /// The wire carries a limit's scope, because a limit that lost it would come back as a per-node one
+    /// — a quota silently multiplied by the node count, which is the very thing the scope exists to say.
+    /// </summary>
+    [Test]
+    public async Task ExecutionLimitsRoundTripKeepsEachLimitsScope()
+    {
+        ExecutionLimits? captured = null;
+        A.CallTo(() => FakeScheduler.SetExecutionLimits(A<ExecutionLimits>._, A<CancellationToken>._))
+            .Invokes((ExecutionLimits limits, CancellationToken _) => captured = limits);
+        A.CallTo(() => FakeScheduler.GetExecutionLimits(A<CancellationToken>._))
+            .ReturnsLazily(() => new ValueTask<ExecutionLimits?>(captured));
+
+        await HttpScheduler.SetExecutionLimits(ExecutionLimitsBuilder.Create()
+            .ForGroup("batch", 2)
+            .ForGroup("tenant", 8, ExecutionLimitScope.Cluster)
+            .ForOtherGroups(1, ExecutionLimitScope.Cluster)
+            .ForDefaultGroup(3)
+            .Build());
+
+        captured.Should().NotBeNull("the server builds the limits it was sent before anything can be read back");
+
+        ExecutionLimits? readBack = await HttpScheduler.GetExecutionLimits();
+
+        readBack.Should().NotBeNull();
+        readBack.Groups.Should().BeEquivalentTo(new[]
+        {
+            new ExecutionGroupLimit(ExecutionGroupScope.Named("batch"), 2),
+            new ExecutionGroupLimit(ExecutionGroupScope.Named("tenant"), 8, ExecutionLimitScope.Cluster),
+            new ExecutionGroupLimit(ExecutionGroupScope.OtherGroups, 1, ExecutionLimitScope.Cluster),
+            new ExecutionGroupLimit(ExecutionGroupScope.Default, 3),
+        });
+    }
+
     [Test]
     public async Task GetSchedulerDetailsShouldWork()
     {

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -121,6 +121,12 @@ namespace Quartz.Dashboard.Services
         public bool Replace { get; init; }
         public bool? StoreNonDurableWhileAwaitingScheduling { get; init; }
     }
+    public readonly struct DashboardExecutionLimit : System.IEquatable<Quartz.Dashboard.Services.DashboardExecutionLimit>
+    {
+        public DashboardExecutionLimit(int? MaxConcurrent, Quartz.ExecutionLimitScope Scope) { }
+        public int? MaxConcurrent { get; init; }
+        public Quartz.ExecutionLimitScope Scope { get; init; }
+    }
     public sealed class DashboardFireInstanceQuery : Quartz.PagedQuery, System.IEquatable<Quartz.Dashboard.Services.DashboardFireInstanceQuery>
     {
         public DashboardFireInstanceQuery() { }
@@ -160,8 +166,8 @@ namespace Quartz.Dashboard.Services
     }
     public sealed class ExecutionLimitsDto : System.IEquatable<Quartz.Dashboard.Services.ExecutionLimitsDto>
     {
-        public ExecutionLimitsDto(System.Collections.Generic.Dictionary<string, int?> Limits) { }
-        public System.Collections.Generic.Dictionary<string, int?> Limits { get; init; }
+        public ExecutionLimitsDto(System.Collections.Generic.Dictionary<string, Quartz.Dashboard.Services.DashboardExecutionLimit> Limits) { }
+        public System.Collections.Generic.Dictionary<string, Quartz.Dashboard.Services.DashboardExecutionLimit> Limits { get; init; }
     }
     public sealed class FireInstanceDto : System.IEquatable<Quartz.Dashboard.Services.FireInstanceDto>
     {

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -1223,6 +1223,97 @@ public abstract class JobStoreContractTest
             .Which.Key.Should().Be(trigger.Key);
     }
 
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Cluster-scoped execution limits
+    //
+    // A cluster-scoped limit is counted against what the store itself holds in flight, not against
+    // anything the caller remembers, so these assertions are about the store's own ledger: the
+    // reservations and executions it is already holding when acquisition asks it for more. Both stores
+    // answer them - the in-memory store's cluster is one process, which makes a cluster-scoped limit
+    // and a node-scoped one the same number there, not a feature it declines.
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task AClusterScopedLimitCountsTheReservationsTheStoreAlreadyHolds()
+    {
+        await GivenAnAcquiredTrigger("held", executionGroup: "tenant");
+        await GivenDueTriggers("tenant", "candidate-one");
+
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 1, ExecutionLimitScope.Cluster)
+            .Build();
+
+        (await AcquireWith(limits)).Should().BeEmpty(
+            "the reservation the store is already holding is the group's one cluster-wide slot, whoever took it");
+    }
+
+    [Test]
+    public async Task AClusterScopedLimitCountsAFiringThatHasAlreadyStarted()
+    {
+        await GivenAFiringInFlight("running", executionGroup: "tenant");
+        await GivenDueTriggers("tenant", "candidate-one");
+
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 1, ExecutionLimitScope.Cluster)
+            .Build();
+
+        (await AcquireWith(limits)).Should().BeEmpty(
+            "a reservation that has turned into a running execution holds the same slot it always did");
+    }
+
+    [Test]
+    public async Task ANodeScopedLimitDoesNotCountWhatTheStoreHoldsInFlight()
+    {
+        await GivenAnAcquiredTrigger("held", executionGroup: "tenant");
+        await GivenDueTriggers("tenant", "candidate-one");
+
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create().ForGroup("tenant", 1).Build();
+
+        (await AcquireWith(limits)).Should().ContainSingle(
+            "a node-scoped limit is what the caller has left to spend, and the caller said one - subtracting this node's own in-flight work from it is the scheduler thread's job, not the store's, and doing it in both places would halve the limit");
+    }
+
+    [Test]
+    public async Task AClusterScopedLimitGoesOnCountingDownWithinOneBatch()
+    {
+        await GivenAnAcquiredTrigger("held", executionGroup: "tenant");
+        await GivenDueTriggers("tenant", "candidate-one", "candidate-two");
+
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 2, ExecutionLimitScope.Cluster)
+            .Build();
+
+        (await AcquireWith(limits)).Should().ContainSingle(
+            "one of the two cluster slots is spoken for, so the batch may take exactly one more - a cluster baseline that did not also count down would let the batch take both");
+    }
+
+    [Test]
+    public async Task AClusterScopedLimitLeavesAnotherGroupAlone()
+    {
+        await GivenAnAcquiredTrigger("held", executionGroup: "tenant");
+        await GivenDueTriggers("other-tenant", "candidate-one");
+
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 1, ExecutionLimitScope.Cluster)
+            .Build();
+
+        (await AcquireWith(limits)).Should().ContainSingle(
+            "the ceiling is per execution group, so work in one group is not charged to another");
+    }
+
+    /// <summary>
+    /// Schedules one due trigger per name, all in the same execution group.
+    /// </summary>
+    private async Task GivenDueTriggers(string executionGroup, params string[] names)
+    {
+        foreach (string name in names)
+        {
+            IJobDetail job = CreateJob(name, JobGroupA);
+            await Store.ScheduleJob(job, CreateTrigger(name, TriggerGroupA, job.Key,
+                startAt: DateTimeOffset.UtcNow.AddSeconds(5), executionGroup: executionGroup));
+        }
+    }
+
     private async Task GivenTwoDueTriggersInOneGroup()
     {
         // Two jobs rather than one, so that DisallowConcurrentExecution is not what limits the batch.

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadLoopTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerThreadLoopTest.cs
@@ -292,6 +292,65 @@ public sealed class QuartzSchedulerThreadLoopTest
             "the firing dispatched from the first pass is still in flight and holds one of the group's two slots");
     }
 
+    /// <summary>
+    /// The mirror image, and the bug a cluster-wide ceiling invites: a cluster-scoped limit must reach
+    /// the store as configured.
+    /// </summary>
+    /// <remarks>
+    /// This node's dispatched firing is already a reservation in the store's own ledger — a
+    /// FIRED_TRIGGERS row for the ADO store — and the store subtracts that when it builds the ledger for
+    /// the acquisition. Taking it off here as well charges the group twice and halves the quota on the
+    /// busiest node, which is exactly the node that would notice least: with one node the store's count
+    /// and this loop's count are the same firings, so nothing single-node ever disagrees.
+    /// </remarks>
+    [Test]
+    public async Task DispatchedWorkIsNotSubtractedFromAClusterScopedLimit()
+    {
+        scheduler.SetExecutionLimits(ExecutionLimitsBuilder.Create()
+            .ForGroup("batch", 2, ExecutionLimitScope.Cluster)
+            .Build());
+        await GivenScheduledJobs(1, executionGroup: "batch");
+
+        StartLoop();
+
+        await ShouldObserve(store.Acquisitions.Reaches(2),
+            "the loop acquires again as soon as it has dispatched a batch");
+
+        LimitFor(store.Acquisitions.Entries[0], "batch").Should().Be(2,
+            "nothing is in flight yet, so the whole quota is on offer");
+        LimitFor(store.Acquisitions.Entries[1], "batch").Should().Be(2,
+            "the firing in flight is already a reservation the store counts, so subtracting it here as well would leave the group a slot short of its own quota");
+
+        store.Acquisitions.Entries[1].ExecutionLimits.Groups.Should().ContainSingle()
+            .Which.Scope.Should().Be(ExecutionLimitScope.Cluster,
+                "the scope travels with the remaining-capacity snapshot, or the store could not tell which limits it still has to lower");
+    }
+
+    /// <summary>
+    /// One set of limits can hold both kinds, and each is treated on its own terms.
+    /// </summary>
+    [Test]
+    public async Task NodeScopedAndClusterScopedLimitsAreSubtractedIndependently()
+    {
+        scheduler.SetExecutionLimits(ExecutionLimitsBuilder.Create()
+            .ForGroup("batch", 2)
+            .ForGroup("tenant", 2, ExecutionLimitScope.Cluster)
+            .Build());
+        await GivenScheduledJobs(1, executionGroup: "batch");
+        await GivenScheduledJobs(1, executionGroup: "tenant", namePrefix: "tenant");
+
+        StartLoop();
+
+        await ShouldObserve(store.Acquisitions.Reaches(2),
+            "the loop acquires again as soon as it has dispatched a batch");
+
+        TriggerAcquisitionRequest second = store.Acquisitions.Entries[1];
+        LimitFor(second, "batch").Should().Be(1,
+            "the node-scoped group has one of this node's firings in flight");
+        LimitFor(second, "tenant").Should().Be(2,
+            "the cluster-scoped group's firing is the store's to count, not this loop's");
+    }
+
     private void StartLoop()
     {
         thread.Start();
@@ -324,17 +383,17 @@ public sealed class QuartzSchedulerThreadLoopTest
     /// <summary>
     /// Puts <paramref name="count" /> one-shot jobs into the store, ready to fire immediately.
     /// </summary>
-    private async Task<IReadOnlyList<TriggerKey>> GivenScheduledJobs(int count, string executionGroup = null)
+    private async Task<IReadOnlyList<TriggerKey>> GivenScheduledJobs(int count, string executionGroup = null, string namePrefix = "")
     {
         List<TriggerKey> keys = new(count);
         for (int i = 0; i < count; i++)
         {
             IJobDetail job = JobBuilder.Create<LoopTestJob>()
-                .WithIdentity($"job{i}", "loop")
+                .WithIdentity($"{namePrefix}job{i}", "loop")
                 .Build();
 
             IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
-                .WithIdentity($"trigger{i}", "loop")
+                .WithIdentity($"{namePrefix}trigger{i}", "loop")
                 .ForJob(job)
                 .WithExecutionGroup(executionGroup)
                 .StartNow()

--- a/src/Quartz.Tests.Unit/ExecutionLimitScopeTest.cs
+++ b/src/Quartz.Tests.Unit/ExecutionLimitScopeTest.cs
@@ -112,6 +112,20 @@ public sealed class ExecutionLimitScopeTest
     }
 
     [Test]
+    public void AnInFlightCountOfNothingLowersNothing()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 1, ExecutionLimitScope.Cluster)
+            .Build();
+
+        // A store is free to report a pair it is tracking but currently holds nothing for, and a row
+        // like that must not spend a slot.
+        ExecutionSlots slots = limits.CreateSlots([new ExecutionGroupInFlight("tenant", AnyTriggerGroup, 0)]);
+
+        slots.TryTake("tenant", AnyTriggerGroup).Should().BeTrue("nothing is in flight, so the whole quota is free");
+    }
+
+    [Test]
     public void ClusterInFlightWorkNeverPushesALimitBelowZero()
     {
         ExecutionLimits limits = ExecutionLimitsBuilder.Create()

--- a/src/Quartz.Tests.Unit/ExecutionLimitScopeTest.cs
+++ b/src/Quartz.Tests.Unit/ExecutionLimitScopeTest.cs
@@ -1,0 +1,221 @@
+using System.Collections.Specialized;
+
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// What an execution limit is counted against, and the arithmetic that follows from it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The scope is the whole of the cluster-wide ceiling as far as the limits themselves are concerned:
+/// a node-scoped limit is lowered by what the scheduler thread has dispatched here, a cluster-scoped
+/// one by what the store says the cluster holds, and each ignores the other's subtraction. That
+/// division is what keeps a firing from being counted twice — as this node's running work and as its
+/// own reservation in the store — and it is invisible in a single-node deployment, where the two
+/// counts are the same firings.
+/// </para>
+/// </remarks>
+public sealed class ExecutionLimitScopeTest
+{
+    /// <summary>
+    /// The trigger group a slot request carries when the limits are not deriving anything from it.
+    /// </summary>
+    private const string AnyTriggerGroup = "trigger-group";
+
+    [Test]
+    public void ALimitIsCountedOnThisNodeUnlessItSaysOtherwise()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("batch", 2)
+            .ForDefaultGroup(1)
+            .ForOtherGroups(3)
+            .Unlimited("free")
+            .Build();
+
+        limits.Groups.Should().OnlyContain(x => x.Scope == ExecutionLimitScope.Node,
+            "execution limits were per node before scopes existed, and configuration that says nothing must go on meaning that");
+        limits.HasClusterScopedLimits.Should().BeFalse();
+    }
+
+    [Test]
+    public void ALimitRemembersTheScopeItWasDeclaredIn()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("batch", 2)
+            .ForGroup("tenant", 8, ExecutionLimitScope.Cluster)
+            .Build();
+
+        limits.Groups.Should().BeEquivalentTo(new[]
+        {
+            new ExecutionGroupLimit(ExecutionGroupScope.Named("batch"), 2),
+            new ExecutionGroupLimit(ExecutionGroupScope.Named("tenant"), 8, ExecutionLimitScope.Cluster),
+        });
+
+        limits.HasClusterScopedLimits.Should().BeTrue(
+            "a store reads this to decide whether the cluster-wide count is worth a round trip");
+    }
+
+    [Test]
+    public void AnExplicitlyUnlimitedGroupIsNotAClusterScopedLimit()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create().Unlimited("free").Build();
+
+        limits.HasClusterScopedLimits.Should().BeFalse(
+            "there is no number to count, so no reason to ask the store for one");
+    }
+
+    [Test]
+    public void AForbiddenGroupIsNotAReasonToCountTheCluster()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("batch", 0, ExecutionLimitScope.Cluster)
+            .Build();
+
+        limits.HasClusterScopedLimits.Should().BeFalse(
+            "nothing in flight can turn a zero into anything else, so the round trip would buy nothing");
+    }
+
+    [Test]
+    public void AScopeThatIsNeitherOfTheTwoIsRejected()
+    {
+        Action act = () => ExecutionLimitsBuilder.Create().ForGroup("batch", 1, (ExecutionLimitScope) 42);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*Node or Cluster*");
+    }
+
+    [Test]
+    public void ClusterInFlightWorkLowersAClusterScopedLimit()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 3, ExecutionLimitScope.Cluster)
+            .Build();
+
+        ExecutionSlots slots = limits.CreateSlots([new ExecutionGroupInFlight("tenant", AnyTriggerGroup, 2)]);
+
+        slots.TryTake("tenant", AnyTriggerGroup).Should().BeTrue("one of the three slots is still free");
+        slots.TryTake("tenant", AnyTriggerGroup).Should().BeFalse("the other two are held elsewhere in the cluster");
+    }
+
+    [Test]
+    public void ClusterInFlightWorkLeavesANodeScopedLimitAlone()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create().ForGroup("batch", 2).Build();
+
+        ExecutionSlots slots = limits.CreateSlots([new ExecutionGroupInFlight("batch", AnyTriggerGroup, 2)]);
+
+        slots.TryTake("batch", AnyTriggerGroup).Should().BeTrue(
+            "a node-scoped limit reaches a store already lowered by what runs here, and lowering it again by a count that includes those same firings would charge them twice");
+        slots.TryTake("batch", AnyTriggerGroup).Should().BeTrue();
+        slots.TryTake("batch", AnyTriggerGroup).Should().BeFalse("two is still two");
+    }
+
+    [Test]
+    public void ClusterInFlightWorkNeverPushesALimitBelowZero()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 1, ExecutionLimitScope.Cluster)
+            .Build();
+
+        ExecutionSlots slots = limits.CreateSlots([new ExecutionGroupInFlight("tenant", AnyTriggerGroup, 5)]);
+
+        slots.TryTake("tenant", AnyTriggerGroup).Should().BeFalse(
+            "a quota that has been overshot is exhausted, not owed slots back");
+    }
+
+    [Test]
+    public void ClusterInFlightCountsForOneGroupAddUp()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 3, ExecutionLimitScope.Cluster)
+            .Build();
+
+        // Two rows, because the store's aggregate groups by trigger group as well; both fold into
+        // the one execution group.
+        ExecutionSlots slots = limits.CreateSlots(
+        [
+            new ExecutionGroupInFlight("tenant", "nightly", 1),
+            new ExecutionGroupInFlight("tenant", "hourly", 2),
+        ]);
+
+        slots.TryTake("tenant", "nightly").Should().BeFalse(
+            "three are already in flight between the two trigger groups, which is the whole quota");
+    }
+
+    [Test]
+    public void TheCatchAllGivesEachUnlistedGroupItsOwnClusterQuota()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForOtherGroups(1, ExecutionLimitScope.Cluster)
+            .Build();
+
+        ExecutionSlots slots = limits.CreateSlots([new ExecutionGroupInFlight("acme", AnyTriggerGroup, 1)]);
+
+        slots.TryTake("acme", AnyTriggerGroup).Should().BeFalse("acme's one cluster-wide slot is taken");
+        slots.TryTake("initech", AnyTriggerGroup).Should().BeTrue(
+            "the catch-all hands each unlisted group an allowance of its own rather than one they share");
+    }
+
+    [Test]
+    public void ClusterInFlightWorkIsFoldedThroughTheSameDerivationTheFilterUses()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("acme", 1, ExecutionLimitScope.Cluster)
+            .UseTriggerGroupWhenUnset()
+            .Build();
+
+        // The in-flight row carries no execution group, exactly as the store persisted it; its trigger
+        // group is what the limits stand in with.
+        ExecutionSlots slots = limits.CreateSlots([new ExecutionGroupInFlight(null, "acme", 1)]);
+
+        slots.TryTake(executionGroup: null, "acme").Should().BeFalse(
+            "the count and the filter have to key work the same way, or a derived group would be counted in one bucket and spent from another");
+    }
+
+    [Test]
+    public void TheDefaultBucketCanBeCappedAcrossTheCluster()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForDefaultGroup(2, ExecutionLimitScope.Cluster)
+            .Build();
+
+        ExecutionSlots slots = limits.CreateSlots([new ExecutionGroupInFlight(null, AnyTriggerGroup, 2)]);
+
+        slots.TryTake(executionGroup: null, AnyTriggerGroup).Should().BeFalse();
+    }
+
+    [Test]
+    public void ClusterInFlightWorkForAnUnlimitedGroupChangesNothing()
+    {
+        ExecutionLimits limits = ExecutionLimitsBuilder.Create()
+            .ForGroup("tenant", 1, ExecutionLimitScope.Cluster)
+            .Build();
+
+        ExecutionSlots slots = limits.CreateSlots([new ExecutionGroupInFlight("something-else", AnyTriggerGroup, 9)]);
+
+        slots.TryTake("tenant", AnyTriggerGroup).Should().BeTrue("the count was for a group nothing limits");
+        slots.TryTake("something-else", AnyTriggerGroup).Should().BeTrue();
+    }
+
+    [Test]
+    public void ClusterExecutionLimitPropertiesAreReadAsClusterScoped()
+    {
+        NameValueCollection properties = new()
+        {
+            ["quartz.executionLimit.batch"] = "2",
+            ["quartz.clusterExecutionLimit.tenant"] = "8",
+            ["quartz.clusterExecutionLimit.*"] = "1",
+        };
+
+        ExecutionLimits limits = ExecutionLimitsParser.Parse(properties);
+
+        limits.Should().NotBeNull();
+        limits.Groups.Should().BeEquivalentTo(new[]
+        {
+            new ExecutionGroupLimit(ExecutionGroupScope.Named("batch"), 2),
+            new ExecutionGroupLimit(ExecutionGroupScope.Named("tenant"), 8, ExecutionLimitScope.Cluster),
+            new ExecutionGroupLimit(ExecutionGroupScope.OtherGroups, 1, ExecutionLimitScope.Cluster),
+        }, "the two prefixes configure the same groups in different scopes, and neither spelling can be mistaken for the other");
+    }
+}

--- a/src/Quartz.Tests.Unit/HttpApi/SetExecutionLimitsRequestTest.cs
+++ b/src/Quartz.Tests.Unit/HttpApi/SetExecutionLimitsRequestTest.cs
@@ -1,0 +1,90 @@
+using Quartz.HttpApiContract;
+
+namespace Quartz.Tests.Unit.HttpApi;
+
+/// <summary>
+/// What the execution-limits endpoint accepts. The body is the one place a limit's scope crosses a
+/// process boundary, so both halves of an entry — the count and the scope — are validated rather than
+/// coerced.
+/// </summary>
+public class SetExecutionLimitsRequestTest
+{
+    [Test]
+    public void ValidateShouldAcceptAnEmptyBody()
+    {
+        new SetExecutionLimitsRequest(null).Validate().Should().BeEmpty(
+            "a body with no limits clears them, which is not a validation failure");
+    }
+
+    [Test]
+    public void ValidateShouldAcceptEveryScopeAndGroupSpelling()
+    {
+        SetExecutionLimitsRequest request = new(new Dictionary<string, ExecutionLimitDto>
+        {
+            ["batch"] = new(2),
+            ["tenant"] = new(8, ExecutionLimitScope.Cluster),
+            ["*"] = new(1, ExecutionLimitScope.Cluster),
+            ["_"] = new(3),
+            ["free"] = new(null),
+        });
+
+        request.Validate().Should().BeEmpty();
+    }
+
+    [Test]
+    public void ValidateShouldRejectABlankGroupKey()
+    {
+        SetExecutionLimitsRequest request = new(new Dictionary<string, ExecutionLimitDto>
+        {
+            ["   "] = new(1),
+        });
+
+        request.Validate().Should().ContainSingle().Which.Should().Contain("is invalid");
+    }
+
+    [Test]
+    public void ValidateShouldRejectAMissingLimit()
+    {
+        SetExecutionLimitsRequest request = new(new Dictionary<string, ExecutionLimitDto>
+        {
+            ["batch"] = null,
+        });
+
+        request.Validate().Should().ContainSingle().Which.Should().Contain("is missing",
+            "a key with no limit object says nothing about the group, and guessing what it meant would be worse than refusing it");
+    }
+
+    [Test]
+    public void ValidateShouldRejectANegativeLimit()
+    {
+        SetExecutionLimitsRequest request = new(new Dictionary<string, ExecutionLimitDto>
+        {
+            ["batch"] = new(-1),
+        });
+
+        request.Validate().Should().ContainSingle().Which.Should().Contain("must be non-negative");
+    }
+
+    [Test]
+    public void ValidateShouldRejectAScopeThatIsNeitherNodeNorCluster()
+    {
+        SetExecutionLimitsRequest request = new(new Dictionary<string, ExecutionLimitDto>
+        {
+            ["batch"] = new(2, (ExecutionLimitScope) 42),
+        });
+
+        request.Validate().Should().ContainSingle().Which.Should().Contain("must be Node or Cluster",
+            "an unknown scope would otherwise be enforced as Node, silently turning a quota into a per-node limit");
+    }
+
+    [Test]
+    public void ValidateShouldReportEveryProblemInOneBody()
+    {
+        SetExecutionLimitsRequest request = new(new Dictionary<string, ExecutionLimitDto>
+        {
+            ["batch"] = new(-1, (ExecutionLimitScope) 42),
+        });
+
+        request.Validate().Should().HaveCount(2, "the count and the scope are separate mistakes and a caller should hear about both at once");
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -1470,6 +1470,80 @@ public class AdoJobStoreBaseTest
             "the override, not the request, has the last word on the criteria the delegate is called with");
     }
 
+    [Test]
+    public async Task AcquireNextTriggers_ShouldNotCountTheClusterWhenNoLimitIsClusterScoped()
+    {
+        GivenNoTriggersToAcquire(driverDelegate);
+
+        await jobStoreSupport.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow,
+            ExecutionLimits = ExecutionLimitsBuilder.Create().ForGroup("batch", 2).Build(),
+        });
+
+        A.CallTo(() => driverDelegate.SelectExecutionGroupsInFlight(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task AcquireNextTriggers_ShouldCountTheClusterOncePerAttemptForAClusterScopedLimit()
+    {
+        List<TriggerAcquisitionCriteria> received = GivenNoTriggersToAcquire(driverDelegate);
+        List<ExecutionGroupInFlight> inFlight = [new ExecutionGroupInFlight("tenant", "nightly", 2)];
+        A.CallTo(() => driverDelegate.SelectExecutionGroupsInFlight(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<List<ExecutionGroupInFlight>>(inFlight));
+
+        await jobStoreSupport.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow,
+            ExecutionLimits = ExecutionLimitsBuilder.Create()
+                .ForGroup("tenant", 3, ExecutionLimitScope.Cluster)
+                .Build(),
+        });
+
+        A.CallTo(() => driverDelegate.SelectExecutionGroupsInFlight(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<CancellationToken>.Ignored))
+            .MustHaveHappenedOnceExactly();
+
+        received.Should().ContainSingle().Which.ClusterInFlight.Should().BeEquivalentTo(inFlight,
+            "the count is what the delegate filters against, so it has to reach the criteria the delegate is called with");
+    }
+
+    /// <summary>
+    /// A store that keeps the cluster count somewhere other than the fired-triggers table says so by
+    /// answering the question in its own override, and the base must not ask again.
+    /// </summary>
+    [Test]
+    public async Task CreateAcquisitionCriteria_ShouldLeaveAnOverridesOwnClusterCountAlone()
+    {
+        OwnClusterCountTestStore store = new();
+        IDriverDelegate del = A.Fake<IDriverDelegate>();
+        store.DirectDelegate = del;
+        store.DirectSignaler = A.Fake<ISchedulerSignaler>();
+        List<TriggerAcquisitionCriteria> received = GivenNoTriggersToAcquire(del);
+
+        await store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow,
+            ExecutionLimits = ExecutionLimitsBuilder.Create()
+                .ForGroup("tenant", 3, ExecutionLimitScope.Cluster)
+                .Build(),
+        });
+
+        A.CallTo(() => del.SelectExecutionGroupsInFlight(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+
+        received.Should().ContainSingle().Which.ClusterInFlight.Should().ContainSingle()
+            .Which.Count.Should().Be(7, "the override, not the base store, had the last word on the count");
+    }
+
     /// <summary>
     /// A store that narrows acquisition through <see cref="AdoJobStoreBase.CreateAcquisitionCriteria" />,
     /// the way a store filtering on job type (issue #2238) would.
@@ -1479,6 +1553,21 @@ public class AdoJobStoreBaseTest
         protected override TriggerAcquisitionCriteria CreateAcquisitionCriteria(TriggerAcquisitionRequest request)
         {
             return base.CreateAcquisitionCriteria(request) with { MaxCount = 1 };
+        }
+    }
+
+    /// <summary>
+    /// A store that answers the cluster in-flight question itself rather than letting the base read it
+    /// off the fired-triggers table.
+    /// </summary>
+    private sealed class OwnClusterCountTestStore : TestAdoJobStoreBase
+    {
+        protected override TriggerAcquisitionCriteria CreateAcquisitionCriteria(TriggerAcquisitionRequest request)
+        {
+            return base.CreateAcquisitionCriteria(request) with
+            {
+                ClusterInFlight = [new ExecutionGroupInFlight("tenant", "nightly", 7)],
+            };
         }
     }
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateExecutionGroupsInFlightTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateExecutionGroupsInFlightTest.cs
@@ -1,0 +1,251 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Data.Common;
+
+using FakeItEasy;
+
+using Microsoft.Data.SqlClient;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The cluster-wide in-flight count a <see cref="ExecutionLimitScope.Cluster" /> execution limit is
+/// enforced against: the statement that reads it, how its rows are turned into
+/// <see cref="ExecutionGroupInFlight" />, and that the result reaches the acquisition filter.
+/// </summary>
+/// <remarks>
+/// Asserted against a faked reader rather than a database, for the same reason
+/// <see cref="StdAdoDelegateGroupMatcherTest" /> is: the SQL has no dialect variants, so what is worth
+/// pinning is the statement text and the reading, and both are the same on every provider. The
+/// end-to-end behaviour against a real database is <c>JobStoreContractTest</c>'s.
+/// </remarks>
+public class StdAdoDelegateExecutionGroupsInFlightTest
+{
+    private StdAdoDelegate adoDelegate;
+    private StubCommand command;
+    private ConnectionAndTransactionHolder conn;
+
+    [SetUp]
+    public void SetUp()
+    {
+        command = A.Fake<StubCommand>();
+
+        A.CallTo(command).Where(x => x.Method.Name == "get_DbParameterCollection")
+            .WithReturnType<DbParameterCollection>()
+            .Returns(new StubParameterCollection());
+
+        A.CallTo(command).Where(x => x.Method.Name == "CreateDbParameter")
+            .WithReturnType<DbParameter>()
+            .ReturnsLazily(() => new SqlParameter());
+
+        IDbProvider dbProvider = A.Fake<IDbProvider>();
+        A.CallTo(() => dbProvider.Metadata).Returns(new DbMetadata { BindByName = true, ParameterNamePrefix = "@" });
+        A.CallTo(() => dbProvider.CreateCommand()).Returns(command);
+
+        adoDelegate = new StdAdoDelegate();
+        adoDelegate.Initialize(new DriverDelegateContext
+        {
+            TablePrefix = "QRTZ_",
+            SchedulerName = "TESTSCHED",
+            InstanceId = "INSTANCE",
+            TypeLoader = new SimpleTypeLoader(),
+            DbProvider = dbProvider
+        });
+
+        conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        command?.Dispose();
+        conn?.Dispose();
+    }
+
+    [Test]
+    public async Task SelectExecutionGroupsInFlight_AggregatesTheFiredTriggersTableByBothGroups()
+    {
+        InstallRows([("tenant-acme", "nightly", 2)]);
+
+        await adoDelegate.SelectExecutionGroupsInFlight(conn);
+
+        command.CommandText.Should().Be(
+            "SELECT EXECUTION_GROUP, TRIGGER_GROUP, COUNT(*) FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName GROUP BY EXECUTION_GROUP, TRIGGER_GROUP",
+            "the count comes from the reservation ledger the store already keeps, scoped to this scheduler, and grouped by both names because the limits derive their key from the pair");
+    }
+
+    [Test]
+    public async Task SelectExecutionGroupsInFlight_ReturnsOneEntryPerPairInFlight()
+    {
+        InstallRows(
+        [
+            ("tenant-acme", "nightly", 2),
+            ("tenant-acme", "hourly", 1),
+            ("batch", "nightly", 5),
+        ]);
+
+        List<ExecutionGroupInFlight> result = await adoDelegate.SelectExecutionGroupsInFlight(conn);
+
+        result.Should().BeEquivalentTo(new[]
+        {
+            new ExecutionGroupInFlight("tenant-acme", "nightly", 2),
+            new ExecutionGroupInFlight("tenant-acme", "hourly", 1),
+            new ExecutionGroupInFlight("batch", "nightly", 5),
+        }, "folding the pairs down to one limit key is the caller's job, so the rows come back as the database grouped them");
+    }
+
+    [Test]
+    public async Task SelectExecutionGroupsInFlight_ReadsARowThatCarriesNoExecutionGroup()
+    {
+        InstallRows([(null, "nightly", 3)]);
+
+        List<ExecutionGroupInFlight> result = await adoDelegate.SelectExecutionGroupsInFlight(conn);
+
+        result.Should().ContainSingle().Which.ExecutionGroup.Should().BeNull(
+            "a firing with no execution group is a NULL in the column, and the ungrouped bucket can be limited too");
+    }
+
+    /// <summary>
+    /// <c>COUNT(*)</c> is <c>Int32</c> on SQL Server and <c>Int64</c> on PostgreSQL, MySQL and SQLite,
+    /// so the reader converts rather than casting. Reading it as either one directly would work on half
+    /// the dialects and throw on the other half.
+    /// </summary>
+    [Test]
+    public async Task SelectExecutionGroupsInFlight_ConvertsACountWhateverWidthTheProviderReturns()
+    {
+        InstallRows([("tenant-acme", "nightly", 2L), ("batch", "nightly", 7)]);
+
+        List<ExecutionGroupInFlight> result = await adoDelegate.SelectExecutionGroupsInFlight(conn);
+
+        result.Select(x => x.Count).Should().Equal([2, 7]);
+    }
+
+    [Test]
+    public async Task SelectExecutionGroupsInFlight_IsEmptyWhenTheClusterIsIdle()
+    {
+        InstallRows([]);
+
+        List<ExecutionGroupInFlight> result = await adoDelegate.SelectExecutionGroupsInFlight(conn);
+
+        result.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The other half of the round trip: what the aggregate returned has to reach the filter that skips
+    /// candidates, or the count would be read and then ignored.
+    /// </summary>
+    [Test]
+    public async Task SelectTriggersToAcquire_SkipsACandidateWhoseGroupIsAtItsClusterCeiling()
+    {
+        InstallAcquisitionRows([("t1", "nightly", "acme"), ("t2", "nightly", "batch")]);
+
+        List<TriggerAcquireResult> results = await adoDelegate.SelectTriggersToAcquire(conn, new TriggerAcquisitionCriteria
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddMinutes(1),
+            NoEarlierThan = DateTimeOffset.UtcNow.AddMinutes(-1),
+            MaxCount = 5,
+            LiveNodeCutoff = DateTimeOffset.UtcNow.AddMinutes(-1),
+            ExecutionLimits = ExecutionLimitsBuilder.Create()
+                .ForGroup("acme", 1, ExecutionLimitScope.Cluster)
+                .Build(),
+            ClusterInFlight = [new ExecutionGroupInFlight("acme", "nightly", 1)],
+        });
+
+        results.Should().ContainSingle("acme's one cluster-wide slot is already held, so only the other candidate may be taken")
+            .Which.ExecutionGroup.Should().Be("batch");
+    }
+
+    /// <summary>
+    /// Fakes the aggregate's result set. The projection is read positionally, so the values are
+    /// positional here too — that is what pins the column order to the ordinals the reader uses.
+    /// </summary>
+    private void InstallRows((string ExecutionGroup, string TriggerGroup, object Count)[] rows)
+    {
+        DbDataReader reader = A.Fake<DbDataReader>();
+        int index = -1;
+
+        A.CallTo(() => reader.ReadAsync(A<CancellationToken>._)).ReturnsLazily(() =>
+        {
+            index++;
+            return index < rows.Length;
+        });
+
+        A.CallTo(() => reader.IsDBNull(A<int>._)).ReturnsLazily((int i) => i == 0 && rows[index].ExecutionGroup is null);
+        A.CallTo(() => reader.GetString(A<int>._)).ReturnsLazily((int i) => i == 0 ? rows[index].ExecutionGroup : rows[index].TriggerGroup);
+        A.CallTo(() => reader.GetValue(A<int>._)).ReturnsLazily((int _) => rows[index].Count);
+
+        InstallReader(reader);
+    }
+
+    /// <summary>
+    /// Fakes the candidate result set the acquisition select produces, which is read by ordinal after
+    /// asking for each column by name.
+    /// </summary>
+    private void InstallAcquisitionRows((string TriggerName, string TriggerGroup, string ExecutionGroup)[] rows)
+    {
+        DbDataReader reader = A.Fake<DbDataReader>();
+        int index = -1;
+
+        A.CallTo(() => reader.ReadAsync(A<CancellationToken>._)).ReturnsLazily(() =>
+        {
+            index++;
+            return index < rows.Length;
+        });
+
+        A.CallTo(() => reader.GetOrdinal(A<string>._)).ReturnsLazily((string name) => name switch
+        {
+            AdoConstants.ColumnTriggerName => 0,
+            AdoConstants.ColumnTriggerGroup => 1,
+            AdoConstants.ColumnJobClass => 2,
+            AdoConstants.ColumnExecutionGroup => 3,
+            _ => throw new ArgumentOutOfRangeException(nameof(name), name, "unexpected column")
+        });
+
+        A.CallTo(() => reader.IsDBNull(A<int>._)).ReturnsLazily((int i) => i == 3 && rows[index].ExecutionGroup is null);
+        A.CallTo(() => reader.GetString(A<int>._)).ReturnsLazily((int i) => i switch
+        {
+            0 => rows[index].TriggerName,
+            1 => rows[index].TriggerGroup,
+            2 => typeof(NoOpJob).AssemblyQualifiedName,
+            _ => rows[index].ExecutionGroup
+        });
+
+        InstallReader(reader);
+    }
+
+    private void InstallReader(DbDataReader reader)
+    {
+        A.CallTo(command)
+            .Where(x => x.Method.Name == "ExecuteDbDataReaderAsync")
+            .WithReturnType<Task<DbDataReader>>()
+            .Returns(Task.FromResult(reader));
+    }
+
+    private sealed class NoOpJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/RAMJobStoreClusterLimitTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/RAMJobStoreClusterLimitTest.cs
@@ -1,0 +1,193 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// How <see cref="RAMJobStore" /> honours a <see cref="ExecutionLimitScope.Cluster" /> execution
+/// limit: by counting what it is itself holding in flight.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The store is never clustered, so its cluster is this one process and a cluster-scoped limit comes
+/// out as the number a node-scoped one would. That is the whole point of asserting it here — a store
+/// contract feature that only the ADO store implements is a divergence, and this is the half of the
+/// pair that needs no database.
+/// </para>
+/// <para>
+/// The same assertions run against both stores in <c>JobStoreContractTest</c>; these exist because
+/// that fixture lives in the integration project, and the in-memory reservation counting is worth
+/// pinning where it can be run without one.
+/// </para>
+/// </remarks>
+public class RAMJobStoreClusterLimitTest
+{
+    private const string Tenant = "tenant-acme";
+    private const string TriggerGroup = "nightly";
+
+    private RAMJobStore store;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        store = TestJobStores.Ram();
+        await store.Initialize(TestJobStores.Identity());
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await store.Shutdown();
+    }
+
+    [Test]
+    public async Task AReservationTheStoreIsHoldingCountsAgainstAClusterScopedLimit()
+    {
+        await GivenDueTrigger("held", Tenant);
+        await AcquireWith(limits: null, maxCount: 1);
+
+        await GivenDueTrigger("candidate", Tenant);
+
+        List<IOperableTrigger> acquired = await AcquireWith(ClusterLimit(1));
+
+        acquired.Should().BeEmpty(
+            "the trigger already acquired holds the group's one cluster-wide slot, and a reservation is spoken for whether or not it has started");
+    }
+
+    [Test]
+    public async Task AFiringThatHasStartedGoesOnHoldingItsSlot()
+    {
+        await GivenDueTrigger("running", Tenant);
+        List<IOperableTrigger> first = await AcquireWith(limits: null, maxCount: 1);
+        await store.TriggersFired(first);
+
+        await GivenDueTrigger("candidate", Tenant);
+
+        List<IOperableTrigger> acquired = await AcquireWith(ClusterLimit(1));
+
+        acquired.Should().BeEmpty(
+            "the reservation became a running execution, which is the same slot under a different name");
+    }
+
+    [Test]
+    public async Task ACompletedFiringGivesItsSlotBack()
+    {
+        await GivenDueTrigger("running", Tenant);
+        List<IOperableTrigger> first = await AcquireWith(limits: null, maxCount: 1);
+        List<TriggerFiredResult> fired = await store.TriggersFired(first);
+        TriggerFiredBundle bundle = fired.Should().ContainSingle().Which.TriggerFiredBundle;
+        await store.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        await GivenDueTrigger("candidate", Tenant);
+
+        List<IOperableTrigger> acquired = await AcquireWith(ClusterLimit(1));
+
+        acquired.Should().ContainSingle("nothing is in flight any more, so the whole quota is on offer again");
+    }
+
+    [Test]
+    public async Task ANodeScopedLimitIsNotLoweredByWhatTheStoreHolds()
+    {
+        await GivenDueTrigger("held", Tenant);
+        await AcquireWith(limits: null, maxCount: 1);
+
+        await GivenDueTrigger("candidate", Tenant);
+
+        ExecutionLimits nodeLimit = ExecutionLimitsBuilder.Create().ForGroup(Tenant, 1).Build();
+
+        (await AcquireWith(nodeLimit)).Should().ContainSingle(
+            "a node-scoped limit arrives already lowered by what runs here; the store lowering it again would charge this node twice for its own work");
+    }
+
+    [Test]
+    public async Task WorkInFlightForOneGroupDoesNotChargeAnother()
+    {
+        await GivenDueTrigger("held", Tenant);
+        await AcquireWith(limits: null, maxCount: 1);
+
+        await GivenDueTrigger("candidate", "tenant-initech");
+
+        (await AcquireWith(ClusterLimit(1))).Should().ContainSingle(
+            "the ceiling is per execution group, so a different tenant's work is not counted against this one");
+    }
+
+    [Test]
+    public async Task TheDerivedGroupIsCountedTheWayTheFilterResolvesIt()
+    {
+        // Neither trigger carries an execution group; the limits stand the trigger group in for it.
+        await GivenDueTrigger("held", executionGroup: null);
+        await AcquireWith(limits: null, maxCount: 1);
+
+        await GivenDueTrigger("candidate", executionGroup: null);
+
+        ExecutionLimits derived = ExecutionLimitsBuilder.Create()
+            .ForGroup(TriggerGroup, 1, ExecutionLimitScope.Cluster)
+            .UseTriggerGroupWhenUnset()
+            .Build();
+
+        (await AcquireWith(derived)).Should().BeEmpty(
+            "the in-flight count and the acquisition filter have to key work the same way, or the derived group would be counted in one bucket and spent from another");
+    }
+
+    private static ExecutionLimits ClusterLimit(int maxConcurrent)
+    {
+        return ExecutionLimitsBuilder.Create()
+            .ForGroup(Tenant, maxConcurrent, ExecutionLimitScope.Cluster)
+            .Build();
+    }
+
+    private async Task GivenDueTrigger(string name, string executionGroup)
+    {
+        IJobDetail job = JobBuilder.Create<ClusterLimitTestJob>()
+            .WithIdentity(name, "jobs")
+            .Build();
+
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity(name, TriggerGroup)
+            .ForJob(job)
+            .WithExecutionGroup(executionGroup)
+            .StartNow()
+            .Build();
+
+        trigger.ComputeFirstFireTimeUtc(calendar: null);
+        await store.ScheduleJob(job, trigger);
+    }
+
+    private ValueTask<List<IOperableTrigger>> AcquireWith(ExecutionLimits limits, int maxCount = 5)
+    {
+        return store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddMinutes(1),
+            MaxCount = maxCount,
+            // Wide enough that the batch does not close on the first trigger's fire time.
+            TimeWindow = TimeSpan.FromMinutes(1),
+            ExecutionLimits = limits,
+        });
+    }
+
+    private sealed class ClusterLimitTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -326,11 +326,19 @@ namespace Quartz
         public bool IsMatch(TKey key) { }
         public static Quartz.EverythingMatcher<TKey> All() { }
     }
+    public readonly struct ExecutionGroupInFlight : System.IEquatable<Quartz.ExecutionGroupInFlight>
+    {
+        public ExecutionGroupInFlight(string? ExecutionGroup, string TriggerGroup, int Count) { }
+        public int Count { get; init; }
+        public string? ExecutionGroup { get; init; }
+        public string TriggerGroup { get; init; }
+    }
     public readonly struct ExecutionGroupLimit : System.IEquatable<Quartz.ExecutionGroupLimit>
     {
-        public ExecutionGroupLimit(Quartz.ExecutionGroupScope Scope, int? MaxConcurrent) { }
+        public ExecutionGroupLimit(Quartz.ExecutionGroupScope Group, int? MaxConcurrent, Quartz.ExecutionLimitScope Scope = 0) { }
+        public Quartz.ExecutionGroupScope Group { get; init; }
         public int? MaxConcurrent { get; init; }
-        public Quartz.ExecutionGroupScope Scope { get; init; }
+        public Quartz.ExecutionLimitScope Scope { get; init; }
     }
     public readonly struct ExecutionGroupScope : System.IEquatable<Quartz.ExecutionGroupScope>
     {
@@ -342,21 +350,27 @@ namespace Quartz
         public override string ToString() { }
         public static Quartz.ExecutionGroupScope Named(string name) { }
     }
+    public enum ExecutionLimitScope
+    {
+        Node = 0,
+        Cluster = 1,
+    }
     public sealed class ExecutionLimits
     {
         public const string OtherGroups = "*";
         public System.Collections.Generic.IReadOnlyList<Quartz.ExecutionGroupLimit> Groups { get; }
+        public bool HasClusterScopedLimits { get; }
         public bool IsEmpty { get; }
         public bool UsesTriggerGroupWhenUnset { get; }
-        public Quartz.ExecutionSlots CreateSlots() { }
-        public bool TryGetLimit(Quartz.ExecutionGroupScope scope, out int? maxConcurrent) { }
+        public Quartz.ExecutionSlots CreateSlots(System.Collections.Generic.IReadOnlyCollection<Quartz.ExecutionGroupInFlight>? clusterInFlight = null) { }
+        public bool TryGetLimit(Quartz.ExecutionGroupScope group, out int? maxConcurrent) { }
     }
     public sealed class ExecutionLimitsBuilder
     {
         public Quartz.ExecutionLimits Build() { }
-        public Quartz.ExecutionLimitsBuilder ForDefaultGroup(int maxConcurrent) { }
-        public Quartz.ExecutionLimitsBuilder ForGroup(string group, int maxConcurrent) { }
-        public Quartz.ExecutionLimitsBuilder ForOtherGroups(int maxConcurrent) { }
+        public Quartz.ExecutionLimitsBuilder ForDefaultGroup(int maxConcurrent, Quartz.ExecutionLimitScope scope = 0) { }
+        public Quartz.ExecutionLimitsBuilder ForGroup(string group, int maxConcurrent, Quartz.ExecutionLimitScope scope = 0) { }
+        public Quartz.ExecutionLimitsBuilder ForOtherGroups(int maxConcurrent, Quartz.ExecutionLimitScope scope = 0) { }
         public Quartz.ExecutionLimitsBuilder Unlimited(string group) { }
         public Quartz.ExecutionLimitsBuilder UseTriggerGroupWhenUnset() { }
         public static Quartz.ExecutionLimitsBuilder Create() { }
@@ -2283,6 +2297,7 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask<int> RepinTriggersFromDeadNode(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string oldPreferredNode, string newPreferredNode, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar?> SelectCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> SelectCalendarNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutionGroupInFlight>> SelectExecutionGroupsInFlight(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> SelectFireInstances(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> SelectFiredTriggerInstanceNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.FiredTriggerRecord>> SelectFiredTriggerRecords(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.FiredTriggerQuery query, System.Threading.CancellationToken cancellationToken = default);
@@ -2616,6 +2631,7 @@ namespace Quartz.Impl.AdoJobStore
         protected string ReplaceTablePrefix(string query) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ICalendar?> SelectCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> SelectCalendarNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ExecutionGroupInFlight>> SelectExecutionGroupsInFlight(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> SelectFireInstances(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> SelectFiredTriggerInstanceNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.FiredTriggerRecord>> SelectFiredTriggerRecords(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Impl.AdoJobStore.FiredTriggerQuery query, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2699,6 +2715,7 @@ namespace Quartz.Impl.AdoJobStore
     public sealed class TriggerAcquisitionCriteria : System.IEquatable<Quartz.Impl.AdoJobStore.TriggerAcquisitionCriteria>
     {
         public TriggerAcquisitionCriteria() { }
+        public System.Collections.Generic.IReadOnlyCollection<Quartz.ExecutionGroupInFlight>? ClusterInFlight { get; init; }
         public Quartz.ExecutionLimits? ExecutionLimits { get; init; }
         public required System.DateTimeOffset LiveNodeCutoff { get; init; }
         public required int MaxCount { get; init; }

--- a/src/Quartz/Configuration/ExecutionLimitsParser.cs
+++ b/src/Quartz/Configuration/ExecutionLimitsParser.cs
@@ -5,7 +5,8 @@ using Quartz.Impl;
 namespace Quartz.Configuration;
 
 /// <summary>
-/// Reads per-node execution group limits from the <c>quartz.executionLimit.*</c> property keys.
+/// Reads execution group limits from the <c>quartz.executionLimit.*</c> and
+/// <c>quartz.clusterExecutionLimit.*</c> property keys.
 /// </summary>
 internal static class ExecutionLimitsParser
 {
@@ -15,17 +16,25 @@ internal static class ExecutionLimitsParser
     public static ExecutionLimits? Parse(NameValueCollection properties)
     {
         var builder = ExecutionLimitsBuilder.Create();
-        var prefix = LegacyPropertyKeys.ExecutionLimitPrefix + ".";
+        var nodePrefix = LegacyPropertyKeys.ExecutionLimitPrefix + ".";
+        var clusterPrefix = LegacyPropertyKeys.ClusterExecutionLimitPrefix + ".";
         var configured = false;
 
         foreach (var key in properties.AllKeys)
         {
-            if (key is null || !key.StartsWith(prefix, StringComparison.Ordinal))
+            if (key is null)
             {
                 continue;
             }
 
-            configured |= Apply(builder, key[prefix.Length..].Trim(), properties[key]?.Trim(), key);
+            if (key.StartsWith(nodePrefix, StringComparison.Ordinal))
+            {
+                configured |= Apply(builder, key[nodePrefix.Length..].Trim(), properties[key]?.Trim(), key, ExecutionLimitScope.Node);
+            }
+            else if (key.StartsWith(clusterPrefix, StringComparison.Ordinal))
+            {
+                configured |= Apply(builder, key[clusterPrefix.Length..].Trim(), properties[key]?.Trim(), key, ExecutionLimitScope.Cluster);
+            }
         }
 
         // Whether anything was configured is tracked as it happens rather than read back off the
@@ -37,7 +46,7 @@ internal static class ExecutionLimitsParser
     /// <summary>
     /// Applies one key, and reports whether it configured anything.
     /// </summary>
-    private static bool Apply(ExecutionLimitsBuilder builder, string groupKey, string? rawValue, string key)
+    private static bool Apply(ExecutionLimitsBuilder builder, string groupKey, string? rawValue, string key, ExecutionLimitScope scope)
     {
         if (groupKey.Length == 0)
         {
@@ -53,7 +62,7 @@ internal static class ExecutionLimitsParser
                 return false;
             }
 
-            builder.ForOtherGroups(limit.Value);
+            builder.ForOtherGroups(limit.Value, scope);
             return true;
         }
 
@@ -65,16 +74,17 @@ internal static class ExecutionLimitsParser
                 return false;
             }
 
-            builder.ForDefaultGroup(limit.Value);
+            builder.ForDefaultGroup(limit.Value, scope);
             return true;
         }
 
         if (limit.HasValue)
         {
-            builder.ForGroup(groupKey, limit.Value);
+            builder.ForGroup(groupKey, limit.Value, scope);
         }
         else
         {
+            // Unlimited takes no scope: there is no number to count, in either of them.
             builder.Unlimited(groupKey);
         }
 

--- a/src/Quartz/Configuration/IQuartzBuilder.cs
+++ b/src/Quartz/Configuration/IQuartzBuilder.cs
@@ -363,7 +363,8 @@ public interface IQuartzBuilder
         Func<IServiceProvider, T> factory, params IReadOnlyCollection<IMatcher<TriggerKey>> matchers) where T : class, ITriggerListener;
 
     /// <summary>
-    /// Configures per-node execution group limits, so resource-hungry jobs cannot saturate every thread.
+    /// Configures execution group limits, so resource-hungry jobs cannot saturate every thread. Each
+    /// limit is counted on this node or across the cluster, as its <see cref="ExecutionLimitScope"/> says.
     /// </summary>
     IQuartzBuilder UseExecutionLimits(Action<ExecutionLimitsBuilder> configure);
 }

--- a/src/Quartz/Configuration/ITriggerConfigurator.cs
+++ b/src/Quartz/Configuration/ITriggerConfigurator.cs
@@ -104,9 +104,9 @@ public interface ITriggerConfigurator<TJob> : ITriggerConfigurator where TJob : 
     ITriggerConfigurator<TJob> WithPriority(int priority);
 
     /// <summary>
-    /// Set the execution group for the Trigger. Execution groups allow per-node
-    /// thread limits to be configured so that resource-intensive jobs do not
-    /// saturate all available threads.
+    /// Set the execution group for the Trigger. Execution groups allow thread
+    /// limits to be configured - per node or across the cluster - so that
+    /// resource-intensive jobs do not saturate all available threads.
     /// </summary>
     /// <param name="executionGroup">the execution group name, or <see langword="null"/> to clear</param>
     /// <returns>the updated TriggerBuilder</returns>

--- a/src/Quartz/Configuration/LegacyPropertyKeys.cs
+++ b/src/Quartz/Configuration/LegacyPropertyKeys.cs
@@ -74,6 +74,17 @@ internal static class LegacyPropertyKeys
     internal const string DataSourcePrefix = "quartz.dataSource";
     internal const string DbProvider = "quartz.dbprovider";
     internal const string ExecutionLimitPrefix = "quartz.executionLimit";
+
+    /// <summary>
+    /// The cluster-scoped twin of <see cref="ExecutionLimitPrefix" />: the same group keys and the same
+    /// values, counted across every node sharing the job store rather than on this one.
+    /// </summary>
+    /// <remarks>
+    /// A prefix of its own rather than a magic value under the existing one, because every key under
+    /// <c>quartz.executionLimit</c> is a group name and every value is a count — there is no spelling
+    /// left in either half that could not also be a real group or a real number.
+    /// </remarks>
+    internal const string ClusterExecutionLimitPrefix = "quartz.clusterExecutionLimit";
     internal const string PluginPrefix = "quartz.plugin";
     internal const string PluginType = "type";
     internal const string JobListenerPrefix = "quartz.jobListener";
@@ -132,6 +143,7 @@ internal static class LegacyPropertyKeys
         DataSourcePrefix,
         DbProvider,
         ExecutionLimitPrefix,
+        ClusterExecutionLimitPrefix,
         PluginPrefix,
         JobListenerPrefix,
         TriggerListenerPrefix,

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -635,9 +635,16 @@ internal sealed class QuartzSchedulerThread
     }
 
     /// <summary>
-    /// Takes prescribed limits for execution groups (if any) and lowers them
+    /// Takes prescribed limits for execution groups (if any) and lowers the node-scoped ones
     /// according to jobs currently executing on this node.
     /// </summary>
+    /// <remarks>
+    /// A <see cref="ExecutionLimitScope.Cluster" /> limit is deliberately left alone here. This node's
+    /// firings are already reservations in the job store — rows in <c>QRTZ_FIRED_TRIGGERS</c> for the
+    /// ADO.NET store — and the store subtracts that count when it builds the acquisition ledger.
+    /// Subtracting them a second time from this side would charge a busy node twice for its own work and
+    /// halve the quota, which no single-node test would show.
+    /// </remarks>
     private ExecutionLimits? ComputeAvailableExecutionGroupLimits()
     {
         ExecutionLimits? limits = qs.GetExecutionLimits();
@@ -646,35 +653,11 @@ internal sealed class QuartzSchedulerThread
             return null;
         }
 
-        Dictionary<string, int?> available = limits.ToWorkingCopy();
+        Dictionary<string, ExecutionGroupAllowance> available = limits.ToWorkingCopy();
 
         foreach (KeyValuePair<string, int> running in runningExecutionGroupCounts)
         {
-            string runningGroup = running.Key;
-            int runningCount = running.Value;
-            if (runningCount <= 0)
-            {
-                continue;
-            }
-
-            if (available.TryGetValue(runningGroup, out int? limit))
-            {
-                if (limit is not null)
-                {
-                    available[runningGroup] = Math.Max(limit.Value - runningCount, 0);
-                }
-                // null means unlimited, nothing to update
-            }
-            else if (runningGroup != ExecutionLimits.DefaultGroupKey
-                     && available.TryGetValue(ExecutionLimits.OtherGroups, out int? defaultLimit))
-            {
-                // OtherGroups ("*") applies to named groups only, not to the
-                // default (ungrouped) key - consistent with CheckExecutionLimits
-                if (defaultLimit is not null)
-                {
-                    available[runningGroup] = Math.Max(defaultLimit.Value - runningCount, 0);
-                }
-            }
+            ExecutionLimits.SubtractInFlight(available, running.Key, running.Value, ExecutionLimitScope.Node);
         }
 
         // The remaining-capacity map carries the derivation flag with it, because the store that reads it

--- a/src/Quartz/ExecutionLimits.cs
+++ b/src/Quartz/ExecutionLimits.cs
@@ -19,21 +19,28 @@
 
 #endregion
 
+using System.Runtime.InteropServices;
+
 namespace Quartz;
 
 /// <summary>
-/// An immutable set of per-node thread limits for execution groups. Execution groups are optional
+/// An immutable set of concurrency limits for execution groups. Execution groups are optional
 /// tags on triggers that characterize the resource requirements of the associated job
 /// (e.g. "batch-jobs", "high-cpu", "large-ram").
 /// </summary>
 /// <remarks>
-/// <para>Each scheduler node can declare its own limits independently:
+/// <para>Every limit says how many concurrent executions its group may have:
 /// <list type="bullet">
 ///   <item>A positive value limits how many threads the group may consume concurrently.</item>
-///   <item>A value of <c>0</c> forbids the group from running on this node.</item>
+///   <item>A value of <c>0</c> forbids the group from running.</item>
 ///   <item><see langword="null"/> means unlimited (no restriction).</item>
 /// </list>
 /// </para>
+/// <para>Every limit also says what it is counted against — see <see cref="ExecutionLimitScope"/>.
+/// A <see cref="ExecutionLimitScope.Node"/> limit, the default, is what this node may run; a
+/// <see cref="ExecutionLimitScope.Cluster"/> limit is what every node sharing the job store may run
+/// between them. The two coexist: a heterogeneous cluster caps heavy work per node, a multi-tenant
+/// one caps a tenant across the cluster, and one deployment can want both.</para>
 /// <para>Use <see cref="OtherGroups"/> as a catch-all default for groups not explicitly listed.</para>
 /// <para>Build one with <see cref="ExecutionLimitsBuilder"/>, either directly or through
 /// <see cref="IQuartzBuilder.UseExecutionLimits"/>; hand it to
@@ -49,7 +56,7 @@ public sealed class ExecutionLimits
     /// <summary>
     /// The key used internally to represent triggers that have no execution group
     /// (<see cref="ITrigger.ExecutionGroup"/> is <see langword="null"/>). It is never a group name a
-    /// caller can use: <see cref="ExecutionGroupLimit.Scope"/> reports the default group as
+    /// caller can use: <see cref="ExecutionGroupLimit.Group"/> reports the default group as
     /// <see cref="ExecutionGroupScope.Default"/>, and
     /// <see cref="ExecutionLimitsBuilder.ForDefaultGroup"/> configures it.
     /// </summary>
@@ -67,19 +74,42 @@ public sealed class ExecutionLimits
     /// </summary>
     internal const string DefaultGroupNullAlias = "null";
 
-    private readonly Dictionary<string, int?> limits;
+    private readonly Dictionary<string, ExecutionGroupAllowance> limits;
     private ExecutionGroupLimit[]? groups;
 
-    internal ExecutionLimits(Dictionary<string, int?> limits, bool usesTriggerGroupWhenUnset = false)
+    internal ExecutionLimits(Dictionary<string, ExecutionGroupAllowance> limits, bool usesTriggerGroupWhenUnset = false)
     {
         this.limits = limits;
         UsesTriggerGroupWhenUnset = usesTriggerGroupWhenUnset;
+
+        foreach (KeyValuePair<string, ExecutionGroupAllowance> pair in limits)
+        {
+            // Null is unlimited and zero is forbidden; neither needs a count to enforce, so neither is
+            // a reason to make a store go and read one.
+            if (pair.Value.Scope == ExecutionLimitScope.Cluster && pair.Value.MaxConcurrent > 0)
+            {
+                HasClusterScopedLimits = true;
+                break;
+            }
+        }
     }
 
     /// <summary>
     /// <see langword="true"/> when nothing is limited, in which case every trigger is free to fire.
     /// </summary>
     public bool IsEmpty => limits.Count == 0;
+
+    /// <summary>
+    /// Whether any group is limited across the cluster rather than on this node alone.
+    /// </summary>
+    /// <remarks>
+    /// A job store reads this to decide whether a cluster-wide in-flight count is worth fetching:
+    /// with no cluster-scoped limit there is nothing such a count could constrain, so the round trip
+    /// is skipped. A group that is explicitly unlimited, or forbidden outright with <c>0</c>, does not
+    /// make this <see langword="true"/> whatever scope it was declared in — neither answer depends on
+    /// what is in flight.
+    /// </remarks>
+    public bool HasClusterScopedLimits { get; }
 
     /// <summary>
     /// Whether a trigger that carries no execution group of its own is limited as though it belonged to
@@ -109,28 +139,42 @@ public sealed class ExecutionLimits
     public IReadOnlyList<ExecutionGroupLimit> Groups => groups ??= Materialize();
 
     /// <summary>
-    /// Reads the limit configured for one scope.
+    /// Reads the limit configured for one group.
     /// </summary>
-    /// <param name="scope">The scope to read: <see cref="ExecutionGroupScope.Default"/>,
+    /// <remarks>
+    /// Only the number; whether it is counted per node or per cluster is on the entries
+    /// <see cref="Groups"/> hands out.
+    /// </remarks>
+    /// <param name="group">The bucket to read: <see cref="ExecutionGroupScope.Default"/>,
     /// <see cref="ExecutionGroupScope.OtherGroups"/>, or a named group via
     /// <see cref="ExecutionGroupScope.Named"/>.</param>
-    /// <param name="maxConcurrent">The limit: a positive count, <c>0</c> when the scope is forbidden,
+    /// <param name="maxConcurrent">The limit: a positive count, <c>0</c> when the group is forbidden,
     /// or <see langword="null"/> when it is explicitly unlimited.</param>
-    /// <returns><see langword="true"/> when the scope has a limit of its own. <see langword="false"/>
+    /// <returns><see langword="true"/> when the group has a limit of its own. <see langword="false"/>
     /// does not mean unlimited — <see cref="ExecutionGroupScope.OtherGroups"/> may still apply to a
     /// named group.</returns>
-    public bool TryGetLimit(ExecutionGroupScope scope, out int? maxConcurrent)
+    public bool TryGetLimit(ExecutionGroupScope group, out int? maxConcurrent)
     {
-        return limits.TryGetValue(scope.StorageKey, out maxConcurrent);
+        if (limits.TryGetValue(group.StorageKey, out ExecutionGroupAllowance allowance))
+        {
+            maxConcurrent = allowance.MaxConcurrent;
+            return true;
+        }
+
+        maxConcurrent = null;
+        return false;
     }
 
     private ExecutionGroupLimit[] Materialize()
     {
         ExecutionGroupLimit[] result = new ExecutionGroupLimit[limits.Count];
         int i = 0;
-        foreach (KeyValuePair<string, int?> pair in limits)
+        foreach (KeyValuePair<string, ExecutionGroupAllowance> pair in limits)
         {
-            result[i++] = new ExecutionGroupLimit(ExecutionGroupScope.FromStorageKey(pair.Key), pair.Value);
+            result[i++] = new ExecutionGroupLimit(
+                ExecutionGroupScope.FromStorageKey(pair.Key),
+                pair.Value.MaxConcurrent,
+                pair.Value.Scope);
         }
         return result;
     }
@@ -140,17 +184,89 @@ public sealed class ExecutionLimits
     /// takes triggers. The snapshot itself is unaffected, so a retried acquisition starts from the limits
     /// again by creating another ledger.
     /// </summary>
-    public ExecutionSlots CreateSlots()
+    /// <param name="clusterInFlight">What the whole cluster already holds in flight, one entry per
+    /// distinct (execution group, trigger group) pair, or <see langword="null"/> when the caller has no
+    /// such count. Only <see cref="ExecutionLimitScope.Cluster"/> limits are lowered by it: a
+    /// <see cref="ExecutionLimitScope.Node"/> limit has already had this node's running work subtracted
+    /// by the scheduler thread, and subtracting a count that includes the same firings again would halve
+    /// the limit on a busy node.</param>
+    public ExecutionSlots CreateSlots(IReadOnlyCollection<ExecutionGroupInFlight>? clusterInFlight = null)
     {
-        return new ExecutionSlots(ToWorkingCopy(), UsesTriggerGroupWhenUnset);
+        Dictionary<string, ExecutionGroupAllowance> working = ToWorkingCopy();
+
+        if (clusterInFlight is not null)
+        {
+            foreach (ExecutionGroupInFlight inFlight in clusterInFlight)
+            {
+                SubtractInFlight(
+                    working,
+                    ResolveGroupKey(inFlight.ExecutionGroup, inFlight.TriggerGroup, UsesTriggerGroupWhenUnset),
+                    inFlight.Count,
+                    ExecutionLimitScope.Cluster);
+            }
+        }
+
+        return new ExecutionSlots(working, UsesTriggerGroupWhenUnset);
     }
 
     /// <summary>
     /// Creates a mutable working copy of the configured limits.
     /// </summary>
-    internal Dictionary<string, int?> ToWorkingCopy()
+    internal Dictionary<string, ExecutionGroupAllowance> ToWorkingCopy()
     {
-        return new Dictionary<string, int?>(limits, StringComparer.Ordinal);
+        return new Dictionary<string, ExecutionGroupAllowance>(limits, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Lowers one group's remaining allowance by what is already in flight against it, but only when
+    /// that allowance is counted in <paramref name="scope"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both places that subtract in-flight work go through this, and they subtract in different scopes:
+    /// the scheduler thread takes off what is running on this node
+    /// (<see cref="ExecutionLimitScope.Node"/>), and a store takes off what the cluster holds
+    /// (<see cref="ExecutionLimitScope.Cluster"/>). Each skips the other's limits, which is what keeps a
+    /// cluster-scoped group from being charged twice for the same firing — this node's reservations are
+    /// already rows in the store's ledger.
+    /// </para>
+    /// <para>
+    /// Repeated calls for one key compose, because the second one reads the value the first wrote.
+    /// </para>
+    /// </remarks>
+    internal static void SubtractInFlight(
+        Dictionary<string, ExecutionGroupAllowance> available,
+        string groupKey,
+        int inFlight,
+        ExecutionLimitScope scope)
+    {
+        if (inFlight <= 0)
+        {
+            return;
+        }
+
+        if (available.TryGetValue(groupKey, out ExecutionGroupAllowance allowance))
+        {
+            if (allowance.Scope == scope && allowance.MaxConcurrent is int limit)
+            {
+                available[groupKey] = allowance with { MaxConcurrent = Math.Max(limit - inFlight, 0) };
+            }
+
+            // A null limit is explicitly unlimited, and a limit in the other scope is not this
+            // caller's to lower.
+            return;
+        }
+
+        // OtherGroups ("*") is a catch-all for named groups only, never for the ungrouped bucket — the
+        // same rule ExecutionSlots.TryTake applies. Materializing the entry here gives each unlisted
+        // group its own allowance rather than one shared between them.
+        if (groupKey != DefaultGroupKey
+            && available.TryGetValue(OtherGroups, out ExecutionGroupAllowance catchAll)
+            && catchAll.Scope == scope
+            && catchAll.MaxConcurrent is int catchAllLimit)
+        {
+            available[groupKey] = catchAll with { MaxConcurrent = Math.Max(catchAllLimit - inFlight, 0) };
+        }
     }
 
     /// <summary>
@@ -203,11 +319,84 @@ public sealed class ExecutionLimits
 /// <summary>
 /// One entry in an <see cref="ExecutionLimits"/> snapshot.
 /// </summary>
-/// <param name="Scope">Which bucket the limit applies to: the default (ungrouped) bucket, the
+/// <param name="Group">Which bucket the limit applies to: the default (ungrouped) bucket, the
 /// catch-all for other groups, or one named group.</param>
-/// <param name="MaxConcurrent">The limit: a positive count, <c>0</c> when the scope is forbidden on
-/// this node, or <see langword="null"/> when it is explicitly unlimited.</param>
-public readonly record struct ExecutionGroupLimit(ExecutionGroupScope Scope, int? MaxConcurrent);
+/// <param name="MaxConcurrent">The limit: a positive count, <c>0</c> when the group is forbidden,
+/// or <see langword="null"/> when it is explicitly unlimited.</param>
+/// <param name="Scope">What the limit is counted against: this node alone, or the whole cluster.</param>
+public readonly record struct ExecutionGroupLimit(
+    ExecutionGroupScope Group,
+    int? MaxConcurrent,
+    ExecutionLimitScope Scope = ExecutionLimitScope.Node);
+
+/// <summary>
+/// What an execution limit is counted against.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two are not alternatives to each other and one set of limits may use both. A node-scoped limit
+/// describes what this machine can stand — the reason a batch node and an API node in the same cluster
+/// declare different numbers. A cluster-scoped limit describes a quota — the reason a tenant may run
+/// eight jobs at a time no matter how many nodes are up.
+/// </para>
+/// </remarks>
+public enum ExecutionLimitScope
+{
+    /// <summary>
+    /// The limit is what this node may run concurrently. Every node enforces its own copy, so an
+    /// N-node cluster can be running N times the number. This is the default, and it is what execution
+    /// limits have always meant.
+    /// </summary>
+    Node = 0,
+
+    /// <summary>
+    /// The limit is what every node sharing the job store may run between them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The count comes from the store, not from any node's memory: for the ADO.NET store it is the
+    /// <c>QRTZ_FIRED_TRIGGERS</c> rows, which already hold both reservations and running executions and
+    /// are already cleaned up when a node dies. That makes the ceiling fail closed — a node that cannot
+    /// reach the store cannot acquire anything either — but also approximate: the default acquisition
+    /// path takes no cluster lock, so two nodes can read the same remaining count and each take from it.
+    /// The overshoot is bounded by the nodes acquiring at that instant, and setting
+    /// <c>AcquireTriggersWithinLock</c> removes it at the cost of serializing acquisition.
+    /// </para>
+    /// <para>
+    /// A store whose <see cref="Extensibility.IJobStore.Clustered"/> is <see langword="false"/> has one
+    /// node, so a cluster-scoped limit and a node-scoped one are the same number there.
+    /// </para>
+    /// </remarks>
+    Cluster = 1,
+}
+
+/// <summary>
+/// How much work one execution group already has in flight across the cluster, as a store reports it
+/// to <see cref="ExecutionLimits.CreateSlots"/>.
+/// </summary>
+/// <remarks>
+/// Both group names are carried because a limit's key is derived from the pair rather than from either
+/// alone: <see cref="ExecutionLimits.UsesTriggerGroupWhenUnset"/> lets the trigger group stand in when
+/// the trigger carries no execution group. A store therefore reports what it has — for the ADO.NET
+/// store, one row per distinct pair in <c>QRTZ_FIRED_TRIGGERS</c> — and the limits resolve the key,
+/// so that the count and the filter can never key work differently.
+/// </remarks>
+/// <param name="ExecutionGroup">The execution group the in-flight work carries, or
+/// <see langword="null"/> when it carries none.</param>
+/// <param name="TriggerGroup">The trigger group the in-flight work belongs to.</param>
+/// <param name="Count">How many reservations and executions the pair has in flight.</param>
+public readonly record struct ExecutionGroupInFlight(string? ExecutionGroup, string TriggerGroup, int Count);
+
+/// <summary>
+/// What one execution group is allowed, as the limits hold it internally: the count and the scope it
+/// is counted in.
+/// </summary>
+/// <remarks>
+/// The public read-side shape is <see cref="ExecutionGroupLimit"/>, which pairs the same two values
+/// with the group they belong to; this one is the dictionary value, so the group is the key.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct ExecutionGroupAllowance(int? MaxConcurrent, ExecutionLimitScope Scope);
 
 /// <summary>
 /// Which bucket an execution limit applies to: the default (ungrouped) bucket, the catch-all for

--- a/src/Quartz/ExecutionLimitsBuilder.cs
+++ b/src/Quartz/ExecutionLimitsBuilder.cs
@@ -22,7 +22,7 @@
 namespace Quartz;
 
 /// <summary>
-/// Builds the per-node <see cref="ExecutionLimits"/> a scheduler applies when it acquires triggers.
+/// Builds the <see cref="ExecutionLimits"/> a scheduler applies when it acquires triggers.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -38,14 +38,15 @@ namespace Quartz;
 /// <example>
 /// <code>
 /// ExecutionLimits limits = ExecutionLimitsBuilder.Create()
-///     .ForGroup("high-cpu", 2)
+///     .ForGroup("high-cpu", 2)                                     // two on this node
+///     .ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster)     // eight across the cluster
 ///     .ForOtherGroups(5)
 ///     .Build();
 /// </code>
 /// </example>
 public sealed class ExecutionLimitsBuilder
 {
-    private readonly Dictionary<string, int?> limits = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ExecutionGroupAllowance> limits = new(StringComparer.Ordinal);
     private bool useTriggerGroupWhenUnset;
 
     internal ExecutionLimitsBuilder()
@@ -66,13 +67,16 @@ public sealed class ExecutionLimitsBuilder
     /// </summary>
     /// <param name="group">The execution group name.</param>
     /// <param name="maxConcurrent">Maximum concurrent threads (must be &gt;= 0), or <c>0</c> to forbid execution.</param>
+    /// <param name="scope">Whether the limit counts what this node runs or what the whole cluster runs.
+    /// Node-scoped unless said otherwise, which is what execution limits have always meant.</param>
     /// <returns>This builder for fluent chaining.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="group"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="group"/> is a reserved name.</exception>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrent"/> is negative.</exception>
-    public ExecutionLimitsBuilder ForGroup(string group, int maxConcurrent)
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrent"/> is negative, or
+    /// <paramref name="scope"/> is not one of the defined values.</exception>
+    public ExecutionLimitsBuilder ForGroup(string group, int maxConcurrent, ExecutionLimitScope scope = ExecutionLimitScope.Node)
     {
-        limits[RequireGroupName(group)] = RequireNonNegative(maxConcurrent);
+        limits[RequireGroupName(group)] = new ExecutionGroupAllowance(RequireNonNegative(maxConcurrent), RequireDefinedScope(scope));
         return this;
     }
 
@@ -80,23 +84,32 @@ public sealed class ExecutionLimitsBuilder
     /// Set the concurrency limit for triggers that have no execution group.
     /// </summary>
     /// <param name="maxConcurrent">Maximum concurrent threads (must be &gt;= 0), or <c>0</c> to forbid execution.</param>
+    /// <param name="scope">Whether the limit counts what this node runs or what the whole cluster runs.</param>
     /// <returns>This builder for fluent chaining.</returns>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrent"/> is negative.</exception>
-    public ExecutionLimitsBuilder ForDefaultGroup(int maxConcurrent)
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrent"/> is negative, or
+    /// <paramref name="scope"/> is not one of the defined values.</exception>
+    public ExecutionLimitsBuilder ForDefaultGroup(int maxConcurrent, ExecutionLimitScope scope = ExecutionLimitScope.Node)
     {
-        limits[ExecutionLimits.DefaultGroupKey] = RequireNonNegative(maxConcurrent);
+        limits[ExecutionLimits.DefaultGroupKey] = new ExecutionGroupAllowance(RequireNonNegative(maxConcurrent), RequireDefinedScope(scope));
         return this;
     }
 
     /// <summary>
     /// Set the default concurrency limit applied to any execution group not explicitly configured.
     /// </summary>
+    /// <remarks>
+    /// The catch-all hands each unlisted group an allowance of its own rather than one they share, and
+    /// that holds whichever scope it is declared in: <c>ForOtherGroups(1, ExecutionLimitScope.Cluster)</c>
+    /// lets three unlisted tenants run one job each across the cluster, not one job between them.
+    /// </remarks>
     /// <param name="maxConcurrent">Maximum concurrent threads (must be &gt;= 0), or <c>0</c> to forbid execution.</param>
+    /// <param name="scope">Whether the limit counts what this node runs or what the whole cluster runs.</param>
     /// <returns>This builder for fluent chaining.</returns>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrent"/> is negative.</exception>
-    public ExecutionLimitsBuilder ForOtherGroups(int maxConcurrent)
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrent"/> is negative, or
+    /// <paramref name="scope"/> is not one of the defined values.</exception>
+    public ExecutionLimitsBuilder ForOtherGroups(int maxConcurrent, ExecutionLimitScope scope = ExecutionLimitScope.Node)
     {
-        limits[ExecutionLimits.OtherGroups] = RequireNonNegative(maxConcurrent);
+        limits[ExecutionLimits.OtherGroups] = new ExecutionGroupAllowance(RequireNonNegative(maxConcurrent), RequireDefinedScope(scope));
         return this;
     }
 
@@ -105,7 +118,8 @@ public sealed class ExecutionLimitsBuilder
     /// </summary>
     /// <remarks>
     /// This is not the same as leaving the group out: an unlisted group falls back to
-    /// <see cref="ForOtherGroups"/>, while an explicitly unlimited one does not.
+    /// <see cref="ForOtherGroups"/>, while an explicitly unlimited one does not. It takes no scope,
+    /// because unlimited on one node and unlimited across the cluster are the same permission.
     /// </remarks>
     /// <param name="group">The execution group name.</param>
     /// <returns>This builder for fluent chaining.</returns>
@@ -113,7 +127,7 @@ public sealed class ExecutionLimitsBuilder
     /// <exception cref="ArgumentException"><paramref name="group"/> is a reserved name.</exception>
     public ExecutionLimitsBuilder Unlimited(string group)
     {
-        limits[RequireGroupName(group)] = null;
+        limits[RequireGroupName(group)] = new ExecutionGroupAllowance(null, ExecutionLimitScope.Node);
         return this;
     }
 
@@ -148,7 +162,7 @@ public sealed class ExecutionLimitsBuilder
     /// </summary>
     public ExecutionLimits Build()
     {
-        return new ExecutionLimits(new Dictionary<string, int?>(limits, StringComparer.Ordinal), useTriggerGroupWhenUnset);
+        return new ExecutionLimits(new Dictionary<string, ExecutionGroupAllowance>(limits, StringComparer.Ordinal), useTriggerGroupWhenUnset);
     }
 
     private static string RequireGroupName(string group)
@@ -174,5 +188,15 @@ public sealed class ExecutionLimitsBuilder
         }
 
         return maxConcurrent;
+    }
+
+    private static ExecutionLimitScope RequireDefinedScope(ExecutionLimitScope scope)
+    {
+        if (scope is not (ExecutionLimitScope.Node or ExecutionLimitScope.Cluster))
+        {
+            throw new ArgumentOutOfRangeException(nameof(scope), scope, "Execution limit scope must be Node or Cluster.");
+        }
+
+        return scope;
     }
 }

--- a/src/Quartz/ExecutionSlots.cs
+++ b/src/Quartz/ExecutionSlots.cs
@@ -34,6 +34,13 @@ namespace Quartz;
 /// the ones shipped with Quartz rather than reinventing them.
 /// </para>
 /// <para>
+/// A <see cref="ExecutionLimitScope.Cluster" /> limit reaches this ledger already lowered by what the
+/// cluster holds in flight, because <see cref="ExecutionLimits.CreateSlots" /> subtracts the counts the
+/// store passed it. Nothing about <see cref="TryTake" /> changes for one: by the time it is asked, a
+/// cluster-scoped group's remaining count is what the whole cluster has left rather than what this node
+/// has left, and it counts down the same way.
+/// </para>
+/// <para>
 /// It is mutable and not thread-safe: one acquisition pass owns one ledger, which is why
 /// <see cref="ExecutionLimits" /> hands out a new one instead of being one. Create a ledger per attempt,
 /// because a retried acquisition must start from the limits again rather than from what the failed
@@ -42,10 +49,10 @@ namespace Quartz;
 /// </remarks>
 public sealed class ExecutionSlots
 {
-    private readonly Dictionary<string, int?> available;
+    private readonly Dictionary<string, ExecutionGroupAllowance> available;
     private readonly bool usesTriggerGroupWhenUnset;
 
-    internal ExecutionSlots(Dictionary<string, int?> available, bool usesTriggerGroupWhenUnset)
+    internal ExecutionSlots(Dictionary<string, ExecutionGroupAllowance> available, bool usesTriggerGroupWhenUnset)
     {
         this.available = available;
         this.usesTriggerGroupWhenUnset = usesTriggerGroupWhenUnset;
@@ -66,23 +73,23 @@ public sealed class ExecutionSlots
     {
         string key = ExecutionLimits.ResolveGroupKey(executionGroup, triggerGroup, usesTriggerGroupWhenUnset);
 
-        int? limit;
-        if (available.TryGetValue(key, out int? groupLimit))
+        ExecutionGroupAllowance allowance;
+        if (available.TryGetValue(key, out ExecutionGroupAllowance groupAllowance))
         {
-            limit = groupLimit;
+            allowance = groupAllowance;
         }
-        else if (key != ExecutionLimits.DefaultGroupKey && available.TryGetValue(ExecutionLimits.OtherGroups, out int? otherLimit))
+        else if (key != ExecutionLimits.DefaultGroupKey && available.TryGetValue(ExecutionLimits.OtherGroups, out ExecutionGroupAllowance otherAllowance))
         {
             // OtherGroups ("*") is a catch-all for named groups only,
             // not for the default (null/ungrouped) triggers
-            limit = otherLimit;
+            allowance = otherAllowance;
         }
         else
         {
             return true; // no limit configured for this group
         }
 
-        if (limit is null)
+        if (allowance.MaxConcurrent is not int limit)
         {
             return true; // unlimited
         }
@@ -94,7 +101,7 @@ public sealed class ExecutionSlots
 
         // Count down against the specific group key, even when the value came from the OtherGroups
         // default, so that each unlisted group gets its own allowance rather than sharing one.
-        available[key] = limit - 1;
+        available[key] = allowance with { MaxConcurrent = limit - 1 };
         return true;
     }
 
@@ -109,6 +116,13 @@ public sealed class ExecutionSlots
     /// that has not been taken from yet.</returns>
     public bool TryGetRemaining(string? executionGroup, out int? remaining)
     {
-        return available.TryGetValue(ExecutionLimits.NormalizeGroupKey(executionGroup), out remaining);
+        if (available.TryGetValue(ExecutionLimits.NormalizeGroupKey(executionGroup), out ExecutionGroupAllowance allowance))
+        {
+            remaining = allowance.MaxConcurrent;
+            return true;
+        }
+
+        remaining = null;
+        return false;
     }
 }

--- a/src/Quartz/Extensibility/IMutableTrigger.cs
+++ b/src/Quartz/Extensibility/IMutableTrigger.cs
@@ -18,8 +18,8 @@ public interface IMutableTrigger : ITrigger
 
     /// <summary>
     /// Gets or sets the execution group for this trigger. Execution groups allow
-    /// per-node thread limits to be configured so that resource-intensive jobs
-    /// do not saturate all available threads.
+    /// thread limits to be configured - per node or across the cluster - so that
+    /// resource-intensive jobs do not saturate all available threads.
     /// </summary>
     /// <remarks>
     /// A <see langword="null"/> value means the trigger has no execution group

--- a/src/Quartz/Extensibility/TriggerAcquisitionRequest.cs
+++ b/src/Quartz/Extensibility/TriggerAcquisitionRequest.cs
@@ -70,11 +70,24 @@ public sealed record TriggerAcquisitionRequest
     }
 
     /// <summary>
-    /// Per-execution-group thread counts still available on this node, which is the configured
+    /// Per-execution-group thread counts still available, which is the configured
     /// <see cref="Quartz.ExecutionLimits" /> less what is already running here. A limit of
     /// <see langword="null" /> means unlimited and <c>0</c> means the group must not fire.
     /// <see langword="null" /> when no execution limits are configured, in which case a store may
     /// ignore execution groups entirely.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only <see cref="ExecutionLimitScope.Node" /> limits arrive already lowered. A
+    /// <see cref="ExecutionLimitScope.Cluster" /> limit arrives as configured, because this node's own
+    /// firings are reservations the store is holding and taking them off here as well would count them
+    /// twice. A store that means to honour cluster-scoped limits — every store whose
+    /// <see cref="IJobStore.Clustered" /> can be <see langword="true" /> — subtracts its own in-flight
+    /// count when it builds the ledger, through
+    /// <see cref="Quartz.ExecutionLimits.CreateSlots" />. A store that does not, or one that has no
+    /// cluster to speak of, simply enforces the configured number, which for a single node is the same
+    /// thing.
+    /// </para>
+    /// </remarks>
     public ExecutionLimits? ExecutionLimits { get; init; }
 }

--- a/src/Quartz/HttpApiContract/HttpApiJson.cs
+++ b/src/Quartz/HttpApiContract/HttpApiJson.cs
@@ -58,6 +58,7 @@ internal static class HttpApiJson
         options.Converters.Add(new JsonStringEnumConverter<TriggerState>());
         options.Converters.Add(new JsonStringEnumConverter<SchedulerStatus>());
         options.Converters.Add(new JsonStringEnumConverter<FireInstanceState>());
+        options.Converters.Add(new JsonStringEnumConverter<ExecutionLimitScope>());
         return options;
     }
 }

--- a/src/Quartz/HttpApiContract/RequestAndResponses.cs
+++ b/src/Quartz/HttpApiContract/RequestAndResponses.cs
@@ -186,9 +186,19 @@ internal record UnscheduleJobsRequest(KeyDto[] Triggers) : IValidatable
     public IEnumerable<string> Validate() => Triggers is null ? ["Missing trigger keys"] : Triggers.SelectMany(x => x.Validate());
 }
 
-internal record ExecutionLimitsResponse(Dictionary<string, int?>? Limits, bool UseTriggerGroupWhenUnset = false);
+/// <summary>
+/// One group's limit on the wire: the count, and what it is counted against.
+/// </summary>
+/// <remarks>
+/// A record rather than a bare number because a limit that lost its scope in transit would come back
+/// as a per-node one, which is a quieter lie than a missing field. <see cref="Scope" /> defaults to
+/// <see cref="ExecutionLimitScope.Node" />, so a body that omits it says what it always said.
+/// </remarks>
+internal record ExecutionLimitDto(int? MaxConcurrent, ExecutionLimitScope Scope = ExecutionLimitScope.Node);
 
-internal record SetExecutionLimitsRequest(Dictionary<string, int?>? Limits, bool UseTriggerGroupWhenUnset = false) : IValidatable
+internal record ExecutionLimitsResponse(Dictionary<string, ExecutionLimitDto>? Limits, bool UseTriggerGroupWhenUnset = false);
+
+internal record SetExecutionLimitsRequest(Dictionary<string, ExecutionLimitDto>? Limits, bool UseTriggerGroupWhenUnset = false) : IValidatable
 {
     public IEnumerable<string> Validate()
     {
@@ -205,9 +215,20 @@ internal record SetExecutionLimitsRequest(Dictionary<string, int?>? Limits, bool
                 yield return $"Limit key '{kvp.Key}' is invalid";
             }
 
-            if (kvp.Value.HasValue && kvp.Value.Value < 0)
+            if (kvp.Value is null)
             {
-                yield return $"Limit value for group '{kvp.Key}' must be non-negative, got {kvp.Value.Value}";
+                yield return $"Limit for group '{kvp.Key}' is missing";
+                continue;
+            }
+
+            if (kvp.Value.MaxConcurrent < 0)
+            {
+                yield return $"Limit value for group '{kvp.Key}' must be non-negative, got {kvp.Value.MaxConcurrent}";
+            }
+
+            if (kvp.Value.Scope is not (ExecutionLimitScope.Node or ExecutionLimitScope.Cluster))
+            {
+                yield return $"Limit scope for group '{kvp.Key}' must be Node or Cluster, got {kvp.Value.Scope}";
             }
         }
     }

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -375,9 +375,10 @@ public interface IScheduler : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Sets the execution group limits for this scheduler node. Execution groups
-    /// allow per-node thread limits so that resource-intensive jobs do not saturate
-    /// all available threads.
+    /// Sets the execution group limits this scheduler enforces. Execution groups allow
+    /// thread limits - per node or across the cluster, as each limit's
+    /// <see cref="ExecutionLimitScope"/> says - so that resource-intensive jobs do not
+    /// saturate all available threads.
     /// </summary>
     /// <remarks>
     /// Limits take effect on the next trigger acquisition cycle. Pass <see langword="null"/>

--- a/src/Quartz/ITrigger.cs
+++ b/src/Quartz/ITrigger.cs
@@ -89,9 +89,9 @@ public interface ITrigger
     string? Description { get; }
 
     /// <summary>
-    /// Gets the execution group for this trigger. Execution groups allow
-    /// per-node thread limits to be configured so that resource-intensive jobs
-    /// do not saturate all available threads.
+    /// Gets the execution group for this trigger. Execution groups allow thread
+    /// limits to be configured - per node or across the cluster - so that
+    /// resource-intensive jobs do not saturate all available threads.
     /// </summary>
     /// <remarks>
     /// A <see langword="null"/> value means the trigger has no execution group

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -3481,6 +3481,12 @@ public abstract class AdoJobStoreBase : IJobStore
     /// silent one.
     /// </para>
     /// <para>
+    /// One property is filled in after this returns:
+    /// <see cref="TriggerAcquisitionCriteria.ClusterInFlight" /> is read from the delegate when the
+    /// limits contain a cluster-scoped one and the override left it <see langword="null" />. An
+    /// override that sets it keeps its own answer.
+    /// </para>
+    /// <para>
     /// <see cref="TriggerAcquisitionCriteria" />'s remarks state the contract a new filter has to
     /// keep: it is another optional property on that record, defaulting to "no additional filtering".
     /// </para>
@@ -3528,6 +3534,18 @@ public abstract class AdoJobStoreBase : IJobStore
             {
                 // Built inside the loop, so each retry asks again and sees the time it retried at.
                 TriggerAcquisitionCriteria criteria = CreateAcquisitionCriteria(request);
+
+                // A cluster-scoped limit is counted against the fired-triggers table, so the count is
+                // read here rather than derived from anything this node remembers. One aggregate per
+                // attempt, and none at all unless a cluster-scoped limit is configured - which is also
+                // why an override that already answered the question is left alone.
+                if (criteria.ClusterInFlight is null && criteria.ExecutionLimits?.HasClusterScopedLimits == true)
+                {
+                    criteria = criteria with
+                    {
+                        ClusterInFlight = await Delegate.SelectExecutionGroupsInFlight(conn, cancellationToken).ConfigureAwait(false),
+                    };
+                }
 
                 List<TriggerAcquireResult> results = await Delegate.SelectTriggersToAcquire(conn, criteria, cancellationToken).ConfigureAwait(false);
 

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -835,6 +835,33 @@ public interface IDriverDelegate
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Counts what the cluster currently holds in flight for each (execution group, trigger group)
+    /// pair, which is what a <see cref="ExecutionLimitScope.Cluster" /> execution limit is counted
+    /// against.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The answer is an aggregate over the fired-triggers table, whose rows already have exactly the
+    /// lifetime a reservation needs: written when a trigger is acquired, updated when it fires, deleted
+    /// when it completes or when cluster recovery cleans up after the node that owned it. So the count
+    /// includes a peer's reservation that has not started yet, and a dead node's rows keep holding
+    /// slots until recovery clears them — under-serving the quota rather than over-serving it, which is
+    /// the safe direction.
+    /// </para>
+    /// <para>
+    /// Both group names are returned because the limits derive their key from the pair; see
+    /// <see cref="ExecutionGroupInFlight" />. Rows are bounded by the distinct pairs currently in
+    /// flight, not by the size of the schedule.
+    /// </para>
+    /// </remarks>
+    /// <param name="conn">The DB connection.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>One entry per distinct pair with work in flight; empty when the cluster is idle.</returns>
+    ValueTask<List<ExecutionGroupInFlight>> SelectExecutionGroupsInFlight(
+        ConnectionAndTransactionHolder conn,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Select the distinct instance names of all fired-trigger records.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -591,6 +591,35 @@ internal static class StdAdoConstants
     public static readonly string SqlCountFireInstances =
         Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
 
+    /// <summary>
+    /// The cluster's in-flight work per execution group, which is what a cluster-scoped execution limit
+    /// is counted against.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The fired-triggers table is already the cluster's reservation ledger — a row appears when a node
+    /// acquires a trigger, turns into the execution, and is deleted on completion or by cluster
+    /// recovery — so the ceiling needs no table, column or migration of its own. Every state counts:
+    /// an ACQUIRED row is a reservation another node has taken and is a slot that is genuinely spoken
+    /// for.
+    /// </para>
+    /// <para>
+    /// The grouping is by both columns rather than by EXECUTION_GROUP alone because
+    /// <see cref="ExecutionLimits.UsesTriggerGroupWhenUnset" /> lets the trigger group stand in for an
+    /// absent execution group; folding the pair down to one key is done in C#, by the same
+    /// <c>ResolveGroupKey</c> the acquisition filter uses, which is why this needs no dialect variants.
+    /// Row count is the number of distinct pairs in flight — tens, not thousands.
+    /// </para>
+    /// <para>
+    /// Deliberately not narrowed to nodes that are still checking in. A node that has missed a check-in
+    /// but is still running jobs would stop counting, which would let the cluster exceed the ceiling;
+    /// counting its rows until recovery deletes them under-serves the quota instead, and that is the
+    /// direction a quota should err in.
+    /// </para>
+    /// </remarks>
+    public static readonly string SqlSelectExecutionGroupsInFlight =
+        Invariant($"SELECT {AdoConstants.ColumnExecutionGroup}, {AdoConstants.ColumnTriggerGroup}, COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName GROUP BY {AdoConstants.ColumnExecutionGroup}, {AdoConstants.ColumnTriggerGroup}");
+
     public static readonly string SqlFireInstanceTriggerGroupEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
 
     public static readonly string SqlFireInstanceTriggerGroupLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -1232,8 +1232,9 @@ public partial class StdAdoDelegate
         AddPreferredNodeParameters(cmd, criteria.LiveNodeCutoff);
 
         // Work on a copy: the slots are decremented as rows are taken, and the caller may reuse the
-        // criteria across retries.
-        ExecutionSlots? executionSlots = criteria.ExecutionLimits?.CreateSlots();
+        // criteria across retries. Cluster-scoped limits arrive already lowered by what the cluster
+        // holds in flight; node-scoped ones were lowered by the scheduler thread before the request.
+        ExecutionSlots? executionSlots = criteria.ExecutionLimits?.CreateSlots(criteria.ClusterInFlight);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         int execGroupOrdinal = -1;
@@ -1283,6 +1284,31 @@ public partial class StdAdoDelegate
         }
 
         return nextTriggers;
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask<List<ExecutionGroupInFlight>> SelectExecutionGroupsInFlight(
+        ConnectionAndTransactionHolder conn,
+        CancellationToken cancellationToken = default)
+    {
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectExecutionGroupsInFlight));
+        AddCommandParameter(cmd, "schedulerName", schedulerName);
+
+        List<ExecutionGroupInFlight> counts = [];
+
+        using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            // Read positionally: the projection is this statement's own and COUNT(*) has no column name
+            // to ask for. Its type is provider-dependent - Int32 on SQL Server, Int64 on PostgreSQL,
+            // MySQL and SQLite - so it is converted rather than read as either.
+            counts.Add(new ExecutionGroupInFlight(
+                rs.IsDBNull(0) ? null : rs.GetString(0),
+                rs.GetString(1),
+                Convert.ToInt32(rs.GetValue(2), CultureInfo.InvariantCulture)));
+        }
+
+        return counts;
     }
 
     /// <inheritdoc />

--- a/src/Quartz/Impl/AdoJobStore/TriggerAcquisitionCriteria.cs
+++ b/src/Quartz/Impl/AdoJobStore/TriggerAcquisitionCriteria.cs
@@ -65,6 +65,28 @@ public sealed record TriggerAcquisitionCriteria
     public ExecutionLimits? ExecutionLimits { get; init; }
 
     /// <summary>
+    /// What the whole cluster already holds in flight per (execution group, trigger group) pair, which
+    /// is what a <see cref="ExecutionLimitScope.Cluster" /> limit is counted against.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="AdoJobStoreBase" /> fills this from
+    /// <see cref="IDriverDelegate.SelectExecutionGroupsInFlight" /> once per acquisition attempt, and
+    /// only when <see cref="Quartz.ExecutionLimits.HasClusterScopedLimits" /> says a cluster-scoped
+    /// limit exists — so a configuration that uses none pays nothing. A
+    /// <see cref="AdoJobStoreBase.CreateAcquisitionCriteria" /> override that sets this itself is left
+    /// alone, which is how a store keeping the count somewhere other than the fired-triggers table says
+    /// so.
+    /// </para>
+    /// <para>
+    /// <see langword="null" /> means "not counted", not "nothing in flight": a delegate handed
+    /// <see langword="null" /> enforces the configured numbers as written, which is correct when no
+    /// limit is cluster-scoped and would be wrong if it were treated as an empty cluster.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyCollection<ExecutionGroupInFlight>? ClusterInFlight { get; init; }
+
+    /// <summary>
     /// Instant before which a node's last check-in is considered stale, releasing its pinned
     /// triggers to other nodes (preferred node / node affinity).
     /// </summary>

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
@@ -21,6 +21,7 @@
 
 using System.Collections.Concurrent;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Quartz.Diagnostics;
@@ -1574,7 +1575,7 @@ public sealed class RAMJobStore : IJobStore
         {
             if (tw.state == StoredTriggerState.Acquired)
             {
-                Count(tw.Trigger.ExecutionGroup, tw.TriggerKey.Group);
+                CountOne(counts, tw.Trigger.ExecutionGroup, tw.TriggerKey.Group);
             }
         }
 
@@ -1582,7 +1583,7 @@ public sealed class RAMJobStore : IJobStore
         {
             foreach (FireInstanceEntry entry in byTrigger.Value.Values)
             {
-                Count(entry.ExecutionGroup, byTrigger.Key.Group);
+                CountOne(counts, entry.ExecutionGroup, byTrigger.Key.Group);
             }
         }
 
@@ -1593,12 +1594,24 @@ public sealed class RAMJobStore : IJobStore
         }
 
         return result;
+    }
 
-        void Count(string? executionGroup, string triggerGroup)
-        {
-            (string? ExecutionGroup, string TriggerGroup) key = (executionGroup, triggerGroup);
-            counts[key] = counts.TryGetValue(key, out int existing) ? existing + 1 : 1;
-        }
+    /// <summary>
+    /// Adds one firing to the tally for its (execution group, trigger group) pair.
+    /// </summary>
+    /// <remarks>
+    /// One hash probe rather than the two a lookup-then-assign costs, and a method taking the
+    /// dictionary rather than a local function closing over it — a captured collection that only grows
+    /// inside a local function reads to symbolic analysis as one nothing ever writes to, which makes
+    /// the caller's enumeration of it look dead.
+    /// </remarks>
+    private static void CountOne(
+        Dictionary<(string? ExecutionGroup, string TriggerGroup), int> counts,
+        string? executionGroup,
+        string triggerGroup)
+    {
+        ref int tally = ref CollectionsMarshal.GetValueRefOrAddDefault(counts, (executionGroup, triggerGroup), out _);
+        tally++;
     }
 
     /// <inheritdoc />

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -1555,6 +1555,52 @@ public sealed class RAMJobStore : IJobStore
                && (query.TriggerName is null || query.TriggerName.IsMatch(triggerKey));
     }
 
+    /// <summary>
+    /// What this store holds in flight per (execution group, trigger group) pair, which is what a
+    /// <see cref="ExecutionLimitScope.Cluster" /> execution limit is counted against.
+    /// </summary>
+    /// <remarks>
+    /// The in-memory counterpart of the ADO store's aggregate over FIRED_TRIGGERS, and deliberately over
+    /// the same set: a wrapper in the acquired state is a reservation, an entry in
+    /// <see cref="executingFireInstances" /> is a running execution. This store is never clustered, so
+    /// its cluster is this one process and a cluster-scoped limit comes out as the same number a
+    /// node-scoped one would — which is why the store honours the scope rather than declining it.
+    /// </remarks>
+    private List<ExecutionGroupInFlight> CollectInFlightExecutionGroupsNoLock()
+    {
+        Dictionary<(string? ExecutionGroup, string TriggerGroup), int> counts = new();
+
+        foreach (TriggerWrapper tw in triggersByKey.Values)
+        {
+            if (tw.state == StoredTriggerState.Acquired)
+            {
+                Count(tw.Trigger.ExecutionGroup, tw.TriggerKey.Group);
+            }
+        }
+
+        foreach (KeyValuePair<TriggerKey, Dictionary<string, FireInstanceEntry>> byTrigger in executingFireInstances)
+        {
+            foreach (FireInstanceEntry entry in byTrigger.Value.Values)
+            {
+                Count(entry.ExecutionGroup, byTrigger.Key.Group);
+            }
+        }
+
+        List<ExecutionGroupInFlight> result = new(counts.Count);
+        foreach (KeyValuePair<(string? ExecutionGroup, string TriggerGroup), int> pair in counts)
+        {
+            result.Add(new ExecutionGroupInFlight(pair.Key.ExecutionGroup, pair.Key.TriggerGroup, pair.Value));
+        }
+
+        return result;
+
+        void Count(string? executionGroup, string triggerGroup)
+        {
+            (string? ExecutionGroup, string TriggerGroup) key = (executionGroup, triggerGroup);
+            counts[key] = counts.TryGetValue(key, out int existing) ? existing + 1 : 1;
+        }
+    }
+
     /// <inheritdoc />
     public async ValueTask<List<IJobDetail>> GetJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
@@ -2410,7 +2456,8 @@ public sealed class RAMJobStore : IJobStore
             DateTimeOffset batchEnd = request.NoLaterThan;
 
             // execution limits will be modified during processing
-            ExecutionSlots? executionSlots = request.ExecutionLimits?.CreateSlots();
+            ExecutionSlots? executionSlots = request.ExecutionLimits?.CreateSlots(
+                request.ExecutionLimits.HasClusterScopedLimits ? CollectInFlightExecutionGroupsNoLock() : null);
 
             while (true)
             {

--- a/src/Quartz/Impl/Triggers/TriggerBase.cs
+++ b/src/Quartz/Impl/Triggers/TriggerBase.cs
@@ -203,8 +203,8 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
 
     /// <summary>
     /// Gets or sets the execution group for this trigger. Execution groups allow
-    /// per-node thread limits to be configured so that resource-intensive jobs
-    /// do not saturate all available threads.
+    /// thread limits to be configured - per node or across the cluster - so that
+    /// resource-intensive jobs do not saturate all available threads.
     /// </summary>
     /// <remarks>
     /// <para>A <see langword="null"/> value means the trigger has no execution group

--- a/src/Quartz/TriggerBuilder.cs
+++ b/src/Quartz/TriggerBuilder.cs
@@ -264,9 +264,9 @@ public sealed class TriggerBuilder<TJob> : ITriggerConfigurator<TJob> where TJob
     }
 
     /// <summary>
-    /// Set the execution group for the Trigger. Execution groups allow per-node
-    /// thread limits to be configured so that resource-intensive jobs do not
-    /// saturate all available threads.
+    /// Set the execution group for the Trigger. Execution groups allow thread
+    /// limits to be configured - per node or across the cluster - so that
+    /// resource-intensive jobs do not saturate all available threads.
     /// </summary>
     /// <param name="executionGroup">the execution group name, or <see langword="null"/> to clear</param>
     /// <returns>the updated TriggerBuilder</returns>

--- a/src/Quartz/TriggerDetailsUpdate.cs
+++ b/src/Quartz/TriggerDetailsUpdate.cs
@@ -173,7 +173,7 @@ public sealed class TriggerDetailsUpdate
     }
 
     /// <summary>
-    /// Set the execution group whose per-node thread limit this trigger's job counts against, or
+    /// Set the execution group whose thread limit this trigger's job counts against, or
     /// <see langword="null" /> to remove it from every group.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
Closes #3337.

Execution limits were enforced per node — the running-count ledger lives on the scheduler thread — so a
group capped at 3 could run 3×N across an N-node cluster. This adds a scope to each limit so the same
API can express both "this machine can stand eight" and "this tenant is entitled to eight".

Built to the design spike on the issue. No new table, no new column, **no migration on either branch**.

## The scope decision, and why it is per limit rather than per snapshot

Per-node limits stay and remain the default. Heterogeneous-hardware limits and tenant quotas are
different concerns that coexist in one deployment — the docs already teach the first — so the scope
belongs on the individual limit:

```csharp
q.UseExecutionLimits(limits => limits
    .ForGroup("high-cpu", 2)                                  // per node, as before
    .ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster)  // per cluster
    .ForOtherGroups(1));
```

`ExecutionLimitScope { Node = 0, Cluster = 1 }`, an optional trailing parameter on `ForGroup` /
`ForOtherGroups` / `ForDefaultGroup`, so every existing call compiles and keeps its old meaning.
`Unlimited(group)` deliberately takes no scope: unlimited on a node and unlimited across the cluster are
the same permission. `quartz.clusterExecutionLimit.<group>` is the property spelling — a prefix of its
own rather than a magic value, because every key under `quartz.executionLimit` is a group name and every
value is a count, so neither half had a spelling to spare.

**One rename a reviewer should look at.** `ExecutionGroupLimit`'s first member was called `Scope` and
held an `ExecutionGroupScope` (which *bucket* — default / catch-all / named). Two types both called
"scope" on one record would be genuinely confusable, so it is now
`ExecutionGroupLimit(ExecutionGroupScope Group, int? MaxConcurrent, ExecutionLimitScope Scope = Node)`:
`Group` says which bucket, `Scope` says what the number is counted against. `main` is pre-release, and
the migration-guide passage that explained the old naming is corrected in the same PR — it would
otherwise have taught the opposite of what the type now says.

## Where the count comes from

`QRTZ_FIRED_TRIGGERS` already is the cluster's reservation ledger, and has carried `EXECUTION_GROUP`
since 3.18: a row is inserted `ACQUIRED` in `AcquireNextTrigger`, updated `EXECUTING` in `TriggerFired`,
and deleted in `TriggeredJobComplete` / `ReleaseAcquiredTrigger` / `ClusterRecover`. Acquisition
aggregates it once per attempt:

```sql
SELECT EXECUTION_GROUP, TRIGGER_GROUP, COUNT(*)
  FROM {0}FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName
 GROUP BY EXECUTION_GROUP, TRIGGER_GROUP
```

Grouping by both columns lets the caller fold rows through `ExecutionLimits.ResolveGroupKey` — the same
function the acquisition filter and the scheduler thread's ledger already use — so
`UseTriggerGroupWhenUnset` needs no SQL of its own and there are no dialect variants. The statement is
emitted **only** when `ExecutionLimits.HasClusterScopedLimits` is true, so a configuration that uses no
cluster-scoped limit pays nothing; a limit of `0` or "unlimited" does not make it true either, since
neither answer depends on what is in flight.

I deliberately did **not** add the spike's optional narrowing to nodes that are still checking in. It
would trade a bounded under-serve (a dead node holds slots until `ClusterRecover`) for an unbounded
over-serve (a live node that missed one check-in stops counting while its jobs keep running). Under-serving
is the safe direction for a quota.

## The lock: not forced, and documented honestly

`AcquireTriggersWithinLock` defaults to `false` and `MaxBatchSize` to `1`, so the default acquisition
path is lock-free and the ceiling is **approximate with a bounded overshoot**. I did not force the lock:
forcing it serializes acquisition cluster-wide for *every* group, not just the limited ones, which is a
large tax to levy on a whole deployment for one tenant's quota. The docs promise exactly this, in these
words:

> The ceiling holds within one acquisition round. Transient overshoot is bounded by the number of nodes
> acquiring concurrently — at most `limit + (nodes − 1) × batchSize`, for as long as it takes the losers
> to notice. Setting `AcquireTriggersWithinLock = true` makes it exact, at the cost of serializing
> acquisition cluster-wide for every group rather than only the limited ones.

The SQLite asymmetry is called out in its own admonition: `AcquireTriggersWithinLock` is force-set to
`true` for SQLite at startup, so the ceiling is exact there and approximate everywhere else — don't read
a SQLite test as evidence about SQL Server.

**Fail-closed is structural, not a policy.** The ledger and the work queue are the same database, so
there is nothing to fail open *to*: an unreachable store or a partitioned node means
`AcquireNextTriggers` throws, `SchedulerError` is raised, the thread backs off, and the node fires
nothing. Documented, because an operator needs to know a database outage stops firing rather than
removing the ceiling.

**Misfire interaction** is documented as a caveat, not solved: a group parked at its ceiling for longer
than `MisfireThreshold` (one minute) feeds its backlog into `RecoverMisfiredJobs`. This bites a
cluster-scoped limit harder than a node-scoped one, because a saturated node loses the trigger to a peer
while a saturated cluster has no peer to lose it to.

## The double-count bug

`QuartzSchedulerThread.ComputeAvailableExecutionGroupLimits` must not pre-subtract this node's running
counts for a cluster-scoped group — those firings are already rows in `FIRED_TRIGGERS`, and subtracting
them twice halves the quota on the busiest node. Both subtractions now go through one scope-filtered
helper (`ExecutionLimits.SubtractInFlight`), so neither side can reach into the other's limits. This is
invisible on a single node, so it has explicit unit tests:
`DispatchedWorkIsNotSubtractedFromAClusterScopedLimit` and
`NodeScopedAndClusterScopedLimitsAreSubtractedIndependently` — both verified to fail when the scope
filter is removed.

## The RAM store honours the same contract

`RAMJobStore.Clustered` is `false`, so its cluster is one process and a cluster-scoped limit resolves to
the number a node-scoped one would. It counts its own acquired reservations plus `executingFireInstances`
— deliberately the same set of things the ADO aggregate counts. Five new assertions in
`JobStoreContractTest` cover both stores rather than recording a divergence; each fails on both stores
when the feature is disabled.

## Verification

```
dotnet build Quartz.slnx                → Build succeeded.  0 Warning(s)  0 Error(s)
dotnet test src/Quartz.Tests.Unit       → Passed!  Failed: 0, Passed: 2922, Skipped: 4, Total: 2926
dotnet test src/Quartz.Tests.AspNetCore → Passed!  Failed: 0, Passed: 312,  Total: 312
QUARTZ_TEST_DATABASE=sqlite dotnet test src/Quartz.Tests.Integration
  --filter RAMJobStoreContractTest|SQLiteJobStoreContractTest
                                        → Passed!  Failed: 0, Passed: 120,  Total: 120
node docs/.vuepress/check-links.mjs     → 211 pages, 685 internal links, 380 fragments; no dead links or anchors
```

I also inverted the feature twice to confirm the tests are real: forcing `SubtractInFlight` to ignore
the scope failed both scheduler-thread tests, and forcing `HasClusterScopedLimits` false failed three
contract tests on *each* store.

### Coverage of the new lines

`.github/workflows/sonar.yml` measures `Compile UnitTest`, which is `Quartz.Tests.Unit` **and**
`Quartz.Tests.AspNetCore` — no integration leg. Reproducing that measurement locally and intersecting
the opencover sequence points with this branch's added lines:

| | new executable lines | covered | uncovered |
|---|---|---|---|
| before | 200 | 145 | 55 (72.5%) |
| after | 202 | 202 | **0 (100%)** |

The 55 split into "unreachable without a container" and "reachable from unit tests and untested", and
the honest answer is that **the first pile was empty** — every one of them was reachable from the
measured set and simply had no test:

- `SelectExecutionGroupsInFlight` (15) — the fake-`DbDataReader` harness `StdAdoDelegateGroupMatcherTest`
  already uses reaches it; no database needed
- `QuartzApiClient` (14) — the dashboard's remote client, reachable with a canned `HttpMessageHandler`
- `RAMJobStore.CollectInFlightExecutionGroupsNoLock` (12) — plainly unit-reachable
- `SetExecutionLimitsRequest.Validate` (7) — pure
- `InProcessQuartzApiClient` + the dashboard DTO (5), and the `inFlight <= 0` guard in
  `SubtractInFlight` (2)

So this needs no coverage override; it needed tests, and 23 of them are now here. Both the SQLite
contract fixture and these unit tests exercise the ADO aggregate, from opposite ends.

**Docker was not available** in the worktree (`docker ps` → *failed to connect to the backend: timed out
dialing Hyper-V socket*), so the container-backed legs did not run. A reviewer with a daemon should run:

```
.uild.cmd Compile UnitTest IntegrationTest
```

and in particular the PostgreSQL and SQL Server legs of `JobStoreContractTest`, which are the ones that
exercise the lock-free acquisition path this feature's guarantee is stated against.

## Public API

Both baselines moved and were regenerated, not hand-edited; the same delta is in the migration guide
under *An execution limit can be cluster-wide*. Summary:

- new `ExecutionLimitScope`, `ExecutionGroupInFlight`
- `ExecutionGroupLimit` gains `Scope`, first member renamed `Scope` → `Group`
- `ExecutionLimits.HasClusterScopedLimits`; `CreateSlots` takes an optional in-flight collection
- `TriggerAcquisitionCriteria.ClusterInFlight`
- `IDriverDelegate.SelectExecutionGroupsInFlight` — **a compile break for anyone implementing
  `IDriverDelegate` from scratch**, deliberately: a stub returning "nothing in flight" would fail the
  ceiling open. `StdAdoDelegate` implements it once for every dialect.
- wire and dashboard DTOs carry the scope per entry rather than a bare `int?`

Nothing is required of an `IJobStore` implementer: a store reporting `Clustered == false` needs no
change at all.

## Deliberately left alone

Tracked in **#3364**, which records the reasoning so none of it has to be re-derived from a PR comment:

- **No benchmark leg** for the aggregate (#3344 is the model). The issue asks for one; it needs
  containers. #3364 states plainly that the feature is opt-in and costs nothing when unused, so this is
  an optimisation question, not a correctness one.
- **No index on `EXECUTION_GROUP`**, deliberately deferred until *after* those numbers. An index is a
  migration, the generator does have `CreateIndex`, the cross-branch rule is being amended under #3336
  for 4.x-only migrations, and the aggregate is already `SCHED_NAME`-scoped so the selectivity question
  is real rather than obvious.
- **No live-node narrowing** of the count, with the under-serve-versus-over-serve reasoning.
- **Spike option A2** (correlated subquery in the candidate select), better revisited with #3335.

Not tracked, and agreed as out of scope: the "candidate skipped, group at cluster limit" debug/metric
signal the spike suggests — separable observability, and this PR is wide enough.

## Docs the rebase pulled in

`docs/documentation/tenancy-patterns.md` merged (#3348) while this branch was open. It is
version-neutral, and three of its statements about execution limits were true when written and are now
true only of 3.x: the capability table's "Cluster-wide quotas or rate limiting | No | No" row, the
"Concurrency limits are per node, not cluster-wide" entry under *what Quartz.NET does not give you*, and
the Celery parallel. Corrected in place, keeping the page's framing — per node stays the default and
stays the trap, and the anti-pattern still warns about assuming otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3wNU6NFXyZztWp12PGQc
