### PR TITLE
Clustered hardening tests: a synthetic killed node, a two-node race, and a SQL Server leg

### DIFF
--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningPostgresTest.cs
@@ -1,0 +1,14 @@
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The clustered hardening scenarios against PostgreSQL, whose store locks through
+/// <c>PostgreSqlSelectForUpdateSemaphore</c>.
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class ClusteredHardeningPostgresTest : ClusteredHardeningTestBase
+{
+    public ClusteredHardeningPostgresTest() : base(TestConstants.PostgresProvider)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningSqlServerTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningSqlServerTest.cs
@@ -1,0 +1,37 @@
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The clustered hardening scenarios against SQL Server, plus the one lock handler only SQL Server can
+/// carry. A clustered SQL Server store locks through <c>SelectForUpdateSemaphore</c> with the
+/// <c>(UPDLOCK,ROWLOCK)</c> hint the store defaults it to, which is a different statement from the
+/// PostgreSQL fixture's <c>SELECT ... FOR UPDATE</c> and is not exercised anywhere else under real
+/// two-node contention.
+/// </summary>
+[Category("db-sqlserver")]
+[NonParallelizable]
+public sealed class ClusteredHardeningSqlServerTest : ClusteredHardeningTestBase
+{
+    public ClusteredHardeningSqlServerTest() : base(TestConstants.DefaultSqlServerProvider)
+    {
+    }
+
+    /// <summary>
+    /// The same race driven through <see cref="Quartz.Impl.AdoJobStore.UpdateRowSemaphore"/> rather than
+    /// the handler the store picks for itself. It is reachable from configuration and nothing else in the
+    /// suite runs its update-or-insert against a real database — the unit tests only prove it retries in
+    /// front of a fake provider.
+    /// </summary>
+    /// <remarks>
+    /// SQL Server only, deliberately. When two nodes first contend for a lock name the row does not exist
+    /// yet, so both fall through to the INSERT and one takes a primary key violation; SQL Server leaves
+    /// the transaction usable so the handler's retry takes the lock, while PostgreSQL marks the whole
+    /// transaction aborted and the retry would fail too. That is the reason PostgreSQL gets its own
+    /// semaphore, and the reason this test would be testing a broken combination if it ran there.
+    /// </remarks>
+    [Test]
+    public Task TwoNodes_EveryOneShotTriggerFiresExactlyOnce_WithUpdateRowSemaphore()
+    {
+        return AssertNoDoubleFire(configure: properties =>
+            properties["quartz.jobStore.lockHandler.type"] = "Quartz.Impl.AdoJobStore.UpdateRowSemaphore, Quartz");
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningTestBase.cs
@@ -1,0 +1,349 @@
+using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Globalization;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The clustered failures nobody can produce by shutting a scheduler down politely: a node that died
+/// mid-flight and left its rows behind, and two live nodes racing for the same due triggers.
+/// <para>
+/// These run against every engine that has a fixture, because the interesting code is the SQL — the row
+/// locking that stops two nodes acquiring the same trigger, and the recovery statements that undo a
+/// dead node's residue — and that SQL differs per engine. PostgreSQL locks with
+/// <c>SELECT ... FOR UPDATE</c>, SQL Server with an <c>(UPDLOCK,ROWLOCK)</c> hint; only running both
+/// says the store works on both.
+/// </para>
+/// </summary>
+public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
+{
+    protected const string Group = "clusterHardening";
+
+    /// <summary>
+    /// The instance id of a node that never existed. Nothing ever starts under this name, so every row
+    /// carrying it is residue by construction and no live check-in can rewrite it underneath a test.
+    /// </summary>
+    private const string DeadNode = "killed-node";
+
+    protected ClusteredHardeningTestBase(string provider) : base(provider)
+    {
+    }
+
+    protected override string SchedulerName => "ClusterHardeningTest";
+
+    [SetUp]
+    public void ResetFirings() => FiringRecordingJob.Reset();
+
+    /// <summary>
+    /// A node killed while it held an acquired trigger leaves the trigger row in ACQUIRED and a
+    /// fired-trigger row naming itself. Nothing acquires an ACQUIRED trigger a second time, so unless a
+    /// survivor recovers it the trigger is lost for good — the "the job stopped running after the pod
+    /// was OOM-killed" report. A node shut down politely cannot produce this state; it releases what it
+    /// holds on the way out. So the state is written directly.
+    /// </summary>
+    [Test]
+    public async Task KilledNode_AcquiredTriggerIsReleasedAndFiredBySurvivor()
+    {
+        IScheduler survivor = await CreateScheduler("survivor");
+        var triggerKey = new TriggerKey("orphanedAcquiredTrigger", Group);
+
+        try
+        {
+            // Created but not started: an unstarted node never checks in and never acquires anything, so
+            // the residue written below is the only thing in play until Start() runs the first check-in.
+            IJobDetail job = JobBuilder.Create<FiringRecordingJob>()
+                .WithIdentity("orphanedAcquiredJob", Group)
+                .StoreDurably()
+                .Build();
+            await survivor.AddJob(job, new AddJobOptions { Replace = true });
+
+            await survivor.ScheduleJob(TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartAt(DateTimeOffset.UtcNow)
+                .Build());
+
+            // The residue of `kill -9` between acquisition and firing. The job columns stay null and the
+            // flags false because that is exactly what StdAdoDelegate.InsertFiredTrigger writes for an
+            // ACQUIRED row — the job has not been loaded at that point.
+            await InsertDeadNodeCheckin();
+            await InsertDeadNodeFiredTrigger(
+                entryId: "killed-node-acquired-1",
+                triggerKey: triggerKey,
+                state: "ACQUIRED",
+                jobKey: null,
+                requestsRecovery: false);
+            await ExecuteNonQuery(
+                "UPDATE QRTZ_TRIGGERS SET TRIGGER_STATE = 'ACQUIRED' "
+                + "WHERE SCHED_NAME = @schedulerName AND TRIGGER_NAME = @triggerName AND TRIGGER_GROUP = @triggerGroup",
+                ("schedulerName", SchedulerName),
+                ("triggerName", triggerKey.Name),
+                ("triggerGroup", triggerKey.Group));
+
+            await survivor.Start();
+
+            await WaitForFirings(1, timeoutMs: 30_000, "the survivor to recover and fire the trigger the dead node was holding");
+
+            FiringRecordingJob.Firings.Should().ContainSingle(
+                    "the released trigger fires once; a fired-trigger row that survived recovery would keep the trigger stuck instead")
+                .Which.InstanceId.Should().Be("survivor");
+
+            (await CountDeadNodeRows("QRTZ_FIRED_TRIGGERS")).Should().Be(0,
+                "ClusterRecover deletes the dead node's fired-trigger rows; leaving them makes the corpse "
+                + "look busy to QueryFireInstances and re-recovered on every subsequent check-in");
+            (await CountDeadNodeRows("QRTZ_SCHEDULER_STATE")).Should().Be(0,
+                "ClusterRecover deletes the dead node's state row once it has finished with it, so the "
+                + "cluster stops paying to rediscover the same corpse");
+        }
+        finally
+        {
+            await survivor.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// The other half of the same crash: the node died while a job that asked for recovery was actually
+    /// executing. Here the survivor has to build a replacement trigger rather than merely release one,
+    /// and the job's own trigger is deliberately parked an hour out so the replacement is the only thing
+    /// that can run it.
+    /// </summary>
+    [Test]
+    public async Task KilledNode_ExecutingRecoverableJobIsRescheduledBySurvivor()
+    {
+        IScheduler survivor = await CreateScheduler("survivor");
+        var triggerKey = new TriggerKey("interruptedTrigger", Group);
+
+        try
+        {
+            IJobDetail job = JobBuilder.Create<FiringRecordingJob>()
+                .WithIdentity("interruptedJob", Group)
+                .StoreDurably()
+                .RequestRecovery()
+                .Build();
+            await survivor.AddJob(job, new AddJobOptions { Replace = true });
+
+            await survivor.ScheduleJob(TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+                .Build());
+
+            await InsertDeadNodeCheckin();
+            await InsertDeadNodeFiredTrigger(
+                entryId: "killed-node-executing-1",
+                triggerKey: triggerKey,
+                state: "EXECUTING",
+                jobKey: job.Key,
+                requestsRecovery: true);
+
+            await survivor.Start();
+
+            await WaitForFirings(1, timeoutMs: 30_000, "the survivor to schedule and run the recovery trigger");
+
+            FiringRecord firing = FiringRecordingJob.Firings.Should().ContainSingle(
+                "the interrupted execution is recovered once, not once per check-in").Subject;
+            firing.InstanceId.Should().Be("survivor");
+            firing.TriggerKey.Group.Should().Be(SchedulerConstants.DefaultRecoveryGroup,
+                "the job runs again through a recovery trigger, not through its own trigger, which is still an hour out");
+            firing.OriginalTriggerName.Should().Be(triggerKey.Name,
+                "a recovered job is told through its data map which trigger's firing it is replaying");
+
+            (await CountDeadNodeRows("QRTZ_FIRED_TRIGGERS")).Should().Be(0);
+            (await CountDeadNodeRows("QRTZ_SCHEDULER_STATE")).Should().Be(0);
+
+            (await survivor.GetTrigger(triggerKey)).Should().NotBeNull(
+                "recovery replays the interrupted firing; it does not consume the original schedule");
+        }
+        finally
+        {
+            await survivor.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// The property the clustered job store exists to provide: two nodes, one set of triggers, every
+    /// trigger fired exactly once.
+    /// </summary>
+    [Test]
+    public Task TwoNodes_EveryOneShotTriggerFiresExactlyOnce()
+    {
+        return AssertNoDoubleFire(configure: null);
+    }
+
+    /// <summary>
+    /// Starts two contending nodes, schedules thirty one-shot triggers due at the same instant, and
+    /// asserts each fired exactly once. Both nodes acquire in batches so they genuinely reach for
+    /// overlapping sets of rows rather than politely taking turns, which is the only arrangement in
+    /// which a broken lock or a lost <c>WHERE TRIGGER_STATE = 'WAITING'</c> guard shows up at all.
+    /// </summary>
+    protected async Task AssertNoDoubleFire(Action<NameValueCollection> configure)
+    {
+        const int TriggerCount = 30;
+
+        void ConfigureNode(NameValueCollection properties)
+        {
+            // A node that acquires ten at a time reaches for overlapping sets of rows rather than
+            // politely taking one each; the thread pool has to grow with it, because the scheduler
+            // refuses a batch larger than the number of threads that could run it.
+            properties["quartz.scheduler.batchTriggerAcquisitionMaxCount"] = "10";
+            properties["quartz.threadPool.maxConcurrency"] = "10";
+            configure?.Invoke(properties);
+        }
+
+        IScheduler nodeA = await CreateScheduler("nodeA", configure: ConfigureNode);
+        IScheduler nodeB = await CreateScheduler("nodeB", configure: ConfigureNode);
+
+        try
+        {
+            await nodeA.Start();
+            await nodeB.Start();
+
+            IJobDetail job = JobBuilder.Create<FiringRecordingJob>()
+                .WithIdentity("noDoubleFireJob", Group)
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, new AddJobOptions { Replace = true });
+
+            // Far enough out that every trigger is stored before any of them is due, so all thirty
+            // become eligible at the same instant with both nodes awake to see them.
+            DateTimeOffset start = DateTimeOffset.UtcNow.AddSeconds(5);
+            string[] expected = new string[TriggerCount];
+            for (int i = 0; i < TriggerCount; i++)
+            {
+                expected[i] = "oneShot-" + i.ToString(CultureInfo.InvariantCulture);
+                await nodeA.ScheduleJob(TriggerBuilder.Create()
+                    .WithIdentity(expected[i], Group)
+                    .ForJob(job)
+                    .StartAt(start)
+                    .Build());
+            }
+
+            await WaitForCondition(
+                () => Task.FromResult(FiringRecordingJob.Firings.Count >= TriggerCount),
+                timeoutMs: 90_000,
+                () =>
+                {
+                    string[] missing = expected.Except(FiredTriggerNames()).ToArray();
+                    return $"all {TriggerCount} one-shot triggers to fire; {missing.Length} never did "
+                           + $"([{string.Join(", ", missing)}]). State:\n{DumpDatabaseState().GetAwaiter().GetResult()}";
+                });
+
+            // Absence cannot be polled for, only waited out: a duplicate acquisition that lost the race by
+            // a few hundred milliseconds arrives after the thirtieth firing, not before it.
+            await Task.Delay(3000);
+
+            TestContext.Out.WriteLine("Firings per node: " + string.Join(", ", FiringRecordingJob.Firings
+                .GroupBy(x => x.InstanceId)
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .Select(x => $"{x.Key}={x.Count()}")));
+
+            FiredTriggerNames().Should().BeEquivalentTo(expected,
+                "a clustered store hands each one-shot trigger to exactly one node — a repeated name means "
+                + "two nodes acquired the same row, and a missing one means a row was acquired and dropped");
+        }
+        finally
+        {
+            await nodeA.Shutdown(waitForJobsToComplete: false);
+            await nodeB.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    private static string[] FiredTriggerNames() => FiringRecordingJob.Firings.Select(x => x.TriggerKey.Name).ToArray();
+
+    private Task WaitForFirings(int count, int timeoutMs, string what)
+    {
+        return WaitForCondition(
+            () => Task.FromResult(FiringRecordingJob.Firings.Count >= count),
+            timeoutMs,
+            () => $"{what}. State:\n{DumpDatabaseState().GetAwaiter().GetResult()}");
+    }
+
+    /// <summary>
+    /// Writes the SCHEDULER_STATE row a node leaves behind, then ages it past the failure threshold. The
+    /// row is inserted at the current time and backdated rather than written already stale, so that the
+    /// helper the staleness waits use is also what makes this node look dead.
+    /// </summary>
+    private async Task InsertDeadNodeCheckin()
+    {
+        await ExecuteNonQuery(
+            "INSERT INTO QRTZ_SCHEDULER_STATE (SCHED_NAME, INSTANCE_NAME, LAST_CHECKIN_TIME, CHECKIN_INTERVAL) "
+            + "VALUES (@schedulerName, @instanceName, @lastCheckinTime, @checkinInterval)",
+            ("schedulerName", SchedulerName),
+            ("instanceName", DeadNode),
+            ("lastCheckinTime", DateTimeOffset.UtcNow.UtcTicks),
+            ("checkinInterval", 1000L));
+
+        await BackdateCheckin(DeadNode, TimeSpan.FromMinutes(5));
+    }
+
+    /// <summary>
+    /// Writes a fired-trigger row owned by the dead node, in the shape
+    /// <c>StdAdoDelegate.InsertFiredTrigger</c> writes for that state.
+    /// </summary>
+    private async Task InsertDeadNodeFiredTrigger(
+        string entryId,
+        TriggerKey triggerKey,
+        string state,
+        JobKey jobKey,
+        bool requestsRecovery)
+    {
+        // Recent enough that a recovery trigger built from it is merely overdue rather than misfired,
+        // which keeps the assertions about what ran clear of misfire policy.
+        long firedTime = DateTimeOffset.UtcNow.AddSeconds(-5).UtcTicks;
+
+        await ExecuteNonQuery(
+            "INSERT INTO QRTZ_FIRED_TRIGGERS "
+            + "(SCHED_NAME, ENTRY_ID, TRIGGER_NAME, TRIGGER_GROUP, INSTANCE_NAME, FIRED_TIME, SCHED_TIME, "
+            + "PRIORITY, STATE, JOB_NAME, JOB_GROUP, IS_NONCONCURRENT, REQUESTS_RECOVERY, EXECUTION_GROUP) "
+            + "VALUES (@schedulerName, @entryId, @triggerName, @triggerGroup, @instanceName, @firedTime, @schedTime, "
+            + "@priority, @state, @jobName, @jobGroup, @isNonConcurrent, @requestsRecovery, NULL)",
+            ("schedulerName", SchedulerName),
+            ("entryId", entryId),
+            ("triggerName", triggerKey.Name),
+            ("triggerGroup", triggerKey.Group),
+            ("instanceName", DeadNode),
+            ("firedTime", firedTime),
+            ("schedTime", firedTime),
+            ("priority", 5),
+            ("state", state),
+            ("jobName", jobKey?.Name),
+            ("jobGroup", jobKey?.Group),
+            ("isNonConcurrent", false),
+            ("requestsRecovery", requestsRecovery));
+    }
+
+    private Task<int> CountDeadNodeRows(string table)
+    {
+        return CountRows(
+            $"SELECT COUNT(*) FROM {table} WHERE SCHED_NAME = @schedulerName AND INSTANCE_NAME = @instanceName",
+            ("schedulerName", SchedulerName),
+            ("instanceName", DeadNode));
+    }
+
+    private sealed record FiringRecord(TriggerKey TriggerKey, string InstanceId, string OriginalTriggerName);
+
+    /// <summary>
+    /// Records the trigger, the node, and — for a recovered firing — the trigger whose firing is being
+    /// replayed. Concurrent by design: the exactly-once property under test belongs to trigger
+    /// acquisition, and <c>[DisallowConcurrentExecution]</c> would hide it behind a queue.
+    /// </summary>
+    private sealed class FiringRecordingJob : IJob
+    {
+        private static volatile ConcurrentQueue<FiringRecord> firings = new();
+
+        public static ConcurrentQueue<FiringRecord> Firings => firings;
+
+        public static void Reset() => Interlocked.Exchange(ref firings, new ConcurrentQueue<FiringRecord>());
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            JobDataMap map = context.MergedJobDataMap;
+            string originalTriggerName = map.ContainsKey(SchedulerConstants.FailedJobOriginalTriggerName)
+                ? map.GetString(SchedulerConstants.FailedJobOriginalTriggerName)
+                : null;
+
+            Firings.Enqueue(new FiringRecord(context.Trigger.Key, context.Scheduler.SchedulerInstanceId, originalTriggerName));
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningTestBase.cs
@@ -17,7 +17,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// </summary>
 public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
 {
-    protected const string Group = "clusterHardening";
+    private const string Group = "clusterHardening";
 
     /// <summary>
     /// The instance id of a node that never existed. Nothing ever starts under this name, so every row
@@ -83,6 +83,7 @@ public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
             await survivor.Start();
 
             await WaitForFirings(1, timeoutMs: 30_000, "the survivor to recover and fire the trigger the dead node was holding");
+            await SettleForRepeatFirings();
 
             FiringRecordingJob.Firings.Should().ContainSingle(
                     "the released trigger fires once; a fired-trigger row that survived recovery would keep the trigger stuck instead")
@@ -139,6 +140,7 @@ public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
             await survivor.Start();
 
             await WaitForFirings(1, timeoutMs: 30_000, "the survivor to schedule and run the recovery trigger");
+            await SettleForRepeatFirings();
 
             FiringRecord firing = FiringRecordingJob.Firings.Should().ContainSingle(
                 "the interrupted execution is recovered once, not once per check-in").Subject;
@@ -221,16 +223,16 @@ public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
             await WaitForCondition(
                 () => Task.FromResult(FiringRecordingJob.Firings.Count >= TriggerCount),
                 timeoutMs: 90_000,
-                () =>
+                async () =>
                 {
                     string[] missing = expected.Except(FiredTriggerNames()).ToArray();
                     return $"all {TriggerCount} one-shot triggers to fire; {missing.Length} never did "
-                           + $"([{string.Join(", ", missing)}]). State:\n{DumpDatabaseState().GetAwaiter().GetResult()}";
+                           + $"([{string.Join(", ", missing)}]). State:\n{await DumpDatabaseState()}";
                 });
 
             // Absence cannot be polled for, only waited out: a duplicate acquisition that lost the race by
             // a few hundred milliseconds arrives after the thirtieth firing, not before it.
-            await Task.Delay(3000);
+            await SettleForRepeatFirings();
 
             TestContext.Out.WriteLine("Firings per node: " + string.Join(", ", FiringRecordingJob.Firings
                 .GroupBy(x => x.InstanceId)
@@ -255,8 +257,15 @@ public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
         return WaitForCondition(
             () => Task.FromResult(FiringRecordingJob.Firings.Count >= count),
             timeoutMs,
-            () => $"{what}. State:\n{DumpDatabaseState().GetAwaiter().GetResult()}");
+            async () => $"{what}. State:\n{await DumpDatabaseState()}");
     }
+
+    /// <summary>
+    /// Gives a repeat firing time to arrive before the caller asserts there was none. Recovery is driven
+    /// by the check-in loop, so a recovery that failed to clean up after itself would run again on the
+    /// next check-in — three of those, at this fixture's one-second interval, pass inside this wait.
+    /// </summary>
+    private static Task SettleForRepeatFirings() => Task.Delay(3000);
 
     /// <summary>
     /// Writes the SCHEDULER_STATE row a node leaves behind, then ages it past the failure threshold. The

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
@@ -19,9 +19,9 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// </para>
 /// <para>
 /// <b>There is deliberately no <c>FakeTimeProvider</c> anywhere in this project.</b> A clustered node
-/// decides that a peer has died by comparing the peer's <c>LAST_CHECKIN_TIME</c> — a wall-clock epoch
-/// stamp sitting in <c>QRTZ_SCHEDULER_STATE</c> — against its own clock, and the same is true of every
-/// other node reading the same row. The database is the clock the cluster agrees on. Handing one node
+/// decides that a peer has died by comparing the peer's <c>LAST_CHECKIN_TIME</c> — an absolute instant
+/// sitting in <c>QRTZ_SCHEDULER_STATE</c> — against its own clock, and the same is true of every other
+/// node reading the same row. The database is the clock the cluster agrees on. Handing one node
 /// a fake clock would move that node's arithmetic while the rows, the peers, the connection timeouts
 /// and the server's own timing stayed on real time, so the test would exercise a cluster that does not
 /// exist. Where a test needs the past, it moves the database instead: see
@@ -107,19 +107,19 @@ public abstract class ClusteredJobStoreTestBase
         int timeoutMs,
         string message)
     {
-        return WaitForCondition(condition, timeoutMs, () => message);
+        return WaitForCondition(condition, timeoutMs, () => Task.FromResult(message));
     }
 
     /// <summary>
     /// Polls until the condition holds or the deadline passes, failing with the message the callback
-    /// produces. The message is deferred so that it can describe what the state actually was at the
-    /// moment of failure — evaluating it eagerly on every successful poll would be both wasteful and,
-    /// for a database dump, wrong.
+    /// produces. The message is deferred, and may itself query the database, so that it can describe
+    /// what the state actually was at the moment of failure — building it eagerly on every successful
+    /// poll would be both wasteful and, for a database dump, wrong.
     /// </summary>
     protected static async Task WaitForCondition(
         Func<Task<bool>> condition,
         int timeoutMs,
-        Func<string> message)
+        Func<Task<string>> message)
     {
         DateTimeOffset start = DateTimeOffset.UtcNow;
         DateTimeOffset deadline = start.AddMilliseconds(timeoutMs);
@@ -131,7 +131,7 @@ public abstract class ClusteredJobStoreTestBase
             }
             await Task.Delay(200);
         }
-        Assert.Fail($"Timed out after {(DateTimeOffset.UtcNow - start).TotalSeconds:F1} s (budget {timeoutMs} ms) waiting for condition: {message()}");
+        Assert.Fail($"Timed out after {(DateTimeOffset.UtcNow - start).TotalSeconds:F1} s (budget {timeoutMs} ms) waiting for condition: {await message()}");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
@@ -1,0 +1,284 @@
+using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Reusable base class for clustered integration tests, parameterized by the database behind them.
+/// Provides scheduler creation, job execution recording, direct SQL against the store's own tables,
+/// and polling helpers.
+/// <para>
+/// Uses the assembly-wide databases (started once by <see cref="TestcontainersDatabaseEnvironment"/>,
+/// addressed through <see cref="ClusteredTestDatabase"/>); it does not provision its own container.
+/// All derived fixtures share those databases, with <see cref="SchedulerName"/> as the only isolation
+/// axis within one of them — derived fixtures must use a unique scheduler name and be marked
+/// <c>[NonParallelizable]</c> because they also share static execution records.
+/// </para>
+/// <para>
+/// <b>There is deliberately no <c>FakeTimeProvider</c> anywhere in this project.</b> A clustered node
+/// decides that a peer has died by comparing the peer's <c>LAST_CHECKIN_TIME</c> — a wall-clock epoch
+/// stamp sitting in <c>QRTZ_SCHEDULER_STATE</c> — against its own clock, and the same is true of every
+/// other node reading the same row. The database is the clock the cluster agrees on. Handing one node
+/// a fake clock would move that node's arithmetic while the rows, the peers, the connection timeouts
+/// and the server's own timing stayed on real time, so the test would exercise a cluster that does not
+/// exist. Where a test needs the past, it moves the database instead: see
+/// <see cref="BackdateCheckin"/>, which ages a check-in row rather than sleeping past a threshold.
+/// </para>
+/// </summary>
+[NonParallelizable]
+public abstract class ClusteredJobStoreTestBase
+{
+    protected ClusteredJobStoreTestBase(string provider)
+    {
+        Database = ClusteredTestDatabase.For(provider);
+    }
+
+    /// <summary>
+    /// The database this fixture's nodes share.
+    /// </summary>
+    protected ClusteredTestDatabase Database { get; }
+
+    protected virtual string SchedulerName => "ClusteredTest";
+
+    [SetUp]
+    public void ResetRecordingJob() => RecordingJob.Reset();
+
+    [TearDown]
+    public async Task CleanUpDatabaseState()
+    {
+        // Tests shut their schedulers down in finally blocks, but a clustered node's own
+        // SCHEDULER_STATE row survives Shutdown (it is only deleted by another node's
+        // ClusterRecover), and scheduler.Clear() does not touch it either. Remove all
+        // rows for this fixture's scheduler so later tests start against a clean cluster.
+        await ExecuteNonQuery(
+            "DELETE FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_SIMPLE_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_CRON_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_SIMPROP_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_BLOB_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_JOB_DETAILS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_CALENDARS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_PAUSED_TRIGGER_GRPS WHERE SCHED_NAME = @schedulerName;" +
+            "DELETE FROM QRTZ_SCHEDULER_STATE WHERE SCHED_NAME = @schedulerName;",
+            ("schedulerName", SchedulerName));
+    }
+
+    protected async Task<IScheduler> CreateScheduler(
+        string instanceId,
+        int checkinIntervalMs = 1000,
+        int checkinMisfireThresholdMs = 2000,
+        Action<NameValueCollection> configure = null)
+    {
+        var properties = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = SchedulerName,
+            ["quartz.scheduler.instanceId"] = instanceId,
+            // Short idle wait so nodes notice remote changes (re-pins, failover resets)
+            // within seconds instead of the 30 s default acquisition cycle
+            ["quartz.scheduler.idleWaitTime"] = "2000",
+            ["quartz.threadPool.maxConcurrency"] = "2",
+            ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.LocalTransactionJobStore, Quartz",
+            ["quartz.jobStore.driverDelegateType"] = Database.DriverDelegateType,
+            ["quartz.jobStore.dataSource"] = "default",
+            ["quartz.jobStore.tablePrefix"] = "QRTZ_",
+            ["quartz.jobStore.clustered"] = "true",
+            ["quartz.jobStore.clusterCheckinInterval"] = checkinIntervalMs.ToString(CultureInfo.InvariantCulture),
+            ["quartz.jobStore.clusterCheckinMisfireThreshold"] = checkinMisfireThresholdMs.ToString(CultureInfo.InvariantCulture),
+            ["quartz.dataSource.default.provider"] = Database.Provider,
+            ["quartz.dataSource.default.connectionString"] = Database.ConnectionString,
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+        };
+
+        configure?.Invoke(properties);
+
+        // Cluster nodes share the scheduler (instance) name, and a factory's repository lookup is
+        // name-only — but each factory owns its own repository, so every call here builds a genuinely
+        // separate node rather than handing back the first one.
+        ISchedulerFactory factory = QuartzSchedulerBuilder.Create().UseProperties(properties).Build();
+        return await factory.GetScheduler();
+    }
+
+    protected static Task WaitForCondition(
+        Func<Task<bool>> condition,
+        int timeoutMs,
+        string message)
+    {
+        return WaitForCondition(condition, timeoutMs, () => message);
+    }
+
+    /// <summary>
+    /// Polls until the condition holds or the deadline passes, failing with the message the callback
+    /// produces. The message is deferred so that it can describe what the state actually was at the
+    /// moment of failure — evaluating it eagerly on every successful poll would be both wasteful and,
+    /// for a database dump, wrong.
+    /// </summary>
+    protected static async Task WaitForCondition(
+        Func<Task<bool>> condition,
+        int timeoutMs,
+        Func<string> message)
+    {
+        DateTimeOffset start = DateTimeOffset.UtcNow;
+        DateTimeOffset deadline = start.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await condition())
+            {
+                return;
+            }
+            await Task.Delay(200);
+        }
+        Assert.Fail($"Timed out after {(DateTimeOffset.UtcNow - start).TotalSeconds:F1} s (budget {timeoutMs} ms) waiting for condition: {message()}");
+    }
+
+    /// <summary>
+    /// Ages a node's cluster check-in by <paramref name="age"/>, which is how every test here reaches
+    /// the state a peer's death produces. The alternative — sleeping until the real check-in falls past
+    /// the misfire threshold — pays ten seconds of wall time for a row update, and still only asserts
+    /// that a timer expired rather than that the row said what recovery needs it to say.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful for a node that is no longer checking in: a live node overwrites the row on its
+    /// next check-in and undoes this. <c>LAST_CHECKIN_TIME</c> holds <see cref="DateTimeOffset.UtcTicks"/>,
+    /// not Unix milliseconds — see <c>StdAdoDelegate.GetDbDateTimeValue</c>, which is the schema contract.
+    /// </remarks>
+    protected async Task BackdateCheckin(string instanceId, TimeSpan age)
+    {
+        int updated = await ExecuteNonQuery(
+            "UPDATE QRTZ_SCHEDULER_STATE SET LAST_CHECKIN_TIME = LAST_CHECKIN_TIME - @age " +
+            "WHERE SCHED_NAME = @schedulerName AND INSTANCE_NAME = @instanceName",
+            ("age", age.Ticks),
+            ("schedulerName", SchedulerName),
+            ("instanceName", instanceId));
+
+        updated.Should().Be(1,
+            "backdating is what makes '{0}' look dead, so a test whose instance id never matched a "
+            + "SCHEDULER_STATE row would go on to wait for a recovery that is never triggered", instanceId);
+    }
+
+    /// <summary>
+    /// Runs a statement (or a batch of them) against the store's own tables.
+    /// </summary>
+    protected async Task<int> ExecuteNonQuery(string sql, params (string Name, object Value)[] parameters)
+    {
+        using DbConnection connection = Database.CreateConnection();
+        await connection.OpenAsync();
+        using DbCommand command = CreateCommand(connection, sql, parameters);
+        return await command.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Counts the rows a query matches, for asserting that recovery removed the residue it should have.
+    /// </summary>
+    protected async Task<int> CountRows(string sql, params (string Name, object Value)[] parameters)
+    {
+        using DbConnection connection = Database.CreateConnection();
+        await connection.OpenAsync();
+        using DbCommand command = CreateCommand(connection, sql, parameters);
+        object result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result, CultureInfo.InvariantCulture);
+    }
+
+    private static DbCommand CreateCommand(DbConnection connection, string sql, (string Name, object Value)[] parameters)
+    {
+        DbCommand command = connection.CreateCommand();
+        command.CommandText = sql;
+        foreach ((string name, object value) in parameters)
+        {
+            DbParameter parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value ?? DBNull.Value;
+            command.Parameters.Add(parameter);
+        }
+        return command;
+    }
+
+    /// <summary>
+    /// Returns a snapshot of this scheduler's trigger, scheduler-state, and fired-trigger
+    /// rows for diagnosing failed cluster assertions. The rows are formatted here rather than by the
+    /// database, so that the same query text works on every engine.
+    /// </summary>
+    protected async Task<string> DumpDatabaseState()
+    {
+        var result = new StringBuilder();
+
+        using DbConnection connection = Database.CreateConnection();
+        await connection.OpenAsync();
+
+        await AppendRows(
+            "SELECT TRIGGER_NAME, TRIGGER_STATE, PREFERRED_NODE, PREFERRED_NODE_AUTO, EXECUTION_GROUP, NEXT_FIRE_TIME "
+            + "FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+            reader => $"TRIGGER: {reader.GetString(0)} state={reader.GetString(1)} "
+                      + $"pin={Text(reader, 2)} auto={reader.GetBoolean(3)} group={Text(reader, 4)} next={Number(reader, 5)}");
+
+        await AppendRows(
+            "SELECT INSTANCE_NAME, LAST_CHECKIN_TIME, CHECKIN_INTERVAL FROM QRTZ_SCHEDULER_STATE WHERE SCHED_NAME = @schedulerName",
+            reader => $"STATE: {reader.GetString(0)} lastCheckin={reader.GetInt64(1)} interval={reader.GetInt64(2)}");
+
+        await AppendRows(
+            "SELECT TRIGGER_NAME, INSTANCE_NAME, STATE, ENTRY_ID FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+            reader => $"FIRED: {reader.GetString(0)} instance={reader.GetString(1)} state={reader.GetString(2)} entry={reader.GetString(3)}");
+
+        return result.Length > 0 ? result.ToString() : "<no rows>";
+
+        async Task AppendRows(string sql, Func<DbDataReader, string> format)
+        {
+            using DbCommand command = CreateCommand(connection, sql, [("schedulerName", SchedulerName)]);
+            using DbDataReader reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                result.AppendLine(format(reader));
+            }
+        }
+
+        static string Text(DbDataReader reader, int ordinal) => reader.IsDBNull(ordinal) ? "<null>" : reader.GetString(ordinal);
+
+        static string Number(DbDataReader reader, int ordinal) => reader.IsDBNull(ordinal) ? "<null>" : reader.GetInt64(ordinal).ToString(CultureInfo.InvariantCulture);
+    }
+
+    protected static async Task WaitForTriggerCompletion(
+        IScheduler scheduler,
+        TriggerKey triggerKey,
+        int timeoutMs)
+    {
+        await WaitForCondition(
+            async () =>
+            {
+                var state = await scheduler.GetTriggerState(triggerKey);
+                return state is TriggerState.Complete or TriggerState.None;
+            },
+            timeoutMs,
+            $"trigger {triggerKey} to complete");
+    }
+
+    protected static async Task WaitForExecutionCount(int count, int timeoutMs)
+    {
+        await WaitForCondition(
+            () => Task.FromResult(RecordingJob.Executions.Count >= count),
+            timeoutMs,
+            $"at least {count} execution(s)");
+    }
+
+    /// <summary>
+    /// Job that records which scheduler instance executed it, proving placement.
+    /// Thread-safe via <see cref="ConcurrentQueue{T}"/>.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class RecordingJob : IJob
+    {
+        private static volatile ConcurrentQueue<string> executions = new();
+
+        public static ConcurrentQueue<string> Executions => executions;
+
+        public static void Reset() => Interlocked.Exchange(ref executions, new ConcurrentQueue<string>());
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Executions.Enqueue(context.Scheduler.SchedulerInstanceId);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredPostgresTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredPostgresTestBase.cs
@@ -1,172 +1,17 @@
-using System.Collections.Concurrent;
-using System.Collections.Specialized;
-using System.Text;
-
-using Npgsql;
-
 namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 
 /// <summary>
-/// Reusable base class for PostgreSQL-backed clustered integration tests.
-/// Provides scheduler creation, job execution recording, and polling helpers.
-/// Uses the assembly-wide PostgreSQL database (started once by TestAssemblySetup,
-/// connection via <see cref="TestConstants.PostgresConnectionString"/>); it does not
-/// provision its own container. All derived fixtures share that single database, with
-/// <see cref="SchedulerName"/> as the only isolation axis — derived fixtures must use
-/// a unique scheduler name and be marked <c>[NonParallelizable]</c> because they also
-/// share the static <see cref="RecordingJob.Executions"/> queue.
+/// <see cref="ClusteredJobStoreTestBase"/> bound to the assembly-wide PostgreSQL database, for
+/// fixtures whose scenario is PostgreSQL-specific or which have no reason to pay for a second engine.
+/// A scenario worth running against more than one database instead derives from
+/// <see cref="ClusteredJobStoreTestBase"/> once and gets one sealed fixture per engine — see
+/// <see cref="ClusteredHardeningTestBase"/>.
 /// </summary>
 [Category("db-postgres")]
 [NonParallelizable]
-public abstract class ClusteredPostgresTestBase
+public abstract class ClusteredPostgresTestBase : ClusteredJobStoreTestBase
 {
-    protected virtual string SchedulerName => "ClusteredTest";
-
-    [SetUp]
-    public void ResetRecordingJob() => RecordingJob.Reset();
-
-    [TearDown]
-    public async Task CleanUpDatabaseState()
+    protected ClusteredPostgresTestBase() : base(TestConstants.PostgresProvider)
     {
-        // Tests shut their schedulers down in finally blocks, but a clustered node's own
-        // SCHEDULER_STATE row survives Shutdown (it is only deleted by another node's
-        // ClusterRecover), and scheduler.Clear() does not touch it either. Remove all
-        // rows for this fixture's scheduler so later tests start against a clean cluster.
-        using var connection = new NpgsqlConnection(TestConstants.PostgresConnectionString);
-        await connection.OpenAsync();
-        using var command = connection.CreateCommand();
-        command.CommandText =
-            "DELETE FROM qrtz_fired_triggers WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_simple_triggers WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_cron_triggers WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_simprop_triggers WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_blob_triggers WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_triggers WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_job_details WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_calendars WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_paused_trigger_grps WHERE sched_name = @schedulerName;" +
-            "DELETE FROM qrtz_scheduler_state WHERE sched_name = @schedulerName;";
-        command.Parameters.AddWithValue("schedulerName", SchedulerName);
-        await command.ExecuteNonQueryAsync();
-    }
-
-    protected async Task<IScheduler> CreateScheduler(
-        string instanceId,
-        int checkinIntervalMs = 1000,
-        int checkinMisfireThresholdMs = 2000,
-        Action<NameValueCollection> configure = null)
-    {
-        var properties = new NameValueCollection
-        {
-            ["quartz.scheduler.instanceName"] = SchedulerName,
-            ["quartz.scheduler.instanceId"] = instanceId,
-            // Short idle wait so nodes notice remote changes (re-pins, failover resets)
-            // within seconds instead of the 30 s default acquisition cycle
-            ["quartz.scheduler.idleWaitTime"] = "2000",
-            ["quartz.threadPool.maxConcurrency"] = "2",
-            ["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.LocalTransactionJobStore, Quartz",
-            ["quartz.jobStore.driverDelegateType"] = "Quartz.Impl.AdoJobStore.PostgreSQLDelegate, Quartz",
-            ["quartz.jobStore.dataSource"] = "default",
-            ["quartz.jobStore.tablePrefix"] = "QRTZ_",
-            ["quartz.jobStore.clustered"] = "true",
-            ["quartz.jobStore.clusterCheckinInterval"] = checkinIntervalMs.ToString(),
-            ["quartz.jobStore.clusterCheckinMisfireThreshold"] = checkinMisfireThresholdMs.ToString(),
-            ["quartz.dataSource.default.provider"] = TestConstants.PostgresProvider,
-            ["quartz.dataSource.default.connectionString"] = TestConstants.PostgresConnectionString,
-            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
-        };
-
-        configure?.Invoke(properties);
-
-        // Cluster nodes share the scheduler (instance) name, and a factory's repository lookup is
-        // name-only — but each factory owns its own repository, so every call here builds a genuinely
-        // separate node rather than handing back the first one.
-        ISchedulerFactory factory = QuartzSchedulerBuilder.Create().UseProperties(properties).Build();
-        return await factory.GetScheduler();
-    }
-
-    protected static async Task WaitForCondition(
-        Func<Task<bool>> condition,
-        int timeoutMs,
-        string message)
-    {
-        var deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            if (await condition())
-            {
-                return;
-            }
-            await Task.Delay(200);
-        }
-        Assert.Fail($"Timed out waiting for condition: {message}");
-    }
-
-    /// <summary>
-    /// Returns a snapshot of this scheduler's trigger, scheduler-state, and fired-trigger
-    /// rows for diagnosing failed cluster assertions.
-    /// </summary>
-    protected async Task<string> DumpDatabaseState()
-    {
-        using var connection = new NpgsqlConnection(TestConstants.PostgresConnectionString);
-        await connection.OpenAsync();
-        using var command = connection.CreateCommand();
-        command.CommandText =
-            "SELECT 'TRIGGER: ' || trigger_name || ' state=' || trigger_state || ' pin=' || COALESCE(preferred_node, '<null>') || ' auto=' || preferred_node_auto || ' group=' || COALESCE(execution_group, '<null>') || ' next=' || next_fire_time FROM qrtz_triggers WHERE sched_name = @schedulerName " +
-            "UNION ALL SELECT 'STATE: ' || instance_name || ' lastCheckin=' || last_checkin_time FROM qrtz_scheduler_state WHERE sched_name = @schedulerName " +
-            "UNION ALL SELECT 'FIRED: ' || trigger_name || ' instance=' || instance_name || ' state=' || state FROM qrtz_fired_triggers WHERE sched_name = @schedulerName";
-        command.Parameters.AddWithValue("schedulerName", SchedulerName);
-        var result = new StringBuilder();
-        using (var reader = await command.ExecuteReaderAsync())
-        {
-            while (await reader.ReadAsync())
-            {
-                result.AppendLine(reader.GetString(0));
-            }
-        }
-        return result.Length > 0 ? result.ToString() : "<no rows>";
-    }
-
-    protected static async Task WaitForTriggerCompletion(
-        IScheduler scheduler,
-        TriggerKey triggerKey,
-        int timeoutMs)
-    {
-        await WaitForCondition(
-            async () =>
-            {
-                var state = await scheduler.GetTriggerState(triggerKey);
-                return state is TriggerState.Complete or TriggerState.None;
-            },
-            timeoutMs,
-            $"trigger {triggerKey} to complete");
-    }
-
-    protected static async Task WaitForExecutionCount(int count, int timeoutMs)
-    {
-        await WaitForCondition(
-            () => Task.FromResult(RecordingJob.Executions.Count >= count),
-            timeoutMs,
-            $"at least {count} execution(s)");
-    }
-
-    /// <summary>
-    /// Job that records which scheduler instance executed it, proving placement.
-    /// Thread-safe via <see cref="ConcurrentQueue{T}"/>.
-    /// </summary>
-    [DisallowConcurrentExecution]
-    public sealed class RecordingJob : IJob
-    {
-        private static volatile ConcurrentQueue<string> executions = new();
-
-        public static ConcurrentQueue<string> Executions => executions;
-
-        public static void Reset() => Interlocked.Exchange(ref executions, new ConcurrentQueue<string>());
-
-        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
-        {
-            Executions.Enqueue(context.Scheduler.SchedulerInstanceId);
-            return default;
-        }
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredTestDatabase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredTestDatabase.cs
@@ -1,0 +1,84 @@
+using System.Data.Common;
+
+using Microsoft.Data.SqlClient;
+
+using Npgsql;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The database a clustered fixture runs against: everything <see cref="ClusteredJobStoreTestBase"/>
+/// needs in order to be written once and executed against more than one engine. Instances are
+/// stateless singletons; the containers themselves are started once per assembly by
+/// <see cref="TestcontainersDatabaseEnvironment"/> and are only addressed here by connection string.
+/// </summary>
+public abstract class ClusteredTestDatabase
+{
+    /// <summary>
+    /// The assembly-wide PostgreSQL database.
+    /// </summary>
+    public static ClusteredTestDatabase Postgres { get; } = new PostgresTestDatabase();
+
+    /// <summary>
+    /// The assembly-wide SQL Server database.
+    /// </summary>
+    public static ClusteredTestDatabase SqlServer { get; } = new SqlServerTestDatabase();
+
+    /// <summary>
+    /// Resolves the database for a <c>quartz.dataSource.default.provider</c> value, which is what an
+    /// NUnit <c>[TestFixture]</c> argument can carry — attribute arguments have to be constants, and
+    /// the provider names already are.
+    /// </summary>
+    public static ClusteredTestDatabase For(string provider) => provider switch
+    {
+        TestConstants.PostgresProvider => Postgres,
+        TestConstants.DefaultSqlServerProvider => SqlServer,
+        _ => throw new ArgumentOutOfRangeException(nameof(provider), provider, "no clustered test database for this provider")
+    };
+
+    /// <summary>
+    /// The ADO.NET provider name, as <c>quartz.dataSource.default.provider</c> spells it.
+    /// </summary>
+    public abstract string Provider { get; }
+
+    /// <summary>
+    /// The connection string of the container this assembly started.
+    /// </summary>
+    public abstract string ConnectionString { get; }
+
+    /// <summary>
+    /// The <c>quartz.jobStore.driverDelegateType</c> for this engine.
+    /// </summary>
+    public abstract string DriverDelegateType { get; }
+
+    /// <summary>
+    /// Opens a connection of this engine's own type, for the fixtures' direct SQL. Test SQL is written
+    /// in unquoted upper case, which SQL Server matches case-insensitively and PostgreSQL folds to the
+    /// lower-case identifiers its scripts create, so the statements themselves stay dialect-neutral.
+    /// </summary>
+    public abstract DbConnection CreateConnection();
+
+    public override string ToString() => Provider;
+
+    private sealed class PostgresTestDatabase : ClusteredTestDatabase
+    {
+        public override string Provider => TestConstants.PostgresProvider;
+
+        public override string ConnectionString => TestConstants.PostgresConnectionString;
+
+        public override string DriverDelegateType => "Quartz.Impl.AdoJobStore.PostgreSQLDelegate, Quartz";
+
+        public override DbConnection CreateConnection() => new NpgsqlConnection(ConnectionString);
+    }
+
+    private sealed class SqlServerTestDatabase : ClusteredTestDatabase
+    {
+        public override string Provider => TestConstants.DefaultSqlServerProvider;
+
+        public override string ConnectionString => TestConstants.SqlServerConnectionString;
+
+        public override string DriverDelegateType => "Quartz.Impl.AdoJobStore.SqlServerDelegate, Quartz";
+
+        public override DbConnection CreateConnection() => new SqlConnection(ConnectionString);
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/PreferredNodeClusteredPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/PreferredNodeClusteredPostgresTest.cs
@@ -148,8 +148,9 @@ public sealed class PreferredNodeClusteredPostgresTest : ClusteredPostgresTestBa
         // Reset recordings so any nodeA executions don't satisfy nodeB's assertions
         RecordingJob.Reset();
 
-        // Wait for nodeA's checkin to become stale
-        await Task.Delay(10_000);
+        // nodeA is gone but its SCHEDULER_STATE row lingers with a fresh timestamp. Age the row
+        // rather than sleeping past the threshold: the survivor reads that column, not a stopwatch.
+        await BackdateCheckin("nodeA", TimeSpan.FromMinutes(5));
 
         IScheduler nodeB = await CreateScheduler("nodeB");
         try

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/PreferredNodeFailoverPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/PreferredNodeFailoverPostgresTest.cs
@@ -47,8 +47,9 @@ public sealed class PreferredNodeFailoverPostgresTest : ClusteredPostgresTestBas
             throw;
         }
 
-        // Wait for nodeA's checkin to become stale
-        await Task.Delay(10_000);
+        // nodeA is gone but its SCHEDULER_STATE row lingers with a fresh timestamp. Age the row
+        // rather than sleeping past the threshold: the survivor reads that column, not a stopwatch.
+        await BackdateCheckin("nodeA", TimeSpan.FromMinutes(5));
 
         IScheduler nodeB = await CreateScheduler("nodeB");
         try
@@ -124,8 +125,9 @@ public sealed class PreferredNodeFailoverPostgresTest : ClusteredPostgresTestBas
         // Reset recordings so nodeA's earlier executions don't satisfy nodeB's assertions
         RecordingJob.Reset();
 
-        // Wait for nodeA's checkin to become stale
-        await Task.Delay(10_000);
+        // nodeA is gone but its SCHEDULER_STATE row lingers with a fresh timestamp. Age the row
+        // rather than sleeping past the threshold: the survivor reads that column, not a stopwatch.
+        await BackdateCheckin("nodeA", TimeSpan.FromMinutes(5));
 
         IScheduler nodeB = await CreateScheduler("nodeB");
         try


### PR DESCRIPTION
Test-only. PR-7 of the funded test workstream.

Closes #3339

## What changed

**`ClusteredPostgresTestBase` is now a shim over a provider-parameterized base.** The reusable half
moved to `ClusteredJobStoreTestBase`, which takes its engine as a `ClusteredTestDatabase` (connection,
provider name, driver delegate). `ClusteredPostgresTestBase` binds it to PostgreSQL and nothing else,
so `ExecutingTriggerStateClusteredPostgresTest`, `PreferredNodeClusteredPostgresTest` and
`PreferredNodeFailoverPostgresTest` are untouched — the whole diff on that file is deletion.

The direct SQL that came with it is dialect-neutral now: unquoted upper-case identifiers, which SQL
Server matches case-insensitively and PostgreSQL folds to the lower case its scripts create. The state
dump is formatted in C# rather than by the database, because `||` versus `+` is one of the few things
these two engines genuinely spell differently.

**A killed node, synthesized.** A scheduler shut down politely releases what it holds, so the state a
`kill -9` leaves cannot be reached by stopping one — it is written directly. A `SCHEDULER_STATE` row
for an instance that never existed, aged past the failure threshold, plus the `FIRED_TRIGGERS` row it
would have left behind:

- **ACQUIRED**, with null job columns and false flags, because that is exactly what
  `StdAdoDelegate.InsertFiredTrigger` writes before the job has been loaded. Nothing ever acquires an
  ACQUIRED trigger a second time, so unless the survivor releases it the trigger is lost for good.
- **EXECUTING with `REQUESTS_RECOVERY`**, with the job's own trigger parked an hour out so the
  replacement trigger `ClusterRecover` builds is the only thing that can run it. The assertion checks
  the firing came through `RECOVERING_JOBS` and carries `QRTZ_FAILED_JOB_ORIG_TRIGGER_NAME`.

Both then let three check-in intervals pass before asserting there was exactly one firing, and assert
the residue is gone — a fired-trigger row that survives recovery makes the corpse look busy to
`QueryFireInstances` and gets re-recovered on every subsequent check-in, so "once" is a claim that has
to be waited for rather than read off the first firing.

**Two-node no-double-fire.** Thirty one-shot triggers due at the same instant, two nodes acquiring in
batches of ten so they reach for overlapping sets of rows rather than taking turns. The assertion is
exactly-once by trigger name, which catches a double fire and a dropped acquisition with the same
statement. The wait for it is a deadline that names the triggers that never fired; the three-second
tail after the thirtieth firing is there because absence cannot be polled for, only waited out.

**No more `Task.Delay(10_000)` staleness waits.** All three are `BackdateCheckin(instanceId, age)`
now. A survivor decides a peer is dead by reading `LAST_CHECKIN_TIME`, so moving that column is the
thing under test; sleeping only asserts that a timer expired. The helper fails loudly when it matches
no row, so a mistyped instance id cannot quietly turn the test back into a wait for a recovery that
never comes. `ExplicitPin_PreservedThroughFailover` and `AutoPin_RepinnedThroughFailover` went from
about 15 s to 5 s each.

**The no-`FakeTimeProvider` rationale is recorded on the base class.** The cluster's clock is the
database, agreed on by every node reading the same row. A fake clock would move one node's arithmetic
while the rows, its peers, the connection timeouts and the server's own timing stayed on real time.

## For a reviewer to decide

**The SQL Server leg is a sibling fixture, not a `ClusteredSqlServerTestBase`.** The issue asks for a
SQL Server subclass; what landed is `ClusteredHardeningTestBase` holding the shared scenarios with
`ClusteredHardeningPostgresTest` and `ClusteredHardeningSqlServerTest` under it. A
`ClusteredSqlServerTestBase` mirroring the PostgreSQL shim would have had exactly one user and could
not have been that user's base, since the shared scenarios already occupy the base slot. Say the word
and I will add it, but it would be dead code today.

**`UpdateRowSemaphore` is not what a clustered SQL Server store picks for itself** — the issue's
parenthetical is one release out of date. `AdoJobStoreBase` defaults SQL Server to
`SelectForUpdateSemaphore` with the `(UPDLOCK,ROWLOCK)` hint. So the SQL Server fixture covers that
default in the three shared scenarios, and adds a fourth test that configures `UpdateRowSemaphore`
explicitly, which nothing else in the suite runs against a real database — the unit tests only prove
it retries in front of a fake provider.

That fourth test is SQL Server only, deliberately. When two nodes first contend for a lock name the
row does not exist yet, so both fall through to the `INSERT` and one takes a primary key violation.
SQL Server leaves the transaction usable and the handler's retry takes the lock; PostgreSQL marks the
whole transaction aborted, so the retry would fail too. That is why PostgreSQL has its own semaphore,
and running the test there would be testing a combination nobody should use.

## Verification

`dotnet build Quartz.slnx` clean, 0 warnings. `Quartz.Tests.Unit` 2922 passed, three times (no public
API baseline moved, as expected for a test-only change; no docs and no database scripts are touched
either). No other test project is affected.

Clustered legs, against real containers on Docker:

| leg | runs | result |
|---|---|---|
| `db-postgres` clustered fixtures — 3 new + the 10 existing | 3 | 13/13 each time |
| `db-sqlserver` `ClusteredHardeningSqlServerTest` | 3 | 4/4 each time |
| the racy `TwoNodes_*` tests on their own | 4 more per engine | green every time |
| full `TestCategory=db-postgres` | 1 | 64/64 |
| full `TestCategory=db-sqlserver` | 1 | 58/58 |

No flakes. The per-node split is printed on every run and was genuinely mixed each time (11/19,
17/13, 18/12, 19/11), so both nodes really do contend rather than one node quietly doing all the work.

## Left alone on purpose

`ThreeNode_AutoPinnedTrigger_SettlesOnSingleSurvivorAfterFailover` and
`Failover_ExecutionGroupSaturatedSurvivor_DoesNotClaimTrigger` still wait out real staleness inside a
30 s bounded poll. Neither contains a `Task.Delay(10_000)`, so neither is in this issue's scope, and
both would benefit from the same `BackdateCheckin` treatment in a follow-up — it can only make
detection arrive sooner.
