### PR TITLE
Every scheduler in a container can be configured at once, and the dashboard uses it

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1566,6 +1566,47 @@ describes, is unchanged.
 The six phases that decide which of a scheduler's descriptions wins — configuration is last-wins,
 registration is first-wins — are now documented on `AddQuartz` itself rather than in comments inside it.
 
+## Every scheduler in the container can be configured at once
+
+`ConfigureAllQuartzSchedulers(Action<IQuartzBuilder>)` is new. It is the options pattern's `ConfigureAll`,
+for schedulers: the delegate is applied to every scheduler `AddQuartz()`, `AddQuartz(name, …)` or
+`AddQuartzSchedulers(…)` registers in the container.
+
+```csharp
+services.AddQuartz();
+services.AddQuartz("acme", q => q.UseInMemoryStore());
+services.AddQuartz("initech", q => q.UseInMemoryStore());
+
+// Both named schedulers and the default one get their own instance of each.
+services.ConfigureAllQuartzSchedulers(q =>
+{
+    q.AddPlugin<AuditPlugin>("audit");
+    q.AddJobListener<TenantMetricsListener>();
+});
+```
+
+**The order of the calls does not matter.** Schedulers already registered are configured where this is
+called; schedulers registered afterwards are configured by their own `AddQuartz`. That is the point: a
+library that adds something to every scheduler cannot know whether the application registers its
+schedulers before or after calling it.
+
+The delegate is handed a builder *per scheduler*, so everything it registers lands under that scheduler's
+own service key — exactly as if it had been written inside that scheduler's `AddQuartz(name, q => …)`
+callback. A plugin or listener added this way is therefore **one instance per scheduler**, each
+initialized with the name of the scheduler it belongs to, rather than one instance shared between them.
+
+It runs after each scheduler's own configuration callback, which is what makes the order immaterial. The
+usual precedence follows: registration is first-wins, so a job store or thread pool a scheduler chose for
+itself is not replaced by one chosen here; options are last-wins, so a value set here overrides the same
+option set on one scheduler, exactly as `ConfigureAll<TOptions>` overrides an earlier named `Configure`.
+
+Remote schedulers registered with `AddQuartzHttpClient` are not built by a builder and are skipped.
+Calling it when no scheduler is registered at all is not an error.
+
+`AddQuartzDashboard()` is its first caller: it installs its live-events and history plugins this way, so
+a scheduler registered with `AddQuartz("acme", …)` finally has a populated live view and execution
+history rather than two silently empty pages.
+
 ## `IScheduler` is a service, keyed by the scheduler's name
 
 `AddQuartz()` now registers `IScheduler` as well as `ISchedulerFactory`. The default scheduler is

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1654,6 +1654,14 @@ second remote scheduler needed a marker interface only because the container had
 The marker interfaces themselves can be deleted, and the first remote scheduler registered is still the
 unkeyed `IScheduler` for a container that holds only one.
 
+In a container that also holds a local scheduler, **`AddQuartz()` goes first**:
+
+| Order | What happens |
+|---|---|
+| `AddQuartz()` then `AddQuartzHttpClient(…)` | The local default scheduler owns `GetRequiredService<IScheduler>()`; the remote one is reached by name. This is the arrangement to write. |
+| `AddQuartzHttpClient(…)` then `AddQuartz()` | `AddQuartz()` throws `InvalidOperationException` at registration, naming `AddQuartzHttpClient`. Registration is first-wins, so this used to make "the scheduler" the remote one with no error at all — a program that thought it held its own scheduler was scheduling jobs in somebody else's process. |
+| `AddQuartzHttpClient(…)` then `AddQuartz("Local", …)` | Fine either way round. A named scheduler is keyed by its name and never wanted the unkeyed slot. |
+
 ### A client is named or built, never handed over
 
 `HttpClientOptions.HttpClient` and the `AddQuartzHttpClient(schedulerName, HttpClient, …)` overload are

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -66,7 +66,7 @@ initialized with its own name, and history entries are attributed to the schedul
 
 It does this with `ConfigureAllQuartzSchedulers`, so nothing extra is written at the call site.
 
-::: warning Changed in 4.0.0-alpha.2
+::: warning Fixed in 4.0.0-alpha.2
 The dashboard's plugins used to be registered without a service key, which meant only a scheduler
 registered by `AddQuartz()` — the unnamed, default one — ever ran them. A named scheduler appeared in the
 scheduler selector and its jobs and triggers rendered, but its Live Logs view and its History page were

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -56,6 +56,23 @@ app.MapQuartzDashboard();
 
 By default, dashboard UI is available at `/quartz`.
 
+## The schedulers the dashboard covers
+
+`AddQuartzDashboard()` installs the dashboard's own two plugins — the live event feed and the execution
+history the History page reads — into **every** scheduler in the container, and the order of the calls
+does not matter. A scheduler registered with `AddQuartz("acme", …)` therefore has a populated Live Logs
+view and History page just like the default one; each scheduler gets its own instance of each plugin,
+initialized with its own name, and history entries are attributed to the scheduler that produced them.
+
+It does this with `ConfigureAllQuartzSchedulers`, so nothing extra is written at the call site.
+
+::: warning Changed in 4.0.0-alpha.2
+The dashboard's plugins used to be registered without a service key, which meant only a scheduler
+registered by `AddQuartz()` — the unnamed, default one — ever ran them. A named scheduler appeared in the
+scheduler selector and its jobs and triggers rendered, but its Live Logs view and its History page were
+silently always empty. There was nothing to configure to get them; this is a fix rather than a new option.
+:::
+
 ## Hosting under a custom path
 
 When the dashboard hosts its own Blazor root, it can be served from a custom base path. Name it where the endpoints are mapped, the way the rest of ASP.NET Core reads (`MapHealthChecks("/health")`):

--- a/docs/documentation/quartz-4.x/packages/http-client.md
+++ b/docs/documentation/quartz-4.x/packages/http-client.md
@@ -96,6 +96,28 @@ IScheduler reporting = provider.GetRequiredKeyedService<IScheduler>("reporting")
 The unkeyed registration is `TryAdd`, so a second remote scheduler does not quietly take over what
 "the scheduler" means — with two of them, inject by key.
 
+### Beside a local scheduler
+
+`AddQuartz()` registers the local default scheduler in the same unkeyed slot, so in a container that has
+both, **call `AddQuartz()` first**:
+
+<!-- snippet: sample_httpclient_beside_local -->
+```csharp
+builder.Services.AddQuartz();                                   // owns GetRequiredService<IScheduler>()
+builder.Services.AddQuartzHttpClient("MyScheduler", "quartz");  // reachable by name
+```
+<!-- endSnippet -->
+
+The local scheduler then owns `GetRequiredService<IScheduler>()`, and the remote one is reached with
+`GetRequiredKeyedService<IScheduler>("MyScheduler")` or `[FromKeyedServices("MyScheduler")]` — which is
+where it always is, whichever order the two calls are written in.
+
+The other order throws an `InvalidOperationException` at registration. Registration is first-wins, so
+`AddQuartzHttpClient(...)` followed by `AddQuartz()` would leave "the scheduler" meaning the remote one
+with nothing said about it, and a program that thought it held its own scheduler would be scheduling jobs
+in somebody else's process. A named local scheduler — `AddQuartz("Local", …)` — is keyed by its name and
+never wanted the unkeyed slot, so it can be registered on either side.
+
 ::: warning Changed in 4.x
 Driving two remote schedulers used to need a marker interface of its own, implemented by a type emitted
 at runtime. The service key says the same thing without the reflection, so the generic

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using BenchmarkDotNet.Attributes;
 using Quartz.Core;
 using Quartz.Impl;
@@ -14,6 +15,12 @@ public class JobRunShellBenchmark
     private readonly TriggerFiredBundle _bundleMayFireAgain;
     private readonly JobRunShell _jobRunShell;
 
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly QuartzScheduler _loggingQuartzScheduler;
+    private readonly StdScheduler _loggingScheduler;
+    private readonly TriggerFiredBundle _loggingBundle;
+    private readonly JobRunShell _loggingJobRunShell;
+
     public JobRunShellBenchmark()
     {
         _basicQuartzScheduler = CreateQuartzScheduler("basic", "basic", 5);
@@ -24,18 +31,58 @@ public class JobRunShellBenchmark
 
         _jobRunShell = new JobRunShell(_basicScheduler, _bundleMayFireAgain, NullLogger<JobRunShell>.Instance);
         _jobRunShell.Initialize(_basicQuartzScheduler).GetAwaiter().GetResult();
+
+        // The same firing under a logger factory that holds a scope-supporting provider. NullLogger
+        // answers BeginScope with a cached singleton and allocates nothing, so it would hide the cost of
+        // a scope the shell opens; a real factory pushes onto its scope provider like an application's.
+        // The provider's loggers are disabled, so what is measured is the scope rather than formatting.
+        _loggerFactory = LoggerFactory.Create(static builder => builder.AddProvider(new ScopedNullLoggerProvider()));
+
+        _loggingQuartzScheduler = CreateQuartzScheduler("logging", "logging", 5);
+        _loggingScheduler = new StdScheduler(_loggingQuartzScheduler);
+
+        _loggingBundle = CreateTriggerFiredBundle();
+        _loggingBundle.Trigger.ComputeFirstFireTimeUtc(null);
+
+        _loggingJobRunShell = new JobRunShell(_loggingScheduler, _loggingBundle, _loggerFactory.CreateLogger<JobRunShell>());
+        _loggingJobRunShell.Initialize(_loggingQuartzScheduler).GetAwaiter().GetResult();
     }
 
     [GlobalCleanup]
     public void GlobalCleanup()
     {
         _basicQuartzScheduler.Shutdown(true).GetAwaiter().GetResult();
+        _loggingQuartzScheduler.Shutdown(true).GetAwaiter().GetResult();
+        _loggerFactory.Dispose();
     }
 
     [Benchmark]
     public ValueTask Success_NoTriggerListenersAndSingleJobListener_MayFireAgain()
     {
         return _jobRunShell.Run();
+    }
+
+    [Benchmark]
+    public ValueTask Success_NoTriggerListenersAndSingleJobListener_MayFireAgain_WithScopedLogger()
+    {
+        return _loggingJobRunShell.Run();
+    }
+
+    /// <summary>
+    /// A provider whose loggers log nothing but which supports external scopes, so
+    /// <see cref="ILogger.BeginScope{TState}" /> costs what it costs in an application.
+    /// </summary>
+    private sealed class ScopedNullLoggerProvider : ILoggerProvider, ISupportExternalScope
+    {
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName) => NullLogger.Instance;
+
+        public void Dispose()
+        {
+        }
     }
 
     private static QuartzScheduler CreateQuartzScheduler(string name, string instanceId, int threadCount)

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -17,13 +17,10 @@
  */
 #endregion
 
-using System.Diagnostics.CodeAnalysis;
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
-using Quartz.Configuration;
 using Quartz.Dashboard.Plugins;
 using Quartz.Dashboard.Services;
 using Quartz.Serialization.SystemTextJson;
@@ -86,28 +83,21 @@ public static class QuartzDashboardServiceCollectionExtensions
         // The dashboard's own plugins, registered rather than named by a quartz.plugin.*.type key. A type
         // name in a property bag is how a plugin is configured from a file; a package that knows its own
         // plugin types has no reason to spell them as strings and have them loaded back by reflection.
-        var quartz = new QuartzBuilder(services, schedulerKey: null);
-        AddDashboardPlugin<DashboardLiveEventsPlugin>(quartz, "quartzDashboardLiveEvents");
-        AddDashboardPlugin<DashboardHistoryPlugin>(quartz, "quartzDashboardHistory");
+        //
+        // Added to every scheduler in the container rather than to the default one. The dashboard renders
+        // whatever schedulers the container holds, so a plugin that only reached the unkeyed registration
+        // left a scheduler registered with AddQuartz(name, …) rendering pages whose live view and history
+        // were always empty, with nothing to say why. Each scheduler gets its own instance, initialized
+        // with its own name, which is what the plugins broadcast and record under. The names are the short
+        // ones these plugins have always been configured with: a plugin is told its name when it is
+        // initialized, and one told a different name would key its history rows differently.
+        services.ConfigureAllQuartzSchedulers(static quartz =>
+        {
+            quartz.AddPlugin<DashboardLiveEventsPlugin>("quartzDashboardLiveEvents");
+            quartz.AddPlugin<DashboardHistoryPlugin>("quartzDashboardHistory");
+        });
 
         return services;
-    }
-
-    /// <summary>
-    /// Adds one of the dashboard's plugins under the short name it has always been configured with.
-    /// </summary>
-    /// <remarks>
-    /// The name is registered separately from the plugin because a plugin is told its name when it is
-    /// initialized, and plugins that derive persisted job keys from that name would otherwise write a
-    /// different set of rows than the same plugin named by a <c>quartz.plugin.&lt;name&gt;.*</c> key.
-    /// </remarks>
-    private static void AddDashboardPlugin<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
-        QuartzBuilder quartz,
-        string name) where T : class, ISchedulerPlugin
-    {
-        quartz.Services.AddSingleton(new SchedulerPluginName(quartz.SchedulerName, typeof(T), name));
-        quartz.AddPlugin<T>();
     }
 
     private static readonly char[] InvalidDashboardPathChars = ['{', '}', '?', '#'];

--- a/src/Quartz.Documentation.Samples/Packages/HttpClientSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/HttpClientSamples.cs
@@ -38,6 +38,16 @@ public static class HttpClientSamples
         #endregion
     }
 
+    public static void BesideALocalScheduler(WebApplicationBuilder builder)
+    {
+        #region sample_httpclient_beside_local
+
+        builder.Services.AddQuartz();                                   // owns GetRequiredService<IScheduler>()
+        builder.Services.AddQuartzHttpClient("MyScheduler", "quartz");  // reachable by name
+
+        #endregion
+    }
+
     /// <summary>
     /// Two containers so the page can show one controller name twice, which is how it contrasts the
     /// single-scheduler and keyed shapes.

--- a/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
+++ b/src/Quartz.HttpClient/QuartzHttpClientServiceCollectionExtensions.cs
@@ -36,11 +36,20 @@ namespace Quartz;
 /// Registers schedulers that live in another process and are driven over Quartz's HTTP API.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A remote scheduler is registered the same way a local one is: keyed by its name, so
 /// <c>GetRequiredKeyedService&lt;IScheduler&gt;("reporting")</c> and
 /// <c>[FromKeyedServices("reporting")] IScheduler</c> reach it, and unkeyed as well while it is the only
 /// scheduler in the container. Before 4.0 a second remote scheduler needed a marker interface of its own,
 /// implemented by a type emitted at runtime; the service key says the same thing without the reflection.
+/// </para>
+/// <para>
+/// That unkeyed registration is a <c>TryAdd</c>, so in a container that also holds a local scheduler the
+/// local one owns <c>GetRequiredService&lt;IScheduler&gt;()</c> and the remote one is reached by name. To
+/// get that, call <c>AddQuartz()</c> <em>before</em> this — the other order is refused rather than left
+/// to be discovered, since a container in which "the scheduler" turned out to be somebody else's process
+/// is not something anything downstream can notice.
+/// </para>
 /// </remarks>
 public static class QuartzHttpClientServiceCollectionExtensions
 {
@@ -137,7 +146,11 @@ public static class QuartzHttpClientServiceCollectionExtensions
 
         // Keyed by name like any other scheduler, and unkeyed as well so that a container holding one
         // remote scheduler and nothing else answers GetRequiredService<IScheduler>() with it. TryAdd,
-        // because a second remote scheduler must not quietly take over what "the scheduler" means.
+        // because a second remote scheduler must not quietly take over what "the scheduler" means — nor
+        // must this one take it over from a local scheduler AddQuartz() has already registered. Doing
+        // this the other way round, before AddQuartz(), is refused there: whichever ran first would win
+        // the slot, and a program that thought it held its own scheduler would be scheduling jobs in
+        // another process.
         services.TryAddSingleton<IScheduler>(
             serviceProvider => serviceProvider.GetRequiredKeyedService<IScheduler>(options.SchedulerName));
 

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardPluginRegistrationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardPluginRegistrationTest.cs
@@ -12,10 +12,17 @@ namespace Quartz.Tests.AspNetCore.Dashboard;
 /// scheduler — and under the names they have always had, since a plugin is told its name when it is
 /// initialized and history rows are keyed by it.
 /// </summary>
+/// <remarks>
+/// The scheduler they have to reach is <em>every</em> scheduler in the container. The dashboard renders
+/// whatever the container holds, and a named scheduler's parts are keyed by its name, so plugins added
+/// only to the unkeyed registration left a scheduler registered with <c>AddQuartz(name, …)</c> showing
+/// pages whose live view and history were always empty. Both keys are asserted here, which is what the
+/// previous version of this test — hard-coded to the default scheduler's <c>null</c> key — could not see.
+/// </remarks>
 public class DashboardPluginRegistrationTest
 {
     [Test]
-    public void DashboardPluginsShouldReachTheSchedulerUnderTheirOwnNames()
+    public void DashboardPluginsShouldReachTheDefaultSchedulerUnderTheirOwnNames()
     {
         var services = new ServiceCollection();
         services.AddQuartzDashboard();
@@ -23,10 +30,78 @@ public class DashboardPluginRegistrationTest
 
         using var provider = services.BuildServiceProvider();
 
-        var plugins = SchedulerPluginFactory.Create(
-            provider, provider.GetServices<ISchedulerPlugin>(), [], new SchedulerKey(null));
+        DashboardPlugins(provider, schedulerKey: null).Should().BeEquivalentTo(
+            [("quartzDashboardLiveEvents", typeof(DashboardLiveEventsPlugin)),
+             ("quartzDashboardHistory", typeof(DashboardHistoryPlugin))]);
+    }
 
-        plugins.Should().ContainSingle(x => x.Name == "quartzDashboardLiveEvents" && x.Plugin is DashboardLiveEventsPlugin);
-        plugins.Should().ContainSingle(x => x.Name == "quartzDashboardHistory" && x.Plugin is DashboardHistoryPlugin);
+    [Test]
+    public void DashboardPluginsShouldReachANamedSchedulerRegisteredAfterTheDashboard()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartzDashboard();
+        services.AddQuartz("acme");
+
+        using var provider = services.BuildServiceProvider();
+
+        DashboardPlugins(provider, "acme").Should().BeEquivalentTo(
+            [("quartzDashboardLiveEvents", typeof(DashboardLiveEventsPlugin)),
+             ("quartzDashboardHistory", typeof(DashboardHistoryPlugin))],
+            "a named scheduler resolves its plugins by service key, so plugins registered unkeyed never "
+            + "reached it and its live view and history were silently always empty");
+    }
+
+    [Test]
+    public void DashboardPluginsShouldReachANamedSchedulerRegisteredBeforeTheDashboard()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz("acme");
+        services.AddQuartzDashboard();
+
+        using var provider = services.BuildServiceProvider();
+
+        DashboardPlugins(provider, "acme").Should().BeEquivalentTo(
+            [("quartzDashboardLiveEvents", typeof(DashboardLiveEventsPlugin)),
+             ("quartzDashboardHistory", typeof(DashboardHistoryPlugin))],
+            "an application is free to register its schedulers on either side of AddQuartzDashboard");
+    }
+
+    [Test]
+    public void EverySchedulerShouldGetItsOwnDashboardPluginInstances()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartzDashboard();
+        services.AddQuartz();
+        services.AddQuartz("acme");
+        services.AddQuartz("initech");
+
+        using var provider = services.BuildServiceProvider();
+
+        List<ISchedulerPlugin> live =
+        [
+            .. new object?[] { null, "acme", "initech" }
+                .Select(key => Plugins(provider, key).OfType<DashboardLiveEventsPlugin>().Single())
+        ];
+
+        live.Distinct().Should().HaveCount(3,
+            "a plugin is told which scheduler it extends when it is initialized, so one instance shared "
+            + "between three schedulers would broadcast every scheduler's events under the last name");
+    }
+
+    private static List<(string Name, Type Type)> DashboardPlugins(IServiceProvider provider, object? schedulerKey)
+    {
+        return
+        [
+            .. SchedulerPluginFactory
+                .Create(provider, Plugins(provider, schedulerKey), [], new SchedulerKey(schedulerKey))
+                .Select(x => (x.Name, x.Plugin.GetType()))
+        ];
+    }
+
+    private static IEnumerable<ISchedulerPlugin> Plugins(IServiceProvider provider, object? schedulerKey)
+    {
+        return schedulerKey is null
+            ? provider.GetServices<ISchedulerPlugin>()
+            : provider.GetKeyedServices<ISchedulerPlugin>(schedulerKey);
     }
 }

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerPluginKeyingTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerPluginKeyingTest.cs
@@ -50,7 +50,7 @@ public sealed class SchedulerPluginKeyingTest
 
         await CreateSchedulers(provider, "acme");
 
-        IReadOnlyList<(RecordingPlugin Plugin, string Scheduler)> initializations = log.Initializations;
+        IReadOnlyList<(RecordingPlugin Plugin, string Scheduler, string Name)> initializations = log.Initializations;
 
         initializations.Should().HaveCount(2, "each scheduler runs the plugin its own properties named");
 
@@ -121,13 +121,42 @@ public sealed class SchedulerPluginKeyingTest
 
         await CreateSchedulers(provider, "acme", "initech");
 
-        IReadOnlyList<(RecordingPlugin Plugin, string Scheduler)> initializations = log.Initializations;
+        IReadOnlyList<(RecordingPlugin Plugin, string Scheduler, string Name)> initializations = log.Initializations;
 
         initializations.Select(x => x.Plugin.Tenant).Should().BeEquivalentTo(["acme", "initech"],
             "a type nobody registered was already built once per scheduler from that scheduler's keys, "
             + "and keying the probe must not have cost that");
 
         initializations[0].Plugin.Should().NotBeSameAs(initializations[1].Plugin);
+    }
+
+    [Test]
+    public async Task APluginAddedToEverySchedulerIsOneInstancePerScheduler()
+    {
+        PluginLog log = new();
+
+        ServiceCollection services = new();
+        services.AddSingleton(log);
+
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.InstanceName = "shared"));
+        services.AddQuartz("acme");
+        services.ConfigureAllQuartzSchedulers(q => q.AddPlugin<RecordingPlugin>("recording"));
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        await CreateSchedulers(provider, "acme");
+
+        IReadOnlyList<(RecordingPlugin Plugin, string Scheduler, string Name)> initializations = log.Initializations;
+
+        initializations.Select(x => x.Scheduler).Should().BeEquivalentTo(["shared", "acme"],
+            "container-wide configuration reaches the default scheduler and the named ones alike");
+
+        initializations.Select(x => x.Name).Should().AllBe("recording",
+            "the plugin is named where it is added, and each scheduler adds it under that name");
+
+        initializations[0].Plugin.Should().NotBeSameAs(initializations[1].Plugin,
+            "a plugin is told which scheduler it extends when it is initialized, so one instance shared "
+            + "between two schedulers has the second initialization overwrite the first");
     }
 
     /// <summary>
@@ -157,9 +186,9 @@ public sealed class SchedulerPluginKeyingTest
 
     private sealed class PluginLog
     {
-        private readonly List<(RecordingPlugin Plugin, string Scheduler)> initializations = [];
+        private readonly List<(RecordingPlugin Plugin, string Scheduler, string Name)> initializations = [];
 
-        public IReadOnlyList<(RecordingPlugin Plugin, string Scheduler)> Initializations
+        public IReadOnlyList<(RecordingPlugin Plugin, string Scheduler, string Name)> Initializations
         {
             get
             {
@@ -170,11 +199,11 @@ public sealed class SchedulerPluginKeyingTest
             }
         }
 
-        public void Record(RecordingPlugin plugin, string scheduler)
+        public void Record(RecordingPlugin plugin, string scheduler, string name)
         {
             lock (initializations)
             {
-                initializations.Add((plugin, scheduler));
+                initializations.Add((plugin, scheduler, name));
             }
         }
     }
@@ -192,7 +221,7 @@ public sealed class SchedulerPluginKeyingTest
 
         public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
         {
-            log.Record(this, scheduler.SchedulerName);
+            log.Record(this, scheduler.SchedulerName, pluginName);
             return default;
         }
 

--- a/src/Quartz.Tests.Unit/Diagnostics/SchedulerLogScopeTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/SchedulerLogScopeTest.cs
@@ -1,0 +1,269 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Quartz.Core;
+using Quartz.Diagnostics;
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Tests.Unit.Core;
+
+namespace Quartz.Tests.Unit.Diagnostics;
+
+/// <summary>
+/// An <see cref="ILogger" /> category is a type name, so two schedulers in one process write log lines
+/// that are identical in everything a log query can filter on, except where a message template happens
+/// to carry the scheduler's name. A logging scope carries it on every line instead.
+/// </summary>
+/// <remarks>
+/// The scope is opened once, for the lifetime of the scheduler thread's loop, and not per firing: a
+/// <c>BeginScope</c> per firing costs an <see cref="AsyncLocal{T}" /> write, which copies the execution
+/// context, and measured at 240 bytes and 14% of a no-op firing. A job inherits the loop's scope through
+/// the execution context the thread pool's dispatch captures, which costs nothing per firing — and
+/// reaches the job only when the loop's own logging goes somewhere, which means when the application has
+/// called <see cref="LogProvider.SetLogProvider" />. That is pinned below, so the day the loop is handed
+/// an injected logger instead, this is what says the reach came with it.
+/// </remarks>
+public sealed class SchedulerLogScopeTest
+{
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
+    [Test]
+    [NonParallelizable]
+    public async Task AJobInheritsTheSchedulersScopeFromTheThreadThatDispatchedIt()
+    {
+        ScopeCapturingLoggerProvider recorder = new();
+        TaskCompletionSource fired = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        ServiceCollection services = new();
+        services.AddLogging(builder => builder.AddProvider(recorder));
+        services.AddSingleton(fired);
+
+        services.AddQuartz("acme", q => q.ScheduleJob<LoggingJob>(
+            trigger => trigger.WithIdentity("now").StartNow(),
+            job => job.WithIdentity("logging")));
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        // The scheduler thread logs through the ambient factory, so this is what makes its scope real
+        // rather than NullLogger's no-op — and the scope is what the dispatch then carries to the job.
+        LogProvider.SetLogProvider(provider.GetRequiredService<ILoggerFactory>());
+        try
+        {
+            IScheduler scheduler = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+            await scheduler.Start();
+            try
+            {
+                await fired.Task.WaitAsync(observationDeadline);
+            }
+            finally
+            {
+                await scheduler.Shutdown(waitForJobsToComplete: true);
+            }
+        }
+        finally
+        {
+            LogProvider.SetLogProvider(NullLoggerFactory.Instance);
+        }
+
+        CapturedEntry entry = recorder.Entries
+            .Should().ContainSingle(x => x.Message == LoggingJob.Message,
+                "the job logs exactly once, with a logger the container gave it")
+            .Subject;
+
+        entry.Scopes.Should().Contain(new KeyValuePair<string, object?>(ActivityTags.SchedulerName, "acme"),
+            "a job's log line says nothing about which tenant it ran for unless the firing puts it there");
+        entry.Scopes.Should().Contain(x => x.Key == ActivityTags.SchedulerId,
+            "the attribute names are the ones the spans and the measurements use, so one query spans all three");
+    }
+
+    [Test]
+    [NonParallelizable]
+    public async Task TheSchedulerThreadsOwnLogLinesNameTheSchedulerToo()
+    {
+        ScopeCapturingLoggerProvider recorder = new();
+        using ILoggerFactory factory = new LoggerFactory();
+        factory.AddProvider(recorder);
+
+        // The scheduler thread logs through the ambient factory rather than an injected logger, so this
+        // is what makes its lines observable at all — the same reason an application that wants to see
+        // them calls it.
+        LogProvider.SetLogProvider(factory);
+
+        FaultInjectingJobStore store = new();
+        await store.Initialize(TestJobStores.Identity());
+
+        QuartzSchedulerResources resources = new()
+        {
+            Name = "acme",
+            InstanceId = "acme-1",
+            IdleWaitTime = TimeSpan.FromSeconds(1),
+            MaxBatchSize = 1,
+            JobStore = store,
+            ThreadPool = new DefaultThreadPool { MaxConcurrency = 1 },
+            JobRunShellFactory = new StdJobRunShellFactory(NullLogger<JobRunShell>.Instance),
+        };
+
+        await resources.ThreadPool.Initialize();
+
+        QuartzScheduler scheduler = new(resources);
+        QuartzSchedulerThread thread = new(scheduler, resources);
+
+        try
+        {
+            // Anything that is not a persistence problem is logged by the loop rather than reported to
+            // scheduler listeners, which is the arm that writes a line of its own.
+            store.OnAcquireNextTriggers = static (_, _, _) => throw new InvalidOperationException("the database is gone");
+
+            thread.Start();
+            thread.TogglePause(pause: false);
+
+            await store.Acquisitions.Reaches(1).WaitAsync(observationDeadline);
+
+            CapturedEntry entry = await Eventually(
+                () => recorder.Entries.FirstOrDefault(x => x.Message.Contains("the database is gone", StringComparison.Ordinal)),
+                "the loop reports the first failure of a run");
+
+            entry.Scopes.Should().Contain(new KeyValuePair<string, object?>(ActivityTags.SchedulerName, "acme"),
+                "an acquisition failure that does not say which scheduler could not reach its store is "
+                + "the same line from either tenant");
+            entry.Scopes.Should().Contain(new KeyValuePair<string, object?>(ActivityTags.SchedulerId, "acme-1"));
+        }
+        finally
+        {
+            await thread.Halt(wait: true);
+            await thread.Shutdown();
+            await store.Shutdown();
+            LogProvider.SetLogProvider(NullLoggerFactory.Instance);
+        }
+    }
+
+    [Test]
+    public void TheScopeCarriesTheSchedulerUnderTheAttributeNamesTheTracesUse()
+    {
+        SchedulerLogScope scope = new("acme", "acme-1");
+
+        scope.Should().Equal(
+            [new KeyValuePair<string, object?>(ActivityTags.SchedulerName, "acme"),
+             new KeyValuePair<string, object?>(ActivityTags.SchedulerId, "acme-1")]);
+
+        scope.ToString().Should().Be("quartz.scheduler.name:acme quartz.scheduler.id:acme-1",
+            "a provider that renders a scope as text asks for this once per line, so it is built once");
+    }
+
+    /// <summary>
+    /// Waits for a log line to arrive. A line is written by the loop rather than returned to the test,
+    /// so there is nothing to await for it directly; the deadline is a way of failing instead of hanging.
+    /// </summary>
+    private static async Task<CapturedEntry> Eventually(Func<CapturedEntry?> read, string because)
+    {
+        DateTime deadline = DateTime.UtcNow + observationDeadline;
+        while (DateTime.UtcNow < deadline)
+        {
+            CapturedEntry? entry = read();
+            if (entry is not null)
+            {
+                return entry;
+            }
+
+            await Task.Delay(20);
+        }
+
+        read().Should().NotBeNull(because);
+        return read()!;
+    }
+
+    public sealed class LoggingJob : IJob
+    {
+        internal const string Message = "the job wrote this";
+
+        private readonly ILogger<LoggingJob> logger;
+        private readonly TaskCompletionSource fired;
+
+        public LoggingJob(ILogger<LoggingJob> logger, TaskCompletionSource fired)
+        {
+            this.logger = logger;
+            this.fired = fired;
+        }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation(Message);
+            fired.TrySetResult();
+            return default;
+        }
+    }
+
+    private sealed record CapturedEntry(string Message, IReadOnlyList<KeyValuePair<string, object?>> Scopes);
+
+    /// <summary>
+    /// Records every line with the scopes that were open when it was written, which is the only way to
+    /// see a scope: it never reaches the message.
+    /// </summary>
+    private sealed class ScopeCapturingLoggerProvider : ILoggerProvider, ISupportExternalScope
+    {
+        private readonly Lock gate = new();
+        private readonly List<CapturedEntry> entries = [];
+        private IExternalScopeProvider? scopeProvider;
+
+        public IReadOnlyList<CapturedEntry> Entries
+        {
+            get
+            {
+                lock (gate)
+                {
+                    return [.. entries];
+                }
+            }
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider) => this.scopeProvider = scopeProvider;
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(this);
+
+        public void Dispose()
+        {
+        }
+
+        private void Record(string message)
+        {
+            List<KeyValuePair<string, object?>> scopes = [];
+            scopeProvider?.ForEachScope(
+                static (scope, state) =>
+                {
+                    if (scope is IReadOnlyList<KeyValuePair<string, object?>> pairs)
+                    {
+                        for (int i = 0; i < pairs.Count; i++)
+                        {
+                            state.Add(pairs[i]);
+                        }
+                    }
+                },
+                scopes);
+
+            lock (gate)
+            {
+                entries.Add(new CapturedEntry(message, scopes));
+            }
+        }
+
+        private sealed class CapturingLogger(ScopeCapturingLoggerProvider provider) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                provider.Record(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/MultipleSchedulerTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/MultipleSchedulerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 using Quartz.Configuration;
+using Quartz.Extensibility;
 using Quartz.Impl;
 
 namespace Quartz.Tests.Unit.Extensions.DependencyInjection;
@@ -467,7 +468,153 @@ public sealed class MultipleSchedulerTests
         act.Should().Throw<ArgumentNullException>();
     }
 
+    [Test]
+    public void ConfigureAllQuartzSchedulers_ShouldReachSchedulersRegisteredAfterIt()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+
+        services.ConfigureAllQuartzSchedulers(q => q.AddJobListener<TestJobListenerA>());
+        services.AddQuartz();
+        services.AddQuartz("Named1", q => { });
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetServices<JobListenerRegistration>().Should().ContainSingle()
+            .Which.ListenerType.Should().Be(typeof(TestJobListenerA),
+                "a package that configures every scheduler cannot know whether the application "
+                + "registers its schedulers before or after it");
+        provider.GetKeyedServices<JobListenerRegistration>("Named1").Should().ContainSingle()
+            .Which.ListenerType.Should().Be(typeof(TestJobListenerA));
+    }
+
+    [Test]
+    public void ConfigureAllQuartzSchedulers_ShouldReachSchedulersRegisteredBeforeIt()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+
+        services.AddQuartz();
+        services.AddQuartz("Named1", q => { });
+        services.ConfigureAllQuartzSchedulers(q => q.AddJobListener<TestJobListenerA>());
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetServices<JobListenerRegistration>().Should().ContainSingle()
+            .Which.ListenerType.Should().Be(typeof(TestJobListenerA),
+                "a scheduler whose AddQuartz call has already returned has nothing else to carry this to it");
+        provider.GetKeyedServices<JobListenerRegistration>("Named1").Should().ContainSingle()
+            .Which.ListenerType.Should().Be(typeof(TestJobListenerA));
+    }
+
+    [Test]
+    public void ConfigureAllQuartzSchedulers_ShouldReachEverySchedulerWhicheverSideItIsCalledFrom()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+
+        services.AddQuartz("Before", q => { });
+        services.ConfigureAllQuartzSchedulers(q => q.AddSchedulerListener<TestSchedulerListenerA>());
+        services.AddQuartz("After", q => { });
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetKeyedServices<SchedulerListenerRegistration>("Before").Should().ContainSingle()
+            .Which.ListenerType.Should().Be(typeof(TestSchedulerListenerA));
+        provider.GetKeyedServices<SchedulerListenerRegistration>("After").Should().ContainSingle()
+            .Which.ListenerType.Should().Be(typeof(TestSchedulerListenerA),
+                "the order of the calls is exactly what this seam exists to stop mattering");
+    }
+
+    [Test]
+    public void ConfigureAllQuartzSchedulers_ShouldNotApplyTwiceWhenTheDefaultSchedulerIsAddedAgain()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+
+        services.AddQuartz();
+        services.ConfigureAllQuartzSchedulers(q => q.AddJobListener<TestJobListenerA>());
+
+        // Registering the default scheduler is additive: this contributes more configuration to the
+        // scheduler that already exists rather than registering a second one.
+        services.AddQuartz(q => { });
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetServices<JobListenerRegistration>().Should().ContainSingle(
+            "a listener registration is not a TryAdd, so a delegate that reached this scheduler twice "
+            + "would attach the listener twice");
+    }
+
+    [Test]
+    public void ConfigureAllQuartzSchedulers_WithNoSchedulerRegistered_ShouldNotThrow()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.ConfigureAllQuartzSchedulers(q => q.AddJobListener<TestJobListenerA>());
+
+        act.Should().NotThrow("configuring every scheduler when there are none applies to none");
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetServices<JobListenerRegistration>().Should().BeEmpty();
+    }
+
+    [Test]
+    public void ConfigureAllQuartzSchedulers_ShouldSetAnOptionOverTheSchedulersOwn()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+
+        services.ConfigureAllQuartzSchedulers(q => q.UseDefaultThreadPool(3));
+        services.AddQuartz("Named1", q => q.UseDefaultThreadPool(7));
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<ThreadPoolOptions>>().Get("Named1");
+
+        options.MaxConcurrency.Should().Be(3,
+            "container-wide configuration runs after the scheduler's own and options are last-wins, "
+            + "which is what ConfigureAll<TOptions> does over an earlier named Configure");
+    }
+
+    [Test]
+    public async Task ConfigureAllQuartzSchedulers_ShouldLoseToAComponentTheSchedulerChoseItself()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+
+        var containerWide = new RecordingJobFactory();
+        var schedulersOwn = new RecordingJobFactory();
+
+        services.ConfigureAllQuartzSchedulers(q => q.UseJobFactory(containerWide));
+        services.AddQuartz("Named1", q => q.UseJobFactory(schedulersOwn));
+        services.AddQuartz("Named2", q => { });
+
+        await using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredKeyedService<IJobFactory>("Named1").Should().BeSameAs(schedulersOwn,
+            "registration is first-wins, so a component a scheduler chose for itself is not replaced "
+            + "by the container-wide default");
+        provider.GetRequiredKeyedService<IJobFactory>("Named2").Should().BeSameAs(containerWide,
+            "a scheduler that chose nothing gets what the container said for everyone");
+    }
+
     #region Test helpers
+
+    private sealed class RecordingJobFactory : IJobFactory
+    {
+        public ValueTask<JobScope> CreateJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException("this factory exists to be resolved, not to build jobs");
+        }
+
+        public ValueTask ReturnJob(JobScope scope, CancellationToken cancellationToken = default) => default;
+    }
 
     private sealed class TestJobA : IJob
     {

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/QuartzHttpClientServiceCollectionExtensionsTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/QuartzHttpClientServiceCollectionExtensionsTest.cs
@@ -176,6 +176,48 @@ public class QuartzHttpClientServiceCollectionExtensionsTest
     }
 
     [Test]
+    public async Task ALocalDefaultSchedulerRegisteredFirstShouldKeepTheUnkeyedSlot()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz();
+        services.AddQuartzHttpClient("Remote", _ => testClient);
+
+        await using var serviceProvider = services.BuildServiceProvider();
+
+        serviceProvider.GetRequiredService<IScheduler>().SchedulerName.Should().Be("QuartzScheduler",
+            "the unkeyed registration is a TryAdd, so the local default scheduler keeps what "
+            + "GetRequiredService<IScheduler>() means");
+        serviceProvider.GetRequiredKeyedService<IScheduler>("Remote").Should().BeOfType<HttpScheduler>(
+            "the remote scheduler is reachable under its own name either way");
+    }
+
+    [Test]
+    public void ADefaultSchedulerCannotBeAddedAfterARemoteOneHasTakenTheUnkeyedSlot()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartzHttpClient("Remote", _ => testClient);
+
+        var act = () => services.AddQuartz();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AddQuartzHttpClient*")
+            .WithMessage("*GetRequiredKeyedService<IScheduler>*",
+                "registration is first-wins, so this order used to make 'the scheduler' the remote one "
+                + "with no error at all — a program scheduling a job would have sent it to another process");
+    }
+
+    [Test]
+    public void ANamedSchedulerCanStillBeAddedBesideARemoteOne()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartzHttpClient("Remote", _ => testClient);
+
+        var act = () => services.AddQuartz("Local");
+
+        act.Should().NotThrow("a named scheduler is keyed by its name and never wanted the unkeyed slot");
+    }
+
+    [Test]
     public async Task EachContainerShouldGetItsOwnSchedulerRepository()
     {
         var firstServices = new ServiceCollection();

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1305,6 +1305,7 @@ namespace Quartz
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddQuartzHostedService<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Quartz.QuartzHostedServiceOptions>? configure = null)
             where T : Quartz.QuartzHostedService { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddQuartzSchedulers(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration, System.Action<Quartz.IQuartzBuilder>? configure = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection ConfigureAllQuartzSchedulers(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Quartz.IQuartzBuilder> configure) { }
     }
     public sealed class RecurrenceScheduleBuilder : Quartz.IScheduleBuilder
     {

--- a/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
@@ -195,6 +195,71 @@ public static partial class QuartzServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Configures every Quartz scheduler in the container, whenever it was registered.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the options pattern's <c>ConfigureAll</c>, for schedulers. <paramref name="configure"/> is
+    /// applied to every scheduler <c>AddQuartz()</c>, <c>AddQuartz(name, …)</c> or
+    /// <c>AddQuartzSchedulers(…)</c> registers in this container: the ones already registered when this
+    /// is called, and the ones registered after it. <strong>The order of the calls does not matter</strong>
+    /// — which is the point, since a package that adds something to every scheduler cannot know whether
+    /// the application registers its schedulers before or after calling it.
+    /// </para>
+    /// <para>
+    /// The delegate is given a builder <em>per scheduler</em>, so what it registers lands under that
+    /// scheduler's own service key, exactly as if it had been written inside that scheduler's
+    /// <c>AddQuartz(name, q =&gt; …)</c> callback. A plugin or listener added here is therefore one
+    /// instance per scheduler, each initialized with the name of the scheduler it belongs to — not one
+    /// instance shared between them, which would leave each scheduler but the last with a component
+    /// pointing at somebody else's.
+    /// </para>
+    /// <para>
+    /// It runs after each scheduler's own configuration callback, which is what makes the order of the two
+    /// calls immaterial: a scheduler registered later is configured then, and one registered earlier is
+    /// configured here, and both are after its own callback either way. The usual precedence follows —
+    /// registration is first-wins, so a component a scheduler chose for itself is not replaced by one
+    /// chosen here; options are last-wins, so a value set here overrides the same option set on one
+    /// scheduler, exactly as <c>ConfigureAll&lt;TOptions&gt;</c> overrides an earlier named
+    /// <c>Configure</c>.
+    /// </para>
+    /// <para>
+    /// Remote schedulers registered with <c>AddQuartzHttpClient</c> are not built by a builder and are
+    /// skipped. Calling this when no scheduler is registered at all is not an error: the delegate simply
+    /// applies to nothing.
+    /// </para>
+    /// </remarks>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="configure">Applied to every scheduler in the container.</param>
+    public static IServiceCollection ConfigureAllQuartzSchedulers(
+        this IServiceCollection services,
+        Action<IQuartzBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        SchedulerNameRegistry registry = SchedulerNameRegistry.For(services);
+
+        // Recorded first, so that a scheduler this delegate goes on to register is covered by it too.
+        registry.AddConfigureAll(configure);
+
+        // The schedulers already registered: their AddQuartz call has been and gone, so nothing else
+        // will carry this to them.
+        if (registry.HasDefaultScheduler)
+        {
+            registry.Apply(configure, services, schedulerName: null);
+        }
+
+        // Indexed, because applying this to one scheduler may register another.
+        for (int i = 0; i < registry.Names.Count; i++)
+        {
+            registry.Apply(configure, services, registry.Names[i]);
+        }
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers a named Quartz scheduler, so several independent schedulers can share a container.
     /// </summary>
     /// <remarks>
@@ -348,6 +413,7 @@ public static partial class QuartzServiceCollectionExtensions
     {
         services.AddOptions();
 
+        SchedulerNameRegistry registry = SchedulerNameRegistry.For(services);
         var optionsName = schedulerName ?? Options.DefaultName;
 
         // Phase 1.
@@ -369,6 +435,10 @@ public static partial class QuartzServiceCollectionExtensions
         // Phase 4.
         configure?.Invoke(new QuartzBuilder(services, schedulerName));
 
+        // Phase 4, for everyone: what ConfigureAllQuartzSchedulers said about every scheduler in the
+        // container, applied after this scheduler's own callback so that a scheduler's own word wins.
+        registry.ApplyConfigureAll(services, schedulerName);
+
         // Phase 5: registration is first-wins, so the implementations named by keys go in after it.
         QuartzPropertyBridge.ApplyRegistrations(services, properties, schedulerName);
 
@@ -377,7 +447,7 @@ public static partial class QuartzServiceCollectionExtensions
 
         if (schedulerName is not null)
         {
-            SchedulerNameRegistry.For(services).Add(schedulerName);
+            registry.Add(schedulerName);
         }
 
         return services;

--- a/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
@@ -452,7 +452,8 @@ public static partial class QuartzServiceCollectionExtensions
         configure?.Invoke(new QuartzBuilder(services, schedulerName));
 
         // Phase 4, for everyone: what ConfigureAllQuartzSchedulers said about every scheduler in the
-        // container, applied after this scheduler's own callback so that a scheduler's own word wins.
+        // container. After this scheduler's own callback, which is where a scheduler registered before
+        // that call gets it too, so the order the two calls were written in does not decide anything.
         registry.ApplyConfigureAll(services, schedulerName);
 
         // Phase 5: registration is first-wins, so the implementations named by keys go in after it.

--- a/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
@@ -118,6 +118,15 @@ public static partial class QuartzServiceCollectionExtensions
     /// serializer is never beaten to the registration by the fallback it was meant to replace.
     /// </description></item>
     /// </list>
+    /// <para>
+    /// The scheduler this registers is the container's unkeyed <see cref="IScheduler"/>, which is what
+    /// <c>GetRequiredService&lt;IScheduler&gt;()</c> answers with. Registering it when something else
+    /// already owns that slot throws an <see cref="InvalidOperationException"/> rather than quietly
+    /// leaving "the scheduler" meaning the other one; <c>AddQuartzHttpClient</c> is the one in the box
+    /// that takes it. The other order is fine and needs no thought: <c>AddQuartz()</c> followed by
+    /// <c>AddQuartzHttpClient(…)</c> leaves the local default scheduler unkeyed and the remote one
+    /// reachable as <c>GetRequiredKeyedService&lt;IScheduler&gt;(schedulerName)</c>.
+    /// </para>
     /// </remarks>
     public static IServiceCollection AddQuartz(
         this IServiceCollection services,
@@ -416,6 +425,13 @@ public static partial class QuartzServiceCollectionExtensions
         SchedulerNameRegistry registry = SchedulerNameRegistry.For(services);
         var optionsName = schedulerName ?? Options.DefaultName;
 
+        // Before anything is registered, so a container that cannot hold this scheduler is not left half
+        // configured by the attempt.
+        if (schedulerName is null && !registry.HasDefaultScheduler)
+        {
+            ThrowIfTheUnkeyedSchedulerIsTaken(services);
+        }
+
         // Phase 1.
         services.Configure<QuartzOptions>(optionsName, options =>
         {
@@ -451,5 +467,37 @@ public static partial class QuartzServiceCollectionExtensions
         }
 
         return services;
+    }
+
+    /// <summary>
+    /// Refuses to register the default scheduler when something else already owns the unkeyed
+    /// <see cref="IScheduler"/>.
+    /// </summary>
+    /// <remarks>
+    /// Registration is first-wins, so whichever of the two ran first would answer
+    /// <c>GetRequiredService&lt;IScheduler&gt;()</c> and the other would be unreachable without a key.
+    /// <c>AddQuartzHttpClient</c> registers the unkeyed slot as well as its own name, so
+    /// <c>AddQuartzHttpClient(…)</c> followed by <c>AddQuartz()</c> silently made "the scheduler" the
+    /// remote one — a program that then scheduled a job sent it over the wire to somebody else's process.
+    /// Said here rather than left to be discovered, because nothing downstream can tell the two apart.
+    /// The opposite order needs no report: the local default owns the unkeyed slot, the remote scheduler
+    /// is still reachable under its name, and that is what both methods document.
+    /// </remarks>
+    private static void ThrowIfTheUnkeyedSchedulerIsTaken(IServiceCollection services)
+    {
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            if (descriptor.ServiceType == typeof(IScheduler) && !descriptor.IsKeyedService)
+            {
+                throw new InvalidOperationException(
+                    "An IScheduler is already registered in this container without a service key, so "
+                    + "AddQuartz() has nowhere to put the default scheduler: registration is first-wins, "
+                    + "and GetRequiredService<IScheduler>() would answer with the registration that is "
+                    + "already there. AddQuartzHttpClient(...) makes one — call it after AddQuartz() "
+                    + "instead of before, and its remote scheduler stays reachable either way as "
+                    + "GetRequiredKeyedService<IScheduler>(schedulerName). Register this scheduler with "
+                    + "AddQuartz(name, ...) if it should have a name of its own.");
+            }
+        }
     }
 }

--- a/src/Quartz/Configuration/SchedulerNameRegistry.cs
+++ b/src/Quartz/Configuration/SchedulerNameRegistry.cs
@@ -108,10 +108,11 @@ internal sealed class SchedulerNameRegistry
     /// Applies every recorded container-wide delegate to one scheduler.
     /// </summary>
     /// <remarks>
-    /// Called from <c>AddQuartz</c> after the caller's own configuration callback, so a scheduler that
-    /// says something for itself is not overruled by what the container says for everyone — options are
-    /// last-wins and registration is first-wins, and this order gives the scheduler's own word the
-    /// stronger side of both.
+    /// Called from <c>AddQuartz</c> after the caller's own configuration callback, which is the same
+    /// place in the order that a scheduler registered earlier gets it — <c>ConfigureAllQuartzSchedulers</c>
+    /// applies it to those where it is called, and that is after their callbacks too. Container-wide
+    /// configuration therefore lands in one position regardless of the order the calls were written in,
+    /// which is the whole point of it.
     /// </remarks>
     public void ApplyConfigureAll(IServiceCollection services, string? schedulerName)
     {

--- a/src/Quartz/Configuration/SchedulerNameRegistry.cs
+++ b/src/Quartz/Configuration/SchedulerNameRegistry.cs
@@ -3,8 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Quartz.Configuration;
 
 /// <summary>
-/// The names <c>AddQuartz(name, …)</c> has been called with, so that a second registration under a name
-/// already taken is refused where it is written rather than where the scheduler is bound.
+/// What the container has been told to register a scheduler under, while it is still being told: the
+/// names <c>AddQuartz(name, …)</c> has been called with, so that a second registration under a name
+/// already taken is refused where it is written rather than where the scheduler is bound, and the
+/// container-wide configuration <c>ConfigureAllQuartzSchedulers</c> has recorded.
 /// </summary>
 /// <remarks>
 /// Names are compared case-insensitively, because <see cref="Quartz.Impl.SchedulerRepository"/> indexes
@@ -14,6 +16,22 @@ namespace Quartz.Configuration;
 internal sealed class SchedulerNameRegistry
 {
     private readonly List<string> names = [];
+
+    /// <summary>
+    /// The delegates <c>ConfigureAllQuartzSchedulers</c> has recorded, in the order they were recorded.
+    /// </summary>
+    private readonly List<Action<IQuartzBuilder>> configureAll = [];
+
+    /// <summary>
+    /// Which of those delegates has already been applied to which scheduler.
+    /// </summary>
+    /// <remarks>
+    /// Registering the default scheduler is additive, so <c>AddQuartz()</c> can be called twice for one
+    /// scheduler — and a delegate that adds a listener would then add it twice, since a listener
+    /// registration is not a <c>TryAdd</c>. A delegate reaches each scheduler once, whichever call
+    /// carries it there.
+    /// </remarks>
+    private readonly HashSet<(Action<IQuartzBuilder> Configure, string? SchedulerName)> applied = [];
 
     public IReadOnlyList<string> Names => names;
 
@@ -75,6 +93,45 @@ internal sealed class SchedulerNameRegistry
     public void AddDefault()
     {
         HasDefaultScheduler = true;
+    }
+
+    /// <summary>
+    /// Records configuration that belongs to every scheduler in the container, so that a scheduler
+    /// registered after <c>ConfigureAllQuartzSchedulers</c> was called still receives it.
+    /// </summary>
+    public void AddConfigureAll(Action<IQuartzBuilder> configure)
+    {
+        configureAll.Add(configure);
+    }
+
+    /// <summary>
+    /// Applies every recorded container-wide delegate to one scheduler.
+    /// </summary>
+    /// <remarks>
+    /// Called from <c>AddQuartz</c> after the caller's own configuration callback, so a scheduler that
+    /// says something for itself is not overruled by what the container says for everyone — options are
+    /// last-wins and registration is first-wins, and this order gives the scheduler's own word the
+    /// stronger side of both.
+    /// </remarks>
+    public void ApplyConfigureAll(IServiceCollection services, string? schedulerName)
+    {
+        // Indexed rather than foreach: a delegate is free to register a further scheduler, which would
+        // append to this list while it is being walked.
+        for (int i = 0; i < configureAll.Count; i++)
+        {
+            Apply(configureAll[i], services, schedulerName);
+        }
+    }
+
+    /// <summary>
+    /// Applies one container-wide delegate to one scheduler, unless it has already reached it.
+    /// </summary>
+    public void Apply(Action<IQuartzBuilder> configure, IServiceCollection services, string? schedulerName)
+    {
+        if (applied.Add((configure, schedulerName)))
+        {
+            configure(new QuartzBuilder(services, schedulerName));
+        }
     }
 
     /// <summary>

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -96,6 +96,17 @@ internal sealed class JobRunShell
     {
         Context.CallerId.Value = Guid.NewGuid();
 
+        // No scheduler logging scope is opened here, though this is where one would have to go for a
+        // job's own log lines to name the scheduler that fired it. It was written, measured and taken
+        // back out: ILogger.BeginScope pushes onto an AsyncLocal, and an AsyncLocal write copies the
+        // execution context, so one scope per firing cost 240 bytes and about 130ns of the roughly 960ns
+        // a no-op firing takes — 14%, for a firing that does no work at all. The scheduler thread opens
+        // the scope once for the lifetime of its loop instead, and the thread pools Quartz ships dispatch
+        // through a Task that captures the execution context, so a job inherits it from there at no
+        // per-firing cost. What that does not cover is an application that has never called
+        // LogProvider.SetLogProvider — the loop logs to NullLogger, whose scope is a no-op — or an
+        // IThreadPool of somebody else's that does not flow the context.
+
         // Create the job here (moved from Initialize) so that AsyncLocal values
         // set during IJobFactory.CreateJob flow correctly to IJob.Execute (#1528)
         IJobDetail jobDetail = firedTriggerBundle.JobDetail;

--- a/src/Quartz/Core/QuartzSchedulerResources.cs
+++ b/src/Quartz/Core/QuartzSchedulerResources.cs
@@ -17,6 +17,7 @@
  */
 #endregion
 
+using Quartz.Diagnostics;
 using Quartz.Extensibility;
 
 namespace Quartz.Core;
@@ -42,6 +43,7 @@ internal sealed class QuartzSchedulerResources
     private int _maxBatchSize;
     private TimeSpan _idleWaitTime;
     private TimeSpan _batchTimeWindow;
+    private SchedulerLogScope? logScope;
 
     public QuartzSchedulerResources()
     {
@@ -72,6 +74,7 @@ internal sealed class QuartzSchedulerResources
             }
 
             name = value;
+            logScope = null;
         }
     }
 
@@ -92,8 +95,21 @@ internal sealed class QuartzSchedulerResources
             }
 
             instanceId = value;
+            logScope = null;
         }
     }
+
+    /// <summary>
+    /// The logging scope that names this scheduler, built once and shared by everything that opens it.
+    /// </summary>
+    /// <remarks>
+    /// Cached rather than built per use, so opening the scope around a trigger firing costs the
+    /// <c>BeginScope</c> call and nothing else. The cache is dropped when the name or the instance id is
+    /// set, which happens while the scheduler is being created and not afterwards: a generated instance
+    /// id is assigned once the generator has run, and a scope built before that would name the scheduler
+    /// by the placeholder it is about to stop having.
+    /// </remarks>
+    public SchedulerLogScope LogScope => logScope ??= new SchedulerLogScope(name, instanceId);
 
 
     /// <summary>

--- a/src/Quartz/Core/QuartzSchedulerResources.cs
+++ b/src/Quartz/Core/QuartzSchedulerResources.cs
@@ -103,14 +103,13 @@ internal sealed class QuartzSchedulerResources
     /// The logging scope that names this scheduler, built once and shared by everything that opens it.
     /// </summary>
     /// <remarks>
-    /// Cached rather than built per use, so opening the scope around a trigger firing costs the
-    /// <c>BeginScope</c> call and nothing else. The cache is dropped when the name or the instance id is
-    /// set, which happens while the scheduler is being created and not afterwards: a generated instance
-    /// id is assigned once the generator has run, and a scope built before that would name the scheduler
-    /// by the placeholder it is about to stop having.
+    /// Cached rather than built per use, so every opener pushes the same object and none of them pays to
+    /// build it. The cache is dropped when the name or the instance id is set, which happens while the
+    /// scheduler is being created and not afterwards: a generated instance id is assigned once the
+    /// generator has run, and a scope built before that would name the scheduler by the placeholder it
+    /// is about to stop having.
     /// </remarks>
     public SchedulerLogScope LogScope => logScope ??= new SchedulerLogScope(name, instanceId);
-
 
     /// <summary>
     /// Get or set the <see cref="ThreadPool" /> for the <see cref="QuartzScheduler" />

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -265,6 +265,12 @@ internal sealed class QuartzSchedulerThread
         int acquiresFailed = 0;
         Context.CallerId.Value = Guid.NewGuid();
 
+        // Everything this loop logs names the scheduler it belongs to. An ILogger category is a type
+        // name, so without this two tenants' acquisition failures, misfire reports and shutdown notices
+        // are the same line written twice with no way to tell which scheduler wrote which. Opened for the
+        // lifetime of the loop, which is the lifetime of the scheduler's own thread.
+        using IDisposable? schedulerScope = logger.BeginScope(qsRsrcs.LogScope);
+
         while (!halted)
         {
             cancellationTokenSource.Token.ThrowIfCancellationRequested();

--- a/src/Quartz/Diagnostics/SchedulerLogScope.cs
+++ b/src/Quartz/Diagnostics/SchedulerLogScope.cs
@@ -1,0 +1,72 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Collections;
+
+namespace Quartz.Diagnostics;
+
+/// <summary>
+/// The logging scope that says which scheduler a log line belongs to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An <see cref="Microsoft.Extensions.Logging.ILogger" /> category is a type name, so two schedulers in
+/// one process write log lines that are identical in everything a log query can filter on — except where
+/// a message template happens to carry the scheduler's name, which most of them do not. A scope carries
+/// it on every line instead, including the lines a job writes with a logger of its own.
+/// </para>
+/// <para>
+/// The attribute names are the ones the spans and the measurements use, from
+/// <see cref="ActivityTags" />, so one query says "this tenant" against traces, metrics and logs alike.
+/// </para>
+/// <para>
+/// It is an <see cref="IReadOnlyList{T}" /> of key-value pairs — the shape ASP.NET Core's request scope
+/// has, and the one every structured logging provider reads without allocating an enumerator — and it is
+/// immutable, so one instance per scheduler is built once and pushed by everything that opens the scope.
+/// That is what keeps opening it around a firing down to the <c>BeginScope</c> call itself.
+/// </para>
+/// </remarks>
+internal sealed class SchedulerLogScope : IReadOnlyList<KeyValuePair<string, object?>>
+{
+    private readonly KeyValuePair<string, object?>[] tags;
+    private readonly string formatted;
+
+    public SchedulerLogScope(string schedulerName, string schedulerInstanceId)
+    {
+        tags =
+        [
+            new KeyValuePair<string, object?>(ActivityTags.SchedulerName, schedulerName),
+            new KeyValuePair<string, object?>(ActivityTags.SchedulerId, schedulerInstanceId)
+        ];
+
+        // Built here rather than on demand, because the providers that render a scope as text ask for
+        // this once per line and would otherwise format the same two values over and over.
+        formatted = $"{ActivityTags.SchedulerName}:{schedulerName} {ActivityTags.SchedulerId}:{schedulerInstanceId}";
+    }
+
+    public int Count => tags.Length;
+
+    public KeyValuePair<string, object?> this[int index] => tags[index];
+
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, object?>>) tags).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => tags.GetEnumerator();
+
+    public override string ToString() => formatted;
+}

--- a/src/Quartz/Diagnostics/SchedulerLogScope.cs
+++ b/src/Quartz/Diagnostics/SchedulerLogScope.cs
@@ -29,7 +29,7 @@ namespace Quartz.Diagnostics;
 /// An <see cref="Microsoft.Extensions.Logging.ILogger" /> category is a type name, so two schedulers in
 /// one process write log lines that are identical in everything a log query can filter on — except where
 /// a message template happens to carry the scheduler's name, which most of them do not. A scope carries
-/// it on every line instead, including the lines a job writes with a logger of its own.
+/// it on every line instead.
 /// </para>
 /// <para>
 /// The attribute names are the ones the spans and the measurements use, from
@@ -38,8 +38,9 @@ namespace Quartz.Diagnostics;
 /// <para>
 /// It is an <see cref="IReadOnlyList{T}" /> of key-value pairs — the shape ASP.NET Core's request scope
 /// has, and the one every structured logging provider reads without allocating an enumerator — and it is
-/// immutable, so one instance per scheduler is built once and pushed by everything that opens the scope.
-/// That is what keeps opening it around a firing down to the <c>BeginScope</c> call itself.
+/// immutable, so one instance per scheduler is built once and pushed by whoever opens the scope. The
+/// scheduler thread opens it once for the lifetime of its loop; a job's own log lines carry it when the
+/// dispatch to the thread pool captured the execution context that the loop's scope is held in.
 /// </para>
 /// </remarks>
 internal sealed class SchedulerLogScope : IReadOnlyList<KeyValuePair<string, object?>>


### PR DESCRIPTION
A container-wide way to configure every scheduler, the dashboard bug that motivated it, and two
tenancy fixes that ride along.

## `ConfigureAllQuartzSchedulers`

```csharp
public static IServiceCollection ConfigureAllQuartzSchedulers(
    this IServiceCollection services,
    Action<IQuartzBuilder> configure);
```

The options pattern's `ConfigureAll`, for schedulers. The delegate is applied to every scheduler
`AddQuartz()`, `AddQuartz(name, …)` or `AddQuartzSchedulers(…)` registers in the container — the ones
already registered when it is called, and the ones registered after it. **The order of the calls does
not matter**, which is the point: a package that adds something to every scheduler cannot know whether
the application registers its schedulers before or after calling it.

Each scheduler is handed its own `IQuartzBuilder`, so what the delegate registers lands under that
scheduler's own service key — exactly as if it had been written inside that scheduler's
`AddQuartz(name, q => …)` callback. A plugin or listener added this way is one instance per scheduler,
each initialized with the name of the scheduler it belongs to.

Mechanically: the delegate is recorded on `SchedulerNameRegistry`, the registration-time singleton the
container already holds as an `ImplementationInstance`, and `AddQuartz` applies the recorded delegates
after its own configuration callback. Schedulers already registered are configured at the
`ConfigureAllQuartzSchedulers` call site — which is also after their callbacks, so container-wide
configuration always lands in the same position in the order however the calls were written.

A delegate reaches each scheduler **once**. Registering the default scheduler is additive, so
`AddQuartz()` can be called twice for one scheduler, and a listener registration is not a `TryAdd` — it
would otherwise be attached twice.

`KeyedService.AnyKey` is not used: `GetKeyedServices<T>(key)` does not see `AnyKey` descriptors, so it
cannot serve enumerable keyed resolution.

## Bug 1: the dashboard's plugins never reached a named scheduler

`AddQuartzDashboard()` built a `QuartzBuilder(services, schedulerKey: null)` and added
`DashboardLiveEventsPlugin` and `DashboardHistoryPlugin` through it, which registers **unkeyed**.
`DefaultSchedulerFactory` resolves a named scheduler's plugins with `GetKeyedServices`. So a scheduler
registered with `AddQuartz("acme", …)` never had either plugin initialized: it appeared in the scheduler
selector, its jobs and triggers rendered, and its **Live Logs view and History page were silently always
empty** — with nothing to configure that would have filled them.

They now go in through `ConfigureAllQuartzSchedulers`, so every scheduler gets its own instance of each,
initialized with its own name. `DashboardHistoryStore` already partitions by scheduler name and its
entries already carry `context.Scheduler.SchedulerName`, and `DashboardLiveEventsPlugin` already
broadcasts to the SignalR group named after the scheduler, so several instances feeding them need
nothing further — checked rather than assumed.

`DashboardPluginRegistrationTest` hard-coded `new SchedulerKey(null)`, which is why nothing caught it.
It now asserts both keys, on either registration order, and that three schedulers get three instances
rather than one shared. **Three of its four tests fail against the unfixed dashboard** (verified by
stashing the fix).

## Bug 2: `AddQuartzHttpClient` could silently capture the unkeyed `IScheduler`

`AddQuartzHttpClient` registers its remote scheduler unkeyed as well as by name, so a container holding
one remote scheduler and nothing else answers `GetRequiredService<IScheduler>()` with it. `AddQuartz()`
registers the local default scheduler in that same slot. Both use `TryAdd`, so whichever ran first owned
it — and `AddQuartzHttpClient(…)` followed by `AddQuartz()` left "the scheduler" meaning the remote one,
with no error. A program that thought it held its own scheduler was scheduling jobs in another process.

`AddQuartz()` now throws `InvalidOperationException` at registration when an unkeyed `IScheduler` is
already present, **before it registers anything**, so a container that cannot hold the scheduler is not
left half configured by the attempt. The message names `AddQuartzHttpClient` and says the remote
scheduler stays reachable under its keyed name whichever order is written.

The other order is unchanged and is the one to write. `AddQuartz("Local", …)` beside a remote scheduler
is fine either way round — a named scheduler never wanted the unkeyed slot. Both methods' XML docs and
`packages/http-client.md` say so.

## Improvement 3: a logging scope naming the scheduler — **the per-firing half was measured out**

The scheduler thread now opens a logging scope for the lifetime of its loop, carrying
`quartz.scheduler.name` and `quartz.scheduler.id` — the same attribute names the spans and the
measurements use (`ActivityTags`), so one query says "this tenant" against traces, metrics and logs
alike. The state is one immutable `SchedulerLogScope` per scheduler implementing
`IReadOnlyList<KeyValuePair<string, object?>>`, cached on `QuartzSchedulerResources` and dropped only
when the name or instance id is set (a generated instance id arrives after construction).

**There is deliberately no scope per firing in `JobRunShell`.** It was written, measured, and taken back
out under the spec's own rule. `ILogger.BeginScope` pushes onto an `AsyncLocal`, and an `AsyncLocal`
write copies the execution context — so it is not one object, it is about five.

`JobRunShellBenchmark`, `--warmupCount 10 --iterationCount 25 --launchCount 1`, .NET 10.0.11, Ryzen
9 5950X. The benchmark previously ran only with `NullLogger`, whose `BeginScope` returns a cached
singleton and allocates nothing — which would have measured the scope as free, for the one reason that
makes the measurement worthless. A second case was added first (committed separately, so the "before"
numbers come from the same harness) that runs the same firing under a logger factory holding a
scope-supporting provider whose loggers are disabled.

| | before | with `JobRunShell` scope | shipped (thread scope only) |
|---|---|---|---|
| `NullLogger`, mean | 957.9 ns | — | 911.3 ns |
| `NullLogger`, allocated | 776 B | 776 B | **776 B** |
| scope-supporting provider, mean | ~950 ns | 1,087.7 ns (**+13.6%**) | 1,034.0 ns |
| scope-supporting provider, allocated | 776 B | 1,016 B (**+240 B**) | **776 B** |

Both fallback conditions in the spec were met (>2% regression, allocations grew by more than one
object), so the per-firing scope came out. The means are noisy run to run — the two benchmark methods
differ by ~6–13% in either direction on identical code — but **allocation is exact and deterministic,
and is back to 776 B on both paths, byte for byte what it was before this branch**.

## What a reviewer must decide

**The thread-lifetime scope only reaches a job when the application has called
`LogProvider.SetLogProvider`.** `QuartzSchedulerThread` logs through the ambient `LogProvider`, not
through an injected logger, and nothing in the hosting path sets it — so for an application on the
generic host that has not called it, the loop logs to `NullLogger`, its scope is a no-op, and jobs get
nothing. When it *is* set, the thread pools Quartz ships dispatch through a `Task` that captures the
execution context, so a job inherits the loop's scope for free; that is what the test pins.

So item 3 as specified — "a job's own log lines carry it too" — is delivered **only** for applications
that set `LogProvider`. Getting it unconditionally needs one of:

1. **Hand `QuartzSchedulerThread` a container `ILogger`** instead of the ambient one. Then the scope is
   real in every DI application and still flows to jobs at zero per-firing cost. This is the right fix
   and is a change of its own — the thread is constructed by `QuartzScheduler`'s constructor from
   `QuartzSchedulerResources`, which holds no logger factory. Not attempted here.
2. **Re-add the `JobRunShell` scope and accept the 240 B / ~14%.** Note that if it is re-added *and*
   `LogProvider` is set, the scheduler is named **twice** in a job's scope chain (measured: tag count 2)
   — harmless to any structured sink, which flattens a scope into properties where the second write of
   the same key with the same value is invisible, but a console formatter with `IncludeScopes` prints it
   twice. Skipping the redundant push would need an `AsyncLocal<SchedulerLogScope?>` of our own, whose
   write is the very cost being avoided.

Everything above is written up in the comment at the top of `JobRunShell.Run` and in the remarks on
`SchedulerLogScopeTest`, so it is not folklore.

## Baselines moved

One line, in `src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt`, accepted through the
Verify workflow:

```diff
+ public static Microsoft.Extensions.DependencyInjection.IServiceCollection ConfigureAllQuartzSchedulers(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Quartz.IQuartzBuilder> configure) { }
```

`SchedulerLogScope` is `internal sealed`, so item 3 moves no baseline.

## Documentation

- `migration-guide.md` — a section for `ConfigureAllQuartzSchedulers`, and a three-row table for the
  `AddQuartz()`/`AddQuartzHttpClient` ordering under the existing remote-scheduler section.
- `packages/dashboard.md` — a new section saying plainly that every scheduler in the container gets the
  dashboard's plugins, with a "Changed in 4.0.0-alpha.2" note describing what was broken.
- `packages/http-client.md` — a "Beside a local scheduler" section. The C# is a real compiled snippet
  (`sample_httpclient_beside_local` in `Quartz.Documentation.Samples`), regenerated with
  `dotnet fallout DocsSnippets`.

`multi-tenancy.md`, `multiple-schedulers.md`, `execution-groups.md` and `tenancy-patterns.md` are
deliberately untouched.

## Verification

```
dotnet build Quartz.slnx                                            0 Warning(s)  0 Error(s)
dotnet test src/Quartz.Tests.Unit                     Failed: 0, Passed: 3108, Skipped: 4
dotnet test src/Quartz.Tests.AspNetCore               Failed: 0, Passed:  317, Skipped: 0
dotnet test src/Quartz.Tests.Integration              Failed: 0, Passed:  316, Skipped: 0
dotnet fallout VerifyDocsSnippets                     up to date (89 markdown files checked)
npm run docs:check-links                              no dead links or anchors
```

The integration suite ran against a live Docker daemon — SQL Server 2017 and 2022, PostgreSQL 15,
MySQL 8, Oracle XE 21 and Firebird 4 — in 8m32s. There is no `Quartz.Tests.AOT` project on this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
