### PR TITLE
The tutorial, how-tos and configuration pages get their C# from the samples project

### DIFF
--- a/docs/.vuepress/components/BlogExcerpt.vue
+++ b/docs/.vuepress/components/BlogExcerpt.vue
@@ -1,29 +1,19 @@
 <!-- /.vuepress/components/BlogExcerpt.vue -->
 
 <template>
-<div>
-    <ul v-for="post in posts">
-        <li>
-            <router-link :to="post.path">{{ post.dateString + ' ' + post.frontmatter.title }}</router-link>
-        </li>
-    </ul>
-</div>
+<ul>
+    <li v-for="post in posts" :key="post.path">
+        <RouteLink :to="post.path">{{ post.date + ' ' + post.title }}</RouteLink>
+    </li>
+</ul>
 </template>
 
-<script>
-export default {
-    computed: {
-        posts() {
-            return [];
-            return this.$site.pages
-                .filter(x => x.id === 'post' && x.frontmatter.hidden !== true && x.frontmatter.promote !== false)
-                .sort((a, b) => b.path.localeCompare(a.path))
-                .slice(0, 5)
-                .map(x => {
-                    x.dateString = x.path.substring(1, 11);
-                    return x;
-                });
-        }
-    }
-}
+<script setup>
+import { computed } from 'vue'
+import { useRoutes } from 'vuepress/client'
+import { promotedPosts } from '../posts.js'
+
+const routes = useRoutes()
+
+const posts = computed(() => promotedPosts(routes.value, 5))
 </script>

--- a/docs/.vuepress/components/BlogIndex.vue
+++ b/docs/.vuepress/components/BlogIndex.vue
@@ -2,31 +2,24 @@
 
 <template>
 <div>
-    <div v-for="post in posts">
+    <div v-for="post in posts" :key="post.path">
         <h2>
-            <router-link :to="post.path">{{ post.dateString + ' ' + post.frontmatter.title }}</router-link>
+            <RouteLink :to="post.path">{{ post.date + ' ' + post.title }}</RouteLink>
         </h2>
 
-        <p>{{ post.frontmatter.description }}</p>
+        <p v-if="post.description">{{ post.description }}</p>
 
-        <p><router-link :to="post.path">Read more</router-link></p>
+        <p><RouteLink :to="post.path">Read more</RouteLink></p>
     </div>
 </div>
 </template>
 
-<script>
-export default {
-    computed: {
-        posts() {
-            return [];
-            return this.$site.pages
-                .filter(x => x.id === 'post' && x.frontmatter.hidden !== true)
-                .sort((a, b) => b.path.localeCompare(a.path))
-                .map(x => {
-                    x.dateString = x.path.substring(1, 11);
-                    return x;
-                });
-        }
-    }
-}
+<script setup>
+import { computed } from 'vue'
+import { useRoutes } from 'vuepress/client'
+import { visiblePosts } from '../posts.js'
+
+const routes = useRoutes()
+
+const posts = computed(() => visiblePosts(routes.value))
 </script>

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -3,6 +3,7 @@ import { webpackBundler } from '@vuepress/bundler-webpack'
 
 import { defaultTheme } from '@vuepress/theme-default'
 import { defineUserConfig } from '@vuepress/cli'
+import type { Page } from 'vuepress/core'
 import { docsearchPlugin } from '@vuepress/plugin-docsearch'
 import { registerComponentsPlugin } from '@vuepress/plugin-register-components'
 import { googleAnalyticsPlugin } from '@vuepress/plugin-google-analytics'
@@ -13,11 +14,39 @@ import { getDirname } from "@vuepress/utils";
 
 const __dirname = getDirname(import.meta.url)
 
+/**
+ * Copies what the blog listings need out of a post and into its route meta.
+ *
+ * A client component can read `useRoutes()` synchronously — route meta is compiled into the routes
+ * module, so it is there during server rendering too — while a page's frontmatter is only reachable
+ * through that page's own async chunk. So the date, title and flags the listings sort and filter on
+ * are put here at build time, and `BlogIndex` / `BlogExcerpt` need nothing else.
+ */
+const extendsPostRouteMeta = (page: Page): void => {
+    const relative = page.filePathRelative?.replace(/\\/g, '/')
+    if (!relative?.startsWith('_posts/')) {
+        return
+    }
+
+    page.routeMeta = {
+        ...page.routeMeta,
+        post: {
+            date: page.date,
+            title: page.title,
+            description: page.frontmatter.description ?? '',
+            hidden: page.frontmatter.hidden === true,
+            promote: page.frontmatter.promote !== false,
+        }
+    }
+}
+
 export default defineUserConfig({
     base: '/',
 
     title: 'Quartz.NET',
     description: 'Open-source scheduling framework for .NET.',
+
+    extendsPage: extendsPostRouteMeta,
 
     bundler: process.env.DOCS_BUNDLER === 'webpack' ? webpackBundler() : viteBundler(),
 

--- a/docs/.vuepress/posts.js
+++ b/docs/.vuepress/posts.js
@@ -1,0 +1,29 @@
+// The one place that knows how a post is recognised among the site's routes.
+//
+// `config.ts` puts what a listing needs into each post's route meta under `post`; both listing
+// components read it back through `useRoutes()`. Newest first, and the path breaks a tie so that
+// two posts released on the same day come out in a stable order rather than in whatever order the
+// routes module happened to list them.
+
+/**
+ * Every published post, newest first.
+ *
+ * @param {Record<string, { meta: Record<string, unknown> }>} routes what `useRoutes()` returned
+ * @returns {{ path: string, date: string, title: string, description: string }[]}
+ */
+export const visiblePosts = (routes) =>
+    Object.entries(routes)
+        .filter(([, route]) => route.meta?.post && !route.meta.post.hidden)
+        .map(([path, route]) => ({ path, ...route.meta.post }))
+        .sort((a, b) => b.date.localeCompare(a.date) || b.path.localeCompare(a.path))
+
+/**
+ * The posts the home page promotes, newest first.
+ *
+ * @param {Record<string, { meta: Record<string, unknown> }>} routes what `useRoutes()` returned
+ * @param {number} count how many to take
+ */
+export const promotedPosts = (routes, count) =>
+    visiblePosts(routes)
+        .filter(post => post.promote)
+        .slice(0, count)

--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -24,6 +24,9 @@ We recommend that code within the `IJob.Execute(..)` method should retrieve
 values from the `MergedJobDataMap` on the `JobExecutionContext`, rather than directly
 from the JobDetail or Trigger.
 
+<!-- Quartz 3.x code — `Task Execute(IJobExecutionContext)` — so it is written out here rather
+     than compiled from the samples project, which is 4.x. -->
+
 ```csharp
 public class SomeJob : IJob 
 {
@@ -54,6 +57,9 @@ parameter as well as on the context:
 To simplify `JobKey` access we recommend defining a static field that allows
 easy access to the job's key.
 
+<!-- Quartz 3.x code — `Task Execute(IJobExecutionContext)` — so it is written out here rather
+     than compiled from the samples project, which is 4.x. -->
+
 ```csharp
 public class SomeJob : IJob 
 {
@@ -65,14 +71,20 @@ public class SomeJob : IJob
 
 then later you can trigger the job directly with
 
+<!-- Quartz 3.x code — `Task Execute(IJobExecutionContext)` — so it is written out here rather
+     than compiled from the samples project, which is 4.x. -->
+
 ```csharp
 public async Task DoSomething(IScheduler schedule, CancellationToken ct)
 {
-    await schedule.TriggerJob(SomeJob.Key, ct)
+    await schedule.TriggerJob(SomeJob.Key, ct);
 }
 ```
 
 or schedule it with a trigger
+
+<!-- Quartz 3.x code — `Task Execute(IJobExecutionContext)` — so it is written out here rather
+     than compiled from the samples project, which is 4.x. -->
 
 ```csharp
 public async Task DoSomething(IScheduler schedule, CancellationToken ct)
@@ -83,7 +95,7 @@ public async Task DoSomething(IScheduler schedule, CancellationToken ct)
                 .StartNow()
                 .Build();
 
-    await schedule.ScheduleJob(trigger, ct)
+    await schedule.ScheduleJob(trigger, ct);
 }
 ```
 
@@ -99,6 +111,7 @@ N firings. On Quartz 3.x the same helpers live on `TriggerUtils`.
 
 When it is necessary to use multiple jobs with a large number of them in a scheduler (e.g. when calling the same job with different JobData) it is rational to call the `ScheduleJobs` method instead of triggering jobs in a loop or calling them manually one by one:
 
+<!-- snippet: sample_best_practices_schedule_jobs -->
 ```csharp
 Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> jobsDictionary = new();
 foreach (var data in allData)
@@ -113,8 +126,9 @@ foreach (var data in allData)
     triggerSet.Add(trigger);
     jobsDictionary.Add(job, triggerSet);
 }
-await scheduler.ScheduleJobs(jobsDictionary, replace: true);
+await scheduler.ScheduleJobs(jobsDictionary, new ScheduleJobOptions { Replace = true });
 ```
+<!-- endSnippet -->
 
 ### Choose the Right Trigger Type
 

--- a/docs/documentation/faq.md
+++ b/docs/documentation/faq.md
@@ -193,6 +193,7 @@ For the simple case — when this job finishes, run that one — Quartz ships
 `JobChainingJobListener`. Register it with the pairs you want chained, and it triggers the second job
 when the first completes:
 
+<!-- snippet: sample_faq_job_chaining -->
 ```csharp
 JobChainingJobListener chain = new("chain");
 chain.AddJobChainLink(new JobKey("extract"), new JobKey("transform"));
@@ -200,6 +201,7 @@ chain.AddJobChainLink(new JobKey("transform"), new JobKey("load"));
 
 scheduler.ListenerManager.AddJobListener(chain);
 ```
+<!-- endSnippet -->
 
 The links live in memory with the listener, so they are re-registered on every start, and the
 second job is fired rather than scheduled — there is no trigger to see in the store.
@@ -363,12 +365,14 @@ Quartz.NET 4.x targets .NET 10.0. You must be running at least .NET 10.0 to use 
 
 Quartz 4.x changed all `Task` return types to `ValueTask`. Your `IJob.Execute` method must now return `ValueTask`:
 
+<!-- snippet: sample_faq_value_task_execute -->
 ```csharp
 public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
 {
     // your job logic
 }
 ```
+<!-- endSnippet -->
 
 If you need `Task` semantics elsewhere (e.g., to await a result multiple times), call `.AsTask()` on the `ValueTask` once and work with the resulting `Task`.
 
@@ -381,6 +385,9 @@ These packages have been merged into the main `Quartz` package in 4.x. You can r
 ## How do I replace SystemTime in Quartz 4.x?
 
 `SystemTime` was removed in 4.x. Use the .NET `TimeProvider` abstraction instead:
+
+<!-- Not a compiled sample: `FakeTimeProvider` comes from `Microsoft.Extensions.TimeProvider.Testing`,
+     which this repository does not reference outside its test projects. -->
 
 ```csharp
 QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create();

--- a/docs/documentation/quartz-4.x/configuration/json.md
+++ b/docs/documentation/quartz-4.x/configuration/json.md
@@ -57,6 +57,7 @@ Each JSON path segment becomes a dot-separated segment in the flat property key,
 
 ### Usage with DI
 
+<!-- snippet: sample_configuration_json_with_di -->
 ```csharp
 services.AddQuartz(Configuration.GetSection("Quartz"), q =>
 {
@@ -64,6 +65,7 @@ services.AddQuartz(Configuration.GetSection("Quartz"), q =>
     q.AddJob<MyJob>(j => j.WithIdentity("codeJob").StoreDurably());
 });
 ```
+<!-- endSnippet -->
 
 ### Usage without DI
 
@@ -71,11 +73,13 @@ services.AddQuartz(Configuration.GetSection("Quartz"), q =>
 `IConfiguration` and it binds the typed options and translates the flat keys itself, exactly as
 `AddQuartz` does.
 
+<!-- snippet: sample_configuration_json_without_di -->
 ```csharp
 ISchedulerFactory factory = QuartzSchedulerBuilder.Create()
     .UseConfiguration(Configuration.GetSection("Quartz"))
     .Build();
 ```
+<!-- endSnippet -->
 
 A `NameValueCollection` you built yourself — from a properties file, from environment variables —
 still goes in through `UseProperties(properties)`.
@@ -266,11 +270,13 @@ When the `Quartz` section contains a `Schedulers` sub-section, each child is aut
 }
 ```
 
+<!-- snippet: sample_configuration_json_named_schedulers -->
 ```csharp
 // Registers "Primary" and "Secondary" named schedulers automatically
 services.AddQuartz(Configuration.GetSection("Quartz"));
 services.AddQuartzHostedService();
 ```
+<!-- endSnippet -->
 
 Each named scheduler section supports the same hierarchical properties, `Schedule` sub-section with `Jobs`/`Triggers`, and code-based overrides.
 
@@ -278,11 +284,13 @@ You can also register a single named scheduler explicitly. The named overload ac
 scheduler's own section or the root `Quartz` section — when given the root section it resolves the
 matching `Schedulers:{name}` sub-section automatically:
 
+<!-- snippet: sample_configuration_json_one_named_scheduler -->
 ```csharp
 // Both lines are equivalent
 services.AddQuartz("Primary", Configuration.GetSection("Quartz"));
 services.AddQuartz("Primary", Configuration.GetSection("Quartz:Schedulers:Primary"));
 ```
+<!-- endSnippet -->
 
 ::: warning
 Defining both a `Schedulers` sub-section and direct scheduler configuration (e.g., `Scheduler`, `ThreadPool` at the top level) is an error. Use one or the other. A top-level `Schedule`/`Scheduling` section cannot be combined with `Schedulers` either — move it under the appropriate `Schedulers:{name}` entry.

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -10,9 +10,11 @@ title: Configuration Reference
 Quartz is configured with strongly typed options. Every option has the same name whether you set it in
 code or in a configuration file, so there is one vocabulary to learn rather than two:
 
+<!-- snippet: sample_reference_one_option -->
 ```csharp
 services.AddQuartz(q => q.ConfigureScheduler(options => options.MaxBatchSize = 5));
 ```
+<!-- endSnippet -->
 
 ```json
 {
@@ -66,6 +68,7 @@ does not and interrupting them is a reasonable thing to want in either case, or 
 | `WhenWaitingForJobs` | Interrupted only on a shutdown that waits — the wait still happens, so a job that checks its cancellation token gets to unwind cleanly. |
 | `Always` | Interrupted on every shutdown. |
 
+<!-- snippet: sample_reference_scheduler_options -->
 ```csharp
 services.AddQuartz(q => q.ConfigureScheduler(options =>
 {
@@ -75,6 +78,7 @@ services.AddQuartz(q => q.ConfigureScheduler(options =>
     options.ShutdownJobInterruption = ShutdownJobInterruption.Always;
 }));
 ```
+<!-- endSnippet -->
 
 ## Thread pool
 
@@ -84,19 +88,24 @@ services.AddQuartz(q => q.ConfigureScheduler(options =>
 |---|---|---|---|
 | `MaxConcurrency` | int | `10` | How many jobs may run at once. |
 
+<!-- snippet: sample_reference_default_thread_pool -->
 ```csharp
 services.AddQuartz(q => q.UseDefaultThreadPool(maxConcurrency: 20));
 ```
+<!-- endSnippet -->
 
 To supply your own implementation:
 
+<!-- snippet: sample_reference_thread_pool_of_your_own -->
 ```csharp
 services.AddQuartz(q => q.UseThreadPool<MyThreadPool>());
 ```
+<!-- endSnippet -->
 
 `ThreadPoolOptions` belongs to the built-in pools — they are what read `MaxConcurrency` — so
 `UseThreadPool<T>()` takes no callback for it. A pool of your own has options of its own:
 
+<!-- snippet: sample_reference_thread_pool_options -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -104,6 +113,7 @@ services.AddQuartz(q =>
     q.UseThreadPool<MyThreadPool>();
 });
 ```
+<!-- endSnippet -->
 
 `ConfigureOptions<TOptions>` registers the callback under this scheduler's options name and declares the
 type as the scheduler's own, so a component that takes `IOptions<MyThreadPoolOptions>` through its
@@ -120,15 +130,18 @@ survive process restarts.
 |---|---|---|---|
 | `MisfireThreshold` | TimeSpan | `00:00:05` | How late a trigger may fire before it counts as misfired. |
 
+<!-- snippet: sample_reference_in_memory_store -->
 ```csharp
 services.AddQuartz(q => q.UseInMemoryStore(options => options.MisfireThreshold = TimeSpan.FromSeconds(30)));
 ```
+<!-- endSnippet -->
 
 ## Persistent job store
 
 `AdoJobStoreOptions`, bound from `Quartz:JobStore`. Choosing a database also selects the driver delegate
 that speaks its SQL dialect, so a connection string is all you normally supply:
 
+<!-- snippet: sample_reference_persistent_store -->
 ```csharp
 services.AddQuartz(q => q.UsePersistentStore(store =>
 {
@@ -136,6 +149,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
     store.UseSystemTextJsonSerializer();
 }));
 ```
+<!-- endSnippet -->
 
 | Option | Type | Default | Description |
 |---|---|---|---|
@@ -180,10 +194,12 @@ legacy `quartz.jobStore.driverDelegateInitString` key still translates to the sa
 
 Each takes either a connection string or a callback over `DataSourceOptions`:
 
+<!-- snippet: sample_reference_connection_string -->
 ```csharp
 store.UseSqlServer(connectionString);
 store.UseSqlServer(db => db.ConnectionStringName = "Scheduler");
 ```
+<!-- endSnippet -->
 
 Where the connection comes from is the data source's own setting, so to connect through a
 `DbDataSource` registered in the container rather than a connection string of Quartz's own, say
@@ -196,6 +212,7 @@ ADO.NET driver: which connection, command and parameter types to instantiate, ho
 and which enum value means "binary column". Quartz ships descriptions for the drivers of every database
 listed above. For anything else, describe the driver in the `UseGenericDatabase` call:
 
+<!-- snippet: sample_reference_generic_database -->
 ```csharp
 store.UseGenericDatabase("MyDatabase", connectionString, () => new DbMetadata
 {
@@ -213,6 +230,7 @@ store.UseGenericDatabase("MyDatabase", connectionString, () => new DbMetadata
     DbBinaryTypeName = "VarBinary",
 });
 ```
+<!-- endSnippet -->
 
 There is a four-argument overload taking a `DataSourceOptions` callback instead of a connection string,
 for a driver described in code that also uses a named connection string.
@@ -305,6 +323,9 @@ knows nothing about is describable, which is what `UseGenericDatabase` is for.
 
 To connect through a `DbDataSource` registered in the container, for example by `AddNpgsqlDataSource`:
 
+<!-- Not a compiled sample: `AddNpgsqlDataSource` comes from `Npgsql.DependencyInjection`, which this
+     repository does not reference, and naming a real provider is the point. -->
+
 ```csharp
 services.AddNpgsqlDataSource(connectionString);
 services.AddQuartz(q => q.UsePersistentStore(store =>
@@ -318,6 +339,8 @@ for an application with one database. A container that holds several — a sched
 reporting scheduler beside the application's own — keys them apart, and `DataSourceServiceKey` says
 which key is this store's:
 
+<!-- Not a compiled sample, for the same reason as the one above: `AddNpgsqlDataSource` is Npgsql's. -->
+
 ```csharp
 services.AddNpgsqlDataSource(tenantA, serviceKey: "tenant-a");
 services.AddNpgsqlDataSource(tenantB, serviceKey: "tenant-b");
@@ -330,9 +353,11 @@ services.AddQuartz("tenant-b", q => q.UsePersistentStore(store =>
 
 A data source that is built rather than registered goes in `DataSourceFactory`, which wins over both:
 
+<!-- snippet: sample_reference_data_source_factory -->
 ```csharp
 store.UsePostgres(db => db.DataSourceFactory = _ => BuildDataSource());
 ```
+<!-- endSnippet -->
 
 Both are set from code rather than from configuration, because a service key can be any object and a
 factory is a delegate — neither is something a configuration binder can produce. Either one means Quartz
@@ -353,6 +378,7 @@ section. Where the connection itself comes from is `DataSourceOptions`' to say, 
 When connections cannot be described at all — a pooled or credential-rotating factory, or a driver
 whose connections need setting up after they are created — hand Quartz the object that makes them:
 
+<!-- snippet: sample_reference_connection_provider -->
 ```csharp
 services.AddQuartz(q => q.UsePersistentStore(store =>
 {
@@ -360,6 +386,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
     store.UseConnectionProvider<MyDbProvider>();   // …but connections come from here
 }));
 ```
+<!-- endSnippet -->
 
 `UseConnectionProvider(factory)` does the same for a provider that needs building first. This is the
 one method on the builder that **replaces** rather than defers: it wins over the provider the database
@@ -395,6 +422,7 @@ configured: the job store reports whether it is clustered, it does not offer a s
 | `CheckinInterval` | TimeSpan | `00:00:07.5` | How often a node records that it is alive. |
 | `CheckinMisfireThreshold` | TimeSpan | `00:00:07.5` | Grace period before a node is treated as failed. |
 
+<!-- snippet: sample_reference_clustering -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -416,6 +444,7 @@ services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 `UseClustering()` enables database locking as well, because clustering has never worked without it.
 
@@ -423,10 +452,12 @@ services.AddQuartz(q =>
 
 A persistent store must be told how to serialize job data.
 
+<!-- snippet: sample_reference_serializers -->
 ```csharp
 store.UseSystemTextJsonSerializer();
 store.UseNewtonsoftJsonSerializer();   // Quartz.Serialization.Newtonsoft
 ```
+<!-- endSnippet -->
 
 ## Scheduling
 
@@ -439,24 +470,30 @@ registered in code, or declared in a file, already exist in the store under the 
 | `IgnoreDuplicates` | bool | `false` | With `OverwriteExistingData` off, a name that already exists is skipped instead of throwing. |
 | `ScheduleTriggerRelativeToReplacedTrigger` | bool | `false` | A replaced trigger's next fire time is computed from the old trigger's last fire time rather than from now. |
 
+<!-- snippet: sample_reference_scheduling_options -->
 ```csharp
 services.Configure<QuartzOptions>(options => options.Scheduling.IgnoreDuplicates = true);
 ```
+<!-- endSnippet -->
 
 ## Job factory
 
 By default jobs are resolved from the container, in a scope created per firing, so a job may take scoped
 dependencies. To replace it:
 
+<!-- snippet: sample_reference_job_factory -->
 ```csharp
 services.AddQuartz(q => q.UseJobFactory<MyJobFactory>());
 ```
+<!-- endSnippet -->
 
 To keep it and only add to the scope it opens:
 
+<!-- snippet: sample_reference_job_scope -->
 ```csharp
 services.AddQuartz(q => q.ConfigureJobScope((scope, bundle, scheduler) => { /* … */ }));
 ```
+<!-- endSnippet -->
 
 ## The other seams
 
@@ -477,6 +514,7 @@ waiting, which is on the real clock.
 
 ## Listeners, calendars and plugins
 
+<!-- snippet: sample_reference_listeners_and_plugins -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -486,6 +524,7 @@ services.AddQuartz(q =>
     q.AddPlugin<MyPlugin>();
 });
 ```
+<!-- endSnippet -->
 
 Listeners and plugins are ordinary services, so they take their dependencies through their constructors.
 
@@ -495,18 +534,22 @@ Registering a scheduler under a name gives it its own job store, thread pool, jo
 The name is the scheduler's instance name, the key its services are registered under, and the name of
 its options.
 
+<!-- snippet: sample_reference_named_schedulers -->
 ```csharp
 services.AddQuartz("reporting", q => q.UsePersistentStore(store => store.UseSqlServer(reportingDb)));
 services.AddQuartz("ingest", q => q.UseInMemoryStore());
 ```
+<!-- endSnippet -->
 
 Resolve them by name:
 
+<!-- snippet: sample_reference_resolving_a_named_scheduler -->
 ```csharp
 var reporting = await serviceProvider
     .GetRequiredKeyedService<ISchedulerFactory>("reporting")
     .GetScheduler();
 ```
+<!-- endSnippet -->
 
 In configuration, use a `Schedulers` section:
 
@@ -527,6 +570,7 @@ Console applications and tests that have no host build a scheduler with `QuartzS
 does not take *the same* configuration API — it **is** the configuration API: `QuartzSchedulerBuilder`
 implements `IQuartzBuilder`, the interface `AddQuartz` hands out, over a container it creates itself.
 
+<!-- snippet: sample_reference_without_a_container -->
 ```csharp
 IScheduler scheduler = await QuartzSchedulerBuilder.Create()
     .ConfigureScheduler(options => options.InstanceName = "reporting")
@@ -534,6 +578,7 @@ IScheduler scheduler = await QuartzSchedulerBuilder.Create()
     .UseInMemoryStore()
     .BuildScheduler();
 ```
+<!-- endSnippet -->
 
 What it adds is the two terminal methods a standalone caller needs, `Build()` for the factory and
 `BuildScheduler()` for the scheduler. Every configuration member returns `QuartzSchedulerBuilder`, so
@@ -542,11 +587,13 @@ the chain reaches them. The `IQuartzBuilder` extension methods — `AddJob`, `Ad
 
 A scheduler configured entirely by flat `quartz.*` keys is built the same way:
 
+<!-- snippet: sample_reference_from_flat_properties -->
 ```csharp
 IScheduler scheduler = await QuartzSchedulerBuilder.Create()
     .UseProperties(properties)
     .BuildScheduler();
 ```
+<!-- endSnippet -->
 
 `UseProperties` checks the keys against the ones Quartz reads, so a misspelling is reported rather
 than silently ignored; set `quartz.checkConfiguration` to `false` to allow keys of your own.

--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -117,27 +117,33 @@ When using `H` through the builder API, the trigger identity is used as the hash
 You **must** call `WithIdentity()` so the hash is derived from a stable, meaningful name
 rather than a random GUID:
 
+<!-- snippet: sample_cron_expressions_hash_from_trigger_name -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("nightly-cleanup")
     .WithCronSchedule("0 H H(0-7) * * ?")
     .Build();
 ```
+<!-- endSnippet -->
 
 You can also provide an explicit hash key, which does not require a trigger identity. The key rides on
 the `CronExpression`, and `WithCronSchedule` takes one directly:
 
+<!-- snippet: sample_cron_expressions_hash_key_on_expression -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithCronSchedule(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup"))
     .Build();
 ```
+<!-- endSnippet -->
 
 Or construct a `CronExpression` directly:
 
+<!-- snippet: sample_cron_expressions_hash_key -->
 ```csharp
 var expr = new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup");
 ```
+<!-- endSnippet -->
 
 ::: tip
 `CronExpressionString` returns the **resolved** expression (e.g., `"0 23 3 * * ?"`) after H
@@ -151,6 +157,7 @@ When a schedule is assembled from user input - for example a scheduling UI that 
 dropdowns instead of a free-form cron field - you can compose the expression with the fluent
 `CronExpressionBuilder` instead of concatenating strings:
 
+<!-- snippet: sample_cron_expressions_builder -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("myTrigger")
@@ -161,6 +168,7 @@ ITrigger trigger = TriggerBuilder.Create()
         .OnWeekdays())               // "0 0/15 8-17 ? * MON-FRI"
     .Build();
 ```
+<!-- endSnippet -->
 
 `WithCronSchedule` accepts the builder (or a built `CronExpression`) directly, so the chain closes
 without naming `CronScheduleBuilder`; call `Build()` yourself when you want the `CronExpression` as a
@@ -170,12 +178,14 @@ Each field offers a single value, list, range and increment form (e.g. `WithHour
 `WithHours`, `WithHourRange`, `WithHourIncrements`), and the special characters are
 available through dedicated methods:
 
+<!-- snippet: sample_cron_expressions_day_rules -->
 ```csharp
 CronExpressionBuilder.Create().OnLastDayOfMonth();                         // "* * * L * ?"
 CronExpressionBuilder.Create().OnNearestWeekdayOfMonth(15);                // "* * * 15W * ?"
 CronExpressionBuilder.Create().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3); // "* * * ? * FRI#3"
 CronExpressionBuilder.Create().OnLastDayOfWeekOfMonth(DayOfWeek.Friday);   // "* * * ? * FRIL"
 ```
+<!-- endSnippet -->
 
 A few rules to be aware of:
 

--- a/docs/documentation/quartz-4.x/how-tos/custom-job-store.md
+++ b/docs/documentation/quartz-4.x/how-tos/custom-job-store.md
@@ -21,6 +21,7 @@ answers.
 
 `DelegatingJobStore` forwards every operation to another store, and every member is `virtual`:
 
+<!-- snippet: sample_custom_job_store_decorator -->
 ```csharp
 public sealed class MetricsJobStore(IJobStore inner, IMeterFactory meters) : DelegatingJobStore(inner)
 {
@@ -44,12 +45,15 @@ public sealed class MetricsJobStore(IJobStore inner, IMeterFactory meters) : Del
     }
 }
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_custom_job_store_registering_a_decorator -->
 ```csharp
 q.UseJobStore(sp => new MetricsJobStore(
     ActivatorUtilities.CreateInstance<RAMJobStore>(sp),
     sp.GetRequiredService<IMeterFactory>()));
 ```
+<!-- endSnippet -->
 
 `protected IJobStore InnerJobStore` reaches the real store through however many layers are in the way.
 
@@ -66,6 +70,9 @@ derive from this.
 
 Four overloads, all singleton and all keyed by scheduler name for a named scheduler:
 
+<!-- A listing of the four overloads rather than code, so it is written out here rather than
+     compiled. -->
+
 ```csharp
 q.UseJobStore<MyStore>();                          // container-constructed
 q.UseJobStore<MyStore, MyStoreOptions>(o => …);    // plus its own options type
@@ -76,6 +83,9 @@ q.UseJobStore(sp => new MyStore(…));               // a factory, e.g. for a de
 The generic forms construct the store with `ActivatorUtilities` through a *scheduler-scoped* view of
 the container, so a store written against the scheduler's own collaborators behaves the same under a
 named scheduler as under the default one. Take what you need:
+
+<!-- An illustration of the constructor rather than a whole store, so it is written out here
+     rather than compiled: the class as shown does not implement `IJobStore`. -->
 
 ```csharp
 public sealed class DocumentJobStore(
@@ -99,6 +109,8 @@ the application is trimmed.
 :::
 
 ## Initialize and identity
+
+<!-- A signature listing rather than code, so it is written out here rather than compiled. -->
 
 ```csharp
 ValueTask Initialize(SchedulerIdentity identity, CancellationToken cancellationToken = default);
@@ -142,9 +154,11 @@ Every store keeps its triggers in one vocabulary — `StoredTriggerState`, nine 
 to the `TriggerState` callers see through one function, so two stores cannot report different states
 for the same situation:
 
+<!-- snippet: sample_custom_job_store_trigger_state_resolver -->
 ```csharp
 TriggerState reported = TriggerStateResolver.Resolve(stored, isExecuting);
 ```
+<!-- endSnippet -->
 
 The precedence is **`None > Error > Paused > Executing > Blocked > Complete > Normal`**. Paused and
 error outrank executing because they are the facts an operator has to act on, and both remain true
@@ -192,6 +206,8 @@ If your storage is relational but the *transaction* model differs — you manage
 or lock differently — derive from `AdoJobStoreBase` rather than writing a store. It has exactly two
 abstract members:
 
+<!-- A signature listing rather than code, so it is written out here rather than compiled. -->
+
 ```csharp
 protected abstract ValueTask<ConnectionAndTransactionHolder> GetLocalTransactionConnection(CancellationToken ct = default);
 
@@ -206,6 +222,8 @@ protected abstract ValueTask<T> ExecuteInLock<T>(
 
 Four members are `protected virtual`, and one of them is a real extension point:
 
+<!-- A signature listing rather than code, so it is written out here rather than compiled. -->
+
 ```csharp
 protected virtual TriggerAcquisitionCriteria CreateAcquisitionCriteria(TriggerAcquisitionRequest request);
 ```
@@ -214,6 +232,7 @@ It maps the store-level request onto the criteria the driver delegate reads. Sta
 return a `with` copy — the criteria are a record, so `with` leaves everything the base decided in
 place:
 
+<!-- snippet: sample_custom_job_store_acquisition_criteria -->
 ```csharp
 protected override TriggerAcquisitionCriteria CreateAcquisitionCriteria(TriggerAcquisitionRequest request)
 {
@@ -221,6 +240,7 @@ protected override TriggerAcquisitionCriteria CreateAcquisitionCriteria(TriggerA
     return criteria with { MaxCount = Math.Min(criteria.MaxCount, this.nodeBudget) };
 }
 ```
+<!-- endSnippet -->
 
 ::: warning The MaxCount rule
 An override may **lower** `MaxCount` but must never raise it above the request's. The choice between

--- a/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
+++ b/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
@@ -19,12 +19,14 @@ roughly a hundred and ten.
 
 `StdAdoDelegate` is `public` and unsealed, with a public parameterless constructor:
 
+<!-- snippet: sample_dialect_delegate_subclass -->
 ```csharp
 public sealed class MyDatabaseDelegate : StdAdoDelegate
 {
     // override only what differs
 }
 ```
+<!-- endSnippet -->
 
 Eight members are the dialect contract. Everything else on `StdAdoDelegate` is an implementation step
 that happens to be `protected virtual` so the class can be composed — treat them as private.
@@ -46,6 +48,7 @@ The default `GetSelectNextTriggerToAcquireSql` ignores `maxCount` entirely — *
 support limits, this is db specific"* — so a dialect that can limit rows should say so. Four shapes
 appear among the shipped dialects:
 
+<!-- snippet: sample_dialect_delegate_row_limiting -->
 ```csharp
 // append (PostgreSQL, Firebird)
 protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
@@ -55,6 +58,7 @@ protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
 // wrap the whole statement (Oracle: SELECT * FROM ( … ) WHERE rownum <= n)
 // append with an index hint (MySQL: FORCE INDEX (…) … LIMIT n)
 ```
+<!-- endSnippet -->
 
 ### Paging
 
@@ -68,6 +72,7 @@ MySQL and SQLite have no such clause, so they override both members — and they
 `AddPagingParameters` too, because their clause names the parameters in the other order and providers
 that bind positionally take them in the order the statement mentions them:
 
+<!-- snippet: sample_dialect_delegate_paging -->
 ```csharp
 protected override string ApplyPaging(string sql, bool takeLimited)
     => takeLimited
@@ -84,6 +89,7 @@ protected override void AddPagingParameters(DbCommand cmd, int skip, int take, b
     AddCommandParameter(cmd, "pageSkip", skip);
 }
 ```
+<!-- endSnippet -->
 
 `takeLimited` is `false` when the caller asked for an unbounded page (`Take = int.MaxValue`), which is
 the case a database with no offset-only form has to spell some other way — MySQL uses a `LIMIT` of the
@@ -97,11 +103,13 @@ is exact without a second query.
 
 Oracle has no boolean column type, so its delegate maps both directions:
 
+<!-- snippet: sample_dialect_delegate_booleans -->
 ```csharp
 public override object GetDbBooleanValue(bool booleanValue) => booleanValue ? "1" : "0";
 
 public override bool GetBooleanFromDbValue(object columnValue) => Convert.ToInt32(columnValue) == 1;
 ```
+<!-- endSnippet -->
 
 `GetDbBooleanValue` is what every `IS_DURABLE`, `REQUESTS_RECOVERY` and similar column is bound
 through, so the two must agree exactly.
@@ -164,6 +172,7 @@ delegate.
 
 ## Registering it
 
+<!-- snippet: sample_dialect_delegate_registration -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -174,6 +183,7 @@ builder.Services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 ::: warning Order matters
 Registration is **first-wins** (`TryAdd`). `UseSqlServer`, `UsePostgres` and the rest each call

--- a/docs/documentation/quartz-4.x/how-tos/lock-handler.md
+++ b/docs/documentation/quartz-4.x/how-tos/lock-handler.md
@@ -10,6 +10,9 @@ something else — Redis, ZooKeeper, a cloud lease, anything that can grant one 
 
 ## The contract
 
+<!-- Quartz's own declaration of the interface, so it is written out here rather than compiled
+     from the samples project: a second `ISemaphore` in that project would shadow the real one. -->
+
 ```csharp
 public interface ISemaphore
 {
@@ -63,6 +66,8 @@ lock the outer one is still relying on.
 When the lock *is* a database row, `DbSemaphore` does the plumbing — ownership tracking, re-entry,
 prefix substitution — and leaves one method:
 
+<!-- A signature listing rather than code, so it is written out here rather than compiled. -->
+
 ```csharp
 protected abstract ValueTask ExecuteSql(
     Guid requestorId,
@@ -78,6 +83,8 @@ records ownership after it returns. Both statements arrive already prefix-expand
 there for the missing-row case.
 
 Two protected helpers are what you issue it through:
+
+<!-- A signature listing rather than code, so it is written out here rather than compiled. -->
 
 ```csharp
 protected DbCommand PrepareCommand(ConnectionAndTransactionHolder conn, string commandText);
@@ -106,6 +113,7 @@ time, so their retry behaviour is testable.
 When the lock does not live in the database, implement the interface and answer `false` to
 `RequiresConnection`:
 
+<!-- snippet: sample_lock_handler_semaphore -->
 ```csharp
 public sealed class LeaseSemaphore : ISemaphore
 {
@@ -122,6 +130,7 @@ public sealed class LeaseSemaphore : ISemaphore
         CancellationToken cancellationToken = default)
     {
         // ... acquire, honouring the re-entry rule ...
+        return true;
     }
 
     public ValueTask ReleaseLock(
@@ -130,9 +139,11 @@ public sealed class LeaseSemaphore : ISemaphore
         CancellationToken cancellationToken = default)
     {
         // ...
+        return default;
     }
 }
 ```
+<!-- endSnippet -->
 
 `RequiresConnection = false` is not cosmetic: it tells the store it can delay opening a database
 connection until *after* the lock has been taken, which is the whole efficiency argument for an
@@ -167,6 +178,7 @@ stopped without releasing the row cannot make progress until the statement gives
 
 ## Registering it
 
+<!-- snippet: sample_lock_handler_registration -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -178,12 +190,14 @@ builder.Services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 There is a factory overload, `UseLockHandler(Func<IServiceProvider, ISemaphore>)`, for a handler that
 needs values rather than services — it registers under the scheduler's own key, which registering
 against `Services` directly would not. `Quartz.Extensions.Redis` uses exactly that public overload;
 nothing about it is privileged:
 
+<!-- snippet: sample_lock_handler_redis -->
 ```csharp
 s.UseRedisLockHandler(o =>
 {
@@ -192,6 +206,7 @@ s.UseRedisLockHandler(o =>
     o.LockTimeToLive = TimeSpan.FromSeconds(30);
 });
 ```
+<!-- endSnippet -->
 
 The legacy key is `quartz.jobStore.lockHandler.type`. Its `.tablePrefix` and `.schedName` sub-keys —
 3.x's spelling, from the `ITablePrefixAware` properties they wrote — are rejected as obsolete, because

--- a/docs/documentation/quartz-4.x/how-tos/multiple-triggers.md
+++ b/docs/documentation/quartz-4.x/how-tos/multiple-triggers.md
@@ -11,6 +11,7 @@ are the same.
 
 Our example job reads both:
 
+<!-- snippet: sample_multiple_triggers_job -->
 ```csharp
 public sealed class CustomerProcessJob : IJob
 {
@@ -35,11 +36,13 @@ public sealed class CustomerProcessJob : IJob
     }
 }
 ```
+<!-- endSnippet -->
 
 ## One job, two triggers
 
 Register the job once and give it two triggers, each with its own data:
 
+<!-- snippet: sample_multiple_triggers_configuration -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -62,6 +65,7 @@ builder.Services.AddQuartz(q =>
         .WithCronSchedule("0 0 2 ? * *"));
 });
 ```
+<!-- endSnippet -->
 
 The hourly firing logs `CustomerId=1 batch-size=50`; the nightly one logs `CustomerId=2 batch-size=500`.
 
@@ -71,6 +75,7 @@ want.
 
 The same two triggers built at run time, for a job whose customers are not known at startup:
 
+<!-- snippet: sample_multiple_triggers_at_run_time -->
 ```csharp
 public async ValueTask ScheduleFor(
     IScheduler scheduler,
@@ -98,6 +103,7 @@ public async ValueTask ScheduleFor(
     }
 }
 ```
+<!-- endSnippet -->
 
 `ScheduleJob(trigger)` — the overload that takes no job detail — schedules a trigger against a job that is
 already stored, which is why the job was added durably first.
@@ -107,10 +113,12 @@ already stored, which is why the job was added durably first.
 `TriggerJob` fires a stored job immediately, with a data map that is merged the same way a trigger's would be.
 It creates no trigger, so this is the way to run a job on demand rather than the way to schedule it:
 
+<!-- snippet: sample_multiple_triggers_ad_hoc -->
 ```csharp
 JobDataMap data = new() { { "CustomerId", "3" }, { "batch-size", 10 } };
 await scheduler.TriggerJob(CustomerProcessJob.Key, data, cancellationToken);
 ```
+<!-- endSnippet -->
 
 ::: warning `GetString` is the strict one
 The numeric accessors are forgiving: `GetInt` parses `"50"` as happily as it returns `50`. `GetString` is not —

--- a/docs/documentation/quartz-4.x/how-tos/one-off-job.md
+++ b/docs/documentation/quartz-4.x/how-tos/one-off-job.md
@@ -13,6 +13,7 @@ or a job and trigger built on the spot.
 When the set of jobs is known at startup, register them where the scheduler is configured and trigger them
 later by key:
 
+<!-- snippet: sample_one_off_job_durable_registration -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -21,6 +22,7 @@ builder.Services.AddQuartz(q =>
         .StoreDurably());
 });
 ```
+<!-- endSnippet -->
 
 `StoreDurably()` is what makes the job stay in the store with no trigger attached. Without it a job is deleted
 as soon as it has no triggers left, and a job registered with no trigger at all would not survive to be
@@ -28,18 +30,21 @@ triggered.
 
 Then, from anywhere that has the scheduler:
 
+<!-- snippet: sample_one_off_job_trigger_now -->
 ```csharp
 public async ValueTask RunNow(IScheduler scheduler, CancellationToken cancellationToken)
 {
     await scheduler.TriggerJob(new JobKey("name", "group"), cancellationToken: cancellationToken);
 }
 ```
+<!-- endSnippet -->
 
 `TriggerJob` fires the job once, immediately. It creates no trigger and leaves nothing behind.
 
 To give that one firing some data of its own, pass a `JobDataMap`. It is merged over the job's own data for
 this firing only, exactly as a trigger's data would be:
 
+<!-- snippet: sample_one_off_job_trigger_now_with_data -->
 ```csharp
 public async ValueTask RunNow(IScheduler scheduler, string customer, CancellationToken cancellationToken)
 {
@@ -47,9 +52,11 @@ public async ValueTask RunNow(IScheduler scheduler, string customer, Cancellatio
     await scheduler.TriggerJob(new JobKey("name", "group"), data, cancellationToken);
 }
 ```
+<!-- endSnippet -->
 
 The same thing at run time, for a job that was not registered at startup, is `AddJob`:
 
+<!-- snippet: sample_one_off_job_add_job -->
 ```csharp
 IJobDetail job = JobBuilder.Create<AnExampleJob>()
     .WithIdentity("name", "group")
@@ -58,6 +65,7 @@ IJobDetail job = JobBuilder.Create<AnExampleJob>()
 
 await scheduler.AddJob(job, new AddJobOptions { Replace = true }, cancellationToken);
 ```
+<!-- endSnippet -->
 
 `Replace` says that re-registering a job under a name that is already taken is intended;
 without it the second call throws `ObjectAlreadyExistsException`. `StoreNonDurableWhileAwaitingScheduling` is
@@ -68,6 +76,7 @@ a trigger is coming. Once one arrives the job is ordinary again — deleted as s
 
 When both the job and its schedule are decided at run time, build the pair and schedule them together:
 
+<!-- snippet: sample_one_off_job_schedule_once -->
 ```csharp
 public async ValueTask ScheduleOnce(IScheduler scheduler, CancellationToken cancellationToken)
 {
@@ -83,6 +92,7 @@ public async ValueTask ScheduleOnce(IScheduler scheduler, CancellationToken canc
     await scheduler.ScheduleJob(job, trigger, cancellationToken);
 }
 ```
+<!-- endSnippet -->
 
 No `StoreDurably()` here, and none wanted: the job arrives with its trigger, and both are gone once the trigger
 has fired and has nothing left to do.
@@ -92,6 +102,7 @@ the scheduler gets to it". Adding `.WithSimpleSchedule()` with no configuration 
 a simple schedule with no interval and no repeat count *is* a single firing — so write it only when you are
 about to configure something on it:
 
+<!-- snippet: sample_one_off_job_misfire_instruction -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("name", "group")
@@ -100,6 +111,7 @@ ITrigger trigger = TriggerBuilder.Create()
         .WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow))
     .Build();
 ```
+<!-- endSnippet -->
 
 ::: tip Misfire behaviour
 A one-shot trigger left on the default `SmartPolicy` resolves to `FireNow`, so a firing missed because the

--- a/docs/documentation/quartz-4.x/how-tos/rescheduling-jobs.md
+++ b/docs/documentation/quartz-4.x/how-tos/rescheduling-jobs.md
@@ -19,6 +19,7 @@ resets the next fire time.
 `RescheduleJob` is delete-and-store in one call. The old trigger goes, the new one is stored, and the
 new one must name the same job:
 
+<!-- snippet: sample_rescheduling_replace_trigger -->
 ```csharp
 ITrigger replacement = TriggerBuilder.Create()
     .WithIdentity("nightly", "reports")
@@ -31,6 +32,7 @@ DateTimeOffset? firstFire = await scheduler.RescheduleJob(
     replacement,
     cancellationToken);
 ```
+<!-- endSnippet -->
 
 The new trigger does **not** have to keep the old name — passing a different `WithIdentity` renames it
 — but it does have to carry a job key, because the old trigger is gone before the new one is stored
@@ -40,6 +42,7 @@ The return value is the new trigger's first fire time, or **`null` if the old tr
 A null return means nothing was stored: the call is not "create if missing". If you are recovering
 from a state where the trigger may or may not exist, check the result:
 
+<!-- snippet: sample_rescheduling_missing_trigger -->
 ```csharp
 DateTimeOffset? next = await scheduler.RescheduleJob(key, replacement, cancellationToken);
 if (next is null)
@@ -48,6 +51,7 @@ if (next is null)
     await scheduler.ScheduleJob(replacement, cancellationToken);
 }
 ```
+<!-- endSnippet -->
 
 Because the trigger is replaced, everything derived from the old one is recomputed. `PreviousFireTimeUtc`
 starts empty, a `SimpleTrigger`'s repeat count starts over, and a paused trigger comes back in whatever
@@ -59,6 +63,7 @@ state the new trigger's group implies. Use it when the *schedule* changed.
 are preserved — a paused trigger stays paused, a trigger due in ten minutes is still due in ten
 minutes.
 
+<!-- snippet: sample_rescheduling_update_details -->
 ```csharp
 bool applied = await scheduler.UpdateTriggerDetails(
     new TriggerKey("nightly", "reports"),
@@ -67,6 +72,7 @@ bool applied = await scheduler.UpdateTriggerDetails(
         .WithDescription("moved up ahead of the invoice run"),
     cancellationToken);
 ```
+<!-- endSnippet -->
 
 `TriggerDetailsUpdate` is a **patch**, not a snapshot: each `With…` call marks one property as
 "change this", and everything you do not call is left alone. That is what makes `null` meaningful —
@@ -97,6 +103,7 @@ The same numeric code means a different policy in each trigger family: `1` is `F
 trigger and `FireOnceNow` on a cron trigger. The typed overloads carry the family with the value, and
 the store rejects an update whose family is not the stored trigger's:
 
+<!-- snippet: sample_rescheduling_typed_misfire_instruction -->
 ```csharp
 // fine — the key resolves to a cron trigger
 await scheduler.UpdateTriggerDetails(cronKey, new TriggerDetailsUpdate()
@@ -106,6 +113,7 @@ await scheduler.UpdateTriggerDetails(cronKey, new TriggerDetailsUpdate()
 await scheduler.UpdateTriggerDetails(cronKey, new TriggerDetailsUpdate()
     .WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow));
 ```
+<!-- endSnippet -->
 
 `WithMisfireInstructionCode(int)` exists for callers holding a bare number — a value read off the
 wire, out of configuration, or from `ITrigger.MisfireInstructionCode`. It skips the family check,
@@ -133,6 +141,7 @@ The tempting middle path — read the trigger, `GetJobBuilder`-style rebuild it,
 
 A job that failed for a transient reason can ask to be run again immediately:
 
+<!-- snippet: sample_rescheduling_refire -->
 ```csharp
 public sealed class ImportJob(IImportService importer) : IJob
 {
@@ -149,6 +158,7 @@ public sealed class ImportJob(IImportService importer) : IJob
     }
 }
 ```
+<!-- endSnippet -->
 
 `RefireImmediately` re-executes the same firing straight away, on the same thread-pool slot, and
 `context.RefireCount` counts how many times that has happened — guard on it, or a permanently failing
@@ -159,12 +169,14 @@ The same exception carries two unschedule flags for the failures that are not wo
 - `UnscheduleFiringTrigger = true` removes the trigger that fired
 - `UnscheduleAllTriggers = true` removes every trigger of the job
 
+<!-- snippet: sample_rescheduling_unschedule_all_triggers -->
 ```csharp
 throw new JobExecutionException($"account {id} no longer exists")
 {
     UnscheduleAllTriggers = true,
 };
 ```
+<!-- endSnippet -->
 
 ::: warning Changed in 4.x
 `JobExecutionException` has four constructors — `()`, `(Exception)`, `(string)` and
@@ -181,6 +193,7 @@ ten, three jobs backing off for a minute each have taken a third of the schedule
 
 When the retry can wait, store a one-off trigger and return normally:
 
+<!-- snippet: sample_rescheduling_retry_trigger -->
 ```csharp
 public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
 {
@@ -200,6 +213,7 @@ public async ValueTask Execute(IJobExecutionContext context, CancellationToken c
     }
 }
 ```
+<!-- endSnippet -->
 
 The trigger name matters. Reuse one fixed retry name and the second retry collides with the first —
 `ObjectAlreadyExistsException`, from inside a job, which is a confusing place to debug it. The fire
@@ -214,6 +228,7 @@ A trigger whose job threw in a way the scheduler could not recover from lands in
 `TriggerState.Error` and stops firing. Finding them is a query — and it pages, so a recovery script
 must loop rather than assume one call sees everything:
 
+<!-- snippet: sample_rescheduling_reset_error_state -->
 ```csharp
 TriggerQuery broken = new() { State = TriggerState.Error, Take = 250 };
 
@@ -235,6 +250,7 @@ while (true)
     }
 }
 ```
+<!-- endSnippet -->
 
 `ResetTriggerFromErrorState(key)` returns `true` when the trigger existed *and* was in the error state,
 `false` for a key that names nothing or a trigger that was not in error — the same missing-key rule

--- a/docs/documentation/quartz-4.x/how-tos/trigger-persistence-delegate.md
+++ b/docs/documentation/quartz-4.x/how-tos/trigger-persistence-delegate.md
@@ -17,6 +17,7 @@ works, and it is a blob: unqueryable, and coupled to your type's shape forever.
 two booleans, a third string and a time zone id. If your schedule fits in those, derive from
 `SimplePropertiesTriggerPersistenceDelegateBase` and write four members:
 
+<!-- snippet: sample_trigger_persistence_delegate -->
 ```csharp
 public sealed class BusinessDayTriggerPersistenceDelegate : SimplePropertiesTriggerPersistenceDelegateBase
 {
@@ -51,6 +52,7 @@ public sealed class BusinessDayTriggerPersistenceDelegate : SimplePropertiesTrig
     }
 }
 ```
+<!-- endSnippet -->
 
 Everything else — the four SQL statements, parameter binding, the reader — is done for you. Note what
 is *not* virtual: `Initialize(TriggerPersistenceDelegateContext)` is a plain `public void` on the base
@@ -91,9 +93,11 @@ six.
 A trigger is rebuilt through `TriggerBuilder`, which carries a schedule but not runtime counters. That
 is what the second constructor parameter is for:
 
+<!-- snippet: sample_trigger_persistence_delegate_apply_state -->
 ```csharp
 new TriggerPropertyBundle(scheduleBuilder, t => ((MyTriggerImpl) t).TimesTriggered = timesTriggered);
 ```
+<!-- endSnippet -->
 
 Pass `null` — or use the one-argument constructor — when your delegate carries no state beyond the
 schedule; the cron delegate does exactly that. The store applies the fire state, then your applier,
@@ -127,6 +131,7 @@ You will also need DDL for the table, in every dialect you support, and a migrat
 
 ## Registering it
 
+<!-- snippet: sample_trigger_persistence_delegate_registration -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -137,6 +142,7 @@ builder.Services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 There is a factory overload too, `UseTriggerPersistenceDelegate(Func<IServiceProvider, ITriggerPersistenceDelegate>)`,
 for a delegate whose constructor takes values rather than services. Either way the delegate is
@@ -180,6 +186,9 @@ what makes the store fall back to a BLOB if you never write one.
 
 **4. A serializer**, for the BLOB path and for job-data round-tripping:
 
+<!-- The three remaining members are elided, so this one is written out here rather than
+     compiled; a class with them left out does not compile. -->
+
 ```csharp
 public sealed class BusinessDayTriggerSerializer : TriggerSerializer<BusinessDayTriggerImpl>
 {
@@ -188,10 +197,12 @@ public sealed class BusinessDayTriggerSerializer : TriggerSerializer<BusinessDay
 }
 ```
 
+<!-- snippet: sample_trigger_persistence_delegate_serializer_registration -->
 ```csharp
 s.UseSystemTextJsonSerializer(registry =>
     registry.AddTriggerSerializer<BusinessDayTriggerImpl>(new BusinessDayTriggerSerializer()));
 ```
+<!-- endSnippet -->
 
 The built-in serializers are public and unsealed on purpose: a trigger deriving from a built-in one
 pairs with a serializer deriving from the built-in one, overriding `SerializeFields` /

--- a/docs/documentation/quartz-4.x/packages/quartz-3rd-party-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-3rd-party-plugins.md
@@ -41,3 +41,12 @@ JobStore implementation for Quartz.NET scheduler using MongoDb.
 ### [Autofac.Extras.Quartz](https://github.com/alphacloud/Autofac.Extras.Quartz)
 
 Autofac integration package for Quartz.Net.
+
+## Schedules
+
+### [NaturalCron.Quartz](https://github.com/hugoj0s3/NaturalCron)
+
+Human-readable schedule expressions for Quartz.NET. `WithNaturalCronSchedule(...)` takes the place of
+`WithCronSchedule(...)` on a `TriggerBuilder` and accepts a sentence — "Every day between monday and
+friday at 6:00pm" — or the same schedule built with a fluent builder. Cron expressions keep working
+alongside it. The package is maintained outside this repository.

--- a/docs/documentation/quartz-4.x/quick-start.md
+++ b/docs/documentation/quartz-4.x/quick-start.md
@@ -38,6 +38,7 @@ configuration files, so there is one vocabulary to learn.
 
 Most applications register Quartz into their service collection:
 
+<!-- snippet: sample_quick_start_host -->
 ```csharp
 builder.AddQuartz(q =>
 {
@@ -74,6 +75,7 @@ builder.AddQuartz(q =>
 
 builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 ```
+<!-- endSnippet -->
 
 The hosted service starts the scheduler with the application and shuts it down with it.
 
@@ -82,6 +84,7 @@ The hosted service starts the scheduler with the application and shuts it down w
 Console applications and tests build a scheduler directly. The configuration API is the same, and the
 whole chain is one expression:
 
+<!-- snippet: sample_quick_start_standalone -->
 ```csharp
 IScheduler scheduler = await QuartzSchedulerBuilder.Create()
     .ConfigureScheduler(options => options.InstanceName = "MyScheduler")
@@ -91,6 +94,7 @@ IScheduler scheduler = await QuartzSchedulerBuilder.Create()
 
 await scheduler.Start();
 ```
+<!-- endSnippet -->
 
 ### From configuration files
 
@@ -108,9 +112,11 @@ same names:
 
 `builder.AddQuartz(...)` reads that section by itself. On a bare `IServiceCollection`, name it:
 
+<!-- snippet: sample_quick_start_from_configuration -->
 ```csharp
 services.AddQuartz(configuration.GetSection("Quartz"));
 ```
+<!-- endSnippet -->
 
 Flat `quartz.*` keys from earlier versions are still accepted and mean the same thing. Full details are
 in the [Quartz Configuration Reference](configuration/reference.md).
@@ -134,6 +140,10 @@ Actually you don't need to define these properties if you don't want to, Quartz.
 The following program builds a scheduler with the default configuration, starts it, and shuts it down:
 
 **Program.cs**
+
+<!-- The three whole-program listings on this page are hand-written rather than compiled from the
+     samples project: they are top-level statements shown with their `using` directives, and a class
+     library can host neither. Everything else here is a snippet. -->
 
 ```csharp
 using Quartz;
@@ -193,6 +203,7 @@ Now starting the application says considerably more:
 
 We need a simple test job to try the scheduler out; let's create a HelloJob that greets the console.
 
+<!-- snippet: sample_quick_start_job -->
 ```csharp
 public sealed class HelloJob : IJob
 {
@@ -202,9 +213,11 @@ public sealed class HelloJob : IJob
     }
 }
 ```
+<!-- endSnippet -->
 
 To do something interesting, add code just after `Start()`, before the `Task.Delay`:
 
+<!-- snippet: sample_quick_start_scheduling -->
 ```csharp
 // define the job and tie it to our HelloJob class
 IJobDetail job = JobBuilder.Create<HelloJob>()
@@ -226,6 +239,7 @@ await scheduler.ScheduleJob(job, trigger);
 // several triggers for one job go together, in one call
 // await scheduler.ScheduleJob(job, [trigger1, trigger2], new ScheduleJobOptions { Replace = true });
 ```
+<!-- endSnippet -->
 
 The complete console application now looks like this:
 

--- a/docs/documentation/quartz-4.x/tutorial/advanced-enterprise-features.md
+++ b/docs/documentation/quartz-4.x/tutorial/advanced-enterprise-features.md
@@ -14,6 +14,7 @@ Clustering needs a persistent store; `RAMJobStore` has nothing to share. `LocalT
 
 ## Enabling it
 
+<!-- snippet: sample_advanced_clustering -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -34,6 +35,7 @@ builder.Services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 Three rules follow from what those settings mean:
 
@@ -53,6 +55,7 @@ Three rules follow from what those settings mean:
 
 ## Tuning the check-in
 
+<!-- snippet: sample_advanced_checkin_interval -->
 ```csharp
 store.UseClustering(cluster =>
 {
@@ -60,6 +63,7 @@ store.UseClustering(cluster =>
     cluster.CheckinMisfireThreshold = TimeSpan.FromSeconds(20);
 });
 ```
+<!-- endSnippet -->
 
 | Option | Default | What it does |
 |---|---|---|
@@ -109,6 +113,7 @@ times are spread out.
 
 So: move the pair together, or leave them alone.
 
+<!-- snippet: sample_advanced_batch_acquisition -->
 ```csharp
 q.ConfigureScheduler(options =>
 {
@@ -116,6 +121,7 @@ q.ConfigureScheduler(options =>
     options.BatchTriggerAcquisitionFireAheadTimeWindow = TimeSpan.FromSeconds(1);
 });
 ```
+<!-- endSnippet -->
 
 That is worth doing when many triggers fire at once — a few hundred at the top of the hour — because
 one acquisition and one `TRIGGERS_FIRED` round trip replace one of each per trigger. It is not worth

--- a/docs/documentation/quartz-4.x/tutorial/configuration-resource-usage-and-scheduler-factory.md
+++ b/docs/documentation/quartz-4.x/tutorial/configuration-resource-usage-and-scheduler-factory.md
@@ -29,6 +29,7 @@ An application with no host — a console application, or a test — builds a sc
 `QuartzSchedulerBuilder`. It takes the same configuration API as `AddQuartz`, creating a container of
 its own and building from it, so what works in one works in the other:
 
+<!-- snippet: sample_configuration_building_a_scheduler -->
 ```csharp
 IScheduler scheduler = await QuartzSchedulerBuilder.Create()
     .ConfigureScheduler(options => options.InstanceName = "reporting")
@@ -36,6 +37,7 @@ IScheduler scheduler = await QuartzSchedulerBuilder.Create()
     .UseInMemoryStore()
     .BuildScheduler();
 ```
+<!-- endSnippet -->
 
 Every configuration method returns the builder itself, so the whole thing is one expression. Nothing
 starts on its own: without a hosted service, starting the scheduler is your call, and so is shutting it
@@ -51,11 +53,13 @@ A scheduler can also be configured from a set of flat `quartz.*` properties (`Na
 instead of in code. The properties are generally stored in and loaded from a file, but can also be
 created by your program and handed to the builder:
 
+<!-- snippet: sample_configuration_from_properties -->
 ```csharp
 await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
     .UseProperties(properties)
     .Build();
 ```
+<!-- endSnippet -->
 
 The keys are translated into the same options and registrations the code-based API produces, so a
 scheduler configured this way is the same scheduler, and the two can be mixed — what is written in code
@@ -74,12 +78,14 @@ does not log much: some information while starting, and then only serious proble
 Only code that reaches Quartz from outside a container — a static helper, a test that constructs pieces by
 hand — has to say where logging goes, and that is one call:
 
+<!-- snippet: sample_configuration_log_provider -->
 ```csharp
 // obtain your logger factory, for example from IServiceProvider
-ILoggerFactory loggerFactory = ...;
+ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
 LogProvider.SetLogProvider(loggerFactory);
 ```
+<!-- endSnippet -->
 
 `LogProvider` is in `Quartz.Diagnostics`, and also hands out loggers — `LogProvider.CreateLogger<T>()` — for
 the same situation.

--- a/docs/documentation/quartz-4.x/tutorial/crontriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/crontriggers.md
@@ -71,6 +71,7 @@ To compose the cron expression string itself programmatically, see
 
 **Build a trigger that will fire every other minute, between 8am and 5pm, every day:**
 
+<!-- snippet: sample_crontriggers_every_other_minute -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger3", "group1")
@@ -78,9 +79,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .ForJob("myJob", "group1")
     .Build();
 ```
+<!-- endSnippet -->
 
 **Build a trigger that will fire daily at 10:42 am:**
 
+<!-- snippet: sample_crontriggers_daily_question_mark_in_day_of_week -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger3", "group1")
@@ -88,9 +91,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .ForJob(myJobKey)
     .Build();
 ```
+<!-- endSnippet -->
 
 or -
 
+<!-- snippet: sample_crontriggers_daily_question_mark_in_day_of_month -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger3", "group1")
@@ -98,9 +103,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .ForJob("myJob", "group1")
     .Build();
 ```
+<!-- endSnippet -->
 
 **Build a trigger that will fire on Wednesdays at 10:42 am, in a TimeZone other than the system's default:**
 
+<!-- snippet: sample_crontriggers_in_time_zone -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger3", "group1")
@@ -109,9 +116,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .ForJob(myJobKey)
     .Build();
 ```
+<!-- endSnippet -->
 
 or, with the schedule built first so that several triggers can share it -
 
+<!-- snippet: sample_crontriggers_schedule_built_separately -->
 ```csharp
 CronScheduleBuilder schedule = CronScheduleBuilder
     .Create("0 42 10 ? * WED")
@@ -123,6 +132,7 @@ ITrigger trigger = TriggerBuilder.Create()
     .ForJob(myJobKey)
     .Build();
 ```
+<!-- endSnippet -->
 
 `TimeZones.FindById` is `TimeZoneInfo.FindSystemTimeZoneById` plus whatever resolvers are registered — which is
 what makes a Windows id resolve on Linux once the
@@ -130,6 +140,7 @@ what makes a Windows id resolve on Linux once the
 
 **Build a trigger that fires once per day at a hash-derived time between midnight and 7:59 AM, spreading load across triggers:**
 
+<!-- snippet: sample_crontriggers_hashed_fire_time -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("nightly-cleanup", "maintenance")
@@ -137,6 +148,7 @@ ITrigger trigger = TriggerBuilder.Create()
     .ForJob("cleanupJob", "maintenance")
     .Build();
 ```
+<!-- endSnippet -->
 
 ## CronTrigger Misfire Instructions
 
@@ -156,6 +168,7 @@ scheduler can, until the schedule has caught up. `CronTriggerImpl.UpdateAfterMis
 
 When building CronTriggers, you specify the misfire instruction as part of the cron schedule (via `WithCronSchedule` extension method):
 
+<!-- snippet: sample_crontriggers_misfire_instruction -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger3", "group1")
@@ -164,3 +177,4 @@ ITrigger trigger = TriggerBuilder.Create()
     .ForJob("myJob", "group1")
     .Build();
 ```
+<!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/tutorial/job-data-map.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-data-map.md
@@ -19,6 +19,7 @@ A job's data can come from two places:
 in both, and **the trigger wins**. It is built once per firing, lazily, and it is the map a job should
 read:
 
+<!-- snippet: sample_job_data_map_merged_map -->
 ```csharp
 public sealed class ReportJob : IJob
 {
@@ -28,9 +29,12 @@ public sealed class ReportJob : IJob
         string region = data.GetString("region")!;
         int lookbackDays = data.GetInt("lookbackDays");
         // ...
+
+        return default;
     }
 }
 ```
+<!-- endSnippet -->
 
 Writing into the merged map does nothing durable. It is a per-firing copy; values set into it are not
 written back to the job's own map, and a job that wants to persist state across fires uses
@@ -47,6 +51,7 @@ nothing else; read scheduler-wide values from `context.Scheduler.Context`.
 
 `JobBuilder<TJob>` and `TriggerBuilder<TJob>` have the same three `UsingJobData` shapes:
 
+<!-- snippet: sample_job_data_map_using_job_data -->
 ```csharp
 IJobDetail job = JobBuilder.Create<ReportJob>()
     .WithIdentity("nightly", "reports")
@@ -55,6 +60,7 @@ IJobDetail job = JobBuilder.Create<ReportJob>()
     .UsingJobData(existingMap)                          // merge a whole map in
     .Build();
 ```
+<!-- endSnippet -->
 
 The expression overload is worth knowing: `UsingJobData(j => j.LookbackDays, 30)` uses the property's
 own name as the key and the property's own type for the value, so a rename or a type change is a
@@ -62,9 +68,11 @@ compile error rather than a silent no-op at fire time. It pairs with property in
 
 Runtime data for a single firing does not need a trigger at all:
 
+<!-- snippet: sample_job_data_map_trigger_job_with_data -->
 ```csharp
 await scheduler.TriggerJob(jobKey, new JobDataMap { ["reason"] = "manual re-run" }, cancellationToken);
 ```
+<!-- endSnippet -->
 
 ## The read side: typed accessors
 
@@ -86,12 +94,14 @@ indexer, `TryGetValue`, `ContainsKey`, `Remove`, `Count`, `Keys`, `Values`, `Cle
 
 **And one generic** — `TryGet<T>(string key, out T value)`, for a type the list does not name:
 
+<!-- snippet: sample_job_data_map_try_get -->
 ```csharp
-if (data.TryGet<ReportOptions>("options", out ReportOptions options))
+if (data.TryGet<ReportOptions>("options", out ReportOptions? options))
 {
     // ...
 }
 ```
+<!-- endSnippet -->
 
 Each accessor accepts the value **either as its own type or as an invariant-culture string**. The
 stored type is matched first, a string is parsed with `CultureInfo.InvariantCulture`, and only an
@@ -120,6 +130,7 @@ unchanged (`map.GetString(…)` still compiles) but nothing should name the old 
 
 `PutAsString` writes a value in a form that survives anything:
 
+<!-- snippet: sample_job_data_map_put_as_string -->
 ```csharp
 JobDataMap data = new();
 data.PutAsString("runAt", DateTimeOffset.UtcNow);   // "O": 2026-08-22T09:15:00.0000000+00:00
@@ -127,6 +138,7 @@ data.PutAsString("window", TimeSpan.FromHours(6));  // invariant "06:00:00"
 data.PutAsString("batchId", Guid.NewGuid());
 data.PutAsString("lookbackDays", 30);               // any IFormattable
 ```
+<!-- endSnippet -->
 
 | Overload | Written as |
 |---|---|
@@ -159,6 +171,7 @@ types are a versioning commitment.
 `quartz.jobStore.useProperties`) makes the store persist the map as name/value string pairs instead of
 a serialized blob:
 
+<!-- snippet: sample_job_data_map_store_as_strings -->
 ```csharp
 q.UsePersistentStore(s =>
 {
@@ -166,6 +179,7 @@ q.UsePersistentStore(s =>
     s.Configure(o => o.StoreJobDataAsStrings = true);
 });
 ```
+<!-- endSnippet -->
 
 That removes the versioning problem entirely and makes `QRTZ_JOB_DETAILS.JOB_DATA` readable in a query
 tool — at the cost of a hard rule: **every value must be a string**. Put a `DateTimeOffset` in the map
@@ -182,6 +196,7 @@ already in the tables leaves rows the store cannot read.
 If a job has settable properties whose names match keys in the merged map, the default job factory
 assigns them before `Execute` runs, and the job never touches the map:
 
+<!-- snippet: sample_job_data_map_property_injection -->
 ```csharp
 public sealed class ReportJob : IJob
 {
@@ -191,9 +206,12 @@ public sealed class ReportJob : IJob
     public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         // Region and LookbackDays are already set
+
+        return default;
     }
 }
 ```
+<!-- endSnippet -->
 
 The conversion rules are the accessors' rules: a `"30"` in the map sets an `int LookbackDays`. What
 happens when a key has no matching property, or the value cannot be converted, is
@@ -210,6 +228,7 @@ By default a job's stored map is written once and read many times. `[PersistJobD
 changes that — the job's own `JobDataMap` is re-persisted after every execution, so a counter or a
 watermark survives:
 
+<!-- snippet: sample_job_data_map_persist_across_fires -->
 ```csharp
 [PersistJobDataAfterExecution]
 [DisallowConcurrentExecution]
@@ -223,6 +242,7 @@ public sealed class IncrementalSyncJob : IJob
     }
 }
 ```
+<!-- endSnippet -->
 
 Note the second attribute. `[PersistJobDataAfterExecution]` without `[DisallowConcurrentExecution]` is
 a race: two firings read the same map, both write, and one of the writes is lost. Use them together.
@@ -230,9 +250,11 @@ a race: two firings read the same map, both write, and one of the writes is lost
 The map tracks whether it changed and is only written when it did. To force a write the map did not
 notice — an in-place mutation of a stored object, for instance — put the well-known key in it:
 
+<!-- snippet: sample_job_data_map_force_dirty -->
 ```csharp
 data[SchedulerConstants.ForceJobDataMapDirty] = "true";
 ```
+<!-- endSnippet -->
 
 ## Thread safety
 

--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -27,6 +27,7 @@ For some applications this is acceptable - or even the desired behavior, but for
 
 **Configuring Quartz to use RAMJobStore**
 
+<!-- snippet: sample_job_stores_in_memory -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -34,6 +35,7 @@ builder.Services.AddQuartz(q =>
     q.UseInMemoryStore(options => options.MisfireThreshold = TimeSpan.FromSeconds(30));
 });
 ```
+<!-- endSnippet -->
 
 To use `RAMJobStore` you don't need to do anything special. Default configuration
 of Quartz.NET uses `RAMJobStore` as job store implementation.
@@ -63,6 +65,7 @@ other one, for a container that manages the ambient transaction itself.
 Everything the store needs is one call. Naming the database also selects the driver delegate that speaks its
 SQL dialect and the ADO.NET provider that talks to it, so a connection string is usually all you supply:
 
+<!-- snippet: sample_job_stores_persistent -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -79,6 +82,7 @@ builder.Services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 One method per database:
 
@@ -127,9 +131,11 @@ types into a BLOB.
 This is the recommended configuration, because it greatly decreases the possibility of type serialization issues.
 :::
 
+<!-- snippet: sample_job_stores_store_job_data_as_strings -->
 ```csharp
 store.Configure(options => options.StoreJobDataAsStrings = true);
 ```
+<!-- endSnippet -->
 
 The flat key for the same setting is `quartz.jobStore.useProperties`, which is the name it had in 3.x.
 
@@ -163,6 +169,7 @@ other fails.
 Telling the store to accept enlisted transactions lets it use a connection your application already owns instead, so
 scheduling commits with the rest of your work or not at all.
 
+<!-- snippet: sample_job_stores_accept_enlisted_transactions -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -173,8 +180,12 @@ builder.Services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 You then hand your connection and transaction to the scheduler for the duration of a scope:
+
+<!-- Not a compiled sample: it is written against Entity Framework Core, which this repository does not
+     reference, and a NuGet dependency taken purely for a documentation sample is not worth it. -->
 
 ```csharp
 await using var tx = await dbContext.Database.BeginTransactionAsync();
@@ -199,6 +210,9 @@ Open the connection inside the scope and enlist that one.
 :::
 
 Inside a `TransactionScope` the shape is the same, except that the connection carries the transaction for you:
+
+<!-- Not a compiled sample: it names Npgsql, which this repository does not reference, and naming the
+     provider is the point — a `DbConnection` would not say which one cannot promote a transaction. -->
 
 ```csharp
 var options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
@@ -257,6 +271,7 @@ whether you are changing *where* scheduling data lives or only what happens arou
 `IJobStore` member to it, so you override only the operations you actually change. The wrapped store is available
 to your code as `InnerJobStore`.
 
+<!-- snippet: sample_job_stores_delegating_store -->
 ```csharp
 public sealed class LoggingJobStore : DelegatingJobStore
 {
@@ -282,6 +297,7 @@ public sealed class LoggingJobStore : DelegatingJobStore
     }
 }
 ```
+<!-- endSnippet -->
 
 The stores Quartz ships are sealed, so this is also how you build on `RAMJobStore` - construct one and hand it
 to the base constructor, as above. Your store's own constructor arguments come from the container, so it can
@@ -299,12 +315,14 @@ and rebuilding one silently swaps it for Quartz's implementation on the job's fi
 
 Either kind is registered the same way, by type:
 
+<!-- snippet: sample_job_stores_registering_your_own -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
     q.UsePersistentStore<LoggingJobStore>(options =>
     {
-        // …store options
+        // … store options
     });
 });
 ```
+<!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/tutorial/jobs-and-triggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/jobs-and-triggers.md
@@ -23,24 +23,26 @@ However, the Scheduler will not actually act on any triggers (execute jobs) unti
 
 Quartz provides "builder" classes that define a Domain Specific Language (or DSL, also sometimes referred to as a "fluent interface"). In the previous lesson you saw an example of it, which we present a portion of here again:
 
+<!-- snippet: sample_jobs_and_triggers_builders -->
 ```csharp
 // define the job and tie it to our HelloJob class
 IJobDetail job = JobBuilder.Create<HelloJob>()
     .WithIdentity("myJob", "group1") // name "myJob", group "group1"
     .Build();
-    
+
 // Trigger the job to run now, and then every 40 seconds
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("myTrigger", "group1")
     .StartNow()
     .WithSimpleSchedule(x => x
         .WithInterval(TimeSpan.FromSeconds(40))
-        .RepeatForever())            
+        .RepeatForever())
     .Build();
-    
+
 // Tell Quartz to schedule the job using our trigger
 await scheduler.ScheduleJob(job, trigger);
 ```
+<!-- endSnippet -->
   
 The block of code that builds the job definition is using `JobBuilder` using fluent interface to create the product, `IJobDetail`.
 Likewise, the block of code that builds the trigger is using `TriggerBuilder`'s fluent interface and extension methods that are specific to given trigger type.
@@ -71,6 +73,9 @@ faked time.
 A job is a class that implements the `IJob` interface, which has only one simple method:
 
 __IJob Interface__
+
+<!-- Quartz's own declaration of the interface, so it is written out here rather than compiled from the
+     samples project: a second `Quartz.IJob` in that project would shadow the real one. -->
 
 ```csharp
 namespace Quartz

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -19,35 +19,39 @@ First lets take a look back at some of that snippet of code we saw in Lesson 1:
 
 __Using Quartz.NET__
 
+<!-- snippet: sample_more_about_jobs_scheduling -->
 ```csharp
 // define the job and tie it to our HelloJob class
 IJobDetail job = JobBuilder.Create<HelloJob>()
- .WithIdentity("myJob", "group1")
- .Build();
+    .WithIdentity("myJob", "group1")
+    .Build();
 
 // Trigger the job to run now, and then every 40 seconds
 ITrigger trigger = TriggerBuilder.Create()
-  .WithIdentity("myTrigger", "group1")
-  .StartNow()
-  .WithSimpleSchedule(x => x
-   .WithInterval(TimeSpan.FromSeconds(40))
-   .RepeatForever())
-  .Build();
-  
+    .WithIdentity("myTrigger", "group1")
+    .StartNow()
+    .WithSimpleSchedule(x => x
+        .WithInterval(TimeSpan.FromSeconds(40))
+        .RepeatForever())
+    .Build();
+
 await scheduler.ScheduleJob(job, trigger);
 ```
+<!-- endSnippet -->
 
 Now consider the job class __HelloJob__  defined as such:
 
+<!-- snippet: sample_more_about_jobs_hello_job -->
 ```csharp
 public class HelloJob : IJob
 {
- public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
- {
-  await Console.Out.WriteLineAsync("HelloJob is executing.");
- }
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        await Console.Out.WriteLineAsync("HelloJob is executing.");
+    }
 }
 ```
+<!-- endSnippet -->
 
 Notice that we give the scheduler a `IJobDetail` instance, and that it refers to the job to be executed by simply
 providing the job's class. Each (and every) time the scheduler executes the job, it creates a new instance of the
@@ -75,35 +79,39 @@ Here's some quick snippets of putting data into the JobDataMap prior to adding t
 
 __Setting Values in a JobDataMap__
 
+<!-- snippet: sample_more_about_jobs_setting_job_data -->
 ```csharp
 // define the job and tie it to our DumbJob class
 IJobDetail job = JobBuilder.Create<DumbJob>()
- .WithIdentity("myJob", "group1") // name "myJob", group "group1"
- .UsingJobData("jobSays", "Hello World!")
- .UsingJobData("myFloatValue", 3.141f)
- .Build();
+    .WithIdentity("myJob", "group1") // name "myJob", group "group1"
+    .UsingJobData("jobSays", "Hello World!")
+    .UsingJobData("myFloatValue", 3.141f)
+    .Build();
 ```
+<!-- endSnippet -->
 
 Here's a quick example of getting data from the JobDataMap during the job's execution:
 
 __Getting Values from a JobDataMap__
 
+<!-- snippet: sample_more_about_jobs_getting_job_data -->
 ```csharp
 public class DumbJob : IJob
 {
- public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
- {
-  JobKey key = context.JobDetail.Key;
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        JobKey key = context.JobDetail.Key;
 
-  JobDataMap dataMap = context.JobDetail.JobDataMap;
+        JobDataMap dataMap = context.JobDetail.JobDataMap;
 
-  string jobSays = dataMap.GetString("jobSays");
-  float myFloatValue = dataMap.GetFloat("myFloatValue");
+        string? jobSays = dataMap.GetString("jobSays");
+        float myFloatValue = dataMap.GetFloat("myFloatValue");
 
-  await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + jobSays + ", and val is: " + myFloatValue);
- }
+        await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + jobSays + ", and val is: " + myFloatValue);
+    }
 }
 ```
+<!-- endSnippet -->
 
 If you use a persistent JobStore (discussed in the JobStore section of this tutorial) you should use some care
 in deciding what you place in the JobDataMap, because the object in it will be serialized, and they therefore
@@ -122,22 +130,31 @@ functionality is not maintained by default when using a custom JobFactory.
 ### Naming the property instead of the key
 
 When the value is meant for one of those properties, you can name the property rather than spell its key.
-The key is then the property's own name, and the value has to be of the property's own type:
+Give the job the properties:
 
+<!-- snippet: sample_more_about_jobs_job_with_properties -->
 ```csharp
 public class DumbJob : IJob
 {
- public string JobSays { get; set; }
- public float FloatValue { get; set; }
- // ...
-}
+    public string JobSays { get; set; } = "";
+    public float FloatValue { get; set; }
 
-IJobDetail job = JobBuilder.Create<DumbJob>()
- .WithIdentity("myJob", "group1")
- .UsingJobData(j => j.JobSays, "Hello World!")
- .UsingJobData(j => j.FloatValue, 3.141f)
- .Build();
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
 ```
+<!-- endSnippet -->
+
+The key is then the property's own name, and the value has to be of the property's own type:
+
+<!-- snippet: sample_more_about_jobs_naming_the_property -->
+```csharp
+IJobDetail job = JobBuilder.Create<DumbJob>()
+    .WithIdentity("myJob", "group1")
+    .UsingJobData(j => j.JobSays, "Hello World!")
+    .UsingJobData(j => j.FloatValue, 3.141f)
+    .Build();
+```
+<!-- endSnippet -->
 
 `JobBuilder.Create<DumbJob>()` returns a `JobBuilder<DumbJob>`, and it is that job type which lets `j` be
 inferred. `JobBuilder.Create()` builds for `IJob`, which has no properties to name, so use the generic
@@ -168,13 +185,15 @@ Otherwise the same care applies as to any other job data: the store has to be ab
 Triggers work the same way through `TriggerBuilder.Create<DumbJob>()`, which is how one job takes different
 inputs per trigger:
 
+<!-- snippet: sample_more_about_jobs_naming_the_property_on_a_trigger -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create<DumbJob>()
- .WithIdentity("myTrigger", "group1")
- .ForJob(job)
- .UsingJobData(j => j.JobSays, "Good evening!")
- .Build();
+    .WithIdentity("myTrigger", "group1")
+    .ForJob(job)
+    .UsingJobData(j => j.JobSays, "Good evening!")
+    .Build();
 ```
+<!-- endSnippet -->
 
 `ForJob(IJobDetail)` also checks that the job really is a `DumbJob`, since that is the one overload that
 knows the job's type.
@@ -183,16 +202,18 @@ The same applies to the configurators in the
 [Microsoft DI integration](../packages/microsoft-di-integration.md), where the job type comes from the call
 itself:
 
+<!-- snippet: sample_more_about_jobs_naming_the_property_under_di -->
 ```csharp
 q.AddJob<DumbJob>(j => j.UsingJobData(x => x.JobSays, "Hello World!"));
 
 q.ScheduleJob<DumbJob>(
- t => t.StartNow().UsingJobData(x => x.JobSays, "Good evening!"),
- j => j.WithIdentity("myJob"));
+    t => t.StartNow().UsingJobData(x => x.JobSays, "Good evening!"),
+    j => j.WithIdentity("myJob"));
 
 // a trigger added on its own names the job type it fires
 q.AddTrigger<DumbJob>(t => t.ForJob(jobKey).UsingJobData(x => x.JobSays, "Good evening!"));
 ```
+<!-- endSnippet -->
 
 `AddTrigger<IJob>` is the untyped form — `IJob` has no properties to name — so name the job's own type
 when you want typed trigger data.
@@ -205,46 +226,50 @@ found on the JobDetail and the one found on the Trigger, with the values in the 
 
 Here's a quick example of getting data from the JobExecutionContext's merged JobDataMap during the job's execution:
 
+<!-- snippet: sample_more_about_jobs_merged_job_data -->
 ```csharp
 public class DumbJob : IJob
 {
- public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
- {
-  JobKey key = context.JobDetail.Key;
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        JobKey key = context.JobDetail.Key;
 
-  JobDataMap dataMap = context.MergedJobDataMap;  // Note the difference from the previous example
+        JobDataMap dataMap = context.MergedJobDataMap;  // Note the difference from the previous example
 
-  string jobSays = dataMap.GetString("jobSays");
-  float myFloatValue = dataMap.GetFloat("myFloatValue");
-  IList<DateTimeOffset> state = (IList<DateTimeOffset>)dataMap["myStateData"];
-  state.Add(DateTimeOffset.UtcNow);
+        string? jobSays = dataMap.GetString("jobSays");
+        float myFloatValue = dataMap.GetFloat("myFloatValue");
+        IList<DateTimeOffset> state = (IList<DateTimeOffset>) dataMap["myStateData"]!;
+        state.Add(DateTimeOffset.UtcNow);
 
-  await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + jobSays + ", and val is: " + myFloatValue);
- }
+        await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + jobSays + ", and val is: " + myFloatValue);
+    }
 }
 ```
+<!-- endSnippet -->
 
 Or if you wish to rely on the JobFactory "injecting" the data map values onto your class, it might look like this instead:
 
+<!-- snippet: sample_more_about_jobs_injected_job_data -->
 ```csharp
 public class DumbJob : IJob
 {
- public string JobSays { private get; set; }
- public float FloatValue { private get; set; }
+    public string JobSays { private get; set; } = "";
+    public float FloatValue { private get; set; }
 
- public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
- {
-  JobKey key = context.JobDetail.Key;
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        JobKey key = context.JobDetail.Key;
 
-  JobDataMap dataMap = context.MergedJobDataMap;  // Note the difference from the previous example
+        JobDataMap dataMap = context.MergedJobDataMap;  // Note the difference from the previous example
 
-  IList<DateTimeOffset> state = (IList<DateTimeOffset>)dataMap["myStateData"];
-  state.Add(DateTimeOffset.UtcNow);
+        IList<DateTimeOffset> state = (IList<DateTimeOffset>) dataMap["myStateData"]!;
+        state.Add(DateTimeOffset.UtcNow);
 
-  await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + JobSays + ", and val is: " + FloatValue);
- }
+        await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + JobSays + ", and val is: " + FloatValue);
+    }
 }
 ```
+<!-- endSnippet -->
 
 You'll notice that the overall code of the class is longer, but the code in the `Execute()` method is cleaner.
 One could also argue that although the code is longer, that it actually took less coding, if the programmer's IDE was used to auto-generate the properties,
@@ -338,10 +363,11 @@ job definition that carries something of yours alongside the ones above — a te
 the rest of your system keys on — you can implement `IJobDetail` yourself. Everything Quartz asks of a detail is
 declared on the interface:
 
+<!-- snippet: sample_more_about_jobs_custom_job_detail -->
 ```csharp
 public sealed class TenantJobDetail : IJobDetail
 {
-    public TenantJobDetail(JobKey key, JobType jobType, string tenant, JobDataMap jobDataMap = null)
+    public TenantJobDetail(JobKey key, JobType jobType, string tenant, JobDataMap? jobDataMap = null)
     {
         Key = key;
         JobType = jobType;
@@ -369,6 +395,7 @@ public sealed class TenantJobDetail : IJobDetail
         => new TenantJobDetail(Key, JobType, Tenant, new JobDataMap(JobDataMap));
 }
 ```
+<!-- endSnippet -->
 
 ::: warning How far it travels
 A detail of your own round-trips through `RAMJobStore`, which holds the instances it is given and hands back
@@ -390,6 +417,7 @@ that you should throw from the execute method is the JobExecutionException. Beca
 execute method with a 'try-catch' block. The exception's directives to the scheduler are init-only
 properties, set with an object initializer:
 
+<!-- snippet: sample_more_about_jobs_job_execution_exception -->
 ```csharp
 catch (Exception ex)
 {
@@ -397,6 +425,7 @@ catch (Exception ex)
     throw new JobExecutionException(ex) { RefireImmediately = true };
 }
 ```
+<!-- endSnippet -->
 
 Besides `RefireImmediately` there are `UnscheduleFiringTrigger` and `UnscheduleAllTriggers`, which stop
 the trigger that fired the job — or every trigger of the job — from firing again. When

--- a/docs/documentation/quartz-4.x/tutorial/more-about-triggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-triggers.md
@@ -56,12 +56,14 @@ Each trigger family has its own set of instructions, and each set is an enum of 
 `DailyTimeIntervalTriggerMisfireInstruction` and `RecurrenceTriggerMisfireInstruction`. You set one on the
 schedule builder for that family, so the only values in scope are the ones that family understands:
 
+<!-- snippet: sample_more_about_triggers_misfire_instruction -->
 ```csharp
 .WithSimpleSchedule(x => x
     .WithInterval(TimeSpan.FromMinutes(5))
     .RepeatForever()
     .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount))
 ```
+<!-- endSnippet -->
 
 Every family has `SmartPolicy`, which is the default, and `IgnoreMisfires`, which fires every missed firing as
 fast as it can once the scheduler is back. `SmartPolicy` has dynamic behaviour chosen by the trigger type and its
@@ -76,6 +78,7 @@ preventing resource-intensive jobs from starving other work.
 
 Set an execution group via `TriggerBuilder`:
 
+<!-- snippet: sample_more_about_triggers_execution_group -->
 ```csharp
 TriggerBuilder.Create()
     .WithIdentity("myTrigger")
@@ -83,6 +86,7 @@ TriggerBuilder.Create()
     // ...
     .Build();
 ```
+<!-- endSnippet -->
 
 See the [Execution Groups tutorial](execution-groups.md) for full details on configuration and usage.
 
@@ -96,6 +100,9 @@ Calendars are useful for excluding blocks of time from the trigger's firing sche
 create a trigger that fires a job every weekday at 9:30 am, but then add a Calendar that excludes all of the business's holidays.
 
 A calendar is any object implementing the `ICalendar` interface, which looks like this:
+
+<!-- Quartz's own declaration of the interface, so it is written out here rather than compiled from the
+     samples project: a second `Quartz.ICalendar` in that project would shadow the real one. -->
 
 ```csharp
 namespace Quartz
@@ -133,6 +140,7 @@ excluded from scheduling. The same calendar can be used by any number of trigger
 
 **Calendar Example**
 
+<!-- snippet: sample_more_about_triggers_calendar -->
 ```csharp
 HolidayCalendar holidays = new();
 holidays.AddExcludedDay(new DateOnly(2026, 12, 24));
@@ -164,12 +172,14 @@ ITrigger t3 = TriggerBuilder.Create()
 
 // .. schedule jobs with triggers
 ```
+<!-- endSnippet -->
 
 Any firing that would have occurred during a period the calendar excludes is skipped.
 
 Re-registering a calendar under a name that is already taken is refused unless you say so, and saying so has
 two parts, which is what `AddCalendarOptions` is for:
 
+<!-- snippet: sample_more_about_triggers_replace_calendar -->
 ```csharp
 await scheduler.AddCalendar("myHolidays", holidays, new AddCalendarOptions
 {
@@ -177,18 +187,21 @@ await scheduler.AddCalendar("myHolidays", holidays, new AddCalendarOptions
     UpdateTriggers = true, // recompute the next fire time of every trigger using it
 });
 ```
+<!-- endSnippet -->
 
 Without `UpdateTriggers`, triggers already scheduled against the old calendar keep the fire times they had
 computed; the new exclusions only take effect the next time each trigger recomputes on its own.
 
 Registering a calendar at configuration time rather than at run time is `q.AddCalendar<T>`:
 
+<!-- snippet: sample_more_about_triggers_add_calendar_at_configuration_time -->
 ```csharp
 q.AddCalendar<HolidayCalendar>("myHolidays", new AddCalendarOptions { Replace = true }, calendar =>
 {
     calendar.AddExcludedDay(new DateOnly(2026, 12, 24));
 });
 ```
+<!-- endSnippet -->
 
 See the `Quartz.Impl.Calendar` namespace for a number of `ICalendar` implementations that may suit your needs:
 `AnnualCalendar` (the same days every year), `CronCalendar`, `DailyCalendar` (a time range each day),

--- a/docs/documentation/quartz-4.x/tutorial/node-affinity.md
+++ b/docs/documentation/quartz-4.x/tutorial/node-affinity.md
@@ -45,6 +45,7 @@ protocol's own markers (`*`, `_`, `null`) are the only names `PreferredNode.For`
 
 Use `TriggerBuilder.WithPreferredNode()`:
 
+<!-- snippet: sample_node_affinity_pin -->
 ```csharp
 // Pin to a specific node
 ITrigger trigger = TriggerBuilder.Create()
@@ -54,7 +55,9 @@ ITrigger trigger = TriggerBuilder.Create()
     .WithCronSchedule("0 0/5 * * * ?")
     .Build();
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_node_affinity_auto_pin -->
 ```csharp
 // Auto-pin: the first node to fire it claims it
 ITrigger trigger = TriggerBuilder.Create()
@@ -64,16 +67,19 @@ ITrigger trigger = TriggerBuilder.Create()
     .WithCronSchedule("0 0/5 * * * ?")
     .Build();
 ```
+<!-- endSnippet -->
 
 Read it back from any `ITrigger`:
 
+<!-- snippet: sample_node_affinity_reading_the_pin -->
 ```csharp
-ITrigger t = await scheduler.GetTrigger(new TriggerKey("myTrigger"));
-PreferredNode pin = t.PreferredNode;
+ITrigger? t = await scheduler.GetTrigger(new TriggerKey("myTrigger"));
+PreferredNode pin = t!.PreferredNode;   // GetTrigger returns null when there is no such trigger
 string? node = pin.Node;         // "production-node-1"; null when unpinned or an unclaimed auto-pin
 bool auto = pin.IsAutomatic;     // false for a pin you named
 bool unpinned = pin.IsNone;
 ```
+<!-- endSnippet -->
 
 ::: warning
 The value must match the instance id **exactly**. Pin comparisons happen in SQL using the database's
@@ -95,14 +101,17 @@ This is ideal when you don't know node names at configuration time but still wan
 
 Rebuilding an auto-pinned trigger preserves the auto-claim:
 
+<!-- snippet: sample_node_affinity_rebuild -->
 ```csharp
 // The rebuilt trigger is still auto-pinned, so it will still fail over if that node dies
 ITrigger rebuilt = trigger.GetTriggerBuilder().WithDescription("updated").Build();
 ```
+<!-- endSnippet -->
 
 The pin carries its own auto-claim flag, so a pin moved from one trigger to another arrives as the pin it
 was. What you write is what you get back:
 
+<!-- snippet: sample_node_affinity_rebuild_with_new_pin -->
 ```csharp
 // a pin you named; IsAutomatic is false
 ITrigger named = trigger.GetTriggerBuilder()
@@ -114,6 +123,7 @@ ITrigger unpinned = trigger.GetTriggerBuilder()
     .WithPreferredNode(PreferredNode.None)
     .Build();
 ```
+<!-- endSnippet -->
 
 `ITrigger.PreferredNode` is read-only, like the rest of a trigger: rebuild the trigger to change it, and hand
 the result to `IScheduler.RescheduleJob` — or, for this one property on its own,
@@ -138,19 +148,23 @@ When the preferred node stops checking in:
 
 You can re-pin without rescheduling:
 
+<!-- snippet: sample_node_affinity_move_pin -->
 ```csharp
 await scheduler.UpdateTriggerDetails(
     new TriggerKey("myTrigger"),
     new TriggerDetailsUpdate().WithPreferredNode(PreferredNode.For("node-2")));
 ```
+<!-- endSnippet -->
 
 Pass `PreferredNode.None` to clear the preference entirely:
 
+<!-- snippet: sample_node_affinity_clear_pin -->
 ```csharp
 await scheduler.UpdateTriggerDetails(
     new TriggerKey("myTrigger"),
     new TriggerDetailsUpdate().WithPreferredNode(PreferredNode.None));
 ```
+<!-- endSnippet -->
 
 ## Requirements and limitations
 

--- a/docs/documentation/quartz-4.x/tutorial/querying-jobs-and-triggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/querying-jobs-and-triggers.md
@@ -53,6 +53,7 @@ part of the same query.
 Every query is a record with init-only filter properties. A null filter matches everything, and the
 filters that are set combine with **AND**:
 
+<!-- snippet: sample_querying_trigger_query -->
 ```csharp
 PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
 {
@@ -61,6 +62,7 @@ PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
     Take = 50,
 });
 ```
+<!-- endSnippet -->
 
 | Query | Filters |
 |---|---|
@@ -83,10 +85,12 @@ The matcher text is a literal, not a pattern: a group named `50%` is selected by
 `Matchers` is the entry point when you would rather not spell the generic argument, and it is where
 the combinators live:
 
+<!-- snippet: sample_querying_combining_matchers -->
 ```csharp
 IMatcher<JobKey> notArchived = Matchers.Group<JobKey>(StringOperator.StartsWith, "archive-").Not();
 IMatcher<TriggerKey> either = Matchers.Key(triggerKey).Or(Matchers.AllTriggers());
 ```
+<!-- endSnippet -->
 
 `Matchers.AllJobs()` and `Matchers.AllTriggers()` return `EverythingMatcher<TKey>`, `Matchers.Key(key)`
 matches one key exactly, and `And`, `Or` and `Not` are extension methods on `IMatcher<TKey>`.
@@ -101,6 +105,7 @@ Results are ordered by group and then name, ordinal, on every store. That is wha
 deterministic: `Skip` and `Take` are offsets into one stable ordering, so page 3 is page 3 whichever
 node answers.
 
+<!-- snippet: sample_querying_paging -->
 ```csharp
 PagedResult<JobHeader> page = await scheduler.QueryJobs(new JobQuery
 {
@@ -108,14 +113,17 @@ PagedResult<JobHeader> page = await scheduler.QueryJobs(new JobQuery
     Take = pageSize,
 });
 ```
+<!-- endSnippet -->
 
 `Take` defaults to `PagedQuery.DefaultTake`, which is **250**. An unpaged call therefore cannot
 accidentally materialize a hundred thousand rows; `PagedResult<T>.HasMore` tells you whether anything
 was left out. Ask for everything explicitly:
 
+<!-- snippet: sample_querying_everything -->
 ```csharp
 JobQuery everything = new() { Take = int.MaxValue };
 ```
+<!-- endSnippet -->
 
 ::: warning Changed in 4.x
 In the 4.0 previews `Take` defaulted to `int.MaxValue`. Code that built a query without setting `Take`
@@ -126,6 +134,7 @@ and expected the whole result now gets the first 250 items with `HasMore = true`
 `HasMore` is exact and effectively free — the stores read one row past `Take` to answer it.
 `TotalCount` is `null` unless you ask for it, because on a persistent store it costs a second query:
 
+<!-- snippet: sample_querying_total_count -->
 ```csharp
 PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
 {
@@ -135,12 +144,14 @@ PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
 
 int total = page.TotalCount!.Value;   // non-null because IncludeTotalCount was set
 ```
+<!-- endSnippet -->
 
 ### Counting without rows
 
 `GetNumberOfJobs`, `GetNumberOfTriggers` and `GetNumberOfCalendars` are gone. A count is a query that
 asks for no rows:
 
+<!-- snippet: sample_querying_count_only -->
 ```csharp
 PagedResult<JobHeader> count = await scheduler.QueryJobs(new JobQuery
 {
@@ -150,6 +161,7 @@ PagedResult<JobHeader> count = await scheduler.QueryJobs(new JobQuery
 
 int jobCount = count.TotalCount!.Value;
 ```
+<!-- endSnippet -->
 
 `Take = 0` is valid and returns an empty `Items`; the stores recognize the combination and run the
 count query alone. The same idiom counts anything the family can select — triggers in the error state,
@@ -160,12 +172,14 @@ calendars whose name starts with a prefix, firings on one node.
 A listing gives you headers. When the user opens a row, or a script needs the actual objects, fetch
 them by key in one round trip rather than in a loop:
 
+<!-- snippet: sample_querying_headers_to_details -->
 ```csharp
 List<JobKey> keys = page.Items.Select(h => h.Key).ToList();
 List<IJobDetail> details = await scheduler.GetJobDetails(keys);
 
 List<ITrigger> triggers = await scheduler.GetTriggers(triggerKeys);
 ```
+<!-- endSnippet -->
 
 Keys that do not exist are simply absent from the result — a bulk fetch is not an existence check, and
 it does not throw for a key that has been deleted since the listing ran. `Exists(JobKey)` and
@@ -181,6 +195,7 @@ it does not throw for a key that has been deleted since the listing ran. `Exists
 whole `IJobExecutionContext` objects, and it had no filter and no paging. `QueryFireInstances` replaces
 it, and because it is store-backed it covers the whole cluster on a persistent store:
 
+<!-- snippet: sample_querying_fire_instances -->
 ```csharp
 PagedResult<FireInstance> running = await scheduler.QueryFireInstances(new FireInstanceQuery
 {
@@ -192,6 +207,7 @@ foreach (FireInstance fire in running.Items)
     Console.WriteLine($"{fire.TriggerKey} on {fire.SchedulerInstanceId} since {fire.FireTimeUtc:O}");
 }
 ```
+<!-- endSnippet -->
 
 A `FireInstance` carries `FireInstanceId`, `TriggerKey`, `JobKey`, `SchedulerInstanceId`, `State`,
 `FireTimeUtc`, `ScheduledFireTimeUtc` and `ExecutionGroup`.
@@ -201,10 +217,12 @@ family with a **non-null default**. A `FireInstanceQuery` that says nothing abou
 running, because that is the question the query is usually asked. Set `State = null` to include
 firings that a node has reserved but not yet started:
 
+<!-- snippet: sample_querying_fire_instance_state -->
 ```csharp
 FireInstanceQuery reservedAndRunning = new() { State = null };
 FireInstanceQuery reservedOnly = new() { State = FireInstanceState.Acquired };
 ```
+<!-- endSnippet -->
 
 `JobKey` is nullable for the same reason: an `Acquired` firing has not resolved its job yet. That also
 means a query filtered by `Job` never matches a reservation, so combining `Job` with `State = null`
@@ -256,15 +274,18 @@ the pause runs, and records the group, but does not impose the pause on jobs add
 
 Pausing and resuming by matcher tells you which groups it touched:
 
+<!-- snippet: sample_querying_pause_triggers -->
 ```csharp
 List<string> pausedGroups = await scheduler.PauseTriggers(
     GroupMatcher<TriggerKey>.GroupStartsWith("nightly-"));
 ```
+<!-- endSnippet -->
 
 ## A worked example: an admin list screen
 
 Page size, a state filter, a total for the pager, and full detail only for the row that was opened:
 
+<!-- snippet: sample_querying_trigger_list_model -->
 ```csharp
 public sealed class TriggerListModel(IScheduler scheduler)
 {
@@ -296,6 +317,7 @@ public sealed class TriggerListModel(IScheduler scheduler)
         scheduler.GetTriggers(keys, cancellationToken);
 }
 ```
+<!-- endSnippet -->
 
 Nothing here loops over keys, and nothing loads a `JobDataMap` the list does not show.
 

--- a/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
+++ b/docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md
@@ -47,6 +47,7 @@ occurrence counting.
 
 **Every 2nd Monday of the month at 9:00 AM:**
 
+<!-- snippet: sample_recurrencetrigger_second_monday -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("monthlyTrigger", "group1")
@@ -54,9 +55,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .StartAt(DateBuilder.Create().InYear(2025).InMonthOnDay(1, 1).AtHourMinuteAndSecond(9, 0, 0).Build())
     .Build();
 ```
+<!-- endSnippet -->
 
 **Every other week on Monday, Wednesday, and Friday:**
 
+<!-- snippet: sample_recurrencetrigger_every_other_week -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("weeklyTrigger", "group1")
@@ -64,9 +67,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .StartNow()
     .Build();
 ```
+<!-- endSnippet -->
 
 **Last weekday of March each year:**
 
+<!-- snippet: sample_recurrencetrigger_last_weekday_of_march -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("yearlyTrigger", "group1")
@@ -74,9 +79,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .StartNow()
     .Build();
 ```
+<!-- endSnippet -->
 
 **Every day, but only on weekdays (skip weekends):**
 
+<!-- snippet: sample_recurrencetrigger_every_weekday -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("weekdayTrigger", "group1")
@@ -84,9 +91,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .StartNow()
     .Build();
 ```
+<!-- endSnippet -->
 
 **Last day of every month:**
 
+<!-- snippet: sample_recurrencetrigger_last_day_of_month -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("lastDayTrigger", "group1")
@@ -94,9 +103,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .StartNow()
     .Build();
 ```
+<!-- endSnippet -->
 
 **Every 3 months on the 1st and 15th, limited to 10 occurrences:**
 
+<!-- snippet: sample_recurrencetrigger_quarterly -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("quarterlyTrigger", "group1")
@@ -104,12 +115,14 @@ ITrigger trigger = TriggerBuilder.Create()
     .StartNow()
     .Build();
 ```
+<!-- endSnippet -->
 
 ## Time Zone Support
 
 By default, recurrence calculations use the system's local time zone. You can specify a different time zone
 using the builder's `InTimeZone` method:
 
+<!-- snippet: sample_recurrencetrigger_in_time_zone -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger1", "group1")
@@ -118,11 +131,13 @@ ITrigger trigger = TriggerBuilder.Create()
     .StartNow()
     .Build();
 ```
+<!-- endSnippet -->
 
 ## DI / Hosted Service Configuration
 
 When using `AddQuartz()` for dependency injection, configure a recurrence trigger with `WithRecurrenceSchedule`:
 
+<!-- snippet: sample_recurrencetrigger_under_di -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -134,6 +149,7 @@ services.AddQuartz(q =>
         .StartNow());
 });
 ```
+<!-- endSnippet -->
 
 ## RecurrenceTrigger Misfire Instructions
 
@@ -146,6 +162,7 @@ plus the generic one every family has. They live on the `RecurrenceTriggerMisfir
 
 If the `SmartPolicy` instruction is used (the default), RecurrenceTrigger will use `FireAndProceed`.
 
+<!-- snippet: sample_recurrencetrigger_misfire_instruction -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger1", "group1")
@@ -153,6 +170,7 @@ ITrigger trigger = TriggerBuilder.Create()
         .WithMisfireInstruction(RecurrenceTriggerMisfireInstruction.DoNothing))
     .Build();
 ```
+<!-- endSnippet -->
 
 ## When to Use RecurrenceTrigger vs Other Triggers
 

--- a/docs/documentation/quartz-4.x/tutorial/scheduler-listeners.md
+++ b/docs/documentation/quartz-4.x/tutorial/scheduler-listeners.md
@@ -18,6 +18,9 @@ Quartz can get in unpredictable state when it is unable to determine whether req
 
 __The ISchedulerListener Interface__
 
+<!-- Quartz's own declaration of the interface, so it is written out here rather than compiled from the
+     samples project: a second `Quartz.ISchedulerListener` in that project would shadow the real one. -->
+
 ```csharp
 public interface ISchedulerListener
 {
@@ -56,26 +59,32 @@ instances of one type with the same scheduler.
 
 __Adding a SchedulerListener:__
 
+<!-- snippet: sample_scheduler_listeners_add -->
 ```csharp
 scheduler.ListenerManager.AddSchedulerListener(mySchedListener);
 ```
+<!-- endSnippet -->
 
 __Removing a SchedulerListener:__
 
+<!-- snippet: sample_scheduler_listeners_remove -->
 ```csharp
 scheduler.ListenerManager.RemoveSchedulerListener(mySchedListener.Name);
 ```
+<!-- endSnippet -->
 
 A listener that belongs to the application, rather than to a moment in its run, is better registered where the
 scheduler is configured — it is then constructed from the container, and it is in place before the scheduler
 starts, so it hears the starting and started notifications too:
 
+<!-- snippet: sample_scheduler_listeners_under_di -->
 ```csharp
 builder.AddQuartz(q =>
 {
     q.AddSchedulerListener<AuditSchedulerListener>();
 });
 ```
+<!-- endSnippet -->
 
 There are overloads for an instance you built yourself and for a factory over the service provider, matching
 [the ones for job and trigger listeners](trigger-and-job-listeners.md#registering-listeners-with-the-container).

--- a/docs/documentation/quartz-4.x/tutorial/simpletriggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/simpletriggers.md
@@ -34,14 +34,16 @@ SimpleTrigger instances are built using `TriggerBuilder` (for the trigger's main
 
 __Build a trigger for a specific moment in time, with no repeats:__
 
+<!-- snippet: sample_simpletriggers_one_shot -->
 ```csharp
 // trigger builder creates simple trigger by default
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger1", "group1")
-    .StartAt(myStartTime) // some Date 
+    .StartAt(myStartTime) // some Date
     .ForJob("job1", "group1") // identify job with name, group strings
     .Build();
 ```
+<!-- endSnippet -->
 
 The trigger family interfaces (`ISimpleTrigger` and friends) are read models: cast to one to *inspect*
 a trigger's schedule, never to change it. To change a schedule, rebuild the trigger with
@@ -49,6 +51,7 @@ a trigger's schedule, never to change it. To change a schedule, rebuild the trig
 
 __Build a trigger for a specific moment in time, then repeating every ten seconds ten times:__
 
+<!-- snippet: sample_simpletriggers_repeat_ten_times -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger3", "group1")
@@ -56,13 +59,14 @@ ITrigger trigger = TriggerBuilder.Create()
     .WithSimpleSchedule(x => x
         .WithInterval(TimeSpan.FromSeconds(10))
         .WithRepeatCount(10)) // note that 10 repeats will give a total of 11 firings
-    .ForJob(myJob) // identify job with handle to its JobDetail itself                   
+    .ForJob(myJob) // identify job with handle to its JobDetail itself
     .Build();
-
 ```
+<!-- endSnippet -->
 
 __Build a trigger that will fire once, five minutes in the future:__
 
+<!-- snippet: sample_simpletriggers_five_minutes_from_now -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger5", "group1")
@@ -70,9 +74,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .ForJob(myJobKey) // identify job with its JobKey
     .Build();
 ```
+<!-- endSnippet -->
 
 __Build a trigger that will fire now, then repeat every five minutes, until the hour 22:00:__
 
+<!-- snippet: sample_simpletriggers_repeat_until_end_time -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger7", "group1")
@@ -82,9 +88,11 @@ ITrigger trigger = TriggerBuilder.Create()
     .EndAt(DateBuilder.Create().AtHourMinuteAndSecond(22, 0, 0).Build())
     .Build();
 ```
+<!-- endSnippet -->
 
 __Build a trigger that will fire at the top of the next hour, then repeat every 2 hours, forever:__
 
+<!-- snippet: sample_simpletriggers_every_two_hours -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger8") // because group is not specified, "trigger8" will be in the default group
@@ -92,12 +100,13 @@ ITrigger trigger = TriggerBuilder.Create()
     .WithSimpleSchedule(x => x
         .WithInterval(TimeSpan.FromHours(2))
         .RepeatForever())
-    // note that in this example, 'forJob(..)' is not called 
-    //  - which is valid if the trigger is passed to the scheduler along with the job  
+    // note that in this example, 'ForJob(..)' is not called
+    //  - which is valid if the trigger is passed to the scheduler along with the job
     .Build();
 
 await scheduler.ScheduleJob(job, trigger);
 ```
+<!-- endSnippet -->
 
 Spend some time looking at all of the available methods in the language defined by `TriggerBuilder` and its extension method `WithSimpleSchedule`
 so that you can be familiar with options available to you that may not have been demonstrated in the examples above.
@@ -135,6 +144,7 @@ the rest of the schedule is not what anyone means by it. The behaviour lives in
 
 When building SimpleTriggers, you specify the misfire instruction as part of the simple schedule (via `SimpleScheduleBuilder`):
 
+<!-- snippet: sample_simpletriggers_misfire_instruction -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger7", "group1")
@@ -144,3 +154,4 @@ ITrigger trigger = TriggerBuilder.Create()
         .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount))
     .Build();
 ```
+<!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
+++ b/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
@@ -9,6 +9,7 @@ its own lifecycle management — all of them want a scheduler and none of them h
 `QuartzSchedulerBuilder` is for those. It creates a container of its own, configures the scheduler with
 the *same* API `AddQuartz` uses, and hands back something you can dispose.
 
+<!-- snippet: sample_standalone_scheduler -->
 ```csharp
 IScheduler scheduler = await QuartzSchedulerBuilder.Create()
     .ConfigureScheduler(o => o.InstanceName = "reporting")
@@ -18,6 +19,7 @@ IScheduler scheduler = await QuartzSchedulerBuilder.Create()
 
 await scheduler.Start();
 ```
+<!-- endSnippet -->
 
 ## One configuration API, two entry points
 
@@ -35,12 +37,14 @@ Learn the configuration API once and it works in both places. Only three members
 
 Every configuration member returns `QuartzSchedulerBuilder`, so the whole thing is one expression:
 
+<!-- snippet: sample_standalone_one_expression -->
 ```csharp
 await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
     .UseInMemoryStore()
     .UseDefaultThreadPool(10)
     .Build();
 ```
+<!-- endSnippet -->
 
 ::: warning Changed in 4.x
 In the 4.0 previews the configuration members returned `IQuartzBuilder`, so a chain had to be broken up
@@ -52,14 +56,20 @@ and the builder held in a variable to reach `Build()`. The returns are covariant
 
 Two endings, for two different needs:
 
+<!-- snippet: sample_standalone_build_scheduler_ending -->
 ```csharp
 // I want the scheduler
 IScheduler scheduler = await QuartzSchedulerBuilder.Create().UseInMemoryStore().BuildScheduler();
+```
+<!-- endSnippet -->
 
+<!-- snippet: sample_standalone_build_ending -->
+```csharp
 // I want to own the lifetime
 await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create().UseInMemoryStore().Build();
 IScheduler scheduler = await factory.GetScheduler();
 ```
+<!-- endSnippet -->
 
 `BuildScheduler()` is `Build().GetScheduler()`, and it drops the factory on the floor — which is fine
 for a process whose scheduler lives as long as the process, and wrong for anything that has to clean
@@ -77,6 +87,7 @@ registered services. That is the order the hosted service uses when an applicati
 way round for a reason: a container disposed underneath a running scheduler leaves it firing triggers
 whose jobs it can no longer build.
 
+<!-- snippet: sample_standalone_factory_owns_the_container -->
 ```csharp
 await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
     .UseInMemoryStore()
@@ -89,6 +100,7 @@ await scheduler.Start();
 
 // leaving the scope shuts the scheduler down, then disposes the container
 ```
+<!-- endSnippet -->
 
 Prefer `await using`. The synchronous `Dispose()` exists so the type fits `using` in code that cannot
 be async; it blocks on the same shutdown, which is all a synchronous door onto asynchronous work can do.
@@ -97,9 +109,11 @@ The shutdown does not wait for running jobs to finish, which is the default that
 `QuartzHostedServiceOptions.WaitForJobsToComplete` and `IScheduler.Shutdown()` both carry. Say so
 yourself when you want to wait, and dispose afterwards — disposal then finds nothing left to shut down:
 
+<!-- snippet: sample_standalone_wait_for_jobs -->
 ```csharp
 await scheduler.Shutdown(waitForJobsToComplete: true);
 ```
+<!-- endSnippet -->
 
 Disposing twice does nothing the second time, and disposing a factory whose `GetScheduler()` was never
 called does nothing at all: a scheduler is never built merely to be torn down.
@@ -126,26 +140,37 @@ new factory instead. `Standby()` / `Start()` is the pause-and-resume pair.
 
 The `IQuartzBuilder` extension methods work here unchanged:
 
+<!-- snippet: sample_standalone_jobs_triggers_and_calendars -->
 ```csharp
-await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
-    .UseInMemoryStore()
+QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create().UseInMemoryStore();
+
+builder
     .AddJob<ReportJob>(j => j.WithIdentity("nightly", "reports").StoreDurably())
     .AddTrigger<ReportJob>(t => t
         .ForJob("nightly", "reports")
         .WithIdentity("nightly-trigger", "reports")
         .WithCronSchedule("0 30 2 * * ?"))
-    .AddCalendar<HolidayCalendar>("holidays", configure: c => c.AddExcludedDay(new DateOnly(2026, 12, 25)))
-    .Build();
+    .AddCalendar<HolidayCalendar>("holidays", configure: c => c.AddExcludedDay(new DateOnly(2026, 12, 25)));
+
+await using StandaloneSchedulerFactory factory = builder.Build();
 ```
+<!-- endSnippet -->
+
+`AddJob`, `AddTrigger`, `ScheduleJob` and `AddCalendar` are extension methods over `IQuartzBuilder`, and
+they return `IQuartzBuilder` rather than the builder's own type — so `Build()` comes off the variable
+rather than off the end of that chain. The interface's own members are covariant, so a chain made only
+of those still ends in `Build()`.
 
 Jobs declared this way are registered with the container, so they can take constructor dependencies:
 
+<!-- snippet: sample_standalone_registering_services -->
 ```csharp
 QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create();
 builder.Services.AddSingleton<IReportRenderer, PdfReportRenderer>();
 builder.Services.AddHttpClient();
 builder.UseInMemoryStore().AddJob<ReportJob>(j => j.WithIdentity("nightly"));
 ```
+<!-- endSnippet -->
 
 `Services` is a real `IServiceCollection`. Anything you would register in an application container you
 can register here.
@@ -157,6 +182,7 @@ exactly the way a host does — hierarchical `Scheduler` and `ThreadPool` sectio
 options, a `Schedule` section becomes jobs and triggers, and flat `quartz.*` keys still mean what they
 always meant:
 
+<!-- snippet: sample_standalone_configuration -->
 ```csharp
 IConfiguration configuration = new ConfigurationBuilder()
     .AddJsonFile("appsettings.json")
@@ -167,10 +193,12 @@ await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
     .UseConfiguration(configuration.GetSection("Quartz"))
     .Build();
 ```
+<!-- endSnippet -->
 
 `UseProperties` is the flat-key path, for a properties file or an environment-derived bag — the shape
 `StdSchedulerFactory` took:
 
+<!-- snippet: sample_standalone_properties -->
 ```csharp
 NameValueCollection properties = new()
 {
@@ -180,6 +208,7 @@ NameValueCollection properties = new()
 
 QuartzSchedulerBuilder.Create().UseProperties(properties);
 ```
+<!-- endSnippet -->
 
 There is also an overload taking `IEnumerable<KeyValuePair<string, string?>>`, which is the shape a
 `Dictionary<string, string?>` and `QuartzOptions.Properties` already have.
@@ -197,6 +226,7 @@ bag.
 
 Nothing about persistence needs a host:
 
+<!-- snippet: sample_standalone_persistent_and_clustered -->
 ```csharp
 await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
     .ConfigureScheduler(o =>
@@ -212,6 +242,7 @@ await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
     })
     .Build();
 ```
+<!-- endSnippet -->
 
 The dialect methods — `UseSqlServer`, `UsePostgres`, `UseMySql`, `UseMySqlConnector`, `UseSqlite`,
 `UseSystemDataSqlite`, `UseOracle`, `UseFirebird`, `UseGenericDatabase` — each take either a connection
@@ -234,6 +265,7 @@ That is what makes parallel tests safe, and it is occasionally not what you want
 points genuinely must share one repository, register a shared instance before building — Quartz's own
 registration is `TryAdd`, so yours wins:
 
+<!-- snippet: sample_standalone_shared_repository -->
 ```csharp
 ISchedulerRepository shared = new SchedulerRepository();
 
@@ -243,6 +275,7 @@ first.Services.AddSingleton(shared);
 QuartzSchedulerBuilder second = QuartzSchedulerBuilder.Create();
 second.Services.AddSingleton(shared);
 ```
+<!-- endSnippet -->
 
 ## What the container-first path adds
 

--- a/docs/documentation/quartz-4.x/tutorial/testing.md
+++ b/docs/documentation/quartz-4.x/tutorial/testing.md
@@ -2,6 +2,12 @@
 title: 'Testing'
 ---
 
+<!-- The blocks on this page without a `snippet:` marker are hand-written on purpose. Compiling a test
+     means a test framework, an assertion library, `Microsoft.Extensions.TimeProvider.Testing` and
+     `Microsoft.AspNetCore.Mvc.Testing` as dependencies of the documentation-samples project, and a
+     NuGet dependency taken purely for a documentation sample is not worth it. Everything here that
+     compiles against Quartz alone is a snippet. -->
+
 Scheduling code is unusually easy to test badly. A test that starts a scheduler, sleeps two seconds and
 asserts that a counter moved is a test that passes on your laptop and fails in CI, and the fix people
 reach for — a longer sleep — makes the suite slower without making it correct.
@@ -171,6 +177,7 @@ from `context.Scheduler.Context`.
 When the thing under test is the *wiring* — that a trigger reaches a job, that a listener vetoes, that
 `[DisallowConcurrentExecution]` does what it says — run a real scheduler in memory:
 
+<!-- snippet: sample_testing_in_memory_scheduler -->
 ```csharp
 await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
     .UseInMemoryStore()
@@ -180,6 +187,7 @@ await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
 IScheduler scheduler = await factory.GetScheduler();
 await scheduler.Start();
 ```
+<!-- endSnippet -->
 
 `BuildScheduler()` is the shortcut when you do not need the factory, but hold the factory in a test:
 disposing it is what shuts the scheduler down and releases its container.
@@ -190,6 +198,7 @@ The one rule that makes level 2 reliable: **the job tells the test when it is do
 `TaskCompletionSource` on a listener is the tidiest form, and because `IJobListener` has a default
 implementation for every member you only write the one you need:
 
+<!-- snippet: sample_testing_completion_listener -->
 ```csharp
 internal sealed class CompletionListener : IJobListener
 {
@@ -208,6 +217,7 @@ internal sealed class CompletionListener : IJobListener
     }
 }
 ```
+<!-- endSnippet -->
 
 ```csharp
 CompletionListener listener = new();
@@ -291,9 +301,11 @@ await scheduler.ScheduleJob(detail, trigger);   // this both schedules and wakes
 
 Where there is nothing natural to signal, shorten the wait instead:
 
+<!-- snippet: sample_testing_idle_wait_time -->
 ```csharp
 .ConfigureScheduler(o => o.IdleWaitTime = TimeSpan.FromSeconds(1))
 ```
+<!-- endSnippet -->
 
 One second is the minimum the option validator accepts; the default is thirty. The misfire handler and
 the cluster manager have the same property — they compute on the `TimeProvider` but wake on their own
@@ -307,11 +319,13 @@ timing, which is the thing the fake clock was supposed to remove.
 Misfire is a comparison between a trigger's scheduled time and now, so a fake clock plus a small
 threshold makes it reachable:
 
+<!-- snippet: sample_testing_misfire_threshold -->
 ```csharp
 QuartzSchedulerBuilder.Create()
     .UseInMemoryStore(o => o.MisfireThreshold = TimeSpan.FromMilliseconds(50))
     .UseTimeProvider(clock)
 ```
+<!-- endSnippet -->
 
 The in-memory store's threshold defaults to five seconds, the ADO store's to one minute, and both must
 be at least one millisecond. Put the scheduler in standby, move the clock past the fire time, then start
@@ -321,6 +335,7 @@ it — the trigger is late by construction, with no sleeping involved.
 
 `DelegatingJobStore` is public, non-sealed and virtual throughout, for exactly this:
 
+<!-- snippet: sample_testing_flaky_job_store -->
 ```csharp
 internal sealed class FlakyJobStore(IJobStore inner) : DelegatingJobStore(inner)
 {
@@ -340,11 +355,14 @@ internal sealed class FlakyJobStore(IJobStore inner) : DelegatingJobStore(inner)
     }
 }
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_testing_fault_injection_registration -->
 ```csharp
 QuartzSchedulerBuilder.Create()
     .UseJobStore(sp => new FlakyJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(sp)))
 ```
+<!-- endSnippet -->
 
 Counting, stalling and failing store calls is how you test retry and backoff behaviour without a
 database. `DelegatingScheduler` is the same idea one layer up.

--- a/docs/documentation/quartz-4.x/tutorial/time-and-timeprovider.md
+++ b/docs/documentation/quartz-4.x/tutorial/time-and-timeprovider.md
@@ -27,18 +27,22 @@ on a fake clock.
 
 One call, on either builder:
 
+<!-- snippet: sample_time_provider_registration -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
     q.UseTimeProvider(myTimeProvider);
 });
 ```
+<!-- endSnippet -->
 
+<!-- snippet: sample_time_provider_standalone -->
 ```csharp
 IScheduler scheduler = await QuartzSchedulerBuilder.Create()
     .UseTimeProvider(myTimeProvider)
     .BuildScheduler();
 ```
+<!-- endSnippet -->
 
 ### Precedence
 
@@ -82,6 +86,8 @@ component belongs to.
 
 Exactly one builder takes a clock:
 
+<!-- A listing of signatures rather than code, so it is written out here rather than compiled. -->
+
 ```csharp
 TriggerBuilder.Create(TimeProvider? timeProvider = null);
 TriggerBuilder.Create<TJob>(TimeProvider? timeProvider = null);
@@ -94,6 +100,7 @@ that does this — is computed against the same clock.
 
 The five schedule builders take **no** clock:
 
+<!-- snippet: sample_time_provider_schedule_builders -->
 ```csharp
 CronScheduleBuilder.Create(cronExpression);
 SimpleScheduleBuilder.Create();
@@ -101,16 +108,19 @@ CalendarIntervalScheduleBuilder.Create();
 DailyTimeIntervalScheduleBuilder.Create();
 RecurrenceScheduleBuilder.Create(recurrenceRule);
 ```
+<!-- endSnippet -->
 
 They describe a *shape* — every day at 09:00, every 15 minutes, the third Tuesday — and a shape needs
 no clock. When one of them does need "now", it gets it from the trigger builder.
 
 `DateBuilder` has two statics, both taking an optional clock:
 
+<!-- snippet: sample_time_provider_date_builder -->
 ```csharp
 DateTimeOffset when = DateBuilder.Create(timeProvider).InYear(2027).InMonthOnDay(3, 15).AtHourOfDay(9).Build();
 DateTimeOffset local = DateBuilder.CreateInTimeZone(tz, timeProvider).AtHourMinuteAndSecond(9, 30, 0).Build();
 ```
+<!-- endSnippet -->
 
 ::: warning Changed in 4.x
 `DateBuilder.NewDate` / `NewDateInTimeZone` are now `Create` / `CreateInTimeZone`, and
@@ -127,6 +137,7 @@ The DI configuration path threads the container's clock through for you. Both
 `TriggerBuilder.Create<TJob>(serviceProvider.GetService<TimeProvider>())`, so a trigger configured
 there starts on the scheduler's clock:
 
+<!-- snippet: sample_time_provider_configured_trigger -->
 ```csharp
 builder.Services.AddQuartz(q =>
 {
@@ -137,9 +148,11 @@ builder.Services.AddQuartz(q =>
         .WithSimpleSchedule(s => s.WithInterval(TimeSpan.FromHours(1)).RepeatForever()));
 });
 ```
+<!-- endSnippet -->
 
 A trigger you build yourself does not:
 
+<!-- snippet: sample_time_provider_wall_clock_trigger -->
 ```csharp
 // StartTimeUtc is the WALL CLOCK, whatever the scheduler's TimeProvider says
 ITrigger trigger = TriggerBuilder.Create()
@@ -147,10 +160,12 @@ ITrigger trigger = TriggerBuilder.Create()
     .WithSimpleSchedule(s => s.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
     .Build();
 ```
+<!-- endSnippet -->
 
 This is the single most common surprise in a fake-clock test: the scheduler is on 2024-01-01, the
 trigger says it starts *now*, and now is whenever the test ran. Pass the clock:
 
+<!-- snippet: sample_time_provider_trigger_builder_clock -->
 ```csharp
 ITrigger trigger = TriggerBuilder.Create(fakeClock)
     .WithIdentity("hourly")
@@ -158,6 +173,7 @@ ITrigger trigger = TriggerBuilder.Create(fakeClock)
     .WithSimpleSchedule(s => s.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
     .Build();
 ```
+<!-- endSnippet -->
 
 An explicit `StartAt` sidesteps the question entirely, which is why it is worth being explicit in tests
 even when you would not bother in production code.
@@ -175,11 +191,13 @@ one.
 `TimeProvider` answers *what instant is it*. `TimeZoneInfo` answers *what does that instant look like
 where the schedule lives*. They are independent, and a fake clock does not fake a time zone.
 
+<!-- snippet: sample_time_provider_time_zone -->
 ```csharp
 TriggerBuilder.Create()
     .WithCronSchedule("0 0 9 * * ?", x => x.InTimeZone(TimeZones.FindById("Europe/Helsinki")))
     .Build();
 ```
+<!-- endSnippet -->
 
 `TimeZones` has three members:
 
@@ -211,6 +229,9 @@ Daylight saving is where the two axes meet, and each trigger family answers it d
 ## Testing with a fake clock
 
 `Microsoft.Extensions.TimeProvider.Testing` gives you `FakeTimeProvider`:
+
+<!-- Not a compiled sample: `FakeTimeProvider` comes from `Microsoft.Extensions.TimeProvider.Testing`,
+     which this repository does not reference outside its test projects. -->
 
 ```csharp
 FakeTimeProvider clock = new(new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero));

--- a/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
+++ b/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
@@ -18,6 +18,9 @@ Jobs can get stuck after Quartz is unable to determine whether required logic in
 
 __The ITriggerListener Interface__
 
+<!-- Quartz's own declaration of the interface, so it is written out here rather than compiled from the
+     samples project: a second `Quartz.ITriggerListener` in that project would shadow the real one. -->
+
 ```csharp
 public interface ITriggerListener
 {
@@ -39,6 +42,9 @@ is about to do with the trigger, from `NoInstruction` through `SetTriggerComplet
 Job-related events include: a notification that the job is about to be executed, and a notification when the job has completed execution.
 
 __The IJobListener Interface__
+
+<!-- Quartz's own declaration of the interface, so it is written out here rather than compiled from the
+     samples project: a second `Quartz.IJobListener` in that project would shadow the real one. -->
 
 ```csharp
 public interface IJobListener
@@ -75,28 +81,36 @@ Hence, each time your application runs, the listeners need to be re-registered w
 
 __Adding a JobListener that is interested in a particular job:__
 
+<!-- snippet: sample_job_listeners_match_one_job -->
 ```csharp
 scheduler.ListenerManager.AddJobListener(myJobListener, Matchers.Key(new JobKey("myJobName", "myJobGroup")));
 ```
+<!-- endSnippet -->
 
 __Adding a JobListener that is interested in all jobs of a particular group:__
 
+<!-- snippet: sample_job_listeners_match_a_group -->
 ```csharp
 scheduler.ListenerManager.AddJobListener(myJobListener, GroupMatcher<JobKey>.GroupEquals("myJobGroup"));
 ```
+<!-- endSnippet -->
 
 __Adding a JobListener that is interested in all jobs of two particular groups:__
 
+<!-- snippet: sample_job_listeners_match_two_groups -->
 ```csharp
 scheduler.ListenerManager.AddJobListener(myJobListener,
- GroupMatcher<JobKey>.GroupEquals("myJobGroup").Or(GroupMatcher<JobKey>.GroupEquals("yourGroup")));
+    GroupMatcher<JobKey>.GroupEquals("myJobGroup").Or(GroupMatcher<JobKey>.GroupEquals("yourGroup")));
 ```
+<!-- endSnippet -->
 
 __Adding a JobListener that is interested in all jobs:__
 
+<!-- snippet: sample_job_listeners_match_every_job -->
 ```csharp
 scheduler.ListenerManager.AddJobListener(myJobListener, Matchers.AllJobs());
 ```
+<!-- endSnippet -->
 
 Passing no matcher at all means the same thing — a listener with no matchers hears about every job — so
 `AddJobListener(myJobListener)` is the shortest way to say it.
@@ -110,6 +124,7 @@ The `Matchers` class is the entry point: its static factories build the roots (`
 A listener that belongs to the application rather than to a moment in its run is registered where the
 scheduler is configured, and constructed from the container like anything else:
 
+<!-- snippet: sample_job_listeners_under_di -->
 ```csharp
 builder.AddQuartz(q =>
 {
@@ -125,6 +140,7 @@ builder.AddQuartz(q =>
     q.AddJobListener(provider => new MeteredListener(provider.GetRequiredService<IMeterFactory>()));
 });
 ```
+<!-- endSnippet -->
 
 This is the same registration the `ListenerManager` calls perform, done before the scheduler starts, which is
 what makes it survive a restart of the host without a startup hook of your own.

--- a/docs/documentation/quartz-4.x/tutorial/using-quartz.md
+++ b/docs/documentation/quartz-4.x/tutorial/using-quartz.md
@@ -21,6 +21,7 @@ of the core package — in 3.x they were the separate `Quartz.Extensions.Depende
 
 A job is a class that implements `IJob`:
 
+<!-- snippet: sample_using_quartz_job -->
 ```csharp
 public sealed class HelloJob : IJob
 {
@@ -38,6 +39,7 @@ public sealed class HelloJob : IJob
     }
 }
 ```
+<!-- endSnippet -->
 
 The job is constructed from the container for every fire, so it can take whatever the rest of your
 application takes — a logger, a `DbContext`, a typed `HttpClient`. The `cancellationToken` is the same
@@ -46,10 +48,8 @@ token as `context.CancellationToken`; pass it on to everything you await, so a s
 
 ## Configure the host
 
+<!-- snippet: sample_using_quartz_host -->
 ```csharp
-using Microsoft.Extensions.Hosting;
-using Quartz;
-
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
 builder.AddQuartz(q =>
@@ -70,6 +70,7 @@ IHost host = builder.Build();
 // blocks until the host is stopped, and then until the last running job completes
 await host.RunAsync();
 ```
+<!-- endSnippet -->
 
 `AddQuartz` registers the scheduler and everything it is made of. `AddQuartzHostedService` starts it when
 the host starts and shuts it down when the host stops; `WaitForJobsToComplete` makes shutdown wait for
@@ -85,6 +86,7 @@ Both hang off `IHostApplicationBuilder`, so the same two lines work in a web app
 taken from the trigger's. When a job has several triggers, or when the job is registered somewhere other
 than where its schedule is, name them separately:
 
+<!-- snippet: sample_using_quartz_several_triggers -->
 ```csharp
 builder.AddQuartz(q =>
 {
@@ -105,6 +107,7 @@ builder.AddQuartz(q =>
         .WithCronSchedule("0 0 9-17 ? * MON-FRI"));
 });
 ```
+<!-- endSnippet -->
 
 The type argument on `AddTrigger<TJob>` is the job the trigger fires. It is what lets the trigger's data
 be named as properties of that job — see
@@ -130,6 +133,7 @@ of the application.
 Not every schedule is known at startup, though. `IScheduler` is an ordinary service, so inject it and
 schedule whenever you like:
 
+<!-- snippet: sample_using_quartz_scheduling_at_run_time -->
 ```csharp
 public sealed class ReportRequests
 {
@@ -156,6 +160,7 @@ public sealed class ReportRequests
     }
 }
 ```
+<!-- endSnippet -->
 
 An application with several schedulers registers each under a name, and injects one by that name with
 `[FromKeyedServices("reporting")] IScheduler scheduler` — see

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -166,6 +166,7 @@ WHERE JOB_CLASS_NAME = 'OldNamespace.OldClassName, OldAssembly';
 
 ### Datasource Configuration Example
 
+<!-- snippet: sample_troubleshooting_pool_size -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -178,6 +179,7 @@ services.AddQuartz(q =>
     });
 });
 ```
+<!-- endSnippet -->
 
 ## Scheduler in Web Environments
 
@@ -191,6 +193,7 @@ By default, IIS recycles and stops application pools due to inactivity. This wil
 
 **Use the Hosted Service integration** (recommended) — Register Quartz as a hosted service so it ties into the ASP.NET Core application lifecycle:
 
+<!-- snippet: sample_troubleshooting_wait_for_jobs -->
 ```csharp
 services.AddQuartz(q =>
 {
@@ -198,6 +201,7 @@ services.AddQuartz(q =>
 });
 services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
 ```
+<!-- endSnippet -->
 
 **Run as a separate process** — For critical scheduling, consider running the scheduler in a Windows Service or Linux systemd service rather than inside a web application.
 
@@ -205,12 +209,14 @@ services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
 
 When the application shuts down, give jobs time to complete:
 
+<!-- snippet: sample_troubleshooting_wait_for_jobs_block -->
 ```csharp
 services.AddQuartzHostedService(options =>
 {
     options.WaitForJobsToComplete = true;
 });
 ```
+<!-- endSnippet -->
 
 Jobs should check `IJobExecutionContext.CancellationToken` to respond to shutdown requests promptly.
 

--- a/src/Quartz.Documentation.Samples/Configuration/ConfigurationSampleTypes.cs
+++ b/src/Quartz.Documentation.Samples/Configuration/ConfigurationSampleTypes.cs
@@ -1,0 +1,95 @@
+using System.Data.Common;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Documentation.Samples.Configuration;
+
+/// <summary>
+/// The types the configuration reference names as stand-ins for your own.
+/// </summary>
+/// <remarks>
+/// They exist only so the registrations that name them compile; none of them appears on a page.
+/// </remarks>
+public sealed class MyJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class MyThreadPoolOptions
+{
+    public int Slots { get; set; }
+}
+
+public sealed class MyThreadPool : IThreadPool
+{
+    public int PoolSize => 0;
+
+    public ValueTask<bool> Drain(CancellationToken cancellationToken = default) => default;
+
+    public ValueTask Initialize(CancellationToken cancellationToken = default) => default;
+
+    public ValueTask Shutdown(bool waitForJobsToComplete = true, CancellationToken cancellationToken = default) => default;
+
+    public ValueTask<bool> TryRun(Func<ValueTask> action, CancellationToken cancellationToken = default) => default;
+
+    public ValueTask<int> WaitForAvailableThreads(CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class MyJobFactory : IJobFactory
+{
+    public ValueTask<JobScope> CreateJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+
+    public ValueTask ReturnJob(JobScope scope, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class MySchedulerListener : ISchedulerListener;
+
+public sealed class MyJobListener : IJobListener;
+
+public sealed class MyTriggerListener : ITriggerListener;
+
+public sealed class MyDbProvider : IDbProvider
+{
+    public string ConnectionString => "";
+
+    public DbMetadata Metadata => new();
+
+    public DbCommand CreateCommand() => null!;
+
+    public DbConnection CreateConnection() => null!;
+
+    public void Shutdown()
+    {
+    }
+}
+
+/// <summary>Stands in for an ADO.NET provider's own types in the <c>DbMetadata</c> sample.</summary>
+public sealed class MyConnection;
+
+public sealed class MyCommand;
+
+public enum MyDbType
+{
+    Text = 0,
+}
+
+public sealed class MyParameter
+{
+    public MyDbType MyDbType { get; set; }
+}
+
+public sealed class MyException : Exception
+{
+    public MyException()
+    {
+    }
+
+    public MyException(string message) : base(message)
+    {
+    }
+
+    public MyException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/Quartz.Documentation.Samples/Configuration/JsonSamples.cs
+++ b/src/Quartz.Documentation.Samples/Configuration/JsonSamples.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Documentation.Samples.Configuration;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/configuration/json.md.
+/// </summary>
+/// <remarks>
+/// The page writes <c>Configuration.GetSection(…)</c>, which is how a class holding the application's
+/// configuration reads. The property below is what makes that name resolve here.
+/// </remarks>
+public static class JsonSamples
+{
+    private static IConfiguration Configuration => null!;
+
+    public static void UnderDependencyInjection(IServiceCollection services)
+    {
+        #region sample_configuration_json_with_di
+
+        services.AddQuartz(Configuration.GetSection("Quartz"), q =>
+        {
+            // Additional code-based configuration still works alongside JSON
+            q.AddJob<MyJob>(j => j.WithIdentity("codeJob").StoreDurably());
+        });
+
+        #endregion
+    }
+
+    public static void WithoutDependencyInjection()
+    {
+        #region sample_configuration_json_without_di
+
+        ISchedulerFactory factory = QuartzSchedulerBuilder.Create()
+            .UseConfiguration(Configuration.GetSection("Quartz"))
+            .Build();
+
+        #endregion
+    }
+
+    public static void SeveralNamedSchedulers(IServiceCollection services)
+    {
+        #region sample_configuration_json_named_schedulers
+
+        // Registers "Primary" and "Secondary" named schedulers automatically
+        services.AddQuartz(Configuration.GetSection("Quartz"));
+        services.AddQuartzHostedService();
+
+        #endregion
+    }
+
+    public static void OneNamedScheduler(IServiceCollection services)
+    {
+        #region sample_configuration_json_one_named_scheduler
+
+        // Both lines are equivalent
+        services.AddQuartz("Primary", Configuration.GetSection("Quartz"));
+        services.AddQuartz("Primary", Configuration.GetSection("Quartz:Schedulers:Primary"));
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Configuration/ReferenceSamples.cs
+++ b/src/Quartz.Documentation.Samples/Configuration/ReferenceSamples.cs
@@ -1,0 +1,272 @@
+using System.Collections.Specialized;
+using System.Data.Common;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Documentation.Samples.Configuration;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/configuration/reference.md.
+/// </summary>
+public static class ReferenceSamples
+{
+    public static void OneSchedulerOption(IServiceCollection services)
+    {
+        #region sample_reference_one_option
+
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.MaxBatchSize = 5));
+
+        #endregion
+    }
+
+    public static void SchedulerOptions(IServiceCollection services)
+    {
+        #region sample_reference_scheduler_options
+
+        services.AddQuartz(q => q.ConfigureScheduler(options =>
+        {
+            options.InstanceName = "core";
+            options.InstanceId = "node-1";
+            options.MaxBatchSize = 5;
+            options.ShutdownJobInterruption = ShutdownJobInterruption.Always;
+        }));
+
+        #endregion
+    }
+
+    public static void DefaultThreadPool(IServiceCollection services)
+    {
+        #region sample_reference_default_thread_pool
+
+        services.AddQuartz(q => q.UseDefaultThreadPool(maxConcurrency: 20));
+
+        #endregion
+    }
+
+    public static void ThreadPoolOfYourOwn(IServiceCollection services)
+    {
+        #region sample_reference_thread_pool_of_your_own
+
+        services.AddQuartz(q => q.UseThreadPool<MyThreadPool>());
+
+        #endregion
+    }
+
+    public static void ThreadPoolWithOptions(IServiceCollection services)
+    {
+        #region sample_reference_thread_pool_options
+
+        services.AddQuartz(q =>
+        {
+            q.ConfigureOptions<MyThreadPoolOptions>(options => options.Slots = 20);
+            q.UseThreadPool<MyThreadPool>();
+        });
+
+        #endregion
+    }
+
+    public static void InMemoryStore(IServiceCollection services)
+    {
+        #region sample_reference_in_memory_store
+
+        services.AddQuartz(q => q.UseInMemoryStore(options => options.MisfireThreshold = TimeSpan.FromSeconds(30)));
+
+        #endregion
+    }
+
+    public static void PersistentStore(IServiceCollection services, string connectionString)
+    {
+        #region sample_reference_persistent_store
+
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(connectionString);
+            store.UseSystemTextJsonSerializer();
+        }));
+
+        #endregion
+    }
+
+    public static void ConnectionStringOrName(IPersistentStoreBuilder store, string connectionString)
+    {
+        #region sample_reference_connection_string
+
+        store.UseSqlServer(connectionString);
+        store.UseSqlServer(db => db.ConnectionStringName = "Scheduler");
+
+        #endregion
+    }
+
+    public static void GenericDatabase(IPersistentStoreBuilder store, string connectionString)
+    {
+        #region sample_reference_generic_database
+
+        store.UseGenericDatabase("MyDatabase", connectionString, () => new DbMetadata
+        {
+            ProductName = "My Database",
+            AssemblyName = typeof(MyConnection).Assembly.FullName,
+            ConnectionType = typeof(MyConnection),
+            CommandType = typeof(MyCommand),
+            ParameterType = typeof(MyParameter),
+            ParameterDbType = typeof(MyDbType),
+            ParameterDbTypePropertyName = nameof(MyParameter.MyDbType),
+            ParameterNamePrefix = "@",
+            ExceptionType = typeof(MyException),
+            UseParameterNamePrefixInParameterCollection = true,
+            BindByName = true,
+            DbBinaryTypeName = "VarBinary",
+        });
+
+        #endregion
+    }
+
+    public static void DataSourceFactory(IPersistentStoreBuilder store)
+    {
+        #region sample_reference_data_source_factory
+
+        store.UsePostgres(db => db.DataSourceFactory = _ => BuildDataSource());
+
+        #endregion
+    }
+
+    public static void ConnectionProvider(IServiceCollection services, string connectionString)
+    {
+        #region sample_reference_connection_provider
+
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(connectionString);          // still selects the driver delegate
+            store.UseConnectionProvider<MyDbProvider>();   // …but connections come from here
+        }));
+
+        #endregion
+    }
+
+    public static void Clustering(IServiceCollection services, string connectionString)
+    {
+        #region sample_reference_clustering
+
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = "core";
+                options.GenerateInstanceId = true;
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer(connectionString);
+                store.UseClustering(cluster =>
+                {
+                    cluster.CheckinInterval = TimeSpan.FromSeconds(10);
+                    cluster.CheckinMisfireThreshold = TimeSpan.FromSeconds(20);
+                });
+                store.UseSystemTextJsonSerializer();
+            });
+        });
+
+        #endregion
+    }
+
+    public static void Serializers(IPersistentStoreBuilder store)
+    {
+        #region sample_reference_serializers
+
+        store.UseSystemTextJsonSerializer();
+        store.UseNewtonsoftJsonSerializer();   // Quartz.Serialization.Newtonsoft
+
+        #endregion
+    }
+
+    public static void SchedulingOptions(IServiceCollection services)
+    {
+        #region sample_reference_scheduling_options
+
+        services.Configure<QuartzOptions>(options => options.Scheduling.IgnoreDuplicates = true);
+
+        #endregion
+    }
+
+    public static void JobFactory(IServiceCollection services)
+    {
+        #region sample_reference_job_factory
+
+        services.AddQuartz(q => q.UseJobFactory<MyJobFactory>());
+
+        #endregion
+    }
+
+    public static void JobScope(IServiceCollection services)
+    {
+        #region sample_reference_job_scope
+
+        services.AddQuartz(q => q.ConfigureJobScope((scope, bundle, scheduler) => { /* … */ }));
+
+        #endregion
+    }
+
+    public static void ListenersAndPlugins(IServiceCollection services)
+    {
+        #region sample_reference_listeners_and_plugins
+
+        services.AddQuartz(q =>
+        {
+            q.AddSchedulerListener<MySchedulerListener>();
+            q.AddJobListener<MyJobListener>(GroupMatcher<JobKey>.GroupEquals("reports"));
+            q.AddTriggerListener<MyTriggerListener>();
+            q.AddPlugin<MyPlugin>();
+        });
+
+        #endregion
+    }
+
+    public static void NamedSchedulers(IServiceCollection services, string reportingDb)
+    {
+        #region sample_reference_named_schedulers
+
+        services.AddQuartz("reporting", q => q.UsePersistentStore(store => store.UseSqlServer(reportingDb)));
+        services.AddQuartz("ingest", q => q.UseInMemoryStore());
+
+        #endregion
+    }
+
+    public static async ValueTask ResolvingANamedScheduler(IServiceProvider serviceProvider)
+    {
+        #region sample_reference_resolving_a_named_scheduler
+
+        var reporting = await serviceProvider
+            .GetRequiredKeyedService<ISchedulerFactory>("reporting")
+            .GetScheduler();
+
+        #endregion
+    }
+
+    public static async ValueTask WithoutAContainer()
+    {
+        #region sample_reference_without_a_container
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "reporting")
+            .UseDefaultThreadPool(maxConcurrency: 20)
+            .UseInMemoryStore()
+            .BuildScheduler();
+
+        #endregion
+    }
+
+    public static async ValueTask FromFlatProperties(NameValueCollection properties)
+    {
+        #region sample_reference_from_flat_properties
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .UseProperties(properties)
+            .BuildScheduler();
+
+        #endregion
+    }
+
+    private static DbDataSource BuildDataSource() => null!;
+}

--- a/src/Quartz.Documentation.Samples/CronExpressionsSamples.cs
+++ b/src/Quartz.Documentation.Samples/CronExpressionsSamples.cs
@@ -1,0 +1,67 @@
+namespace Quartz.Documentation.Samples;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/cron-expressions.md.
+/// </summary>
+public static class CronExpressionsSamples
+{
+    public static void HashSeededByTriggerName()
+    {
+        #region sample_cron_expressions_hash_from_trigger_name
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("nightly-cleanup")
+            .WithCronSchedule("0 H H(0-7) * * ?")
+            .Build();
+
+        #endregion
+    }
+
+    public static void HashSeededExplicitly()
+    {
+        #region sample_cron_expressions_hash_key_on_expression
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithCronSchedule(new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup"))
+            .Build();
+
+        #endregion
+    }
+
+    public static void HashKeyOnItsOwn()
+    {
+        #region sample_cron_expressions_hash_key
+
+        var expr = new CronExpression("0 H H(0-7) * * ?", "nightly-cleanup");
+
+        #endregion
+    }
+
+    public static void BuildingAnExpression()
+    {
+        #region sample_cron_expressions_builder
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("myTrigger")
+            .WithCronSchedule(CronExpressionBuilder.Create()
+                .WithSecond(0)
+                .WithMinuteIncrements(0, 15) // every 15 minutes
+                .WithHourRange(8, 17)        // between 8:00 and 17:59
+                .OnWeekdays())               // "0 0/15 8-17 ? * MON-FRI"
+            .Build();
+
+        #endregion
+    }
+
+    public static void TheAwkwardDayRules()
+    {
+        #region sample_cron_expressions_day_rules
+
+        CronExpressionBuilder.Create().OnLastDayOfMonth();                         // "* * * L * ?"
+        CronExpressionBuilder.Create().OnNearestWeekdayOfMonth(15);                // "* * * 15W * ?"
+        CronExpressionBuilder.Create().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3); // "* * * ? * FRI#3"
+        CronExpressionBuilder.Create().OnLastDayOfWeekOfMonth(DayOfWeek.Friday);   // "* * * ? * FRIL"
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/HowTos/CustomJobStoreSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/CustomJobStoreSamples.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/custom-job-store.md.
+/// </summary>
+public static class CustomJobStoreSamples
+{
+    public static void RegisteringADecorator(IServiceCollection services)
+    {
+        services.AddQuartz(q =>
+        {
+            #region sample_custom_job_store_registering_a_decorator
+
+            q.UseJobStore(sp => new MetricsJobStore(
+                ActivatorUtilities.CreateInstance<RAMJobStore>(sp),
+                sp.GetRequiredService<IMeterFactory>()));
+
+            #endregion
+        });
+    }
+
+    public static void ResolvingTriggerState(StoredTriggerState stored, bool isExecuting)
+    {
+        #region sample_custom_job_store_trigger_state_resolver
+
+        TriggerState reported = TriggerStateResolver.Resolve(stored, isExecuting);
+
+        #endregion
+    }
+}
+
+#region sample_custom_job_store_decorator
+
+public sealed class MetricsJobStore(IJobStore inner, IMeterFactory meters) : DelegatingJobStore(inner)
+{
+    private readonly Histogram<double> acquireDuration = meters
+        .Create("App.Quartz")
+        .CreateHistogram<double>("app.quartz.acquire.duration", "s");
+
+    public override async ValueTask<List<IOperableTrigger>> AcquireNextTriggers(
+        TriggerAcquisitionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        long start = Stopwatch.GetTimestamp();
+        try
+        {
+            return await base.AcquireNextTriggers(request, cancellationToken);
+        }
+        finally
+        {
+            acquireDuration.Record(Stopwatch.GetElapsedTime(start).TotalSeconds);
+        }
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Scaffolding for the one member the page shows: <c>AdoJobStoreBase</c> has an eleven-parameter
+/// constructor its subclasses forward, and none of that belongs on the page.
+/// </summary>
+internal sealed class BudgetedJobStore(
+    ISchedulerSignaler schedulerSignaler,
+    ITypeLoader typeLoader,
+    TimeProvider timeProvider,
+    IOptions<QuartzSchedulerOptions> schedulerOptions,
+    IOptions<AdoJobStoreOptions> storeOptions,
+    IOptions<ClusteringOptions> clusteringOptions,
+    IObjectSerializer objectSerializer,
+    IDbProvider dbProvider,
+    IDriverDelegate driverDelegate)
+    : LocalTransactionJobStore(
+        schedulerSignaler,
+        typeLoader,
+        timeProvider,
+        schedulerOptions,
+        storeOptions,
+        clusteringOptions,
+        objectSerializer,
+        dbProvider,
+        driverDelegate)
+{
+    private readonly int nodeBudget = 5;
+
+    #region sample_custom_job_store_acquisition_criteria
+
+    protected override TriggerAcquisitionCriteria CreateAcquisitionCriteria(TriggerAcquisitionRequest request)
+    {
+        TriggerAcquisitionCriteria criteria = base.CreateAcquisitionCriteria(request);
+        return criteria with { MaxCount = Math.Min(criteria.MaxCount, this.nodeBudget) };
+    }
+
+    #endregion
+}

--- a/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
@@ -1,0 +1,85 @@
+using System.Data.Common;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+#region sample_dialect_delegate_subclass
+
+public sealed class MyDatabaseDelegate : StdAdoDelegate
+{
+    // override only what differs
+}
+
+#endregion
+
+/// <summary>
+/// The individual overrides the page shows, each of which would be a member of a delegate like the
+/// one above. They live on a second delegate so that each can be its own region.
+/// </summary>
+internal sealed class DialectDelegateOverrides : StdAdoDelegate
+{
+    #region sample_dialect_delegate_row_limiting
+
+    // append (PostgreSQL, Firebird)
+    protected override string GetSelectNextTriggerToAcquireSql(int maxCount)
+        => base.GetSelectNextTriggerToAcquireSql(maxCount) + " LIMIT " + maxCount;
+
+    // splice a prefix (SQL Server: SELECT TOP n)
+    // wrap the whole statement (Oracle: SELECT * FROM ( … ) WHERE rownum <= n)
+    // append with an index hint (MySQL: FORCE INDEX (…) … LIMIT n)
+
+    #endregion
+
+    #region sample_dialect_delegate_paging
+
+    protected override string ApplyPaging(string sql, bool takeLimited)
+        => takeLimited
+            ? sql + " LIMIT @pageTake OFFSET @pageSkip"
+            : sql + " LIMIT -1 OFFSET @pageSkip";
+
+    protected override void AddPagingParameters(DbCommand cmd, int skip, int take, bool takeLimited)
+    {
+        if (takeLimited)
+        {
+            AddCommandParameter(cmd, "pageTake", take);
+        }
+
+        AddCommandParameter(cmd, "pageSkip", skip);
+    }
+
+    #endregion
+
+    #region sample_dialect_delegate_booleans
+
+    public override object GetDbBooleanValue(bool booleanValue) => booleanValue ? "1" : "0";
+
+    public override bool GetBooleanFromDbValue(object columnValue) => Convert.ToInt32(columnValue) == 1;
+
+    #endregion
+}
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/dialect-delegate.md.
+/// </summary>
+public static class DialectDelegateSamples
+{
+    public static void Registration(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_dialect_delegate_registration
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(s =>
+            {
+                s.UseDriverDelegate<MyDatabaseDelegate>();
+                s.UseGenericDatabase("MyProvider", connectionString);
+            });
+        });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/HowTos/HowToSampleTypes.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/HowToSampleTypes.cs
@@ -1,0 +1,38 @@
+namespace Quartz.Documentation.Samples.HowTos;
+
+/// <summary>
+/// The services, jobs and exceptions the how-to samples name in passing.
+/// </summary>
+/// <remarks>
+/// A page that shows one of these in full wraps it in its own region; the rest are here only so the
+/// samples that name them compile.
+/// </remarks>
+public interface IOrderService
+{
+    ValueTask<int> Process(string? region, CancellationToken cancellationToken = default);
+}
+
+public interface IImportService
+{
+    ValueTask Run(CancellationToken cancellationToken = default);
+}
+
+public sealed class TransientImportException : Exception
+{
+    public TransientImportException()
+    {
+    }
+
+    public TransientImportException(string message) : base(message)
+    {
+    }
+
+    public TransientImportException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+public sealed class AnExampleJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}

--- a/src/Quartz.Documentation.Samples/HowTos/JobTemplateSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/JobTemplateSamples.cs
@@ -1,15 +1,9 @@
----
+using Microsoft.Extensions.Logging;
 
-title: Job Template
----
+namespace Quartz.Documentation.Samples.HowTos;
 
-# Job Template
+#region sample_job_template
 
-This page pulls the recommendations scattered through the documentation into one job class that can be copied
-and cut down.
-
-<!-- snippet: sample_job_template -->
-```csharp
 // one job definition at a time: a second firing waits for the one in progress
 [DisallowConcurrentExecution]
 public sealed class SampleJob : IJob
@@ -63,21 +57,5 @@ public sealed class SampleJob : IJob
         }
     }
 }
-```
-<!-- endSnippet -->
 
-A few notes on the choices in it:
-
-* **`[DisallowConcurrentExecution]`** applies per job definition, not per class, so two different job details of
-  the same class still run side by side. Leave it off for a job that is safe to overlap; a job that writes to
-  the same rows every run usually is not.
-* **`JobExecutionException`** is the exception to throw out of `Execute`. Its directives are init-only
-  properties: `RefireImmediately` re-runs the same firing, and `UnscheduleFiringTrigger` /
-  `UnscheduleAllTriggers` stop this trigger, or every trigger of the job, from firing again. Any other
-  exception is caught, logged, reported to scheduler listeners as a `JobExecutionProcessException` and wrapped
-  in a `JobExecutionException` with none of those flags set — so the failure is visible, but the schedule
-  simply carries on.
-* **The cancellation token** is the same one as `context.CancellationToken`. Forwarding it is what makes a
-  shutdown that waits for jobs, or an `Interrupt` call, actually reach the work.
-* **`context.Result`** is stored on the execution context and passed to job listeners after the job returns.
-  It is not persisted.
+#endregion

--- a/src/Quartz.Documentation.Samples/HowTos/LockHandlerSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/LockHandlerSamples.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+#region sample_lock_handler_semaphore
+
+public sealed class LeaseSemaphore : ISemaphore
+{
+    private string schedulerName = "";
+
+    public bool RequiresConnection => false;
+
+    public void Initialize(SemaphoreContext context) => schedulerName = context.SchedulerName;
+
+    public async ValueTask<bool> ObtainLock(
+        Guid requestorId,
+        ConnectionAndTransactionHolder? conn,
+        SchedulerLock lockKind,
+        CancellationToken cancellationToken = default)
+    {
+        // ... acquire, honouring the re-entry rule ...
+        return true;
+    }
+
+    public ValueTask ReleaseLock(
+        Guid requestorId,
+        SchedulerLock lockKind,
+        CancellationToken cancellationToken = default)
+    {
+        // ...
+        return default;
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/lock-handler.md.
+/// </summary>
+public static class LockHandlerSamples
+{
+    public static void Registration(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_lock_handler_registration
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(s =>
+            {
+                s.UseLockHandler<LeaseSemaphore>();
+                s.UseSqlServer(connectionString);
+                s.UseClustering();
+            });
+        });
+
+        #endregion
+    }
+
+    public static void RedisLockHandler(IPersistentStoreBuilder s)
+    {
+        #region sample_lock_handler_redis
+
+        s.UseRedisLockHandler(o =>
+        {
+            o.RedisConfiguration = "localhost:6379";
+            o.KeyPrefix = "quartz:";
+            o.LockTimeToLive = TimeSpan.FromSeconds(30);
+        });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/HowTos/MultipleTriggersSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/MultipleTriggersSamples.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+#region sample_multiple_triggers_job
+
+public sealed class CustomerProcessJob : IJob
+{
+    public static readonly JobKey Key = new("customer-process", "batch");
+
+    private readonly ILogger<CustomerProcessJob> logger;
+
+    public CustomerProcessJob(ILogger<CustomerProcessJob> logger)
+    {
+        this.logger = logger;
+    }
+
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        JobDataMap data = context.MergedJobDataMap;
+
+        string? customerId = data.GetString("CustomerId");
+        int batchSize = data.GetInt("batch-size");
+
+        logger.LogInformation("CustomerId={CustomerId} batch-size={BatchSize}", customerId, batchSize);
+        return default;
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/multiple-triggers.md.
+/// </summary>
+public static class MultipleTriggersSamples
+{
+    public static void AtConfigurationTime(IHostApplicationBuilder builder)
+    {
+        #region sample_multiple_triggers_configuration
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.AddJob<CustomerProcessJob>(j => j
+                .WithIdentity(CustomerProcessJob.Key)
+                .StoreDurably()
+                .UsingJobData("batch-size", 50));
+
+            q.AddTrigger<CustomerProcessJob>(t => t
+                .ForJob(CustomerProcessJob.Key)
+                .WithIdentity("customer-1-hourly")
+                .UsingJobData("CustomerId", "1")
+                .WithCronSchedule("0 0 * ? * *"));
+
+            q.AddTrigger<CustomerProcessJob>(t => t
+                .ForJob(CustomerProcessJob.Key)
+                .WithIdentity("customer-2-nightly")
+                .UsingJobData("CustomerId", "2")
+                .UsingJobData("batch-size", 500)   // this trigger overrides the job's value
+                .WithCronSchedule("0 0 2 ? * *"));
+        });
+
+        #endregion
+    }
+
+    public static async ValueTask AdHocFiring(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        #region sample_multiple_triggers_ad_hoc
+
+        JobDataMap data = new() { { "CustomerId", "3" }, { "batch-size", 10 } };
+        await scheduler.TriggerJob(CustomerProcessJob.Key, data, cancellationToken);
+
+        #endregion
+    }
+}
+
+public sealed class CustomerSchedules
+{
+    #region sample_multiple_triggers_at_run_time
+
+    public async ValueTask ScheduleFor(
+        IScheduler scheduler,
+        IReadOnlyCollection<string> customers,
+        CancellationToken cancellationToken)
+    {
+        IJobDetail job = JobBuilder.Create<CustomerProcessJob>()
+            .WithIdentity(CustomerProcessJob.Key)
+            .StoreDurably()
+            .UsingJobData("batch-size", 50)
+            .Build();
+
+        await scheduler.AddJob(job, new AddJobOptions { Replace = true }, cancellationToken);
+
+        foreach (string customer in customers)
+        {
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity($"customer-{customer}", "batch")
+                .ForJob(CustomerProcessJob.Key)
+                .UsingJobData("CustomerId", customer)
+                .WithCronSchedule("0 0 * ? * *")
+                .Build();
+
+            await scheduler.ScheduleJob(trigger, cancellationToken);
+        }
+    }
+
+    #endregion
+}

--- a/src/Quartz.Documentation.Samples/HowTos/OneOffJobSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/OneOffJobSamples.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/one-off-job.md.
+/// </summary>
+public sealed class OneOffJobSamples
+{
+    public static void ADurableJobWithNoTrigger(IHostApplicationBuilder builder)
+    {
+        #region sample_one_off_job_durable_registration
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.AddJob<AnExampleJob>(j => j
+                .WithIdentity("name", "group")
+                .StoreDurably());
+        });
+
+        #endregion
+    }
+
+    #region sample_one_off_job_trigger_now
+
+    public async ValueTask RunNow(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        await scheduler.TriggerJob(new JobKey("name", "group"), cancellationToken: cancellationToken);
+    }
+
+    #endregion
+
+    public static async ValueTask AddingTheJobAtRunTime(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        #region sample_one_off_job_add_job
+
+        IJobDetail job = JobBuilder.Create<AnExampleJob>()
+            .WithIdentity("name", "group")
+            .StoreDurably()
+            .Build();
+
+        await scheduler.AddJob(job, new AddJobOptions { Replace = true }, cancellationToken);
+
+        #endregion
+    }
+
+    public static void MisfireInstructionForAOneShotTrigger()
+    {
+        #region sample_one_off_job_misfire_instruction
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("name", "group")
+            .StartNow()
+            .WithSimpleSchedule(x => x
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow))
+            .Build();
+
+        #endregion
+    }
+}
+
+public sealed class OneOffJobWithData
+{
+    #region sample_one_off_job_trigger_now_with_data
+
+    public async ValueTask RunNow(IScheduler scheduler, string customer, CancellationToken cancellationToken)
+    {
+        JobDataMap data = new() { { "CustomerId", customer } };
+        await scheduler.TriggerJob(new JobKey("name", "group"), data, cancellationToken);
+    }
+
+    #endregion
+}
+
+public sealed class OneOffJobScheduledOnce
+{
+    #region sample_one_off_job_schedule_once
+
+    public async ValueTask ScheduleOnce(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        IJobDetail job = JobBuilder.Create<AnExampleJob>()
+            .WithIdentity("name", "group")
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("name", "group")
+            .StartAt(DateTimeOffset.UtcNow.AddMinutes(5))
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger, cancellationToken);
+    }
+
+    #endregion
+}

--- a/src/Quartz.Documentation.Samples/HowTos/ReschedulingJobsSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/ReschedulingJobsSamples.cs
@@ -1,0 +1,160 @@
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/rescheduling-jobs.md.
+/// </summary>
+public static class ReschedulingJobsSamples
+{
+    public static async ValueTask ReplacingATrigger(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        #region sample_rescheduling_replace_trigger
+
+        ITrigger replacement = TriggerBuilder.Create()
+            .WithIdentity("nightly", "reports")
+            .ForJob(new JobKey("build-report", "reports"))
+            .WithCronSchedule("0 30 2 * * ?")
+            .Build();
+
+        DateTimeOffset? firstFire = await scheduler.RescheduleJob(
+            new TriggerKey("nightly", "reports"),
+            replacement,
+            cancellationToken);
+
+        #endregion
+    }
+
+    public static async ValueTask WhenTheOldTriggerIsGone(
+        IScheduler scheduler,
+        TriggerKey key,
+        ITrigger replacement,
+        CancellationToken cancellationToken)
+    {
+        #region sample_rescheduling_missing_trigger
+
+        DateTimeOffset? next = await scheduler.RescheduleJob(key, replacement, cancellationToken);
+        if (next is null)
+        {
+            // the old trigger was gone; store the new one on its own terms
+            await scheduler.ScheduleJob(replacement, cancellationToken);
+        }
+
+        #endregion
+    }
+
+    public static async ValueTask UpdatingDetailsInPlace(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        #region sample_rescheduling_update_details
+
+        bool applied = await scheduler.UpdateTriggerDetails(
+            new TriggerKey("nightly", "reports"),
+            new TriggerDetailsUpdate()
+                .WithPriority(10)
+                .WithDescription("moved up ahead of the invoice run"),
+            cancellationToken);
+
+        #endregion
+    }
+
+    public static async ValueTask MisfireInstructionsAreTyped(IScheduler scheduler, TriggerKey cronKey)
+    {
+        #region sample_rescheduling_typed_misfire_instruction
+
+        // fine — the key resolves to a cron trigger
+        await scheduler.UpdateTriggerDetails(cronKey, new TriggerDetailsUpdate()
+            .WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing));
+
+        // rejected — the key resolves to a cron trigger, not a simple one
+        await scheduler.UpdateTriggerDetails(cronKey, new TriggerDetailsUpdate()
+            .WithMisfireInstruction(SimpleTriggerMisfireInstruction.FireNow));
+
+        #endregion
+    }
+
+    public static void GivingUpOnAJob(string id)
+    {
+        #region sample_rescheduling_unschedule_all_triggers
+
+        throw new JobExecutionException($"account {id} no longer exists")
+        {
+            UnscheduleAllTriggers = true,
+        };
+
+        #endregion
+    }
+
+    public static async ValueTask ResettingErroredTriggers(
+        IScheduler scheduler,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        #region sample_rescheduling_reset_error_state
+
+        TriggerQuery broken = new() { State = TriggerState.Error, Take = 250 };
+
+        while (true)
+        {
+            PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(broken, cancellationToken);
+            if (page.Items.Count == 0)
+            {
+                break;
+            }
+
+            List<TriggerKey> keys = page.Items.Select(h => h.Key).ToList();
+            List<TriggerKey> reset = await scheduler.ResetTriggersFromErrorState(keys, cancellationToken);
+            logger.LogInformation("Reset {Count} triggers", reset.Count);
+
+            if (!page.HasMore)
+            {
+                break;
+            }
+        }
+
+        #endregion
+    }
+}
+
+#region sample_rescheduling_refire
+
+public sealed class ImportJob(IImportService importer) : IJob
+{
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await importer.Run(cancellationToken);
+        }
+        catch (TransientImportException ex) when (context.RefireCount < 3)
+        {
+            throw new JobExecutionException(ex) { RefireImmediately = true };
+        }
+    }
+}
+
+#endregion
+
+public sealed class RetryingImportJob(IImportService importer) : IJob
+{
+    #region sample_rescheduling_retry_trigger
+
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await importer.Run(cancellationToken);
+        }
+        catch (TransientImportException) when (context.RefireCount == 0)
+        {
+            ITrigger retry = TriggerBuilder.Create()
+                .WithIdentity($"{context.Trigger.Key.Name}-retry-{context.FireInstanceId}", "retries")
+                .ForJob(context.JobDetail.Key)
+                .StartAt(DateTimeOffset.UtcNow.AddMinutes(5))
+                .Build();
+
+            await context.Scheduler.ScheduleJob(retry, cancellationToken);
+        }
+    }
+
+    #endregion
+}

--- a/src/Quartz.Documentation.Samples/HowTos/TriggerPersistenceDelegateSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/TriggerPersistenceDelegateSamples.cs
@@ -1,0 +1,167 @@
+using System.Text.Json;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.Triggers;
+using Quartz.Serialization.SystemTextJson.Triggers;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+#region sample_trigger_persistence_delegate
+
+public sealed class BusinessDayTriggerPersistenceDelegate : SimplePropertiesTriggerPersistenceDelegateBase
+{
+    public override string GetHandledTriggerTypeDiscriminator() => "BUSDAY";
+
+    public override bool CanHandleTriggerType(IOperableTrigger trigger)
+        => trigger is BusinessDayTriggerImpl impl && !impl.HasAdditionalProperties;
+
+    protected override SimplePropertiesTriggerProperties GetTriggerProperties(IOperableTrigger trigger)
+    {
+        BusinessDayTriggerImpl t = (BusinessDayTriggerImpl) trigger;
+        return new SimplePropertiesTriggerProperties
+        {
+            Int1 = t.SkipCount,
+            Long1 = t.TimesTriggered,
+            String1 = t.CalendarSystem,
+            TimeZoneId = t.TimeZone.Id,
+        };
+    }
+
+    protected override TriggerPropertyBundle GetTriggerPropertyBundle(SimplePropertiesTriggerProperties props)
+    {
+        BusinessDayScheduleBuilder schedule = BusinessDayScheduleBuilder.Create()
+            .SkippingDays(props.Int1)
+            .InCalendarSystem(props.String1!)
+            .InTimeZone(TimeZones.FindById(props.TimeZoneId!));
+
+        long timesTriggered = props.Long1;
+        return new TriggerPropertyBundle(
+            schedule,
+            t => ((BusinessDayTriggerImpl) t).TimesTriggered = timesTriggered);
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/trigger-persistence-delegate.md.
+/// </summary>
+public static class TriggerPersistenceDelegateSamples
+{
+    public static void ApplyState(IScheduleBuilder scheduleBuilder, long timesTriggered)
+    {
+        #region sample_trigger_persistence_delegate_apply_state
+
+        new TriggerPropertyBundle(scheduleBuilder, t => ((MyTriggerImpl) t).TimesTriggered = timesTriggered);
+
+        #endregion
+    }
+
+    public static void Registration(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_trigger_persistence_delegate_registration
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(s =>
+            {
+                s.UseSqlServer(connectionString);
+                s.UseTriggerPersistenceDelegate<BusinessDayTriggerPersistenceDelegate>();
+            });
+        });
+
+        #endregion
+    }
+
+    public static void RegisteringTheSerializer(IPersistentStoreBuilder s)
+    {
+        #region sample_trigger_persistence_delegate_serializer_registration
+
+        s.UseSystemTextJsonSerializer(registry =>
+            registry.AddTriggerSerializer<BusinessDayTriggerImpl>(new BusinessDayTriggerSerializer()));
+
+        #endregion
+    }
+}
+
+/// <summary>
+/// The trigger type the page invents, made real enough to compile the delegate that stores it.
+/// Everything below is scaffolding; none of it appears on the page.
+/// </summary>
+public class BusinessDayTriggerImpl : TriggerBase
+{
+    public int SkipCount { get; set; }
+
+    public long TimesTriggered { get; set; }
+
+    public string? CalendarSystem { get; set; }
+
+    public TimeZoneInfo TimeZone { get; set; } = TimeZoneInfo.Utc;
+
+    public override DateTimeOffset? FinalFireTimeUtc => null;
+
+    public override DateTimeOffset? PreviousFireTimeUtc { get; set; }
+
+    public override DateTimeOffset? NextFireTimeUtc { get; set; }
+
+    public override bool MayFireAgain => false;
+
+    protected override bool HasMillisecondPrecision => false;
+
+    public override IScheduleBuilder GetScheduleBuilder() => BusinessDayScheduleBuilder.Create();
+
+    public override DateTimeOffset? ComputeFirstFireTimeUtc(ICalendar? calendar) => null;
+
+    public override DateTimeOffset? GetFireTimeAfter(DateTimeOffset? afterTime) => null;
+
+    public override void Triggered(ICalendar? calendar)
+    {
+    }
+
+    public override void UpdateAfterMisfire(ICalendar? calendar)
+    {
+    }
+
+    public override void UpdateWithNewCalendar(ICalendar calendar, TimeSpan misfireThreshold)
+    {
+    }
+
+    protected override bool ValidateMisfireInstruction(int misfireInstruction) => true;
+}
+
+/// <summary>The trigger the <c>applyState</c> sample casts to; scaffolding, like the one above.</summary>
+public sealed class MyTriggerImpl : BusinessDayTriggerImpl;
+
+public sealed class BusinessDayScheduleBuilder : IScheduleBuilder
+{
+    private BusinessDayScheduleBuilder()
+    {
+    }
+
+    public static BusinessDayScheduleBuilder Create() => new();
+
+    public BusinessDayScheduleBuilder SkippingDays(int days) => this;
+
+    public BusinessDayScheduleBuilder InCalendarSystem(string calendarSystem) => this;
+
+    public BusinessDayScheduleBuilder InTimeZone(TimeZoneInfo timeZone) => this;
+
+    public IMutableTrigger Build() => new BusinessDayTriggerImpl();
+}
+
+public sealed class BusinessDayTriggerSerializer : TriggerSerializer<BusinessDayTriggerImpl>
+{
+    public override string TriggerTypeName => "BusinessDayTrigger";
+
+    public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, JsonSerializerOptions options)
+        => BusinessDayScheduleBuilder.Create();
+
+    protected override void SerializeFields(Utf8JsonWriter writer, BusinessDayTriggerImpl trigger, JsonSerializerOptions options)
+    {
+        writer.WriteNumber("SkipCount", trigger.SkipCount);
+    }
+}

--- a/src/Quartz.Documentation.Samples/QuickStartSamples.cs
+++ b/src/Quartz.Documentation.Samples/QuickStartSamples.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/quick-start.md.
+/// </summary>
+/// <remarks>
+/// The three whole-program listings on that page stay hand-written fences: they are top-level
+/// statements with their <c>using</c> directives shown, and a class library can host neither.
+/// </remarks>
+public static class QuickStartSamples
+{
+    public static void UnderAHost(IHostApplicationBuilder builder)
+    {
+        #region sample_quick_start_host
+
+        builder.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.InstanceName = "MyScheduler");
+
+            // default max concurrency is 10
+            q.UseDefaultThreadPool(maxConcurrency: 5);
+
+            q.UsePersistentStore(store =>
+            {
+                // there are other databases supported too
+                store.UseSqlServer("my connection string");
+                store.UseClustering();
+
+                // System.Text.Json is built in; the Newtonsoft one is a package away
+                store.UseSystemTextJsonSerializer();
+
+                store.Configure(options =>
+                {
+                    // store job data as strings, which avoids surprises when a serialized
+                    // type changes shape later
+                    options.StoreJobDataAsStrings = true;
+                });
+            });
+
+            // reads jobs and triggers from XML; requires the Quartz.Plugins package
+            q.UseXmlSchedulingConfiguration(x =>
+            {
+                x.Files.Add("~/quartz_jobs.xml");
+                x.FailOnFileNotFound = true;
+                x.FailOnSchedulingError = true;
+            });
+        });
+
+        builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    public static async ValueTask WithoutAHost()
+    {
+        #region sample_quick_start_standalone
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "MyScheduler")
+            .UseDefaultThreadPool(maxConcurrency: 5)
+            .UseInMemoryStore()
+            .BuildScheduler();
+
+        await scheduler.Start();
+
+        #endregion
+    }
+
+    public static void FromConfiguration(IServiceCollection services, IConfiguration configuration)
+    {
+        #region sample_quick_start_from_configuration
+
+        services.AddQuartz(configuration.GetSection("Quartz"));
+
+        #endregion
+    }
+
+    public static async ValueTask SchedulingTheJob(IScheduler scheduler)
+    {
+        #region sample_quick_start_scheduling
+
+        // define the job and tie it to our HelloJob class
+        IJobDetail job = JobBuilder.Create<HelloJob>()
+            .WithIdentity("job1", "group1")
+            .Build();
+
+        // Trigger the job to run now, and then repeat every 10 seconds
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .StartNow()
+            .WithSimpleSchedule(x => x
+                .WithInterval(TimeSpan.FromSeconds(10))
+                .RepeatForever())
+            .Build();
+
+        // Tell Quartz to schedule the job using our trigger
+        await scheduler.ScheduleJob(job, trigger);
+
+        // several triggers for one job go together, in one call
+        // await scheduler.ScheduleJob(job, [trigger1, trigger2], new ScheduleJobOptions { Replace = true });
+
+        #endregion
+    }
+}
+
+#region sample_quick_start_job
+
+public sealed class HelloJob : IJob
+{
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        await Console.Out.WriteLineAsync("Greetings from HelloJob!");
+    }
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Tutorial/AdvancedEnterpriseFeaturesSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/AdvancedEnterpriseFeaturesSamples.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/advanced-enterprise-features.md.
+/// </summary>
+public static class AdvancedEnterpriseFeaturesSamples
+{
+    public static void Clustering(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_advanced_clustering
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                // every node in the cluster shares this name: it is what makes them one cluster
+                options.InstanceName = "orders";
+
+                // ...and each needs its own id. Generating one is the easy way to be sure.
+                options.GenerateInstanceId = true;
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer(connectionString);
+                store.UseSystemTextJsonSerializer();
+                store.UseClustering();
+            });
+        });
+
+        #endregion
+    }
+
+    public static void CheckinInterval(IPersistentStoreBuilder store)
+    {
+        #region sample_advanced_checkin_interval
+
+        store.UseClustering(cluster =>
+        {
+            cluster.CheckinInterval = TimeSpan.FromSeconds(10);
+            cluster.CheckinMisfireThreshold = TimeSpan.FromSeconds(20);
+        });
+
+        #endregion
+    }
+
+    public static void BatchAcquisition(IServiceCollection services)
+    {
+        services.AddQuartz(q =>
+        {
+            #region sample_advanced_batch_acquisition
+
+            q.ConfigureScheduler(options =>
+            {
+                options.MaxBatchSize = 10;
+                options.BatchTriggerAcquisitionFireAheadTimeWindow = TimeSpan.FromSeconds(1);
+            });
+
+            #endregion
+        });
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/ConfigurationAndResourceUsageSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/ConfigurationAndResourceUsageSamples.cs
@@ -1,0 +1,51 @@
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Quartz.Diagnostics;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for
+/// docs/documentation/quartz-4.x/tutorial/configuration-resource-usage-and-scheduler-factory.md.
+/// </summary>
+public static class ConfigurationAndResourceUsageSamples
+{
+    public static async ValueTask BuildingAScheduler()
+    {
+        #region sample_configuration_building_a_scheduler
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "reporting")
+            .UseDefaultThreadPool(maxConcurrency: 10)
+            .UseInMemoryStore()
+            .BuildScheduler();
+
+        #endregion
+    }
+
+    public static async ValueTask FromProperties(NameValueCollection properties)
+    {
+        #region sample_configuration_from_properties
+
+        await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create()
+            .UseProperties(properties)
+            .Build();
+
+        #endregion
+    }
+
+    public static void Logging(IServiceProvider serviceProvider)
+    {
+        #region sample_configuration_log_provider
+
+        // obtain your logger factory, for example from IServiceProvider
+        ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+
+        LogProvider.SetLogProvider(loggerFactory);
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/CronTriggersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/CronTriggersSamples.cs
@@ -1,0 +1,104 @@
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/crontriggers.md.
+/// </summary>
+public static class CronTriggersSamples
+{
+    public static void EveryOtherMinuteDuringBusinessHours()
+    {
+        #region sample_crontriggers_every_other_minute
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger3", "group1")
+            .WithCronSchedule("0 0/2 8-17 * * ?")
+            .ForJob("myJob", "group1")
+            .Build();
+
+        #endregion
+    }
+
+    public static void DailyAtTenFortyTwo(JobKey myJobKey)
+    {
+        #region sample_crontriggers_daily_question_mark_in_day_of_week
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger3", "group1")
+            .WithCronSchedule("0 42 10 ? * *")
+            .ForJob(myJobKey)
+            .Build();
+
+        #endregion
+    }
+
+    public static void DailyAtTenFortyTwoQuestionMarkInDayOfMonth()
+    {
+        #region sample_crontriggers_daily_question_mark_in_day_of_month
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger3", "group1")
+            .WithCronSchedule("0 42 10 * * ?")
+            .ForJob("myJob", "group1")
+            .Build();
+
+        #endregion
+    }
+
+    public static void InATimeZone(JobKey myJobKey)
+    {
+        #region sample_crontriggers_in_time_zone
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger3", "group1")
+            .WithCronSchedule("0 42 10 ? * WED", x => x
+                .InTimeZone(TimeZones.FindById("Central America Standard Time")))
+            .ForJob(myJobKey)
+            .Build();
+
+        #endregion
+    }
+
+    public static void WithAScheduleBuiltSeparately(JobKey myJobKey)
+    {
+        #region sample_crontriggers_schedule_built_separately
+
+        CronScheduleBuilder schedule = CronScheduleBuilder
+            .Create("0 42 10 ? * WED")
+            .InTimeZone(TimeZones.FindById("Central America Standard Time"));
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger3", "group1")
+            .WithCronSchedule(schedule)
+            .ForJob(myJobKey)
+            .Build();
+
+        #endregion
+    }
+
+    public static void HashedFireTime()
+    {
+        #region sample_crontriggers_hashed_fire_time
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("nightly-cleanup", "maintenance")
+            .WithCronSchedule("0 H H(0-7) * * ?")
+            .ForJob("cleanupJob", "maintenance")
+            .Build();
+
+        #endregion
+    }
+
+    public static void MisfireInstruction()
+    {
+        #region sample_crontriggers_misfire_instruction
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger3", "group1")
+            .WithCronSchedule("0 0/2 8-17 * * ?", x => x
+                .WithMisfireInstruction(CronTriggerMisfireInstruction.FireAndProceed))
+            .ForJob("myJob", "group1")
+            .Build();
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/JobDataMapSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobDataMapSamples.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/job-data-map.md.
+/// </summary>
+/// <remarks>
+/// The page shows two different jobs called <c>ReportJob</c> — one reading the merged map, one having
+/// its properties injected — so each lives in a nested class of its own.
+/// </remarks>
+public static class JobDataMapSamples
+{
+    public sealed class ReportOptions;
+
+    public static class ReadingTheMergedMap
+    {
+        #region sample_job_data_map_merged_map
+
+        public sealed class ReportJob : IJob
+        {
+            public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                JobDataMap data = context.MergedJobDataMap;
+                string region = data.GetString("region")!;
+                int lookbackDays = data.GetInt("lookbackDays");
+                // ...
+
+                return default;
+            }
+        }
+
+        #endregion
+    }
+
+    public static class PropertyInjection
+    {
+        #region sample_job_data_map_property_injection
+
+        public sealed class ReportJob : IJob
+        {
+            public string Region { get; set; } = "";
+            public int LookbackDays { get; set; }
+
+            public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                // Region and LookbackDays are already set
+
+                return default;
+            }
+        }
+
+        #endregion
+
+        public static void PuttingValuesIn(JobDataMap existingMap)
+        {
+            #region sample_job_data_map_using_job_data
+
+            IJobDetail job = JobBuilder.Create<ReportJob>()
+                .WithIdentity("nightly", "reports")
+                .UsingJobData("region", "emea")                     // key and value
+                .UsingJobData(j => j.LookbackDays, 30)              // name the property, not the key
+                .UsingJobData(existingMap)                          // merge a whole map in
+                .Build();
+
+            #endregion
+        }
+    }
+
+    public static async ValueTask DataForASingleFiring(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken)
+    {
+        #region sample_job_data_map_trigger_job_with_data
+
+        await scheduler.TriggerJob(jobKey, new JobDataMap { ["reason"] = "manual re-run" }, cancellationToken);
+
+        #endregion
+    }
+
+    public static void TheGenericReader(JobDataMap data)
+    {
+        #region sample_job_data_map_try_get
+
+        if (data.TryGet<ReportOptions>("options", out ReportOptions? options))
+        {
+            // ...
+        }
+
+        #endregion
+    }
+
+    public static void PuttingValuesInAsStrings()
+    {
+        #region sample_job_data_map_put_as_string
+
+        JobDataMap data = new();
+        data.PutAsString("runAt", DateTimeOffset.UtcNow);   // "O": 2026-08-22T09:15:00.0000000+00:00
+        data.PutAsString("window", TimeSpan.FromHours(6));  // invariant "06:00:00"
+        data.PutAsString("batchId", Guid.NewGuid());
+        data.PutAsString("lookbackDays", 30);               // any IFormattable
+
+        #endregion
+    }
+
+    public static void StringMode(IServiceCollection services, string connectionString)
+    {
+        services.AddQuartz(q =>
+        {
+            #region sample_job_data_map_store_as_strings
+
+            q.UsePersistentStore(s =>
+            {
+                s.UseSqlServer(connectionString);
+                s.Configure(o => o.StoreJobDataAsStrings = true);
+            });
+
+            #endregion
+        });
+    }
+
+    public static void ForcingAWrite(JobDataMap data)
+    {
+        #region sample_job_data_map_force_dirty
+
+        data[SchedulerConstants.ForceJobDataMapDirty] = "true";
+
+        #endregion
+    }
+}
+
+#region sample_job_data_map_persist_across_fires
+
+[PersistJobDataAfterExecution]
+[DisallowConcurrentExecution]
+public sealed class IncrementalSyncJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        JobDataMap data = context.JobDetail.JobDataMap;
+        data.PutAsString("lastSyncedAt", DateTimeOffset.UtcNow);
+        return default;
+    }
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Tutorial/JobStoresSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobStoresSamples.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/job-stores.md.
+/// </summary>
+public static class JobStoresSamples
+{
+    public static void InMemoryStore(IHostApplicationBuilder builder)
+    {
+        #region sample_job_stores_in_memory
+
+        builder.Services.AddQuartz(q =>
+        {
+            // this is the default, so the call is only needed to change one of its settings
+            q.UseInMemoryStore(options => options.MisfireThreshold = TimeSpan.FromSeconds(30));
+        });
+
+        #endregion
+    }
+
+    public static void PersistentStore(IHostApplicationBuilder builder)
+    {
+        #region sample_job_stores_persistent
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer("Server=localhost;Database=quartz;Trusted_Connection=True;Encrypt=False");
+                store.UseSystemTextJsonSerializer();
+
+                store.Configure(options =>
+                {
+                    options.TablePrefix = "QRTZ_";
+                    options.StoreJobDataAsStrings = true;
+                });
+            });
+        });
+
+        #endregion
+    }
+
+    public static void StoreJobDataAsStrings(IPersistentStoreBuilder store)
+    {
+        #region sample_job_stores_store_job_data_as_strings
+
+        store.Configure(options => options.StoreJobDataAsStrings = true);
+
+        #endregion
+    }
+
+    public static void AcceptEnlistedTransactions(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_job_stores_accept_enlisted_transactions
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(store =>
+            {
+                store.UsePostgres(connectionString);
+                store.Configure(options => options.AcceptEnlistedTransactions = true);
+            });
+        });
+
+        #endregion
+    }
+
+    public static void JobStoreOfYourOwn(IHostApplicationBuilder builder)
+    {
+        #region sample_job_stores_registering_your_own
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore<LoggingJobStore>(options =>
+            {
+                // … store options
+            });
+        });
+
+        #endregion
+    }
+}
+
+#region sample_job_stores_delegating_store
+
+public sealed class LoggingJobStore : DelegatingJobStore
+{
+    private readonly ILogger<LoggingJobStore> logger;
+
+    public LoggingJobStore(
+        ILoggerFactory loggerFactory,
+        ISchedulerSignaler signaler,
+        TimeProvider timeProvider,
+        ILogger<LoggingJobStore> logger)
+        : base(new RAMJobStore(loggerFactory, signaler, timeProvider))
+    {
+        this.logger = logger;
+    }
+
+    public override async ValueTask ScheduleJob(
+        IJobDetail job,
+        IOperableTrigger trigger,
+        CancellationToken cancellationToken = default)
+    {
+        await base.ScheduleJob(job, trigger, cancellationToken);
+        logger.LogInformation("Scheduled {JobKey} on {TriggerKey}", job.Key, trigger.Key);
+    }
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Tutorial/JobsAndTriggersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobsAndTriggersSamples.cs
@@ -1,0 +1,31 @@
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/jobs-and-triggers.md.
+/// </summary>
+public static class JobsAndTriggersSamples
+{
+    public static async ValueTask TheBuilderDsl(IScheduler scheduler)
+    {
+        #region sample_jobs_and_triggers_builders
+
+        // define the job and tie it to our HelloJob class
+        IJobDetail job = JobBuilder.Create<HelloJob>()
+            .WithIdentity("myJob", "group1") // name "myJob", group "group1"
+            .Build();
+
+        // Trigger the job to run now, and then every 40 seconds
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("myTrigger", "group1")
+            .StartNow()
+            .WithSimpleSchedule(x => x
+                .WithInterval(TimeSpan.FromSeconds(40))
+                .RepeatForever())
+            .Build();
+
+        // Tell Quartz to schedule the job using our trigger
+        await scheduler.ScheduleJob(job, trigger);
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/ListenersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/ListenersSamples.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics.Metrics;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/scheduler-listeners.md and
+/// docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md.
+/// </summary>
+public static class ListenersSamples
+{
+    public static void RegisteringASchedulerListener(IScheduler scheduler, ISchedulerListener mySchedListener)
+    {
+        #region sample_scheduler_listeners_add
+
+        scheduler.ListenerManager.AddSchedulerListener(mySchedListener);
+
+        #endregion
+    }
+
+    public static void RemovingASchedulerListener(IScheduler scheduler, ISchedulerListener mySchedListener)
+    {
+        #region sample_scheduler_listeners_remove
+
+        scheduler.ListenerManager.RemoveSchedulerListener(mySchedListener.Name);
+
+        #endregion
+    }
+
+    public static void RegisteringASchedulerListenerUnderDependencyInjection(IHostApplicationBuilder builder)
+    {
+        #region sample_scheduler_listeners_under_di
+
+        builder.AddQuartz(q =>
+        {
+            q.AddSchedulerListener<AuditSchedulerListener>();
+        });
+
+        #endregion
+    }
+
+    public static void MatchingOneJob(IScheduler scheduler, IJobListener myJobListener)
+    {
+        #region sample_job_listeners_match_one_job
+
+        scheduler.ListenerManager.AddJobListener(myJobListener, Matchers.Key(new JobKey("myJobName", "myJobGroup")));
+
+        #endregion
+    }
+
+    public static void MatchingAGroup(IScheduler scheduler, IJobListener myJobListener)
+    {
+        #region sample_job_listeners_match_a_group
+
+        scheduler.ListenerManager.AddJobListener(myJobListener, GroupMatcher<JobKey>.GroupEquals("myJobGroup"));
+
+        #endregion
+    }
+
+    public static void MatchingTwoGroups(IScheduler scheduler, IJobListener myJobListener)
+    {
+        #region sample_job_listeners_match_two_groups
+
+        scheduler.ListenerManager.AddJobListener(myJobListener,
+            GroupMatcher<JobKey>.GroupEquals("myJobGroup").Or(GroupMatcher<JobKey>.GroupEquals("yourGroup")));
+
+        #endregion
+    }
+
+    public static void MatchingEveryJob(IScheduler scheduler, IJobListener myJobListener)
+    {
+        #region sample_job_listeners_match_every_job
+
+        scheduler.ListenerManager.AddJobListener(myJobListener, Matchers.AllJobs());
+
+        #endregion
+    }
+
+    public static void RegisteringListenersUnderDependencyInjection(IHostApplicationBuilder builder)
+    {
+        #region sample_job_listeners_under_di
+
+        builder.AddQuartz(q =>
+        {
+            // every job
+            q.AddJobListener<AuditListener>();
+
+            // only the reporting group, and only triggers whose name starts with "nightly"
+            q.AddJobListener<ReportAuditListener>(GroupMatcher<JobKey>.GroupEquals("reports"));
+            q.AddTriggerListener<NightlyListener>(NameMatcher<TriggerKey>.NameStartsWith("nightly"));
+
+            // an instance you built yourself, or a factory over the provider
+            q.AddTriggerListener(new VetoWeekends(), Matchers.AllTriggers());
+            q.AddJobListener(provider => new MeteredListener(provider.GetRequiredService<IMeterFactory>()));
+        });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/MoreAboutJobsSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/MoreAboutJobsSamples.cs
@@ -1,0 +1,251 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/more-about-jobs.md.
+/// </summary>
+/// <remarks>
+/// The page shows four different jobs all called <c>DumbJob</c>, so each lives in a nested class of
+/// its own — the region never includes the enclosing declaration, so the page shows only the job.
+/// </remarks>
+public static class MoreAboutJobsSamples
+{
+    public static class Basics
+    {
+        public static async ValueTask SchedulingAJob(IScheduler scheduler)
+        {
+            #region sample_more_about_jobs_scheduling
+
+            // define the job and tie it to our HelloJob class
+            IJobDetail job = JobBuilder.Create<HelloJob>()
+                .WithIdentity("myJob", "group1")
+                .Build();
+
+            // Trigger the job to run now, and then every 40 seconds
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("myTrigger", "group1")
+                .StartNow()
+                .WithSimpleSchedule(x => x
+                    .WithInterval(TimeSpan.FromSeconds(40))
+                    .RepeatForever())
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+
+            #endregion
+        }
+
+        #region sample_more_about_jobs_hello_job
+
+        public class HelloJob : IJob
+        {
+            public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                await Console.Out.WriteLineAsync("HelloJob is executing.");
+            }
+        }
+
+        #endregion
+    }
+
+    public static class JobDataByKey
+    {
+        public static void SettingValues()
+        {
+            #region sample_more_about_jobs_setting_job_data
+
+            // define the job and tie it to our DumbJob class
+            IJobDetail job = JobBuilder.Create<DumbJob>()
+                .WithIdentity("myJob", "group1") // name "myJob", group "group1"
+                .UsingJobData("jobSays", "Hello World!")
+                .UsingJobData("myFloatValue", 3.141f)
+                .Build();
+
+            #endregion
+        }
+
+        #region sample_more_about_jobs_getting_job_data
+
+        public class DumbJob : IJob
+        {
+            public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                JobKey key = context.JobDetail.Key;
+
+                JobDataMap dataMap = context.JobDetail.JobDataMap;
+
+                string? jobSays = dataMap.GetString("jobSays");
+                float myFloatValue = dataMap.GetFloat("myFloatValue");
+
+                await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + jobSays + ", and val is: " + myFloatValue);
+            }
+        }
+
+        #endregion
+    }
+
+    public static class JobDataByProperty
+    {
+        #region sample_more_about_jobs_job_with_properties
+
+        public class DumbJob : IJob
+        {
+            public string JobSays { get; set; } = "";
+            public float FloatValue { get; set; }
+
+            public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+        }
+
+        #endregion
+
+        public static IJobDetail NamingTheProperty()
+        {
+            #region sample_more_about_jobs_naming_the_property
+
+            IJobDetail job = JobBuilder.Create<DumbJob>()
+                .WithIdentity("myJob", "group1")
+                .UsingJobData(j => j.JobSays, "Hello World!")
+                .UsingJobData(j => j.FloatValue, 3.141f)
+                .Build();
+
+            #endregion
+
+            return job;
+        }
+
+        public static void NamingThePropertyOnATrigger()
+        {
+            IJobDetail job = NamingTheProperty();
+
+            #region sample_more_about_jobs_naming_the_property_on_a_trigger
+
+            ITrigger trigger = TriggerBuilder.Create<DumbJob>()
+                .WithIdentity("myTrigger", "group1")
+                .ForJob(job)
+                .UsingJobData(j => j.JobSays, "Good evening!")
+                .Build();
+
+            #endregion
+        }
+
+        public static void NamingThePropertyUnderDependencyInjection(IServiceCollection services)
+        {
+            JobKey jobKey = new("myJob");
+
+            services.AddQuartz(q =>
+            {
+                #region sample_more_about_jobs_naming_the_property_under_di
+
+                q.AddJob<DumbJob>(j => j.UsingJobData(x => x.JobSays, "Hello World!"));
+
+                q.ScheduleJob<DumbJob>(
+                    t => t.StartNow().UsingJobData(x => x.JobSays, "Good evening!"),
+                    j => j.WithIdentity("myJob"));
+
+                // a trigger added on its own names the job type it fires
+                q.AddTrigger<DumbJob>(t => t.ForJob(jobKey).UsingJobData(x => x.JobSays, "Good evening!"));
+
+                #endregion
+            });
+        }
+    }
+
+    public static class MergedJobData
+    {
+        #region sample_more_about_jobs_merged_job_data
+
+        public class DumbJob : IJob
+        {
+            public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                JobKey key = context.JobDetail.Key;
+
+                JobDataMap dataMap = context.MergedJobDataMap;  // Note the difference from the previous example
+
+                string? jobSays = dataMap.GetString("jobSays");
+                float myFloatValue = dataMap.GetFloat("myFloatValue");
+                IList<DateTimeOffset> state = (IList<DateTimeOffset>) dataMap["myStateData"]!;
+                state.Add(DateTimeOffset.UtcNow);
+
+                await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + jobSays + ", and val is: " + myFloatValue);
+            }
+        }
+
+        #endregion
+    }
+
+    public static class InjectedJobData
+    {
+        #region sample_more_about_jobs_injected_job_data
+
+        public class DumbJob : IJob
+        {
+            public string JobSays { private get; set; } = "";
+            public float FloatValue { private get; set; }
+
+            public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                JobKey key = context.JobDetail.Key;
+
+                JobDataMap dataMap = context.MergedJobDataMap;  // Note the difference from the previous example
+
+                IList<DateTimeOffset> state = (IList<DateTimeOffset>) dataMap["myStateData"]!;
+                state.Add(DateTimeOffset.UtcNow);
+
+                await Console.Error.WriteLineAsync("Instance " + key + " of DumbJob says: " + JobSays + ", and val is: " + FloatValue);
+            }
+        }
+
+        #endregion
+    }
+
+    public static async ValueTask RefiringFromAJobExecutionException()
+    {
+        try
+        {
+            await Task.Yield();
+        }
+        #region sample_more_about_jobs_job_execution_exception
+        catch (Exception ex)
+        {
+            // ask the scheduler to run this fire again with the same context
+            throw new JobExecutionException(ex) { RefireImmediately = true };
+        }
+        #endregion
+    }
+}
+
+#region sample_more_about_jobs_custom_job_detail
+
+public sealed class TenantJobDetail : IJobDetail
+{
+    public TenantJobDetail(JobKey key, JobType jobType, string tenant, JobDataMap? jobDataMap = null)
+    {
+        Key = key;
+        JobType = jobType;
+        Tenant = tenant;
+        JobDataMap = jobDataMap ?? new JobDataMap();
+    }
+
+    public string Tenant { get; }
+
+    public JobKey Key { get; }
+    public string Description => $"jobs for {Tenant}";
+    public JobType JobType { get; }
+    public JobDataMap JobDataMap { get; }
+    public bool Durable => true;
+    public bool PersistJobDataAfterExecution => true;
+    public bool ConcurrentExecutionDisallowed => true;
+    public bool RequestsRecovery => false;
+
+    // How a job store re-stores the data a [PersistJobDataAfterExecution] job left behind: it asks the
+    // detail for a copy of itself rather than building one, which it could only do as Quartz's own type.
+    public IJobDetail WithJobData(JobDataMap jobDataMap)
+        => new TenantJobDetail(Key, JobType, Tenant, jobDataMap);
+
+    public IJobDetail Clone()
+        => new TenantJobDetail(Key, JobType, Tenant, new JobDataMap(JobDataMap));
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Tutorial/MoreAboutTriggersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/MoreAboutTriggersSamples.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/more-about-triggers.md.
+/// </summary>
+public static class MoreAboutTriggersSamples
+{
+    public static void MisfireInstructionOnTheScheduleBuilder()
+    {
+        ITrigger trigger = TriggerBuilder.Create()
+            #region sample_more_about_triggers_misfire_instruction
+
+            .WithSimpleSchedule(x => x
+                .WithInterval(TimeSpan.FromMinutes(5))
+                .RepeatForever()
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithRemainingCount))
+
+            #endregion
+            .Build();
+    }
+
+    public static void ExecutionGroup()
+    {
+        #region sample_more_about_triggers_execution_group
+
+        TriggerBuilder.Create()
+            .WithIdentity("myTrigger")
+            .WithExecutionGroup("batch-jobs")
+            // ...
+            .Build();
+
+        #endregion
+    }
+
+    public static async ValueTask Calendars(IScheduler scheduler)
+    {
+        #region sample_more_about_triggers_calendar
+
+        HolidayCalendar holidays = new();
+        holidays.AddExcludedDay(new DateOnly(2026, 12, 24));
+
+        await scheduler.AddCalendar("myHolidays", holidays);
+
+        ITrigger t = TriggerBuilder.Create()
+            .WithIdentity("myTrigger")
+            .ForJob("myJob")
+            .WithCronSchedule("0 30 9 ? * *")  // execute job daily at 9:30
+            .WithCalendarName("myHolidays")    // but not on holidays
+            .Build();
+
+        ITrigger t2 = TriggerBuilder.Create()
+            .WithIdentity("myTrigger2")
+            .ForJob("myJob2")
+            .WithCronSchedule("0 30 11 ? * *") // execute job daily at 11:30
+            .WithCalendarName("myHolidays")    // but not on holidays
+            .Build();
+
+        // Use H (hash) to spread triggers across time instead of a fixed schedule.
+        // The trigger identity is used as the hash seed, so each trigger fires at a unique time.
+        ITrigger t3 = TriggerBuilder.Create()
+            .WithIdentity("myTrigger3")
+            .ForJob("myJob3")
+            .WithCronSchedule("0 H H(9-17) * * ?") // a hash-derived time during business hours
+            .WithCalendarName("myHolidays")
+            .Build();
+
+        // .. schedule jobs with triggers
+
+        #endregion
+    }
+
+    public static async ValueTask ReplacingACalendar(IScheduler scheduler, HolidayCalendar holidays)
+    {
+        #region sample_more_about_triggers_replace_calendar
+
+        await scheduler.AddCalendar("myHolidays", holidays, new AddCalendarOptions
+        {
+            Replace = true,        // there is already a calendar under this name
+            UpdateTriggers = true, // recompute the next fire time of every trigger using it
+        });
+
+        #endregion
+    }
+
+    public static void RegisteringACalendarAtConfigurationTime(IServiceCollection services)
+    {
+        services.AddQuartz(q =>
+        {
+            #region sample_more_about_triggers_add_calendar_at_configuration_time
+
+            q.AddCalendar<HolidayCalendar>("myHolidays", new AddCalendarOptions { Replace = true }, calendar =>
+            {
+                calendar.AddExcludedDay(new DateOnly(2026, 12, 24));
+            });
+
+            #endregion
+        });
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/NodeAffinitySamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/NodeAffinitySamples.cs
@@ -1,0 +1,99 @@
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/node-affinity.md.
+/// </summary>
+public static class NodeAffinitySamples
+{
+    public static void PinToANode(IJobDetail job)
+    {
+        #region sample_node_affinity_pin
+
+        // Pin to a specific node
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("myTrigger")
+            .ForJob(job)
+            .WithPreferredNode(PreferredNode.For("production-node-1"))
+            .WithCronSchedule("0 0/5 * * * ?")
+            .Build();
+
+        #endregion
+    }
+
+    public static void AutoPin(IJobDetail job)
+    {
+        #region sample_node_affinity_auto_pin
+
+        // Auto-pin: the first node to fire it claims it
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("myTrigger")
+            .ForJob(job)
+            .WithPreferredNode(PreferredNode.Auto)
+            .WithCronSchedule("0 0/5 * * * ?")
+            .Build();
+
+        #endregion
+    }
+
+    public static async ValueTask ReadingThePin(IScheduler scheduler)
+    {
+        #region sample_node_affinity_reading_the_pin
+
+        ITrigger? t = await scheduler.GetTrigger(new TriggerKey("myTrigger"));
+        PreferredNode pin = t!.PreferredNode;   // GetTrigger returns null when there is no such trigger
+        string? node = pin.Node;         // "production-node-1"; null when unpinned or an unclaimed auto-pin
+        bool auto = pin.IsAutomatic;     // false for a pin you named
+        bool unpinned = pin.IsNone;
+
+        #endregion
+    }
+
+    public static void RebuildingKeepsThePin(ITrigger trigger)
+    {
+        #region sample_node_affinity_rebuild
+
+        // The rebuilt trigger is still auto-pinned, so it will still fail over if that node dies
+        ITrigger rebuilt = trigger.GetTriggerBuilder().WithDescription("updated").Build();
+
+        #endregion
+    }
+
+    public static void ChangingThePinWhileRebuilding(ITrigger trigger)
+    {
+        #region sample_node_affinity_rebuild_with_new_pin
+
+        // a pin you named; IsAutomatic is false
+        ITrigger named = trigger.GetTriggerBuilder()
+            .WithPreferredNode(PreferredNode.For("node-2"))
+            .Build();
+
+        // no preference at all
+        ITrigger unpinned = trigger.GetTriggerBuilder()
+            .WithPreferredNode(PreferredNode.None)
+            .Build();
+
+        #endregion
+    }
+
+    public static async ValueTask MovingAPin(IScheduler scheduler)
+    {
+        #region sample_node_affinity_move_pin
+
+        await scheduler.UpdateTriggerDetails(
+            new TriggerKey("myTrigger"),
+            new TriggerDetailsUpdate().WithPreferredNode(PreferredNode.For("node-2")));
+
+        #endregion
+    }
+
+    public static async ValueTask ClearingAPin(IScheduler scheduler)
+    {
+        #region sample_node_affinity_clear_pin
+
+        await scheduler.UpdateTriggerDetails(
+            new TriggerKey("myTrigger"),
+            new TriggerDetailsUpdate().WithPreferredNode(PreferredNode.None));
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/QueryingJobsAndTriggersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/QueryingJobsAndTriggersSamples.cs
@@ -1,0 +1,169 @@
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/querying-jobs-and-triggers.md.
+/// </summary>
+public static class QueryingJobsAndTriggersSamples
+{
+    public static async ValueTask QueryingTriggers(IScheduler scheduler)
+    {
+        #region sample_querying_trigger_query
+
+        PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
+        {
+            Group = GroupMatcher<TriggerKey>.GroupStartsWith("reporting-"),
+            State = TriggerState.Error,
+            Take = 50,
+        });
+
+        #endregion
+    }
+
+    public static void CombiningMatchers(TriggerKey triggerKey)
+    {
+        #region sample_querying_combining_matchers
+
+        IMatcher<JobKey> notArchived = Matchers.Group<JobKey>(StringOperator.StartsWith, "archive-").Not();
+        IMatcher<TriggerKey> either = Matchers.Key(triggerKey).Or(Matchers.AllTriggers());
+
+        #endregion
+    }
+
+    public static async ValueTask Paging(IScheduler scheduler, int pageNumber, int pageSize)
+    {
+        #region sample_querying_paging
+
+        PagedResult<JobHeader> page = await scheduler.QueryJobs(new JobQuery
+        {
+            Skip = (pageNumber - 1) * pageSize,
+            Take = pageSize,
+        });
+
+        #endregion
+    }
+
+    public static void EverythingInOnePage()
+    {
+        #region sample_querying_everything
+
+        JobQuery everything = new() { Take = int.MaxValue };
+
+        #endregion
+    }
+
+    public static async ValueTask TotalCount(IScheduler scheduler, int pageSize)
+    {
+        #region sample_querying_total_count
+
+        PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
+        {
+            Take = pageSize,
+            IncludeTotalCount = true,
+        });
+
+        int total = page.TotalCount!.Value;   // non-null because IncludeTotalCount was set
+
+        #endregion
+    }
+
+    public static async ValueTask CountOnly(IScheduler scheduler)
+    {
+        #region sample_querying_count_only
+
+        PagedResult<JobHeader> count = await scheduler.QueryJobs(new JobQuery
+        {
+            Take = 0,
+            IncludeTotalCount = true,
+        });
+
+        int jobCount = count.TotalCount!.Value;
+
+        #endregion
+    }
+
+    public static async ValueTask FromHeadersToDetails(
+        IScheduler scheduler,
+        PagedResult<JobHeader> page,
+        IReadOnlyCollection<TriggerKey> triggerKeys)
+    {
+        #region sample_querying_headers_to_details
+
+        List<JobKey> keys = page.Items.Select(h => h.Key).ToList();
+        List<IJobDetail> details = await scheduler.GetJobDetails(keys);
+
+        List<ITrigger> triggers = await scheduler.GetTriggers(triggerKeys);
+
+        #endregion
+    }
+
+    public static async ValueTask QueryingFireInstances(IScheduler scheduler)
+    {
+        #region sample_querying_fire_instances
+
+        PagedResult<FireInstance> running = await scheduler.QueryFireInstances(new FireInstanceQuery
+        {
+            TriggerGroup = GroupMatcher<TriggerKey>.GroupEquals("reporting"),
+        });
+
+        foreach (FireInstance fire in running.Items)
+        {
+            Console.WriteLine($"{fire.TriggerKey} on {fire.SchedulerInstanceId} since {fire.FireTimeUtc:O}");
+        }
+
+        #endregion
+    }
+
+    public static void ReservedVersusRunning()
+    {
+        #region sample_querying_fire_instance_state
+
+        FireInstanceQuery reservedAndRunning = new() { State = null };
+        FireInstanceQuery reservedOnly = new() { State = FireInstanceState.Acquired };
+
+        #endregion
+    }
+
+    public static async ValueTask PausingAGroup(IScheduler scheduler)
+    {
+        #region sample_querying_pause_triggers
+
+        List<string> pausedGroups = await scheduler.PauseTriggers(
+            GroupMatcher<TriggerKey>.GroupStartsWith("nightly-"));
+
+        #endregion
+    }
+}
+
+#region sample_querying_trigger_list_model
+
+public sealed class TriggerListModel(IScheduler scheduler)
+{
+    public async Task<(IReadOnlyList<TriggerHeader> Rows, int Total)> GetPage(
+        int pageNumber,
+        int pageSize,
+        TriggerState? state,
+        string? groupPrefix,
+        CancellationToken cancellationToken)
+    {
+        TriggerQuery query = new()
+        {
+            Skip = (pageNumber - 1) * pageSize,
+            Take = pageSize,
+            IncludeTotalCount = true,
+            State = state,
+            Group = groupPrefix is null
+                ? null
+                : GroupMatcher<TriggerKey>.GroupStartsWith(groupPrefix),
+        };
+
+        PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(query, cancellationToken);
+        return (page.Items, page.TotalCount ?? page.Items.Count);
+    }
+
+    public ValueTask<List<ITrigger>> Expand(
+        IReadOnlyCollection<TriggerKey> keys,
+        CancellationToken cancellationToken) =>
+        scheduler.GetTriggers(keys, cancellationToken);
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Tutorial/RecurrenceTriggerSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/RecurrenceTriggerSamples.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/recurrencetrigger.md.
+/// </summary>
+public static class RecurrenceTriggerSamples
+{
+    public static void SecondMondayOfEveryMonth()
+    {
+        #region sample_recurrencetrigger_second_monday
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("monthlyTrigger", "group1")
+            .WithRecurrenceSchedule("FREQ=MONTHLY;BYDAY=2MO")
+            .StartAt(DateBuilder.Create().InYear(2025).InMonthOnDay(1, 1).AtHourMinuteAndSecond(9, 0, 0).Build())
+            .Build();
+
+        #endregion
+    }
+
+    public static void EveryOtherWeek()
+    {
+        #region sample_recurrencetrigger_every_other_week
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("weeklyTrigger", "group1")
+            .WithRecurrenceSchedule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR")
+            .StartNow()
+            .Build();
+
+        #endregion
+    }
+
+    public static void LastWeekdayOfMarch()
+    {
+        #region sample_recurrencetrigger_last_weekday_of_march
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("yearlyTrigger", "group1")
+            .WithRecurrenceSchedule("FREQ=YEARLY;BYMONTH=3;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1")
+            .StartNow()
+            .Build();
+
+        #endregion
+    }
+
+    public static void EveryWeekday()
+    {
+        #region sample_recurrencetrigger_every_weekday
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("weekdayTrigger", "group1")
+            .WithRecurrenceSchedule("FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR")
+            .StartNow()
+            .Build();
+
+        #endregion
+    }
+
+    public static void LastDayOfEveryMonth()
+    {
+        #region sample_recurrencetrigger_last_day_of_month
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("lastDayTrigger", "group1")
+            .WithRecurrenceSchedule("FREQ=MONTHLY;BYMONTHDAY=-1")
+            .StartNow()
+            .Build();
+
+        #endregion
+    }
+
+    public static void QuarterlyWithACount()
+    {
+        #region sample_recurrencetrigger_quarterly
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("quarterlyTrigger", "group1")
+            .WithRecurrenceSchedule("FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1,15;COUNT=10")
+            .StartNow()
+            .Build();
+
+        #endregion
+    }
+
+    public static void InATimeZone()
+    {
+        #region sample_recurrencetrigger_in_time_zone
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithRecurrenceSchedule("FREQ=MONTHLY;BYDAY=2MO", b => b
+                .InTimeZone(TimeZones.FindById("Eastern Standard Time")))
+            .StartNow()
+            .Build();
+
+        #endregion
+    }
+
+    public static void UnderDependencyInjection(IServiceCollection services)
+    {
+        #region sample_recurrencetrigger_under_di
+
+        services.AddQuartz(q =>
+        {
+            q.AddJob<MyJob>(j => j.WithIdentity("myJob"));
+            q.AddTrigger<IJob>(t => t
+                .ForJob("myJob")
+                .WithIdentity("myTrigger")
+                .WithRecurrenceSchedule("FREQ=MONTHLY;BYDAY=2MO")
+                .StartNow());
+        });
+
+        #endregion
+    }
+
+    public static void MisfireInstruction()
+    {
+        #region sample_recurrencetrigger_misfire_instruction
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithRecurrenceSchedule("FREQ=WEEKLY;BYDAY=MO", b => b
+                .WithMisfireInstruction(RecurrenceTriggerMisfireInstruction.DoNothing))
+            .Build();
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/SimpleTriggersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/SimpleTriggersSamples.cs
@@ -1,0 +1,99 @@
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/simpletriggers.md.
+/// </summary>
+public static class SimpleTriggersSamples
+{
+    public static void OneShot(DateTimeOffset myStartTime)
+    {
+        #region sample_simpletriggers_one_shot
+
+        // trigger builder creates simple trigger by default
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .StartAt(myStartTime) // some Date
+            .ForJob("job1", "group1") // identify job with name, group strings
+            .Build();
+
+        #endregion
+    }
+
+    public static void RepeatTenTimes(DateTimeOffset myTimeToStartFiring, IJobDetail myJob)
+    {
+        #region sample_simpletriggers_repeat_ten_times
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger3", "group1")
+            .StartAt(myTimeToStartFiring) // if a start time is not given (if this line were omitted), "now" is implied
+            .WithSimpleSchedule(x => x
+                .WithInterval(TimeSpan.FromSeconds(10))
+                .WithRepeatCount(10)) // note that 10 repeats will give a total of 11 firings
+            .ForJob(myJob) // identify job with handle to its JobDetail itself
+            .Build();
+
+        #endregion
+    }
+
+    public static void FiveMinutesFromNow(JobKey myJobKey)
+    {
+        #region sample_simpletriggers_five_minutes_from_now
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger5", "group1")
+            .StartAt(DateTimeOffset.UtcNow.AddMinutes(5))
+            .ForJob(myJobKey) // identify job with its JobKey
+            .Build();
+
+        #endregion
+    }
+
+    public static void EveryFiveMinutesUntilTen()
+    {
+        #region sample_simpletriggers_repeat_until_end_time
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger7", "group1")
+            .WithSimpleSchedule(x => x
+                .WithInterval(TimeSpan.FromMinutes(5))
+                .RepeatForever())
+            .EndAt(DateBuilder.Create().AtHourMinuteAndSecond(22, 0, 0).Build())
+            .Build();
+
+        #endregion
+    }
+
+    public static async ValueTask EveryTwoHoursForever(IScheduler scheduler, IJobDetail job)
+    {
+        #region sample_simpletriggers_every_two_hours
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger8") // because group is not specified, "trigger8" will be in the default group
+            .StartAt(DateBuilder.Create().AtMinute(0).AtSecond(0).Build().AddHours(1)) // the next even hour
+            .WithSimpleSchedule(x => x
+                .WithInterval(TimeSpan.FromHours(2))
+                .RepeatForever())
+            // note that in this example, 'ForJob(..)' is not called
+            //  - which is valid if the trigger is passed to the scheduler along with the job
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+
+        #endregion
+    }
+
+    public static void MisfireInstruction()
+    {
+        #region sample_simpletriggers_misfire_instruction
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger7", "group1")
+            .WithSimpleSchedule(x => x
+                .WithInterval(TimeSpan.FromMinutes(5))
+                .RepeatForever()
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.NextWithExistingCount))
+            .Build();
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/StandaloneSchedulerSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/StandaloneSchedulerSamples.cs
@@ -1,0 +1,189 @@
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md.
+/// </summary>
+public static class StandaloneSchedulerSamples
+{
+    public static async ValueTask TheWholeThing()
+    {
+        #region sample_standalone_scheduler
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(o => o.InstanceName = "reporting")
+            .UseDefaultThreadPool(maxConcurrency: 20)
+            .UseInMemoryStore()
+            .BuildScheduler();
+
+        await scheduler.Start();
+
+        #endregion
+    }
+
+    public static async ValueTask OneExpression()
+    {
+        #region sample_standalone_one_expression
+
+        await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
+            .UseInMemoryStore()
+            .UseDefaultThreadPool(10)
+            .Build();
+
+        #endregion
+    }
+
+    public static async ValueTask BuildSchedulerEnding()
+    {
+        #region sample_standalone_build_scheduler_ending
+
+        // I want the scheduler
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create().UseInMemoryStore().BuildScheduler();
+
+        #endregion
+    }
+
+    public static async ValueTask BuildEnding()
+    {
+        #region sample_standalone_build_ending
+
+        // I want to own the lifetime
+        await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create().UseInMemoryStore().Build();
+        IScheduler scheduler = await factory.GetScheduler();
+
+        #endregion
+    }
+
+    public static async ValueTask TheFactoryOwnsTheContainer()
+    {
+        #region sample_standalone_factory_owns_the_container
+
+        await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
+            .UseInMemoryStore()
+            .Build();
+
+        IScheduler scheduler = await factory.GetScheduler();
+        await scheduler.Start();
+
+        // ... do work ...
+
+        // leaving the scope shuts the scheduler down, then disposes the container
+
+        #endregion
+    }
+
+    public static async ValueTask WaitingForJobs(IScheduler scheduler)
+    {
+        #region sample_standalone_wait_for_jobs
+
+        await scheduler.Shutdown(waitForJobsToComplete: true);
+
+        #endregion
+    }
+
+    public static async ValueTask JobsTriggersAndCalendars()
+    {
+        #region sample_standalone_jobs_triggers_and_calendars
+
+        QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create().UseInMemoryStore();
+
+        builder
+            .AddJob<ReportJob>(j => j.WithIdentity("nightly", "reports").StoreDurably())
+            .AddTrigger<ReportJob>(t => t
+                .ForJob("nightly", "reports")
+                .WithIdentity("nightly-trigger", "reports")
+                .WithCronSchedule("0 30 2 * * ?"))
+            .AddCalendar<HolidayCalendar>("holidays", configure: c => c.AddExcludedDay(new DateOnly(2026, 12, 25)));
+
+        await using StandaloneSchedulerFactory factory = builder.Build();
+
+        #endregion
+    }
+
+    public static void RegisteringYourOwnServices()
+    {
+        #region sample_standalone_registering_services
+
+        QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create();
+        builder.Services.AddSingleton<IReportRenderer, PdfReportRenderer>();
+        builder.Services.AddHttpClient();
+        builder.UseInMemoryStore().AddJob<ReportJob>(j => j.WithIdentity("nightly"));
+
+        #endregion
+    }
+
+    public static async ValueTask ConfigurationFromAFile()
+    {
+        #region sample_standalone_configuration
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .AddEnvironmentVariables()
+            .Build();
+
+        await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
+            .UseConfiguration(configuration.GetSection("Quartz"))
+            .Build();
+
+        #endregion
+    }
+
+    public static void FlatProperties()
+    {
+        #region sample_standalone_properties
+
+        NameValueCollection properties = new()
+        {
+            ["quartz.scheduler.instanceName"] = "reporting",
+            ["quartz.threadPool.maxConcurrency"] = "20",
+        };
+
+        QuartzSchedulerBuilder.Create().UseProperties(properties);
+
+        #endregion
+    }
+
+    public static async ValueTask PersistentAndClustered(string connectionString)
+    {
+        #region sample_standalone_persistent_and_clustered
+
+        await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(o =>
+            {
+                o.InstanceName = "orders";
+                o.InstanceId = Environment.MachineName;
+            })
+            .UsePersistentStore(s =>
+            {
+                s.UseSqlServer(connectionString);
+                s.UseClustering(c => c.CheckinInterval = TimeSpan.FromSeconds(10));
+                s.Configure(o => o.TablePrefix = "QRTZ_");
+            })
+            .Build();
+
+        #endregion
+    }
+
+    public static void SharingASchedulerRepository()
+    {
+        #region sample_standalone_shared_repository
+
+        ISchedulerRepository shared = new SchedulerRepository();
+
+        QuartzSchedulerBuilder first = QuartzSchedulerBuilder.Create();
+        first.Services.AddSingleton(shared);
+
+        QuartzSchedulerBuilder second = QuartzSchedulerBuilder.Create();
+        second.Services.AddSingleton(shared);
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/TestingSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/TestingSamples.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/testing.md.
+/// </summary>
+/// <remarks>
+/// The blocks that assert, or that drive a <c>FakeTimeProvider</c>, stay hand-written fences on the
+/// page: compiling them would mean a test framework, an assertion library and
+/// <c>Microsoft.Extensions.TimeProvider.Testing</c> as dependencies of a documentation project.
+/// </remarks>
+public static class TestingSamples
+{
+    public static async ValueTask AnInMemorySchedulerPerTest()
+    {
+        #region sample_testing_in_memory_scheduler
+
+        await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
+            .UseInMemoryStore()
+            .ConfigureScheduler(o => o.InstanceName = $"test-{Guid.NewGuid():N}")
+            .Build();
+
+        IScheduler scheduler = await factory.GetScheduler();
+        await scheduler.Start();
+
+        #endregion
+    }
+
+    public static void ShorteningTheIdleWait()
+    {
+        QuartzSchedulerBuilder.Create()
+            #region sample_testing_idle_wait_time
+
+            .ConfigureScheduler(o => o.IdleWaitTime = TimeSpan.FromSeconds(1))
+
+            #endregion
+            .UseInMemoryStore();
+    }
+
+    public static void MisfireThreshold(TimeProvider clock)
+    {
+        QuartzSchedulerBuilder builder =
+            #region sample_testing_misfire_threshold
+
+            QuartzSchedulerBuilder.Create()
+                .UseInMemoryStore(o => o.MisfireThreshold = TimeSpan.FromMilliseconds(50))
+                .UseTimeProvider(clock)
+
+            #endregion
+            ;
+    }
+
+    public static void InjectingAFault()
+    {
+        IQuartzBuilder builder =
+            #region sample_testing_fault_injection_registration
+
+            QuartzSchedulerBuilder.Create()
+                .UseJobStore(sp => new FlakyJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(sp)))
+
+            #endregion
+            ;
+    }
+}
+
+#region sample_testing_completion_listener
+
+internal sealed class CompletionListener : IJobListener
+{
+    private readonly TaskCompletionSource<JobExecutionException?> completed =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task<JobExecutionException?> Completed => completed.Task;
+
+    public ValueTask JobWasExecuted(
+        IJobExecutionContext context,
+        JobExecutionException? jobException,
+        CancellationToken cancellationToken = default)
+    {
+        completed.TrySetResult(jobException);
+        return default;
+    }
+}
+
+#endregion
+
+#region sample_testing_flaky_job_store
+
+internal sealed class FlakyJobStore(IJobStore inner) : DelegatingJobStore(inner)
+{
+    public int AcquireCalls { get; private set; }
+
+    public override ValueTask<List<IOperableTrigger>> AcquireNextTriggers(
+        TriggerAcquisitionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        AcquireCalls++;
+        if (AcquireCalls == 1)
+        {
+            throw new JobPersistenceException("simulated outage");
+        }
+
+        return base.AcquireNextTriggers(request, cancellationToken);
+    }
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Tutorial/TimeAndTimeProviderSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/TimeAndTimeProviderSamples.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/time-and-timeprovider.md.
+/// </summary>
+public static class TimeAndTimeProviderSamples
+{
+    public static void RegisteringATimeProvider(IHostApplicationBuilder builder, TimeProvider myTimeProvider)
+    {
+        #region sample_time_provider_registration
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UseTimeProvider(myTimeProvider);
+        });
+
+        #endregion
+    }
+
+    public static async ValueTask RegisteringATimeProviderStandalone(TimeProvider myTimeProvider)
+    {
+        #region sample_time_provider_standalone
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .UseTimeProvider(myTimeProvider)
+            .BuildScheduler();
+
+        #endregion
+    }
+
+    public static void ScheduleBuildersReadNoClock(string cronExpression, string recurrenceRule)
+    {
+        #region sample_time_provider_schedule_builders
+
+        CronScheduleBuilder.Create(cronExpression);
+        SimpleScheduleBuilder.Create();
+        CalendarIntervalScheduleBuilder.Create();
+        DailyTimeIntervalScheduleBuilder.Create();
+        RecurrenceScheduleBuilder.Create(recurrenceRule);
+
+        #endregion
+    }
+
+    public static void DateBuilderReadsTheClock(TimeProvider timeProvider, TimeZoneInfo tz)
+    {
+        #region sample_time_provider_date_builder
+
+        DateTimeOffset when = DateBuilder.Create(timeProvider).InYear(2027).InMonthOnDay(3, 15).AtHourOfDay(9).Build();
+        DateTimeOffset local = DateBuilder.CreateInTimeZone(tz, timeProvider).AtHourMinuteAndSecond(9, 30, 0).Build();
+
+        #endregion
+    }
+
+    public static void ConfiguredTriggersSeeTheFakeClock(IHostApplicationBuilder builder, TimeProvider fakeClock)
+    {
+        #region sample_time_provider_configured_trigger
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UseTimeProvider(fakeClock);
+
+            // this trigger's implicit start time is the fake clock's now
+            q.AddTrigger<ReportJob>(t => t
+                .WithSimpleSchedule(s => s.WithInterval(TimeSpan.FromHours(1)).RepeatForever()));
+        });
+
+        #endregion
+    }
+
+    public static void ABuilderWithNoClockUsesTheWallClock()
+    {
+        #region sample_time_provider_wall_clock_trigger
+
+        // StartTimeUtc is the WALL CLOCK, whatever the scheduler's TimeProvider says
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("hourly")
+            .WithSimpleSchedule(s => s.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+
+        #endregion
+    }
+
+    public static void HandingTheBuilderTheClock(TimeProvider fakeClock)
+    {
+        #region sample_time_provider_trigger_builder_clock
+
+        ITrigger trigger = TriggerBuilder.Create(fakeClock)
+            .WithIdentity("hourly")
+            .StartAt(fakeClock.GetUtcNow())
+            .WithSimpleSchedule(s => s.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+
+        #endregion
+    }
+
+    public static void TimeZoneOnTheSchedule()
+    {
+        #region sample_time_provider_time_zone
+
+        TriggerBuilder.Create()
+            .WithCronSchedule("0 0 9 * * ?", x => x.InTimeZone(TimeZones.FindById("Europe/Helsinki")))
+            .Build();
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/Tutorial/TutorialSampleTypes.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/TutorialSampleTypes.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.Metrics;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// The jobs and listeners the tutorial samples name in passing.
+/// </summary>
+/// <remarks>
+/// A page that shows one of these in full wraps it in its own region; the rest are here only so the
+/// samples that name them compile.
+/// </remarks>
+public sealed class MyJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class BackupJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class AuditListener : IJobListener;
+
+public sealed class ReportAuditListener : IJobListener;
+
+public sealed class NightlyListener : ITriggerListener;
+
+public sealed class VetoWeekends : ITriggerListener;
+
+public sealed class MeteredListener(IMeterFactory meterFactory) : IJobListener;
+
+public interface IReportRenderer;
+
+public sealed class PdfReportRenderer : IReportRenderer;

--- a/src/Quartz.Documentation.Samples/Tutorial/UsingQuartzSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/UsingQuartzSamples.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+#region sample_using_quartz_job
+
+public sealed class HelloJob : IJob
+{
+    private readonly ILogger<HelloJob> logger;
+
+    public HelloJob(ILogger<HelloJob> logger)
+    {
+        this.logger = logger;
+    }
+
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Hello from {JobKey}", context.JobDetail.Key);
+        return default;
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/using-quartz.md.
+/// </summary>
+public static class UsingQuartzSamples
+{
+    public static async ValueTask ConfigureTheHost(string[] args)
+    {
+        #region sample_using_quartz_host
+
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+        builder.AddQuartz(q =>
+        {
+            // run HelloJob now, and then every 40 seconds
+            q.ScheduleJob<HelloJob>(trigger => trigger
+                .WithIdentity("helloTrigger")
+                .StartNow()
+                .WithSimpleSchedule(x => x
+                    .WithInterval(TimeSpan.FromSeconds(40))
+                    .RepeatForever()));
+        });
+
+        builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        IHost host = builder.Build();
+
+        // blocks until the host is stopped, and then until the last running job completes
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    public static void JobWithSeveralTriggers(IHostApplicationBuilder builder)
+    {
+        #region sample_using_quartz_several_triggers
+
+        builder.AddQuartz(q =>
+        {
+            JobKey jobKey = new("reportJob");
+
+            q.AddJob<ReportJob>(j => j
+                .WithIdentity(jobKey)
+                .WithDescription("nightly and on-demand sales report"));
+
+            q.AddTrigger<ReportJob>(t => t
+                .ForJob(jobKey)
+                .WithIdentity("nightly")
+                .WithCronSchedule("0 0 2 * * ?"));
+
+            q.AddTrigger<ReportJob>(t => t
+                .ForJob(jobKey)
+                .WithIdentity("hourly-on-weekdays")
+                .WithCronSchedule("0 0 9-17 ? * MON-FRI"));
+        });
+
+        #endregion
+    }
+}
+
+#region sample_using_quartz_scheduling_at_run_time
+
+public sealed class ReportRequests
+{
+    private readonly IScheduler scheduler;
+
+    public ReportRequests(IScheduler scheduler)
+    {
+        this.scheduler = scheduler;
+    }
+
+    public async ValueTask QueueFor(string customer, CancellationToken cancellationToken)
+    {
+        IJobDetail job = JobBuilder.Create<ReportJob>()
+            .WithIdentity(customer, "reports")
+            .UsingJobData("customer", customer)
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity(customer, "reports")
+            .StartAt(DateTimeOffset.UtcNow.AddMinutes(5))
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger, cancellationToken);
+    }
+}
+
+#endregion

--- a/src/Quartz.Documentation.Samples/VersionNeutralPageSamples.cs
+++ b/src/Quartz.Documentation.Samples/VersionNeutralPageSamples.cs
@@ -1,0 +1,112 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Listeners;
+
+namespace Quartz.Documentation.Samples;
+
+/// <summary>
+/// Samples for the version-neutral pages: docs/documentation/best-practices.md,
+/// docs/documentation/troubleshooting.md and docs/documentation/faq.md.
+/// </summary>
+/// <remarks>
+/// Only the 4.x blocks on those pages are compiled from here. A block written against 3.x stays a
+/// hand-written fence, because this project is 4.x and could not compile it.
+/// </remarks>
+public static class VersionNeutralPageSamples
+{
+    public static async ValueTask ScheduleJobsInOneCall(IScheduler scheduler, IReadOnlyCollection<int> allData)
+    {
+        #region sample_best_practices_schedule_jobs
+
+        Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> jobsDictionary = new();
+        foreach (var data in allData)
+        {
+            var triggerSet = new HashSet<ITrigger>();
+            IJobDetail job = JobBuilder.Create<JobName>()
+                .UsingJobData("jobData", data.ToString())
+                .Build();
+            ITrigger trigger = TriggerBuilder.Create()
+                .ForJob(job)
+                .Build();
+            triggerSet.Add(trigger);
+            jobsDictionary.Add(job, triggerSet);
+        }
+        await scheduler.ScheduleJobs(jobsDictionary, new ScheduleJobOptions { Replace = true });
+
+        #endregion
+    }
+
+    public static void PoolSize(IServiceCollection services, string connectionString)
+    {
+        #region sample_troubleshooting_pool_size
+
+        services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(s =>
+            {
+                s.UseSystemTextJsonSerializer();
+                s.UseSqlServer(connectionString);
+                // Ensure your connection string has an adequate pool size
+                // e.g., "...;Max Pool Size=25;"
+            });
+        });
+
+        #endregion
+    }
+
+    public static void WaitForJobsToComplete(IServiceCollection services)
+    {
+        #region sample_troubleshooting_wait_for_jobs
+
+        services.AddQuartz(q =>
+        {
+            // configure jobs and triggers
+        });
+        services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    public static void WaitForJobsToCompleteWithABlock(IServiceCollection services)
+    {
+        #region sample_troubleshooting_wait_for_jobs_block
+
+        services.AddQuartzHostedService(options =>
+        {
+            options.WaitForJobsToComplete = true;
+        });
+
+        #endregion
+    }
+
+    public static void ChainingJobs(IScheduler scheduler)
+    {
+        #region sample_faq_job_chaining
+
+        JobChainingJobListener chain = new("chain");
+        chain.AddJobChainLink(new JobKey("extract"), new JobKey("transform"));
+        chain.AddJobChainLink(new JobKey("transform"), new JobKey("load"));
+
+        scheduler.ListenerManager.AddJobListener(chain);
+
+        #endregion
+    }
+}
+
+/// <summary>Stands in for a job of your own in the <c>ScheduleJobs</c> sample.</summary>
+public sealed class JobName : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+public sealed class FaqJob : IJob
+{
+    #region sample_faq_value_task_execute
+
+    public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        // your job logic
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Extends the compiled-snippet convention from the fifteen `packages/` pages to the rest of the 4.x
documentation. **193 of the 229 C# blocks** in scope are now `#region sample_*` blocks in
`src/Quartz.Documentation.Samples`, injected by `dotnet fallout DocsSnippets` — so a documented call
that outlives its API now fails `Compile` rather than sitting on the site.

Two small docs fixes ride along.

## Converted, by folder

| Folder | Converted | Left as a plain fence |
|---|---:|---:|
| `quartz-4.x/tutorial/` (every page but `execution-groups.md`, which is converted on another branch) | 117 | 17 |
| `quartz-4.x/how-tos/` | 35 | 9 |
| `quartz-4.x/configuration/` | 25 | 2 |
| `quartz-4.x/db/`, `cron-expressions.md`, `quick-start.md` | 10 | 3 |
| `best-practices.md`, `troubleshooting.md`, `faq.md` | 6 | 5 |
| **Total** | **193** | **36** |

`quartz-4.x/db/index.md` carries no C# at all, so there was nothing to convert there.

New samples live in `Tutorial/`, `HowTos/` and `Configuration/` sub-directories, one file per page,
regions named after the page and the concept — the layout #3358 established. Nothing named
`Tutorial/ExecutionGroupsSamples.cs` or `MultiTenancySamples.cs`, both of which exist on
`docs-tenancy-corrections`.

## Documentation bugs the compiler found

Every one of these is a block that did **not** compile as written. Nothing in the product changed to
accommodate a sample.

| Page | What was wrong |
|---|---|
| `tutorial/more-about-jobs.md` | `string jobSays = dataMap.GetString("jobSays");` — `GetString` returns `string?` |
| `tutorial/more-about-jobs.md` | `(IList<DateTimeOffset>)dataMap["myStateData"]` — the indexer returns `object?` (twice) |
| `tutorial/more-about-jobs.md` | a `DumbJob` shown with two properties and `// ...` never implemented `IJob` |
| `tutorial/more-about-jobs.md` | `public string JobSays { get; set; }` and `{ private get; set; }` — non-nullable, uninitialised |
| `tutorial/more-about-jobs.md` | `TenantJobDetail(…, JobDataMap jobDataMap = null)` — the parameter was not annotated nullable |
| `tutorial/job-data-map.md` | two `Execute` bodies fell off the end without returning |
| `tutorial/job-data-map.md` | `TryGet<ReportOptions>("options", out ReportOptions options)` — `[MaybeNullWhen(false)]` needs a nullable out variable |
| `tutorial/node-affinity.md` | `ITrigger t = await scheduler.GetTrigger(key);` — `GetTrigger` returns `ITrigger?` |
| `tutorial/standalone-scheduler.md` | `Create()…AddJob(…).AddTrigger(…).AddCalendar(…).Build()` does not compile — see below |
| `tutorial/configuration-resource-usage-and-scheduler-factory.md` | `ILoggerFactory loggerFactory = ...;` is not C# |
| `best-practices.md` | `ScheduleJobs(jobsDictionary, replace: true)` is the 3.x signature; 4.x takes a `ScheduleJobOptions` |
| `best-practices.md` | two `await` statements were missing their semicolon (in blocks that stay 3.x fences) |

### One for a reviewer to decide

**`AddJob` / `AddTrigger` / `ScheduleJob` / `AddCalendar` break a `QuartzSchedulerBuilder` chain.**
They are extension methods over `IQuartzBuilder` and return `IQuartzBuilder`, which has no `Build()`.
So `standalone-scheduler.md`'s worked example could not compile, and the page's own "Changed in 4.x"
note — "the returns are covariant now and `Create()…Build()` is one statement" — is only true of the
interface's own members.

I fixed the page: the sample holds the builder in a variable, and a new sentence says why. The
alternative is an API change (generic `TBuilder` extension methods, or `Build()`/`BuildScheduler()`
on `IQuartzBuilder`), which is not something a docs pull request should decide. Worth a look while
`main` is still pre-release.

## Blocks deliberately left as plain fences

Each carries an HTML comment above it saying which case it is, so the next person does not have to
work it out again.

**Quartz's own interface declarations** (6) — `IJob`, `ICalendar`, `ISchedulerListener`,
`ITriggerListener`, `IJobListener`, `ISemaphore`. A second `Quartz.IJob` in the samples project would
shadow the real one and break every sample that names it.

**Listings of signatures rather than code** (7) — `TriggerBuilder.Create(TimeProvider?)`, the four
`UseJobStore` overloads, `IJobStore.Initialize`, `AdoJobStoreBase`'s two abstract members,
`CreateAcquisitionCriteria`, `DbSemaphore.ExecuteSql` and its two protected helpers.

**Deliberate elisions** (2) — `DocumentJobStore` and `BusinessDayTriggerSerializer` omit members on
purpose, and a class with them left out does not compile. The `LeaseSemaphore` sketch is the same
shape but *is* converted, with `return true;` / `return default;` added under its ellipsis comments.

**A NuGet dependency taken purely for a sample** (14), or a shape a class library cannot hold (3). No
package was added to the samples project:

| Page | Blocks | Needs |
|---|---:|---|
| `tutorial/testing.md` | 8 | NUnit, an assertion library, `Microsoft.Extensions.TimeProvider.Testing`, `Microsoft.AspNetCore.Mvc.Testing` |
| `tutorial/job-stores.md` | 2 | Entity Framework Core; Npgsql |
| `tutorial/time-and-timeprovider.md` | 1 | `Microsoft.Extensions.TimeProvider.Testing` |
| `configuration/reference.md` | 2 | `Npgsql.DependencyInjection` (`AddNpgsqlDataSource`) |
| `faq.md` | 1 | `Microsoft.Extensions.TimeProvider.Testing` |
| `quick-start.md` | 3 | — top-level statements shown with their `using` directives; a class library can host neither |

**3.x code on a version-neutral page** (4) — `best-practices.md`'s `Task Execute(IJobExecutionContext)`
samples. The samples project is 4.x and cannot compile them.

## The two riders

**#3350 — the blog index rendered empty.** `BlogIndex.vue` opened its `posts` computed property with
an unconditional `return []`. So did `BlogExcerpt.vue`, which is the home page's "Latest News" — the
same bug, so both are fixed. Deleting the stub was not enough: the code under it was VuePress 1
(`this.$site.pages`, `page.id === 'post'`). VuePress 2 gives a client component `useRoutes()`, whose
route meta is compiled into the routes module and is therefore present during server rendering — but
only what a page puts there, so `config.ts` now copies each post's date, title, description and flags
into its route meta as the page is created. Both components read them back through one shared
`docs/.vuepress/posts.js`. `npm run docs:build` renders 53 entries into `blog.html` (the 54th post is
the `hidden: true` redirect stub), newest first.

**#2773 — NaturalCron.** Added to `packages/quartz-3rd-party-plugins.md` under a new **Schedules**
heading, in the page's existing shape, with the plain statement that it is maintained outside this
repository.

## Verification

```
dotnet build Quartz.slnx                    Build succeeded. 0 Warning(s) 0 Error(s)
dotnet fallout DocsSnippets                 Succeeded
dotnet fallout VerifyDocsSnippets           Documentation snippets are up to date (89 markdown files checked)
dotnet test Quartz.Tests.Unit               Passed! Failed: 0, Passed: 3094, Skipped: 4, Total: 3098
dotnet test Quartz.Tests.AspNetCore         Passed! Failed: 0, Passed: 314, Total: 314
npm ci                                      879 packages, found 0 vulnerabilities
npm run docs:check-links                    211 pages, 697 internal links, 392 fragments — no dead links or anchors
npm run docs:check-links-test               7 pass, 0 fail
npm run docs:build                          success, 212 pages rendered
npm run docs:lint                           121 errors, byte-identical to the same list at d575f637 — none added
```

`Quartz.Tests.Integration` was not run: Docker is available here, but nothing outside `docs/` and the
documentation-samples project changed, so there is no product behaviour for it to exercise.

Closes #3350, closes #2773; part of #3357
