### PR TITLE
Registered schedulers can be listed, and a shared database says when two of them disagree about the table prefix

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1459,6 +1459,24 @@ make when you want the live schedulers themselves rather than an inventory.
 sketches for runtime tenant lifecycle. Adding and removing schedulers at runtime is a 4.1 concern; when it
 lands, its manager interface extends this one rather than replacing it.
 
+## A shared database says so when two schedulers disagree about the table prefix
+
+Two schedulers sharing a database are told apart by `SCHED_NAME` and share one table prefix. Pointing one
+of them at a different prefix by accident used to be silent in the worst possible way: the scheduler
+connects, `PerformSchemaValidation` passes against the tables it *was* pointed at, it starts, it reports
+healthy, and it never sees its tenant's data.
+
+Creating a scheduler now records its database and table prefix, and a scheduler that shares a database
+with one already created but disagrees about the prefix is reported at `Warning`, naming both schedulers
+and both prefixes. It is a warning rather than an error because separate table sets in one database are
+legal and occasionally deliberate; the message says which two registrations to look at and leaves the
+decision where it belongs.
+
+The check sees what one container can see, which is its own schedulers. Two processes, or two containers
+in one process, sharing a database cannot be compared this way, and a database reached through a provider
+that reports no connection string and no `DbDataSource` is not guessed about. Nothing about the check is
+configurable, and nothing fails because of it.
+
 ## Several schedulers are registered explicitly
 
 `AddQuartz(IConfiguration)` used to look for a `Schedulers` sub-section and, if it found one, register

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1416,6 +1416,49 @@ configures it under — some plugins derive persisted job and trigger keys from 
 deployment's identity rather than a label. Left unset, the plugin's type name is used, exactly as
 before.
 
+## Registered schedulers can be listed without being started
+
+`ISchedulerFactory.GetAllSchedulers()` — `GetAllSchedulers()` on 3.x too — lists the schedulers
+*something has already created*. It reads `ISchedulerRepository`, and a repository holds instances, so a
+scheduler nobody has asked for is not in it. Under a scheduler-per-tenant registration that meant there
+was no way to ask a container which tenants it knows about short of building every one of them, which is
+the opposite of what an operator wanted when they asked.
+
+`ISchedulerRegistry` answers from the registrations instead, and is registered by `AddQuartz`, so any
+container with Quartz in it has one:
+
+```csharp
+foreach (SchedulerRegistration registration in await registry.QuerySchedulers())
+{
+    Console.WriteLine($"{registration.Name}: {registration.Status?.ToString() ?? "not created"}");
+}
+```
+
+```csharp
+public sealed record SchedulerRegistration(string Name, SchedulerOrigin Origin, SchedulerStatus? Status)
+{
+    public bool IsCreated { get; }   // Status is not null
+}
+
+public enum SchedulerOrigin { Container, Runtime }
+```
+
+- **`Status` is `null` exactly when nothing has been built under that name.** Asking does not build it —
+  that is the whole point.
+- **`Origin.Container`** is a scheduler `AddQuartz()` or `AddQuartz(name, …)` registered.
+  **`Origin.Runtime`** is one that is in the repository without a registration behind it: a
+  `QuartzSchedulerBuilder` scheduler bound by hand, or a remote scheduler from `AddQuartzHttpClient`.
+  Nothing in the container owns a runtime scheduler's lifetime.
+- The default scheduler is listed under its configured `InstanceName`, which is the one name that is not
+  the name it was registered under — it has no service key at all.
+
+Nothing is removed: `GetAllSchedulers()` still means what it always meant, and it is still the call to
+make when you want the live schedulers themselves rather than an inventory.
+
+`ISchedulerRegistry` is deliberately the *narrow* half of the API [#3338](https://github.com/quartznet/quartznet/issues/3338)
+sketches for runtime tenant lifecycle. Adding and removing schedulers at runtime is a 4.1 concern; when it
+lands, its manager interface extends this one rather than replacing it.
+
 ## Several schedulers are registered explicitly
 
 `AddQuartz(IConfiguration)` used to look for a `Schedulers` sub-section and, if it found one, register

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -82,6 +82,33 @@ Trying to give a named scheduler and the default scheduler the same name is caug
 calls, rather than as a duplicate-name `ArgumentException` from somewhere inside host start. Names are
 compared case-insensitively.
 
+### Listing them
+
+`ISchedulerFactory.GetAllSchedulers()` lists the schedulers something has already *created*. Under this
+model that is the wrong question: a tenant nobody has asked for yet is still a tenant, and building every
+one of them to find out what exists is exactly the cost you were avoiding.
+
+`ISchedulerRegistry` reads the registrations instead:
+
+```csharp
+ISchedulerRegistry registry = provider.GetRequiredService<ISchedulerRegistry>();
+
+foreach (SchedulerRegistration tenant in await registry.QuerySchedulers())
+{
+    Console.WriteLine($"{tenant.Name}: {tenant.Status?.ToString() ?? "registered, not created"}");
+}
+```
+
+`Status` is `null` exactly when nothing has been built under that name, and asking does not build it.
+`Origin` says where the scheduler came from: `Container` for one `AddQuartz` registered, `Runtime` for
+one that is in the repository without a registration behind it — a `QuartzSchedulerBuilder` scheduler
+bound by hand, or a remote scheduler from `AddQuartzHttpClient`. The default scheduler appears under its
+configured `InstanceName`.
+
+Under `AddQuartzHostedService()` every registration is created and started before the application runs,
+so once the host is up the distinction matters less than it looks. It matters when you resolve schedulers
+yourself, when a start failed, and whenever you want an inventory rather than a list of live objects.
+
 ### What is per scheduler
 
 Almost everything. Each named scheduler gets its own keyed registration of the job factory, the
@@ -112,6 +139,7 @@ A handful of things are container-wide, shared by every scheduler in the process
 |---|---|
 | `ITypeLoader` | type loading is a container-wide concern; `UseTypeLoader<T>()` **replaces** it for everyone |
 | `ISchedulerRepository` | one per container — that is what makes `GetAllSchedulers` and the dashboard see all of them |
+| `ISchedulerRegistry` | one per container — it answers for every registration in it, which is what makes it an inventory rather than a scheduler's own view |
 | `SystemTextJsonSerializerRegistry` | the HTTP API, the dashboard and the HTTP client serialize triggers without knowing which scheduler they came from |
 | `Meters` | built from the container's `IMeterFactory` |
 | `DataSourceOptions` | named after the **data source**, not the scheduler, so several schedulers can read through the same one |
@@ -339,9 +367,11 @@ authorizes on the `{schedulerName}` route segment.
 
 **Tenants cannot be onboarded at runtime *through the DI path*.** Schedulers are registered against
 `IServiceCollection`, which is closed once the container is built, and the hosted service enumerates
-them once at start. Nor can a scheduler be restarted after `Shutdown()`: the container owns its parts'
-lifetimes, and `GetScheduler()` throws rather than resurrecting a thread pool and a job store
-underneath a scheduler that can never run again. `Standby()` / `Start()` is the pause-and-resume pair.
+them once at start. (Enumerating what *is* registered no longer requires starting anything —
+[`ISchedulerRegistry`](#listing-them) — but adding to it does still require a new container.) Nor can a
+scheduler be restarted after `Shutdown()`: the container owns its parts' lifetimes, and `GetScheduler()`
+throws rather than resurrecting a thread pool and a job store underneath a scheduler that can never run
+again. `Standby()` / `Start()` is the pause-and-resume pair.
 
 That is a limit of the DI path, not of the library. `QuartzSchedulerBuilder` builds a scheduler from a
 container of its own, at any point in the process's life, and `ISchedulerRepository.Bind` makes the

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -99,7 +99,12 @@ foreach (SchedulerRegistration tenant in await registry.QuerySchedulers())
 }
 ```
 
-`Status` is `null` exactly when nothing has been built under that name, and asking does not build it.
+`Status` is `null` when no scheduler exists under that name, and asking does not build one. A scheduler
+that has been *shut down* reads as `null` too rather than as `Shutdown`, because the repository drops a
+shut-down scheduler as soon as a read notices it — and a shut-down scheduler cannot be rebuilt in the same
+container anyway, so "not yet" and "not any more" are the same answer here: not a name you can get a
+working scheduler out of.
+
 `Origin` says where the scheduler came from: `Container` for one `AddQuartz` registered, `Runtime` for
 one that is in the repository without a registration behind it — a `QuartzSchedulerBuilder` scheduler
 bound by hand, or a remote scheduler from `AddQuartzHttpClient`. The default scheduler appears under its

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -268,15 +268,34 @@ builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s =>
 }));
 ```
 
-Three rules:
+Four rules:
 
 - **Different scheduler name is enough.** Prefixes are for keeping tenants in separate *tables*, which
   is a backup-and-restore or a permissions decision, not an isolation one.
 - **The prefix has to match the DDL.** Nothing derives one from the other; you run the DDL with the
   prefix substituted.
-- **A wrong prefix is caught at startup.** `PerformSchemaValidation` is on by default, and a missing or
-  mis-prefixed table is reported once, by name, with a message telling you to run the schema scripts —
-  rather than surfacing as the first failing operation an hour later.
+- **A prefix pointing at tables that do not exist is caught at startup.**
+  `PerformSchemaValidation` is on by default, and a missing or mis-prefixed table is reported once, by
+  name, with a message telling you to run the schema scripts — rather than surfacing as the first failing
+  operation an hour later.
+- **A prefix pointing at the *wrong* tables is reported too, as a warning.** Schema validation cannot
+  catch that one: the tables exist, they are simply somebody else's, and the scheduler starts, reports
+  healthy and never sees its own data. So creating a scheduler records its database and its table prefix,
+  and a scheduler that shares a database with one already created but disagrees about the prefix produces
+  a `Warning` naming both schedulers and both prefixes.
+
+::: tip Why that one is a warning and not an error
+Separate table sets in one database are legal, and the arrangement above is exactly how you ask for them.
+Nothing Quartz can see tells a deliberate `ACME_QRTZ_` apart from a mistyped `QRTZ2_`, and an error that
+fires on a legitimate arrangement is worse than the silence it replaces. If the two prefixes are meant to
+differ, the warning is expected and can be filtered out on the
+`Quartz.Configuration.SharedDatabaseValidator` category.
+
+It also only sees what one container can see. Two processes — or two containers in one process — sharing
+a database are invisible to each other, and so is a database reached through a provider that reports
+neither a connection string nor a `DbDataSource`. Being wrong in that direction is deliberate: a check
+that stays quiet when it cannot tell costs you nothing.
+:::
 
 ::: warning
 Two schedulers sharing a database with the **same** `SCHED_NAME` are, by construction, indistinguishable

--- a/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
+++ b/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
@@ -175,6 +175,12 @@ The repository is scoped to the container, not the process. A scheduler built by
 [the migration guide](../migration-guide.md#no-process-global-scheduler-or-connection-state).
 :::
 
+To ask what the container has *registered* rather than what it has built, resolve `ISchedulerRegistry`
+and call `QuerySchedulers()`. It returns one `SchedulerRegistration` per registration — plus one for
+anything bound into the repository without a registration behind it — and reports a `null` `Status` for a
+scheduler that has not been created, without creating it. That is the call for an inventory; `LookupAll`
+stays the call for the live schedulers themselves.
+
 ## Mixing Default and Named Schedulers
 
 You can combine the traditional unnamed `AddQuartz()` with named schedulers:

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -429,6 +429,7 @@ rather than an isolation one.
 | `SCHED_NAME` row separation | Yes | Yes |
 | Per-scheduler table prefix | Yes | Yes |
 | Startup schema validation | Yes, `PerformSchemaValidation` on by default | Yes, `PerformSchemaValidation` on by default |
+| Shared database, mismatched table prefix | No — silent; each scheduler sees an empty table set | Yes, warns naming both schedulers and both prefixes |
 | Listing tenants without starting them | No — the repository lists live schedulers only | Yes, `ISchedulerRegistry.QuerySchedulers()` |
 | Execution groups and per-node limits | Yes | Yes |
 | Trigger group as the execution group | No — tag every trigger explicitly | Yes, `UseTriggerGroupWhenUnset()` |

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -429,6 +429,7 @@ rather than an isolation one.
 | `SCHED_NAME` row separation | Yes | Yes |
 | Per-scheduler table prefix | Yes | Yes |
 | Startup schema validation | Yes, `PerformSchemaValidation` on by default | Yes, `PerformSchemaValidation` on by default |
+| Listing tenants without starting them | No — the repository lists live schedulers only | Yes, `ISchedulerRegistry.QuerySchedulers()` |
 | Execution groups and per-node limits | Yes | Yes |
 | Trigger group as the execution group | No — tag every trigger explicitly | Yes, `UseTriggerGroupWhenUnset()` |
 | Cluster-wide concurrency quota | No | Yes, `ExecutionLimitScope.Cluster` — approximate unless `AcquireTriggersWithinLock` |

--- a/src/Quartz.Tests.Unit/Configuration/SharedDatabaseValidatorTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SharedDatabaseValidatorTest.cs
@@ -1,0 +1,265 @@
+using System.Data.Common;
+
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Quartz.Configuration;
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Tests.Unit.Plugin.History;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Two schedulers sharing a database are separated by <c>SCHED_NAME</c> and share one table prefix. Get
+/// the prefix wrong and the misconfigured scheduler connects, validates its schema against the tables it
+/// was pointed at, starts, looks healthy and never sees its tenant's data — which is the failure shape
+/// that has to be said out loud, because nothing else in the system will.
+/// </summary>
+/// <remarks>
+/// Non-parallelizable because one of these builds two schedulers out of a container.
+/// </remarks>
+[NonParallelizable]
+public sealed class SharedDatabaseValidatorTest
+{
+    private const string ConnectionString = "Data Source=tenants;Initial Catalog=quartz;User ID=sa;Password=hunter2";
+
+    [Test]
+    public void TwoSchedulersOnOneDatabaseWithDifferentPrefixesAreReported()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider(ConnectionString))),
+            ("initech", TestJobStores.Tx(tablePrefix: "QRTZ2_", dbProvider: TestJobStores.DbProvider(ConnectionString))));
+
+        LogEntry entry = entries.Should().ContainSingle().Subject;
+
+        entry.Level.Should().Be(LogLevel.Warning, "a legal-but-unusual arrangement is not an error");
+
+        string message = entry.Message;
+        message.Should().Contain("'acme'").And.Contain("'initech'",
+            "a reader has to know which two schedulers disagreed without going back to the configuration");
+        message.Should().Contain("'QRTZ_'").And.Contain("'QRTZ2_'",
+            "and which two prefixes, since either one of them may be the intended one");
+        message.Should().NotContain("hunter2", "a connection string is never part of a diagnostic");
+    }
+
+    [Test]
+    public void TheSupportedArrangementIsNotReported()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider(ConnectionString))),
+            ("initech", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider(ConnectionString))));
+
+        entries.Should().BeEmpty(
+            "one database, one table prefix and two scheduler names is exactly the arrangement multi-tenancy is built on");
+    }
+
+    [Test]
+    public void PrefixesThatDifferOnlyByCaseAreNotReported()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider(ConnectionString))),
+            ("initech", TestJobStores.Tx(tablePrefix: "qrtz_", dbProvider: TestJobStores.DbProvider(ConnectionString))));
+
+        entries.Should().BeEmpty(
+            "every database Quartz supports folds an unquoted identifier to one case, so these are the same table set");
+    }
+
+    [Test]
+    public void SchedulersOnDifferentDatabasesAreNotReported()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider(ConnectionString))),
+            ("initech", TestJobStores.Tx(tablePrefix: "QRTZ2_", dbProvider: TestJobStores.DbProvider("Data Source=other;Initial Catalog=quartz"))));
+
+        entries.Should().BeEmpty(
+            "a prefix per database is the database-per-tenant model, and nothing about it is suspicious");
+    }
+
+    [Test]
+    public void ConnectionStringsSpellingTheSameSettingsDifferentlyAreOneDatabase()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider("Data Source=tenants;Initial Catalog=quartz"))),
+            ("initech", TestJobStores.Tx(tablePrefix: "QRTZ2_", dbProvider: TestJobStores.DbProvider("initial catalog=quartz; data source=tenants"))));
+
+        entries.Should().ContainSingle(
+            "two appsettings entries that describe one database rarely agree on the order or the casing of the keywords");
+    }
+
+    [Test]
+    public void AnInMemorySchedulerBesideAPersistentOneIsNotReported()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider(ConnectionString))),
+            ("initech", TestJobStores.Ram()));
+
+        entries.Should().BeEmpty("an in-memory scheduler shares a database with nobody");
+    }
+
+    [Test]
+    public void AProviderThatKeepsItsConnectionDetailsToItselfIsNotGuessedAbout()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider())),
+            ("initech", TestJobStores.Tx(tablePrefix: "QRTZ2_", dbProvider: TestJobStores.DbProvider())));
+
+        entries.Should().BeEmpty(
+            "two providers that report no connection string are not evidence of one database, and a check that "
+            + "fires on a legitimate arrangement is worse than the silence it replaces");
+    }
+
+    [Test]
+    public void OneRegisteredDataSourceServingTwoSchedulersIsOneDatabase()
+    {
+        using StubDataSource shared = new();
+
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: new DataSourceDbProvider(Metadata(), shared))),
+            ("initech", TestJobStores.Tx(tablePrefix: "QRTZ2_", dbProvider: new DataSourceDbProvider(Metadata(), shared))));
+
+        entries.Should().ContainSingle(
+            "a DbDataSource reports no connection string, so the data source object itself is what says the two "
+            + "schedulers talk to one database");
+    }
+
+    [Test]
+    public void RecordingTheSameSchedulerTwiceDoesNotMakeItItsOwnNeighbour()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider(ConnectionString))),
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ2_", dbProvider: TestJobStores.DbProvider(ConnectionString))));
+
+        entries.Should().BeEmpty("a scheduler cannot disagree with itself about its own table prefix");
+    }
+
+    [Test]
+    public void AConnectionStringNoBuilderCanParseIsStillComparedAsWritten()
+    {
+        const string Opaque = "an opaque handle a custom provider understands";
+
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: TestJobStores.DbProvider(Opaque))),
+            ("initech", TestJobStores.Tx(tablePrefix: "QRTZ2_", dbProvider: TestJobStores.DbProvider(Opaque))));
+
+        entries.Should().ContainSingle(
+            "a string that is not keyword/value pairs still identifies a database, and two schedulers holding the "
+            + "same one are on the same database whether or not it can be parsed");
+    }
+
+    [Test]
+    public void AProviderThatRefusesToAnswerCannotStopASchedulerFromStarting()
+    {
+        List<LogEntry> entries = Validate(
+            ("acme", TestJobStores.Tx(tablePrefix: "QRTZ_", dbProvider: new UnanswerableDbProvider())),
+            ("initech", TestJobStores.Tx(tablePrefix: "QRTZ2_", dbProvider: new UnanswerableDbProvider())));
+
+        entries.Should().OnlyContain(x => x.Level == LogLevel.Debug,
+            "this runs on the path that creates a scheduler, so a diagnostic that throws would turn a warning "
+            + "nobody asked for into a startup failure");
+    }
+
+    [Test]
+    public async Task TheCheckRunsWhereSchedulersAreCreated()
+    {
+        RecordingLoggerProvider recorder = new();
+
+        ServiceCollection services = new();
+        services.AddLogging(logging => logging.AddProvider(recorder));
+        services.AddQuartz("acme", q => StubbedPersistentStore(q, "QRTZ_"));
+        services.AddQuartz("initech", q => StubbedPersistentStore(q, "QRTZ2_"));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler acme = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+        IScheduler initech = await provider.GetRequiredKeyedService<ISchedulerFactory>("initech").GetScheduler();
+        try
+        {
+            recorder.Entries.Should().ContainSingle(x => x.Message.Contains("different table prefixes"),
+                "the check is only worth anything if something calls it - and creating the second scheduler is "
+                + "the first moment at which the arrangement exists to be judged");
+        }
+        finally
+        {
+            await acme.Shutdown();
+            await initech.Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// A persistent store that never reaches a database: schema validation off, and a provider that
+    /// refuses to connect. What is under test is the arrangement, not the driver.
+    /// </summary>
+    private static void StubbedPersistentStore(IQuartzBuilder builder, string tablePrefix)
+    {
+        builder.UsePersistentStore(store =>
+        {
+            store.Configure(options =>
+            {
+                options.DataSource = "tenants";
+                options.TablePrefix = tablePrefix;
+                options.PerformSchemaValidation = false;
+            });
+
+            store.Services.AddKeyedSingleton<IDbProvider>(builder.SchedulerName, new StubDbProvider(ConnectionString));
+        });
+    }
+
+    private static List<LogEntry> Validate(params (string SchedulerName, IJobStore JobStore)[] schedulers)
+    {
+        RecordingLoggerProvider recorder = new();
+        using LoggerFactory factory = new();
+        factory.AddProvider(recorder);
+
+        SharedDatabaseValidator validator = new(factory.CreateLogger<SharedDatabaseValidator>());
+        foreach ((string schedulerName, IJobStore jobStore) in schedulers)
+        {
+            validator.Validate(schedulerName, jobStore);
+        }
+
+        return recorder.Entries;
+    }
+
+    /// <summary>
+    /// A driver description good enough to construct a provider: <see cref="DbProvider"/> builds command
+    /// and connection constructors from it eagerly, so the types have to be real ones.
+    /// </summary>
+    private static DbMetadata Metadata()
+    {
+        return new DbMetadata { ConnectionType = typeof(SqlConnection), CommandType = typeof(SqlCommand) };
+    }
+
+    /// <summary>
+    /// A provider that will not say what it connects to, the way a driver wrapper written elsewhere
+    /// might.
+    /// </summary>
+    private sealed class UnanswerableDbProvider : IDbProvider
+    {
+        public string ConnectionString => throw new InvalidOperationException("This provider does not publish its connection string.");
+
+        public DbMetadata Metadata { get; } = new();
+
+        public DbCommand CreateCommand() => throw new NotSupportedException();
+
+        public DbConnection CreateConnection() => throw new NotSupportedException();
+
+        public void Shutdown()
+        {
+        }
+    }
+
+    /// <summary>
+    /// A data source that never connects. It exists to be compared by reference, which is all the
+    /// shared-database check asks of one.
+    /// </summary>
+    private sealed class StubDataSource : DbDataSource
+    {
+        public override string ConnectionString => "Data Source=held-by-the-data-source";
+
+        protected override DbConnection CreateDbConnection()
+        {
+            throw new NotSupportedException("StubDataSource does not connect.");
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/SchedulerRegistryTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/SchedulerRegistryTest.cs
@@ -1,0 +1,205 @@
+using FakeItEasy;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Configuration;
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Extensions.DependencyInjection;
+
+/// <summary>
+/// <see cref="ISchedulerRegistry" /> is the read that separates <em>registered</em> from
+/// <em>running</em>: an operator has to be able to enumerate tenants without starting every one of
+/// them, which is precisely what <c>LookupAll</c> and <c>GetAllSchedulers</c> cannot do.
+/// </summary>
+[NonParallelizable]
+public sealed class SchedulerRegistryTest
+{
+    [Test]
+    public async Task ARegisteredSchedulerIsListedWithoutBeingCreated()
+    {
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddQuartz("acme", _ => { });
+            services.AddQuartz("initech", _ => { });
+        });
+
+        List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        registrations.Select(x => x.Name).Should().Equal(["acme", "initech"]);
+        registrations.Should().OnlyContain(x => x.Origin == SchedulerOrigin.Container);
+        registrations.Should().OnlyContain(x => x.Status == null && !x.IsCreated,
+            "asking what is registered must not build anything - starting every tenant is the cost this query exists to avoid");
+
+        provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty(
+            "nothing was created, so the repository - which is what GetAllSchedulers reads - still knows about nothing");
+    }
+
+    [Test]
+    public async Task CreatingOneSchedulerLeavesTheOthersRegisteredAndUncreated()
+    {
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddQuartz("acme", _ => { });
+            services.AddQuartz("initech", _ => { });
+        });
+
+        await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+
+        List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        registrations.Should().ContainSingle(x => x.Name == "acme")
+            .Which.Status.Should().Be(SchedulerStatus.Standby,
+                "a scheduler that exists and has not been started is alive and firing nothing, which is what standby means");
+        registrations.Should().ContainSingle(x => x.Name == "initech")
+            .Which.Status.Should().BeNull("the second tenant is still only a registration");
+    }
+
+    [Test]
+    public async Task AStartedSchedulerIsReportedAsRunningAndAStandbyOneAsStandby()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        IScheduler scheduler = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+        await scheduler.Start();
+
+        ISchedulerRegistry registry = provider.GetRequiredService<ISchedulerRegistry>();
+        List<SchedulerRegistration> started = await registry.QuerySchedulers();
+        started.Should().ContainSingle().Which.Status.Should().Be(SchedulerStatus.Running);
+
+        await scheduler.Standby();
+
+        List<SchedulerRegistration> standby = await registry.QuerySchedulers();
+        standby.Should().ContainSingle().Which.Status.Should().Be(SchedulerStatus.Standby);
+
+        await scheduler.Shutdown();
+    }
+
+    [Test]
+    public async Task TheDefaultSchedulerIsListedUnderTheNameItsOptionsGiveIt()
+    {
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddQuartz(q => q.ConfigureScheduler(o => o.InstanceName = "TheDefaultOne"));
+            services.AddQuartz("acme", _ => { });
+        });
+
+        List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        registrations.Select(x => x.Name).Should().Equal(
+            ["TheDefaultOne", "acme"],
+            "the default scheduler has no service key, so its name comes from its options - and the order is ordinal by name");
+        registrations.Should().OnlyContain(x => x.Origin == SchedulerOrigin.Container);
+    }
+
+    [Test]
+    public async Task AContainerWithOnlyNamedSchedulersDoesNotInventADefaultOne()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        registrations.Select(x => x.Name).Should().Equal(
+            ["acme"],
+            "AddQuartz(name, ...) registers no default scheduler, and QuartzScheduler is the name one would otherwise have had");
+    }
+
+    [Test]
+    public async Task ASchedulerBoundByHandIsReportedAsRuntime()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        IScheduler standalone = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(o => o.InstanceName = "bound-by-hand")
+            .BuildScheduler();
+
+        try
+        {
+            provider.GetRequiredService<ISchedulerRepository>().Bind(standalone);
+
+            List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+            registrations.Should().ContainSingle(x => x.Name == "acme")
+                .Which.Origin.Should().Be(SchedulerOrigin.Container);
+            registrations.Should().ContainSingle(x => x.Name == "bound-by-hand")
+                .Which.Origin.Should().Be(SchedulerOrigin.Runtime,
+                    "nothing in this container registered it, so nothing in this container owns its lifetime");
+        }
+        finally
+        {
+            await standalone.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ARegistrationAndTheSchedulerBuiltFromItAreOneEntry()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("Acme", _ => { }));
+
+        IScheduler standalone = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(o => o.InstanceName = "ACME")
+            .BuildScheduler();
+
+        try
+        {
+            provider.GetRequiredService<ISchedulerRepository>().Bind(standalone);
+
+            List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+            SchedulerRegistration registration = registrations.Should().ContainSingle(
+                "the repository indexes names ignoring case, so the join against it has to as well - otherwise one "
+                + "scheduler is listed twice, once as a registration and once as a stranger").Subject;
+            registration.Name.Should().Be("Acme", "a registration is reported with the spelling it was registered with");
+            registration.Origin.Should().Be(SchedulerOrigin.Container);
+        }
+        finally
+        {
+            await standalone.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task RegisteringTheGraphDirectlyStillCountsAsADefaultScheduler()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartzScheduler());
+
+        List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        SchedulerRegistration registration = registrations.Should().ContainSingle(
+            "AddQuartzScheduler() is the call every road to a default scheduler passes through - AddQuartz(), "
+            + "the standalone builder, and registering the graph by hand").Subject;
+        registration.Name.Should().Be(QuartzSchedulerOptions.DefaultInstanceName);
+        registration.Origin.Should().Be(SchedulerOrigin.Container);
+        registration.Status.Should().BeNull();
+    }
+
+    [Test]
+    public async Task ASchedulerThatCannotAnswerIsListedRatherThanThrown()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        IScheduler unreachable = A.Fake<IScheduler>();
+        A.CallTo(() => unreachable.SchedulerName).Returns("far-away");
+        A.CallTo(() => unreachable.IsShutdown).Throws(new HttpRequestException("the remote scheduler is not answering"));
+
+        provider.GetRequiredService<ISchedulerRepository>().Bind(unreachable, "remote");
+
+        List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        registrations.Should().ContainSingle(x => x.Name == "far-away")
+            .Which.Status.Should().Be(SchedulerStatus.Unknown,
+                "unreachable is not the same as absent, and an inventory of tenants must not fail because one of "
+                + "them is behind a network that is down");
+    }
+
+    private static ServiceProvider Container(Action<IServiceCollection> configure)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/SchedulerRegistryTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/SchedulerRegistryTest.cs
@@ -161,6 +161,24 @@ public sealed class SchedulerRegistryTest
     }
 
     [Test]
+    public async Task AShutDownSchedulerLeavesItsRegistrationBehindWithNoStatus()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        IScheduler scheduler = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+        await scheduler.Shutdown();
+
+        List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        SchedulerRegistration registration = registrations.Should().ContainSingle(
+            "shutting a scheduler down does not unregister it - the registration is what the container was told").Subject;
+        registration.Origin.Should().Be(SchedulerOrigin.Container);
+        registration.Status.Should().BeNull(
+            "the repository drops a shut-down scheduler as soon as a read notices it, and one cannot be rebuilt in "
+            + "the same container either way, so null covers both 'not yet' and 'not any more'");
+    }
+
+    [Test]
     public async Task RegisteringTheGraphDirectlyStillCountsAsADefaultScheduler()
     {
         using ServiceProvider provider = Container(services => services.AddQuartzScheduler());

--- a/src/Quartz.Tests.Unit/TestJobStores.cs
+++ b/src/Quartz.Tests.Unit/TestJobStores.cs
@@ -30,7 +30,7 @@ public static class TestJobStores
     /// <summary>
     /// A database provider that never connects, for tests that only exercise the store's logic.
     /// </summary>
-    public static IDbProvider DbProvider() => new StubDbProvider();
+    public static IDbProvider DbProvider(string connectionString = "") => new StubDbProvider(connectionString);
 
     public static IDriverDelegate DriverDelegate() => new StdAdoDelegate();
 
@@ -98,17 +98,20 @@ public static class TestJobStores
         ITypeLoader? typeLoader = null,
         TimeProvider? timeProvider = null,
         string instanceName = "TestScheduler",
-        string instanceId = "TestInstance")
+        string instanceId = "TestInstance",
+        string dataSource = "test",
+        string tablePrefix = AdoConstants.DefaultTablePrefix,
+        IDbProvider? dbProvider = null)
     {
         return new LocalTransactionJobStore(
             signaler ?? new NoOpSchedulerSignaler(),
             typeLoader ?? new SimpleTypeLoader(),
             timeProvider ?? TimeProvider.System,
             SchedulerOptions(instanceName, instanceId),
-            StoreOptions(),
+            StoreOptions(dataSource, tablePrefix),
             ClusteringOptions(),
             Serializer(),
-            DbProvider(),
+            dbProvider ?? DbProvider(),
             DriverDelegate(),
             LockHandler());
     }
@@ -138,7 +141,12 @@ public static class TestJobStores
 /// </summary>
 public sealed class StubDbProvider : IDbProvider
 {
-    public string ConnectionString => "";
+    public StubDbProvider(string connectionString = "")
+    {
+        ConnectionString = connectionString;
+    }
+
+    public string ConnectionString { get; }
 
     public DbMetadata Metadata { get; } = new();
 

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -734,6 +734,10 @@ namespace Quartz
         System.Threading.Tasks.ValueTask TriggersPaused(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggersResumed(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default);
     }
+    public interface ISchedulerRegistry
+    {
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.SchedulerRegistration>> QuerySchedulers(System.Threading.CancellationToken cancellationToken = default);
+    }
     public interface ISimpleTrigger : Quartz.ITrigger
     {
         Quartz.SimpleTriggerMisfireInstruction MisfireInstruction { get; }
@@ -1377,6 +1381,11 @@ namespace Quartz
         public required string ThreadPoolTypeName { get; init; }
         public required string Version { get; init; }
     }
+    public enum SchedulerOrigin
+    {
+        Container = 0,
+        Runtime = 1,
+    }
     public static class SchedulerQueryExtensions
     {
         public static System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> GetCalendarNames(this Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
@@ -1388,6 +1397,14 @@ namespace Quartz
         public static System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ITrigger>> GetTriggersOfJob(this Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.ValueTask<bool> IsJobGroupPaused(this Quartz.IScheduler scheduler, string groupName, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.ValueTask<bool> IsTriggerGroupPaused(this Quartz.IScheduler scheduler, string groupName, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public sealed class SchedulerRegistration : System.IEquatable<Quartz.SchedulerRegistration>
+    {
+        public SchedulerRegistration(string Name, Quartz.SchedulerOrigin Origin, Quartz.SchedulerStatus? Status) { }
+        public bool IsCreated { get; }
+        public string Name { get; init; }
+        public Quartz.SchedulerOrigin Origin { get; init; }
+        public Quartz.SchedulerStatus? Status { get; init; }
     }
     public enum SchedulerStatus
     {

--- a/src/Quartz/Configuration/ContainerSchedulerRegistry.cs
+++ b/src/Quartz/Configuration/ContainerSchedulerRegistry.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.Options;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// Answers <see cref="ISchedulerRegistry" /> from what one container was told to register, joined with
+/// what its repository currently holds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two halves answer different questions and neither is enough on its own.
+/// <see cref="SchedulerNameRegistry" /> is written while <c>AddQuartz</c> runs, so it knows every
+/// registration whether or not anything ever resolved it — but it holds names, not schedulers.
+/// <see cref="ISchedulerRepository" /> holds schedulers, but only the ones something already built, plus
+/// any a caller bound by hand. Joining them by name is what turns "these exist" and "these are alive"
+/// into one answer.
+/// </para>
+/// <para>
+/// Nothing here creates a scheduler. That is the point: enumerating tenants must not start them.
+/// </para>
+/// </remarks>
+internal sealed class ContainerSchedulerRegistry : ISchedulerRegistry
+{
+    private readonly SchedulerNameRegistry names;
+    private readonly ISchedulerRepository repository;
+    private readonly IOptionsMonitor<QuartzSchedulerOptions> schedulerOptions;
+
+    public ContainerSchedulerRegistry(
+        SchedulerNameRegistry names,
+        ISchedulerRepository repository,
+        IOptionsMonitor<QuartzSchedulerOptions> schedulerOptions)
+    {
+        this.names = names;
+        this.repository = repository;
+        this.schedulerOptions = schedulerOptions;
+    }
+
+    public ValueTask<List<SchedulerRegistration>> QuerySchedulers(CancellationToken cancellationToken = default)
+    {
+        // Names are matched the way the repository indexes them, so a registration and the scheduler
+        // built from it are never reported as two schedulers because their spelling differs in case.
+        Dictionary<string, IScheduler> live = new(StringComparer.OrdinalIgnoreCase);
+        foreach (IScheduler scheduler in repository.LookupAll())
+        {
+            // A name can hold several entries - proxies to different nodes of one cluster - and they
+            // are one scheduler as far as a registration is concerned. The first one answers for it.
+            live.TryAdd(scheduler.SchedulerName, scheduler);
+        }
+
+        List<SchedulerRegistration> registrations = [];
+        HashSet<string> reported = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string name in RegisteredNames())
+        {
+            if (!reported.Add(name))
+            {
+                continue;
+            }
+
+            registrations.Add(new SchedulerRegistration(name, SchedulerOrigin.Container, StatusOf(live, name)));
+        }
+
+        foreach (IScheduler scheduler in live.Values)
+        {
+            if (!reported.Add(scheduler.SchedulerName))
+            {
+                continue;
+            }
+
+            registrations.Add(new SchedulerRegistration(
+                scheduler.SchedulerName,
+                SchedulerOrigin.Runtime,
+                Status(scheduler)));
+        }
+
+        // Deterministic order, ordinal, as the paged queries over a job store are.
+        registrations.Sort(static (left, right) => string.CompareOrdinal(left.Name, right.Name));
+
+        return new ValueTask<List<SchedulerRegistration>>(registrations);
+    }
+
+    /// <summary>
+    /// The names <c>AddQuartz</c> registered, the default scheduler included.
+    /// </summary>
+    /// <remarks>
+    /// The default scheduler is the one registration whose name is not the name it was registered
+    /// under — it has no service key at all, and its name is whatever its options say. Reading them is
+    /// therefore the only way to learn it, and it is also what validates them.
+    /// </remarks>
+    private IEnumerable<string> RegisteredNames()
+    {
+        if (names.HasDefaultScheduler)
+        {
+            yield return schedulerOptions.Get(Options.DefaultName).InstanceName;
+        }
+
+        foreach (string name in names.Names)
+        {
+            yield return name;
+        }
+    }
+
+    private static SchedulerStatus? StatusOf(Dictionary<string, IScheduler> live, string name)
+    {
+        return live.TryGetValue(name, out IScheduler? scheduler) ? Status(scheduler) : null;
+    }
+
+    /// <summary>
+    /// Asks a scheduler what state it is in, treating an unanswerable question as
+    /// <see cref="SchedulerStatus.Unknown" />.
+    /// </summary>
+    /// <remarks>
+    /// A local scheduler reads three fields. A remote one answers over the network and may simply be
+    /// unreachable — and a listing of tenants is exactly the call that must not fail because one of them
+    /// is. <see cref="SchedulerStatus.Unknown" /> already means "state could not be determined", so it is
+    /// reported rather than the registration being dropped or the exception escaping.
+    /// </remarks>
+    private static SchedulerStatus Status(IScheduler scheduler)
+    {
+        try
+        {
+            return scheduler.GetStatus();
+        }
+        catch
+        {
+            return SchedulerStatus.Unknown;
+        }
+    }
+}

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -64,6 +64,11 @@ internal static class QuartzServiceRegistration
         // than by how it was built.
         services.TryAddSingleton<ISchedulerRepository, SchedulerRepository>();
 
+        // What the container was told to register, which the repository cannot know - it holds
+        // schedulers, and a registration nothing has resolved yet has none. Listing tenants must not
+        // start them, so the two are read together rather than by building everything registered.
+        services.TryAddSingleton<ISchedulerRegistry, ContainerSchedulerRegistry>();
+
         // The container-wide set of trigger and calendar serializers, holding the built-in types. This is
         // what the parts of Quartz that are not tied to one scheduler read — the HTTP API, the dashboard
         // and the HTTP client all serialize triggers without knowing which scheduler they came from — so
@@ -97,6 +102,15 @@ internal static class QuartzServiceRegistration
     public static IServiceCollection AddQuartzScheduler(this IServiceCollection services, string? schedulerName = null)
     {
         services.AddQuartzSharedServices();
+
+        // Recorded here rather than beside the named registrations because this is the one call every
+        // road to a default scheduler passes through - AddQuartz(), the standalone builder, and a caller
+        // registering the graph by hand. A named scheduler is added to the registry by AddQuartz(name),
+        // which is where a duplicate name is refused.
+        if (schedulerName is null)
+        {
+            SchedulerNameRegistry.For(services).AddDefault();
+        }
 
         // Every scheduler resolves these two, so a bad value in either is a mistake the host can report
         // at startup instead of leaving for whichever component reads it first. The store, clustering

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -69,6 +69,9 @@ internal static class QuartzServiceRegistration
         // start them, so the two are read together rather than by building everything registered.
         services.TryAddSingleton<ISchedulerRegistry, ContainerSchedulerRegistry>();
 
+        // "Another scheduler shares this database" is only knowable here, one level above the store.
+        services.TryAddSingleton<SharedDatabaseValidator>();
+
         // The container-wide set of trigger and calendar serializers, holding the built-in types. This is
         // what the parts of Quartz that are not tied to one scheduler read — the HTTP API, the dashboard
         // and the HTTP client all serialize triggers without knowing which scheduler they came from — so

--- a/src/Quartz/Configuration/SchedulerNameRegistry.cs
+++ b/src/Quartz/Configuration/SchedulerNameRegistry.cs
@@ -18,6 +18,19 @@ internal sealed class SchedulerNameRegistry
     public IReadOnlyList<string> Names => names;
 
     /// <summary>
+    /// Whether a default scheduler is registered — <c>AddQuartz()</c> without a name, or
+    /// <c>AddQuartzScheduler()</c> directly, which is also how the standalone builder registers its one
+    /// scheduler.
+    /// </summary>
+    /// <remarks>
+    /// The default scheduler is not in <see cref="Names"/> and cannot be: it has no service key, and its
+    /// name is whatever its options end up saying rather than something the call site chose. So the flag
+    /// records that it exists, and its name is read from its options by whoever needs it — which is how
+    /// <see cref="ISchedulerRegistry"/> can list it beside the named ones.
+    /// </remarks>
+    public bool HasDefaultScheduler { get; private set; }
+
+    /// <summary>
     /// Returns the registry belonging to a service collection, registering one on first use.
     /// </summary>
     /// <remarks>
@@ -49,6 +62,19 @@ internal sealed class SchedulerNameRegistry
         }
 
         names.Add(name);
+    }
+
+    /// <summary>
+    /// Records that the default scheduler is registered.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not a duplicate check, unlike <see cref="Add"/>: registering the default scheduler is
+    /// additive — calling <c>AddQuartz()</c> twice contributes two sets of configuration to one scheduler
+    /// rather than registering a second — so saying so twice is not an error.
+    /// </remarks>
+    public void AddDefault()
+    {
+        HasDefaultScheduler = true;
     }
 
     /// <summary>

--- a/src/Quartz/Configuration/SharedDatabaseValidator.cs
+++ b/src/Quartz/Configuration/SharedDatabaseValidator.cs
@@ -1,0 +1,197 @@
+using System.Data.Common;
+using System.Security.Cryptography;
+using System.Text;
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// Reports two schedulers of one container that share a database and disagree about the table prefix.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The supported arrangement for tenants sharing a database is one table set and one prefix, with
+/// <c>SCHED_NAME</c> telling the tenants apart — every Quartz table has it as the first column of its
+/// primary key and every statement filters on it. Separate table sets in one database are legal, and
+/// occasionally deliberate for backup or permissions reasons, but a prefix that differs by *accident*
+/// produces the worst failure this area has: the misconfigured scheduler connects, passes
+/// <c>PerformSchemaValidation</c> against its own empty table set, starts, reports healthy, and fires
+/// nothing ever again.
+/// </para>
+/// <para>
+/// Schema validation is the natural neighbour and cannot see this — it asks whether the tables this
+/// store reads exist, and they do. Nor can the store: "another scheduler shares this database" is only
+/// knowable one level up, where the schedulers of a container are all visible. So the check lives here,
+/// and each scheduler records its arrangement as it is created; the first pair that disagrees is
+/// reported.
+/// </para>
+/// <para>
+/// It only ever warns. Deliberately separate table sets are a legitimate arrangement, and an error that
+/// fires on a legitimate arrangement is worse than the silence it replaces — so the message names both
+/// schedulers and both prefixes and lets the reader decide which of the two they meant.
+/// </para>
+/// </remarks>
+internal sealed class SharedDatabaseValidator
+{
+    private readonly ILogger<SharedDatabaseValidator> logger;
+    private readonly Lock syncRoot = new();
+
+    /// <summary>
+    /// The schedulers seen so far, grouped by the database they talk to. The key is an opaque identity —
+    /// a <see cref="DbDataSource"/> instance, or a hash of the connection string — never anything that
+    /// could be logged.
+    /// </summary>
+    private readonly Dictionary<object, List<Arrangement>> byDatabase = [];
+
+    public SharedDatabaseValidator(ILogger<SharedDatabaseValidator> logger)
+    {
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Records one scheduler's arrangement and reports it against the ones already recorded.
+    /// </summary>
+    /// <param name="schedulerName">The scheduler's name, as it will appear in <c>SCHED_NAME</c>.</param>
+    /// <param name="jobStore">
+    /// The scheduler's job store. Anything that is not a database store is ignored: an in-memory
+    /// scheduler shares no database with anybody.
+    /// </param>
+    public void Validate(string schedulerName, IJobStore jobStore)
+    {
+        try
+        {
+            Record(schedulerName, jobStore);
+        }
+        catch (Exception e)
+        {
+            // A diagnostic must never be the reason a scheduler fails to start. The one thing below that
+            // can throw is a job store of somebody else's answering for its connection details, and a
+            // provider that refuses to say could not have been compared with anything anyway.
+            logger.LogDebug(
+                e,
+                "The shared-database check could not read what database scheduler '{SchedulerName}' talks to.",
+                schedulerName);
+        }
+    }
+
+    private void Record(string schedulerName, IJobStore jobStore)
+    {
+        if (jobStore is not AdoJobStoreBase store)
+        {
+            return;
+        }
+
+        object? database = DatabaseIdentity(store.DbProvider);
+        if (database is null)
+        {
+            // Nothing identifies the database - a provider that keeps its connection details to itself.
+            // Guessing here is how a check like this starts firing on unrelated schedulers.
+            return;
+        }
+
+        Arrangement arrangement = new(schedulerName, store.DataSource, store.TablePrefix);
+        List<Arrangement> disagreeing;
+
+        lock (syncRoot)
+        {
+            if (!byDatabase.TryGetValue(database, out List<Arrangement>? sharing))
+            {
+                byDatabase[database] = [arrangement];
+                return;
+            }
+
+            // A scheduler that records itself twice is the same scheduler, not a second one sharing the
+            // database with itself.
+            sharing.RemoveAll(other => string.Equals(other.SchedulerName, schedulerName, StringComparison.OrdinalIgnoreCase));
+
+            // Prefixes are compared ignoring case because an unquoted identifier is folded to one case by
+            // every database Quartz supports, so 'qrtz_' and 'QRTZ_' are the same table set and reporting
+            // them would be a false positive.
+            disagreeing = sharing.FindAll(other =>
+                !string.Equals(other.TablePrefix, arrangement.TablePrefix, StringComparison.OrdinalIgnoreCase));
+
+            sharing.Add(arrangement);
+        }
+
+        foreach (Arrangement other in disagreeing)
+        {
+            logger.LogWarning(
+                "Scheduler '{SchedulerName}' (data source '{DataSource}', table prefix '{TablePrefix}') and scheduler "
+                + "'{OtherSchedulerName}' (data source '{OtherDataSource}', table prefix '{OtherTablePrefix}') use the same "
+                + "database with different table prefixes, so neither can see the other's rows. Schedulers sharing a database "
+                + "are normally told apart by SCHED_NAME and share one table prefix; separate table sets are legal, and if that "
+                + "is what you meant this warning is expected. If it is not, the scheduler with the wrong prefix starts cleanly, "
+                + "passes schema validation against the tables it was pointed at, and never sees its own data.",
+                arrangement.SchedulerName,
+                arrangement.DataSource,
+                arrangement.TablePrefix,
+                other.SchedulerName,
+                other.DataSource,
+                other.TablePrefix);
+        }
+    }
+
+    /// <summary>
+    /// What identifies the database a provider talks to, or <see langword="null"/> when nothing does.
+    /// </summary>
+    private static object? DatabaseIdentity(IDbProvider provider)
+    {
+        if (provider is DataSourceDbProvider dataSourceProvider)
+        {
+            // A DbDataSource holds its own connection details and reports no connection string here, so
+            // the data source object is the identity. Two schedulers pointed at one registered
+            // DbDataSource hold the same instance, which is exactly the arrangement this looks for.
+            return dataSourceProvider.DataSource;
+        }
+
+        string connectionString = provider.ConnectionString;
+        return string.IsNullOrWhiteSpace(connectionString) ? null : Fingerprint(connectionString);
+    }
+
+    /// <summary>
+    /// Reduces a connection string to a value that is equal for two strings describing the same
+    /// database, and that carries no credentials.
+    /// </summary>
+    /// <remarks>
+    /// Hashed rather than kept, because this dictionary lives as long as the container and a connection
+    /// string holds a password. The normalization before it only makes the check catch more true
+    /// positives — two strings spelling the same settings in a different order or case. Two strings that
+    /// reach the same database by different spellings of a *key* (<c>Server</c> against
+    /// <c>Data Source</c>) still fingerprint differently and simply go unreported, which is the right
+    /// direction to be wrong in.
+    /// </remarks>
+    private static string Fingerprint(string connectionString)
+    {
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Normalize(connectionString))));
+    }
+
+    private static string Normalize(string connectionString)
+    {
+        try
+        {
+            DbConnectionStringBuilder builder = new() { ConnectionString = connectionString };
+            List<string> pairs = new(builder.Count);
+            foreach (object key in builder.Keys)
+            {
+                string name = (string) key;
+                pairs.Add(name + "=" + builder[name]);
+            }
+
+            pairs.Sort(StringComparer.OrdinalIgnoreCase);
+            return string.Join(';', pairs).ToLowerInvariant();
+        }
+        catch (ArgumentException)
+        {
+            // Not a keyword/value connection string the builder can parse. It still identifies a
+            // database, so it is compared as written.
+            return connectionString.Trim().ToLowerInvariant();
+        }
+    }
+
+    private readonly record struct Arrangement(string SchedulerName, string DataSource, string TablePrefix);
+}

--- a/src/Quartz/ISchedulerRegistry.cs
+++ b/src/Quartz/ISchedulerRegistry.cs
@@ -1,0 +1,53 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// Lists the schedulers a container knows about, whether or not any of them has been created.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the read that distinguishes <em>registered</em> from <em>running</em>.
+/// <see cref="Extensibility.ISchedulerRepository" /> holds scheduler <em>instances</em>, so
+/// <c>LookupAll()</c> and <see cref="ISchedulerFactory.GetAllSchedulers" /> can only report the
+/// schedulers something already asked for — under a multi-tenant registration that means an operator
+/// cannot enumerate tenants without starting every one of them. This one reads the registrations, and
+/// says of each whether a scheduler exists behind it.
+/// </para>
+/// <para>
+/// Registered by <c>AddQuartz</c>, so any container with Quartz in it has one. It answers for the
+/// container it belongs to and no other; a second container in the same process has its own.
+/// </para>
+/// </remarks>
+public interface ISchedulerRegistry
+{
+    /// <summary>
+    /// Returns every scheduler this container has registered, plus every scheduler bound into its
+    /// repository that no registration accounts for, ordered by name.
+    /// </summary>
+    /// <remarks>
+    /// Nothing is created by asking: a registration that has never been resolved is reported with a
+    /// <see langword="null" /> <see cref="SchedulerRegistration.Status" /> rather than built.
+    /// </remarks>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask<List<SchedulerRegistration>> QuerySchedulers(CancellationToken cancellationToken = default);
+}

--- a/src/Quartz/Impl/AdoJobStore/Common/DataSourceDbProvider.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/DataSourceDbProvider.cs
@@ -21,6 +21,17 @@ internal sealed class DataSourceDbProvider : DbProvider
         this.source = source;
     }
 
+    /// <summary>
+    /// The data source connections come from.
+    /// </summary>
+    /// <remarks>
+    /// Read by the shared-database check, which uses the object itself as the identity of the database:
+    /// a data source keeps its connection details to itself, so <see cref="DbProvider.ConnectionString"/>
+    /// is empty here and cannot answer for it, while two schedulers pointed at one registered data source
+    /// hold the same instance.
+    /// </remarks>
+    internal DbDataSource DataSource => source;
+
     public override DbConnection CreateConnection()
     {
         return source.CreateConnection();

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -173,6 +173,10 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
 
             await resources.JobStore.Initialize(identity, cancellationToken).ConfigureAwait(false);
 
+            // After the store has validated its own schema, so a missing table is reported as the error
+            // it is before anything is said about how this scheduler's tables relate to a sibling's.
+            serviceProvider.GetRequiredService<SharedDatabaseValidator>().Validate(resources.Name, resources.JobStore);
+
             resources.JobRunShellFactory.Initialize(scheduler);
 
             foreach (var (name, plugin) in plugins)

--- a/src/Quartz/SchedulerOrigin.cs
+++ b/src/Quartz/SchedulerOrigin.cs
@@ -1,0 +1,42 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// Where a scheduler <see cref="ISchedulerRegistry.QuerySchedulers" /> reports came from.
+/// </summary>
+public enum SchedulerOrigin
+{
+    /// <summary>
+    /// Registered with the container by <c>AddQuartz()</c> or <c>AddQuartz(name, …)</c>. The container
+    /// holds its object graph, and the hosted service creates and starts it.
+    /// </summary>
+    Container = 0,
+
+    /// <summary>
+    /// Bound into the container's <see cref="Extensibility.ISchedulerRepository" /> rather than
+    /// registered as a scheduler of this container: a scheduler built by
+    /// <c>QuartzSchedulerBuilder</c> and made visible by hand, or a remote scheduler registered with
+    /// <c>AddQuartzHttpClient</c>. Nothing in the container owns its lifetime.
+    /// </summary>
+    Runtime = 1
+}

--- a/src/Quartz/SchedulerRegistration.cs
+++ b/src/Quartz/SchedulerRegistration.cs
@@ -32,9 +32,17 @@ namespace Quartz;
 /// </param>
 /// <param name="Origin">Where the scheduler came from.</param>
 /// <param name="Status">
-/// What state the scheduler is in, or <see langword="null" /> when no scheduler has been created under
-/// this name yet. Null is the answer this query exists to give: the registration is there, nothing has
-/// been built from it, and asking did not build it.
+/// What state the scheduler is in, or <see langword="null" /> when no scheduler exists under this name.
+/// Null is the answer this query exists to give: the registration is there, nothing has been built from
+/// it, and asking did not build it.
+/// <para>
+/// A scheduler that has been <em>shut down</em> also reads as null rather than as
+/// <see cref="SchedulerStatus.Shutdown" />, because
+/// <see cref="Extensibility.ISchedulerRepository" /> drops a shut-down scheduler as soon as a read
+/// notices it. So null means "no live scheduler under this name" — for a registration, either not yet or
+/// not any more. The two are not worth telling apart here: a shut-down scheduler cannot be created again
+/// within the same container, so neither is a name you can get a working scheduler out of.
+/// </para>
 /// </param>
 public sealed record SchedulerRegistration(string Name, SchedulerOrigin Origin, SchedulerStatus? Status)
 {

--- a/src/Quartz/SchedulerRegistration.cs
+++ b/src/Quartz/SchedulerRegistration.cs
@@ -1,0 +1,46 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// One scheduler a container knows about, as reported by
+/// <see cref="ISchedulerRegistry.QuerySchedulers" />.
+/// </summary>
+/// <param name="Name">
+/// The scheduler's name, spelled as it was registered. For a named registration this is the name
+/// <c>AddQuartz(name, …)</c> was given, which is also the service key and the options name; for the
+/// default scheduler it is its configured <see cref="QuartzSchedulerOptions.InstanceName" />.
+/// </param>
+/// <param name="Origin">Where the scheduler came from.</param>
+/// <param name="Status">
+/// What state the scheduler is in, or <see langword="null" /> when no scheduler has been created under
+/// this name yet. Null is the answer this query exists to give: the registration is there, nothing has
+/// been built from it, and asking did not build it.
+/// </param>
+public sealed record SchedulerRegistration(string Name, SchedulerOrigin Origin, SchedulerStatus? Status)
+{
+    /// <summary>
+    /// Whether a scheduler exists under this name. A registration nothing has resolved yet reports
+    /// <see langword="false" />; <see cref="Status" /> says what state a scheduler that does exist is in.
+    /// </summary>
+    public bool IsCreated => Status is not null;
+}


### PR DESCRIPTION
Two of the additive gaps from the multi-tenancy audit: **A8** (enumerate registered schedulers without
starting them) and **C2** (validate the shared-database arrangement). **A7 is deliberately not here** —
it is deferred to 4.1 beside #3338, per the scope comment on the issue.

## A8 — `ISchedulerRegistry.QuerySchedulers()`

`ISchedulerFactory.GetAllSchedulers()` reads `ISchedulerRepository`, and a repository holds *instances*,
so it lists only schedulers something has already created. Under a scheduler-per-tenant registration
that left no way to ask a container which tenants it knows about short of building every one of them.

```csharp
public interface ISchedulerRegistry
{
    ValueTask<List<SchedulerRegistration>> QuerySchedulers(CancellationToken cancellationToken = default);
}

public sealed record SchedulerRegistration(string Name, SchedulerOrigin Origin, SchedulerStatus? Status)
{
    public bool IsCreated { get; }   // Status is not null
}

public enum SchedulerOrigin { Container, Runtime }
```

- `Status` is `null` when no scheduler exists under that name, and asking does not build one — that is
  the registered-versus-running distinction the item exists for. When a scheduler *does* exist,
  the existing public `SchedulerStatus` (`Unknown`/`Running`/`Standby`/`Shutdown`) says which, so this
  introduces no second vocabulary for scheduler state.
- A scheduler that has been **shut down** also reads as `null`, not as `SchedulerStatus.Shutdown`:
  `ISchedulerRepository` drops a shut-down scheduler as soon as a read notices it, and there is no
  non-evicting read to ask instead. Null therefore means "no live scheduler under this name" — for a
  registration, either not yet or not any more. The two are not worth telling apart through this API,
  because a shut-down scheduler cannot be rebuilt in the same container, so neither is a name you can get
  a working scheduler out of. Said in the XML docs, in the multi-tenancy page, and pinned by a test.
- `Origin.Container` is an `AddQuartz` registration; `Origin.Runtime` is anything in the repository with
  no registration behind it — a `QuartzSchedulerBuilder` scheduler bound by hand, or a remote scheduler
  from `AddQuartzHttpClient`. Both values carry weight today rather than being reserved for later.
- The default scheduler is listed under its configured `InstanceName`, which is the one name that is not
  the name it was registered under. `SchedulerNameRegistry` grew a `HasDefaultScheduler` flag for that,
  set in `AddQuartzScheduler()` — the one call every road to a default scheduler passes through,
  including the standalone builder.

### The one deliberate divergence from the `Query*` family

`QuerySchedulers()` takes **no query record and returns a `List<T>`, not `PagedResult<T>`.** The verb and
the "record with named fields rather than bare strings" half of the family are kept; the paging is not.
Paging exists in `QueryJobs`/`QueryTriggers`/`QueryCalendarNames`/`QueryFireInstances` because a job store
holds an unbounded number of rows and materializing them all is the hazard. A container's registrations
are an in-memory list fixed when the container was built and bounded by the number of `AddQuartz` calls in
the program's source. A `PagedResult` whose `HasMore` is `false` forever would be ceremony that teaches
something untrue about the shape of the data.

It also matches the #3338 spike exactly, which proposes
`ValueTask<List<SchedulerRegistration>> QuerySchedulers(CancellationToken)` on the eventual
`ISchedulerManager` — so 4.1 inherits this rather than reconciling with it.

**Why a new interface rather than a member on `ISchedulerFactory`:** the spike's reasoning holds —
`ISchedulerFactory` is an extensibility point applications implement, and every added member breaks every
implementor. `ISchedulerRegistry` is deliberately the narrow half; 4.1's manager interface extends it.

## C2 — the shared-database check

**Where it lives, and why:** a container-level check, invoked from `DefaultSchedulerFactory.Create`
immediately after `IJobStore.Initialize` (so schema validation reports a missing table first). Each
ADO-backed scheduler records the database it talks to and its table prefix into a container singleton;
the first pair that shares a database and disagrees about the prefix is logged at `Warning`, naming both
schedulers and both prefixes.

**What it can see:** the schedulers of one container, as they are created, with their *effective*
connection string and prefix rather than their options.

**What it cannot:** two processes, or two containers in one process, sharing a database — that
information does not exist anywhere one component can read it. A scheduler that is registered and never
created is also not compared, which is fine: a scheduler that never starts cannot silently fire nothing.

**Why not a store-level probe.** The obvious one — "my table set has rows for other `SCHED_NAME`s and
none for mine" — fires on every legitimate first start of a new tenant, which is the most common path
through this code. It cannot distinguish a new tenant from a mis-prefixed one, so it would be a false
positive generator. Rejected rather than shipped alongside.

**False positives, and the one that is left.** Two schedulers deliberately using different prefixes in
one database *will* warn. That case is indistinguishable from the mistake by anything the process can
observe, so — as the issue asks — the output is a warning naming both schedulers and both prefixes, not
an error. It can be filtered on the `Quartz.Configuration.SharedDatabaseValidator` log category; there is
no configuration knob, deliberately.

Everything else errs towards silence:

- databases are compared by a SHA-256 of the connection string normalized through
  `DbConnectionStringBuilder` (so key order and casing do not matter), or by the `DbDataSource` instance
  when the provider keeps its connection details to itself. A provider that reports neither is recorded
  as nothing and never compared;
- the hash means the process does not retain a second copy of anybody's credentials, and the warning
  cannot print one;
- prefixes are compared ignoring case, because every database Quartz supports folds an unquoted
  identifier to one case;
- the whole check is wrapped: a custom `IDbProvider` that throws from `ConnectionString` produces a debug
  line, not a scheduler that fails to start. A diagnostic must never be the reason startup fails.

## For a reviewer to decide

1. **`ISchedulerRegistry` beside `ISchedulerRepository`.** Two similarly-named services with genuinely
   different jobs (registrations versus live instances). The XML docs and the multi-tenancy page draw the
   line, but if the pair reads as one concept too many, `ISchedulerCatalog` is the alternative name that
   was considered.
2. **`Runtime` as the name for "in the repository, not registered here".** It matches the spike, and it
   also covers `AddQuartzHttpClient` proxies, which *are* container-registered but not as Quartz
   schedulers. That is documented rather than special-cased.
3. **The `List<T>`-not-`PagedResult<T>` divergence** argued above.

## Left alone on purpose

- **The HTTP API and the dashboard still list live schedulers only.** Both read `ISchedulerRepository`,
  and surfacing registrations there would change the HTTP contract. Out of scope for an additive item.
- **D1, D3, D4** from #3340 are untouched.
- **`docs/documentation/quartz-3.x/`** is untouched.

## Verification

`dotnet build Quartz.slnx` — succeeded, 0 warnings, 0 errors.

| suite | result |
|---|---|
| `Quartz.Tests.Unit` | Passed — 2944 passed, 4 skipped, 0 failed |
| `Quartz.Tests.AspNetCore` | Passed — 312 passed, 0 failed |
| `Quartz.Tests.Integration` | Passed — 297 passed, 0 failed (6 m 55 s) |

The integration suite ran for real against containers — SQL Server 2017 and 2022, PostgreSQL, MySQL,
Oracle XE and Firebird — which matters here, because it is what exercises
`DefaultSchedulerFactory.Create` against actual databases, and that is where the C2 check was inserted.
Sonar's coverage figure is computed from unit tests only, and it reports **0 uncovered new lines** out of
104 lines to cover, so nothing added here is reachable only from an integration test.

Each commit builds and passes the unit suite on its own. CI is green on all 15 checks, and the SonarCloud
quality gate reports `OK` — A on all three new-code ratings, 99.3% new-code coverage, 0.0% duplication.

`src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt` moved by exactly the three new public
types and nothing else; regenerated through Verify, and the same delta is in
`docs/documentation/quartz-4.x/migration-guide.md`.

Addresses **A8** and **C2** of #3340. A7, D1, D3 and D4 are untouched, so that issue stays open — no
closing keyword here on purpose.
