### PR TITLE
The ConfigureAllQuartzSchedulers sample compiles, and the page says what shipped

### DIFF
--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -281,7 +281,7 @@ Writing the same three lines inside every `AddQuartz(tenant, …)` is what a `fo
 saves you, right up until the tenants come from configuration and the loop is not yours to write.
 `ConfigureAllQuartzSchedulers` applies one configuration callback to every scheduler in the container:
 
-<!-- TODO(tenancy-configure-all): a compiled sample once the API lands; see the pull request that adds it. -->
+<!-- snippet: sample_tenancy_configure_all -->
 ```csharp
 builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s => s.UseSqlServer(acme)));
 builder.Services.AddQuartzSchedulers(builder.Configuration.GetSection("Quartz"));
@@ -293,22 +293,35 @@ builder.Services.ConfigureAllQuartzSchedulers(q =>
     q.AddJobListener<AuditListener>();
 });
 ```
+<!-- endSnippet -->
 
 Four things it promises:
 
-- **Order does not matter.** Schedulers already registered get the callback immediately; schedulers
-  registered later get it after their own configure callback has run, so a scheduler's own
-  configuration is what a shared callback refines rather than the other way round.
-- **Every scheduler gets its own instance of whatever the callback adds.** A plugin added this way to
-  three schedulers is three plugin instances, each initialized with the name of the scheduler it
+- **Order does not matter.** It runs after each scheduler's own configuration callback either way: a
+  scheduler registered before this call is configured here, one registered after it is configured by its
+  own `AddQuartz`, and both get it *after* their own callback. So a scheduler's own configuration is
+  what a shared callback refines whichever order the two calls were written in — which is the point,
+  since a package that adds something to every scheduler cannot know when the application registers its
+  schedulers.
+- **The usual precedence follows from that.** Registration is first-wins, so a job store or thread pool
+  a tenant chose for itself is not replaced by one chosen here; options are last-wins, so a value set
+  here overrides the same option set on one tenant, exactly as `ConfigureAll<TOptions>` overrides an
+  earlier named `Configure`.
+- **Every scheduler gets its own instance of whatever the callback adds.** The delegate is handed a
+  builder *per scheduler*, so what it registers lands under that scheduler's key: a plugin added this
+  way to three schedulers is three plugin instances, each initialized with the name of the scheduler it
   extends — which is exactly what a plugin registered unkeyed cannot be.
 - **It reaches `AddQuartz()`, `AddQuartz(name, …)` and `AddQuartzSchedulers(…)` alike**, because all
-  three register a builder.
-- **Remote schedulers are skipped.** A scheduler from `AddQuartzHttpClient` lives in another process;
-  there is no builder here to configure, and nothing this callback adds could reach it.
+  three register a builder. Remote schedulers from `AddQuartzHttpClient` are skipped: they live in
+  another process, so there is no builder here to configure and nothing this callback adds could reach
+  them. Calling it when no scheduler is registered at all is not an error — the delegate applies to
+  nothing.
 
 It is the options pattern's `ConfigureAll` for schedulers, and it is how `AddQuartzDashboard` gives
-every scheduler the dashboard's own plugins rather than only the default one.
+every scheduler the dashboard's own plugins rather than only the default one — which is what stops a
+named scheduler's live view and history pages from being permanently empty. The [migration
+guide](migration-guide.md#every-scheduler-in-the-container-can-be-configured-at-once) states the same
+rules for a reader arriving from 3.x.
 
 ### What is not
 

--- a/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
+++ b/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
@@ -130,6 +130,23 @@ public static class MultiTenancySamples
         #endregion
     }
 
+    public static void ConfigureEveryScheduler(IHostApplicationBuilder builder, string acme)
+    {
+        #region sample_tenancy_configure_all
+
+        builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s => s.UseSqlServer(acme)));
+        builder.Services.AddQuartzSchedulers(builder.Configuration.GetSection("Quartz"));
+
+        // Every scheduler above, and every scheduler registered after this line
+        builder.Services.ConfigureAllQuartzSchedulers(q =>
+        {
+            q.AddPlugin<TenantAuditPlugin>();
+            q.AddJobListener<AuditListener>();
+        });
+
+        #endregion
+    }
+
     public static void PerTenantHealthCheck(IHostApplicationBuilder builder)
     {
         #region sample_tenancy_health_checks
@@ -324,3 +341,13 @@ public sealed class ExportJob(IExportSink sink) : IJob
 
 /// <inheritdoc cref="NightlyReportJob" />
 public sealed class AuditListener : IJobListener;
+
+/// <inheritdoc cref="NightlyReportJob" />
+public sealed class TenantAuditPlugin : ISchedulerPlugin
+{
+    public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+
+    public ValueTask Start(CancellationToken cancellationToken = default) => default;
+
+    public ValueTask Shutdown(CancellationToken cancellationToken = default) => default;
+}


### PR DESCRIPTION
Follow-up to #3390, now that #3389 has landed `ConfigureAllQuartzSchedulers` on `main`.

## The sample is compiled

The block under "Giving every scheduler the same thing" on
`docs/documentation/quartz-4.x/multi-tenancy.md` was the one plain fence #3390 had to leave behind: a
`#region` naming a method that did not exist would have failed `dotnet build Quartz.slnx` and taken
every other check with it. The API exists now, so it is a region like everything else on the page.

**The code on the page is unchanged.** The snippet `DocsSnippets` wrote back is byte-identical to the
fence it replaced — it is now compiled rather than asserted. The region lives in
`src/Quartz.Documentation.Samples/MultiTenancySamples.cs` beside the page's other 19, with a
`TenantAuditPlugin` added to the tenant-shaped sample types at the bottom of that file. The
`<!-- TODO(tenancy-configure-all) -->` comment is gone.

## One thing the page had subtly wrong

Re-reading the section against the merged implementation, the precedence bullet said:

> Schedulers already registered get the callback immediately; schedulers registered later get it after
> their own configure callback has run

which reads as though the two cases differ. They do not, and that is precisely why the order of the
calls is immaterial:

* `AddQuartzScheduler` (`src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs`) invokes
  `configure?.Invoke(new QuartzBuilder(services, schedulerName))` and *then*
  `registry.ApplyConfigureAll(services, schedulerName)`.
* `ConfigureAllQuartzSchedulers` applies the delegate to the schedulers already registered — whose own
  `AddQuartz` callback has been and gone.

Both paths therefore land **after** that scheduler's own callback. The bullet now says so.

Two rules the page omitted are on it as well, in the words
[the migration guide](https://github.com/quartznet/quartznet/blob/main/docs/documentation/quartz-4.x/migration-guide.md)
already uses under "Every scheduler in the container can be configured at once":

* registration is first-wins, so a job store or thread pool a tenant chose for itself is not replaced
  by one chosen here; options are last-wins, exactly as `ConfigureAll<TOptions>` overrides an earlier
  named `Configure`;
* calling it when no scheduler is registered at all is not an error.

The section now links to that migration-guide section, so a reader arriving from 3.x and a reader
arriving from the tenancy page get the same rules. `packages/multiple-schedulers.md`'s one-sentence
pointer was checked and needs no change — it states no precedence, and what it does say matches.

## Verification

```
dotnet build Quartz.slnx            Build succeeded. 0 Warning(s) 0 Error(s)
dotnet fallout DocsSnippets         Succeeded — Updated docs\documentation\quartz-4.x\multi-tenancy.md
dotnet fallout VerifyDocsSnippets   Documentation snippets are up to date (89 markdown files checked)
npm run docs:check-links            211 pages, 704 internal links, 399 fragments — no dead links or anchors
npm run docs:build                  VuePress build completed, 212 pages
```

Link and fragment counts are up by one each: the new cross-reference to the migration guide resolves.

`npm run docs:lint` still exits 1 with the same 122 pre-existing errors — I diffed the
line-number-normalized lists against `d37477609` and they are identical, so this adds none. It is not a
CI gate; `.github/workflows/docs-pr.yml` runs `VerifyDocsSnippets`, `docs:check-links-test` and
`docs:check-links`.

No product code, no tests affected. Integration tests were not run — they need a Docker daemon and
nothing here touches product code.

Part of #3357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
