### PR TITLE
Every packable project ships a readme written for nuget.org

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -11,6 +11,10 @@ on:
       # the compiled samples the documentation shows, and the target that injects them
       - 'src/Quartz.Documentation.Samples/**'
       - 'build/**'
+      # the package readmes carry the same snippet markers, so they go stale the same way. Only the
+      # pull request job: they are not site content, so a readme alone must not trigger a deploy that
+      # would then find nothing to commit.
+      - 'src/*/README.md'
 permissions:
   contents: read
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,12 @@ plus a bridge entry on main.
   blocks deliberately left as plain fences, are written up in `CONTRIBUTING.md` under "Code samples in
   the documentation". Pages outside `docs/documentation/quartz-4.x/packages/` still carry hand-written
   fences; converting one is welcome, converting it halfway is not.
+- **A package's readme is `src/<Project>/README.md`, never a documentation page.** That file is what
+  nuget.org renders, and nuget.org renders CommonMark with none of VuePress's extensions — frontmatter
+  becomes a horizontal rule and a literal `title:`, a `::: tip` becomes literal text, a relative link
+  404s. `PackageReadmeTest` fails on each of those, on a packable project with no readme, and on a csproj
+  that packs anything out of `docs/`. The readmes carry the same `<!-- snippet: … -->` markers as the
+  documentation, so keep them short and let the site hold the prose.
 - **`src/Quartz.Tests.Unit/Verify/PublicApiTest_*.verified.txt` are the public API baselines.**
   Any change to public API fails those tests; review the diff, and if the change is intended,
   accept the new baseline and carry the same diff into

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,20 @@ The documentation website is built and published from this **`main`** branch. Al
 
 The published Quartz 3.x package pages under `docs/documentation/quartz-3.x/packages/` are mirrored, in compact NuGet-rendered form, by the per-package `src/<Project>/README.md` files on the `3.x` branch (which are packed into the NuGet packages). When you change one, update the other in a companion PR so the published page and the shipped package README stay consistent.
 
+### Package readmes
+
+Every packable project carries its own `src/<Project>/README.md`. That file is what `dotnet pack` puts in
+the `.nupkg` and what nuget.org renders on the package page, and it is deliberately **not** a
+documentation page: nuget.org renders CommonMark with none of VuePress's extensions, so frontmatter comes
+out as a horizontal rule followed by a literal `title:`, a `::: tip` container comes out as literal text,
+and a relative link 404s. `PackageReadmeTest` fails on all three, on a missing or undeclared readme, and
+on a csproj that packs anything out of `docs/`.
+
+Keep them short — what the package is, how to install it, the smallest useful example, and absolute links
+to the documentation site, which is where longer prose belongs. Their code samples come from the same
+compiled-snippet mechanism as the documentation pages, described below, so a readme carries snippet
+markers rather than typed C#.
+
 ### Building the site
 
 `npm ci` then `npm run docs:build`. `npm ci` runs `postinstall`, which is `patch-package`, which applies
@@ -69,7 +83,8 @@ Then put a marker pair where the fenced block would have gone:
 
 and run `npm run docs:snippets` (or `dotnet fallout DocsSnippets`) to fill it in. Commit the filled-in
 markdown: it is what GitHub and the published site both render, and reviewing the generated code is
-half the point.
+half the point. The same markers work in the package readmes under `src/<Project>/README.md`, which are
+processed by the same target.
 
 A few things worth knowing:
 

--- a/build/Build.Docs.Snippets.cs
+++ b/build/Build.Docs.Snippets.cs
@@ -31,6 +31,11 @@ using Serilog;
 /// takes the directory predicates as parameters, so they are spelled out below instead.
 /// </para>
 /// <para>
+/// The per-package <c>src/&lt;Package&gt;/README.md</c> files nuget.org shows are processed alongside the
+/// documentation. A sample on a package page is the first code a new user meets, so it is the last place
+/// that should be allowed to rot.
+/// </para>
+/// <para>
 /// Three things fail rather than warn: a marker naming a snippet that does not exist, a marker that came
 /// out empty (which is how a skipped directory would show up), and markdown that does not match what the
 /// samples currently say. The last one is why <see cref="VerifyDocsSnippets" /> exists — the upstream tool
@@ -43,6 +48,11 @@ public partial class Build
     AbsolutePath DocsDirectory => RootDirectory / "docs";
 
     AbsolutePath DocumentationSamplesDirectory => SourceDirectory / "Quartz.Documentation.Samples";
+
+    /// <summary>
+    /// The readmes nuget.org renders on the package pages. One per packable project, beside its csproj.
+    /// </summary>
+    IEnumerable<AbsolutePath> PackageReadmeFiles => SourceDirectory.GlobFiles("*/README.md");
 
     /// <summary>
     /// Markdown trees that are frozen at the names their release shipped with, or are not documentation.
@@ -84,6 +94,7 @@ public partial class Build
         var markdownFiles = DocsDirectory
             .GlobFiles("**/*.md")
             .Where(x => !IsExcludedMarkdown(x))
+            .Concat(PackageReadmeFiles)
             .ToList();
 
         var before = markdownFiles.ToDictionary(x => x.ToString(), x => File.ReadAllText(x), StringComparer.Ordinal);
@@ -92,7 +103,7 @@ public partial class Build
             RootDirectory,
             appendSnippets: AppendSnippet,
             directoryIncludes: ShouldTraverse,
-            markdownDirectoryIncludes: IsDocumentationDirectory,
+            markdownDirectoryIncludes: HoldsProcessedMarkdown,
             snippetDirectoryIncludes: IsSampleDirectory,
             convention: DocumentConvention.InPlaceOverwrite,
             log: x => Log.Debug("{Message}", x),
@@ -182,8 +193,18 @@ public partial class Build
     static bool ShouldTraverse(string path) =>
         !TraversalExclusions.Contains(Path.GetFileName(path), StringComparer.OrdinalIgnoreCase);
 
+    bool HoldsProcessedMarkdown(string path) =>
+        IsDocumentationDirectory(path) || IsPackageDirectory(path);
+
     bool IsDocumentationDirectory(string path) =>
         IsUnder(path, DocsDirectory) && !IsExcludedMarkdown(path);
+
+    /// <summary>
+    /// A project directory directly under <c>src</c>, which is where a package's own README.md sits.
+    /// Deeper directories are left out on purpose: nothing else under <c>src</c> is published markdown.
+    /// </summary>
+    bool IsPackageDirectory(string path) =>
+        NormalizePath(Path.GetDirectoryName(path) ?? "").Equals(NormalizePath(SourceDirectory), StringComparison.OrdinalIgnoreCase);
 
     bool IsSampleDirectory(string path) => IsUnder(path, DocumentationSamplesDirectory);
 

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -6,11 +6,11 @@
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Lewis Zou, Marko Lahma, Quartz.NET</Authors>
-    <PackageReadmeFile>aspnet-core-integration.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../docs/documentation/quartz-4.x/packages/aspnet-core-integration.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.AspNetCore/README.md
+++ b/src/Quartz.AspNetCore/README.md
@@ -1,0 +1,45 @@
+# Quartz.AspNetCore
+
+[Quartz.AspNetCore](https://www.nuget.org/packages/Quartz.AspNetCore) adds the two things a Quartz.NET
+scheduler wants from an ASP.NET Core application: an
+[HTTP API](https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/http-api.html) that exposes
+scheduler management endpoints, and a
+[health check](https://learn.microsoft.com/aspnet/core/host-and-deploy/health-checks) that reports
+unhealthy when the scheduler is not running or cannot reach its store.
+
+Hosting itself is in the core [Quartz](https://www.nuget.org/packages/Quartz) package — `AddQuartz` and
+`AddQuartzHostedService` need no extra reference. Quartz 3's `AddQuartzServer`, which registered the
+hosted service and a health check together, is gone.
+
+## Installation
+
+```shell
+dotnet add package Quartz.AspNetCore
+```
+
+## Usage
+
+<!-- snippet: sample_readme_aspnetcore -->
+```csharp
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.AddQuartz(q => q.AddQuartzHttpApi());
+builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+builder.Services.AddHealthChecks().AddQuartz();
+
+WebApplication app = builder.Build();
+
+app.MapQuartzHttpApi().RequireAuthorization();
+app.MapHealthChecks("/healthz");
+```
+<!-- endSnippet -->
+
+The API manages jobs and triggers, so authorize it: `MapQuartzHttpApi` returns the endpoint convention
+builder to say so on. The health check takes tags, so it can be filtered into separate liveness and
+readiness probes, and a named scheduler gets a check of its own.
+
+## Documentation
+
+- [ASP.NET Core integration](https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/aspnet-core-integration.html)
+- [HTTP API](https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/http-api.html)
+- [Quartz.NET documentation](https://www.quartz-scheduler.net/documentation/quartz-4.x/)

--- a/src/Quartz.Dashboard/Quartz.Dashboard.csproj
+++ b/src/Quartz.Dashboard/Quartz.Dashboard.csproj
@@ -5,12 +5,12 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz.Dashboard</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <PackageReadmeFile>dashboard.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>$(NoWarn);IL2110;IL2111</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../docs/documentation/quartz-4.x/packages/dashboard.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Dashboard/README.md
+++ b/src/Quartz.Dashboard/README.md
@@ -1,0 +1,49 @@
+# Quartz.Dashboard
+
+[Quartz.Dashboard](https://www.nuget.org/packages/Quartz.Dashboard) is a Blazor dashboard for
+Quartz.NET that runs inside your ASP.NET Core application and drives the scheduler through the Quartz
+[HTTP API](https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/http-api.html).
+
+**The dashboard is a work in progress and its API surface may change between releases.**
+
+## Installation
+
+The API it reads ships in `Quartz.AspNetCore`, which this package brings along, so one reference is
+enough:
+
+```shell
+dotnet add package Quartz.Dashboard
+```
+
+## Usage
+
+<!-- snippet: sample_readme_dashboard -->
+```csharp
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.AddQuartz(q => q.AddQuartzHttpApi());
+builder.Services.AddQuartzDashboard();
+builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+WebApplication app = builder.Build();
+
+app.UseAntiforgery();
+app.MapQuartzHttpApi();
+app.MapQuartzDashboard();
+```
+<!-- endSnippet -->
+
+The UI is then at `/quartz`. `MapQuartzDashboard("/ops/quartz")` serves it somewhere else — pages,
+assets and the Blazor circuit all move with it — and `AddQuartzDashboard(options => …)` takes an
+authorization policy, which is what a deployment reachable by anyone but you needs.
+
+Execution-history views stay empty until the scheduler records history: add
+`q.UseJobHistoryLogging()` and `q.UseTriggerHistoryLogging()` from
+[Quartz.Plugins](https://www.nuget.org/packages/Quartz.Plugins).
+
+## Documentation
+
+The full guide covers custom paths and reverse proxies, authorization, integrating into an existing
+Blazor application, and production hardening:
+
+<https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/dashboard.html>

--- a/src/Quartz.Documentation.Samples/PackageReadmeSamples.cs
+++ b/src/Quartz.Documentation.Samples/PackageReadmeSamples.cs
@@ -1,0 +1,204 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Jobs;
+
+namespace Quartz.Documentation.Samples;
+
+/// <summary>
+/// The code the per-package readmes show — <c>src/&lt;Package&gt;/README.md</c>, which is what nuget.org
+/// renders on a package page.
+/// </summary>
+/// <remarks>
+/// Deliberately separate from the samples under <c>Packages</c>, which belong to the documentation pages:
+/// a readme is a shop window and wants the shortest thing that works, where a page wants the whole story.
+/// Both are compiled here, so neither can outlive the API it names — and a broken sample on nuget.org is
+/// the first thing a new user meets.
+/// </remarks>
+public static class PackageReadmeSamples
+{
+    public static class Core
+    {
+        #region sample_readme_quartz_job
+
+        public sealed class HelloJob : IJob
+        {
+            public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                await Console.Out.WriteLineAsync("Greetings from HelloJob!");
+            }
+        }
+
+        #endregion
+
+        public static void UnderAHost(string[] args)
+        {
+            #region sample_readme_quartz_host
+
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+            builder.AddQuartz(q => q.ScheduleJob<HelloJob>(trigger => trigger
+                .WithIdentity("hello")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever())));
+
+            builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+            #endregion
+        }
+
+        public static async ValueTask WithoutAHost()
+        {
+            #region sample_readme_quartz_standalone
+
+            IScheduler scheduler = await QuartzSchedulerBuilder.Create().BuildScheduler();
+            await scheduler.Start();
+
+            #endregion
+        }
+    }
+
+    public static class AspNetCore
+    {
+        public static void Registration(string[] args)
+        {
+            #region sample_readme_aspnetcore
+
+            WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+            builder.AddQuartz(q => q.AddQuartzHttpApi());
+            builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+            builder.Services.AddHealthChecks().AddQuartz();
+
+            WebApplication app = builder.Build();
+
+            app.MapQuartzHttpApi().RequireAuthorization();
+            app.MapHealthChecks("/healthz");
+
+            #endregion
+        }
+    }
+
+    public static class Dashboard
+    {
+        public static void Registration(string[] args)
+        {
+            #region sample_readme_dashboard
+
+            WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+            builder.AddQuartz(q => q.AddQuartzHttpApi());
+            builder.Services.AddQuartzDashboard();
+            builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+            WebApplication app = builder.Build();
+
+            app.UseAntiforgery();
+            app.MapQuartzHttpApi();
+            app.MapQuartzDashboard();
+
+            #endregion
+        }
+    }
+
+    public static class Redis
+    {
+        public static void LockHandler(IHostApplicationBuilder builder, string connectionString)
+        {
+            #region sample_readme_redis
+
+            builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer(connectionString);
+                store.UseClustering();
+
+                // job and trigger data stays in the database; only the locks move to Redis
+                store.UseRedisLockHandler(redis => redis.RedisConfiguration = "redis-server:6379");
+            }));
+
+            #endregion
+        }
+    }
+
+    public static class HttpClient
+    {
+        public static void Registration(IHostApplicationBuilder builder)
+        {
+            #region sample_readme_httpclient
+
+            builder.Services.AddHttpClient("quartz", client =>
+                client.BaseAddress = new Uri("https://scheduler.example.com/quartz-api/"));
+
+            builder.Services.AddQuartzHttpClient(schedulerName: "MyScheduler", httpClientName: "quartz");
+
+            #endregion
+        }
+    }
+
+    public static class Jobs
+    {
+        public static void SendMail(IHostApplicationBuilder builder)
+        {
+            #region sample_readme_jobs
+
+            builder.Services.AddQuartz(q => q.ScheduleJob<SendMailJob>(
+                trigger => trigger.WithIdentity("nightlyDigest").WithCronSchedule("0 0 6 * * ?"),
+                job => job.UsingSendMailOptions(new SendMailOptions
+                {
+                    SmtpHost = "smtp.example.com",
+                    Sender = "scheduler@example.com",
+                    Recipient = "ops@example.com",
+                    Subject = "Nightly digest",
+                    Message = "Everything ran.",
+                })));
+
+            #endregion
+        }
+    }
+
+    public static class Plugins
+    {
+        public static void Registration(IHostApplicationBuilder builder)
+        {
+            #region sample_readme_plugins
+
+            builder.Services.AddQuartz(q =>
+            {
+                q.UseStructuredJobLogging();
+                q.UseStructuredTriggerLogging();
+                q.UseJobAutoInterrupt(options => options.DefaultMaxRunTime = TimeSpan.FromMinutes(5));
+            });
+
+            #endregion
+        }
+    }
+
+    public static class TimeZoneConverter
+    {
+        public static void Registration(IHostApplicationBuilder builder)
+        {
+            #region sample_readme_timezoneconverter
+
+            builder.Services.AddQuartz(q => q.UseTimeZoneConverter());
+
+            #endregion
+        }
+    }
+
+    public static class Newtonsoft
+    {
+        public static void Registration(IHostApplicationBuilder builder, string connectionString)
+        {
+            #region sample_readme_newtonsoft
+
+            builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer(connectionString);
+                store.Configure(options => options.StoreJobDataAsStrings = true);
+                store.UseNewtonsoftJsonSerializer();
+            }));
+
+            #endregion
+        }
+    }
+}

--- a/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
+++ b/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
@@ -6,11 +6,11 @@
     <Title>Quartz.NET Redis Integration</Title>
     <Description>Quartz.NET Redis integration - distributed lock handler for clustered scheduling; $(Description)</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <PackageReadmeFile>redis.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../docs/documentation/quartz-4.x/packages/redis.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Extensions.Redis/README.md
+++ b/src/Quartz.Extensions.Redis/README.md
@@ -1,0 +1,40 @@
+# Quartz.Extensions.Redis
+
+[Quartz.Extensions.Redis](https://www.nuget.org/packages/Quartz.Extensions.Redis) provides a Redis-based
+distributed lock handler that replaces the database row locks a clustered Quartz.NET scheduler otherwise
+coordinates trigger acquisition with.
+
+The default handler takes `SELECT ... FOR UPDATE` locks on the `QRTZ_LOCKS` table. Under heavy
+scheduling load that shows up as deadlocks, lock-wait timeouts and contention on one row. This handler
+uses Redis `SET NX PX` instead; job and trigger data stays where it was.
+
+## Installation
+
+```shell
+dotnet add package Quartz.Extensions.Redis
+```
+
+## Usage
+
+<!-- snippet: sample_readme_redis -->
+```csharp
+builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer(connectionString);
+    store.UseClustering();
+
+    // job and trigger data stays in the database; only the locks move to Redis
+    store.UseRedisLockHandler(redis => redis.RedisConfiguration = "redis-server:6379");
+}));
+```
+<!-- endSnippet -->
+
+`UseRedisLockHandler` hangs off the same store configurator with or without a host, and the flat
+`quartz.jobStore.lockHandler.*` keys configure the same handler. `RedisLockHandlerOptions` carries the
+connection string, the key prefix (`quartz:lock:`), the lock time to live (30 seconds) and the retry
+interval (100 milliseconds); the scheduler name that namespaces the keys comes from the job store, not
+from you.
+
+## Documentation
+
+<https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/redis.html>

--- a/src/Quartz.HttpClient/Quartz.HttpClient.csproj
+++ b/src/Quartz.HttpClient/Quartz.HttpClient.csproj
@@ -5,7 +5,12 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/src/Quartz.HttpClient/README.md
+++ b/src/Quartz.HttpClient/README.md
@@ -1,0 +1,43 @@
+# Quartz.HttpClient
+
+[Quartz.HttpClient](https://www.nuget.org/packages/Quartz.HttpClient) is the client half of the Quartz
+[HTTP API](https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/http-api.html).
+`HttpScheduler` is a full `IScheduler` implementation whose calls go over the wire, so an operator
+process, a control panel or a deployment script schedules jobs against a remote scheduler with the same
+code it would use against a local one.
+
+## Installation
+
+```shell
+dotnet add package Quartz.HttpClient
+```
+
+The server has to be running the HTTP API, which ships in
+[Quartz.AspNetCore](https://www.nuget.org/packages/Quartz.AspNetCore).
+
+## Usage
+
+<!-- snippet: sample_readme_httpclient -->
+```csharp
+builder.Services.AddHttpClient("quartz", client =>
+    client.BaseAddress = new Uri("https://scheduler.example.com/quartz-api/"));
+
+builder.Services.AddQuartzHttpClient(schedulerName: "MyScheduler", httpClientName: "quartz");
+```
+<!-- endSnippet -->
+
+`IScheduler` is then injectable like any local one — keyed by scheduler name, and unkeyed while it is
+the only scheduler in the container. `new HttpScheduler(name, httpClient)` does the same without a
+container.
+
+Two things must line up: the base address plus the API path have to reach the endpoints, and the name
+the client is registered with has to be the remote scheduler's own `SchedulerName` — a mismatch is a
+`404`, not a connection error. The base address must end in `/`.
+
+Listeners are not remotable; they run where jobs run. And the property members of `IScheduler`
+(`IsStarted`, `InStandbyMode`, `Context`, …) each block the calling thread for a round trip, so use
+`GetMetadata()` on a request path.
+
+## Documentation
+
+<https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/http-client.html>

--- a/src/Quartz.Jobs/Quartz.Jobs.csproj
+++ b/src/Quartz.Jobs/Quartz.Jobs.csproj
@@ -5,11 +5,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <PackageReadmeFile>quartz-jobs.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../docs/documentation/quartz-4.x/packages/quartz-jobs.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Jobs/README.md
+++ b/src/Quartz.Jobs/README.md
@@ -1,0 +1,50 @@
+# Quartz.Jobs
+
+[Quartz.Jobs](https://www.nuget.org/packages/Quartz.Jobs) provides ready-made jobs for the things
+schedules are most often asked to do.
+
+| Job | What it does |
+|---|---|
+| `DirectoryScanJob` | watches a directory and calls an `IDirectoryScanListener` when files are added, changed or deleted |
+| `FileScanJob` | watches a single file and calls an `IFileScanListener` when it changes |
+| `NativeJob` | runs a native executable in a separate process |
+| `SendMailJob` | sends an e-mail with configured content to a configured recipient |
+
+## Installation
+
+```shell
+dotnet add package Quartz.Jobs
+```
+
+## Usage
+
+Each job reads its settings from its `JobDataMap`. Those keys are the persisted form, so each job also
+has an options type that writes exactly them — the key cannot be misspelled and the value cannot be of
+the wrong type:
+
+<!-- snippet: sample_readme_jobs -->
+```csharp
+builder.Services.AddQuartz(q => q.ScheduleJob<SendMailJob>(
+    trigger => trigger.WithIdentity("nightlyDigest").WithCronSchedule("0 0 6 * * ?"),
+    job => job.UsingSendMailOptions(new SendMailOptions
+    {
+        SmtpHost = "smtp.example.com",
+        Sender = "scheduler@example.com",
+        Recipient = "ops@example.com",
+        Subject = "Nightly digest",
+        Message = "Everything ran.",
+    })));
+```
+<!-- endSnippet -->
+
+`UsingDirectoryScanOptions`, `UsingFileScanOptions` and `UsingNativeJobOptions` are the same thing for
+the other three, and all of them work on `JobBuilder.Create<TJob>()` as well as on the configurator
+`AddJob<TJob>(…)` hands you.
+
+These jobs live in the `Quartz.Jobs` namespace. In Quartz 3 it was the singular `Quartz.Job`; a
+configuration string or a stored `JOB_CLASS_NAME` naming the old spelling still resolves, with a
+warning.
+
+## Documentation
+
+<https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/quartz-jobs.html>

--- a/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
+++ b/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
@@ -7,11 +7,11 @@
     <Description>Quartz.NET TimeZoneConverter integration https://github.com/mj1856/TimeZoneConverter; $(Description)</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Sean Farrow, Quartz.NET</Authors>
-    <PackageReadmeFile>timezoneconverter-integration.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../docs/documentation/quartz-4.x/packages/timezoneconverter-integration.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Plugins.TimeZoneConverter/README.md
+++ b/src/Quartz.Plugins.TimeZoneConverter/README.md
@@ -1,0 +1,36 @@
+# Quartz.Plugins.TimeZoneConverter
+
+[Quartz.Plugins.TimeZoneConverter](https://www.nuget.org/packages/Quartz.Plugins.TimeZoneConverter)
+plugs [TimeZoneConverter](https://github.com/mj1856/TimeZoneConverter) into Quartz.NET's time zone
+lookup, so that both Windows ids (`Central America Standard Time`) and IANA ids
+(`America/Guatemala`) resolve on either operating system.
+
+Every trigger that names a time zone names it by id, and `TimeZoneInfo.FindSystemTimeZoneById` answers
+with whatever ids the machine happens to know. A schedule written on Windows and run on Linux therefore
+throws `TimeZoneNotFoundException` where the trigger is built or read back — and a schedule kept in a
+database is exactly the one that gets moved between them.
+
+## Installation
+
+```shell
+dotnet add package Quartz.Plugins.TimeZoneConverter
+```
+
+## Usage
+
+<!-- snippet: sample_readme_timezoneconverter -->
+```csharp
+builder.Services.AddQuartz(q => q.UseTimeZoneConverter());
+```
+<!-- endSnippet -->
+
+`UseTimeZoneConverter` hangs off `IQuartzBuilder`, so the same call configures a scheduler built
+without a host. The flat key `quartz.plugin.timeZoneConverter.type` does the same from configuration.
+
+Adding the plugin registers a resolver with `Quartz.TimeZones`, which is what Quartz's own lookups go
+through: both spellings then resolve everywhere, and a stored trigger keeps firing after its scheduler
+moves host.
+
+## Documentation
+
+<https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/timezoneconverter-integration.html>

--- a/src/Quartz.Plugins/Quartz.Plugins.csproj
+++ b/src/Quartz.Plugins/Quartz.Plugins.csproj
@@ -5,11 +5,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <PackageReadmeFile>quartz-plugins.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../docs/documentation/quartz-4.x/packages/quartz-plugins.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Plugins/README.md
+++ b/src/Quartz.Plugins/README.md
@@ -1,0 +1,46 @@
+# Quartz.Plugins
+
+[Quartz.Plugins](https://www.nuget.org/packages/Quartz.Plugins) provides ready-made
+`ISchedulerPlugin` implementations: logging a history of job and trigger events, loading jobs and
+triggers from a file at startup, interrupting jobs that overrun, and shutting the scheduler down
+cleanly when the process exits.
+
+| Plugin | Extension |
+|---|---|
+| `StructuredLoggingJobHistoryPlugin` / `StructuredLoggingTriggerHistoryPlugin` | `UseStructuredJobLogging(…)` / `UseStructuredTriggerLogging(…)` |
+| `LoggingJobHistoryPlugin` / `LoggingTriggerHistoryPlugin` | `UseJobHistoryLogging(…)` / `UseTriggerHistoryLogging(…)` |
+| `XmlSchedulingDataProcessorPlugin` / `JsonSchedulingDataProcessorPlugin` | `UseXmlSchedulingConfiguration(…)` / `UseJsonSchedulingConfiguration(…)` |
+| `JobInterruptMonitorPlugin` | `UseJobAutoInterrupt(…)` |
+| `ShutdownHookPlugin` | `UseShutdownHook(…)` |
+
+## Installation
+
+```shell
+dotnet add package Quartz.Plugins
+```
+
+## Usage
+
+The extensions hang off `IQuartzBuilder`, so the same calls configure a scheduler with or without a
+host:
+
+<!-- snippet: sample_readme_plugins -->
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    q.UseStructuredJobLogging();
+    q.UseStructuredTriggerLogging();
+    q.UseJobAutoInterrupt(options => options.DefaultMaxRunTime = TimeSpan.FromMinutes(5));
+});
+```
+<!-- endSnippet -->
+
+The flat `quartz.plugin.{name}.{property}` keys Quartz 3 used still work and mean the same thing, and
+`AddPlugin<TPlugin>()` registers a plugin of your own so the container constructs it.
+
+These plugins live in the `Quartz.Plugins.*` namespaces. In Quartz 3 they were the singular
+`Quartz.Plugin.*`; a `quartz.plugin.<name>.type` naming the old spelling still resolves, with a warning.
+
+## Documentation
+
+<https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/quartz-plugins.html>

--- a/src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj
+++ b/src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj
@@ -6,11 +6,11 @@
     <Title>Quartz.NET JSON Serialization</Title>
     <Description>Quartz.NET JSON Serialization Support; $(Description)</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <PackageReadmeFile>json-serialization.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../docs/documentation/quartz-4.x/packages/json-serialization.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Serialization.Newtonsoft/README.md
+++ b/src/Quartz.Serialization.Newtonsoft/README.md
@@ -1,0 +1,39 @@
+# Quartz.Serialization.Newtonsoft
+
+[Quartz.Serialization.Newtonsoft](https://www.nuget.org/packages/Quartz.Serialization.Newtonsoft)
+serializes what a Quartz.NET ADO.NET job store persists — job data maps, calendars and trigger state —
+with [Json.NET](https://www.newtonsoft.com/json).
+
+System.Text.Json serialization is built into the core
+[Quartz](https://www.nuget.org/packages/Quartz) package and is the default, so reach for this one when
+what is already in your database was written by Json.NET, or when your job data depends on how Json.NET
+handles it. It is the successor to Quartz 3's `Quartz.Serialization.Json`.
+
+## Installation
+
+```shell
+dotnet add package Quartz.Serialization.Newtonsoft
+```
+
+## Usage
+
+<!-- snippet: sample_readme_newtonsoft -->
+```csharp
+builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer(connectionString);
+    store.Configure(options => options.StoreJobDataAsStrings = true);
+    store.UseNewtonsoftJsonSerializer();
+}));
+```
+<!-- endSnippet -->
+
+The same `UseNewtonsoftJsonSerializer` call configures a store built without a host, and the flat key
+`quartz.serializer.type = newtonsoft` selects it from configuration.
+
+`StoreJobDataAsStrings` is worth setting whichever serializer you use: it keeps job data out of the
+serializer altogether, which is what avoids surprises when a persisted type later changes shape.
+
+## Documentation
+
+<https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/json-serialization.html>

--- a/src/Quartz.Tests.Unit/PackageReadmeTest.cs
+++ b/src/Quartz.Tests.Unit/PackageReadmeTest.cs
@@ -1,0 +1,147 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// What nuget.org shows on a package page.
+/// </summary>
+/// <remarks>
+/// Every packable project carries its own <c>README.md</c>. They used to pack a VuePress documentation
+/// page instead, and nuget.org renders CommonMark with none of VuePress's extensions: the frontmatter
+/// came out as a horizontal rule followed by <c>title:</c>, every <c>::: tip</c> container came out as
+/// literal text, and every relative link 404'd (#3370). Nothing failed, because nothing looked.
+/// </remarks>
+public class PackageReadmeTest
+{
+    private const string ReadmeFileName = "README.md";
+
+    /// <summary>
+    /// Inline link destinations — <c>[text](destination)</c>, and the image form.
+    /// </summary>
+    private static readonly Regex InlineLink = new(@"\]\((?<destination>[^)\s]+)", RegexOptions.None, TimeSpan.FromSeconds(5));
+
+    /// <summary>
+    /// Fenced code blocks, which are sample code rather than prose and are not scanned for links.
+    /// </summary>
+    private static readonly Regex FencedCode = new("^```.*?^```", RegexOptions.Multiline | RegexOptions.Singleline, TimeSpan.FromSeconds(5));
+
+    [TestCaseSource(nameof(PackableProjects))]
+    public void PackableProjectDeclaresItsOwnReadme(FileInfo project)
+    {
+        XDocument document = XDocument.Load(project.FullName);
+
+        string declared = document.Descendants("PackageReadmeFile").Select(x => x.Value.Trim()).SingleOrDefault();
+        declared.Should().Be(ReadmeFileName,
+            $"{project.Name} is packable, and a package with no readme shows an empty page on nuget.org");
+
+        FileInfo readme = new(Path.Combine(project.DirectoryName!, ReadmeFileName));
+        readme.Exists.Should().BeTrue($"{project.Name} declares {ReadmeFileName} as its package readme");
+
+        XElement packed = document
+            .Descendants("None")
+            .SingleOrDefault(x => string.Equals((string) x.Attribute("Include"), ReadmeFileName, StringComparison.Ordinal));
+
+        packed.Should().NotBeNull(
+            $"declaring PackageReadmeFile does not pack the file, so {project.Name} also needs a None item for it");
+        ((string) packed.Attribute("Pack")).Should().Be("true", "otherwise the file is not in the package at all");
+        ((string) packed.Attribute("PackagePath")).Should().NotBeNullOrEmpty(
+            "the readme has to land at the package root, where PackageReadmeFile looks for it");
+    }
+
+    [TestCaseSource(nameof(PackableProjects))]
+    public void PackableProjectDoesNotPackADocumentationPage(FileInfo project)
+    {
+        IEnumerable<string> packedFromDocs = XDocument.Load(project.FullName)
+            .Descendants()
+            .Where(x => x.Name.LocalName is "None" or "Content")
+            .Where(x => string.Equals((string) x.Attribute("Pack"), "true", StringComparison.OrdinalIgnoreCase))
+            .Select(x => (string) x.Attribute("Include"))
+            .Where(x => x is not null && x.Replace('\\', '/').Contains("docs/", StringComparison.OrdinalIgnoreCase));
+
+        packedFromDocs.Should().BeEmpty(
+            $"{project.Name} must not ship a documentation page as package content — the docs site renders VuePress markup and nuget.org does not");
+    }
+
+    [TestCaseSource(nameof(PackageReadmes))]
+    public void ReadmeHasNoFrontMatter(FileInfo readme)
+    {
+        File.ReadAllText(readme.FullName).Should().StartWith("# ",
+            $"{readme.Directory!.Name}'s readme opens the nuget.org page, and a leading '---' renders there as a horizontal rule followed by literal 'title:' rather than as frontmatter");
+    }
+
+    [TestCaseSource(nameof(PackageReadmes))]
+    public void ReadmeHasNoVuePressContainer(FileInfo readme)
+    {
+        IEnumerable<string> containers = File.ReadAllLines(readme.FullName)
+            .Where(x => x.TrimStart().StartsWith(":::", StringComparison.Ordinal));
+
+        containers.Should().BeEmpty(
+            $"::: containers are a VuePress extension, and nuget.org renders {readme.Directory!.Name}'s readme as literal text instead");
+    }
+
+    [TestCaseSource(nameof(PackageReadmes))]
+    public void ReadmeLinksAreAbsolute(FileInfo readme)
+    {
+        IEnumerable<string> relative = InlineLink
+            .Matches(FencedCode.Replace(File.ReadAllText(readme.FullName), string.Empty))
+            .Select(x => x.Groups["destination"].Value)
+            .Where(x => !x.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+                        && !x.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                        && !x.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+                        && !x.StartsWith('#'));
+
+        relative.Should().BeEmpty(
+            $"a link in {readme.Directory!.Name}'s readme is resolved by nuget.org against nuget.org, so anything but an absolute URL is a 404 from a package page");
+    }
+
+    public static IEnumerable<TestCaseData> PackableProjects() =>
+        FindPackableProjects().Select(x => new TestCaseData(x).SetArgDisplayNames(x.Directory!.Name));
+
+    public static IEnumerable<TestCaseData> PackageReadmes() =>
+        FindPackableProjects()
+            .Select(x => new FileInfo(Path.Combine(x.DirectoryName!, ReadmeFileName)))
+            .Where(x => x.Exists)
+            .Select(x => new TestCaseData(x).SetArgDisplayNames(x.Directory!.Name));
+
+    /// <summary>
+    /// Every project under <c>src</c> that produces a package. <c>Directory.Build.props</c> turns packing
+    /// on for the repository, so the packable ones are the ones that have not turned it back off.
+    /// </summary>
+    /// <remarks>
+    /// Only the project file at the top of each project directory. A recursive search would also find the
+    /// projects BenchmarkDotNet generates under <c>bin</c>, which are packable by default and would fail
+    /// every assertion here on a machine that has run the benchmarks.
+    /// </remarks>
+    private static List<FileInfo> FindPackableProjects()
+    {
+        List<FileInfo> projects = FindRepositoryRoot()
+            .GetDirectories("src")
+            .Single()
+            .GetDirectories()
+            .SelectMany(x => x.GetFiles("*.csproj", SearchOption.TopDirectoryOnly))
+            .Where(x => !IsOptedOut(x))
+            .OrderBy(x => x.Name, StringComparer.Ordinal)
+            .ToList();
+
+        projects.Should().NotBeEmpty("the packable projects are found by walking the repository, and that walk must reach them");
+        return projects;
+    }
+
+    private static bool IsOptedOut(FileInfo project) => XDocument.Load(project.FullName)
+        .Descendants("IsPackable")
+        .Any(x => string.Equals(x.Value.Trim(), "false", StringComparison.OrdinalIgnoreCase));
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        DirectoryInfo directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Quartz.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory ?? throw new InvalidOperationException(
+            $"No Quartz.slnx above {AppContext.BaseDirectory}, so the packable projects cannot be found.");
+    }
+}

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -4,13 +4,13 @@
     <AssemblyTitle>Quartz.NET</AssemblyTitle>
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <PackageReadmeFile>quick-start.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../docs/documentation/quartz-4.x/quick-start.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz/README.md
+++ b/src/Quartz/README.md
@@ -1,0 +1,73 @@
+# Quartz.NET
+
+[Quartz.NET](https://www.nuget.org/packages/Quartz) is a full-featured, open source job scheduling
+system that can be used from the smallest apps to large scale enterprise systems.
+
+## Installation
+
+```shell
+dotnet add package Quartz
+```
+
+That is everything a scheduler needs: dependency injection, hosting and System.Text.Json serialization
+are part of this package, where Quartz 3 shipped them as three separate ones.
+
+## Quick start
+
+A job is a class with one method:
+
+<!-- snippet: sample_readme_quartz_job -->
+```csharp
+public sealed class HelloJob : IJob
+{
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        await Console.Out.WriteLineAsync("Greetings from HelloJob!");
+    }
+}
+```
+<!-- endSnippet -->
+
+Register it with a trigger that fires it; the hosted service starts and stops the scheduler with the
+application:
+
+<!-- snippet: sample_readme_quartz_host -->
+```csharp
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+builder.AddQuartz(q => q.ScheduleJob<HelloJob>(trigger => trigger
+    .WithIdentity("hello")
+    .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever())));
+
+builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+```
+<!-- endSnippet -->
+
+Console applications and tests build a scheduler without a host, from the same configuration API:
+
+<!-- snippet: sample_readme_quartz_standalone -->
+```csharp
+IScheduler scheduler = await QuartzSchedulerBuilder.Create().BuildScheduler();
+await scheduler.Start();
+```
+<!-- endSnippet -->
+
+## Optional packages
+
+| Package | For |
+|---|---|
+| [Quartz.AspNetCore](https://www.nuget.org/packages/Quartz.AspNetCore) | health checks and the HTTP API |
+| [Quartz.Dashboard](https://www.nuget.org/packages/Quartz.Dashboard) | the web dashboard |
+| [Quartz.HttpClient](https://www.nuget.org/packages/Quartz.HttpClient) | driving a remote scheduler over the HTTP API |
+| [Quartz.Jobs](https://www.nuget.org/packages/Quartz.Jobs) | ready-made jobs: file scanning, sending mail, running a process |
+| [Quartz.Plugins](https://www.nuget.org/packages/Quartz.Plugins) | history logging, XML and JSON schedule files, the interrupt monitor |
+| [Quartz.Plugins.TimeZoneConverter](https://www.nuget.org/packages/Quartz.Plugins.TimeZoneConverter) | Windows and IANA time zone ids resolving on either operating system |
+| [Quartz.Serialization.Newtonsoft](https://www.nuget.org/packages/Quartz.Serialization.Newtonsoft) | persisting with Newtonsoft.Json instead of System.Text.Json |
+| [Quartz.Extensions.Redis](https://www.nuget.org/packages/Quartz.Extensions.Redis) | Redis distributed locks for a cluster |
+
+## Documentation
+
+- [Quick start](https://www.quartz-scheduler.net/documentation/quartz-4.x/quick-start.html)
+- [Tutorial](https://www.quartz-scheduler.net/documentation/quartz-4.x/tutorial/)
+- [Configuration reference](https://www.quartz-scheduler.net/documentation/quartz-4.x/configuration/reference.html)
+- [Migrating from Quartz 3](https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html)


### PR DESCRIPTION
Every package on nuget.org currently opens with a horizontal rule and a literal `title:`, because
every packable project packs a VuePress documentation page as its NuGet readme and nuget.org renders
CommonMark with none of VuePress's extensions. Eighteen `::: tip` containers across six packages come
out as prose, ten relative links 404, and the pages are 63–342 lines of documentation where a package
page wants a shop window. `Quartz.HttpClient` shipped with no readme at all.

This is option A from #3370, and a regression rather than something new: `3.x` has carried
`src/<Package>/README.md` on every package all along, and `main` lost them.

## What is here

**Nine readmes.** `Quartz`, `Quartz.AspNetCore`, `Quartz.Dashboard`, `Quartz.Extensions.Redis`,
`Quartz.HttpClient`, `Quartz.Jobs`, `Quartz.Plugins`, `Quartz.Plugins.TimeZoneConverter`,
`Quartz.Serialization.Newtonsoft`. Each answers what the package is, how to install it, what the
smallest useful thing looks like, and where to go next — 36 to 50 lines, except the core `Quartz`
one at 73. Absolute `quartz-scheduler.net` and `nuget.org` links throughout; the documentation site
keeps the long prose. Each csproj now declares `<PackageReadmeFile>README.md</PackageReadmeFile>` and
packs it, replacing the docs-page include.

**The 3.x text was deliberately not copied.** Most of it is wrong for 4.x, and plausibly-wrong
readmes would be worse than visibly-broken ones:

| 3.x readme says | 4.x |
|---|---|
| quick start builds a `StdSchedulerFactory` | no properties-based factory exists; it is `QuartzSchedulerBuilder.Create().BuildScheduler()` |
| "also add `Quartz.Serialization.SystemTextJson`" | System.Text.Json is in the core package and is the default |
| `Quartz.Extensions.Hosting` "may be enough" | hosting is in the core package; there is no such package |
| `AddQuartzServer` registers hosting plus a health check | gone — `AddQuartzHostedService` and `AddQuartzHealthChecks` are separate |
| `IJob.Execute(context)` returning `Task` | `ValueTask Execute(context, cancellationToken = default)` |
| `Quartz.Serialization.Json`, `UseJsonSerializer` | `Quartz.Serialization.Newtonsoft`, `UseNewtonsoftJsonSerializer` |
| `WithIntervalInSeconds(10)` | `WithInterval(TimeSpan.FromSeconds(10))` |
| dashboard mapped via `UseEndpoints(e => e.MapQuartzDashboard())` | `app.MapQuartzDashboard()`, served over the HTTP API |
| Redis options `lockTtlMilliseconds` / `lockRetryIntervalMilliseconds` | `LockTimeToLive` / `LockRetryInterval` |
| plugins in `Quartz.Plugin.*`, jobs in `Quartz.Job` | `Quartz.Plugins.*` and `Quartz.Jobs` (old spellings still resolve, with a warning) |

**The samples are compiled.** #3358's mechanism reached `src/**/README.md` without contortion:
`DocsSnippets` now processes the package readmes alongside `docs/`, the code lives in
`src/Quartz.Documentation.Samples/PackageReadmeSamples.cs`, and `VerifyDocsSnippets` holds the
readmes to the same staleness gate. A broken sample on nuget.org is the first thing a new user meets,
so this is the highest-value place in the repository for that guarantee.

The `<!-- snippet: … -->` markers travel into the package. I checked what nuget.org does with them
rather than assuming: it **strips** HTML comments rather than escaping them
(NuGet/NuGetGallery#9187 is a bug report about exactly that, filed because comments *inside* code
blocks disappear too). Verified against a live page — `Verify.Xunit`'s shipped readme carries five
HTML comments and none of their text appears in the rendered HTML, nor is there any escaped
`&lt;!--`.

**A guard.** `PackageReadmeTest` walks `src`, takes every project `Directory.Build.props` leaves
packable, and asserts per project:

- `PackageReadmeFile` is declared and is `README.md`
- the file it names exists
- a `None` item packs it to the package root
- the readme has no YAML frontmatter, no `:::` container and no relative link
- the project packs nothing at all out of `docs/` — the shape this regression had

I watched all five fail before trusting them: frontmatter, a `::: tip`, a `](../tutorial/…)` link, a
deleted readme, and a csproj pointed back at `packages/quartz-plugins.md`.

## Verification

```
dotnet build Quartz.slnx           Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test  Quartz.Tests.Unit     Passed! Failed: 0, Passed: 2989, Skipped: 4, Total: 2993
dotnet test  Quartz.Tests.AspNetCore   Passed! Failed: 0, Passed: 312, Total: 312
dotnet fallout VerifyDocsSnippets  Documentation snippets are up to date (89 markdown files checked)
```

`dotnet pack Quartz.slnx -c Release`, then each `.nupkg` opened and its declared readme extracted:

```
Quartz.4.0.0.nupkg                            readme=README.md  lines=73  frontmatter=no  containers=0  relative-links=0
Quartz.AspNetCore.4.0.0.nupkg                 readme=README.md  lines=45  frontmatter=no  containers=0  relative-links=0
Quartz.Dashboard.4.0.0.nupkg                  readme=README.md  lines=49  frontmatter=no  containers=0  relative-links=0
Quartz.Extensions.Redis.4.0.0.nupkg           readme=README.md  lines=40  frontmatter=no  containers=0  relative-links=0
Quartz.HttpClient.4.0.0.nupkg                 readme=README.md  lines=43  frontmatter=no  containers=0  relative-links=0
Quartz.Jobs.4.0.0.nupkg                       readme=README.md  lines=50  frontmatter=no  containers=0  relative-links=0
Quartz.Plugins.4.0.0.nupkg                    readme=README.md  lines=46  frontmatter=no  containers=0  relative-links=0
Quartz.Plugins.TimeZoneConverter.4.0.0.nupkg  readme=README.md  lines=36  frontmatter=no  containers=0  relative-links=0
Quartz.Serialization.Newtonsoft.4.0.0.nupkg   readme=README.md  lines=39  frontmatter=no  containers=0  relative-links=0
```

The extracted bytes are identical to the working-tree files, and the nuspec `<readme>` element names
`README.md` in each.

## For a reviewer to decide

- **`src/Quartz/README.md` is 73 lines**, where the brief asked for the 3.x files' 59-and-under. The
  overrun is the eight-row sibling-package table — 4.x folded three packages into core, so "which
  other packages exist" is the question a nuget.org visitor most needs answered — plus a third
  compiled sample showing the no-host `QuartzSchedulerBuilder` path, which is exactly where 3.x's
  readme is wrong. Happy to cut either.
- **`docs-pr.yml` gained `src/*/README.md`, `docs.yml` did not.** The push workflow deploys the site,
  and its `git commit -am` fails on an unchanged tree — a readme-only push would produce identical
  `dist` and redden `main`. Readmes are not site content, so the pull-request gate is the right one.
  The cost is that a readme changed by a direct push to `main` is not snippet-verified.
- **Package descriptions and titles are untouched.** Several are terse (`Quartz.NET Jobs;` …) and
  nuget.org shows them above the readme, but that is a separate edit.

## Left alone deliberately

- `docs/documentation/quartz-4.x/` pages keep their frontmatter and `:::` containers — they are
  VuePress pages and render correctly on the site. The only change is that no csproj packs them.
- `docs/documentation/quartz-3.x/` untouched.
- The `3.x` branch already does this correctly and needs no companion PR.

Closes #3370
