### PR TITLE
The multi-tenancy documentation says what the code does, and its samples compile

### DIFF
--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -189,7 +189,8 @@ A listener and a plugin are both "registered per scheduler", and they treat a pl
 
 The asymmetry is the difference between a listener, which is told which scheduler it is hearing from on
 every callback, and a plugin, which is *bound* to one when it is initialized. So several schedulers
-cannot share a plugin instance; each needs its own.
+cannot share a plugin instance; each needs its own, and
+[`ConfigureAllQuartzSchedulers`](#giving-every-scheduler-the-same-thing) is how to ask for that once.
 :::
 
 Options are **named options** whose name is the scheduler's name, and the container rewrites
@@ -273,6 +274,41 @@ initialization overwrites the first.
 
 To give a named scheduler a plugin instance you built yourself, register it under that scheduler —
 `q.AddPlugin<T>(provider => …)` — rather than unkeyed on `IServiceCollection`.
+
+### Giving every scheduler the same thing
+
+Writing the same three lines inside every `AddQuartz(tenant, …)` is what a `foreach` over the tenants
+saves you, right up until the tenants come from configuration and the loop is not yours to write.
+`ConfigureAllQuartzSchedulers` applies one configuration callback to every scheduler in the container:
+
+<!-- TODO(tenancy-configure-all): a compiled sample once the API lands; see the pull request that adds it. -->
+```csharp
+builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s => s.UseSqlServer(acme)));
+builder.Services.AddQuartzSchedulers(builder.Configuration.GetSection("Quartz"));
+
+// Every scheduler above, and every scheduler registered after this line
+builder.Services.ConfigureAllQuartzSchedulers(q =>
+{
+    q.AddPlugin<TenantAuditPlugin>();
+    q.AddJobListener<AuditListener>();
+});
+```
+
+Four things it promises:
+
+- **Order does not matter.** Schedulers already registered get the callback immediately; schedulers
+  registered later get it after their own configure callback has run, so a scheduler's own
+  configuration is what a shared callback refines rather than the other way round.
+- **Every scheduler gets its own instance of whatever the callback adds.** A plugin added this way to
+  three schedulers is three plugin instances, each initialized with the name of the scheduler it
+  extends — which is exactly what a plugin registered unkeyed cannot be.
+- **It reaches `AddQuartz()`, `AddQuartz(name, …)` and `AddQuartzSchedulers(…)` alike**, because all
+  three register a builder.
+- **Remote schedulers are skipped.** A scheduler from `AddQuartzHttpClient` lives in another process;
+  there is no builder here to configure, and nothing this callback adds could reach it.
+
+It is the options pattern's `ConfigureAll` for schedulers, and it is how `AddQuartzDashboard` gives
+every scheduler the dashboard's own plugins rather than only the default one.
 
 ### What is not
 

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -576,9 +576,9 @@ on whether the *container* knows the job type.
   be constructed at all: reported when the container is validated, or at the first fire in a container
   that does not validate.
 - **A job type the container does not hold is activated by the job factory**, through the
-  scheduler-scoped provider, and its dependencies resolve to *its own* scheduler's parts. This is the
-  case for a job named only by an XML or JSON schedule, and for one whose registration
-  `AddJob<T>` skipped.
+  scheduler-scoped provider, and its dependencies resolve to *its own* scheduler's parts. That is any
+  job the container was never told about: one scheduled at runtime with `ScheduleJob(jobDetail, …)`,
+  and one named only by an XML or JSON schedule, which nothing describes to the container.
 
 That the two differ is the point worth carrying away, because nothing about the job says which path it
 is on. **Do not inject a scheduler's own parts into a job.** A job that needs the scheduler running it

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -572,8 +572,9 @@ on whether the *container* knows the job type.
   `TryAddScoped`, so the job is resolved as an ordinary scoped service and its constructor dependencies
   are resolved **unkeyed**. A job on scheduler `acme` that injects `ISchedulerFactory`, `IJobStore`,
   `IThreadPool` or `IOptions<QuartzSchedulerOptions>` therefore gets the *default* scheduler's — and in
-  a container holding only named schedulers there is no unkeyed registration to get, so it fails
-  container validation instead.
+  a container holding only named schedulers there is no unkeyed registration to get, so the job cannot
+  be constructed at all: reported when the container is validated, or at the first fire in a container
+  that does not validate.
 - **A job type the container does not hold is activated by the job factory**, through the
   scheduler-scoped provider, and its dependencies resolve to *its own* scheduler's parts. This is the
   case for a job named only by an XML or JSON schedule, and for one whose registration

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -36,6 +36,7 @@ been built.
 are registered under, and the name of its options — so its registrations and its configuration always
 agree.
 
+<!-- snippet: sample_tenancy_scheduler_per_tenant -->
 ```csharp
 foreach (string tenant in tenants)
 {
@@ -54,22 +55,45 @@ foreach (string tenant in tenants)
 
 builder.Services.AddQuartzHostedService(o => o.WaitForJobsToComplete = true);
 ```
+<!-- endSnippet -->
 
 One `AddQuartzHostedService` starts them all. Calling the named overload —
 `AddQuartzHostedService(tenant, o => …)` — configures *that* scheduler's start options and still
 registers only one hosted service; two would each start every scheduler in the container.
 
+### Starting and stopping all of them
+
+The hosted service builds every scheduler in the container while the host starts, and then starts
+them: immediately under `AwaitApplicationStarted = false`, and otherwise — which is the default —
+once `ApplicationStarted` fires. So a tenant's scheduler exists before the application runs and is
+firing shortly after it does.
+
+Two things about that follow the tenant count rather than the code:
+
+- **A start that fails takes the tenants already created down with it.** The schedulers built before
+  the failure are already bound to the repository, so the hosted service shuts them down before it
+  rethrows rather than leaving them running with nothing left to stop them.
+- **Shutdown is one deadline for every tenant, not one each.** The schedulers are shut down
+  concurrently, so `HostOptions.ShutdownTimeout` bounds the whole set — with
+  `WaitForJobsToComplete = true` the host waits as long as the slowest tenant's jobs take, not as long
+  as all of them added together. Each scheduler owns its own thread pool, job store and scheduler
+  thread, so there is nothing for them to serialize behind.
+
 ### Injecting one
 
 A named scheduler is keyed by its name:
 
+<!-- snippet: sample_tenancy_inject_named -->
 ```csharp
 public sealed class TenantOpsService([FromKeyedServices("acme")] IScheduler scheduler);
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_tenancy_resolve_named -->
 ```csharp
 IScheduler scheduler = provider.GetRequiredKeyedService<IScheduler>(tenant);
 ```
+<!-- endSnippet -->
 
 ::: warning
 The unkeyed `IScheduler` is **the default scheduler** — the one registered by `AddQuartz(q => …)` with
@@ -79,8 +103,23 @@ no name. In a container holding only named schedulers there is no unkeyed regist
 
 Trying to give a named scheduler and the default scheduler the same name is caught at registration:
 `AddQuartz(o => o.InstanceName = "acme")` beside `AddQuartz("acme", …)` fails with a message naming both
-calls, rather than as a duplicate-name `ArgumentException` from somewhere inside host start. Names are
-compared case-insensitively.
+calls, rather than as a duplicate-name `ArgumentException` from somewhere inside host start.
+
+::: warning A scheduler name is compared two different ways
+Not one, and knowing which is which saves an afternoon:
+
+- **Case-insensitive**: the duplicate-name check, and every `ISchedulerRepository` lookup. So
+  `AddQuartz("Acme", …)` beside `AddQuartz("acme", …)` is refused as one name, `repository.Lookup("acme")`
+  finds the scheduler registered as `Acme`, and so does the HTTP API route `…/schedulers/acme/…`, which
+  resolves through that repository.
+- **Ordinal**: keyed resolution out of the container, and named options. So for a scheduler registered
+  as `Acme`, `GetRequiredKeyedService<IScheduler>("acme")` throws — the container compares service keys
+  by equality, and string equality is ordinal — and `Configure<QuartzOptions>("acme", …)` configures
+  nothing, because the options framework matches instance names ordinally too.
+
+Neither comparison is wrong for what it does; they are simply different, and only the first one is
+forgiving. Spell the name once, put it in a constant, and use that constant everywhere.
+:::
 
 ### Listing them
 
@@ -90,6 +129,7 @@ one of them to find out what exists is exactly the cost you were avoiding.
 
 `ISchedulerRegistry` reads the registrations instead:
 
+<!-- snippet: sample_tenancy_scheduler_registry -->
 ```csharp
 ISchedulerRegistry registry = provider.GetRequiredService<ISchedulerRegistry>();
 
@@ -98,21 +138,35 @@ foreach (SchedulerRegistration tenant in await registry.QuerySchedulers())
     Console.WriteLine($"{tenant.Name}: {tenant.Status?.ToString() ?? "registered, not created"}");
 }
 ```
+<!-- endSnippet -->
 
 `Status` is `null` when no scheduler exists under that name, and asking does not build one. A scheduler
 that has been *shut down* reads as `null` too rather than as `Shutdown`, because the repository drops a
 shut-down scheduler as soon as a read notices it — and a shut-down scheduler cannot be rebuilt in the same
 container anyway, so "not yet" and "not any more" are the same answer here: not a name you can get a
-working scheduler out of.
+working scheduler out of. A scheduler whose state cannot be read at all — a remote one from
+`AddQuartzHttpClient`, when the other process is unreachable — is reported as `SchedulerStatus.Unknown`
+rather than dropped from the listing or allowed to throw: an inventory of tenants is exactly the call
+that must not fail because one of them is down.
 
 `Origin` says where the scheduler came from: `Container` for one `AddQuartz` registered, `Runtime` for
 one that is in the repository without a registration behind it — a `QuartzSchedulerBuilder` scheduler
 bound by hand, or a remote scheduler from `AddQuartzHttpClient`. The default scheduler appears under its
 configured `InstanceName`.
 
-Under `AddQuartzHostedService()` every registration is created and started before the application runs,
-so once the host is up the distinction matters less than it looks. It matters when you resolve schedulers
-yourself, when a start failed, and whenever you want an inventory rather than a list of live objects.
+Under `AddQuartzHostedService()` every registration is *built* while the host starts, so once the host is
+up the distinction matters less than it looks. It matters while the host is still starting, when you
+resolve schedulers yourself, when a start failed, and whenever you want an inventory rather than a list
+of live objects.
+
+::: warning The dashboard and the HTTP API list the repository, not the registry
+Both resolve a scheduler by looking it up in `ISchedulerRepository`, which holds the schedulers something
+has already built. A tenant that is registered but has never been created is therefore absent from the
+dashboard's scheduler list, and its API routes answer `404` — not because the name is unknown, but
+because nothing has built it yet. Under `AddQuartzHostedService()` that window closes as the host starts;
+outside it — a scheduler resolved lazily, or one whose start failed — the two views disagree, and
+`ISchedulerRegistry` is the one that knows the tenant exists.
+:::
 
 ### What is per scheduler
 
@@ -121,17 +175,40 @@ signaler, the thread pool, the job store, the driver delegate, the object serial
 generator, the scheduler itself and its factory — plus its own listeners, plugins, calendars, jobs and
 triggers.
 
+::: warning Listeners and plugins are not symmetrical about the unkeyed registration
+A listener and a plugin are both "registered per scheduler", and they treat a plain
+`IServiceCollection` registration in opposite ways.
+
+- **An unkeyed `ISchedulerListener`, `IJobListener` or `ITriggerListener` service reaches every
+  scheduler in the container.** A scheduler unions the unkeyed listener services with the ones keyed to
+  it, so `services.AddSingleton<IJobListener, AuditListener>()` is a container-wide listener — not the
+  default scheduler's. Keyed registrations belong to the scheduler they name.
+- **An unkeyed `ISchedulerPlugin` service reaches only the default scheduler.** A named scheduler reads
+  the plugins keyed to it and nothing else, and [the properties probe](#plugins-named-by-properties) has
+  no unkeyed fallback either.
+
+The asymmetry is the difference between a listener, which is told which scheduler it is hearing from on
+every callback, and a plugin, which is *bound* to one when it is initialized. So several schedulers
+cannot share a plugin instance; each needs its own.
+:::
+
 Options are **named options** whose name is the scheduler's name, and the container rewrites
 `IOptions<T>` for a scheduler's own components so that `.Value` means *that* scheduler's settings.
-`QuartzSchedulerOptions`, `ThreadPoolOptions`, `InMemoryJobStoreOptions`, `AdoJobStoreOptions`,
-`ClusteringOptions`, `QuartzOptions` and `JobFactoryOptions` all work this way, and
-`ConfigureOptions<TOptions>()` opts your own options type in.
+Quartz's own option types — `QuartzSchedulerOptions`, `ThreadPoolOptions`, `InMemoryJobStoreOptions`,
+`AdoJobStoreOptions`, `ClusteringOptions` and `QuartzOptions` — are declared that way once, in the
+container; every other options type opts in by being *declared*, which is what
+`ConfigureOptions<TOptions>()` does. That is also how `JobFactoryOptions` becomes per-scheduler:
+`ConfigureJobScope(…)` is a `ConfigureOptions<JobFactoryOptions>` call, so the declaration arrives with
+the hook rather than being built in. `AddPlugin<T, TOptions>()` does the same for a plugin's own
+options type.
 
 A clock is per scheduler too, when you set one:
 
+<!-- snippet: sample_tenancy_time_provider -->
 ```csharp
 builder.Services.AddQuartz("acme", q => q.UseTimeProvider(acmeClock));
 ```
+<!-- endSnippet -->
 
 A scheduler with no clock of its own inherits the container's, which is what lets an application-wide
 `TimeProvider` reach all of them without being told about each.
@@ -144,6 +221,7 @@ one scheduler and not enough for several: the first registration would be what e
 
 `AddJobType` gives one scheduler its own:
 
+<!-- snippet: sample_tenancy_job_types -->
 ```csharp
 builder.Services.AddQuartz("acme", q =>
 {
@@ -154,6 +232,7 @@ builder.Services.AddQuartz("acme", q =>
     q.AddJob<ReportJob>(j => j.WithIdentity("report"));
 });
 ```
+<!-- endSnippet -->
 
 The job factory looks for this scheduler's registration first and falls back to the container's, so a
 scheduler given nothing of its own resolves what the container holds and the default scheduler — which
@@ -174,13 +253,15 @@ Two things worth knowing before reaching for it:
 A `quartz.plugin.<name>.*` entry is read from the property bag of the scheduler it was configured on,
 so two tenants each configuring an XML plugin get two instances with their own files:
 
+<!-- snippet: sample_tenancy_plugin_by_properties -->
 ```csharp
 builder.Services.AddQuartz("acme", new NameValueCollection
 {
-    ["quartz.plugin.xml.type"] = typeof(XMLSchedulingDataProcessorPlugin).AssemblyQualifiedName,
+    ["quartz.plugin.xml.type"] = typeof(XmlSchedulingDataProcessorPlugin).AssemblyQualifiedName,
     ["quartz.plugin.xml.fileNames"] = "acme-jobs.xml",
 });
 ```
+<!-- endSnippet -->
 
 Before the instance is built, the container is asked whether that type is registered as a service —
 and that question is asked **under this scheduler's key**. So a named scheduler gets the registration
@@ -203,7 +284,7 @@ A handful of things are container-wide, shared by every scheduler in the process
 | `ISchedulerRepository` | one per container — that is what makes `GetAllSchedulers` and the dashboard see all of them |
 | `ISchedulerRegistry` | one per container — it answers for every registration in it, which is what makes it an inventory rather than a scheduler's own view |
 | `IJobExecutionContextAccessor` | one per container, and the firing it reports is a property of the asynchronous flow rather than of a scheduler — a flow is inside at most one firing, whichever scheduler started it |
-| `SystemTextJsonSerializerRegistry` | the HTTP API, the dashboard and the HTTP client serialize triggers without knowing which scheduler they came from |
+| `SystemTextJsonSerializerRegistry` | one per container by default — the HTTP API, the dashboard and the HTTP client serialize triggers without knowing which scheduler they came from. A named scheduler *can* be given its own, see below |
 | `Meters` | built from the container's `IMeterFactory` |
 | `DataSourceOptions` | named after the **data source**, not the scheduler, so several schedulers can read through the same one |
 | `QuartzHttpApiOptions` | one per process — see [honest limits](#honest-limits) |
@@ -211,14 +292,25 @@ A handful of things are container-wide, shared by every scheduler in the process
 And one that is not a container service at all: **`LogProvider`** is process-wide static state.
 `SetLogProvider(loggerFactory)` sets it for everything in the process, deliberately.
 
+The serializer registry is the one row in that table with a way out. A named scheduler resolves its
+registry by key and falls back to the container's, so `services.AddKeyedSingleton(schedulerName, registry)`
+— or the per-store `UseSystemTextJsonSerializer(json => …)` callback, which is the same thing — gives one
+tenant its own custom trigger and calendar serializers. What that changes is what *that scheduler's job
+store* persists and reads. Everything that serializes without a scheduler in hand — the HTTP API's
+responses, the dashboard, `Quartz.HttpClient` — still reads the container's registry, so a custom type
+those must render has to be registered there as well. See
+[System.Text.Json serialization](packages/system-text-json.md#making-custom-serializers-visible-outside-the-job-store).
+
 ### Health checks per tenant
 
 `AddQuartzHealthChecks` called on a *scheduler's* builder checks that scheduler, and defaults its name
 to `quartz-scheduler-<scheduler name>` so several can be registered side by side:
 
+<!-- snippet: sample_tenancy_health_checks -->
 ```csharp
 builder.Services.AddQuartz("acme", q => q.AddQuartzHealthChecks(o => o.Tags.Add("tenant:acme")));
 ```
+<!-- endSnippet -->
 
 Called on `IServiceCollection` instead, it checks the default scheduler only.
 
@@ -226,13 +318,16 @@ Called on `IServiceCollection` instead, it checks the default scheduler only.
 
 One scheduler; the tenant is the group half of every key.
 
+<!-- snippet: sample_tenancy_group_keys -->
 ```csharp
 JobKey job = new("nightly-report", tenantId);
 TriggerKey trigger = new("nightly", tenantId);
 ```
+<!-- endSnippet -->
 
 Everything that takes a matcher then becomes tenant-scoped:
 
+<!-- snippet: sample_tenancy_group_matchers -->
 ```csharp
 // everything this tenant has scheduled
 PagedResult<TriggerHeader> theirs = await scheduler.QueryTriggers(new TriggerQuery
@@ -250,6 +345,7 @@ PagedResult<TriggerGroup> group = await scheduler.QueryTriggerGroups(
     new TriggerGroupQuery { Name = tenantId, Take = 1 });
 bool suspended = group.Items is [{ Paused: true }];
 ```
+<!-- endSnippet -->
 
 Pause state is real and queryable for both trigger groups and job groups — the ADO store persists a
 paused job group in `QRTZ_PAUSED_JOB_GRPS`, so `QueryJobGroups(new JobGroupQuery { Name = tenantId,
@@ -259,9 +355,11 @@ trigger paused on either store, where a paused job group does so only in the in-
 
 Listeners take matchers too, so a per-tenant listener is one registration:
 
+<!-- snippet: sample_tenancy_group_listener -->
 ```csharp
 q.AddJobListener<AuditListener>(Matchers.Group<JobKey>(StringOperator.Equality, tenantId));
 ```
+<!-- endSnippet -->
 
 ### Per-tenant concurrency quotas
 
@@ -269,6 +367,7 @@ Execution groups cap how many threads a category of work may use. When the sched
 work by trigger group — a tenant per group — the trigger group can stand in for the execution group, so
 a quota is one line per tenant and no change to any trigger:
 
+<!-- snippet: sample_tenancy_execution_limits -->
 ```csharp
 q.UseExecutionLimits(limits => limits
     .UseTriggerGroupWhenUnset()
@@ -276,6 +375,7 @@ q.UseExecutionLimits(limits => limits
     .ForGroup("initech", 2, ExecutionLimitScope.Cluster)
     .ForOtherGroups(1, ExecutionLimitScope.Cluster));          // everyone else gets one thread each
 ```
+<!-- endSnippet -->
 
 `ExecutionLimitScope.Cluster` is what makes these quotas rather than capacity settings: the number is
 what every node sharing the job store may run **between them**, counted from the reservations the store
@@ -303,9 +403,11 @@ honour has to be set on every node, or configured rather than set.
 
 ::: warning What a cluster-scoped quota does and does not promise
 The ceiling holds **within one acquisition round**, and by default acquisition takes no cluster lock, so
-a brief overshoot is possible while several nodes acquire at once — at most
-`limit + (nodes − 1) × batchSize`, until the losers notice. `AcquireTriggersWithinLock = true` makes it
-exact and serializes acquisition cluster-wide.
+a brief overshoot is possible while several nodes acquire at once — at most `limit + (nodes − 1)`, until
+the losers notice. The lock-free path exists only when a round acquires a single trigger: the ADO store
+takes the `TRIGGER_ACCESS` lock whenever it is asked for more than one, so a node acquiring without the
+lock can add at most one over the ceiling. `AcquireTriggersWithinLock = true` makes it exact and
+serializes acquisition cluster-wide.
 
 It **fails closed**: the quota ledger and the work queue are the same database, so a node that cannot
 reach the store fires nothing at all rather than firing unmetered. Plan for a database outage stopping
@@ -326,6 +428,7 @@ that is a property of the schema rather than of the code paths — there is no q
 Table prefix is the other axis. `AdoJobStoreOptions.TablePrefix` (default `QRTZ_`) is a per-scheduler
 option, so two tenants can have entirely separate table *sets* in one database:
 
+<!-- snippet: sample_tenancy_table_prefix -->
 ```csharp
 builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s =>
 {
@@ -333,6 +436,7 @@ builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s =>
     s.Configure(o => o.TablePrefix = "ACME_QRTZ_");
 }));
 ```
+<!-- endSnippet -->
 
 Four rules:
 
@@ -348,7 +452,9 @@ Four rules:
   catch that one: the tables exist, they are simply somebody else's, and the scheduler starts, reports
   healthy and never sees its own data. So creating a scheduler records its database and its table prefix,
   and a scheduler that shares a database with one already created but disagrees about the prefix produces
-  a `Warning` naming both schedulers and both prefixes.
+  a `Warning` naming both schedulers and both prefixes. Prefixes are compared **ignoring case**, because
+  every database Quartz supports folds an unquoted identifier to one case — `qrtz_` and `QRTZ_` are one
+  table set, and two tenants told apart only by the casing of their prefix are one tenant.
 
 ::: tip Why that one is a warning and not an error
 Separate table sets in one database are legal, and the arrangement above is exactly how you ask for them.
@@ -376,6 +482,7 @@ A job needs to reach *its* tenant's database, its tenant's configuration, its te
 The scheduler builds jobs from a DI scope, and `ConfigureJobScope` prepares that scope before the job
 and everything it injects are constructed:
 
+<!-- snippet: sample_tenancy_ambient_tenant -->
 ```csharp
 public static class TenantContext
 {
@@ -388,13 +495,16 @@ public static class TenantContext
     }
 }
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_tenancy_configure_job_scope -->
 ```csharp
 q.ConfigureJobScope((scope, bundle, scheduler) =>
 {
     TenantContext.Current = bundle.Trigger.Key.Group;
 });
 ```
+<!-- endSnippet -->
 
 Two things make this work, and both are deliberate:
 
@@ -417,20 +527,66 @@ depend on execution context flow. For everything that reads the tenant when it i
 when it is constructed, `IJobExecutionContextAccessor` below is neither.
 :::
 
+### Which scheduler's parts a job is built from
+
+Two jobs on the same named scheduler can be handed different collaborators, and which one you get turns
+on whether the *container* knows the job type.
+
+- **A job type the container holds is built by the container.** `AddJob<T>` registers the type with
+  `TryAddScoped`, so the job is resolved as an ordinary scoped service and its constructor dependencies
+  are resolved **unkeyed**. A job on scheduler `acme` that injects `ISchedulerFactory`, `IJobStore`,
+  `IThreadPool` or `IOptions<QuartzSchedulerOptions>` therefore gets the *default* scheduler's — and in
+  a container holding only named schedulers there is no unkeyed registration to get, so it fails
+  container validation instead.
+- **A job type the container does not hold is activated by the job factory**, through the
+  scheduler-scoped provider, and its dependencies resolve to *its own* scheduler's parts. This is the
+  case for a job named only by an XML or JSON schedule, and for one whose registration
+  `AddJob<T>` skipped.
+
+That the two differ is the point worth carrying away, because nothing about the job says which path it
+is on. **Do not inject a scheduler's own parts into a job.** A job that needs the scheduler running it
+takes `IJobExecutionContext.Scheduler`, which is that scheduler under either path:
+
+<!-- snippet: sample_tenancy_job_reads_its_scheduler -->
+```csharp
+public sealed class RotateTenantKeysJob : IJob
+{
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        // The scheduler running this fire, whichever tenant it belongs to. An injected
+        // ISchedulerFactory would have been the default scheduler's.
+        IScheduler mine = context.Scheduler;
+
+        await mine.PauseTriggers(
+            GroupMatcher<TriggerKey>.GroupEquals(context.Trigger.Key.Group),
+            cancellationToken);
+    }
+}
+```
+<!-- endSnippet -->
+
+and a service the job calls into reads the firing from [`IJobExecutionContextAccessor`](#reading-the-firing-from-anywhere-in-it).
+Where the job genuinely has to be *constructed* with something of its scheduler's, register it with
+`AddJobType<T>(factory)` and resolve that by key inside the factory.
+
 ### Reading the firing from anywhere in it
 
 A great deal of code that wants the tenant is not the job and cannot be handed the context: a scoped
 service, a logging enricher, a repository three calls below `Execute`. `IJobExecutionContextAccessor` is
 the firing that code is part of:
 
+<!-- snippet: sample_tenancy_execution_context_accessor -->
 ```csharp
-public sealed class TenantConnectionFactory(IJobExecutionContextAccessor accessor)
+public sealed class TenantConnectionFactory(
+    IJobExecutionContextAccessor accessor,
+    IReadOnlyDictionary<string, string> connectionStrings)
 {
     public string ConnectionString =>
         connectionStrings[accessor.Current?.Trigger.Key.Group
             ?? throw new InvalidOperationException("no job is running on this flow")];
 }
 ```
+<!-- endSnippet -->
 
 It is registered by `AddQuartz` as a singleton, and it exposes the whole `IJobExecutionContext` rather
 than a tenant-shaped projection of it — Quartz has no tenant concept, so a narrower type here would be
@@ -473,9 +629,11 @@ Things multi-tenant deployments ask Quartz for and do not get:
 **A cluster-wide concurrency ceiling is approximate, not exact, unless you pay for exactness.**
 `ExecutionLimitScope.Cluster` counts a group's in-flight work from `QRTZ_FIRED_TRIGGERS`, which is
 transactional and cluster-wide, but the default acquisition path takes no cluster lock — so the ceiling
-holds within one acquisition round and can transiently overshoot by up to
-`(nodes − 1) × batchSize` while several nodes acquire at once. `AcquireTriggersWithinLock = true` removes
-the overshoot and serializes acquisition for every group, limited or not. There is no third setting that
+holds within one acquisition round and can transiently overshoot by up to `nodes − 1` while several
+nodes acquire at once. The overshoot is one trigger per node and no more, because the lock-free path is
+only taken when a round acquires a single trigger: asking for a batch takes the `TRIGGER_ACCESS` lock,
+which is the same lock `AcquireTriggersWithinLock = true` takes on every round. That setting removes the
+overshoot and serializes acquisition for every group, limited or not. There is no third setting that
 gives you both.
 
 **There is no rate limiting.** Execution limits cap *concurrency*, not throughput. "This tenant may run
@@ -504,6 +662,7 @@ That is a limit of the DI path, not of the library. `QuartzSchedulerBuilder` bui
 container of its own, at any point in the process's life, and `ISchedulerRepository.Bind` makes the
 result visible to `GetAllSchedulers`, the dashboard and the HTTP API:
 
+<!-- snippet: sample_tenancy_runtime_onboarding -->
 ```csharp
 StandaloneSchedulerFactory tenantFactory = QuartzSchedulerBuilder.Create()
     .ConfigureScheduler(o => o.InstanceName = tenantId)
@@ -516,6 +675,7 @@ await tenant.Start();
 tenantFactories[tenantId] = tenantFactory;
 app.Services.GetRequiredService<ISchedulerRepository>().Bind(tenant);
 ```
+<!-- endSnippet -->
 
 Keep the factory for as long as the tenant exists — `tenantFactories` above is a dictionary keyed by
 tenant id — because it owns the container and is the only handle that can shut the tenant down again.
@@ -525,27 +685,48 @@ that lives as long as the process and wrong for one that has to be offboarded.
 What you take on by doing this: the returned `StandaloneSchedulerFactory` owns the container, so *you*
 start the scheduler and dispose the factory — the hosted service will not; the scheduler's jobs resolve
 from its own container rather than the application's unless you give it an `IJobFactory` that bridges;
-and health checks registered at startup do not cover it. `Bind` throws on a duplicate name.
+and health checks registered at startup do not cover it.
+
+`Bind` refuses a duplicate **(name, instance id)** pair, not a duplicate name: two schedulers of one
+name and different instance ids coexist by design, which is how proxies to several nodes of one cluster
+are held. In practice the common case still throws, because a scheduler that has not opted into
+clustering takes the default instance id `NON_CLUSTERED` — so two non-clustered tenants sharing a name
+collide on the pair. Give each tenant's scheduler a distinct `InstanceName` and the question does not
+arise.
 
 Offboarding is disposing the factory, which shuts the tenant's scheduler down and then disposes its
 container. Unbind it too, so the application's repository stops listing it at once rather than at its
 next read:
 
+<!-- snippet: sample_tenancy_offboarding -->
 ```csharp
 StandaloneSchedulerFactory tenantFactory = tenantFactories[tenantId];
 tenantFactories.Remove(tenantId);
 
+// Disposal shuts the scheduler down without waiting for its jobs, so ask for the wait here.
+IScheduler tenant = await tenantFactory.GetScheduler();
+await tenant.Shutdown(waitForJobsToComplete: true);
+
 await tenantFactory.DisposeAsync();
 app.Services.GetRequiredService<ISchedulerRepository>().Remove(tenantId);
 ```
+<!-- endSnippet -->
 
-::: warning Fixed in 4.0.0-alpha.2
-Unbinding is not offboarding on its own: `Remove` makes a tenant invisible, and only the disposal stops
-it. That distinction used to be fatal — in 4.0.0-alpha.1 disposing the factory disposed only its
-container, so this recipe took the tenant out of `GetAllSchedulers`, off the dashboard and out of the
-HTTP API while it went on firing its triggers for the rest of the process's life, with nothing left able
-to reach it ([#3380](https://github.com/quartznet/quartznet/issues/3380)). Disposal shuts the scheduler
-down as of 4.0.0-alpha.2, which is what makes the two steps above safe in either order.
+::: warning Disposal does not wait for running jobs
+`StandaloneSchedulerFactory.DisposeAsync` shuts down with `waitForJobsToComplete: false`, so a tenant's
+jobs are cut short — which is the same default `IScheduler.Shutdown()` and `QuartzHostedServiceOptions`
+both carry, and two Quartz-owned shutdown paths that disagreed about it would be a trap. Waiting is a
+call you make first, as above: `await scheduler.Shutdown(waitForJobsToComplete: true)` leaves the
+factory with nothing left to shut down, so the two compose and the disposal only releases the container.
+:::
+
+::: warning Unbinding is not offboarding
+`Remove` makes a tenant invisible; only the disposal stops it. That distinction used to be fatal — in
+4.0.0-alpha.1 disposing the factory disposed only its container, so this recipe took the tenant out of
+`GetAllSchedulers`, off the dashboard and out of the HTTP API while it went on firing its triggers for
+the rest of the process's life, with nothing left able to reach it
+([#3380](https://github.com/quartznet/quartznet/issues/3380)). Disposal shuts the scheduler down as of
+4.0.0-alpha.2, which is what makes the steps above safe in either order.
 :::
 
 Weigh that against the group-per-tenant model, where onboarding is a `ScheduleJob` call and none of

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -183,7 +183,8 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
 - Pause, resume, trigger-now, and unschedule/delete actions (when not in read-only mode)
 - Trigger detail cron reschedule and job detail trigger-with-overrides actions
 - Calendar create/replace (cron calendar), details, and delete actions
-- Multi-scheduler selection
+- Multi-scheduler selection, over the schedulers the container has *built* — the dashboard lists
+  `ISchedulerRepository`, so a registered scheduler nothing has created yet does not appear
 - Read-only mode support via dashboard options
 
 ## Integrating with an existing Blazor Server app

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -179,7 +179,9 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
 - Job details and trigger details pages
 - Currently executing jobs view — cluster-wide with a persistent job store, showing which node owns each
   execution, and interrupting the one execution a row names rather than every execution of its job
-- Live event/log stream for scheduler activity
+- Live event/log stream for scheduler activity, fed by plugins `AddQuartzDashboard` installs on every
+  scheduler in the container — so a named scheduler streams its own events, each plugin instance
+  initialized with the name of the scheduler it belongs to
 - Pause, resume, trigger-now, and unschedule/delete actions (when not in read-only mode)
 - Trigger detail cron reschedule and job detail trigger-with-overrides actions
 - Calendar create/replace (cron calendar), details, and delete actions

--- a/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
+++ b/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
@@ -130,8 +130,10 @@ asynchronous and a container constructs synchronously. Every asynchronous member
 so they are always safe. The synchronous ones — `IsStarted`, `InStandbyMode`, `IsShutdown`,
 `SchedulerInstanceId`, `Context` and `ListenerManager` — can only answer once the scheduler exists, and
 throw `InvalidOperationException` if reading one would have to build it. Under
-`AddQuartzHostedService()` that cannot happen: every scheduler in the container is built and started
-before the application runs. `SchedulerName` never builds anything.
+`AddQuartzHostedService()` that cannot happen once the host has started: the hosted service builds every
+scheduler in the container while the host starts, before anything of yours runs. (It *starts* them
+afterwards, once `ApplicationStarted` fires, unless `AwaitApplicationStarted` is turned off — but built
+is all these members need.) `SchedulerName` never builds anything.
 :::
 
 ### Finding a scheduler at runtime
@@ -287,5 +289,12 @@ builder.Services.AddQuartzHostedService("DurableScheduler", options =>
 
 ## Limitations
 
-- **Job types are shared** — job classes are resolved from the shared DI container. The same job type can be used across multiple schedulers.
-- **Scheduler names must be unique** — each call to `AddQuartz(name, ...)` must use a distinct name.
+- **Scheduler names must be unique** — each call to `AddQuartz(name, ...)` must use a distinct name,
+  compared ignoring case.
+
+Job types are *not* a limitation any more. `AddJob<T>` still registers the type unkeyed, so the same job
+class can be used across schedulers and usually should be — but `AddJobType<TJob, TImplementation>()`,
+`AddJobType<TJob>(lifetime)` and `AddJobType<TJob>(factory)` register under one scheduler's key, and the
+job factory looks that key up before falling back to the container's registration. Two schedulers in one
+container can therefore build the same job type differently. See
+[Multi-Tenancy](../multi-tenancy.md#job-types).

--- a/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
+++ b/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
@@ -287,6 +287,16 @@ builder.Services.AddQuartzHostedService("DurableScheduler", options =>
 ```
 <!-- endSnippet -->
 
+## Configuring every scheduler at once
+
+`AddQuartzHostedService(configure)` is not the only call that means "all of them".
+`ConfigureAllQuartzSchedulers(configure)` applies a builder callback to every scheduler registered
+through `AddQuartz`, `AddQuartz(name, …)` or `AddQuartzSchedulers` — whether it was registered before
+the call or after it — and each scheduler gets its own instance of whatever the callback adds, so a
+plugin added this way to three schedulers is three plugin instances. Remote schedulers from
+`AddQuartzHttpClient` have no builder and are skipped. See
+[Multi-Tenancy](../multi-tenancy.md#giving-every-scheduler-the-same-thing).
+
 ## Limitations
 
 - **Scheduler names must be unique** — each call to `AddQuartz(name, ...)` must use a distinct name,

--- a/docs/documentation/quartz-4.x/tutorial/execution-groups.md
+++ b/docs/documentation/quartz-4.x/tutorial/execution-groups.md
@@ -281,10 +281,12 @@ triggers *without* taking the cluster's `TRIGGER_ACCESS` lock (`AcquireTriggersW
 > cluster-wide for *every* group rather than only the limited ones.
 
 One trigger per node is the whole of the overshoot, because the lock-free path only exists at an
-effective batch of one: the store takes `TRIGGER_ACCESS` whenever it is asked for more than one trigger,
-and a round asks for `min(available threads, MaxBatchSize)`. Raising `MaxBatchSize` therefore does not
-widen the overshoot — it removes it, by taking the lock on every round that has threads to spare, which
-is the same trade `AcquireTriggersWithinLock` makes deliberately.
+*effective* batch of one: the store takes `TRIGGER_ACCESS` whenever it is asked for more than one
+trigger, and a round asks for `min(available threads, MaxBatchSize)`. Raising `MaxBatchSize` therefore
+does not widen the overshoot — it removes it for every round with more than one thread free, by taking
+that lock, which is the same trade `AcquireTriggersWithinLock` makes deliberately. A node down to its
+last free thread still acquires lock-free whatever `MaxBatchSize` says, which is why the bound is
+stated per node rather than per batch.
 
 That is a real improvement on `limit × nodes`, and it is what a tenant quota actually needs: "8,
 occasionally 9 for a moment" is fine, "8 became 24" is not. If you need exactness more than you need
@@ -331,10 +333,10 @@ than a container's. Two things came out of it:
   acquisition attempt's own candidate select, and 1,311 µs (± 34) on SQL Server against 2,992 µs (± 68).
   The two databases differ because their candidate selects do; the aggregate costs much the same on
   both, and much the same at a thousand rows as at ten — which is to say the round trip is the whole of
-  it. So the ceiling's price at `MaxBatchSize = 1` — the default, and the only setting at which the
-  ceiling is approximate at all — is *one extra round trip*, not one extra scan. Raising `MaxBatchSize`
-  amortises that round trip over the whole batch, and makes the ceiling exact into the bargain, since a
-  batched acquisition takes the cluster lock; what it costs instead is that lock's traffic.
+  it. So the ceiling's price at `MaxBatchSize = 1` — the default — is *one extra round trip*, not one
+  extra scan. Raising `MaxBatchSize` amortises that round trip over the whole batch, and takes the
+  cluster lock while doing it, so what it buys in throughput it pays for in lock traffic — and gets
+  an exact ceiling on those rounds as change.
 - **Above that the scan starts to show.** At ten thousand rows and sixty-four groups the aggregate took
   2,723 µs (± 116) on PostgreSQL and 7,821 µs (± 167) on SQL Server. `QRTZ_FIRED_TRIGGERS` holds one row
   per reservation or running execution, so ten thousand is past what a realistic cluster's thread pools

--- a/docs/documentation/quartz-4.x/tutorial/execution-groups.md
+++ b/docs/documentation/quartz-4.x/tutorial/execution-groups.md
@@ -30,6 +30,7 @@ node-scoped, which is what execution limits have always meant.
 
 Use `TriggerBuilder.WithExecutionGroup()`:
 
+<!-- snippet: sample_execution_groups_trigger -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("myTrigger")
@@ -38,12 +39,14 @@ ITrigger trigger = TriggerBuilder.Create()
     .WithCronSchedule("0 0 2 * * ?")
     .Build();
 ```
+<!-- endSnippet -->
 
 Triggers without an execution group (`null`) use the default behavior. It is expected that all triggers
 for a given job share the same execution group.
 
 A stored trigger can be moved between groups without rescheduling it:
 
+<!-- snippet: sample_execution_groups_update_trigger -->
 ```csharp
 await scheduler.UpdateTriggerDetails(
     trigger.Key,
@@ -54,6 +57,7 @@ await scheduler.UpdateTriggerDetails(
     trigger.Key,
     new TriggerDetailsUpdate().WithExecutionGroup(null));
 ```
+<!-- endSnippet -->
 
 The new group applies from the next acquisition cycle; a job already running keeps counting against the
 group it was acquired under.
@@ -98,6 +102,7 @@ Special values for the limit:
 
 ### Via dependency injection
 
+<!-- snippet: sample_execution_groups_dependency_injection -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -111,12 +116,14 @@ services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 `ForGroup`, `ForDefaultGroup` and `ForOtherGroups` all take an optional trailing
 `ExecutionLimitScope`, defaulting to `Node`.
 
 ### Via scheduler API at runtime
 
+<!-- snippet: sample_execution_groups_set_at_runtime -->
 ```csharp
 await scheduler.SetExecutionLimits(
     ExecutionLimitsBuilder.Create()
@@ -125,6 +132,7 @@ await scheduler.SetExecutionLimits(
         .ForOtherGroups(5)
         .Build());
 ```
+<!-- endSnippet -->
 
 `ExecutionLimitsBuilder` is mutable and `ExecutionLimits` — what `Build()` returns and what the scheduler
 reads — is not, so limits cannot change underneath the scheduler thread that is acquiring triggers with them.
@@ -135,6 +143,7 @@ Some schedules already partition their work by trigger group: a group per tenant
 Tagging every one of those triggers with an execution group of the same name would be a second copy of a
 fact the key already carries. `UseTriggerGroupWhenUnset()` says so once instead:
 
+<!-- snippet: sample_execution_groups_trigger_group_when_unset -->
 ```csharp
 await scheduler.SetExecutionLimits(
     ExecutionLimitsBuilder.Create()
@@ -143,6 +152,7 @@ await scheduler.SetExecutionLimits(
         .ForOtherGroups(2)         // every other tenant gets two
         .Build());
 ```
+<!-- endSnippet -->
 
 With the option on, a trigger that carries no execution group is limited as though its group were its own
 `TriggerKey.Group`. Three things are worth knowing:
@@ -166,6 +176,7 @@ Read one back with `TryGetLimit(group, out int? maxConcurrent)`, or enumerate `G
 group), `OtherGroups` (the catch-all) and `Named(name)` — so reading limits never involves sentinel
 strings, and its `Scope` says which scope the number is counted in:
 
+<!-- snippet: sample_execution_groups_read_limits -->
 ```csharp
 ExecutionLimits? limits = await scheduler.GetExecutionLimits();
 foreach (ExecutionGroupLimit limit in limits?.Groups ?? [])
@@ -178,12 +189,15 @@ foreach (ExecutionGroupLimit limit in limits?.Groups ?? [])
 
 limits?.TryGetLimit(ExecutionGroupScope.Named("batch-jobs"), out int? batchLimit);
 ```
+<!-- endSnippet -->
 
 Limits take effect on the next trigger acquisition cycle. Pass `null` to clear all limits:
 
+<!-- snippet: sample_execution_groups_clear_limits -->
 ```csharp
 await scheduler.SetExecutionLimits(null);
 ```
+<!-- endSnippet -->
 
 ### The `*` in configuration keys, and the other `*`
 
@@ -242,10 +256,12 @@ batch jobs. That is the right answer for hardware capacity and the wrong one for
 
 A cluster-scoped limit is one number for the whole cluster, and every node enforces the same one:
 
+<!-- snippet: sample_execution_groups_cluster_scope -->
 ```csharp
 q.UseExecutionLimits(limits => limits
     .ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster));
 ```
+<!-- endSnippet -->
 
 **Where the count comes from.** `QRTZ_FIRED_TRIGGERS` already is the cluster's reservation ledger — a
 row appears when any node acquires a trigger, becomes the running execution, and is deleted when the job
@@ -260,9 +276,15 @@ triggers *without* taking the cluster's `TRIGGER_ACCESS` lock (`AcquireTriggersW
 `MaxBatchSize` is `1`), so two nodes can read "2 of 3 in flight" in the same instant and each take one.
 
 > The ceiling holds within one acquisition round. Transient overshoot is bounded by the number of nodes
-> acquiring concurrently — at most `limit + (nodes − 1) × batchSize`, for as long as it takes the losers
-> to notice. Setting `AcquireTriggersWithinLock = true` makes it exact, at the cost of serializing
-> acquisition cluster-wide for *every* group rather than only the limited ones.
+> acquiring concurrently — at most `limit + (nodes − 1)`, for as long as it takes the losers to notice.
+> Setting `AcquireTriggersWithinLock = true` makes it exact, at the cost of serializing acquisition
+> cluster-wide for *every* group rather than only the limited ones.
+
+One trigger per node is the whole of the overshoot, because the lock-free path only exists at an
+effective batch of one: the store takes `TRIGGER_ACCESS` whenever it is asked for more than one trigger,
+and a round asks for `min(available threads, MaxBatchSize)`. Raising `MaxBatchSize` therefore does not
+widen the overshoot — it removes it, by taking the lock on every round that has threads to spare, which
+is the same trade `AcquireTriggersWithinLock` makes deliberately.
 
 That is a real improvement on `limit × nodes`, and it is what a tenant quota actually needs: "8,
 occasionally 9 for a moment" is fine, "8 became 24" is not. If you need exactness more than you need
@@ -309,8 +331,10 @@ than a container's. Two things came out of it:
   acquisition attempt's own candidate select, and 1,311 µs (± 34) on SQL Server against 2,992 µs (± 68).
   The two databases differ because their candidate selects do; the aggregate costs much the same on
   both, and much the same at a thousand rows as at ten — which is to say the round trip is the whole of
-  it. So the ceiling's price at `MaxBatchSize = 1` is *one extra round trip*, not one extra scan. At a
-  batch of five the same round trip is amortised over five triggers.
+  it. So the ceiling's price at `MaxBatchSize = 1` — the default, and the only setting at which the
+  ceiling is approximate at all — is *one extra round trip*, not one extra scan. Raising `MaxBatchSize`
+  amortises that round trip over the whole batch, and makes the ceiling exact into the bargain, since a
+  batched acquisition takes the cluster lock; what it costs instead is that lock's traffic.
 - **Above that the scan starts to show.** At ten thousand rows and sixty-four groups the aggregate took
   2,723 µs (± 116) on PostgreSQL and 7,821 µs (± 167) on SQL Server. `QRTZ_FIRED_TRIGGERS` holds one row
   per reservation or running execution, so ten thousand is past what a realistic cluster's thread pools
@@ -394,6 +418,7 @@ The Quartz Dashboard shows execution group information:
 
 ### Preventing batch jobs from starving interactive work
 
+<!-- snippet: sample_execution_groups_batch_versus_interactive -->
 ```csharp
 q.UseExecutionLimits(limits =>
 {
@@ -401,6 +426,7 @@ q.UseExecutionLimits(limits =>
     limits.ForOtherGroups(maxConcurrent: 10);      // everything else gets up to 10
 });
 ```
+<!-- endSnippet -->
 
 ### Dedicating a node to specific workloads
 
@@ -414,11 +440,13 @@ quartz.executionLimit.* = 0
 
 A tenant quota is a property of the tenant, not of the machine, so it is cluster-scoped:
 
+<!-- snippet: sample_execution_groups_tenant_quotas -->
 ```csharp
 limits.ForGroup("tenant-a", 5, ExecutionLimitScope.Cluster);
 limits.ForGroup("tenant-b", 5, ExecutionLimitScope.Cluster);
 limits.ForGroup("tenant-c", 5, ExecutionLimitScope.Cluster);
 ```
+<!-- endSnippet -->
 
 Node-scoped instead (`limits.ForGroup("tenant-a", 5)`) would give each tenant five threads *per node*,
 which on a three-node cluster is fifteen. See [Multi-tenancy](../multi-tenancy.md) for the rest of the

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -488,8 +488,9 @@ whenever a node is down.
 4.x adds the real thing: `ForGroup("acme", 8, ExecutionLimitScope.Cluster)` is counted from
 `QRTZ_FIRED_TRIGGERS`, which is already the cluster's reservation ledger. Read what it promises before
 relying on it — the ceiling holds within one acquisition round and can transiently overshoot by
-`(nodes − 1) × batchSize` unless `AcquireTriggersWithinLock` is on, and it fails closed, so a node that
-cannot reach the store fires nothing rather than firing unmetered.
+`nodes − 1`, one trigger per node, because the lock-free acquisition path that allows the overshoot
+exists only when a round acquires a single trigger. It fails closed, so a node that cannot reach the
+store fires nothing rather than firing unmetered.
 
 **There is no rate limiting.** Execution limits cap *concurrency*, not throughput. "This tenant may
 run 100 jobs an hour" is not something Quartz.NET can express; build it in the job, or in the thing

--- a/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
+++ b/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
@@ -1,0 +1,326 @@
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Extensibility;
+using Quartz.Plugins.Xml;
+
+namespace Quartz.Documentation.Samples.Tenancy;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/multi-tenancy.md.
+/// </summary>
+/// <remarks>
+/// In a namespace of its own so the tenant-shaped job types at the bottom of the file can carry the
+/// names the page uses — <c>ReportJob</c> in particular — without colliding with the shared ones in
+/// <c>SampleTypes.cs</c>.
+/// </remarks>
+public static class MultiTenancySamples
+{
+    public static void SchedulerPerTenant(
+        IHostApplicationBuilder builder,
+        IReadOnlyList<string> tenants,
+        IReadOnlyDictionary<string, string> connectionStrings)
+    {
+        #region sample_tenancy_scheduler_per_tenant
+
+        foreach (string tenant in tenants)
+        {
+            builder.Services.AddQuartz(tenant, q =>
+            {
+                q.UsePersistentStore(s =>
+                {
+                    s.UseSqlServer(connectionStrings[tenant]);
+                    s.UseClustering();
+                });
+                q.UseDefaultThreadPool(maxConcurrency: 5);
+                q.AddJob<NightlyReportJob>(j => j.WithIdentity("nightly"));
+                q.AddTrigger<NightlyReportJob>(t => t.WithCronSchedule("0 30 2 * * ?"));
+            });
+        }
+
+        builder.Services.AddQuartzHostedService(o => o.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    #region sample_tenancy_inject_named
+
+    public sealed class TenantOpsService([FromKeyedServices("acme")] IScheduler scheduler);
+
+    #endregion
+
+    public static void ResolveNamed(IServiceProvider provider, string tenant)
+    {
+        #region sample_tenancy_resolve_named
+
+        IScheduler scheduler = provider.GetRequiredKeyedService<IScheduler>(tenant);
+
+        #endregion
+    }
+
+    public static async Task ListRegistrations(IServiceProvider provider)
+    {
+        #region sample_tenancy_scheduler_registry
+
+        ISchedulerRegistry registry = provider.GetRequiredService<ISchedulerRegistry>();
+
+        foreach (SchedulerRegistration tenant in await registry.QuerySchedulers())
+        {
+            Console.WriteLine($"{tenant.Name}: {tenant.Status?.ToString() ?? "registered, not created"}");
+        }
+
+        #endregion
+    }
+
+    public static void PerTenantClock(IHostApplicationBuilder builder, TimeProvider acmeClock)
+    {
+        #region sample_tenancy_time_provider
+
+        builder.Services.AddQuartz("acme", q => q.UseTimeProvider(acmeClock));
+
+        #endregion
+    }
+
+    public static void PerTenantJobTypes(IHostApplicationBuilder builder)
+    {
+        #region sample_tenancy_job_types
+
+        builder.Services.AddQuartz("acme", q =>
+        {
+            q.AddJobType<ReportJob, AcmeReportJob>();            // a different implementation
+            q.AddJobType<AuditJob>(ServiceLifetime.Singleton);   // a different lifetime
+            q.AddJobType<ExportJob>(sp => new ExportJob(sp.GetRequiredKeyedService<IExportSink>("acme")));
+
+            q.AddJob<ReportJob>(j => j.WithIdentity("report"));
+        });
+
+        #endregion
+    }
+
+    #region sample_tenancy_job_reads_its_scheduler
+
+    public sealed class RotateTenantKeysJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            // The scheduler running this fire, whichever tenant it belongs to. An injected
+            // ISchedulerFactory would have been the default scheduler's.
+            IScheduler mine = context.Scheduler;
+
+            await mine.PauseTriggers(
+                GroupMatcher<TriggerKey>.GroupEquals(context.Trigger.Key.Group),
+                cancellationToken);
+        }
+    }
+
+    #endregion
+
+    public static void PluginNamedByProperties(IHostApplicationBuilder builder)
+    {
+        #region sample_tenancy_plugin_by_properties
+
+        builder.Services.AddQuartz("acme", new NameValueCollection
+        {
+            ["quartz.plugin.xml.type"] = typeof(XmlSchedulingDataProcessorPlugin).AssemblyQualifiedName,
+            ["quartz.plugin.xml.fileNames"] = "acme-jobs.xml",
+        });
+
+        #endregion
+    }
+
+    public static void PerTenantHealthCheck(IHostApplicationBuilder builder)
+    {
+        #region sample_tenancy_health_checks
+
+        builder.Services.AddQuartz("acme", q => q.AddQuartzHealthChecks(o => o.Tags.Add("tenant:acme")));
+
+        #endregion
+    }
+
+    public static void GroupPerTenant(string tenantId)
+    {
+        #region sample_tenancy_group_keys
+
+        JobKey job = new("nightly-report", tenantId);
+        TriggerKey trigger = new("nightly", tenantId);
+
+        #endregion
+    }
+
+    public static async Task GroupScopedQueries(IScheduler scheduler, string tenantId)
+    {
+        #region sample_tenancy_group_matchers
+
+        // everything this tenant has scheduled
+        PagedResult<TriggerHeader> theirs = await scheduler.QueryTriggers(new TriggerQuery
+        {
+            Group = GroupMatcher<TriggerKey>.GroupEquals(tenantId),
+            Take = 100,
+            IncludeTotalCount = true,
+        });
+
+        // suspend a tenant
+        List<string> paused = await scheduler.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals(tenantId));
+
+        // is a tenant suspended?
+        PagedResult<TriggerGroup> group = await scheduler.QueryTriggerGroups(
+            new TriggerGroupQuery { Name = tenantId, Take = 1 });
+        bool suspended = group.Items is [{ Paused: true }];
+
+        #endregion
+    }
+
+    public static void PerTenantListener(IQuartzBuilder q, string tenantId)
+    {
+        #region sample_tenancy_group_listener
+
+        q.AddJobListener<AuditListener>(Matchers.Group<JobKey>(StringOperator.Equality, tenantId));
+
+        #endregion
+    }
+
+    public static void PerTenantQuotas(IQuartzBuilder q)
+    {
+        #region sample_tenancy_execution_limits
+
+        q.UseExecutionLimits(limits => limits
+            .UseTriggerGroupWhenUnset()
+            .ForGroup("acme", 8, ExecutionLimitScope.Cluster)          // a big tenant
+            .ForGroup("initech", 2, ExecutionLimitScope.Cluster)
+            .ForOtherGroups(1, ExecutionLimitScope.Cluster));          // everyone else gets one thread each
+
+        #endregion
+    }
+
+    public static void PerTenantTablePrefix(IHostApplicationBuilder builder, string sharedConnectionString)
+    {
+        #region sample_tenancy_table_prefix
+
+        builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s =>
+        {
+            s.UseSqlServer(sharedConnectionString);
+            s.Configure(o => o.TablePrefix = "ACME_QRTZ_");
+        }));
+
+        #endregion
+    }
+
+    #region sample_tenancy_ambient_tenant
+
+    public static class TenantContext
+    {
+        private static readonly AsyncLocal<string?> current = new();
+
+        public static string? Current
+        {
+            get => current.Value;
+            internal set => current.Value = value;
+        }
+    }
+
+    #endregion
+
+    public static void PrepareJobScope(IQuartzBuilder q)
+    {
+        #region sample_tenancy_configure_job_scope
+
+        q.ConfigureJobScope((scope, bundle, scheduler) =>
+        {
+            TenantContext.Current = bundle.Trigger.Key.Group;
+        });
+
+        #endregion
+    }
+
+    #region sample_tenancy_execution_context_accessor
+
+    public sealed class TenantConnectionFactory(
+        IJobExecutionContextAccessor accessor,
+        IReadOnlyDictionary<string, string> connectionStrings)
+    {
+        public string ConnectionString =>
+            connectionStrings[accessor.Current?.Trigger.Key.Group
+                ?? throw new InvalidOperationException("no job is running on this flow")];
+    }
+
+    #endregion
+
+    public static async Task OnboardAtRuntime(
+        IHost app,
+        string tenantId,
+        IReadOnlyDictionary<string, string> connectionStrings,
+        Dictionary<string, StandaloneSchedulerFactory> tenantFactories)
+    {
+        #region sample_tenancy_runtime_onboarding
+
+        StandaloneSchedulerFactory tenantFactory = QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(o => o.InstanceName = tenantId)
+            .UsePersistentStore(s => s.UseSqlServer(connectionStrings[tenantId]))
+            .Build();
+
+        IScheduler tenant = await tenantFactory.GetScheduler();
+        await tenant.Start();
+
+        tenantFactories[tenantId] = tenantFactory;
+        app.Services.GetRequiredService<ISchedulerRepository>().Bind(tenant);
+
+        #endregion
+    }
+
+    public static async Task Offboard(
+        IHost app,
+        string tenantId,
+        Dictionary<string, StandaloneSchedulerFactory> tenantFactories)
+    {
+        #region sample_tenancy_offboarding
+
+        StandaloneSchedulerFactory tenantFactory = tenantFactories[tenantId];
+        tenantFactories.Remove(tenantId);
+
+        // Disposal shuts the scheduler down without waiting for its jobs, so ask for the wait here.
+        IScheduler tenant = await tenantFactory.GetScheduler();
+        await tenant.Shutdown(waitForJobsToComplete: true);
+
+        await tenantFactory.DisposeAsync();
+        app.Services.GetRequiredService<ISchedulerRepository>().Remove(tenantId);
+
+        #endregion
+    }
+}
+
+/// <summary>
+/// The tenant-shaped jobs and listeners the samples above name.
+/// </summary>
+public sealed class NightlyReportJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+/// <inheritdoc cref="NightlyReportJob" />
+public class ReportJob : IJob
+{
+    public virtual ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+/// <inheritdoc cref="NightlyReportJob" />
+public sealed class AcmeReportJob : ReportJob;
+
+/// <inheritdoc cref="NightlyReportJob" />
+public sealed class AuditJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+/// <inheritdoc cref="NightlyReportJob" />
+public interface IExportSink;
+
+/// <inheritdoc cref="NightlyReportJob" />
+public sealed class ExportJob(IExportSink sink) : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+/// <inheritdoc cref="NightlyReportJob" />
+public sealed class AuditListener : IJobListener;

--- a/src/Quartz.Documentation.Samples/Tutorial/ExecutionGroupsSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/ExecutionGroupsSamples.cs
@@ -1,0 +1,147 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/execution-groups.md.
+/// </summary>
+public static class ExecutionGroupsSamples
+{
+    public static void BuildTrigger(IJobDetail job)
+    {
+        #region sample_execution_groups_trigger
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("myTrigger")
+            .ForJob(job)
+            .WithExecutionGroup("batch-jobs")
+            .WithCronSchedule("0 0 2 * * ?")
+            .Build();
+
+        #endregion
+    }
+
+    public static async Task MoveBetweenGroups(IScheduler scheduler, ITrigger trigger)
+    {
+        #region sample_execution_groups_update_trigger
+
+        await scheduler.UpdateTriggerDetails(
+            trigger.Key,
+            new TriggerDetailsUpdate().WithExecutionGroup("batch-jobs"));
+
+        // pass null to take the trigger out of every group
+        await scheduler.UpdateTriggerDetails(
+            trigger.Key,
+            new TriggerDetailsUpdate().WithExecutionGroup(null));
+
+        #endregion
+    }
+
+    public static void ConfigureLimits(IServiceCollection services)
+    {
+        #region sample_execution_groups_dependency_injection
+
+        services.AddQuartz(q =>
+        {
+            q.UseExecutionLimits(limits =>
+            {
+                limits.ForGroup("batch-jobs", maxConcurrent: 2);                        // per node
+                limits.ForGroup("high-cpu", maxConcurrent: 3);                          // per node
+                limits.ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster);         // per cluster
+                limits.ForDefaultGroup(maxConcurrent: 10);
+                limits.ForOtherGroups(maxConcurrent: 5);
+            });
+        });
+
+        #endregion
+    }
+
+    public static async Task SetAtRuntime(IScheduler scheduler)
+    {
+        #region sample_execution_groups_set_at_runtime
+
+        await scheduler.SetExecutionLimits(
+            ExecutionLimitsBuilder.Create()
+                .ForGroup("batch-jobs", 2)
+                .ForDefaultGroup(10)
+                .ForOtherGroups(5)
+                .Build());
+
+        #endregion
+    }
+
+    public static async Task DeriveFromTriggerGroup(IScheduler scheduler)
+    {
+        #region sample_execution_groups_trigger_group_when_unset
+
+        await scheduler.SetExecutionLimits(
+            ExecutionLimitsBuilder.Create()
+                .UseTriggerGroupWhenUnset()
+                .ForGroup("tenant-a", 4)   // names a trigger group here, because none of its triggers name one
+                .ForOtherGroups(2)         // every other tenant gets two
+                .Build());
+
+        #endregion
+    }
+
+    public static async Task ReadLimitsBack(IScheduler scheduler)
+    {
+        #region sample_execution_groups_read_limits
+
+        ExecutionLimits? limits = await scheduler.GetExecutionLimits();
+        foreach (ExecutionGroupLimit limit in limits?.Groups ?? [])
+        {
+            string group = limit.Group.IsDefault ? "(no group)"
+                : limit.Group.IsOtherGroups ? "(other groups)"
+                : limit.Group.Name!;
+            Console.WriteLine($"{group}: {limit.MaxConcurrent?.ToString() ?? "unlimited"} per {limit.Scope}");
+        }
+
+        limits?.TryGetLimit(ExecutionGroupScope.Named("batch-jobs"), out int? batchLimit);
+
+        #endregion
+    }
+
+    public static async Task ClearLimits(IScheduler scheduler)
+    {
+        #region sample_execution_groups_clear_limits
+
+        await scheduler.SetExecutionLimits(null);
+
+        #endregion
+    }
+
+    public static void ClusterScopedLimit(IQuartzBuilder q)
+    {
+        #region sample_execution_groups_cluster_scope
+
+        q.UseExecutionLimits(limits => limits
+            .ForGroup("tenant-acme", 8, ExecutionLimitScope.Cluster));
+
+        #endregion
+    }
+
+    public static void ProtectInteractiveWork(IQuartzBuilder q)
+    {
+        #region sample_execution_groups_batch_versus_interactive
+
+        q.UseExecutionLimits(limits =>
+        {
+            limits.ForGroup("batch", maxConcurrent: 3);    // max 3 batch jobs
+            limits.ForOtherGroups(maxConcurrent: 10);      // everything else gets up to 10
+        });
+
+        #endregion
+    }
+
+    public static void TenantQuotas(ExecutionLimitsBuilder limits)
+    {
+        #region sample_execution_groups_tenant_quotas
+
+        limits.ForGroup("tenant-a", 5, ExecutionLimitScope.Cluster);
+        limits.ForGroup("tenant-b", 5, ExecutionLimitScope.Cluster);
+        limits.ForGroup("tenant-c", 5, ExecutionLimitScope.Cluster);
+
+        #endregion
+    }
+}


### PR DESCRIPTION
The multi-tenancy documentation said several things the code does not do, omitted several it does,
and none of its C# was compiled. This corrects it against the source and puts the tenancy pages on
the compiled-snippet convention.

Pages: `docs/documentation/quartz-4.x/multi-tenancy.md`,
`docs/documentation/quartz-4.x/packages/multiple-schedulers.md`,
`docs/documentation/quartz-4.x/tutorial/execution-groups.md`,
`docs/documentation/tenancy-patterns.md`, and two bullets on
`docs/documentation/quartz-4.x/packages/dashboard.md`.

## Corrections, with the source that decides each

| Was | Is | Decided by |
|---|---|---|
| "Job types are shared — job classes are resolved from the shared DI container" (`multiple-schedulers.md` Limitations) | `AddJobType` registers under the scheduler's key, and the job factory reads that key before the unkeyed registration | `Configuration/QuartzBuilderExtensions.cs` `Describe` / `SchedulerServiceKey`; `Impl/MicrosoftDependencyInjectionJobFactory.cs` `ResolveJob` |
| Cluster-quota overshoot `limit + (nodes − 1) × batchSize` (three pages, four places) | `limit + (nodes − 1)` — one trigger per node | `Impl/AdoJobStore/AdoJobStoreBase.cs` `AcquireNextTriggers` takes `TRIGGER_ACCESS` when `AcquireTriggersWithinLock \|\| request.MaxCount > 1`; `Core/QuartzSchedulerThread.cs` sets `MaxCount = Math.Min(availThreadCount, MaxBatchSize)`. The lock-free path therefore exists only at an effective batch of one |
| "at a batch of five the same round trip is amortised over five triggers" (`execution-groups.md` benchmark note) | Raising `MaxBatchSize` amortises the round trip **and** removes the overshoot, because a batched acquisition takes the lock | same |
| "`Bind` throws on a duplicate name" | `Bind` throws on a duplicate **(name, instance id)** pair; two schedulers of one name with different instance ids coexist by design. The common case still throws, because the default instance id is `NON_CLUSTERED` | `Impl/SchedulerRepository.cs` (the `InstanceId` comparison in `Bind`, and the class remarks); `Configuration/QuartzSchedulerOptions.cs` `DefaultInstanceId` |
| "every scheduler … is built and started before the application runs" | Built while the host starts; started after `ApplicationStarted` under the default `AwaitApplicationStarted = true`. Built is all the deferred handle's synchronous members need | `Hosting/QuartzHostedService.cs` `StartAsync` / `AwaitStartupCompletionAndStartSchedulers`; `Hosting/QuartzHostedServiceOptions.cs` |
| `JobFactoryOptions` listed among the option types the container rewrites | The static table has six types and not that one; `JobFactoryOptions` is per-scheduler because `ConfigureJobScope` is a `ConfigureOptions<JobFactoryOptions>` call, which registers the `SchedulerNamedOptions` declaration | `Configuration/SchedulerScopedServiceProvider.cs` `DeclareQuartzOptions`; `Configuration/QuartzBuilderExtensions.cs` `ConfigureJobScope`; `Configuration/QuartzBuilder.cs` `ConfigureOptions` |
| "names are compared case-insensitively" | Case-insensitive for the duplicate check and `ISchedulerRepository`; **ordinal** for keyed DI resolution and named options | `Configuration/SchedulerNameRegistry.cs` `Find`; `Impl/SchedulerRepository.cs` (`OrdinalIgnoreCase` dictionary); `Configuration/QuartzServiceRegistration.cs` `GetScheduler<T>`; `Configuration/SchedulerScopedServiceProvider.cs` (`SchedulerOptionsMonitor.OnChange`, `StringComparison.Ordinal`) |
| `SystemTextJsonSerializerRegistry` flatly container-wide | Container-wide by default; a named scheduler can be given its own | `Configuration/QuartzServiceRegistration.cs` (`TryAddKeyedSingleton<SystemTextJsonSerializerRegistry>` and its comment naming `services.AddKeyedSingleton(schedulerName, registry)`) |

## Additions

* **Two comparisons for one name.** Spelled out with the failing example: `AddQuartz("Acme")` then
  `GetRequiredKeyedService<IScheduler>("acme")` throws, while `repository.Lookup("acme")` and the
  route `…/schedulers/acme/…` both work.
* **Which scheduler's parts a job is built from.** A job type the container holds (`AddJob<T>`
  `TryAddScoped`s it) is activated by the container, so an injected `ISchedulerFactory`, `IJobStore`,
  `IThreadPool` or `IOptions<QuartzSchedulerOptions>` is the *default* scheduler's — or fails
  container validation in a named-only container. A job type the container does not hold is activated
  through the scheduler-scoped provider and gets its own scheduler's parts
  (`MicrosoftDependencyInjectionJobFactory.ResolveJob` → `JobActivatorCache`). The migration guide
  recorded the first half only. The page now records both, and recommends
  `IJobExecutionContext.Scheduler` or `IJobExecutionContextAccessor`.
* **Listeners and plugins are not symmetrical.** An unkeyed `ISchedulerListener`/`IJobListener`/
  `ITriggerListener` service reaches *every* scheduler (`SchedulerContentInitializer.ListenerServices`
  unions unkeyed and keyed); an unkeyed plugin reaches only the default one
  (`DefaultSchedulerFactory` passes `GetSchedulerServices<ISchedulerPlugin>(Key)`), and the
  property-named plugin probe has no unkeyed fallback (`SchedulerPluginFactory.Build`).
* **Starting and stopping all of them.** `QuartzHostedService.ShutdownSchedulers` shuts every
  scheduler down concurrently, so `HostOptions.ShutdownTimeout` is one deadline for all tenants
  rather than a sum; a start failure shuts down the schedulers already created.
* **Offboarding cuts running jobs short.** `StandaloneSchedulerFactory.DisposeAsync` shuts down with
  `waitForJobsToComplete: false`, so the recipe now composes with `Shutdown(true)` the way the type's
  own remarks describe.
* **The dashboard and the HTTP API list the repository, not the registry.** Both resolve through
  `ISchedulerRepository` (`InProcessQuartzApiClient`, `EndpointHelper.ExecuteWithScheduler`), so a
  registered-but-uncreated scheduler is absent from the dashboard and 404s on the API.
* **`SchedulerStatus.Unknown`** is what a scheduler whose status cannot be read is listed as
  (`ContainerSchedulerRegistry.Status`).
* **Table prefixes are compared ignoring case** (`SharedDatabaseValidator`), so two tenants told
  apart only by prefix casing are one tenant.

## Snippet conversion

Every `csharp` fence on `multi-tenancy.md`, `multiple-schedulers.md` and `execution-groups.md` is now
a `#region sample_*` in `src/Quartz.Documentation.Samples`:

* `src/Quartz.Documentation.Samples/MultiTenancySamples.cs` — 19 samples, in a namespace of its own so
  the tenant-shaped job types can carry the names the page uses.
* `src/Quartz.Documentation.Samples/Tutorial/ExecutionGroupsSamples.cs` — 10 samples.
* `multiple-schedulers.md` was already converted; nothing to do there.

`docs/documentation/tenancy-patterns.md` has **no fenced code blocks at all**, so there was nothing to
convert on it. It is already inside the injector's scan (`Build.Docs.Snippets.cs` excludes only
`quartz-1.x`, `quartz-2.x`, `quartz-3.x`, `_posts` and `.vuepress`), so the include set needed no
change either.

### Samples that did not compile as written on the page

1. **`typeof(XMLSchedulingDataProcessorPlugin)`** — the 3.x spelling. The 4.x type is
   `Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin`, as the migration guide's own rename table
   says. Fixed on the page.
2. **`TenantConnectionFactory`** indexed a `connectionStrings` that nothing gave it. It now takes an
   `IReadOnlyDictionary<string, string>` alongside the accessor, which is also better documentation —
   the class is the whole sample, so its dependencies have to be visible.

Everything else compiled unchanged.

## Depends on `tenancy-configure-all`

The third commit — "One call configures every scheduler, and the dashboard's live events reach all of
them" — documents `ConfigureAllQuartzSchedulers(this IServiceCollection, Action<IQuartzBuilder>)`,
which does not exist on `main` yet. **Merge `tenancy-configure-all` first, or drop that commit.**
Three passages depend on it:

* `multi-tenancy.md` — the "Giving every scheduler the same thing" section, plus the cross-reference
  to it from the listeners/plugins warning.
* `multiple-schedulers.md` — the "Configuring every scheduler at once" section.
* `dashboard.md` — the live-event-stream bullet. Named schedulers get **no** live events today,
  because `AddQuartzDashboard` registers its plugins through `new QuartzBuilder(services,
  schedulerKey: null)`; the bullet is written to be true once the implementation lands.

**The `ConfigureAllQuartzSchedulers` sample is a plain fence, not a `#region`.** The samples project is
in `Quartz.slnx`, so a region calling a method that does not exist fails `dotnet build Quartz.slnx`
and takes every other check down with it — the build system cannot tolerate an uncompilable sample.
The fence carries a `<!-- TODO(tenancy-configure-all) -->` comment; turn it into a compiled snippet
once the API merges.

## Verification

```
dotnet build Quartz.slnx            Build succeeded. 0 Warning(s) 0 Error(s)
dotnet fallout DocsSnippets         Succeeded
dotnet fallout VerifyDocsSnippets   Documentation snippets are up to date (89 markdown files checked)
npm ci                              879 packages, 0 vulnerabilities (gray-matter patch applied)
npm run docs:check-links            211 pages, 703 internal links, 398 fragments — no dead links or anchors
npm run docs:check-links-test       7 pass, 0 fail
npm run docs:build                  VuePress build completed, 212 pages
dotnet test Quartz.Tests.Unit       Passed! Failed: 0, Passed: 3094, Skipped: 4
dotnet test Quartz.Tests.AspNetCore Passed! Failed: 0, Passed: 314, Skipped: 0
```

`npm run docs:lint` exits 1 with 122 errors — but it does so identically on `main`
(`9c18da609`); the normalized error lists before and after this branch are byte-identical, so this
branch adds none. It is not a CI gate: `.github/workflows/docs-pr.yml` runs `VerifyDocsSnippets`,
`docs:check-links-test` and `docs:check-links`.

Integration tests were not run — they need a Docker daemon, and this change touches no product code.

## Related issues

Nothing here closes an issue, deliberately:

* **#3388** — the `AddJob<T>` activation trap. That issue is explicitly about *whether to change it*,
  and calls the documentation pass "the floor, not the answer". This lays the floor; leave it open for
  the decision between validating at startup and making registered jobs scheduler-aware.
* **#3357** — the compiled-snippet rollout tracker. This ticks `multi-tenancy.md` and one page of
  `tutorial/`; the rest of that checklist stands.
* **#3338** — runtime tenant lifecycle. Untouched; this only documents what the standalone builder
  does today, including that its disposal does not wait for running jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
