### PR TITLE
AGENTS.md routes rather than recites, and every tool it names can reach it

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,4 @@
+# Aider loads no instruction file on its own, so this points it at the one this repository has.
+# The instructions live in AGENTS.md; keep this a pointer, never a copy.
+read:
+  - AGENTS.md

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,5 @@
+{
+  "context": {
+    "fileName": ["AGENTS.md"]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,11 @@
 
 The instructions for this repository live in [`AGENTS.md`](../AGENTS.md) at the repository root.
 
-Copilot reads `AGENTS.md` directly, so this file exists only so that a tool looking for the older
-path still finds its way there. Do not copy instructions into it — Copilot *combines* instruction
-files rather than picking one, so duplicated guidance would be applied twice.
+This file exists for **Copilot in Visual Studio and JetBrains IDEs**, which read
+`.github/copilot-instructions.md` and have no `AGENTS.md` support at all — without it they would be
+given nothing. Copilot's cloud agent, its CLI and its VS Code integration read `AGENTS.md` directly
+and do not need this file.
+
+Do not copy instructions into it. Copilot *combines* the instruction files it finds rather than
+picking one, so anything duplicated here is applied twice on the surfaces that read both — and drifts
+from `AGENTS.md` on all of them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,72 @@
 
 Instructions for AI coding agents working in this repository.
 
-This is the single source of truth. `AGENTS.md` is read directly by most agents — GitHub Copilot,
-Codex, Cursor, Aider, Gemini CLI, Windsurf and others. Claude Code reads `CLAUDE.md`, which does
-nothing but import this file, and `.github/copilot-instructions.md` is a pointer for the same
-reason. **Edit this file; the other two should stay one-liners.**
+This is the single source of truth, and it is the whole of it — there are no per-area instruction
+files, so a tool that reads only the repository root still gets everything. `AGENTS.md` is read
+directly by Codex, Cursor, Amp, Windsurf, Devin and Copilot's cloud agent, CLI and VS Code
+integrations. The rest arrive through a file that exists only to route them here:
 
+| File | Exists for |
+|---|---|
+| `CLAUDE.md` | Claude Code, which does not read `AGENTS.md` (anthropics/claude-code#6235). It imports this file with `@AGENTS.md` |
+| `.github/copilot-instructions.md` | Copilot in Visual Studio and JetBrains, which read that path only and have no `AGENTS.md` support |
+| `.gemini/settings.json` | Gemini CLI, whose context file is `GEMINI.md` until `context.fileName` names another |
+| `.aider.conf.yml` | Aider, which loads no instruction file on its own; `read:` puts this one in every session |
+
+**Edit this file; the other four stay pointers.** A pointer that grows instructions of its own drifts
+from this file, and Copilot combines the instruction files it finds rather than picking one, so
+anything duplicated is applied twice. `AgentInstructionsTest` fails a pointer that stops naming
+`AGENTS.md`, and any instruction file over 32,768 bytes — Codex's `project_doc_max_bytes`, which is a
+running budget across the whole root-to-working-directory chain and the only documented cap that
+binds this repository.
+
+
+## Key Conventions
+
+- **File-scoped namespaces** — enforced as error (`csharp_style_namespace_declarations = file_scoped:error`).
+- **Explicit types over `var`** — prefer explicit types everywhere (`csharp_style_var_for_built_in_types = false`).
+- **Nullable enabled** globally; test projects may disable it.
+- **Warnings as errors** — `TreatWarningsAsErrors` is true; code style is enforced in build.
+- **`Quartz` builds with the trim analyzer on**, so an `IL2xxx` is an error. The known-reflective types are
+  recorded in `src/Quartz/TrimAnalysisBaseline.cs` (and mirrored for ILLink in `src/Quartz/ILLink.Suppressions.xml`,
+  which the worker example's trimmed publish applies). A warning in a type not listed there means new
+  reflection — fix it rather than adding a line; that file explains the order to try fixes in. Neither file
+  ships, so consumers still see every warning. Tracked on #3341.
+- **Allman brace style** — braces on new lines for methods, types, control blocks, properties, accessors, lambdas.
+- **No `DateTime.Now`/`DateTimeOffset.Now`** — banned via Roslyn analyzer (`BannedSymbols.txt`). Use `TimeProvider` instead.
+- **No implicit `DateTime` → `DateTimeOffset` cast** — also banned.
+- **All public APIs return `ValueTask`** rather than `Task` (e.g., `IJob.Execute`, `IScheduler` methods). This
+  holds for classes too. The single exception is `Quartz.Dashboard.Hubs.IQuartzDashboardHubClient`, whose shape
+  SignalR dictates: its typed-client proxy only implements `Task`-returning members, and it is emitted into a
+  dynamic assembly, so the interface and its DTOs cannot be internal either — a strong-named assembly can only
+  grant `InternalsVisibleTo` to a friend it names by public key. `QuartzDashboardHubClientProxyTest` is the guard.
+- **No `Async` suffix** on Quartz-authored members; the bare verb *is* the async one. Only names dictated by a BCL interface (`IHostedService`, `IAsyncDisposable`, `IHealthCheck`) carry it.
+- **Every async member ends with `CancellationToken cancellationToken = default`.** There are no exceptions left.
+- **Return concrete collection types, accept abstractions** — `List<T>` or `T[]` out, `IReadOnlyCollection<T>`/`IReadOnlyList<T>` in.
+- **No setter-only properties on interfaces.** Identity and configuration arrive by constructor or an explicit context parameter.
+- **Strong-named assemblies** — signed with `quartz.net.snk` (except examples).
+- **Central package management** — package versions in `Directory.Packages.props`.
+- **Single target** — everything targets `net10.0`.
+- **SDK**: .NET 10 SDK (see `global.json`), with `rollForward: latestMinor`.
+- **License headers** — source files include Apache 2.0 license region at the top.
+
+### Naming decisions that are settled
+
+Two spots look inconsistent on purpose. Both were examined and ratified in the 4.0 API-finalization
+pass; do not "finish" either one.
+
+- **The scheduler's noun is `JobDetail`; the store's noun is `Job`.** `IScheduler` hands users
+  `IJobDetail`, so it says `GetJobDetail`/`GetJobDetails`. `IJobStore` speaks in storage terms, so it
+  says `GetJob`/`GetJobs` (beside `GetTrigger`/`GetTriggers`). Singular/plural pairs are consistent
+  *within* each interface; the two interfaces deliberately differ, and aligning one with the other
+  would break the consistent pairs on whichever side got "fixed".
+- **`StdAdoDelegate` and the `*Delegate` dialect family keep their names.** "A class named Delegate
+  that isn't a delegate" is regrettable in .NET, but this vocabulary is Quartz's cross-ecosystem
+  identity: Java parity, twenty years of Stack Overflow answers, `quartz.jobStore.driverDelegateType`
+  spelled in countless configuration files, `database/README.md`, and the dialect docs all teach
+  against `IDriverDelegate`/`SqlServerDelegate`/`PostgreSQLDelegate`/…. The `Std` prefix was retired
+  everywhere else (the semaphore renames finished that); `StdAdoDelegate` is the sole deliberate
+  survivor, because renaming it would orphan the pedagogy without helping anyone.
 
 ## Build & Test
 
@@ -125,7 +186,8 @@ internals behind them.
 The container constructs the scheduler; there is no reflective instantiation from type-name strings, and
 there is no properties-based `StdSchedulerFactory` any more. Legacy flat `quartz.*` keys are translated
 to typed options and registrations by `QuartzPropertyBridge`, which is the only place that understands
-them; `LegacyPropertyKeys` holds the key strings and rejects a misspelled one.
+them; `LegacyPropertyKeys` holds the key strings and rejects a misspelled one. A new setting is therefore
+a typed option plus a bridge entry, never a string read somewhere else.
 
 ### Serialization
 
@@ -139,75 +201,8 @@ Pluggable serialization for job store persistence:
 - For OpenTelemetry, use [OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz).
 - Logging uses `Microsoft.Extensions.Logging` via `Quartz.Diagnostics.LogProvider`.
 
-## Porting changes between 3.x and main
+## Documentation and generated artifacts
 
-`3.x` is the maintenance branch and `main` is 4.x. A change written against one usually needs
-relocating for the other. This maps where things moved; when a port does not compile, check here
-before assuming the code is missing.
-
-### Namespaces
-
-| 3.x | main |
-|-----|------|
-| `Quartz.Spi` | `Quartz.Extensibility` |
-| `Quartz.Simpl` | `Quartz.Impl` (merged into the one that already existed) |
-| `Quartz.Extensions.DependencyInjection` | `Quartz.Configuration` in the core package (the `AddQuartz` extensions stay in `Quartz`) |
-| `Quartz.Extensions.Hosting` | `src/Quartz/Hosting/` in the core package (types are in the `Quartz` namespace) |
-| `Quartz.Serialization.SystemTextJson` | core package (`SystemTextJsonObjectSerializer`) |
-
-Directory layout follows: `src/Quartz/SPI/` → `src/Quartz/Extensibility/`, `src/Quartz/Simpl/` →
-`src/Quartz/Impl/`. String-typed configuration naming the old namespaces still resolves through a
-fallback in `SimpleTypeLoader`, with a warning.
-
-### Contracts that changed shape
-
-| 3.x | main |
-|-----|------|
-| `IJob.Execute(context)` | `Execute(context, cancellationToken)` — same token as `context.CancellationToken` |
-| `IJobFactory.NewJob(...)` → `IJob` | `CreateJob(...)` → `ValueTask<JobScope>` |
-| `IJobFactory.ReturnJob(IJob)` | `ReturnJob(JobScope, CancellationToken)` |
-| `internal IJobWithAsyncReturnFactory` | gone — merged into `IJobFactory` |
-| `IJobWrapper` | gone — per-fire state rides in `JobScope.State` |
-| `PropertySettingJobFactory.InstantiateJob` (sync) | `CreateJobInstance` → `ValueTask<JobScope>` |
-| `ITrigger.GetNextFireTimeUtc()` | `ITrigger.NextFireTimeUtc` (method kept as `[Obsolete]` forwarder) |
-| `IOperableTrigger.SetNextFireTimeUtc(v)` | `NextFireTimeUtc = v` on `IMutableTrigger` (no forwarder) |
-| `IThreadPool.RunInThread` / `BlockForAvailableThreads` | `TryRun(Func<ValueTask>)` / `WaitForAvailableThreads`, both `ValueTask` |
-| `IThreadPool.InstanceId` / `InstanceName` | removed — nothing read them |
-| `IObjectSerializer.DeSerialize` | `Deserialize`; `Initialize()` gone (options built on first use) |
-| `ITypeLoadHelper` | `ITypeLoader`; its `Initialize()` is gone |
-| `IInstanceIdGenerator` → `ValueTask<string?>` | `ValueTask<string>` |
-| `IRemotableSchedulerProxyFactory` | `ISchedulerProxyFactory` |
-| `ISchedulerListener.SchedulerShuttingdown` | `SchedulerShuttingDown` |
-| `IListenerManager.GetSchedulerListeners()` → `IReadOnlyCollection<T>` | `ISchedulerListener[]` |
-| `IJobStore.EstimatedTimeToReleaseAndAcquireTrigger` (`long` ms) | `TimeSpan` |
-| two `IJobStore.AcquireNextTriggers` overloads | one, taking a `TriggerAcquisitionRequest` record |
-| `IScheduler`/`IJobStore` `GetJobKeys` / `GetTriggerKeys` | `QueryJobs` / `QueryTriggers` → `PagedResult<JobHeader\|TriggerHeader>` |
-| `Get{Job,Trigger}GroupNames`, `GetPausedTriggerGroups`, `Is{Job,Trigger}GroupPaused` | `Query{Job,Trigger}Groups` with `JobGroupQuery`/`TriggerGroupQuery.Paused` |
-| `GetCalendarNames` | `QueryCalendarNames(CalendarQuery)` |
-| `IJobStore.GetNumberOf{Jobs,Triggers,Calendars}`, `CalendarExists` | a query with `Take = 0, IncludeTotalCount = true`; `RetrieveCalendar` non-null |
-| the eight removed `IScheduler` listing members | back as extension methods on `SchedulerQueryExtensions` — old call shapes still compile, but a null matcher now throws |
-| (new) | `IScheduler`/`IJobStore.GetJobDetails(keys)` / `GetTriggers(keys)` — bulk fetch by key |
-| `IScheduler.GetCurrentlyExecutingJobs()` | gone — `QueryFireInstances(FireInstanceQuery)` → `PagedResult<FireInstance>`, cluster-wide with a persistent store. Live-context uses keep their own `IJobListener`; `QuartzScheduler`'s internal sync member stays, so Interrupt is never a store round trip |
-| `IJobStore.Initialize(ct)` | `Initialize(SchedulerIdentity, ct)` — a generated instance id does not exist at construction |
-| (new) | `IDriverDelegate.SelectFireInstances(conn, FireInstanceQuery, ct)`; `FiredTriggerQuery` stays deliberately unpaged |
-| `ExecutionSlots.TryTake(executionGroup)` | `TryTake(executionGroup, triggerGroup)` — `ExecutionLimits.UsesTriggerGroupWhenUnset` may derive from the latter |
-| `IDriverDelegate.Select{Calendars,JobGroups(conn,ct),PausedTriggerGroups,Num*}` | `Select{CalendarNames,JobHeaders,TriggerHeaders,JobGroups,TriggerGroups}` taking a query record |
-| three `SelectFiredTriggerRecords*` + four `DeleteFiredTriggers` overloads | one of each, taking `FiredTriggerQuery` |
-| two `IDriverDelegate.SelectTriggerToAcquire` overloads | `SelectTriggersToAcquire(conn, TriggerAcquisitionCriteria, ct)` |
-| `GetSelectNextMisfiredTriggersInStateToAcquireSql` + dialect overrides | gone; dialect paging is `ApplyPaging` / `AddPagingParameters` |
-| `JobRunShell`, `IJobRunShellFactory` (public) | `internal` |
-
-### Configuration
-
-3.x configures from flat `quartz.*` strings and reflective instantiation. On main the container
-builds the scheduler; flat keys still work but are translated by `QuartzPropertyBridge`, which is
-the only place that understands them. A 3.x change that adds a property key needs a typed option
-plus a bridge entry on main.
-
-### Practical notes
-
-- **Ported code that fails to build is usually a rename, not a missing feature.** Check the tables
-  above and `docs/documentation/quartz-4.x/migration-guide.md`, which explains the reasoning for each.
 - **`docs/documentation/quartz-3.x/` must keep the old names.** Only update `quartz-4.x/`.
 - **Heading fragments are checked with the site's own slugger, not GitHub's.** `npm run docs:check-links`
   parses the docs with the markdown-it instance VuePress renders them with, so the ids it validates
@@ -234,8 +229,8 @@ plus a bridge entry on main.
   `docs/documentation/quartz-4.x/migration-guide.md`. Never hand-edit them.
 - **`3.x` carries the same baselines, so the 4.0 API delta is a `git diff`.** Reach for it when
   writing the migration guide, reviewing API ergonomics, or checking whether a 3.x change has a
-  counterpart here — it is exhaustive and always current, unlike the tables above. `git diff` takes
-  `<rev>:<path>` blob arguments, so this is the same command in PowerShell and bash:
+  counterpart here — it is exhaustive and always current, which no prose summary of the delta can be.
+  `git diff` takes `<rev>:<path>` blob arguments, so this is the same command in PowerShell and bash:
 
   ```shell
   git fetch origin
@@ -248,70 +243,17 @@ plus a bridge entry on main.
   git diff origin/3.x origin/main -- src/Quartz.Tests.Unit/Verify src/Quartz.Tests.AspNetCore/Verify
   ```
 
-  Package boundaries moved, so match the files up first:
-
-  | 3.x baseline | main baseline |
-  |---|---|
-  | `PublicApiTest_Quartz` | `PublicApiTest_Quartz` — ours also absorbs DI, Hosting and SystemTextJson |
-  | `PublicApiTest_Quartz.Extensions.DependencyInjection` | folded into `Quartz` (`Quartz.Configuration`) |
-  | `PublicApiTest_Quartz.Extensions.Hosting` | folded into `Quartz` (`src/Quartz/Hosting/`) |
-  | `PublicApiTest_Quartz.Serialization.SystemTextJson` | folded into `Quartz` (`SystemTextJsonObjectSerializer`) |
-  | `PublicApiTest_Quartz.Serialization.Json` | `PublicApiTest_Quartz.Serialization.Newtonsoft` |
-  | `Quartz.Jobs`, `Quartz.Plugins`, `Quartz.Plugins.TimeZoneConverter`, `Quartz.Extensions.Redis`, `Quartz.AspNetCore`, `Quartz.Dashboard` | same name on both sides |
-  | `PublicApiTest_Quartz.OpenTracing` | dropped here |
-  | (no 3.x baseline — its ancient `OpenTelemetry` dependency fails restore there) | dropped here; use `OpenTelemetry.Instrumentation.Quartz` |
-  | — | `PublicApiTest_Quartz.HttpClient` — new here |
-
-  Two differences are systematic and are **not** deltas worth reporting: `Task` → `ValueTask` on
-  nearly every member, and the namespace moves tabulated above. 3.x snapshots on `net10.0` only, so
-  its `net472`/`REMOTING` surface never appears in the diff.
+  Package boundaries moved between the two, so match the files up first — the migration guide's
+  appendix says which 3.x baseline became which. Two differences are systematic and are **not**
+  deltas worth reporting: `Task` → `ValueTask` on nearly every member, and the namespace moves.
 - **Release notes live in GitHub releases, not in the repository.** There is no changelog file on
   either branch; the tag's release is the record. Unreleased 4.x notes accumulate in the `v4.0.0`
   draft release.
 
-## Key Conventions
+## Porting changes between 3.x and main
 
-- **File-scoped namespaces** — enforced as error (`csharp_style_namespace_declarations = file_scoped:error`).
-- **Explicit types over `var`** — prefer explicit types everywhere (`csharp_style_var_for_built_in_types = false`).
-- **Nullable enabled** globally; test projects may disable it.
-- **Warnings as errors** — `TreatWarningsAsErrors` is true; code style is enforced in build.
-- **`Quartz` builds with the trim analyzer on**, so an `IL2xxx` is an error. The known-reflective types are
-  recorded in `src/Quartz/TrimAnalysisBaseline.cs` (and mirrored for ILLink in `src/Quartz/ILLink.Suppressions.xml`,
-  which the worker example's trimmed publish applies). A warning in a type not listed there means new
-  reflection — fix it rather than adding a line; that file explains the order to try fixes in. Neither file
-  ships, so consumers still see every warning. Tracked on #3341.
-- **Allman brace style** — braces on new lines for methods, types, control blocks, properties, accessors, lambdas.
-- **No `DateTime.Now`/`DateTimeOffset.Now`** — banned via Roslyn analyzer (`BannedSymbols.txt`). Use `TimeProvider` instead.
-- **No implicit `DateTime` → `DateTimeOffset` cast** — also banned.
-- **All public APIs return `ValueTask`** rather than `Task` (e.g., `IJob.Execute`, `IScheduler` methods). This
-  holds for classes too. The single exception is `Quartz.Dashboard.Hubs.IQuartzDashboardHubClient`, whose shape
-  SignalR dictates: its typed-client proxy only implements `Task`-returning members, and it is emitted into a
-  dynamic assembly, so the interface and its DTOs cannot be internal either — a strong-named assembly can only
-  grant `InternalsVisibleTo` to a friend it names by public key. `QuartzDashboardHubClientProxyTest` is the guard.
-- **No `Async` suffix** on Quartz-authored members; the bare verb *is* the async one. Only names dictated by a BCL interface (`IHostedService`, `IAsyncDisposable`, `IHealthCheck`) carry it.
-- **Every async member ends with `CancellationToken cancellationToken = default`.** There are no exceptions left.
-- **Return concrete collection types, accept abstractions** — `List<T>` or `T[]` out, `IReadOnlyCollection<T>`/`IReadOnlyList<T>` in.
-- **No setter-only properties on interfaces.** Identity and configuration arrive by constructor or an explicit context parameter.
-- **Strong-named assemblies** — signed with `quartz.net.snk` (except examples).
-- **Central package management** — package versions in `Directory.Packages.props`.
-- **Single target** — everything targets `net10.0`.
-- **SDK**: .NET 10 SDK (see `global.json`), with `rollForward: latestMinor`.
-- **License headers** — source files include Apache 2.0 license region at the top.
-
-### Naming decisions that are settled
-
-Two spots look inconsistent on purpose. Both were examined and ratified in the 4.0 API-finalization
-pass; do not "finish" either one.
-
-- **The scheduler's noun is `JobDetail`; the store's noun is `Job`.** `IScheduler` hands users
-  `IJobDetail`, so it says `GetJobDetail`/`GetJobDetails`. `IJobStore` speaks in storage terms, so it
-  says `GetJob`/`GetJobs` (beside `GetTrigger`/`GetTriggers`). Singular/plural pairs are consistent
-  *within* each interface; the two interfaces deliberately differ, and aligning one with the other
-  would break the consistent pairs on whichever side got "fixed".
-- **`StdAdoDelegate` and the `*Delegate` dialect family keep their names.** "A class named Delegate
-  that isn't a delegate" is regrettable in .NET, but this vocabulary is Quartz's cross-ecosystem
-  identity: Java parity, twenty years of Stack Overflow answers, `quartz.jobStore.driverDelegateType`
-  spelled in countless configuration files, `database/README.md`, and the dialect docs all teach
-  against `IDriverDelegate`/`SqlServerDelegate`/`PostgreSQLDelegate`/…. The `Std` prefix was retired
-  everywhere else (the semaphore renames finished that); `StdAdoDelegate` is the sole deliberate
-  survivor, because renaming it would orphan the pedagogy without helping anyone.
+`3.x` is the maintenance branch and `main` is 4.x, and a change written against one usually needs
+relocating for the other. **The map is `docs/documentation/quartz-4.x/migration-guide.md`** — every
+namespace move, every contract that changed shape, and an appendix indexed by the name you would have
+typed. Ported code that fails to build is usually a rename, not a missing feature, so look there
+before assuming the feature is missing.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3507,7 +3507,9 @@ changes unless you call it. See
 [Execution Groups](/documentation/quartz-4.x/tutorial/execution-groups.html#letting-the-trigger-group-stand-in).
 
 One signature moved with it: `ExecutionSlots.TryTake` takes the trigger group as a second argument, so a
-job store of your own cannot silently opt out of the derivation by not passing it.
+job store of your own cannot silently opt out of the derivation by not passing it. Whether the second
+argument is used at all is `ExecutionLimits.UsesTriggerGroupWhenUnset`, which is what the builder method
+sets.
 
 ```diff
 - if (!slots.TryTake(candidate.ExecutionGroup))
@@ -4643,6 +4645,10 @@ your job. `IJobExecutionContext.JobInstance` and every listener now see the type
 `CreateJobInstance` shown above. The old hook was synchronous even after `NewJob` became asynchronous, so a factory
 that needed to do real work had to override `NewJob` outright and reimplement the property setting.
 
+There is one job factory interface again. 3.x carried a second, internal `IJobWithAsyncReturnFactory` beside
+`IJobFactory`, so that a factory returning its job asynchronously could be recognised without changing the
+released interface; the asynchronous shape is `IJobFactory`'s own now, and the internal one is gone.
+
 `SimpleJobFactory`'s `protected static Dispose(object?)` helper is `DisposeIfDisposable(object?, CancellationToken)`,
 which is what it has always done: it disposes the argument only when the argument is disposable.
 
@@ -4794,7 +4800,9 @@ directly. **The `quartz.threadPool.threadCount` configuration key is unaffected*
 
 `Quartz.Spi` is now `Quartz.Extensibility`, and `Quartz.Simpl` merged into the existing `Quartz.Impl`. Both old
 names were transliterations of `org.quartz.spi` and `org.quartz.simpl`. For source code this is a find-and-replace
-over `using` directives that the compiler will walk you through.
+over `using` directives that the compiler will walk you through. Quartz's own directory layout followed, so if you
+read the source or port a patch between the branches, `src/Quartz/SPI/` is `src/Quartz/Extensibility/` and
+`src/Quartz/Simpl/` is `src/Quartz/Impl/`.
 
 Configuration is the part that would not have failed loudly, because it names types by string:
 
@@ -7108,7 +7116,22 @@ explaining it a second time.
 It is derived mechanically, by diffing the public API baselines both branches keep under
 `src/Quartz.Tests.Unit/Verify/` and `src/Quartz.Tests.AspNetCore/Verify/`, so it names **every**
 public type 3.x had and 4.0 does not — all 94, across every package — rather than the ones that came
-to mind.
+to mind. If you want the raw delta for one package rather than this summary, `git diff` its baseline
+across the two branches; package boundaries moved, so match the files up with this first:
+
+| 3.x baseline | 4.x baseline |
+|---|---|
+| `PublicApiTest_Quartz` | `PublicApiTest_Quartz` — which also absorbs DI, Hosting and SystemTextJson |
+| `PublicApiTest_Quartz.Extensions.DependencyInjection` | folded into `Quartz` (`Quartz.Configuration`) |
+| `PublicApiTest_Quartz.Extensions.Hosting` | folded into `Quartz` (`src/Quartz/Hosting/`) |
+| `PublicApiTest_Quartz.Serialization.SystemTextJson` | folded into `Quartz` (`SystemTextJsonObjectSerializer`) |
+| `PublicApiTest_Quartz.Serialization.Json` | `PublicApiTest_Quartz.Serialization.Newtonsoft` |
+| `Quartz.Jobs`, `Quartz.Plugins`, `Quartz.Plugins.TimeZoneConverter`, `Quartz.Extensions.Redis`, `Quartz.AspNetCore`, `Quartz.Dashboard` | same name on both sides |
+| `PublicApiTest_Quartz.OpenTracing` | dropped; there is no 4.x package |
+| (no 3.x baseline — its ancient `OpenTelemetry` dependency fails restore there) | dropped; use [OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz) |
+| — | `PublicApiTest_Quartz.HttpClient` — new in 4.x |
+
+3.x snapshots `net10.0` only, so its `net472` and `REMOTING` surface never appears in that diff.
 
 Two whole-surface changes are deliberately left out, because repeating them per type would bury
 everything else: `Task` became [`ValueTask`](#tasks-changed-to-valuetask) on nearly every member, and

--- a/src/Quartz.Tests.Unit/AgentInstructionsTest.cs
+++ b/src/Quartz.Tests.Unit/AgentInstructionsTest.cs
@@ -1,0 +1,140 @@
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The files AI coding agents read before they touch anything.
+/// </summary>
+/// <remarks>
+/// <c>AGENTS.md</c> is the single source of truth and every other file is a pointer to it (#3369). Two
+/// things quietly break that: a pointer that grows instructions of its own and drifts, and a root file
+/// that outgrows what a tool will read. Codex's <c>project_doc_max_bytes</c> is 32,768 and is a running
+/// budget over the whole root-to-working-directory chain, which makes it the cap that binds here.
+/// </remarks>
+public class AgentInstructionsTest
+{
+    /// <summary>
+    /// Codex's <c>project_doc_max_bytes</c> default, and the smallest documented budget of the tools
+    /// this repository is written for. Past it, the file is truncated mid-sentence without a word.
+    /// </summary>
+    private const int MaxInstructionBytes = 32 * 1024;
+
+    /// <summary>
+    /// A pointer is a paragraph saying where the instructions are. Anything longer is a copy.
+    /// </summary>
+    private const int MaxPointerBytes = 2 * 1024;
+
+    /// <summary>
+    /// Every instruction file this repository has, root-relative. Adding one means adding it here,
+    /// which is what keeps <see cref="EveryInstructionFileIsOneTheRootAccountsFor"/> honest.
+    /// </summary>
+    private static readonly string[] InstructionFiles =
+    [
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".github/copilot-instructions.md",
+    ];
+
+    /// <summary>
+    /// The files that exist only to route a tool to <c>AGENTS.md</c>, root-relative.
+    /// </summary>
+    private static readonly string[] PointerFiles =
+    [
+        "CLAUDE.md",
+        ".github/copilot-instructions.md",
+        ".aider.conf.yml",
+        ".gemini/settings.json",
+    ];
+
+    /// <summary>
+    /// The names a tool discovers on its own. A file with one of these names is loaded whether or not
+    /// anyone remembered it exists, so the set of them has to match what the root declares.
+    /// </summary>
+    private static readonly string[] DiscoveredNames = ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "copilot-instructions.md"];
+
+    private static readonly string[] NotSearched = ["bin", "obj", "node_modules", ".git", ".vs", ".vuepress", "dist", "packages", "TestResults"];
+
+    [TestCaseSource(nameof(InstructionFileCases))]
+    public void InstructionFileFitsTheSmallestDocumentedBudget(FileInfo file)
+    {
+        file.Exists.Should().BeTrue($"{file.Name} is one of the instruction files the repository declares");
+        file.Length.Should().BeLessThanOrEqualTo(MaxInstructionBytes,
+            $"{file.Name} is truncated without warning past Codex's project_doc_max_bytes, and the budget is spent across every instruction file it loads, not per file");
+    }
+
+    [TestCaseSource(nameof(PointerFileCases))]
+    public void PointerFileNamesTheInstructionsItPointsAt(FileInfo file)
+    {
+        File.ReadAllText(file.FullName).Should().Contain("AGENTS.md",
+            $"{file.Name} exists to route a tool to the instructions, and a pointer that stops naming them routes nowhere");
+    }
+
+    [TestCaseSource(nameof(PointerFileCases))]
+    public void PointerFileStaysAPointer(FileInfo file)
+    {
+        file.Length.Should().BeLessThanOrEqualTo(MaxPointerBytes,
+            $"{file.Name} has grown past a pointer into a copy, and a copy drifts from AGENTS.md — Copilot combines the instruction files it finds rather than picking one, so a duplicated rule is also applied twice");
+    }
+
+    [Test]
+    public void EveryInstructionFileIsOneTheRootAccountsFor()
+    {
+        DirectoryInfo root = FindRepositoryRoot();
+
+        List<string> found = Discover(root)
+            .Select(x => Path.GetRelativePath(root.FullName, x.FullName).Replace('\\', '/'))
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        found.Should().BeEquivalentTo(InstructionFiles,
+            "a nested instruction file is loaded by four of the surfaces this repository is written for and ignored by the rest, so a rule that lives in one is a rule most agents never read; if one is added deliberately it belongs in this list, where the size budget also covers it");
+    }
+
+    public static IEnumerable<TestCaseData> InstructionFileCases() => Cases(InstructionFiles);
+
+    public static IEnumerable<TestCaseData> PointerFileCases() => Cases(PointerFiles);
+
+    private static IEnumerable<TestCaseData> Cases(IReadOnlyList<string> relativePaths)
+    {
+        DirectoryInfo root = FindRepositoryRoot();
+
+        return relativePaths
+            .Select(x => new TestCaseData(new FileInfo(Path.Combine(root.FullName, x))).SetArgDisplayNames(x))
+            .ToList();
+    }
+
+    private static IEnumerable<FileInfo> Discover(DirectoryInfo directory)
+    {
+        foreach (FileInfo file in directory.GetFiles())
+        {
+            if (DiscoveredNames.Contains(file.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                yield return file;
+            }
+        }
+
+        foreach (DirectoryInfo child in directory.GetDirectories())
+        {
+            if (NotSearched.Contains(child.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (FileInfo file in Discover(child))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        DirectoryInfo directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Quartz.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory ?? throw new InvalidOperationException(
+            $"No Quartz.slnx above {AppContext.BaseDirectory}, so the instruction files cannot be found.");
+    }
+}


### PR DESCRIPTION
`AGENTS.md` put the rules that bind every change last, behind 124 lines of 3.x→4.x rename tables that
matter only when porting. Every task paid for all of it, and a reader working down the file met the
porting map first. This reorders it, moves the porting map to where the porting map belongs, and closes
the three tool-reach holes the research on the issue turned up.

**It does not adopt the per-area nesting the issue body proposes.** Codex never reads below the working
directory and its `project_doc_max_bytes` is a running budget across the whole root→cwd chain, so nesting
spends headroom rather than buying it; only four of fourteen surfaces auto-load a nested `AGENTS.md`. At
22.8 KB this file is inside every documented budget, so the honest answer here is zero area files —
including for `database/`, whose 1.8 KB does not justify a file ten of fourteen tools never load.

Rebased onto `9d59dc175` after #3374 merged. The two database-scripts bullets it rewrote are carried
through **byte-identical** — `git diff 9d59dc175 HEAD -- AGENTS.md` shows no line mentioning
`migrations/4.0` or `Supports*Column` on either side — and the retired justification ("a companion would
hand 3.x a script for a feature 3.x does not have") appears nowhere in this branch.

Closes #3369.

## What changed

**The porting section is one paragraph pointing at the migration guide.** It was 44% of the file and has
a known expiry, and the guide covers the same ground at length — and, unlike the table, gets updated when
the API moves. One row had already rotted: it mapped `IRemotableSchedulerProxyFactory` to an
`ISchedulerProxyFactory` that does not exist on `main` (both were removed; the guide says so correctly).

Every row was checked before deleting it, by identifier, against
`docs/documentation/quartz-4.x/migration-guide.md`. Four things were not covered and were **moved there**
rather than dropped:

| Not covered | Where it went |
|---|---|
| `src/Quartz/SPI/` → `src/Quartz/Extensibility/`, `src/Quartz/Simpl/` → `src/Quartz/Impl/` | "Quartz.Spi and Quartz.Simpl were renamed" — the sentence now covers reading the source and porting a patch, not only `using` directives |
| `internal IJobWithAsyncReturnFactory` merged into `IJobFactory` | "The job factory hands out a scope". It was internal on 3.x, so the appendix — which is derived from the public baselines — could never have named it |
| `ExecutionLimits.UsesTriggerGroupWhenUnset` | "An unset execution group can be the trigger's group", which documented the builder method and the `TryTake` signature but not the property they set |
| the 3.x↔4.x public API baseline file mapping | the appendix intro, beside the sentence saying the appendix is derived by diffing those files |

The notes in that section that were never about porting — the docs anchor rule, the generated samples, the
package readmes, the public API baselines, the release notes — are gathered under a new **Documentation and
generated artifacts** heading rather than dropped. One judgement call: the cross-branch `git diff` recipe for
the baselines **stayed in the root** and only its file-mapping table moved to the guide. Two of its three
stated uses (writing the migration guide, reviewing API ergonomics) are repository work that outlives porting,
and it is the durable replacement for the table this PR deletes: derive the delta rather than read a summary
of it. Easy to overrule if you disagree.

**Order is now conventions → build and test → architecture → docs and generated artifacts → porting.**

**Three tools were getting nothing.** Aider loads no instruction file on its own and the repository had
neither `.aider.conf.yml` nor `CONVENTIONS.md`; it now has a `read:` entry. Gemini CLI reads `GEMINI.md`
unless `context.fileName` names another, and there was no `.gemini/settings.json`; it now names `AGENTS.md`
directly rather than growing a second copy. And `.github/copilot-instructions.md` said *"Copilot reads
`AGENTS.md` directly"* — true of the cloud agent, the CLI and VS Code, **false of Visual Studio and
JetBrains**, which read only that path and have no `AGENTS.md` support, so the surfaces that need the file
most were following a pointer they cannot follow. The file stays (deleting it strips those two entirely) and
now says which surfaces it is for. Both additions are pointers; neither carries a rule of its own.

**`AgentInstructionsTest`** holds every instruction file to 32,768 bytes — Codex's `project_doc_max_bytes`,
the only documented cap that binds here — holds each pointer to naming `AGENTS.md` and to staying a pointer,
and fails if an instruction file appears that the root does not account for. That last one is the design
decision written down: verified by adding a `src/Quartz/AGENTS.md` and watching it fail.

## Nothing-was-lost check

Scripted, not eyeballed, per the caveat on the issue. Every heading, every bolded bullet and every distinct
non-blank line of `9d59dc175:AGENTS.md` — the **rebased** base, re-captured after #3374 landed — compared
against the union of the new `AGENTS.md`, the four pointers and the migration guide; unmatched lines retried
by the symbols they name. The two bullets #3374 rewrote come back `verbatim`, which is the check doing the
job Marko described.

```
old AGENTS.md: 318 lines, 240 distinct non-blank lines
headings: 21, bolded bullets: 36
verbatim: 173  by-symbol: 30  unmatched: 37
37 of 37 unmatched lines name nothing that is missing
```

The residue is 12 lines carrying no symbol at all, each adjudicated by reading:

- three headings deliberately gone (`### Namespaces`, `### Contracts that changed shape`, `### Practical notes`)
- two table header rows (`| 3.x | main |`, `| 3.x baseline | main baseline |`)
- *"Edit this file; the other two should stay one-liners"* → *"the other four stay pointers"*, because there are four now
- *"This maps where things moved; when a port does not compile, check here"* → the new porting paragraph
- *"Ported code that fails to build is usually a rename, not a missing feature"* → kept, in that paragraph
- *"A 3.x change that adds a property key needs a typed option plus a bridge entry on main"* → generalized into **Hosting & DI**, where `QuartzPropertyBridge` and `LegacyPropertyKeys` are already described
- *"Package boundaries moved, so match the files up first"* → kept in the root, pointing at the table now in the guide

**I did not ship it as a test.** It compares a file against its own predecessor, so it is a one-shot
migration check with nothing to assert against tomorrow. The durable half of what it protects — a pointer
that stops pointing, a file that outgrows the budget, an instruction file nobody registered — is what
`AgentInstructionsTest` asserts instead. The script is in the scratchpad if you want it committed.

## Byte counts

Repository blobs (LF; what a Linux checkout has on disk), measured against `9d59dc175`. A Windows checkout
is one byte per line larger — `AGENTS.md` is 23,098 → 18,309 there.

| File | Before | After |
|---|---:|---:|
| `AGENTS.md` | 22,780 | **18,050** (−20.8%) |
| `CLAUDE.md` | 186 | 186 |
| `.github/copilot-instructions.md` | 388 | 656 |
| `.aider.conf.yml` | — | 189 |
| `.gemini/settings.json` | — | 53 |
| total | 23,354 | 19,134 |

`AGENTS.md` is 318 lines before and 259 after.

The root landing at ~18 KB rather than the ~12 KB estimated on the issue is because the practical notes that
were never about porting stay here, as agreed — they are 4.5 KB of the section by themselves.

## For a reviewer to decide

1. The `git diff` recipe for the public API baselines staying in the root (above). The alternative is moving
   it whole into the guide's appendix.
2. Whether the nothing-was-lost script should be committed rather than run once.
3. `.github/agents/squad.agent.md` is **74,306 bytes** and left alone. It is a vendored third-party custom
   agent definition, loaded only when that agent is selected rather than on every session, so it is not a
   repository instruction file and the size test does not cover it. Flagging it because the number is
   startling next to a 32 KB cap.

## Verification

```
dotnet build Quartz.slnx                                    Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit                           Passed! Failed: 0, Passed: 3031, Skipped: 4
dotnet test src/Quartz.Tests.AspNetCore                     Passed! Failed: 0, Passed: 312, Skipped: 0
dotnet fallout VerifyDocsSnippets                           Documentation snippets are up to date (89 files)
npm run docs:check-links                                    211 pages, 689 internal links, 384 fragments
                                                            no dead links or anchors
npm run docs:build                                          VuePress build completed, 212 pages
```

`npm run docs:lint` reports 118 errors on this branch and 118 on `9d59dc175` — all pre-existing, none on a
line this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3wNU6NFXyZztWp12PGQc
