### PR TITLE
Disposing the standalone scheduler factory shuts its scheduler down

### DIFF
--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -505,20 +505,48 @@ container of its own, at any point in the process's life, and `ISchedulerReposit
 result visible to `GetAllSchedulers`, the dashboard and the HTTP API:
 
 ```csharp
-IScheduler tenant = await QuartzSchedulerBuilder.Create()
+StandaloneSchedulerFactory tenantFactory = QuartzSchedulerBuilder.Create()
     .ConfigureScheduler(o => o.InstanceName = tenantId)
     .UsePersistentStore(s => s.UseSqlServer(connectionStrings[tenantId]))
-    .BuildScheduler();
+    .Build();
 
+IScheduler tenant = await tenantFactory.GetScheduler();
 await tenant.Start();
+
+tenantFactories[tenantId] = tenantFactory;
 app.Services.GetRequiredService<ISchedulerRepository>().Bind(tenant);
 ```
+
+Keep the factory for as long as the tenant exists — `tenantFactories` above is a dictionary keyed by
+tenant id — because it owns the container and is the only handle that can shut the tenant down again.
+`BuildScheduler()` is the shorter spelling that drops it on the floor, which is fine for a scheduler
+that lives as long as the process and wrong for one that has to be offboarded.
 
 What you take on by doing this: the returned `StandaloneSchedulerFactory` owns the container, so *you*
 start the scheduler and dispose the factory — the hosted service will not; the scheduler's jobs resolve
 from its own container rather than the application's unless you give it an `IJobFactory` that bridges;
-and health checks registered at startup do not cover it. `Bind` throws on a duplicate name, and
-offboarding is `Remove` plus disposing the factory.
+and health checks registered at startup do not cover it. `Bind` throws on a duplicate name.
+
+Offboarding is disposing the factory, which shuts the tenant's scheduler down and then disposes its
+container. Unbind it too, so the application's repository stops listing it at once rather than at its
+next read:
+
+```csharp
+StandaloneSchedulerFactory tenantFactory = tenantFactories[tenantId];
+tenantFactories.Remove(tenantId);
+
+await tenantFactory.DisposeAsync();
+app.Services.GetRequiredService<ISchedulerRepository>().Remove(tenantId);
+```
+
+::: warning Fixed in 4.0.0-alpha.2
+Unbinding is not offboarding on its own: `Remove` makes a tenant invisible, and only the disposal stops
+it. That distinction used to be fatal — in 4.0.0-alpha.1 disposing the factory disposed only its
+container, so this recipe took the tenant out of `GetAllSchedulers`, off the dashboard and out of the
+HTTP API while it went on firing its triggers for the rest of the process's life, with nothing left able
+to reach it ([#3380](https://github.com/quartznet/quartznet/issues/3380)). Disposal shuts the scheduler
+down as of 4.0.0-alpha.2, which is what makes the two steps above safe in either order.
+:::
 
 Weigh that against the group-per-tenant model, where onboarding is a `ScheduleJob` call and none of
 the above applies.

--- a/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
+++ b/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
@@ -71,9 +71,11 @@ registration mistake surfaces there rather than at the first job execution.
 ## The factory owns the container
 
 `StandaloneSchedulerFactory` is an `ISchedulerFactory` that also implements `IDisposable` and
-`IAsyncDisposable`. Disposing it disposes the service provider it was built with, which shuts the
-scheduler down and disposes everything the container created — the job store, the thread pool, your own
-registered services.
+`IAsyncDisposable`. Disposing it shuts the scheduler down and *then* disposes the service provider it
+was built with, along with everything that container created — the job store, the thread pool, your own
+registered services. That is the order the hosted service uses when an application stops, and it is that
+way round for a reason: a container disposed underneath a running scheduler leaves it firing triggers
+whose jobs it can no longer build.
 
 ```csharp
 await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
@@ -85,11 +87,29 @@ await scheduler.Start();
 
 // ... do work ...
 
-// leaving the scope shuts the scheduler down
+// leaving the scope shuts the scheduler down, then disposes the container
 ```
 
 Prefer `await using`. The synchronous `Dispose()` exists so the type fits `using` in code that cannot
-be async, but `DisposeAsync` is what lets the shutdown actually await.
+be async; it blocks on the same shutdown, which is all a synchronous door onto asynchronous work can do.
+
+The shutdown does not wait for running jobs to finish, which is the default that
+`QuartzHostedServiceOptions.WaitForJobsToComplete` and `IScheduler.Shutdown()` both carry. Say so
+yourself when you want to wait, and dispose afterwards — disposal then finds nothing left to shut down:
+
+```csharp
+await scheduler.Shutdown(waitForJobsToComplete: true);
+```
+
+Disposing twice does nothing the second time, and disposing a factory whose `GetScheduler()` was never
+called does nothing at all: a scheduler is never built merely to be torn down.
+
+::: warning Fixed in 4.0.0-alpha.2
+In 4.0.0-alpha.1 disposing the factory disposed only the container. The scheduler stayed running and
+kept firing, and where something had injected `IScheduler` the synchronous `Dispose()` threw
+`InvalidOperationException` instead of shutting anything down
+([#3380](https://github.com/quartznet/quartznet/issues/3380)).
+:::
 
 **Never disposing is a supported choice.** A console application whose scheduler runs until the process
 ends behaves exactly as it did with the process-lifetime scheduler of earlier versions. The dispose

--- a/docs/documentation/quartz-4.x/tutorial/testing.md
+++ b/docs/documentation/quartz-4.x/tutorial/testing.md
@@ -387,8 +387,8 @@ Four things keep tests from contaminating each other:
 - **One container per test.** `QuartzSchedulerBuilder.Build()` creates its own service provider and
   therefore its own scheduler repository — two builders never see each other's schedulers. That is what
   makes parallel tests safe, and it is also why a test cannot look up another test's scheduler.
-- **`await using` the factory.** Disposing `StandaloneSchedulerFactory` disposes its container and
-  shuts the scheduler down. A leaked scheduler keeps a scheduling loop running for the rest of the run.
+- **`await using` the factory.** Disposing `StandaloneSchedulerFactory` shuts the scheduler down and
+  disposes its container. A leaked scheduler keeps a scheduling loop running for the rest of the run.
 - **`Shutdown(waitForJobsToComplete: true)`** when a job may still be in flight and you need it
   finished before assertions or cleanup.
 

--- a/src/Quartz.Tests.Unit/Configuration/StandaloneSchedulerFactoryDisposalTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/StandaloneSchedulerFactoryDisposalTest.cs
@@ -1,0 +1,260 @@
+using System.Collections.Concurrent;
+
+using FakeItEasy;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Disposing the factory <see cref="QuartzSchedulerBuilder.Build"/> hands back has to shut the scheduler
+/// down, on both of the paths a container can take through it.
+/// </summary>
+/// <remarks>
+/// The factory owns the container, and the container is the only thing holding the scheduler, so
+/// disposal is the whole of a standalone scheduler's teardown story. Both branches used to be wrong, and
+/// wrong in opposite ways: with nothing having resolved <see cref="IScheduler"/> the container had
+/// nothing to dispose and the scheduler kept firing, and with something having resolved it the container
+/// held an <see cref="IAsyncDisposable"/>-only singleton and synchronous disposal threw.
+/// </remarks>
+[NonParallelizable]
+public class StandaloneSchedulerFactoryDisposalTest
+{
+    private static readonly ConcurrentDictionary<string, int> fires = new();
+
+    public sealed class CountingJob : IJob
+    {
+        public const string RunIdKey = "runId";
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            string runId = context.MergedJobDataMap.GetString(RunIdKey)!;
+            fires.AddOrUpdate(runId, 1, static (_, count) => count + 1);
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// A listener that wants the scheduler, which is the ordinary way a container ends up holding the
+    /// <see cref="IScheduler"/> singleton.
+    /// </summary>
+    public sealed class SchedulerAwareListener : ISchedulerListener
+    {
+        public SchedulerAwareListener(IScheduler scheduler)
+        {
+            Scheduler = scheduler;
+        }
+
+        public IScheduler Scheduler { get; }
+    }
+
+    /// <summary>
+    /// A listener whose construction says a scheduler was built, since the container resolves the
+    /// listeners only while building one.
+    /// </summary>
+    public sealed class ProbeListener : ISchedulerListener
+    {
+    }
+
+    [Test]
+    public async Task DisposeAsyncShutsTheSchedulerDown()
+    {
+        string runId = nameof(DisposeAsyncShutsTheSchedulerDown);
+        StandaloneSchedulerFactory factory = Builder(runId).Build();
+        IScheduler scheduler = await StartFiring(factory, runId);
+
+        await factory.DisposeAsync();
+
+        scheduler.IsShutdown.Should().BeTrue("the factory owns the scheduler's lifetime, so disposing it has to end that lifetime");
+        await AssertNoLongerFiring(runId);
+    }
+
+    [Test]
+    public async Task DisposeShutsTheSchedulerDown()
+    {
+        string runId = nameof(DisposeShutsTheSchedulerDown);
+        StandaloneSchedulerFactory factory = Builder(runId).Build();
+        IScheduler scheduler = await StartFiring(factory, runId);
+
+        factory.Dispose();
+
+        scheduler.IsShutdown.Should().BeTrue("a caller that wrote 'using' rather than 'await using' still disposed the factory");
+        await AssertNoLongerFiring(runId);
+    }
+
+    [Test]
+    public async Task DisposeAsyncShutsTheSchedulerDownWhenTheContainerHandedOutItsScheduler()
+    {
+        string runId = nameof(DisposeAsyncShutsTheSchedulerDownWhenTheContainerHandedOutItsScheduler);
+        StandaloneSchedulerFactory factory = BuilderWithSchedulerAwareListener(runId).Build();
+        IScheduler scheduler = await StartFiring(factory, runId);
+
+        await factory.DisposeAsync();
+
+        scheduler.IsShutdown.Should().BeTrue("the scheduler the container handed to a listener is the same one the factory built");
+        await AssertNoLongerFiring(runId);
+    }
+
+    [Test]
+    public async Task DisposeShutsTheSchedulerDownWhenTheContainerHandedOutItsScheduler()
+    {
+        string runId = nameof(DisposeShutsTheSchedulerDownWhenTheContainerHandedOutItsScheduler);
+        StandaloneSchedulerFactory factory = BuilderWithSchedulerAwareListener(runId).Build();
+        IScheduler scheduler = await StartFiring(factory, runId);
+
+        Action act = factory.Dispose;
+
+        act.Should().NotThrow("a container holding the IAsyncDisposable-only scheduler handle used to make synchronous disposal throw");
+        scheduler.IsShutdown.Should().BeTrue();
+        await AssertNoLongerFiring(runId);
+    }
+
+    [Test]
+    public async Task DisposingTwiceIsHarmless()
+    {
+        string runId = nameof(DisposingTwiceIsHarmless);
+        StandaloneSchedulerFactory factory = Builder(runId).Build();
+        IScheduler scheduler = await StartFiring(factory, runId);
+
+        await factory.DisposeAsync();
+
+        Func<Task> again = async () => await factory.DisposeAsync();
+        await again.Should().NotThrowAsync("disposal has to be idempotent, and disposing twice is a normal accident");
+
+        Action synchronously = factory.Dispose;
+        synchronously.Should().NotThrow();
+
+        scheduler.IsShutdown.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task DisposingAfterAnExplicitShutdownIsHarmless()
+    {
+        string runId = nameof(DisposingAfterAnExplicitShutdownIsHarmless);
+        StandaloneSchedulerFactory factory = Builder(runId).Build();
+        IScheduler scheduler = await StartFiring(factory, runId);
+
+        await scheduler.Shutdown(waitForJobsToComplete: true);
+
+        Func<Task> act = async () => await factory.DisposeAsync();
+
+        await act.Should().NotThrowAsync("a caller that wants to wait for its jobs shuts down itself, and then disposes");
+        scheduler.IsShutdown.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task AFailedShutdownIsReportedAndTheContainerIsDisposedAnyway()
+    {
+        IJobStore store = A.Fake<IJobStore>();
+        A.CallTo(() => store.Shutdown(A<CancellationToken>._))
+            .Throws(new InvalidOperationException("the store refused to shut down"));
+
+        StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = nameof(AFailedShutdownIsReportedAndTheContainerIsDisposedAnyway))
+            .UseJobStore(store)
+            .Build();
+
+        await factory.GetScheduler();
+
+        Func<Task> dispose = async () => await factory.DisposeAsync();
+
+        (await dispose.Should().ThrowAsync<AggregateException>("a shutdown that failed is not a shutdown, and swallowing it would hide it"))
+            .WithInnerException<InvalidOperationException>();
+
+        Func<Task> afterwards = async () => await factory.GetScheduler();
+        await afterwards.Should().ThrowAsync<ObjectDisposedException>(
+            "the container is the factory's to release, and holding on to it after a failed shutdown would leak the thread pool and the store too");
+    }
+
+    [Test]
+    public async Task DisposingAFactoryThatNeverBuiltASchedulerBuildsNothing()
+    {
+        bool listenerConstructed = false;
+        StandaloneSchedulerFactory factory = Builder(nameof(DisposingAFactoryThatNeverBuiltASchedulerBuildsNothing))
+            .AddSchedulerListener(_ =>
+            {
+                listenerConstructed = true;
+                return new ProbeListener();
+            })
+            .Build();
+
+        Func<Task> act = async () => await factory.DisposeAsync();
+
+        await act.Should().NotThrowAsync();
+        listenerConstructed.Should().BeFalse(
+            "nothing asked for a scheduler, so disposal must not build one just to tear it down");
+    }
+
+    private static QuartzSchedulerBuilder Builder(string instanceName)
+    {
+        return QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = instanceName)
+            .UseDefaultThreadPool(maxConcurrency: 2)
+            // Nothing on the firing path may need the container, or "still firing" stops being
+            // observable the moment the container is disposed — which is the state under test. The
+            // default factory builds each job from a dependency injection scope, so a scheduler left
+            // running by a broken disposal would fail every firing rather than count it, and the test
+            // would pass for the wrong reason.
+            .UseJobFactory<SimpleJobFactory>()
+            .UseInMemoryStore();
+    }
+
+    private static QuartzSchedulerBuilder BuilderWithSchedulerAwareListener(string instanceName)
+    {
+        return Builder(instanceName)
+            .AddSchedulerListener(provider => new SchedulerAwareListener(provider.GetRequiredService<IScheduler>()));
+    }
+
+    /// <summary>
+    /// Hands back a started scheduler whose repeating trigger has fired at least once, so that "it
+    /// stopped firing" is a statement about the disposal rather than about a trigger that never ran.
+    /// </summary>
+    private static async Task<IScheduler> StartFiring(StandaloneSchedulerFactory factory, string runId)
+    {
+        IScheduler scheduler = await factory.GetScheduler();
+        await scheduler.Start();
+
+        IJobDetail job = JobBuilder.Create<CountingJob>()
+            .WithIdentity(runId)
+            .UsingJobData(CountingJob.RunIdKey, runId)
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity(runId)
+            .StartNow()
+            .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromMilliseconds(50)).RepeatForever())
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+
+        for (int attempt = 0; attempt < 400 && FireCount(runId) == 0; attempt++)
+        {
+            await Task.Delay(50);
+        }
+
+        FireCount(runId).Should().BePositive("the trigger has to be firing before disposal can be shown to stop it");
+        return scheduler;
+    }
+
+    private static async Task AssertNoLongerFiring(string runId)
+    {
+        // A job already running when the shutdown began still gets to finish and count itself, so the
+        // count is allowed to settle before it is pinned. Generously, because a loaded build agent is
+        // the one machine where a straggler takes its time.
+        await Task.Delay(500);
+        int settled = FireCount(runId);
+
+        await Task.Delay(1000);
+
+        FireCount(runId).Should().Be(settled,
+            "the trigger repeats every 50 ms, so a scheduler still running would have fired many times over");
+    }
+
+    private static int FireCount(string runId)
+    {
+        return fires.GetValueOrDefault(runId);
+    }
+}

--- a/src/Quartz/QuartzSchedulerBuilder.cs
+++ b/src/Quartz/QuartzSchedulerBuilder.cs
@@ -179,6 +179,12 @@ public sealed class QuartzSchedulerBuilder : IQuartzBuilder
     /// <summary>
     /// Builds the scheduler.
     /// </summary>
+    /// <remarks>
+    /// The factory that owns the container is dropped, so the container outlives every reference to it:
+    /// shutting this scheduler down is still <see cref="IScheduler.Shutdown"/>, but nothing will ever
+    /// dispose what built it. That is the right trade for a scheduler that lives as long as the process
+    /// and the wrong one for anything shorter-lived — use <see cref="Build"/> and keep the factory there.
+    /// </remarks>
     public ValueTask<IScheduler> BuildScheduler(CancellationToken cancellationToken = default)
     {
         return Build().GetScheduler(cancellationToken);

--- a/src/Quartz/StandaloneSchedulerFactory.cs
+++ b/src/Quartz/StandaloneSchedulerFactory.cs
@@ -9,13 +9,25 @@ namespace Quartz;
 /// <para>
 /// This is what <see cref="QuartzSchedulerBuilder.Build"/> returns. A scheduler built without an
 /// application-supplied container has one of its own, and something has to own it — so the factory
-/// does, and disposing the factory disposes the container and everything in it, the scheduler
-/// included.
+/// does. Disposing the factory shuts down every scheduler that container built and then disposes the
+/// container, which is what the hosted service does for an application that has one.
+/// </para>
+/// <para>
+/// The shutdown does not wait for running jobs, which is the default
+/// <see cref="QuartzHostedServiceOptions.WaitForJobsToComplete"/> and
+/// <see cref="IScheduler.Shutdown"/> both carry — two Quartz-owned shutdown paths that disagreed about
+/// whether a job gets to finish would be a trap. A caller that wants to wait says so and then disposes:
+/// <c>await scheduler.Shutdown(waitForJobsToComplete: true)</c> leaves the factory with nothing left to
+/// shut down, so the two compose.
 /// </para>
 /// <para>
 /// Disposal is asynchronous where the caller can await it: shutting a scheduler down is asynchronous
 /// work, and <see cref="IDisposable.Dispose"/> can only block on it. Prefer
 /// <c>await using</c> over <c>using</c>.
+/// </para>
+/// <para>
+/// Disposing twice does nothing the second time, and disposing a factory whose scheduler was never
+/// asked for does nothing at all — a scheduler is never built merely to be torn down.
 /// </para>
 /// <para>
 /// A caller that never disposes behaves exactly as one did with the process-lifetime scheduler of
@@ -26,6 +38,7 @@ public sealed class StandaloneSchedulerFactory : ISchedulerFactory, IDisposable,
 {
     private readonly ServiceProvider provider;
     private readonly ISchedulerFactory inner;
+    private int disposed;
 
     internal StandaloneSchedulerFactory(ServiceProvider provider)
     {
@@ -52,16 +65,69 @@ public sealed class StandaloneSchedulerFactory : ISchedulerFactory, IDisposable,
     }
 
     /// <summary>
-    /// Disposes the container this factory owns, shutting its scheduler down.
+    /// Shuts down the schedulers this factory's container built, then disposes the container.
     /// </summary>
+    /// <remarks>
+    /// Blocking, because a synchronous door onto asynchronous work can do nothing else, and the
+    /// alternative is what this used to do: return promptly with the scheduler still running. It also
+    /// cannot be a bare container disposal, synchronous or not — a container that handed its
+    /// <see cref="IScheduler"/> to anything holds a singleton implementing only
+    /// <see cref="IAsyncDisposable"/>, and disposing such a container synchronously throws.
+    /// </remarks>
     public void Dispose()
     {
-        provider.Dispose();
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
     }
 
     /// <inheritdoc cref="Dispose" />
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        return provider.DisposeAsync();
+        if (Interlocked.Exchange(ref disposed, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            await ShutdownSchedulers().ConfigureAwait(false);
+        }
+        finally
+        {
+            // Even when a shutdown failed: the container is this factory's to release, and leaking it
+            // would leak the thread pool and the job store the failure left behind.
+            await provider.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Shuts down whatever this container actually built, reporting all the failures rather than the
+    /// first one.
+    /// </summary>
+    /// <remarks>
+    /// The repository asked here is this container's own, and a scheduler enters it when it is created
+    /// and leaves it when it is shut down. So this is nothing at all for a factory whose scheduler was
+    /// never asked for, and nothing again for one the caller has already shut down — neither case
+    /// builds a scheduler in order to tear it down.
+    /// </remarks>
+    private async ValueTask ShutdownSchedulers()
+    {
+        List<Exception>? exceptions = null;
+        foreach (IScheduler scheduler in await inner.GetAllSchedulers().ConfigureAwait(false))
+        {
+            try
+            {
+                await scheduler.Shutdown(waitForJobsToComplete: false).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                exceptions ??= [];
+                exceptions.Add(e);
+            }
+        }
+
+        if (exceptions is not null)
+        {
+            throw new AggregateException("One or more scheduler shutdowns failed.", exceptions);
+        }
     }
 }


### PR DESCRIPTION
Disposing `StandaloneSchedulerFactory` — what `QuartzSchedulerBuilder.Build()` hands back — did not shut
its scheduler down. Its whole disposal was `provider.Dispose()` / `provider.DisposeAsync()`, and nothing
in the scheduler graph is disposable, so on the path the documentation teaches the scheduler kept running
and kept firing. Where something *had* resolved `IScheduler` from the container, the captured
`DeferredScheduler` singleton is `IAsyncDisposable`-only and the synchronous `Dispose()` threw
`InvalidOperationException` instead. Two branches, mutually exclusive, neither of them a shutdown.

Closes #3380.

## Reproduced first

`StandaloneSchedulerFactoryDisposalTest` was written against the unfixed code and watched fail. Five of
its cases failed, one per broken branch:

```
Failed DisposeAsyncShutsTheSchedulerDown
   Expected scheduler.IsShutdown to be True …, but found False.
Failed DisposeShutsTheSchedulerDown
   Expected scheduler.IsShutdown to be True …, but found False.
Failed DisposeAsyncShutsTheSchedulerDownWhenTheContainerHandedOutItsScheduler
   Expected scheduler.IsShutdown to be True …, but found False.
Failed DisposeShutsTheSchedulerDownWhenTheContainerHandedOutItsScheduler
   Did not expect any exception …, but found System.InvalidOperationException:
   'Quartz.Impl.DeferredScheduler' type only implements IAsyncDisposable.
   Use DisposeAsync to dispose the container.
Failed DisposingTwiceIsHarmless
   Expected scheduler.IsShutdown to be True, but found False.
Failed!  - Failed: 5, Passed: 2, Total: 7
```

With the firing assertion moved ahead of the `IsShutdown` one, the same run reports the symptom the issue
describes directly — one second after `await factory.DisposeAsync()` the job had run twenty more times:

```
Expected FireCount(runId) to be 7 because the trigger repeats every 50 ms …, but found 27
```

All eight pass with the fix.

Note that the fire counter only observes this because the fixture configures `SimpleJobFactory`. Under the
default DI job factory a scheduler left running by the old disposal cannot *build* its jobs any more — it
goes on firing triggers and failing every one of them — so a job-body counter would have gone quiet and
the test would have passed for the wrong reason.

## The fix

`DisposeAsync` shuts down every scheduler this container built and then disposes the container, in that
order, because a container disposed underneath a running scheduler leaves it firing triggers whose jobs it
can no longer construct. The schedulers come from the container's own `ISchedulerRepository` rather than
from a remembered field: a scheduler enters it when it is created and leaves it when it is shut down, so
the list is empty for a factory whose `GetScheduler()` was never called and empty again for one the caller
already shut down. Nothing is built in order to be torn down, and the `LookupScheduler`-created scheduler
is covered as well as the `GetScheduler`-created one. A shutdown that fails is reported rather than
swallowed, and the container is disposed in a `finally` either way, so a failure does not also leak the
thread pool and the job store it left behind — `AFailedShutdownIsReportedAndTheContainerIsDisposedAnyway`
pins both halves with a job store whose `Shutdown` throws.

`BuildScheduler()` gained a remark saying what it costs, since it is the spelling that drops the factory
and therefore never disposes the container at all. That is the right trade for a process-lifetime
scheduler and the wrong one for anything shorter-lived, and it was not written down anywhere near the
method.

### `WaitForJobsToComplete`: `false`

`QuartzHostedServiceOptions.WaitForJobsToComplete` defaults to `false` and `IScheduler.Shutdown()` defaults
to `false`; a third Quartz-owned shutdown path defaulting to `true` would mean the same application
behaving differently depending on whether it was hosted, which is exactly the trap the issue warns about.
A caller who wants to wait says so and then disposes — `await scheduler.Shutdown(waitForJobsToComplete:
true)` leaves the factory with nothing left to shut down, so the two compose rather than fight. No new knob
was added for it: the standalone factory has no hosted service, so reading `QuartzHostedServiceOptions`
here would be borrowing an options type for a scenario it does not describe, and a `WaitForJobsToComplete`
property on the factory would be a second spelling of a call that already exists.

### Synchronous `Dispose()`: blocks

It blocks on `DisposeAsync()`, which is what the type's own documentation always claimed it did, and it is
the only option that leaves both branches correct:

- Throwing "use `DisposeAsync`" would break every existing `using StandaloneSchedulerFactory factory =
  …` — including ten in this repository's own test suite — and shipped in alpha.1 as a supported spelling.
- Keeping `provider.Dispose()` cannot work at all on the second branch: that call is precisely what throws
  when the container holds the `IAsyncDisposable`-only `DeferredScheduler`.

Blocking is safe here rather than merely tolerable: every `await` on the shutdown path in `QuartzScheduler`,
`QuartzSchedulerThread` and `TaskSchedulingThreadPool` uses `ConfigureAwait(false)`, as does
`ServiceProvider.DisposeAsync`, so no continuation needs the blocked thread even under a synchronization
context.

### Idempotence

An `Interlocked` claim makes the second disposal a no-op, in either spelling and in either order —
`DisposingTwiceIsHarmless` disposes asynchronously and then synchronously. Disposing after the caller's own
`Shutdown()` is covered by `DisposingAfterAnExplicitShutdownIsHarmless`.

## Documentation

- `src/Quartz/StandaloneSchedulerFactory.cs` — the two XML doc comments the issue names, plus the
  `WaitForJobsToComplete` choice and the idempotence guarantee.
- `docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md` — the ordering, the sample comment, what
  synchronous `Dispose()` does, how to wait for jobs, and a `Fixed in 4.0.0-alpha.2` note.
- `docs/documentation/quartz-4.x/multi-tenancy.md` — the runtime-tenant recipe. **This one needed more than
  a rewording:** its sample called `BuildScheduler()`, which drops the factory on the floor, while the prose
  beside it said to dispose that factory — so the offboarding it taught could not be followed at all, and
  the nearest thing to it (unbinding alone) removed the tenant from the repository, the dashboard and the
  HTTP API while it went on firing forever. The sample keeps the factory now, and offboarding is disposal
  with the unbind alongside it rather than instead of it.
- `docs/documentation/quartz-4.x/tutorial/testing.md` — one line that had the two halves the wrong way
  round.

`docs/documentation/quartz-3.x/` untouched. No public API moved, so the Verify baselines are unchanged and
there is no migration-guide delta; the guide's existing claim that "disposal shuts the scheduler down,
which is asynchronous work that `Dispose()` can only block on" is simply true now.

## For a reviewer to decide

- **`waitForJobsToComplete: false`** is the load-bearing choice. Everything else follows from it.
- **A blocking `Dispose()`** is a deliberate refusal to throw. It is friendlier to existing code and matches
  the documented contract, at the cost of being a sync-over-async call in a library.
- **The repository-driven shutdown** shuts down every scheduler in the container, not only the one handed
  out. For a standalone container that is the same set today; it stays right if a caller registers a second
  scheduler through `builder.Services`.
- **Not fixed here:** disposal races a concurrent `GetScheduler()` — a scheduler created after the shutdown
  loop has passed would survive the container's disposal. Serializing that needs a lock on a path that has
  never had one, and the pre-existing behaviour was worse in every case.

## Verification

```
dotnet build Quartz.slnx
  Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
  Passed!  - Failed: 0, Passed: 3082, Skipped: 4, Total: 3086, Duration: 50 s

dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
  Passed!  - Failed: 0, Passed: 314, Skipped: 0, Total: 314, Duration: 4 s
```

Integration tests were not run — this change touches neither a job store nor a database, and the scheduler
lifecycle it covers is exercised by the unit suite.
