### PR TITLE
The key-set delete and unschedule answer with the keys they removed

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5157,6 +5157,63 @@ Over HTTP the key-set forms are new endpoints, described in
 `…/triggers/keys/reset-from-error-state`. They live under `keys/` because the collection-level `pause`
 and `resume` already belong to the group-matcher forms.
 
+## The key-set delete and unschedule answer with the keys they removed
+
+`DeleteJobs` and `UnscheduleJobs` predate that convention and used to answer one `bool` meaning "every
+key given was found". That answer was lossy in the case a caller most needs to know about: delete
+three of five existing jobs and **three jobs are deleted** while the call answers `false`, which is
+indistinguishable from nothing having happened. A caller who retried on `false` never learned that
+most of the work had already succeeded. They now answer the way the rest of the key-set family does.
+
+| Member | 3.x / 4.0 preview returned | 4.0 returns |
+|---|---|---|
+| `IScheduler.DeleteJobs(IReadOnlyCollection<JobKey>)` | `ValueTask<bool>` — every key was found | `ValueTask<List<JobKey>>` of the keys it deleted |
+| `IScheduler.UnscheduleJobs(IReadOnlyCollection<TriggerKey>)` | `ValueTask<bool>` | `ValueTask<List<TriggerKey>>` of the keys it removed |
+| `IJobStore.DeleteJobs(IReadOnlyCollection<JobKey>)` | `ValueTask<bool>` | `ValueTask<List<JobKey>>` |
+| `IJobStore.DeleteTriggers(IReadOnlyCollection<TriggerKey>)` | `ValueTask<bool>` | `ValueTask<List<TriggerKey>>` |
+
+**To get the old answer back**, compare the counts:
+
+```csharp
+List<JobKey> deleted = await scheduler.DeleteJobs(jobKeys);
+bool allFound = deleted.Count == jobKeys.Count;   // what the bool used to say
+```
+
+That one line is why the change is a replacement rather than a second overload: the old answer is
+still available to anyone who wants it, while the question it could not answer — *which* keys — now
+has one.
+
+Three consequences worth knowing:
+
+* **A key that named nothing no longer raises a listener event.** The old implementation raised one
+  `ISchedulerListener.JobDeleted` / `JobUnscheduled` per key **given**, so a mistyped key told every
+  listener that a job by that name had been deleted. The events now follow the keys the call applied
+  to, which is what the single-key `DeleteJob` and the whole key-set pause family already did. The
+  scheduling change is still signalled once for the call, and not at all when nothing was removed.
+* **An empty key set never reaches the store**, and a `null` one is an `ArgumentNullException` rather
+  than a `NullReferenceException` — again matching the key-set pause family.
+* **Repeating a key in the set no longer poisons the answer.** The second pass finds nothing left to
+  delete; before, that dragged the whole call's `bool` to `false`.
+
+If you implement `IJobStore`, both members are now **default implementations** that walk the set one
+key at a time, so a store that only implements the single-key `DeleteJob` / `DeleteTrigger` is correct
+without writing them. That has one trap: a store that still declares
+`ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey>, CancellationToken)` **still compiles** — the
+method simply stops implementing the interface member, and the per-key default silently takes over.
+Change the return type. Both shipped stores override the pair to walk inside one lock and one
+transaction, and `JobStoreContractTest` fails a store that has left the default in place.
+
+The ADO store's walk stays per key on purpose. Deleting a job there is a cascade rather than a
+statement — its triggers and their sub-table rows, the fired-trigger rows that would otherwise
+resurrect it, then the job detail row — and a set-based `DELETE … WHERE … IN (…)` reports a row count
+rather than which keys it hit. Naming the deleted keys therefore costs no extra round trip: each
+iteration's result was already there and was being folded into a boolean and thrown away.
+
+Over HTTP, `POST …/jobs/delete` and `POST …/triggers/unschedule` answer `{"jobs": [ … ]}` and
+`{"triggers": [ … ]}` instead of `{"allFound": …}`, which makes them ordinary members of
+[the key-set family](packages/http-api.md#a-whole-set-of-keys-in-one-call) and removes the one
+exception to the flag-naming rule.
+
 ## One wire contract, and its enums have names
 
 The DTOs that define the HTTP API's JSON used to live in `Quartz.HttpClient`, and `Quartz.AspNetCore`
@@ -5213,18 +5270,16 @@ of predicting it.
 | `POST …/jobs/interrupt/{fireInstanceId}` | `{"interrupted": …}` | `{"applied": …}` |
 | `POST …/triggers/{group}/{name}/unschedule` | `{"triggerFound": …}` | `{"applied": …}` |
 | `DELETE …/calendars/{name}` | `{"calendarFound": …}` | `{"applied": …}` |
-| `POST …/jobs/delete` | `{"allJobsFound": …}` | `{"allFound": …}` |
-| `POST …/triggers/unschedule` | `{"allTriggersFound": …}` | `{"allFound": …}` |
+| `POST …/jobs/delete` | `{"allJobsFound": …}` | `{"jobs": [ … ]}` |
+| `POST …/triggers/unschedule` | `{"allTriggersFound": …}` | `{"triggers": [ … ]}` |
 
-`applied` means the entity existed and the operation changed it. The last two rows keep a name of
-their own because they report a different fact: `IScheduler.DeleteJobs` and `UnscheduleJobs` answer
-one `bool` for a whole key set, meaning "every key was found", and a partial hit **still deletes the
-keys it found**. Calling that `"applied": false` would be a false statement about what happened, and
-a caller who retried on it would never learn that most of the work had already succeeded. What is
-uniform is the *shape* — one boolean, on the operations that have something to report; the name still
-has to describe the value. Having those two answer with the applied keys, as the key-set pause and
-resume do, is the better end state and is tracked in
-[#3360](https://github.com/quartznet/quartznet/issues/3360).
+`applied` means the entity existed and the operation changed it, and there is no second spelling: an
+operation that cannot answer that question about a single entity is a key-set form, and answers with
+the keys instead. The last two rows are the ones that changed *shape* rather than name — they are key
+sets, and a single boolean could only say that not every key was found, which a caller could not tell
+from nothing having happened. See
+[the key-set delete and unschedule](#the-key-set-delete-and-unschedule-answer-with-the-keys-they-removed)
+for the scheduler API behind them.
 
 `HttpScheduler` reads the new spellings, so a client and server upgraded together need no code change;
 a hand-written client reading the old names does.

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -121,31 +121,19 @@ was:
 | A read that found its target | `200` with the object |
 | A read whose target does not exist | `404` with RFC 7807 problem details |
 | A mutation that always acts | `200` with an **empty body** — `AddJob`, `TriggerJob`, `PauseAll`, `ScheduleJobs`, `AddCalendar`, `Start`, `Standby`, `Shutdown`, `Clear`, the execution-limit writes |
-| A mutation whose effect may be a no-op | `200` with one flag, **named for what it reports** — `{ "applied": … }` almost everywhere, `{ "allFound": … }` on the two forms below |
+| A mutation whose effect may be a no-op | `200` with one flag, **named for what it reports** — `{ "applied": … }` |
 | …the same, aimed at a group matcher or a key set | `200` with what it applied to — `{ "groups": [ … ] }`, `{ "jobs": [ … ] }`, `{ "triggers": [ … ] }` |
 | A mutation that computed something | `200` with that value — `{ "firstFireTimeUtc": … }` from schedule and reschedule |
 
 An unknown scheduler is `404` whatever the operation was.
 
 The flag is always one boolean, and it is **named for the fact it reports**: `applied` — the entity
-existed and the operation changed it — except where the underlying scheduler API can only answer
-whether *every* key was found, which is `allFound`:
-
-| Endpoint | Flag | Means |
-|---|---|---|
-| every other single-key mutation | `applied` | this key existed and the operation changed it |
-| `POST …/jobs/delete` | `allFound` | every key in the body was found |
-| `POST …/triggers/unschedule` | `allFound` | every key in the body was found |
-
-Those two report `allFound` rather than `applied` because a partial hit **still deletes the keys it
-found** — `IScheduler.DeleteJobs` and `UnscheduleJobs` return one `bool` for the whole set and cannot
-say which. Calling that `"applied": false` would be a false statement about what happened, and a
-caller who retried on it would never learn that most of the work had already succeeded. Answering
-with the applied keys, as the key-set pause and resume do, is the better end state and is tracked in
-[#3360](https://github.com/quartznet/quartznet/issues/3360).
+existed and the operation changed it. There is no second spelling; an operation that cannot answer
+that question about a single entity is a key-set form, and answers with the keys instead.
 
 ::: warning Changed in 4.x
-Five endpoints spelled the applied flag their own way in the 4.0 previews:
+Five endpoints spelled the applied flag their own way in the 4.0 previews, and the two key-set forms
+answered with a flag they could not honestly name:
 
 | Endpoint | 4.0 preview | 4.0 |
 |---|---|---|
@@ -153,8 +141,13 @@ Five endpoints spelled the applied flag their own way in the 4.0 previews:
 | `POST …/jobs/{group}/{name}/interrupt`, `POST …/jobs/interrupt/{fireInstanceId}` | `{ "interrupted": … }` | `{ "applied": … }` |
 | `POST …/triggers/{group}/{name}/unschedule` | `{ "triggerFound": … }` | `{ "applied": … }` |
 | `DELETE …/calendars/{name}` | `{ "calendarFound": … }` | `{ "applied": … }` |
-| `POST …/jobs/delete` | `{ "allJobsFound": … }` | `{ "allFound": … }` |
-| `POST …/triggers/unschedule` | `{ "allTriggersFound": … }` | `{ "allFound": … }` |
+| `POST …/jobs/delete` | `{ "allJobsFound": … }` | `{ "jobs": [ … ] }` |
+| `POST …/triggers/unschedule` | `{ "allTriggersFound": … }` | `{ "triggers": [ … ] }` |
+
+The last two changed shape, not just spelling: a partial hit **still deletes the keys it found**, and
+a single boolean could only say that not all of them were found — which a caller could not tell from
+nothing having happened. `jobs.length === request.jobs.length` is the old answer, computed from the
+new one.
 :::
 
 ### Errors are one shape per kind
@@ -292,8 +285,8 @@ the same way:
 { "applied": true }
 ```
 
-(`POST …/jobs/delete` and `POST …/triggers/unschedule` take a key set and answer `{ "allFound": … }`
-instead, [for the reason given above](#response-shape-conventions).)
+(`POST …/jobs/delete` and `POST …/triggers/unschedule` take a key set, so they answer with the keys
+they applied to, [like every other key-set form](#a-whole-set-of-keys-in-one-call).)
 
 `applied` is `false` when the key does not exist or the operation was a no-op (pausing an already
 paused trigger, resuming a trigger that was not paused, resetting a trigger that is not in the error
@@ -323,19 +316,26 @@ they applied to:
 | `POST …/jobs/keys/pause`, `…/jobs/keys/resume` | `{ "jobs": [ { "name": …, "group": … } ] }` | `{ "jobs": [ … ] }` |
 | `POST …/triggers/keys/pause`, `…/triggers/keys/resume` | `{ "triggers": [ { "name": …, "group": … } ] }` | `{ "triggers": [ … ] }` |
 | `POST …/triggers/keys/reset-from-error-state` | `{ "triggers": [ … ] }` | `{ "triggers": [ … ] }` |
+| `POST …/jobs/delete` | `{ "jobs": [ { "name": …, "group": … } ] }` | `{ "jobs": [ … ] }` |
+| `POST …/triggers/unschedule` | `{ "triggers": [ { "name": …, "group": … } ] }` | `{ "triggers": [ … ] }` |
 
 The answer is the plural of `{ "applied": … }`: a key the operation did not apply to — one that names
 nothing, one that was already paused, one that was not in the error state — is simply **absent** from
-the list, never an error. The order is the order the keys were given in.
+the list, never an error. The order is the order the keys were given in. `answer.length ===
+request.length` is the "every key was found" question, and when it is not, the list says which ones
+were.
 
-They live under `keys/` because the collection-level `pause` and `resume` already belong to the
-group-matcher forms, which select by query string rather than by body.
+The pause, resume and reset forms live under `keys/` because the collection-level `pause` and
+`resume` already belong to the group-matcher forms, which select by query string rather than by body.
+`delete` and `unschedule` have no group-matcher form to make room for, so they keep the plain path
+they have always had.
 
 The server does the whole set in one pass — one lock and one transaction for the ADO store — and
 signals the scheduling change once for the call. Listener events stay per key: one `TriggerPaused` /
-`JobPaused` / `TriggerResumed` / `JobResumed` for each key the operation applied to, and nothing at
-all for the rest. There is no key-set listener event, deliberately: `TriggersPaused(null)` means
-*every group*, and a monitoring listener would read it as a total outage.
+`JobPaused` / `TriggerResumed` / `JobResumed` / `JobDeleted` / `JobUnscheduled` for each key the
+operation applied to, and nothing at all for the rest. There is no key-set listener event,
+deliberately: `TriggersPaused(null)` means *every group*, and a monitoring listener would read it as
+a total outage.
 
 ## Configuration options
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
@@ -424,13 +424,14 @@ internal static class JobEndpoints
     }
 
     /// <summary>
-    /// Deletes a set of jobs, answering whether every key given was found.
+    /// Deletes a set of jobs, answering with the keys it deleted.
     /// </summary>
     /// <remarks>
-    /// The one mutation body that is not <c>applied</c>: a partial hit deletes the jobs it found, so
-    /// see <see cref="AllKeysFoundResponse" /> for why it may not claim to have applied.
+    /// A partial hit deletes the jobs it found, so the answer is the keys rather than a flag: a key
+    /// that names no job is absent from the list, and <c>jobs.length == request.jobs.length</c> is
+    /// the "every key was found" question a caller used to have to take on trust.
     /// </remarks>
-    [ProducesResponseType(typeof(AllKeysFoundResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(AppliedJobKeysResponse), StatusCodes.Status200OK)]
     private static Task<IResult> DeleteJobs(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -442,8 +443,8 @@ internal static class JobEndpoints
         return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var jobKeys = request.Jobs.Select(x => x.AsJobKey()).ToArray();
-            var allJobsFound = await scheduler.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
-            return new AllKeysFoundResponse(allJobsFound);
+            var deleted = await scheduler.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
+            return new AppliedJobKeysResponse([.. deleted.Select(KeyDto.Create)]);
         });
     }
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
@@ -449,13 +449,15 @@ internal static class TriggerEndpoints
     }
 
     /// <summary>
-    /// Unschedules a set of triggers, answering whether every key given was found.
+    /// Unschedules a set of triggers, answering with the keys it removed.
     /// </summary>
     /// <remarks>
-    /// The one mutation body that is not <c>applied</c>: a partial hit unschedules the triggers it
-    /// found, so see <see cref="AllKeysFoundResponse" /> for why it may not claim to have applied.
+    /// A partial hit unschedules the triggers it found, so the answer is the keys rather than a flag:
+    /// a key that names no trigger is absent from the list, and
+    /// <c>triggers.length == request.triggers.length</c> is the "every key was found" question a
+    /// caller used to have to take on trust.
     /// </remarks>
-    [ProducesResponseType(typeof(AllKeysFoundResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(AppliedTriggerKeysResponse), StatusCodes.Status200OK)]
     private static Task<IResult> UnscheduleJobs(
         EndpointHelper endpointHelper,
         ISchedulerRepository schedulerRepository,
@@ -467,8 +469,8 @@ internal static class TriggerEndpoints
         return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var triggerKeys = request.Triggers.Select(x => x.AsTriggerKey()).ToArray();
-            var allTriggersFound = await scheduler.UnscheduleJobs(triggerKeys, cancellationToken).ConfigureAwait(false);
-            return new AllKeysFoundResponse(allTriggersFound);
+            var unscheduled = await scheduler.UnscheduleJobs(triggerKeys, cancellationToken).ConfigureAwait(false);
+            return new AppliedTriggerKeysResponse([.. unscheduled.Select(KeyDto.Create)]);
         });
     }
 

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -250,7 +250,7 @@ public class JobRunShellBenchmark
             throw new NotImplementedException();
         }
 
-        public ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+        public ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
@@ -260,7 +260,7 @@ public class JobRunShellBenchmark
             throw new NotImplementedException();
         }
 
-        public ValueTask<bool> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+        public ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -265,18 +265,18 @@ public sealed class HttpScheduler : IScheduler
         return result.Applied;
     }
 
-    public async ValueTask<bool> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+    public async ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
 
-        var result = await httpClient.PostWithResponse<UnscheduleJobsRequest, AllKeysFoundResponse>(
+        var result = await httpClient.PostWithResponse<UnscheduleJobsRequest, AppliedTriggerKeysResponse>(
             $"{TriggerEndpointUrl()}/unschedule",
             new UnscheduleJobsRequest(triggerKeys.Select(KeyDto.Create).ToArray()),
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        return result.AllFound;
+        return [.. result.Triggers.Select(x => x.AsTriggerKey())];
     }
 
     public async ValueTask<DateTimeOffset?> RescheduleJob(TriggerKey triggerKey, ITrigger newTrigger, CancellationToken cancellationToken = default)
@@ -375,18 +375,18 @@ public sealed class HttpScheduler : IScheduler
         return result.Applied;
     }
 
-    public async ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+    public async ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobKeys);
 
-        var result = await httpClient.PostWithResponse<DeleteJobsRequest, AllKeysFoundResponse>(
+        var result = await httpClient.PostWithResponse<DeleteJobsRequest, AppliedJobKeysResponse>(
             $"{JobEndpointUrl()}/delete",
             new DeleteJobsRequest(jobKeys.Select(KeyDto.Create).ToArray()),
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        return result.AllFound;
+        return [.. result.Jobs.Select(x => x.AsJobKey())];
     }
 
     public ValueTask TriggerJob(JobKey jobKey, JobDataMap? data = null, CancellationToken cancellationToken = default)

--- a/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
@@ -487,14 +487,29 @@ public class JobEndpointsTest : WebApiTest
     [Test]
     public async Task DeleteJobsShouldWork()
     {
-        A.CallTo(() => FakeScheduler.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._))
+            .Returns(new List<JobKey> { jobKeyOne, jobKeyTwo });
 
         var result = await HttpScheduler.DeleteJobs([jobKeyOne, jobKeyTwo]);
-        result.Should().BeTrue();
+        result.Should().Equal([jobKeyOne, jobKeyTwo]);
 
         A.CallTo(() => FakeScheduler.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._))
             .WhenArgumentsMatch((IReadOnlyCollection<JobKey> jobKeys, CancellationToken _) => jobKeys.Contains(jobKeyOne) && jobKeys.Contains(jobKeyTwo))
             .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public async Task DeleteJobsShouldCarryThePartialHitBackToTheCaller()
+    {
+        // The whole point of the key list: three of five deleted used to answer false, which a caller
+        // could not tell from nothing having happened.
+        A.CallTo(() => FakeScheduler.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._))
+            .Returns(new List<JobKey> { jobKeyTwo });
+
+        var result = await HttpScheduler.DeleteJobs([jobKeyOne, jobKeyTwo]);
+
+        result.Should().Equal([jobKeyTwo],
+            "the key the server did not find is absent from the answer, and the one it deleted is named");
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
@@ -564,14 +564,28 @@ public class TriggerEndpointsTest : WebApiTest
     [Test]
     public async Task UnscheduleJobsShouldWork()
     {
-        A.CallTo(() => FakeScheduler.UnscheduleJobs(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.UnscheduleJobs(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._))
+            .Returns(new List<TriggerKey> { triggerKeyOne, triggerKeyTwo });
 
         var response = await HttpScheduler.UnscheduleJobs([triggerKeyOne, triggerKeyTwo]);
-        response.Should().BeTrue();
+        response.Should().Equal([triggerKeyOne, triggerKeyTwo]);
 
         A.CallTo(() => FakeScheduler.UnscheduleJobs(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._))
             .WhenArgumentsMatch((IReadOnlyCollection<TriggerKey> keys, CancellationToken _) => keys.Count == 2 && keys.Contains(triggerKeyOne) && keys.Contains(triggerKeyTwo))
             .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public async Task UnscheduleJobsShouldCarryThePartialHitBackToTheCaller()
+    {
+        A.CallTo(() => FakeScheduler.UnscheduleJobs(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._))
+            .Returns(new List<TriggerKey> { triggerKeyOne });
+
+        var response = await HttpScheduler.UnscheduleJobs([triggerKeyOne, triggerKeyTwo]);
+
+        response.Should().Equal([triggerKeyOne],
+            "one of the two keys was found, and the answer says which — the old flag could only say "
+            + "that not all of them were");
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
@@ -252,7 +252,8 @@ public class WireFormatSnapshotTest : WebApiTest
     /// <summary>
     /// The status code an operation answers with is as much of a contract as the body, and the
     /// conventions are not the obvious ones: a mutation that found nothing to change still answers 200
-    /// with a flag in the body, and only a missing scheduler or a missing read target is a 404.
+    /// saying so in the body — a flag, or an empty list of applied keys — and only a missing scheduler
+    /// or a missing read target is a 404.
     /// </summary>
     [Test]
     public async Task StatusCodesFollowTheApiConventions()
@@ -275,8 +276,10 @@ public class WireFormatSnapshotTest : WebApiTest
             .Returns(new List<JobKey> { existingJob });
         A.CallTo(() => FakeScheduler.DeleteJob(existingJob, A<CancellationToken>._)).Returns(true);
         A.CallTo(() => FakeScheduler.DeleteJob(missingJob, A<CancellationToken>._)).Returns(false);
-        A.CallTo(() => FakeScheduler.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).Returns(false);
-        A.CallTo(() => FakeScheduler.UnscheduleJobs(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._))
+            .Returns(new List<JobKey> { existingJob });
+        A.CallTo(() => FakeScheduler.UnscheduleJobs(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._))
+            .Returns(new List<TriggerKey> { existingTrigger });
         A.CallTo(() => FakeScheduler.DeleteCalendar("existing", A<CancellationToken>._)).Returns(true);
         A.CallTo(() => FakeScheduler.DeleteCalendar("missing", A<CancellationToken>._)).Returns(false);
         A.CallTo(() => FakeScheduler.UnscheduleJob(existingTrigger, A<CancellationToken>._)).Returns(true);
@@ -347,15 +350,15 @@ public class WireFormatSnapshotTest : WebApiTest
             await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/interrupt", HttpStatusCode.OK, expectedBody: """{"applied":true}""");
             await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/missing/interrupt", HttpStatusCode.OK, expectedBody: """{"applied":false}""");
 
-            // the plural delete and unschedule are the exception, and the field is named for what
-            // they can actually report: a partial hit deleted the keys it found, so calling that
-            // "applied": false would be a false statement about what happened
+            // the plural delete and unschedule are key sets, so they answer the way every other key
+            // set does: with what they applied to. A partial hit deletes the keys it found and names
+            // exactly those, which no single flag could say.
             await Row(HttpMethod.Post, $"{SchedulerUrl}/jobs/delete", HttpStatusCode.OK,
                 """{"jobs":[{"name":"existing","group":"group"},{"name":"missing","group":"group"}]}""",
-                expectedBody: """{"allFound":false}""");
+                expectedBody: """{"jobs":[{"name":"existing","group":"group"}]}""");
             await Row(HttpMethod.Post, $"{SchedulerUrl}/triggers/unschedule", HttpStatusCode.OK,
                 """{"triggers":[{"name":"existing","group":"group"}]}""",
-                expectedBody: """{"allFound":true}""");
+                expectedBody: """{"triggers":[{"name":"existing","group":"group"}]}""");
 
             // a malformed request is a 400, never a 404 or a 500
             await Row(HttpMethod.Get, $"{SchedulerUrl}/jobs?skip=-1", HttpStatusCode.BadRequest);

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -226,13 +226,18 @@ public abstract class JobStoreContractTest
         // The defaults on IJobStore walk the set one key at a time, which is correct but costs a lock
         // or a round trip per key. Every shipped store does the walk in one pass instead, and the
         // answers are identical either way — so this is the only place the difference is visible.
+        // It is also what catches an override that has quietly stopped overriding: a member whose
+        // signature no longer matches the interface's still compiles, and the per-key default takes
+        // over without a word.
         string[] keySetMembers =
         [
             nameof(IJobStore.PauseTriggers),
             nameof(IJobStore.ResumeTriggers),
             nameof(IJobStore.PauseJobs),
             nameof(IJobStore.ResumeJobs),
-            nameof(IJobStore.ResetTriggersFromErrorState)
+            nameof(IJobStore.ResetTriggersFromErrorState),
+            nameof(IJobStore.DeleteJobs),
+            nameof(IJobStore.DeleteTriggers)
         ];
 
         System.Reflection.InterfaceMapping map = Store.GetType().GetInterfaceMap(typeof(IJobStore));
@@ -538,6 +543,73 @@ public abstract class JobStoreContractTest
         // otherwise never show a caller a way to resume.
         (await Store.QueryJobGroups(new JobGroupQuery { Paused = true })).Items.Should().BeEmpty(
             "resume-all resumed everything, job groups included");
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Deleting a set of keys
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task DeletingASetOfJobsReportsOnlyTheKeysItRemoved()
+    {
+        await ScheduleJobWithTrigger("first", JobGroupA, TriggerGroupA);
+        await ScheduleJobWithTrigger("second", JobGroupB, TriggerGroupB);
+        await ScheduleJobWithTrigger("survivor", JobGroupA, TriggerGroupA);
+
+        JobKey firstJob = new JobKey("first", JobGroupA);
+        JobKey secondJob = new JobKey("second", JobGroupB);
+        JobKey survivor = new JobKey("survivor", JobGroupA);
+
+        List<JobKey> deleted = await Store.DeleteJobs([firstJob, MissingJobKey, secondJob]);
+
+        deleted.Should().Equal([firstJob, secondJob],
+            "the answer names the jobs the call actually deleted, in the order they were given — the "
+            + "key that names no job is absent rather than turning the whole answer into a failure");
+
+        (await Store.Exists(firstJob)).Should().BeFalse();
+        (await Store.Exists(secondJob)).Should().BeFalse();
+        (await Store.Exists(survivor)).Should().BeTrue("a key that was not asked for is not touched");
+    }
+
+    [Test]
+    public async Task DeletingASetOfTriggersReportsOnlyTheKeysItRemoved()
+    {
+        IOperableTrigger first = await ScheduleJobWithTrigger("first", JobGroupA, TriggerGroupA);
+        IOperableTrigger second = await ScheduleJobWithTrigger("second", JobGroupB, TriggerGroupB);
+        IOperableTrigger survivor = await ScheduleJobWithTrigger("survivor", JobGroupA, TriggerGroupA);
+
+        List<TriggerKey> deleted = await Store.DeleteTriggers([first.Key, MissingTriggerKey, second.Key]);
+
+        deleted.Should().Equal([first.Key, second.Key],
+            "the answer names the triggers the call actually removed, in the order they were given");
+
+        (await Store.Exists(first.Key)).Should().BeFalse();
+        (await Store.Exists(second.Key)).Should().BeFalse();
+        (await Store.Exists(survivor.Key)).Should().BeTrue();
+
+        (await Store.Exists(new JobKey("first", JobGroupA))).Should().BeFalse(
+            "removing the last trigger of a non-durable job takes the job with it, exactly as the "
+            + "single-key form does");
+    }
+
+    /// <summary>
+    /// A key given twice is deleted once and named once.
+    /// </summary>
+    /// <remarks>
+    /// The old <see cref="bool" /> hid this: a repeated key made the second pass answer "not found"
+    /// and dragged the whole call's answer to <see langword="false" />, which read as a failure. With
+    /// the applied keys it is simply one entry, and the two stores have to agree that it is one.
+    /// </remarks>
+    [Test]
+    public async Task ADuplicateKeyInTheSetIsDeletedOnceAndNamedOnce()
+    {
+        await ScheduleJobWithTrigger("twice", JobGroupA, TriggerGroupA);
+        JobKey job = new JobKey("twice", JobGroupA);
+
+        List<JobKey> deleted = await Store.DeleteJobs([job, job]);
+
+        deleted.Should().Equal([job], "the second pass over the same key found nothing left to delete");
+        (await Store.Exists(job)).Should().BeFalse();
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -979,9 +1051,7 @@ public abstract class JobStoreContractTest
     public static IEnumerable<MissingEntityCase> MissingEntityCases()
     {
         yield return new MissingEntityCase(nameof(IJobStore.DeleteJob), store => store.DeleteJob(MissingJobKey));
-        yield return new MissingEntityCase(nameof(IJobStore.DeleteJobs), store => store.DeleteJobs([MissingJobKey]));
         yield return new MissingEntityCase(nameof(IJobStore.DeleteTrigger), store => store.DeleteTrigger(MissingTriggerKey));
-        yield return new MissingEntityCase(nameof(IJobStore.DeleteTriggers), store => store.DeleteTriggers([MissingTriggerKey]));
         yield return new MissingEntityCase(nameof(IJobStore.ReplaceTrigger), store => store.ReplaceTrigger(
             MissingTriggerKey,
             CreateTrigger("replacement", TriggerGroupA, AnchorJobKey)));
@@ -1052,8 +1122,8 @@ public abstract class JobStoreContractTest
     {
         await SeedAnchor();
 
-        (await Store.DeleteJobs([])).Should().BeTrue("nothing was asked for, so nothing is missing");
-        (await Store.DeleteTriggers([])).Should().BeTrue();
+        (await Store.DeleteJobs([])).Should().BeEmpty("nothing was asked for, so nothing was deleted");
+        (await Store.DeleteTriggers([])).Should().BeEmpty();
 
         (await Store.Exists(AnchorJobKey)).Should().BeTrue("an empty batch deletes nothing");
     }

--- a/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
+++ b/src/Quartz.Tests.Integration/Impl/SmokeTestPerformer.cs
@@ -433,6 +433,7 @@ public class SmokeTestPerformer
                 await scheduler.GetTriggerGroupNames();
 
                 await TestExecutionGroups(scheduler);
+                await TestKeySetDeletes(scheduler);
                 await TestMatchers(scheduler);
                 await TestGetTriggerStateExecutingWhileJobRuns(scheduler);
             }
@@ -442,6 +443,62 @@ public class SmokeTestPerformer
             customTimeZoneResolverRegistration?.Dispose();
             await scheduler.Shutdown(false);
         }
+    }
+
+    /// <summary>
+    /// The key-set delete and unschedule answer with the keys they applied to, against whichever
+    /// dialect this run is driving.
+    /// </summary>
+    /// <remarks>
+    /// The ADO store walks the set inside one <c>TriggerAccess</c> lock and one transaction, deleting
+    /// per key because each delete is a cascade rather than a statement. That the walk still reports
+    /// per key — and reports the same keys the in-memory store would — is the whole of #3360, and it
+    /// is dialect-sensitive: the answer comes from each delete's affected-row count, which is the one
+    /// thing every provider spells its own way.
+    /// </remarks>
+    private async Task TestKeySetDeletes(IScheduler scheduler)
+    {
+        await scheduler.Clear();
+
+        JobKey firstJob = new JobKey("bulk-first", "bulk");
+        JobKey secondJob = new JobKey("bulk-second", "bulk");
+        JobKey survivingJob = new JobKey("bulk-survivor", "bulk");
+        JobKey missingJob = new JobKey("bulk-missing", "bulk");
+
+        foreach (JobKey key in new[] { firstJob, secondJob, survivingJob })
+        {
+            IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity(key).StoreDurably().Build();
+            await scheduler.AddJob(job, new AddJobOptions { Replace = true });
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(key.Name, "bulk")
+                .ForJob(job)
+                .WithSimpleSchedule(s => s.WithRepeatCount(0))
+                .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+                .Build();
+            await scheduler.ScheduleJob(trigger);
+        }
+
+        List<TriggerKey> unscheduled = await scheduler.UnscheduleJobs(
+            [new TriggerKey("bulk-first", "bulk"), new TriggerKey("bulk-missing", "bulk")]);
+
+        unscheduled.Should().Equal([new TriggerKey("bulk-first", "bulk")],
+            "the unschedule names the triggers it removed, and the key that names no trigger is absent");
+
+        List<JobKey> deleted = await scheduler.DeleteJobs([firstJob, missingJob, secondJob]);
+
+        deleted.Should().Equal([firstJob, secondJob],
+            "the delete names the jobs it removed, in the order they were given — a partial hit deletes "
+            + "what it found rather than reporting one failure for the whole set");
+
+        (await scheduler.Exists(firstJob)).Should().BeFalse();
+        (await scheduler.Exists(secondJob)).Should().BeFalse();
+        (await scheduler.Exists(survivingJob)).Should().BeTrue("a key that was not asked for is untouched");
+
+        (await scheduler.DeleteJobs([missingJob])).Should().BeEmpty(
+            "a set in which nothing was found is an empty answer, not a throw");
+
+        await scheduler.Clear();
     }
 
     private async Task TestExecutionGroups(IScheduler scheduler)

--- a/src/Quartz.Tests.Unit/Core/BulkKeySetOperationsTest.cs
+++ b/src/Quartz.Tests.Unit/Core/BulkKeySetOperationsTest.cs
@@ -30,7 +30,7 @@ using Quartz.Listeners;
 namespace Quartz.Tests.Unit.Core;
 
 /// <summary>
-/// What a key-set pause, resume or error-state reset tells the outside world.
+/// What a key-set pause, resume, error-state reset, delete or unschedule tells the outside world.
 /// </summary>
 /// <remarks>
 /// The answers themselves belong to the job store contract; what belongs here is the part only the
@@ -41,7 +41,7 @@ namespace Quartz.Tests.Unit.Core;
 /// covers the whole set. That is why the scheduler must reach the store once, and never loop.
 /// </remarks>
 [NonParallelizable]
-public class BulkPauseResumeTest
+public class BulkKeySetOperationsTest
 {
     private CountingJobStore store = null!;
     private RecordingSchedulerListener listener = null!;
@@ -143,6 +143,71 @@ public class BulkPauseResumeTest
     }
 
     [Test]
+    public async Task DeletingASetOfJobsAnswersWithTheKeysItDeletedAndRaisesOneEventEach()
+    {
+        // Durable, so that removing the job's trigger does not orphan it: the store announces a job it
+        // deletes on its own account, and this test is about what the scheduler announces.
+        await Schedule("first", durable: true);
+        await Schedule("second", durable: true);
+        JobKey firstJob = new JobKey("first", "jobs");
+        JobKey secondJob = new JobKey("second", "jobs");
+        JobKey missing = new JobKey("missing", "nowhere");
+
+        List<JobKey> deleted = await scheduler.DeleteJobs([firstJob, missing, secondJob]);
+
+        deleted.Should().Equal([firstJob, secondJob],
+            "two of the three keys named a job, and the answer says which two — the old bool could "
+            + "only say that not all three did, which a caller could not tell from nothing happening");
+
+        listener.DeletedJobs.Should().Equal([firstJob, secondJob],
+            "a key that named no job was never deleted, so nothing is announced for it");
+
+        store.BulkDeleteJobCalls.Should().Be(1, "one call into the store is what makes one scheduling signal possible");
+        store.SingleDeleteJobCalls.Should().Be(0, "a loop over the single-key member would signal per key");
+
+        (await scheduler.Exists(firstJob)).Should().BeFalse();
+        (await scheduler.Exists(secondJob)).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task UnschedulingASetOfTriggersAnswersWithTheKeysItRemovedAndRaisesOneEventEach()
+    {
+        TriggerKey first = await Schedule("first");
+        TriggerKey second = await Schedule("second");
+        TriggerKey missing = new TriggerKey("missing", "nowhere");
+
+        List<TriggerKey> unscheduled = await scheduler.UnscheduleJobs([first, missing, second]);
+
+        unscheduled.Should().Equal([first, second]);
+        listener.UnscheduledTriggers.Should().Equal([first, second]);
+
+        store.BulkDeleteTriggerCalls.Should().Be(1);
+        store.SingleDeleteTriggerCalls.Should().Be(0);
+    }
+
+    /// <summary>
+    /// A key that named nothing used to be announced as deleted anyway.
+    /// </summary>
+    /// <remarks>
+    /// The old implementation raised one <c>JobDeleted</c> per key <em>given</em>, so a caller who
+    /// passed a mistyped key told every scheduler listener that a job by that name had been deleted.
+    /// The key-set pause family never did that, and neither does the single-key <c>DeleteJob</c>.
+    /// </remarks>
+    [Test]
+    public async Task AKeySetThatDeletedNothingAnnouncesNothing()
+    {
+        JobKey missing = new JobKey("missing", "nowhere");
+        TriggerKey missingTrigger = new TriggerKey("missing", "nowhere");
+
+        (await scheduler.DeleteJobs([missing])).Should().BeEmpty();
+        (await scheduler.UnscheduleJobs([missingTrigger])).Should().BeEmpty();
+
+        listener.DeletedJobs.Should().BeEmpty(
+            "a job that was never there was never deleted, and saying otherwise misinforms every listener");
+        listener.UnscheduledTriggers.Should().BeEmpty();
+    }
+
+    [Test]
     public async Task AKeySetThatMovedNothingRaisesNothing()
     {
         TriggerKey missing = new TriggerKey("missing", "nowhere");
@@ -161,12 +226,16 @@ public class BulkPauseResumeTest
         (await scheduler.PauseJobs([])).Should().BeEmpty();
         (await scheduler.ResumeJobs([])).Should().BeEmpty();
         (await scheduler.ResetTriggersFromErrorState([])).Should().BeEmpty();
+        (await scheduler.DeleteJobs([])).Should().BeEmpty();
+        (await scheduler.UnscheduleJobs([])).Should().BeEmpty();
 
         store.BulkPauseTriggerCalls.Should().Be(0, "nothing to do is answered without opening a connection");
         store.BulkResumeTriggerCalls.Should().Be(0);
         store.BulkPauseJobCalls.Should().Be(0);
         store.BulkResumeJobCalls.Should().Be(0);
         store.BulkResetCalls.Should().Be(0);
+        store.BulkDeleteJobCalls.Should().Be(0);
+        store.BulkDeleteTriggerCalls.Should().Be(0);
     }
 
     [Test]
@@ -174,11 +243,17 @@ public class BulkPauseResumeTest
     {
         Func<Task> pausingNothing = async () => await scheduler.PauseTriggers((IReadOnlyCollection<TriggerKey>) null!);
         await pausingNothing.Should().ThrowAsync<ArgumentNullException>();
+
+        Func<Task> deletingNothing = async () => await scheduler.DeleteJobs(null!);
+        await deletingNothing.Should().ThrowAsync<ArgumentNullException>();
+
+        Func<Task> unschedulingNothing = async () => await scheduler.UnscheduleJobs(null!);
+        await unschedulingNothing.Should().ThrowAsync<ArgumentNullException>();
     }
 
-    private async Task<TriggerKey> Schedule(string name)
+    private async Task<TriggerKey> Schedule(string name, bool durable = false)
     {
-        IJobDetail job = JobBuilder.Create<NoOpBulkJob>().WithIdentity(name, "jobs").Build();
+        IJobDetail job = JobBuilder.Create<NoOpBulkJob>().WithIdentity(name, "jobs").StoreDurably(durable).Build();
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity(name, "triggers")
             .ForJob(job)
@@ -206,11 +281,39 @@ public class BulkPauseResumeTest
 
         public int SinglePauseTriggerCalls { get; private set; }
         public int SingleResumeTriggerCalls { get; private set; }
+        public int SingleDeleteJobCalls { get; private set; }
+        public int SingleDeleteTriggerCalls { get; private set; }
         public int BulkPauseTriggerCalls { get; private set; }
         public int BulkResumeTriggerCalls { get; private set; }
         public int BulkPauseJobCalls { get; private set; }
         public int BulkResumeJobCalls { get; private set; }
         public int BulkResetCalls { get; private set; }
+        public int BulkDeleteJobCalls { get; private set; }
+        public int BulkDeleteTriggerCalls { get; private set; }
+
+        public override ValueTask<bool> DeleteJob(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            SingleDeleteJobCalls++;
+            return base.DeleteJob(jobKey, cancellationToken);
+        }
+
+        public override ValueTask<bool> DeleteTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        {
+            SingleDeleteTriggerCalls++;
+            return base.DeleteTrigger(triggerKey, cancellationToken);
+        }
+
+        public override ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+        {
+            BulkDeleteJobCalls++;
+            return base.DeleteJobs(jobKeys, cancellationToken);
+        }
+
+        public override ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+        {
+            BulkDeleteTriggerCalls++;
+            return base.DeleteTriggers(triggerKeys, cancellationToken);
+        }
 
         public override ValueTask<bool> PauseTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
@@ -261,6 +364,8 @@ public class BulkPauseResumeTest
         public List<TriggerKey> ResumedTriggers { get; } = [];
         public List<JobKey> PausedJobs { get; } = [];
         public List<JobKey> ResumedJobs { get; } = [];
+        public List<JobKey> DeletedJobs { get; } = [];
+        public List<TriggerKey> UnscheduledTriggers { get; } = [];
         public List<string?> PausedTriggerGroups { get; } = [];
         public List<string?> ResumedTriggerGroups { get; } = [];
         public List<string?> PausedJobGroups { get; } = [];
@@ -272,10 +377,24 @@ public class BulkPauseResumeTest
             ResumedTriggers.Clear();
             PausedJobs.Clear();
             ResumedJobs.Clear();
+            DeletedJobs.Clear();
+            UnscheduledTriggers.Clear();
             PausedTriggerGroups.Clear();
             ResumedTriggerGroups.Clear();
             PausedJobGroups.Clear();
             ResumedJobGroups.Clear();
+        }
+
+        public ValueTask JobDeleted(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            DeletedJobs.Add(jobKey);
+            return default;
+        }
+
+        public ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        {
+            UnscheduledTriggers.Add(triggerKey);
+            return default;
         }
 
         public ValueTask TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken = default)

--- a/src/Quartz.Tests.Unit/Core/JobStoreKeySetDefaultsTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobStoreKeySetDefaultsTest.cs
@@ -1,0 +1,149 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using FakeItEasy;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// The key-set members <see cref="IJobStore" /> supplies a default body for, exercised as a store
+/// that has not overridden them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every shipped store overrides all seven to walk the set in one lock or one transaction, so no other
+/// test ever runs the defaults — and the interface promises that <em>the answer must not change when
+/// a store overrides it</em>. That promise is only worth the paper it is written on if both sides of
+/// it are asserted, and <c>JobStoreContractTest</c> asserts only the overriding side.
+/// </para>
+/// <para>
+/// The store here is a fake whose plural member calls its base — the default implementation — while
+/// its singular member answers from the table below it. That is exactly the shape of a third-party
+/// store that implements only the single-key members.
+/// </para>
+/// </remarks>
+public class JobStoreKeySetDefaultsTest
+{
+    private static readonly JobKey FirstJob = new JobKey("first", "jobs");
+    private static readonly JobKey SecondJob = new JobKey("second", "jobs");
+    private static readonly JobKey MissingJob = new JobKey("missing", "jobs");
+
+    private static readonly TriggerKey FirstTrigger = new TriggerKey("first", "triggers");
+    private static readonly TriggerKey SecondTrigger = new TriggerKey("second", "triggers");
+    private static readonly TriggerKey MissingTrigger = new TriggerKey("missing", "triggers");
+
+    private IJobStore store;
+
+    [SetUp]
+    public void BuildStoreThatOverridesNothing()
+    {
+        store = A.Fake<IJobStore>();
+
+        A.CallTo(() => store.DeleteJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => store.DeleteTriggers(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => store.PauseJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => store.PauseTriggers(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => store.ResumeJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => store.ResumeTriggers(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => store.ResetTriggersFromErrorState(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+    }
+
+    [Test]
+    public async Task TheDefaultDeleteWalksTheSetAndNamesTheKeysTheSingleKeyMemberFound()
+    {
+        GivenTheseJobsExist(FirstJob, SecondJob);
+
+        List<JobKey> deleted = await store.DeleteJobs([FirstJob, MissingJob, SecondJob]);
+
+        deleted.Should().Equal([FirstJob, SecondJob],
+            "the default is the plural of DeleteJob: it keeps the keys that answered true, in the "
+            + "order they were given");
+
+        A.CallTo(() => store.DeleteJob(A<JobKey>._, A<CancellationToken>._)).MustHaveHappened(3, Times.Exactly);
+    }
+
+    [Test]
+    public async Task TheDefaultUnscheduleWalksTheSetAndNamesTheKeysTheSingleKeyMemberFound()
+    {
+        GivenTheseTriggersExist(FirstTrigger, SecondTrigger);
+
+        List<TriggerKey> deleted = await store.DeleteTriggers([FirstTrigger, MissingTrigger, SecondTrigger]);
+
+        deleted.Should().Equal([FirstTrigger, SecondTrigger]);
+    }
+
+    [Test]
+    public async Task ADefaultAnswersNothingForAnEmptySet()
+    {
+        (await store.DeleteJobs([])).Should().BeEmpty();
+        (await store.DeleteTriggers([])).Should().BeEmpty();
+
+        A.CallTo(() => store.DeleteJob(A<JobKey>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => store.DeleteTrigger(A<TriggerKey>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// The other five, so the whole family is exercised the same way rather than only the two this
+    /// test file was written for.
+    /// </summary>
+    [Test]
+    public async Task EveryOtherKeySetDefaultIsThePluralOfItsSingleKeyMember()
+    {
+        GivenTheseJobsExist(FirstJob);
+        GivenTheseTriggersExist(FirstTrigger);
+
+        (await store.PauseJobs([FirstJob, MissingJob])).Should().Equal([FirstJob]);
+        (await store.ResumeJobs([FirstJob, MissingJob])).Should().Equal([FirstJob]);
+        (await store.PauseTriggers([FirstTrigger, MissingTrigger])).Should().Equal([FirstTrigger]);
+        (await store.ResumeTriggers([FirstTrigger, MissingTrigger])).Should().Equal([FirstTrigger]);
+        (await store.ResetTriggersFromErrorState([FirstTrigger, MissingTrigger])).Should().Equal([FirstTrigger]);
+    }
+
+    private void GivenTheseJobsExist(params JobKey[] existing)
+    {
+        A.CallTo(() => store.DeleteJob(A<JobKey>._, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => store.PauseJob(A<JobKey>._, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => store.ResumeJob(A<JobKey>._, A<CancellationToken>._)).Returns(false);
+
+        foreach (JobKey key in existing)
+        {
+            A.CallTo(() => store.DeleteJob(key, A<CancellationToken>._)).Returns(true);
+            A.CallTo(() => store.PauseJob(key, A<CancellationToken>._)).Returns(true);
+            A.CallTo(() => store.ResumeJob(key, A<CancellationToken>._)).Returns(true);
+        }
+    }
+
+    private void GivenTheseTriggersExist(params TriggerKey[] existing)
+    {
+        A.CallTo(() => store.DeleteTrigger(A<TriggerKey>._, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => store.PauseTrigger(A<TriggerKey>._, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => store.ResumeTrigger(A<TriggerKey>._, A<CancellationToken>._)).Returns(false);
+        A.CallTo(() => store.ResetTriggerFromErrorState(A<TriggerKey>._, A<CancellationToken>._)).Returns(false);
+
+        foreach (TriggerKey key in existing)
+        {
+            A.CallTo(() => store.DeleteTrigger(key, A<CancellationToken>._)).Returns(true);
+            A.CallTo(() => store.PauseTrigger(key, A<CancellationToken>._)).Returns(true);
+            A.CallTo(() => store.ResumeTrigger(key, A<CancellationToken>._)).Returns(true);
+            A.CallTo(() => store.ResetTriggerFromErrorState(key, A<CancellationToken>._)).Returns(true);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoBulkDeleteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoBulkDeleteTest.cs
@@ -1,0 +1,191 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Data.Common;
+using System.Reflection;
+
+using FakeItEasy;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// What the ADO store's key-set delete and unschedule answer, and what they cost to answer it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The end-to-end proof is <c>JobStoreContractTest</c> against a real SQLite database, and
+/// <c>SmokeTestPerformer</c> against every dialect CI runs. What only this level can show is the two
+/// facts the design turns on: the answer is assembled from the per-key deletes the cascade already
+/// performs, so naming the keys costs no extra round trip, and the whole set runs inside **one**
+/// <see cref="SchedulerLock.TriggerAccess" /> scope rather than one per key.
+/// </para>
+/// <para>
+/// The delegate is faked, so "a key that exists" here means one whose delete reports a deleted row —
+/// which is exactly what the store has to go on against a real database.
+/// </para>
+/// </remarks>
+public class AdoBulkDeleteTest
+{
+    private static readonly JobKey FirstJob = new JobKey("first", "jobs");
+    private static readonly JobKey SecondJob = new JobKey("second", "jobs");
+    private static readonly JobKey MissingJob = new JobKey("missing", "jobs");
+
+    private static readonly TriggerKey FirstTrigger = new TriggerKey("first", "triggers");
+    private static readonly TriggerKey SecondTrigger = new TriggerKey("second", "triggers");
+    private static readonly TriggerKey MissingTrigger = new TriggerKey("missing", "triggers");
+
+    private LockCountingJobStore store;
+    private IDriverDelegate driverDelegate;
+
+    [SetUp]
+    public void SetUp()
+    {
+        store = new LockCountingJobStore();
+        driverDelegate = A.Fake<IDriverDelegate>();
+        store.DirectDelegate = driverDelegate;
+
+        // A faked ValueTask<List<T>> yields null, which the store would then enumerate.
+        A.CallTo(() => driverDelegate.SelectTriggerKeysForJob(
+                A<ConnectionAndTransactionHolder>._,
+                A<JobKey>._,
+                A<CancellationToken>._))
+            .Returns(new List<TriggerKey>());
+    }
+
+    [Test]
+    public async Task DeletingASetOfJobsNamesTheKeysWhoseRowsWereDeleted()
+    {
+        GivenJobDetailDeleteAffectsRowsFor(FirstJob, SecondJob);
+
+        List<JobKey> deleted = await store.DeleteJobs([FirstJob, MissingJob, SecondJob]);
+
+        deleted.Should().Equal([FirstJob, SecondJob],
+            "the answer is each delete's own outcome, in the order the keys were given — the key whose "
+            + "delete affected no row is absent");
+    }
+
+    [Test]
+    public async Task DeletingASetOfJobsCostsOneRoundTripPerKeyAndNoMore()
+    {
+        GivenJobDetailDeleteAffectsRowsFor(FirstJob, SecondJob);
+
+        await store.DeleteJobs([FirstJob, MissingJob, SecondJob]);
+
+        A.CallTo(() => driverDelegate.DeleteJobDetail(
+                A<ConnectionAndTransactionHolder>._,
+                A<JobKey>._,
+                A<CancellationToken>._))
+            .MustHaveHappened(3, Times.Exactly);
+
+        store.LockScopes.Should().Be(1,
+            "the set is deleted inside one TriggerAccess scope and one transaction — reporting which "
+            + "keys were deleted must not cost a lock per key");
+    }
+
+    [Test]
+    public async Task DeletingASetOfTriggersNamesTheKeysWhoseRowsWereDeleted()
+    {
+        A.CallTo(() => driverDelegate.DeleteTrigger(A<ConnectionAndTransactionHolder>._, A<TriggerKey>._, A<CancellationToken>._))
+            .Returns(0);
+        A.CallTo(() => driverDelegate.DeleteTrigger(A<ConnectionAndTransactionHolder>._, FirstTrigger, A<CancellationToken>._))
+            .Returns(1);
+        A.CallTo(() => driverDelegate.DeleteTrigger(A<ConnectionAndTransactionHolder>._, SecondTrigger, A<CancellationToken>._))
+            .Returns(1);
+
+        List<TriggerKey> deleted = await store.DeleteTriggers([FirstTrigger, MissingTrigger, SecondTrigger]);
+
+        deleted.Should().Equal([FirstTrigger, SecondTrigger]);
+        store.LockScopes.Should().Be(1);
+    }
+
+    [Test]
+    public async Task ASetInWhichNothingWasFoundIsAnEmptyAnswer()
+    {
+        A.CallTo(() => driverDelegate.DeleteJobDetail(A<ConnectionAndTransactionHolder>._, A<JobKey>._, A<CancellationToken>._))
+            .Returns(0);
+
+        List<JobKey> deleted = await store.DeleteJobs([MissingJob]);
+
+        deleted.Should().BeEmpty("nothing was there to delete, which is an answer rather than an error");
+    }
+
+    private void GivenJobDetailDeleteAffectsRowsFor(params JobKey[] existing)
+    {
+        A.CallTo(() => driverDelegate.DeleteJobDetail(A<ConnectionAndTransactionHolder>._, A<JobKey>._, A<CancellationToken>._))
+            .Returns(0);
+
+        foreach (JobKey key in existing)
+        {
+            A.CallTo(() => driverDelegate.DeleteJobDetail(A<ConnectionAndTransactionHolder>._, key, A<CancellationToken>._))
+                .Returns(1);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="AdoJobStoreBase" /> whose lock runs its callback and counts how often it was
+    /// entered, over a connection holder that reaches no database.
+    /// </summary>
+    private sealed class LockCountingJobStore : AdoJobStoreBase
+    {
+        public LockCountingJobStore()
+            : base(
+                TestJobStores.Signaler(),
+                TestJobStores.TypeLoader(),
+                TimeProvider.System,
+                TestJobStores.SchedulerOptions(),
+                TestJobStores.StoreOptions(),
+                TestJobStores.ClusteringOptions(),
+                TestJobStores.Serializer(),
+                TestJobStores.DbProvider(),
+                TestJobStores.DriverDelegate(),
+                TestJobStores.LockHandler())
+        {
+        }
+
+        public int LockScopes { get; private set; }
+
+        internal IDriverDelegate DirectDelegate
+        {
+            set
+            {
+                FieldInfo fieldInfo = typeof(AdoJobStoreBase).GetField("driverDelegate", BindingFlags.Instance | BindingFlags.NonPublic);
+                fieldInfo.Should().NotBeNull();
+                fieldInfo.SetValue(this, value);
+            }
+        }
+
+        protected override ValueTask<ConnectionAndTransactionHolder> GetLocalTransactionConnection(CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<ConnectionAndTransactionHolder>(new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null));
+        }
+
+        protected override ValueTask<T> ExecuteInLock<T>(
+            SchedulerLock? lockKind,
+            Func<ConnectionAndTransactionHolder, ValueTask<T>> txCallback,
+            CancellationToken cancellationToken = default)
+        {
+            lockKind.Should().Be(SchedulerLock.TriggerAccess, "a delete mutates triggers");
+            LockScopes++;
+            return txCallback(new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null));
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -100,7 +100,7 @@ public class QuartzHostedServiceTests
             throw new NotImplementedException();
         }
 
-        public ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+        public ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
@@ -343,7 +343,7 @@ public class QuartzHostedServiceTests
             throw new NotImplementedException();
         }
 
-        public ValueTask<bool> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+        public ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
@@ -29,7 +29,7 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask<bool> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -77,7 +77,7 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask StartDelayed(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerJob(Quartz.JobKey jobKey, Quartz.JobDataMap? data = null, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> UnscheduleJob(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask<bool> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> UpdateTriggerDetails(Quartz.TriggerKey triggerKey, Quartz.TriggerDetailsUpdate update, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public static class QuartzHttpClientServiceCollectionExtensions

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -654,7 +654,7 @@ namespace Quartz
         System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<bool> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
         new System.Threading.Tasks.ValueTask DisposeAsync();
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
@@ -702,7 +702,7 @@ namespace Quartz
         System.Threading.Tasks.ValueTask StartDelayed(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggerJob(Quartz.JobKey jobKey, Quartz.JobDataMap? data = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> UnscheduleJob(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<bool> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> UpdateTriggerDetails(Quartz.TriggerKey triggerKey, Quartz.TriggerDetailsUpdate update, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface ISchedulerFactory
@@ -1772,9 +1772,9 @@ namespace Quartz.Extensibility
         System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<bool> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<bool> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.TimeSpan GetAcquireRetryDelay(int failureCount);
@@ -2077,11 +2077,11 @@ namespace Quartz.Impl.AdoJobStore
         protected System.Threading.Tasks.ValueTask<bool> DeleteCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, bool activeDeleteSafe, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask<bool> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, Quartz.IJobDetail? job, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask<bool> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> DoCheckin(System.Guid requestorId, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<Quartz.Impl.AdoJobStore.RecoverMisfiredJobsResult> DoRecoverMisfires(System.Guid requestorId, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask ExecuteInLocalTransactionLock(Quartz.Impl.AdoJobStore.SchedulerLock? lockKind, System.Func<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder, System.Threading.Tasks.ValueTask> txCallback, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2991,9 +2991,9 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask<bool> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask<bool> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.TimeSpan GetAcquireRetryDelay(int failureCount) { }
@@ -3055,7 +3055,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask<bool> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3103,7 +3103,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask StartDelayed(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask TriggerJob(Quartz.JobKey jobKey, Quartz.JobDataMap? data = null, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> UnscheduleJob(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask<bool> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> UpdateTriggerDetails(Quartz.TriggerKey triggerKey, Quartz.TriggerDetailsUpdate update, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public abstract class HostNameBasedIdGenerator : Quartz.Extensibility.IInstanceIdGenerator
@@ -3176,9 +3176,9 @@ namespace Quartz.Impl
         public System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask<bool> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask<bool> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.TimeSpan GetAcquireRetryDelay(int failureCount) { }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -701,19 +701,29 @@ internal sealed class QuartzScheduler
         return result;
     }
 
-    public async ValueTask<bool> DeleteJobs(
+    public async ValueTask<List<JobKey>> DeleteJobs(
         IReadOnlyCollection<JobKey> jobKeys,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(jobKeys);
         ValidateState();
 
-        bool result = await resources.JobStore.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
-        NotifySchedulerThread(null);
-        foreach (JobKey key in jobKeys)
+        if (jobKeys.Count == 0)
         {
-            await NotifySchedulerListenersJobDeleted(key, cancellationToken).ConfigureAwait(false);
+            return [];
         }
-        return result;
+
+        List<JobKey> deleted = await resources.JobStore.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
+        if (deleted.Count > 0)
+        {
+            NotifySchedulerThread(null);
+            foreach (JobKey key in deleted)
+            {
+                await NotifySchedulerListenersJobDeleted(key, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return deleted;
     }
 
     public async ValueTask ScheduleJobs(
@@ -800,16 +810,29 @@ internal sealed class QuartzScheduler
         return ScheduleJobs(triggersAndJobs, options, cancellationToken);
     }
 
-    public async ValueTask<bool> UnscheduleJobs(
+    public async ValueTask<List<TriggerKey>> UnscheduleJobs(
         IReadOnlyCollection<TriggerKey> triggerKeys,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(triggerKeys);
         ValidateState();
 
-        bool result = await resources.JobStore.DeleteTriggers(triggerKeys, cancellationToken).ConfigureAwait(false);
-        NotifySchedulerThread(null);
-        await Task.WhenAll(triggerKeys.Select(x => NotifySchedulerListenersUnscheduled(x, cancellationToken).AsTask())).ConfigureAwait(false);
-        return result;
+        if (triggerKeys.Count == 0)
+        {
+            return [];
+        }
+
+        List<TriggerKey> unscheduled = await resources.JobStore.DeleteTriggers(triggerKeys, cancellationToken).ConfigureAwait(false);
+        if (unscheduled.Count > 0)
+        {
+            NotifySchedulerThread(null);
+            foreach (TriggerKey key in unscheduled)
+            {
+                await NotifySchedulerListenersUnscheduled(key, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return unscheduled;
     }
 
     /// <summary>

--- a/src/Quartz/Extensibility/IJobStore.cs
+++ b/src/Quartz/Extensibility/IJobStore.cs
@@ -156,7 +156,23 @@ public interface IJobStore
     /// </returns>
     ValueTask<bool> DeleteJob(JobKey jobKey, CancellationToken cancellationToken = default);
 
-    ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Remove (delete) the <see cref="IJob" />s with the given keys, and any
+    /// <see cref="ITrigger" />s that reference them.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation walks the set one key at a time. A store overrides it to do the
+    /// walk inside a single lock or connection scope; the answer must not change when it does.
+    /// </remarks>
+    /// <returns>
+    /// The keys this call removed, in the order they were given. A key that names no job is simply
+    /// absent — the plural of the single-key <see langword="bool" />, not a failure.
+    /// </returns>
+    /// <seealso cref="DeleteJob" />
+    ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+    {
+        return ApplyToEach(jobKeys, DeleteJob, cancellationToken);
+    }
 
     /// <summary>
     /// Retrieve the <see cref="IJobDetail" /> for the given
@@ -199,7 +215,24 @@ public interface IJobStore
     /// </returns>
     ValueTask<bool> DeleteTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default);
 
-    ValueTask<bool> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Remove (delete) the <see cref="ITrigger" />s with the given keys.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation walks the set one key at a time. A store overrides it to do the
+    /// walk inside a single lock or connection scope; the answer must not change when it does.
+    /// </remarks>
+    /// <returns>
+    /// The keys this call removed, in the order they were given. A key that names no trigger is
+    /// simply absent — the plural of the single-key <see langword="bool" />, not a failure. A job
+    /// left orphaned and non-durable by the removal is deleted too, as in the single-key form, but
+    /// the answer names triggers only.
+    /// </returns>
+    /// <seealso cref="DeleteTrigger" />
+    ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+    {
+        return ApplyToEach(triggerKeys, DeleteTrigger, cancellationToken);
+    }
 
     /// <summary>
     /// Remove (delete) the <see cref="ITrigger" /> with the

--- a/src/Quartz/HttpApiContract/RequestAndResponses.cs
+++ b/src/Quartz/HttpApiContract/RequestAndResponses.cs
@@ -62,21 +62,6 @@ internal record GroupPausedResponse(bool Paused);
 internal record OperationAppliedResponse(bool Applied);
 
 /// <summary>
-/// The answer of a key-set delete or unschedule: <c>AllFound</c> is <see langword="true" /> when every
-/// key given was found.
-/// </summary>
-/// <remarks>
-/// Deliberately not <see cref="OperationAppliedResponse" />, whose shape it shares. A partial hit
-/// deletes the keys it found and reports <see langword="false" />, so calling that "applied" would be
-/// a false statement about what happened, and a caller who retried on it would never learn that most
-/// of the work had already succeeded. <c>IScheduler.DeleteJobs</c> and <c>UnscheduleJobs</c> return
-/// one <see cref="bool" /> for the whole set and cannot say more; until they answer with the keys they
-/// applied to, as the key-set pause and resume do, this field is named for what it can actually
-/// report.
-/// </remarks>
-internal record AllKeysFoundResponse(bool AllFound);
-
-/// <summary>
 /// Answer of a group-matcher pause/resume: the names of the groups the operation affected.
 /// </summary>
 internal record AffectedGroupsResponse(string[] Groups);
@@ -98,14 +83,15 @@ internal record TriggerKeySetRequest(KeyDto[] Triggers) : IValidatable
 }
 
 /// <summary>
-/// Answer of a key-set job mutation: the keys the operation applied to, the plural of
-/// <see cref="OperationAppliedResponse" />. A key that was not found is simply absent.
+/// Answer of a key-set job mutation — pause, resume or delete: the keys the operation applied to, the
+/// plural of <see cref="OperationAppliedResponse" />. A key that was not found is simply absent.
 /// </summary>
 internal record AppliedJobKeysResponse(KeyDto[] Jobs);
 
 /// <summary>
-/// Answer of a key-set trigger mutation: the keys the operation applied to, the plural of
-/// <see cref="OperationAppliedResponse" />. A key that did not move is simply absent.
+/// Answer of a key-set trigger mutation — pause, resume, error-state reset or unschedule: the keys the
+/// operation applied to, the plural of <see cref="OperationAppliedResponse" />. A key that did not
+/// move is simply absent.
 /// </summary>
 internal record AppliedTriggerKeysResponse(KeyDto[] Triggers);
 

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -329,13 +329,23 @@ public interface IScheduler : IAsyncDisposable
     /// <remarks>
     /// <para>If the related job does not have any other triggers, and the job is
     /// not durable, then the job will also be deleted.</para>
-    /// Note that while this bulk operation is likely more efficient than
+    /// <para>Note that while this bulk operation is likely more efficient than
     /// invoking <see cref="UnscheduleJob" /> several
     /// times, it may have the adverse affect of holding data locks for a
     /// single long duration of time (rather than lots of small durations
-    /// of time).
+    /// of time).</para>
+    /// <para>One <see cref="ISchedulerListener.JobUnscheduled" /> is raised per key the removal
+    /// applied to, and the scheduling change is signalled once for the whole call. A key that was
+    /// not found raises nothing, as the single-key form raises nothing when it answers
+    /// <see langword="false" />.</para>
     /// </remarks>
-    ValueTask<bool> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default);
+    /// <returns>
+    /// The keys this call removed, in the order they were given. A key that names no trigger is
+    /// simply absent, never a throw — <c>result.Count == triggerKeys.Count</c> is the "every key was
+    /// found" answer, and the list itself says which ones when it is not.
+    /// </returns>
+    /// <seealso cref="UnscheduleJob" />
+    ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Remove (delete) the <see cref="ITrigger" /> with the
@@ -437,12 +447,18 @@ public interface IScheduler : IAsyncDisposable
     /// times, it may have the adverse affect of holding data locks for a
     /// single long duration of time (rather than lots of small durations
     /// of time).</para>
+    /// <para>One <see cref="ISchedulerListener.JobDeleted" /> is raised per key the deletion applied
+    /// to, and the scheduling change is signalled once for the whole call. A key that was not found
+    /// raises nothing, as the single-key form raises nothing when it answers
+    /// <see langword="false" />.</para>
     /// </remarks>
     /// <returns>
-    /// true if all of the Jobs were found and deleted, false if
-    /// one or more were not deleted.
+    /// The keys this call deleted, in the order they were given. A key that names no job is simply
+    /// absent, never a throw — <c>result.Count == jobKeys.Count</c> is the "every key was found"
+    /// answer, and the list itself says which ones when it is not.
     /// </returns>
-    ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default);
+    /// <seealso cref="DeleteJob" />
+    ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Trigger the identified <see cref="IJobDetail" /> (Execute it now).

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -1673,7 +1673,19 @@ public abstract class AdoJobStoreBase : IJobStore
         }
     }
 
-    public ValueTask<bool> DeleteJobs(
+    /// <summary>
+    /// Delete the identified jobs, and the triggers that reference them, in one lock and one
+    /// transaction.
+    /// </summary>
+    /// <remarks>
+    /// The walk is per key, and deliberately so: deleting a job is not one statement but a cascade —
+    /// its triggers and their sub-table rows, the fired-trigger rows that would otherwise resurrect
+    /// it (#1696), and finally the job detail row. A set-based <c>DELETE … WHERE … IN (…)</c> would
+    /// report a row count rather than which keys it hit, which is precisely the answer this member
+    /// owes its caller. Naming the deleted keys therefore costs nothing beyond what the cascade
+    /// already spends: each iteration's result was previously folded into a boolean and thrown away.
+    /// </remarks>
+    public ValueTask<List<JobKey>> DeleteJobs(
         IReadOnlyCollection<JobKey> jobKeys,
         CancellationToken cancellationToken = default)
     {
@@ -1682,19 +1694,27 @@ public abstract class AdoJobStoreBase : IJobStore
             () => ExecuteInLock(
                 SchedulerLock.TriggerAccess, async conn =>
                 {
-                    bool allFound = true;
-
-                    // TODO: make this more efficient with a true bulk operation...
+                    List<JobKey> deleted = new List<JobKey>(jobKeys.Count);
                     foreach (JobKey jobKey in jobKeys)
                     {
-                        allFound = await DeleteJob(conn, jobKey, true, cancellationToken).ConfigureAwait(false) && allFound;
+                        if (await DeleteJob(conn, jobKey, true, cancellationToken).ConfigureAwait(false))
+                        {
+                            deleted.Add(jobKey);
+                        }
                     }
 
-                    return allFound;
+                    return deleted;
                 }, cancellationToken));
     }
 
-    public ValueTask<bool> DeleteTriggers(
+    /// <summary>
+    /// Delete the identified triggers in one lock and one transaction.
+    /// </summary>
+    /// <remarks>
+    /// Per key for the same reason <see cref="DeleteJobs" /> is: removing a trigger also removes its
+    /// sub-table row, its fired-trigger rows, and the job it orphans when that job is not durable.
+    /// </remarks>
+    public ValueTask<List<TriggerKey>> DeleteTriggers(
         IReadOnlyCollection<TriggerKey> triggerKeys,
         CancellationToken cancellationToken = default)
     {
@@ -1704,15 +1724,16 @@ public abstract class AdoJobStoreBase : IJobStore
                 SchedulerLock.TriggerAccess,
                 async conn =>
                 {
-                    bool allFound = true;
-
-                    // TODO: make this more efficient with a true bulk operation...
+                    List<TriggerKey> deleted = new List<TriggerKey>(triggerKeys.Count);
                     foreach (TriggerKey triggerKey in triggerKeys)
                     {
-                        allFound = await DeleteTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false) && allFound;
+                        if (await DeleteTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false))
+                        {
+                            deleted.Add(triggerKey);
+                        }
                     }
 
-                    return allFound;
+                    return deleted;
                 }, cancellationToken));
     }
 

--- a/src/Quartz/Impl/DeferredScheduler.cs
+++ b/src/Quartz/Impl/DeferredScheduler.cs
@@ -194,7 +194,7 @@ internal sealed class DeferredScheduler : IScheduler
         return await target.UnscheduleJob(triggerKey, cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask<bool> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+    public async ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         var target = await Resolve(cancellationToken).ConfigureAwait(false);
         return await target.UnscheduleJobs(triggerKeys, cancellationToken).ConfigureAwait(false);
@@ -236,7 +236,7 @@ internal sealed class DeferredScheduler : IScheduler
         return await target.DeleteJob(jobKey, cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+    public async ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         var target = await Resolve(cancellationToken).ConfigureAwait(false);
         return await target.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Impl/DelegatingJobStore.cs
+++ b/src/Quartz/Impl/DelegatingJobStore.cs
@@ -105,7 +105,7 @@ public class DelegatingJobStore : IJobStore
         return jobStore.DeleteJob(jobKey, cancellationToken);
     }
 
-    public virtual ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+    public virtual ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         return jobStore.DeleteJobs(jobKeys, cancellationToken);
     }
@@ -125,7 +125,7 @@ public class DelegatingJobStore : IJobStore
         return jobStore.DeleteTrigger(triggerKey, cancellationToken);
     }
 
-    public virtual ValueTask<bool> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+    public virtual ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         return jobStore.DeleteTriggers(triggerKeys, cancellationToken);
     }

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -97,7 +97,7 @@ public class DelegatingScheduler : IScheduler
         return scheduler.UnscheduleJob(triggerKey, cancellationToken);
     }
 
-    public virtual ValueTask<bool> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+    public virtual ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         return scheduler.UnscheduleJobs(triggerKeys, cancellationToken);
     }
@@ -132,7 +132,7 @@ public class DelegatingScheduler : IScheduler
         return scheduler.DeleteJob(jobKey, cancellationToken);
     }
 
-    public virtual ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+    public virtual ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         return scheduler.DeleteJobs(jobKeys, cancellationToken);
     }

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -360,18 +360,21 @@ public sealed class RAMJobStore : IJobStore
         return found;
     }
 
-    public async ValueTask<bool> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+    public async ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            bool allFound = true;
+            List<JobKey> deleted = new List<JobKey>(jobKeys.Count);
             foreach (JobKey key in jobKeys)
             {
-                allFound = await RemoveJobNoLock(key, cancellationToken).ConfigureAwait(false) && allFound;
+                if (await RemoveJobNoLock(key, cancellationToken).ConfigureAwait(false))
+                {
+                    deleted.Add(key);
+                }
             }
 
-            return allFound;
+            return deleted;
         }
         finally
         {
@@ -379,18 +382,21 @@ public sealed class RAMJobStore : IJobStore
         }
     }
 
-    public async ValueTask<bool> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+    public async ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            bool allFound = true;
+            List<TriggerKey> deleted = new List<TriggerKey>(triggerKeys.Count);
             foreach (TriggerKey key in triggerKeys)
             {
-                allFound = await RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false) && allFound;
+                if (await RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false))
+                {
+                    deleted.Add(key);
+                }
             }
 
-            return allFound;
+            return deleted;
         }
         finally
         {

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -217,7 +217,7 @@ internal sealed class StdScheduler : IScheduler
         return scheduler.AddJob(jobDetail, options, cancellationToken);
     }
 
-    public ValueTask<bool> DeleteJobs(
+    public ValueTask<List<JobKey>> DeleteJobs(
         IReadOnlyCollection<JobKey> jobKeys,
         CancellationToken cancellationToken = default)
     {
@@ -241,7 +241,7 @@ internal sealed class StdScheduler : IScheduler
         return scheduler.ScheduleJob(jobDetail, triggersForJob, options, cancellationToken);
     }
 
-    public ValueTask<bool> UnscheduleJobs(
+    public ValueTask<List<TriggerKey>> UnscheduleJobs(
         IReadOnlyCollection<TriggerKey> triggerKeys,
         CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
`IScheduler.DeleteJobs` and `UnscheduleJobs` answered one `bool` meaning "every key given was found".
Delete three of five existing jobs and the call answered `false` while **three jobs were deleted** —
nothing in the answer distinguished that from nothing having happened, and a caller who retried on
`false` never learned that most of the work had already succeeded.

They now answer with the keys they applied to, which is what the key-set pause, resume and
error-state reset already did. One rule for the whole family, and
`bool allFound = result.Count == keys.Count` recovers the old answer, so this is a replacement rather
than a trade.

```csharp
ValueTask<List<JobKey>>     DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, …);
ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, …);
```

## The ADO path, which is where this either works or does not

It already walked the set one key at a time under a `// TODO: make this more efficient with a true
bulk operation...`, folding each iteration's result into a boolean with `&&`. **Collecting the keys
instead costs nothing** — the per-key answer was already there and was being thrown away. No extra
round trip, no `IDriverDelegate` change, still one `SchedulerLock.TriggerAccess` scope and one
transaction for the whole set.

The TODO is replaced by a comment saying why the walk stays per key rather than why it should not:
deleting a job is a cascade, not a statement — its triggers and their sub-table rows, the
fired-trigger rows that would otherwise resurrect it (#1696), then the job detail row — and a
set-based `DELETE … WHERE … IN (…)` reports a row count rather than which keys it hit, which is
precisely the answer the member owes its caller.

## Both stores are held to the same answers

`JobStoreContractTest` gains three cases that run against **both** the in-memory store and a real
SQLite ADO one: a partial delete of jobs, a partial unschedule of triggers (including that the
orphaned non-durable job goes with the trigger), and a key repeated in the set — which the old `bool`
hid, because the second pass found nothing left to delete and dragged the whole call's answer to
`false`.

`TheKeySetMembersAreImplementedRatherThanLeftToTheLoopingDefault` now covers both members, and
`SmokeTestPerformer` gains a `TestKeySetDeletes` step so the ADO path is exercised on **every dialect
CI runs**, not just SQLite.

## Behaviour that changed beyond the return type

- **A key that named nothing no longer raises a listener event.** The old implementation raised one
  `JobDeleted` / `JobUnscheduled` per key *given*, so a mistyped key told every scheduler listener
  that a job by that name had been deleted. The single-key `DeleteJob` and the key-set pause family
  never did that.
- **An empty set never reaches the store**; a `null` one is an `ArgumentNullException`.
- **The scheduling change is signalled once**, and not at all when nothing was removed.

## The two HTTP endpoints, under #3359's rule

#3359 established that a `200` carries a body exactly when the operation has something to say the
caller could not work out for itself, and that the flag is named for what it reports. It named these
two `allFound` rather than `applied` precisely because the underlying API could not support
`applied`, and pointed here.

With real applied keys available, `POST …/jobs/delete` and `POST …/triggers/unschedule` become
ordinary members of the key-set family: they answer `{"jobs": […]}` and `{"triggers": […]}`, reusing
`AppliedJobKeysResponse` / `AppliedTriggerKeysResponse`. `AllKeysFoundResponse` is deleted, and the
flag-naming rule loses its only exception — the conventions table in `http-api.md` no longer needs an
"except where…" clause.

## Reviewer decisions

1. **`IJobStore.DeleteJobs` / `DeleteTriggers` became default implementations** (`ApplyToEach`),
   joining the five key-set members that already were. That makes the family uniform and makes
   `custom-job-store.md`'s existing claim about them true — it already said they had defaults, which
   they did not. The cost: a third-party store still declaring `ValueTask<bool> DeleteJobs` **still
   compiles**, silently stops implementing the member, and inherits the per-key default. The
   migration guide says so in as many words, and the contract test's key-set guard catches it for
   anyone running it. The alternative — leaving them required, so the reshape is a compile error —
   was weighed and rejected: the asymmetry it leaves behind has no durable justification, and
   somebody would "finish" it after 4.0.
2. **`DeleteJobsRequest` / `UnscheduleJobsRequest` were left alone.** They are now structurally
   identical to `JobKeySetRequest` / `TriggerKeySetRequest`, and folding them would change no wire
   bytes — only the OpenAPI schema component names. #3359 was about response naming, so this felt
   like scope worth naming rather than taking.

## Baselines and docs

Public API baselines regenerated through Verify; the diff is exactly the four members across
`IScheduler`, `IJobStore`, `AdoJobStoreBase`, `RAMJobStore`, `DelegatingJobStore`,
`DelegatingScheduler` and `HttpScheduler`, with no collateral. Note the generator renders a default
interface member the same as an abstract one, so the baseline cannot show that these two gained
defaults — the migration guide carries that.

The same delta is written up in `migration-guide.md` under "The key-set delete and unschedule answer
with the keys they removed", with the one-line recipe for the old answer, and the wire change is
carried into the "One flag per mutation" section and `packages/http-api.md`.

Closes #3360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3wNU6NFXyZztWp12PGQc
