### PR TITLE
Sonar skips Dependabot's pull requests, and two trigger tests stop reading the wall clock

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -44,8 +44,11 @@ jobs:
   analyze:
     name: analyze
     # A pull request from a fork cannot read SONAR_TOKEN, so the scanner would have nothing to
-    # authenticate with. Those pull requests keep every other check.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # authenticate with. Neither can one Dependabot opened: those runs draw on Dependabot's own
+    # secret store, which is separate from the repository's and holds no SONAR_TOKEN — and a
+    # dependency bump changes no code Sonar has anything to say about. Both kinds of pull request
+    # keep every other check.
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/src/Quartz.Tests.Unit/CronTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CronTriggerTest.cs
@@ -300,19 +300,30 @@ public class CronTriggerTest
     [Test]
     public void TriggerWithFutureStartTimeIsUnaffectedByPastGuard()
     {
-        var futureStart = DateTimeOffset.UtcNow.AddHours(1);
+        // A frozen clock, with a fraction of a second on it that is the whole of the story. Read
+        // from the wall clock instead, this test failed for one second in every five minutes: when
+        // an hour from now lands on a "0 */5" slot, the trigger rounds that start time down to the
+        // whole second it sits in and fires exactly there - on its own start, but below the
+        // un-rounded value the test had handed in and was comparing against.
+        DateTimeOffset now = new DateTimeOffset(2026, 8, 22, 22, 50, 0, TimeSpan.Zero).AddTicks(4_543_838);
+        DateTimeOffset futureStart = now.AddHours(1);
 
-        var trigger = (IOperableTrigger) TriggerBuilder.Create()
-            .WithIdentity("trigger1", "group1")
-            .WithCronSchedule("0 */5 * ? * *")
-            .StartAt(futureStart)
-            .Build();
+        CronTriggerImpl trigger = new CronTriggerImpl(new FixedTimeProvider(now))
+        {
+            Key = new TriggerKey("trigger1", "group1"),
+            CronExpressionString = "0 */5 * ? * *",
+            TimeZone = TimeZoneInfo.Utc,
+            StartTimeUtc = futureStart
+        };
 
-        var firstFireTime = trigger.ComputeFirstFireTimeUtc(null);
+        DateTimeOffset? firstFireTime = trigger.ComputeFirstFireTimeUtc(null);
 
-        Assert.That(firstFireTime, Is.Not.Null);
-        Assert.That(firstFireTime!.Value, Is.GreaterThanOrEqualTo(futureStart),
-            "Fire time should be on or after the future start time");
+        trigger.StartTimeUtc.Should().Be(new DateTimeOffset(2026, 8, 22, 23, 50, 0, TimeSpan.Zero),
+            "a cron trigger keeps its start time to the whole second, so the sub-second part of what was handed in is gone");
+
+        firstFireTime.Should().Be(trigger.StartTimeUtc,
+            "the guard moves a fire time only when it fell before now, and this one is an hour ahead of it; "
+            + "had it run, the answer would have been the first slot after now, 22:55");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/DailyTimeIntervalScheduleBuilderTest.cs
@@ -64,25 +64,27 @@ public class DailyTimeIntervalScheduleBuilderTest
     [Test]
     public async Task TestScheduleInMiddleOfDailyInterval()
     {
-        DateTimeOffset currTime = DateTimeOffset.UtcNow;
-
-        // this test won't work out well in the early hours, where 'backing up' would give previous day,
-        // or where daylight savings transitions could occur and confuse the assertions...
-        if (currTime.Hour < 3)
-        {
-            return;
-        }
+        // A fixed afternoon rather than whatever hour the suite happens to run in, and UTC rather
+        // than the machine's zone. Fire times are whole seconds counted off from 02:15, so a start
+        // time read from the wall clock can land on one of them - 22:50 does, counting five minutes
+        // at a time from 02:15 - and the trigger then starts on the slot it is already standing on
+        // rather than after it, which is what failed here at 22:50 UTC. The early-hours bail-out
+        // this test used to open with was the same dependence on the wall clock at the other end of
+        // the day, and goes with it: nothing here reads a clock any more.
+        FakeTimeProvider clock = new FakeTimeProvider(new DateTimeOffset(2026, 8, 22, 14, 32, 17, TimeSpan.Zero));
+        DateTimeOffset currTime = clock.GetUtcNow();
 
         NameValueCollection properties = new NameValueCollection
         {
             ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
         };
-        ISchedulerFactory sf = QuartzSchedulerBuilder.Create().UseProperties(properties).Build();
+        ISchedulerFactory sf = QuartzSchedulerBuilder.Create().UseProperties(properties).UseTimeProvider(clock).Build();
         IScheduler scheduler = await sf.GetScheduler();
 
         IJobDetail job = JobBuilder.Create<NoOpJob>().Build();
-        ITrigger trigger = TriggerBuilder.Create().WithIdentity("test")
+        ITrigger trigger = TriggerBuilder.Create(clock).WithIdentity("test")
             .WithDailyTimeIntervalSchedule(x => x
+                .InTimeZone(TimeZoneInfo.Utc)
                 .StartingDailyAt(new TimeOnly(2, 15))
                 .WithInterval(5, IntervalUnit.Minute))
             .StartAt(currTime)
@@ -91,17 +93,18 @@ public class DailyTimeIntervalScheduleBuilderTest
         await scheduler.ScheduleJob(job, trigger);
 
         trigger = await scheduler.GetTrigger(trigger.Key);
-        var nextFireTime = trigger.NextFireTimeUtc;
 
-        Assert.That(nextFireTime, Is.Not.Null);
-        Assert.That(nextFireTime, Is.GreaterThan(currTime));
+        trigger.NextFireTimeUtc.Should().Be(new DateTimeOffset(2026, 8, 22, 14, 35, 0, TimeSpan.Zero),
+            "starting in the middle of the day picks the schedule up at its next slot after 14:32:17, "
+            + "rather than backing up to where the day's firings began");
 
-        DateTimeOffset startTime = TestDates.TodayAt(2, 15, 0);
+        DateTimeOffset startTime = new DateTimeOffset(2026, 8, 22, 2, 15, 0, TimeSpan.Zero);
 
         job = JobBuilder.Create<NoOpJob>().Build();
 
-        trigger = TriggerBuilder.Create().WithIdentity("test2")
+        trigger = TriggerBuilder.Create(clock).WithIdentity("test2")
             .WithDailyTimeIntervalSchedule(x => x
+                .InTimeZone(TimeZoneInfo.Utc)
                 .StartingDailyAt(new TimeOnly(2, 15))
                 .WithInterval(5, IntervalUnit.Minute))
             .StartAt(startTime)
@@ -109,10 +112,9 @@ public class DailyTimeIntervalScheduleBuilderTest
         await scheduler.ScheduleJob(job, trigger);
 
         trigger = await scheduler.GetTrigger(trigger.Key);
-        nextFireTime = trigger.NextFireTimeUtc;
 
-        Assert.That(nextFireTime, Is.Not.Null);
-        Assert.That(nextFireTime, Is.EqualTo(startTime));
+        trigger.NextFireTimeUtc.Should().Be(startTime,
+            "a trigger that starts exactly where the daily window opens fires there, not an interval later");
 
         await scheduler.Shutdown();
     }


### PR DESCRIPTION
Two unrelated pieces of CI hygiene, one commit each.

## Sonar stands down on Dependabot's pull requests

The `analyze` job's `if:` skipped pull requests from forks, because a fork cannot read
`SONAR_TOKEN`. Dependabot's cannot either, for a different reason: its runs draw on Dependabot's
own secret store, which is separate from the repository's and holds no `SONAR_TOKEN`. So the job
trips its own guard — `SONAR_TOKEN is not set` — on every dependency bump. All six open Dependabot
pull requests are red on it (#3349, #3351, #3353, #3354, #3355, #3356; see run 32600551087).

A dependency bump changes no code Sonar has anything to say about, so the job has nothing to lose
by standing down. Those pull requests keep every other check.

**For a reviewer to decide:** the condition is `github.actor != 'dependabot[bot]'`, which is
GitHub's documented recipe and what this change was specified as. It keys off the actor rather than
the pull request's author, so a maintainer who re-runs a failed Dependabot job becomes the actor and
the analysis will attempt to run — and fail the same way, because the secret store is still
Dependabot's. `github.event.pull_request.user.login != 'dependabot[bot]'` would close that gap.
Flagging rather than changing, since re-running a job that has never once passed is not a normal
move.

## Two trigger tests read a fixed clock rather than the hour they run in

Both failed in run 32603448133 at 22:50 UTC and pass at every other time of day. One reason,
approached from two directions: **a fire time is a whole second, and a start time taken from
`DateTimeOffset.UtcNow` is not.**

Reproduced before touching either test, by driving the same code with a frozen clock at the exact
instants CI held. Both reproduce the CI failure to the tick:

| Test | Requested start | First fire time |
|---|---|---|
| `TriggerWithFutureStartTimeIsUnaffectedByPastGuard` | `2026-08-22T23:50:00.4543838Z` | `2026-08-22T23:50:00.0000000Z` |
| `TestScheduleInMiddleOfDailyInterval` | `2026-08-22T22:50:00.6815924Z` | `2026-08-22T22:50:00.0000000Z` |

### Root cause, cron

`CronTriggerImpl.StartTimeUtc` rounds a start time down to the whole second it sits in — deliberate,
and commented as such in the setter. The test handed in `UtcNow.AddHours(1)` and then compared the
fire time against that same un-rounded value. Whenever the hour ahead landed on a `0 */5` slot, the
first fire time was the slot itself: correct, and equal to the trigger's own start time, but below
what the assertion held. That is one second in every five minutes, which is exactly how often this
went red.

The trigger did the right thing throughout. This one is a test artefact.

### Root cause, daily time interval

`DailyTimeIntervalTriggerImpl` does **not** round its start time. `ComputeFirstFireTimeUtc` backs off
a second and hands the result to `GetFireTimeAfter`, which clamps `afterTime` up to `startTimeUtc`
and then computes the slot as

```csharp
long secondsAfterStart = (long) (fireTime.Value - startOfDayUtc).TotalSeconds;
```

The `(long)` discards the fraction, which undoes the clamp made two dozen lines above. `22:50:00` is
exactly slot 247 of a 02:15 + 5-minute schedule, so the first fire time came out at `22:50:00.000` —
0.68 s before the `StartTimeUtc` the trigger holds. The test asserted strictly-after and lost.

**Left alone deliberately, and worth a second opinion.** No product code is touched here. But the two
trigger implementations disagree: `CronTriggerImpl` normalises a start time to a whole second and
`DailyTimeIntervalTriggerImpl` does not, so only the latter can report a `NextFireTimeUtc` below its
own `StartTimeUtc`. The overshoot is sub-second and Quartz's model is second-granular throughout —
`StartTimeOfDay`/`EndTimeOfDay` are `TimeOnly`, misfire thresholds are seconds — so nothing observable
follows from it. Whether it is worth closing, and on which side, is a separate call from this one.

### What the tests do now

Frozen clocks and named instants, asserting the exact fire time rather than an inequality — a
stronger claim than what they replace, and one that still bites if the behaviour regresses. Had the
cron past-guard run when it should not, the answer would have been `22:55:00` rather than `23:50:00`;
had the daily trigger backed up to the start of its window, `02:15:00` rather than `14:35:00`.

- `CronTriggerTest` builds `CronTriggerImpl` directly on the file's existing `FixedTimeProvider`,
  as the frozen-clock test beside it already does. It has to: `CronScheduleBuilder.Build()` calls
  `new CronTriggerImpl()`, so a clock handed to `TriggerBuilder.Create(timeProvider)` never reaches
  the trigger, and the past guard reads `TimeProvider.System` regardless.
- `DailyTimeIntervalScheduleBuilderTest` keeps its builder-and-scheduler shape, on a
  `FakeTimeProvider` passed to both `QuartzSchedulerBuilder.UseTimeProvider` and
  `TriggerBuilder.Create`. The schedule is pinned to UTC with `InTimeZone`, so the machine's own zone
  no longer decides where the slots fall.
- The early-hours `return` at the top of the second test is gone. It was the same dependence on the
  wall clock seen from the other end of the day, and there is no clock left to guard against.

## Verification

```
dotnet build Quartz.slnx
  Build succeeded.  0 Warning(s)  0 Error(s)

dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
  Passed!  - Failed: 0, Passed: 3094, Skipped: 4, Total: 3098, Duration: 52 s

dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
  Passed!  - Failed: 0, Passed: 314, Skipped: 0, Total: 314, Duration: 6 s
```

Integration tests were not run: nothing here reaches them. Docker was available, so that is a
choice rather than a limitation.

No public API moved, so no baseline and no migration-guide entry. No issue tracks either of these,
so there is nothing to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
