### PR TITLE
The trim leg proves something: Quartz compiles with the analyzer on, against a baseline

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -34,7 +34,7 @@
         "Pack",
         "PackZip",
         "Publish",
-        "PublishAot",
+        "PublishTrimmed",
         "Restore",
         "UnitTest",
         "VerifyDocsSnippets",

--- a/.github/workflows/pr-tests-unit.yml
+++ b/.github/workflows/pr-tests-unit.yml
@@ -48,8 +48,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishAot'
-        run: dotnet fallout VerifyMigrations Compile UnitTest PublishAot
+      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishTrimmed'
+        run: dotnet fallout VerifyMigrations Compile UnitTest PublishTrimmed
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
@@ -62,8 +62,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishAot'
-        run: dotnet fallout VerifyMigrations Compile UnitTest PublishAot
+      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishTrimmed'
+        run: dotnet fallout VerifyMigrations Compile UnitTest PublishTrimmed
   macos-latest:
     name: macos-latest
     runs-on: macos-latest
@@ -76,5 +76,5 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishAot'
-        run: dotnet fallout VerifyMigrations Compile UnitTest PublishAot
+      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishTrimmed'
+        run: dotnet fallout VerifyMigrations Compile UnitTest PublishTrimmed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,11 @@ plus a bridge entry on main.
 - **Explicit types over `var`** — prefer explicit types everywhere (`csharp_style_var_for_built_in_types = false`).
 - **Nullable enabled** globally; test projects may disable it.
 - **Warnings as errors** — `TreatWarningsAsErrors` is true; code style is enforced in build.
+- **`Quartz` builds with the trim analyzer on**, so an `IL2xxx` is an error. The known-reflective types are
+  recorded in `src/Quartz/TrimAnalysisBaseline.cs` (and mirrored for ILLink in `src/Quartz/ILLink.Suppressions.xml`,
+  which the worker example's trimmed publish applies). A warning in a type not listed there means new
+  reflection — fix it rather than adding a line; that file explains the order to try fixes in. Neither file
+  ships, so consumers still see every warning. Tracked on #3341.
 - **Allman brace style** — braces on new lines for methods, types, control blocks, properties, accessors, lambdas.
 - **No `DateTime.Now`/`DateTimeOffset.Now`** — banned via Roslyn analyzer (`BannedSymbols.txt`). Use `TimeProvider` instead.
 - **No implicit `DateTime` → `DateTimeOffset` cast** — also banned.

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -16,7 +16,7 @@ using Quartz.Build;
     OnPullRequestIncludePaths = ["**/*"],
     OnPullRequestExcludePaths = ["docs/**/*", "package.json", "package-lock.json", "readme.md"],
     PublishArtifacts = false,
-    InvokedTargets = [nameof(VerifyMigrations), nameof(ICompile.Compile), nameof(UnitTest), nameof(PublishAot)],
+    InvokedTargets = [nameof(VerifyMigrations), nameof(ICompile.Compile), nameof(UnitTest), nameof(PublishTrimmed)],
     CacheKeyFiles = [],
     TimeoutMinutes = 10,
     ConcurrencyCancelInProgress = true,

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -126,11 +126,21 @@ partial class Build : FalloutBuild, ICompile, IPack
         .SetVersionPrefix(VersionPrefix)
         .SetVersionSuffix(VersionSuffix);
 
-    Target PublishAot => _ => _
+    /// <summary>
+    /// Publishes the example applications, one of which is the repository's trim canary.
+    /// </summary>
+    /// <remarks>
+    /// Named <c>PublishAot</c> until issue #3341: nothing here has ever published native AOT, and
+    /// leaving the misnomer in place would have collided with the real thing when it arrives.
+    /// <c>Quartz.Examples.Worker</c> publishes fully trimmed over Quartz and nothing else, so an IL2xxx
+    /// warning it reports is Quartz's own and fails this leg. <c>Quartz.Examples.AspNetCore</c> is a
+    /// plain publish, because Razor Pages, MVC and Blazor Server are not trimmable and never will be —
+    /// its csproj says so at length.
+    /// </remarks>
+    Target PublishTrimmed => _ => _
         .After<ICompile>()
         .Executes(() =>
         {
-            // also check that publish with trimming doesn't produce errors
             var solution = ((IHasSolution) this).Solution;
             var configuration = ((ICompile) this).Configuration;
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3130,6 +3130,20 @@ needs the same annotation:
       => q.ScheduleJob<TJob>(t => t.StartNow());
 ```
 
+`Quartz` is also marked `IsTrimmable` now, which changes what a trimmed publish tells you about it. On
+3.x the assembly is not marked, so ILLink collapses everything it finds in Quartz into one
+`IL2104: Assembly 'Quartz' produced trim warnings`. On 4.0 you get the individual warnings instead —
+around fifty of them, at the reflective call sites listed in `src/Quartz/TrimAnalysisBaseline.cs`.
+
+That is not a regression: the same reflection was there before and the same code could break under
+trimming; you can now see which parts. Quartz is **not** trim-safe yet, and none of those warnings is
+suppressed in the shipped assembly, deliberately — suppressing them would hide a real risk from you.
+Configuration by flat `quartz.*` keys, jobs named as strings (`job_scheduling_data` XML, a persisted
+`JOB_CLASS_NAME`), and `JobDataMap` values bound onto job properties are the paths that need reflection;
+an application that configures in code, references its job types statically and keeps job data to
+primitives exercises far less of it. Progress is tracked on
+[#3341](https://github.com/quartznet/quartznet/issues/3341).
+
 ## Executing is a trigger state
 
 There was no way to ask whether a trigger's job is running right now. 3.x's

--- a/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
+++ b/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
@@ -7,15 +7,27 @@
     <NoWarn>$(NoWarn);MA0004</NoWarn>
     <!-- https://github.com/dotnet/aspnetcore/issues/50836 -->
     <NoWarn>$(NoWarn);AD0001</NoWarn>
-
-    <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>full</TrimMode>
-    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
-    <!-- we want to publish despite the warnings to see if app runs -->
-    <NoWarn>$(NoWarn);IL2080;IL2065;IL2075;IL2087;IL2057;IL2060;IL2070;IL2067;IL2072;IL2026;IL2104</NoWarn>
-    <!-- Blazor Server component libraries trigger these when parameters with DynamicallyAccessedMembers are set via reflection -->
-    <NoWarn>$(NoWarn);IL2110;IL2111</NoWarn>
   </PropertyGroup>
+
+  <!--
+    This example is deliberately not published trimmed, and putting it back needs an argument.
+
+    It used to be, under a NoWarn that silenced the whole IL2xxx family. Unsuppressing that (issue
+    #3341, step 1) produced 217 warnings, of which 106 belong to assemblies Quartz cannot fix and never
+    will: Razor Pages says so itself ("Razor Pages does not currently support trimming or native AOT"),
+    and MVC model binding, Blazor Server's route table, NSwag/NJsonSchema/Newtonsoft.Json, YamlDotNet,
+    Microsoft.Data.SqlClient and System.Configuration.ConfigurationManager are all reflection-driven by
+    design. Trimming this application measured the framework, not Quartz, and every ASP.NET Core patch
+    bump would have churned whatever baseline recorded it.
+
+    The trim gate lives where it says something instead: Quartz.Examples.Worker publishes fully trimmed
+    over Quartz alone and must stay warning-free, and Quartz itself compiles with EnableTrimAnalyzer.
+    Quartz.AspNetCore (214 analyzer warnings) and Quartz.Dashboard (26) are still unanalysed; that is
+    tracked on issue #3341 rather than hidden here.
+
+    Publishing it at all is still worth doing, because publish is where a Blazor asset or an
+    NSwag document generator breaks in ways a build never notices.
+  -->
 
   <ItemGroup>
     <ProjectReference Include="..\Quartz.AspNetCore\Quartz.AspNetCore.csproj" />

--- a/src/Quartz.Examples.Worker/Quartz.Examples.Worker.csproj
+++ b/src/Quartz.Examples.Worker/Quartz.Examples.Worker.csproj
@@ -7,8 +7,6 @@
     <NoWarn>$(NoWarn);MA0004</NoWarn>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>full</TrimMode>
-    <!-- we want to publish despite the warnings to see if app runs -->
-    <NoWarn>$(NoWarn);IL2080;IL2065;IL2075;IL2087;IL2057;IL2060;IL2070;IL2067;IL2072;IL2026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +17,21 @@
 
   <ItemGroup>
     <TrimmerRootAssembly Include="Quartz" />
+  </ItemGroup>
+
+  <!--
+    This is the repository's trim canary: a fully trimmed application over Quartz and nothing else, so
+    every IL2xxx it reports is Quartz's own. It used to NoWarn the whole IL2xxx family, which meant the
+    leg proved the examples publish rather than that Quartz survives trimming (issue #3341, step 1).
+
+    Nothing is suppressed by warning code any more. What is suppressed is the recorded set of types in
+    ILLink.Suppressions.xml, which fails the publish the moment a type outside it starts warning; that
+    file explains why it exists separately from the compile-time baseline beside it. The item is the
+    SDK's own hook for an ILLink link-attributes file (Microsoft.NET.ILLink.targets); if a future SDK
+    renames it the suppressions stop applying and this publish fails loudly rather than quietly.
+  -->
+  <ItemGroup>
+    <_ILLinkSuppressions Include="..\Quartz\ILLink.Suppressions.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz/ILLink.Suppressions.xml
+++ b/src/Quartz/ILLink.Suppressions.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  The ILLink half of the trim baseline recorded in issue #3341. It lists exactly the same types as
+  TrimAnalysisBaseline.cs beside it, for exactly the same reasons — read that file first; the reasoning
+  lives there and is not repeated here.
+
+  Two files are needed because the two tools cannot be told the same way. SuppressMessageAttribute is
+  [Conditional("CODE_ANALYSIS")], so the C# baseline never reaches metadata and ILLink cannot see it;
+  ILLink is told through its link-attributes option instead. The unconditional attribute would cover
+  both, but it would be baked into the shipped assembly and silence these warnings for every consumer
+  publishing a trimmed application. That would be a lie: the reflection below can break under trimming, and
+  a consumer deserves to be told. So this file is applied only by our own example publish, which is what
+  makes the CI trim leg green without making anyone else's build quieter than it should be.
+
+  fullname carries a trailing '*' throughout, because ILLink reports against compiler-generated closure
+  and state-machine types (Type/<>c__DisplayClass4_0, Type/<AsyncMethod>d__7) whose names change the
+  moment a lambda is added to or removed from the file. Matching the type and its nested companions in
+  one entry keeps the baseline stable under ordinary edits; naming them individually would not survive a
+  refactoring.
+
+  When ILLink reports a warning against a type that is not listed here, that is the baseline working.
+  Fix the reflection, or make the case for a new entry — see TrimAnalysisBaseline.cs for the order to
+  try the fixes in.
+
+  One local-only wrinkle: the link step is incremental on the assemblies it consumes and does not track
+  this file, so editing it alone may not re-link. Delete the example's linked output, or touch a source
+  file, to see the effect. CI always builds from clean and is unaffected.
+-->
+<linker>
+  <assembly fullname="Quartz">
+
+    <!-- Types named by string -->
+    <type fullname="Quartz.Impl.SimpleTypeLoader*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2057</argument>
+        <property name="Justification">The default ITypeLoader exists to resolve a configured type name; that is its contract.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.JobType*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2057</argument>
+        <property name="Justification">A name-constructed JobType resolves through Type.GetType when the caller supplied no resolver.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Impl.AdoJobStore.StdAdoDelegate*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2057</argument>
+        <property name="Justification">A persisted job's type is the JOB_CLASS_NAME column, which is a string by the time it is read back.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2072</argument>
+        <property name="Justification">A persisted job's type reaches JobBuilder.OfType as a Type resolved from JOB_CLASS_NAME.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Impl.AdoJobStore.Common.BuiltInDbMetadataFactory*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2057</argument>
+        <property name="Justification">An ADO.NET provider's connection type is named by the driver description, so the provider assembly need not be referenced.</property>
+      </attribute>
+    </type>
+
+    <!-- Types constructed at runtime -->
+    <type fullname="Quartz.Configuration.QuartzPropertyBridge*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2067</argument>
+        <property name="Justification">Translating legacy quartz.* keys means constructing the component each key names.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2072</argument>
+        <property name="Justification">Translating legacy quartz.* keys means constructing the component each key names.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Configuration.SchedulerPluginFactory*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2067</argument>
+        <property name="Justification">A plugin registered by type is constructed through the container from that Type.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Configuration.PropertyListenerFactory*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2072</argument>
+        <property name="Justification">A listener registered by quartz.*.listener.* keys is constructed from the type the key names.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2075</argument>
+        <property name="Justification">A listener's Name is set through the property of that name, on a type known only at runtime.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Impl.JobActivatorCache*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2067</argument>
+        <property name="Justification">A job type reaches the activator as a Type; that is the whole point of the cache.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Configuration.JsonSchedulingHelper*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2057</argument>
+        <property name="Justification">The type loader named by quartz.scheduler.typeLoaderType is resolved from that name.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2072</argument>
+        <property name="Justification">Jobs declared in configuration name their type as a string.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Xml.XmlSchedulingDataProcessor*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2072</argument>
+        <property name="Justification">Jobs declared in job_scheduling_data XML name their type as a string.</property>
+      </attribute>
+    </type>
+
+    <!-- Properties bound by name -->
+    <type fullname="Quartz.Util.ObjectUtils*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">TypeDescriptor.GetConverter is how a configuration string becomes a property's value.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2057</argument>
+        <property name="Justification">A property typed as Type takes its value from a type name in configuration.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2067</argument>
+        <property name="Justification">The conversion target arrives as a Type read off the property being set.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2070</argument>
+        <property name="Justification">The conversion target arrives as a Type read off the property being set.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2072</argument>
+        <property name="Justification">The conversion target arrives as a Type read off the property being set.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2075</argument>
+        <property name="Justification">Setting a property named by a configuration key means looking it up on the target's runtime type.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2080</argument>
+        <property name="Justification">Setting a property named by a configuration key means looking it up on the target's runtime type.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Impl.PropertySettingJobFactory*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2075</argument>
+        <property name="Justification">Pushing a JobDataMap onto a job means finding properties by the map's keys.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Util.JobDataExpression*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2070</argument>
+        <property name="Justification">The check that the job factory will find the property is itself a property lookup by name.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Impl.AdoJobStore.Common.DbProvider*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2075</argument>
+        <property name="Justification">A provider's connection string and command properties are named by its DbMetadata, not referenced.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Impl.AdoJobStore.Common.DbMetadata*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2075</argument>
+        <property name="Justification">A provider's connection string and command properties are named by its DbMetadata, not referenced.</property>
+      </attribute>
+    </type>
+
+    <!-- Duck-typed exception inspection -->
+    <type fullname="Quartz.Impl.AdoJobStore.TransientErrorDetector*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2070</argument>
+        <property name="Justification">Retry classification reads provider error codes off exception types Quartz deliberately does not reference.</property>
+      </attribute>
+    </type>
+
+    <!-- Reflection-based serialization; issue #3341, step 4 -->
+    <type fullname="Quartz.Impl.SystemTextJsonObjectSerializer*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">Job data is serialized as whatever the application stored; issue #3341, step 4.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">Job data is serialized as whatever the application stored; issue #3341, step 4.</property>
+      </attribute>
+    </type>
+
+    <!-- Configuration binding -->
+    <type fullname="Quartz.Configuration.QuartzTypedOptions*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">Binding the quartz configuration section reflects over the options types; the source-generated binder is the fix.</property>
+      </attribute>
+    </type>
+
+  </assembly>
+</linker>

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -5,9 +5,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>quick-start.md</PackageReadmeFile>
-    <!--
+    <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz/TrimAnalysisBaseline.cs
+++ b/src/Quartz/TrimAnalysisBaseline.cs
@@ -1,0 +1,113 @@
+#region License
+
+/*
+ * Copyright 2009- Marko Lahma
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+
+// The recorded set of trim-analysis warnings Quartz produced when EnableTrimAnalyzer was first turned
+// on (https://github.com/quartznet/quartznet/issues/3341). It is a baseline, not an all-clear: none of
+// these call sites is trim-safe, and every one of them is work still to do. What the baseline buys is
+// that a *new* one fails the build, because TreatWarningsAsErrors makes IL2xxx an error and nothing
+// suppresses a warning that is not listed here.
+//
+// Adding an entry is the wrong first move. Reach for it only after establishing that the reflection is
+// genuinely unavoidable, and then say in the group comment why. The preferred fixes, in order:
+//
+//   1. Resolve the type statically — a generic parameter or a typed option instead of a type name.
+//   2. Annotate with [DynamicallyAccessedMembers], so the requirement travels to the caller that does
+//      know the type. Check where it propagates to first, and whether it can travel at all: on the fire
+//      path it cannot, because JobType.Type erases the annotation — a job named by a string has no
+//      annotatable type. That is why ObjectUtils is left alone here (issue #3341, step 3).
+//   3. Mark the API [RequiresUnreferencedCode], for opt-in surface a trimmed app can avoid entirely.
+//
+// Scope is deliberately the type rather than the member. ILLink reports these against compiler-
+// generated closure types whose names change whenever a lambda is added to or removed from the file, so
+// the companion ILLink.Suppressions.xml has to key on types; keying this file the same way keeps the two
+// readable side by side. The cost is that a second reflective call in an already-listed type does not
+// fail the build. Every type listed here is reflective by construction, so that is the right trade —
+// which is also why a *new* type appearing in this list deserves an argument, not a line.
+//
+// SuppressMessageAttribute is [Conditional("CODE_ANALYSIS")] and never reaches metadata, so this file
+// silences the analyzer during Quartz's own compile and nothing else. Consumers publishing a trimmed
+// application still see every warning below, which is honest: their app really is affected. The
+// unconditional form would hide it from them too, and that would be a lie until step 3 lands.
+
+// --- Types named by string --------------------------------------------------------------------------
+// Configuration and persistence both store types as text: the flat quartz.* keys, the JOB_CLASS_NAME
+// column, job_scheduling_data XML, and JobType's name-constructed form. A type resolved from a string
+// cannot be proven reachable, so the trimmer cannot keep it.
+
+[assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.Impl.SimpleTypeLoader", Justification = "The default ITypeLoader exists to resolve a configured type name; that is its contract.")]
+[assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.JobType", Justification = "A name-constructed JobType resolves through Type.GetType when the caller supplied no resolver.")]
+[assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.StdAdoDelegate", Justification = "A persisted job's type is the JOB_CLASS_NAME column, which is a string by the time it is read back.")]
+[assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.Common.BuiltInDbMetadataFactory", Justification = "An ADO.NET provider's connection type is named by the driver description, so the provider assembly need not be referenced.")]
+
+// --- Types constructed at runtime -------------------------------------------------------------------
+// Once a type arrives as a Type rather than a generic argument, Activator/ActivatorUtilities cannot
+// promise its constructor survives, and JobBuilder.OfType wants its members annotated.
+
+[assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Configuration.QuartzPropertyBridge", Justification = "Translating legacy quartz.* keys means constructing the component each key names.")]
+[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Configuration.QuartzPropertyBridge", Justification = "Translating legacy quartz.* keys means constructing the component each key names.")]
+[assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Configuration.SchedulerPluginFactory", Justification = "A plugin registered by type is constructed through the container from that Type.")]
+[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Configuration.PropertyListenerFactory", Justification = "A listener registered by quartz.*.listener.* keys is constructed from the type the key names.")]
+[assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Impl.JobActivatorCache", Justification = "A job type reaches the activator as a Type; that is the whole point of the cache.")]
+[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Configuration.JsonSchedulingHelper", Justification = "Jobs declared in configuration name their type as a string.")]
+[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Xml.XmlSchedulingDataProcessor", Justification = "Jobs declared in job_scheduling_data XML name their type as a string.")]
+[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.StdAdoDelegate", Justification = "A persisted job's type reaches JobBuilder.OfType as a Type resolved from JOB_CLASS_NAME.")]
+
+// --- Properties bound by name -----------------------------------------------------------------------
+// The flat quartz.* keys and JobDataMap both set properties on a target the compiler cannot see the
+// type of. ObjectUtils is the shared implementation and the structural blocker for the whole track:
+// annotating it would reach IJobDetail and out into every consumer's code, so it stays as it is until
+// issue #3341, step 3 redesigns it.
+
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "TypeDescriptor.GetConverter is how a configuration string becomes a property's value.")]
+[assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "A property typed as Type takes its value from a type name in configuration.")]
+[assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "The conversion target arrives as a Type read off the property being set.")]
+[assembly: SuppressMessage("Trimming", "IL2070", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "The conversion target arrives as a Type read off the property being set.")]
+[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "The conversion target arrives as a Type read off the property being set.")]
+[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "Setting a property named by a configuration key means looking it up on the target's runtime type.")]
+[assembly: SuppressMessage("Trimming", "IL2080", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "Setting a property named by a configuration key means looking it up on the target's runtime type.")]
+[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Impl.PropertySettingJobFactory", Justification = "Pushing a JobDataMap onto a job means finding properties by the map's keys.")]
+[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Configuration.PropertyListenerFactory", Justification = "A listener's Name is set through the property of that name, on a type known only at runtime.")]
+[assembly: SuppressMessage("Trimming", "IL2070", Scope = "type", Target = "T:Quartz.Util.JobDataExpression", Justification = "The check that the job factory will find the property is itself a property lookup by name.")]
+[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.Common.DbProvider", Justification = "A provider's connection string and command properties are named by its DbMetadata, not referenced.")]
+[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.Common.DbMetadata.DerivedMetadata", Justification = "A provider's connection string and command properties are named by its DbMetadata, not referenced.")]
+
+// --- Duck-typed exception inspection ------------------------------------------------------------------
+// Whether a database error is worth retrying lives in provider-specific properties (SqlException.Number,
+// SqliteException.SqliteErrorCode). Quartz must not reference the provider assemblies to read them.
+
+[assembly: SuppressMessage("Trimming", "IL2070", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.TransientErrorDetector", Justification = "Retry classification reads provider error codes off exception types Quartz deliberately does not reference.")]
+
+// --- Reflection-based serialization ---------------------------------------------------------------------
+// A JobDataMap holds whatever the application put in it, so the payload's types are not known until it
+// is serialized. Issue #3341, step 4 replaces the closed set of wire DTOs with a source-generated
+// JsonSerializerContext; the open part of the registry stays reflective on purpose.
+
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Impl.SystemTextJsonObjectSerializer", Justification = "Job data is serialized as whatever the application stored; issue #3341, step 4.")]
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions", Justification = "Job data is serialized as whatever the application stored; issue #3341, step 4.")]
+
+// --- Configuration binding ------------------------------------------------------------------------------
+// IServiceCollection.Configure<TOptions>(name, section) is RequiresUnreferencedCode: the binder reflects
+// over TOptions. The options types are ours and closed, so the source-generated binder is the fix; that
+// is a separate change from this baseline.
+
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Configuration.QuartzTypedOptions", Justification = "Binding the quartz configuration section reflects over the options types; the source-generated binder is the fix.")]


### PR DESCRIPTION
Steps 1 and 2 of #3341. Step 3 is out of scope by instruction; what I learned about `ObjectUtils` while doing these two is posted as [a comment on the issue](https://github.com/quartznet/quartznet/issues/3341#issuecomment-5384661567) so that step starts from evidence rather than from the summary above it. The short version: the annotation cannot reach `IJobDetail` and leak outward, because `JobType.Type` erases it first — which makes step 3 a different job from the one the issue describes.

## What the leg was proving before

`PublishAot` publishes `Quartz.Examples.Worker` and `Quartz.Examples.AspNetCore` with `PublishTrimmed`/`TrimMode=full`. Both csproj files carried

```xml
<!-- we want to publish despite the warnings to see if app runs -->
<NoWarn>$(NoWarn);IL2080;IL2065;IL2075;IL2087;IL2057;IL2060;IL2070;IL2067;IL2072;IL2026[;IL2104]</NoWarn>
```

which is all but the whole IL2xxx family (three of the codes listed, IL2065, IL2060 and IL2087, no longer fire at all). The leg asserted "these two apps publish", and `0 Warning(s)` meant nothing. The name was wrong too — nothing here has ever published native AOT.

## Step 1 — the inventory

Unsuppressed, in Release, on SDK 10.0.400.

**`Quartz.Examples.Worker`** — 50 unique warnings, every one of them Quartz's own (it references Quartz and nothing else):

| code | count | what it means here |
|---|---:|---|
| IL2072 | 13 | a runtime `Type` passed to a parameter annotated `DynamicallyAccessedMembers` |
| IL2026 | 12 | calling a `RequiresUnreferencedCode` member |
| IL2057 | 7 | `Type.GetType(string)` on an unrecognised value |
| IL2070 | 7 | reflecting on an unannotated `Type` parameter |
| IL2075 | 5 | reflecting on the return of `object.GetType()` |
| IL2067 | 4 | a runtime `Type` passed to an annotated parameter, from a parameter |
| IL2080 | 2 | reflecting on an unannotated field |

By root cause — this is the useful axis, because the codes cut across it:

| root cause | sites | types |
|---|---:|---|
| a type named by a configuration string, a database column or XML, resolved with `Type.GetType` | 7 | `SimpleTypeLoader`, `JobType`, `StdAdoDelegate`, `BuiltInDbMetadataFactory`, `ObjectUtils`, `JsonSchedulingHelper` |
| that type then constructed — `Activator.CreateInstance` / `ActivatorUtilities.CreateInstance` — or handed to `JobBuilder.OfType` | 17 | `QuartzPropertyBridge` (8), `SchedulerPluginFactory`, `PropertyListenerFactory`, `JobActivatorCache`, `JsonSchedulingHelper`, `XmlSchedulingDataProcessor`, `StdAdoDelegate`, `ObjectUtils` |
| a property found by name on a target whose type is not statically known | 10 | `ObjectUtils` (6), `PropertySettingJobFactory`, `PropertyListenerFactory`, `JobDataExpression`, `DbProvider`, `DbMetadata.DerivedMetadata` |
| duck-typed exception sniffing for retry classification | 4 | `TransientErrorDetector` |
| reflection-based `System.Text.Json` over job data | 4 | `SystemTextJsonObjectSerializer`, `Utf8JsonWriterExtensions` |
| `IConfiguration` binding (`Configure<TOptions>` is `RequiresUnreferencedCode`) | 6 | `QuartzTypedOptions` |
| `TypeDescriptor.GetConverter` | 2 | `ObjectUtils` |

Concentration: `ObjectUtils` 11, `QuartzPropertyBridge` 8, `QuartzTypedOptions` 6, `TransientErrorDetector` 4, everything else 1–2.

**`Quartz.Examples.AspNetCore`** — 217 unique warnings, and this is where the leg stops being about Quartz:

| owner | count | why |
|---|---:|---|
| ASP.NET Core / `Microsoft.Extensions` internals | 84 | MVC model binding, Razor Pages, `Http.Json` |
| `IL2104` rollups for reflection-based packages | 22 | NSwag, NJsonSchema, Newtonsoft.Json, YamlDotNet, `Microsoft.Data.SqlClient`, `System.Configuration.ConfigurationManager`, nine `Microsoft.AspNetCore.*` |
| `Quartz.AspNetCore` | 57 | one per minimal-API `MapGet`/`MapPost`, all `IL2026` from `RequestDelegateFactory` |
| `Quartz` | 47 | a subset of the 50 above |
| `Quartz.Dashboard` | 9 | Blazor route table `Assembly.GetTypes()`, `IL2110`/`IL2111` on `LayoutView` |
| the example's own code | 6 | `AddRazorPages`, `GetFromJsonAsync`, its `CustomTypeLoader` |

Razor Pages' own warning text is *"Razor Pages does not currently support trimming or native AOT"*. 106 of the 217 belong to code Quartz cannot fix and never will.

## What I fixed versus baselined

**Fixed: nothing.** Every one of the 50 is a deliberate reflective contract, not an oversight. Each of the three available fixes is either out of scope or wrong here:

- resolving statically would delete features — flat `quartz.*` keys, `job_scheduling_data` XML, `JOB_CLASS_NAME` round-tripping, `JobDataMap` property binding;
- `[DynamicallyAccessedMembers]` propagation is exactly the viral problem #3341 defers to step 3;
- `[RequiresUnreferencedCode]` on a fire-path API reaches `IJobDetail` and out into user code.

**Baselined: all 50, by type and warning code.**

## Step 2 — the baseline

`src/Quartz/Quartz.csproj` now sets `IsTrimmable` and `EnableTrimAnalyzer` (commented out since #2195). Two baseline files, both listing the same types for the same reasons:

- **`src/Quartz/TrimAnalysisBaseline.cs`** — `[assembly: SuppressMessage("Trimming", "ILxxxx", Scope = "type", Target = "T:...")]`, one entry per (type, code), grouped under a root-cause comment, each with a justification. This is what makes `dotnet build` green with `TreatWarningsAsErrors`.
- **`src/Quartz/ILLink.Suppressions.xml`** — the same list as an ILLink link-attributes file, applied by the worker example's publish through the SDK's `_ILLinkSuppressions` item.

**Why two files, and why neither ships.** `SuppressMessageAttribute` is `[Conditional("CODE_ANALYSIS")]`, so the C# baseline never reaches metadata and ILLink cannot see it — ILLink has to be told through link-attributes. The one mechanism that covers both is `[UnconditionalSuppressMessage]` in source, and that is baked into the shipped assembly: it would silence these warnings for every consumer publishing a trimmed app. That would be a lie. The reflection really can break under trimming, and a consumer publishing trimmed deserves to be told. So the suppression is local to our own build and our own example publish, and consumers keep seeing all 50.

**Granularity is the type, not the member,** because ILLink reports against compiler-generated closure and state-machine types (`QuartzPropertyBridge/<>c__DisplayClass17_0`, `StdAdoDelegate/<SelectJobForTrigger>d__70`) whose names change the moment a lambda is added to or removed from a file. The XML keys on `Type*` so it survives ordinary edits; the C# file keys the same way so the two read side by side. The cost is that a second reflective call in an already-listed type does not fail the build. Every type in the list is reflective by construction, so that is the right trade — and a *new* type appearing in the list is meant to require an argument, not a line.

**What a contributor sees when they hit it.** A new reflective call site in a type not in the baseline is `error IL20xx` at `dotnet build`, with `TreatWarningsAsErrors` doing the work — verified below. The file header states the order to try fixes in (resolve statically → annotate, checking where the annotation propagates → `RequiresUnreferencedCode` for opt-in surface) before adding an entry.

**Known limitation:** a *stale* entry is silent. `IL2121` (unused suppression) would catch it, but the SDK `NoWarn`s it and the `Type*` wildcards would make it fire constantly. The baseline gates additions, not removals.

## The two example projects

**`Quartz.Examples.Worker` is now the trim canary.** No `NoWarn` at all; fully trimmed over Quartz alone; must publish warning-free. I also ran the published binary — it starts, schedules and fires.

**`Quartz.Examples.AspNetCore` is no longer published trimmed,** and the csproj says why at length. Trimming it measured the framework rather than Quartz, and any baseline recording those 106 framework warnings would have churned on every ASP.NET Core patch bump. It is still published, because publish is where a Blazor asset or an NSwag document generator breaks in ways a build never notices. Nothing is lost relative to `main`: those warnings were 100% suppressed before.

## `PublishAot` renamed to `PublishTrimmed`

Worth the churn, and this is the cheapest moment for it. The name has never been accurate, and #3341 step 5 adds real AOT — leaving the misnomer in place would have forced the rename then anyway, in the PR that could least afford the distraction. `dotnet fallout` regenerated `pr-tests-unit.yml` and `.fallout/build.schema.json`; the diff is the rename and nothing else.

## Documentation

An `IL2xxx` error names the call site, not the baseline, so `AGENTS.md` now carries the pointer to `TrimAnalysisBaseline.cs` and the instruction to fix rather than add a line. The migration guide's existing "Trimming annotations" section gains a paragraph on `IsTrimmable`, because a consumer publishing trimmed will see individual warnings where 3.x gave them one `IL2104` rollup, and deserves to be told which paths need the reflection.

## For a reviewer to decide

1. **`IsTrimmable=true` changes what consumers see.** Quartz is a `PackageReference` for them, so today ILLink collapses it to one `IL2104` rollup; with `IsTrimmable` they get the 50 detailed warnings instead. More actionable, and noisier. #3341 asks for it and I think detailed is right, but it is a visible change for anyone already publishing trimmed and it is your call.
2. **`_ILLinkSuppressions` is an SDK-private item** (underscore-prefixed, in `Microsoft.NET.ILLink.targets`, used by dotnet/runtime). It is the only hook for an app-level link-attributes file. If a future SDK renames it, the suppressions stop applying and the publish fails loudly rather than quietly — but it is a private contract and you should know it is being used.
3. **`Quartz.AspNetCore` (214) and `Quartz.Dashboard` (26) are unanalysed.** Turning `EnableTrimAnalyzer` on for them is tractable but would have tripled this PR, and it is not what step 2 asked for. Both counts are recorded here and on the issue.

## Verification

Local, SDK 10.0.400, Windows.

```
$ dotnet build Quartz.slnx
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
Passed!  - Failed: 0, Passed: 2922, Skipped: 4, Total: 2926, Duration: 46 s

$ dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
Passed!  - Failed: 0, Passed: 312, Skipped: 0, Total: 312, Duration: 4 s

$ dotnet fallout VerifyMigrations Compile UnitTest PublishTrimmed
Target              Status      Duration
Restore             Succeeded       0:01
Compile             Succeeded       0:04
UnitTest            Succeeded       0:54
VerifyMigrations    Succeeded     < 1sec
PublishTrimmed      Succeeded       0:18
Build succeeded.
```

Warning counts, `dotnet publish -c Release` on the two examples:

| | before | with `NoWarn` removed | after this PR |
|---|---:|---:|---:|
| `Quartz.Examples.Worker` | 0 | 50 | 0 |
| `Quartz.Examples.AspNetCore` | 0 | 217 | 0 (not trimmed) |

Integration tests: the container-free `basic` category ran green — `Failed: 0, Passed: 146, Skipped: 0, Duration: 1m 24s`. The per-database categories were not run; nothing in this PR touches product code, so there is no path by which they could be affected.

The baseline was checked in both directions, not just for green:

```
# an entry removed from ILLink.Suppressions.xml
src\Quartz\Util\JobDataExpression.cs(114,13): Trim analysis error IL2070: ...
error NETSDK1144: Optimizing assemblies for size failed.
```

and the compile-time half fails the same way: with `TrimAnalysisBaseline.cs` removed, `dotnet build src/Quartz/Quartz.csproj -c Release -t:Rebuild` reports exactly 50 distinct `error IL2xxx`.

Public API baselines are untouched: `PublicApiTest` excludes `AssemblyMetadataAttribute`, so `IsTrimmable` does not move them, and `SuppressMessageAttribute` is never emitted. `git status` on `src/Quartz.Tests.Unit/Verify` and `src/Quartz.Tests.AspNetCore/Verify` is clean after a full test run.

Refs #3341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3wNU6NFXyZztWp12PGQc
