### PR TITLE
The declared job type stays declared through the fire path

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1271,6 +1271,54 @@ default value that is an enum from an assembly which only ships in a shared fram
 constant whose type coverlet's Cecil resolver cannot resolve, and it silently drops the *entire*
 containing assembly from the coverage report.
 
+## Naming a job type by string says so under trimming
+
+`Quartz` is marked trimmable in 4.0, and the job-type APIs say what they need. Nothing here is a
+source or binary break — the attributes are annotations — but an application published with
+`PublishTrimmed` now gets told things 3.x never mentioned.
+
+**The typed spelling carries the requirement.** `JobBuilder.Create<T>()`, `JobBuilder<TJob>.OfType<T>()`
+and `OfType(Type)`, `AddJob<T>()`, `AddJob(Type, …)`, `AddJobType<T>()`, `AddJobType<TJob, TImpl>()`,
+`AddTrigger<TJob>()`, `ScheduleJob<T>()`, `TriggerBuilder.Create<TJob>()`, `new JobType(Type)` and the
+implicit `Type` → `JobType` conversion all declare
+`[DynamicallyAccessedMembers(PublicConstructors | PublicProperties | Interfaces)]` on the job type —
+what a job factory constructs, what a `JobDataMap` binds onto, and where
+`[DisallowConcurrentExecution]` may be inherited from. The generic `JobBuilder<TJob>`,
+`TriggerBuilder<TJob>`, `IJobConfigurator<TJob>` and `ITriggerConfigurator<TJob>` declare the same on
+their type parameter. `PublicMethods`, which some of these declared in earlier 4.0 previews, is gone:
+a kept property keeps its accessors, and `IJob.Execute` is reached through the interface.
+
+If you pass a `Type` variable rather than a `typeof` or a generic argument, the compiler now asks the
+same of *your* code, which is the annotation doing its job:
+
+```diff
+- static IJobDetail Build(Type jobType) => JobBuilder.Create().OfType(jobType).Build();
++ static IJobDetail Build(
++     [DynamicallyAccessedMembers(
++         DynamicallyAccessedMemberTypes.PublicConstructors
++         | DynamicallyAccessedMemberTypes.PublicProperties
++         | DynamicallyAccessedMemberTypes.Interfaces)] Type jobType)
++     => JobBuilder.Create().OfType(jobType).Build();
+```
+
+**The name-taking spelling is `[RequiresUnreferencedCode]`.** `JobBuilder<TJob>.OfType(string)`, the
+`JobType(string)` constructor and the explicit `string` → `JobType` cast report `IL2026` in a trimmed
+build, because a type resolved from a string cannot be proven reachable. So does the
+`job_scheduling_data` XML loader. Prefer the typed spelling, or root the type yourself with a
+[trimmer root descriptor](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#root-descriptors).
+See [Trimming](tutorial/more-about-jobs.md#trimming) in the tutorial for what a trimmed application has
+to do.
+
+`DbMetadata.ConnectionType`, `.CommandType` and `.ParameterType` carry annotations too, saying what
+`DbProvider` does with each: constructs connections and commands, and reads the properties the metadata
+names. A `UseGenericDatabase` callback that sets them from `typeof(...)` already satisfies that.
+
+**One behaviour change came with it.** An ADO.NET store's trigger acquisition decided
+`[DisallowConcurrentExecution]` with a check that did not look at interfaces, while
+`IJobDetail.ConcurrentExecutionDisallowed` did. A job that inherited the attribute from an interface
+was therefore serialized when it fired but not when it was acquired, so a batch could hold two of its
+triggers and the second was released again. Both now ask the same question.
+
 ## The job scope is prepared without writing a job factory
 
 `ConfigureScope` — the hook that prepares the dependency injection scope a job is built in, and the place

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -383,6 +383,48 @@ come back.
 describes the detail rather than preserving it: what it builds is Quartz's `IJobDetail`. Use `WithJobData` to
 vary the data of a detail of your own, and `Clone()` to copy one.
 
+## Trimming
+
+The `Quartz` package is marked trimmable, so an application published with `PublishTrimmed` can cut
+away what it does not use. A job type is only kept if something the trimmer can see points at it, and
+that is the one thing an application has to get right.
+
+**Name job types as types.** `JobBuilder.Create<TJob>()`, `OfType<TJob>()`, `AddJob<TJob>()` and
+`AddJobType<TJob>()` all declare what Quartz reflects over on a job — its public constructors, its
+public properties and the interfaces it implements — so the trimmer keeps exactly those:
+
+```csharp
+builder.AddJob<SendEmailJob>(j => j.WithIdentity("send-email"));
+```
+
+**An API that takes a type name says so.** The ones that accept a name instead of a type carry
+`[RequiresUnreferencedCode]`, so publishing trimmed reports them:
+
+```csharp
+// IL2026: a type named only by a string is not guaranteed to survive trimming
+IJobDetail detail = JobBuilder.Create().OfType("Acme.Jobs.SendEmailJob, Acme.Jobs").Build();
+```
+
+That is `JobBuilder<TJob>.OfType(string)`, the `JobType(string)` constructor and the explicit cast from
+`string`. Prefer the typed spelling; where you cannot, tell the trimmer to keep the type anyway with a
+[trimmer root descriptor](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#root-descriptors).
+
+**Three places name job types by string whatever you do**, and each needs the job type registered or
+rooted:
+
+- an ADO.NET job store, because a stored job's type is the `JOB_CLASS_NAME` column;
+- `job_scheduling_data` XML, whose loader is `[RequiresUnreferencedCode]` for that reason;
+- the flat `quartz.*` configuration keys, which name plugins, listeners and job stores by string, and
+  set their properties by name.
+
+Registering every job type with `AddJob<TJob>()` or `AddJobType<TJob>()` covers the first of those:
+those calls are what the trimmer follows, and the store then finds the type it needs.
+
+::: tip
+Native AOT is not supported yet — that work is tracked on
+[issue #3341](https://github.com/quartznet/quartznet/issues/3341).
+:::
+
 ## JobExecutionException
 
 Finally, we need to inform you of a few details of the `IJob.Execute(..)` method. The only type of exception

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -1703,6 +1703,123 @@ public class AdoJobStoreBaseTest
 
     #endregion
 
+    #region Concurrency at acquisition
+
+    /// <summary>
+    /// Arranges an acquisition pass that finds <paramref name="triggers" /> ready to fire, all of them
+    /// belonging to jobs of <paramref name="jobType" />, and lets every one of them win its state update.
+    /// </summary>
+    private void GivenTriggersToAcquire(Type jobType, params IOperableTrigger[] triggers)
+    {
+        A.CallTo(() => driverDelegate.SelectTriggersToAcquire(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<TriggerAcquisitionCriteria>.Ignored,
+                A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<List<TriggerAcquireResult>>(
+                triggers.Select(x => new TriggerAcquireResult(x.Key, jobType.AssemblyQualifiedName, null)).ToList()));
+
+        foreach (IOperableTrigger trigger in triggers)
+        {
+            IOperableTrigger captured = trigger;
+            A.CallTo(() => driverDelegate.SelectTrigger(
+                    A<ConnectionAndTransactionHolder>.Ignored,
+                    A<TriggerKey>.That.IsEqualTo(captured.Key),
+                    A<CancellationToken>.Ignored))
+                .Returns(new ValueTask<IOperableTrigger>(captured));
+        }
+
+        A.CallTo(() => driverDelegate.UpdateTriggerStateFromOtherStateWithNextFireTime(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<TriggerKey>.Ignored,
+                A<StoredTriggerState>.Ignored,
+                A<StoredTriggerState>.Ignored,
+                A<DateTimeOffset>.Ignored,
+                A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<int>(1));
+    }
+
+    /// <summary>
+    /// A trigger the acquisition loop will take: it has a next fire time, which a builder-built trigger
+    /// only gets once its first fire time has been computed, and the loop skips one that has none.
+    /// </summary>
+    private static IOperableTrigger CreateReadyTrigger(string name, DateTimeOffset fireTime)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity(name, "g1")
+            .ForJob("j1", "jg1")
+            .StartAt(fireTime)
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+        trigger.FireInstanceId = name + "-fire";
+        trigger.NextFireTimeUtc = fireTime;
+        return trigger;
+    }
+
+    private async Task<List<IOperableTrigger>> AcquireTwoTriggersForOneJob(Type jobType)
+    {
+        // One fire time for both, so the batch window the first acquisition sets cannot exclude the
+        // second and turn a concurrency decision into an arithmetic one.
+        DateTimeOffset fireTime = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
+        GivenTriggersToAcquire(jobType, CreateReadyTrigger("t1", fireTime), CreateReadyTrigger("t2", fireTime));
+
+        return await jobStoreSupport.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow + TimeSpan.FromHours(1),
+            MaxCount = 5,
+        });
+    }
+
+    /// <summary>
+    /// The acquisition loop decided this with the non-walking attribute check while
+    /// <see cref="IJobDetail.ConcurrentExecutionDisallowed" /> walked interfaces, so a job that inherited
+    /// the attribute from an interface was serialized when it fired and not when it was acquired. Both
+    /// now ask <c>JobTypeInformation</c>, so the answer is the same one in both places.
+    /// </summary>
+    [Test]
+    public async Task AcquireNextTriggers_ShouldTakeOneTriggerForAJobThatInheritsDisallowConcurrentFromAnInterface()
+    {
+        List<IOperableTrigger> acquired = await AcquireTwoTriggersForOneJob(typeof(InterfaceNonConcurrentJob));
+
+        acquired.Should().ContainSingle(
+            "the job is non-concurrent, so a batch may hold only one of its triggers - and it is non-concurrent because an interface it implements says so");
+    }
+
+    [Test]
+    public async Task AcquireNextTriggers_ShouldTakeOneTriggerForAJobThatCarriesDisallowConcurrentItself()
+    {
+        List<IOperableTrigger> acquired = await AcquireTwoTriggersForOneJob(typeof(DisallowConcurrentTestJob));
+
+        acquired.Should().ContainSingle("the attribute on the job type itself has always been honored here");
+    }
+
+    [Test]
+    public async Task AcquireNextTriggers_ShouldTakeEveryTriggerForAConcurrentJob()
+    {
+        List<IOperableTrigger> acquired = await AcquireTwoTriggersForOneJob(typeof(ConcurrentTestJob));
+
+        acquired.Should().HaveCount(2, "nothing limits how many triggers of a concurrent job one batch may hold");
+
+        A.CallTo(() => driverDelegate.IsJobCurrentlyExecuting(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<JobKey>.Ignored,
+                A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// A job that carries <see cref="DisallowConcurrentExecutionAttribute" /> on an interface it
+    /// implements rather than on itself, which is the case the two checks used to disagree about.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    private interface INonConcurrentContract : IJob;
+
+    private sealed class InterfaceNonConcurrentJob : INonConcurrentContract
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    #endregion
+
     #region Cluster check-in and recovery
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Utils/ObjectUtilsTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/ObjectUtilsTest.cs
@@ -134,6 +134,34 @@ public class ObjectUtilsTest
         });
     }
 
+    /// <summary>
+    /// The interfaces are walked flat rather than recursively, which is only right because
+    /// <see cref="Type.GetInterfaces" /> already reports the ones an interface itself inherits. This is
+    /// what says so.
+    /// </summary>
+    [Test]
+    public void IsAnyInterfaceAttributePresentShouldSeeAnAttributeOnAnInheritedInterface()
+    {
+        ObjectUtils.IsAnyInterfaceAttributePresent(typeof(DerivedContractJob), typeof(DisallowConcurrentExecutionAttribute))
+            .Should().BeTrue("the attribute is on an interface the job's own interface inherits, two hops away");
+
+        ObjectUtils.IsAnyInterfaceAttributePresent(typeof(DerivedContractJob), typeof(PersistJobDataAfterExecutionAttribute))
+            .Should().BeFalse("nothing in the hierarchy carries that one");
+
+        ObjectUtils.IsAttributePresent(typeof(DerivedContractJob), typeof(DisallowConcurrentExecutionAttribute))
+            .Should().BeFalse("the non-walking check is the one the two ADO paths used to disagree over, and it still does not look at interfaces");
+    }
+
+    [DisallowConcurrentExecution]
+    private interface INonConcurrentContract : IJob;
+
+    private interface IDerivedContract : INonConcurrentContract;
+
+    private sealed class DerivedContractJob : IDerivedContract
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
     [Test]
     public void ShouldBeAbleToSetValuesToExplicitlyImplementedInterfaceMembers()
     {

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -457,7 +457,7 @@ namespace Quartz
     {
         System.Threading.Tasks.ValueTask Execute(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default);
     }
-    public interface IJobConfigurator<TJob>
+    public interface IJobConfigurator<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>
         where TJob : Quartz.IJob
     {
         Quartz.IJobConfigurator<TJob> DisallowConcurrentExecution(bool concurrentExecutionDisallowed = true);
@@ -775,7 +775,7 @@ namespace Quartz
     {
         Quartz.ITriggerConfigurator WithSchedule(Quartz.IScheduleBuilder scheduleBuilder);
     }
-    public interface ITriggerConfigurator<TJob> : Quartz.ITriggerConfigurator
+    public interface ITriggerConfigurator<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob> : Quartz.ITriggerConfigurator
         where TJob : Quartz.IJob
     {
         Quartz.ITriggerConfigurator<TJob> EndAt(System.DateTimeOffset? endTimeUtc);
@@ -825,19 +825,22 @@ namespace Quartz
     public static class JobBuilder
     {
         public static Quartz.JobBuilder<Quartz.IJob> Create() { }
-        public static Quartz.JobBuilder<T> Create<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>()
+        public static Quartz.JobBuilder<T> Create<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  T>()
             where T : Quartz.IJob { }
     }
-    public sealed class JobBuilder<TJob> : Quartz.IJobConfigurator<TJob>
+    public sealed class JobBuilder<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob> : Quartz.IJobConfigurator<TJob>
         where TJob : Quartz.IJob
     {
         public Quartz.JobKey? Key { get; }
         public Quartz.IJobDetail Build() { }
         public Quartz.JobBuilder<TJob> DisallowConcurrentExecution(bool concurrentExecutionDisallowed = true) { }
         public Quartz.JobBuilder<TJob> OfType(Quartz.JobType jobType) { }
-        public Quartz.JobBuilder<TJob> OfType([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] System.Type type) { }
+        public Quartz.JobBuilder<TJob> OfType([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)] System.Type type) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T" +
+            ">(); a type named only by a string in configuration or in the database is not gu" +
+            "aranteed to survive trimming.")]
         public Quartz.JobBuilder<TJob> OfType(string typeName) { }
-        public Quartz.JobBuilder<TJob> OfType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>()
+        public Quartz.JobBuilder<TJob> OfType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  T>()
             where T : TJob { }
         public Quartz.JobBuilder<TJob> PersistJobDataAfterExecution(bool persistJobDataAfterExecution = true) { }
         public Quartz.JobBuilder<TJob> RequestRecovery(bool shouldRecover = true) { }
@@ -961,7 +964,10 @@ namespace Quartz
     }
     public sealed class JobType : System.IEquatable<Quartz.JobType>
     {
-        public JobType(System.Type type) { }
+        public JobType([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)] System.Type type) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T" +
+            ">(); a type named only by a string in configuration or in the database is not gu" +
+            "aranteed to survive trimming.")]
         public JobType(string fullName) { }
         public string FullName { get; }
         public System.Type Type { get; }
@@ -969,9 +975,12 @@ namespace Quartz
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
-        public bool TryResolve([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Type? resolved) { }
+        public bool TryResolve([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)] [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Type? resolved) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T" +
+            ">(); a type named only by a string in configuration or in the database is not gu" +
+            "aranteed to survive trimming.")]
         public static Quartz.JobType op_Explicit(string fullName) { }
-        public static Quartz.JobType op_Implicit(System.Type type) { }
+        public static Quartz.JobType op_Implicit([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)] System.Type type) { }
         public static bool operator !=(Quartz.JobType? left, Quartz.JobType? right) { }
         public static bool operator ==(Quartz.JobType? left, Quartz.JobType? right) { }
     }
@@ -1142,34 +1151,34 @@ namespace Quartz
             where T : Quartz.ICalendar, new () { }
         public static Quartz.IQuartzBuilder AddCalendar<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(this Quartz.IQuartzBuilder builder, string name, Quartz.AddCalendarOptions options = default, System.Action<T>? configure = null)
             where T : Quartz.ICalendar, new () { }
-        public static Quartz.IQuartzBuilder AddJob(this Quartz.IQuartzBuilder builder, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] System.Type jobType, System.Action<Quartz.IJobConfigurator<Quartz.IJob>> configure) { }
-        public static Quartz.IQuartzBuilder AddJob(this Quartz.IQuartzBuilder builder, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] System.Type jobType, System.Action<System.IServiceProvider, Quartz.IJobConfigurator<Quartz.IJob>> configure) { }
-        public static Quartz.IQuartzBuilder AddJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>(this Quartz.IQuartzBuilder builder, System.Action<Quartz.IJobConfigurator<T>> configure)
+        public static Quartz.IQuartzBuilder AddJob(this Quartz.IQuartzBuilder builder, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)] System.Type jobType, System.Action<Quartz.IJobConfigurator<Quartz.IJob>> configure) { }
+        public static Quartz.IQuartzBuilder AddJob(this Quartz.IQuartzBuilder builder, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)] System.Type jobType, System.Action<System.IServiceProvider, Quartz.IJobConfigurator<Quartz.IJob>> configure) { }
+        public static Quartz.IQuartzBuilder AddJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  T>(this Quartz.IQuartzBuilder builder, System.Action<Quartz.IJobConfigurator<T>> configure)
             where T : Quartz.IJob { }
-        public static Quartz.IQuartzBuilder AddJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>(this Quartz.IQuartzBuilder builder, System.Action<System.IServiceProvider, Quartz.IJobConfigurator<T>> configure)
+        public static Quartz.IQuartzBuilder AddJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  T>(this Quartz.IQuartzBuilder builder, System.Action<System.IServiceProvider, Quartz.IJobConfigurator<T>> configure)
             where T : Quartz.IJob { }
-        public static Quartz.IQuartzBuilder AddJobType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TJob>(this Quartz.IQuartzBuilder builder)
+        public static Quartz.IQuartzBuilder AddJobType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(this Quartz.IQuartzBuilder builder)
             where TJob :  class, Quartz.IJob { }
-        public static Quartz.IQuartzBuilder AddJobType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TJob>(this Quartz.IQuartzBuilder builder, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime)
+        public static Quartz.IQuartzBuilder AddJobType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(this Quartz.IQuartzBuilder builder, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime)
             where TJob :  class, Quartz.IJob { }
         public static Quartz.IQuartzBuilder AddJobType<TJob>(this Quartz.IQuartzBuilder builder, System.Func<System.IServiceProvider, TJob> implementationFactory)
             where TJob :  class, Quartz.IJob { }
         public static Quartz.IQuartzBuilder AddJobType<TJob>(this Quartz.IQuartzBuilder builder, System.Func<System.IServiceProvider, TJob> implementationFactory, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime)
             where TJob :  class, Quartz.IJob { }
-        public static Quartz.IQuartzBuilder AddJobType<TJob, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TImplementation>(this Quartz.IQuartzBuilder builder)
+        public static Quartz.IQuartzBuilder AddJobType<TJob, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TImplementation>(this Quartz.IQuartzBuilder builder)
             where TJob :  class, Quartz.IJob
             where TImplementation :  class, TJob { }
-        public static Quartz.IQuartzBuilder AddJobType<TJob, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TImplementation>(this Quartz.IQuartzBuilder builder, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime)
+        public static Quartz.IQuartzBuilder AddJobType<TJob, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TImplementation>(this Quartz.IQuartzBuilder builder, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime)
             where TJob :  class, Quartz.IJob
             where TImplementation :  class, TJob { }
-        public static Quartz.IQuartzBuilder AddTrigger<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TJob>(this Quartz.IQuartzBuilder builder, System.Action<Quartz.ITriggerConfigurator<TJob>> configure)
+        public static Quartz.IQuartzBuilder AddTrigger<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(this Quartz.IQuartzBuilder builder, System.Action<Quartz.ITriggerConfigurator<TJob>> configure)
             where TJob : Quartz.IJob { }
-        public static Quartz.IQuartzBuilder AddTrigger<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TJob>(this Quartz.IQuartzBuilder builder, System.Action<System.IServiceProvider, Quartz.ITriggerConfigurator<TJob>> configure)
+        public static Quartz.IQuartzBuilder AddTrigger<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(this Quartz.IQuartzBuilder builder, System.Action<System.IServiceProvider, Quartz.ITriggerConfigurator<TJob>> configure)
             where TJob : Quartz.IJob { }
         public static Quartz.IQuartzBuilder ConfigureJobScope(this Quartz.IQuartzBuilder builder, System.Action<Microsoft.Extensions.DependencyInjection.IServiceScope, Quartz.Extensibility.TriggerFiredBundle, Quartz.IScheduler> configure) { }
-        public static Quartz.IQuartzBuilder ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>(this Quartz.IQuartzBuilder builder, System.Action<Quartz.ITriggerConfigurator<T>> trigger, System.Action<Quartz.IJobConfigurator<T>>? job = null)
+        public static Quartz.IQuartzBuilder ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  T>(this Quartz.IQuartzBuilder builder, System.Action<Quartz.ITriggerConfigurator<T>> trigger, System.Action<Quartz.IJobConfigurator<T>>? job = null)
             where T : Quartz.IJob { }
-        public static Quartz.IQuartzBuilder ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>(this Quartz.IQuartzBuilder builder, System.Action<System.IServiceProvider, Quartz.ITriggerConfigurator<T>> trigger, System.Action<System.IServiceProvider, Quartz.IJobConfigurator<T>>? job = null)
+        public static Quartz.IQuartzBuilder ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  T>(this Quartz.IQuartzBuilder builder, System.Action<System.IServiceProvider, Quartz.ITriggerConfigurator<T>> trigger, System.Action<System.IServiceProvider, Quartz.IJobConfigurator<T>>? job = null)
             where T : Quartz.IJob { }
         public static Quartz.IQuartzBuilder UseSimpleTypeLoader(this Quartz.IQuartzBuilder builder) { }
     }
@@ -1549,10 +1558,10 @@ namespace Quartz
     public static class TriggerBuilder
     {
         public static Quartz.TriggerBuilder<Quartz.IJob> Create(System.TimeProvider? timeProvider = null) { }
-        public static Quartz.TriggerBuilder<TJob> Create<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TJob>(System.TimeProvider? timeProvider = null)
+        public static Quartz.TriggerBuilder<TJob> Create<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(System.TimeProvider? timeProvider = null)
             where TJob : Quartz.IJob { }
     }
-    public sealed class TriggerBuilder<TJob> : Quartz.ITriggerConfigurator, Quartz.ITriggerConfigurator<TJob>
+    public sealed class TriggerBuilder<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob> : Quartz.ITriggerConfigurator, Quartz.ITriggerConfigurator<TJob>
         where TJob : Quartz.IJob
     {
         public Quartz.ITrigger Build() { }
@@ -2845,13 +2854,16 @@ namespace Quartz.Impl.AdoJobStore.Common
         public DbMetadata() { }
         public string? AssemblyName { get; init; }
         public bool BindByName { get; init; }
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
         public System.Type? CommandType { get; init; }
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
         public System.Type? ConnectionType { get; init; }
         public string? DbBinaryTypeName { get; init; }
         public System.Type? ExceptionType { get; init; }
         public System.Type? ParameterDbType { get; init; }
         public string ParameterDbTypePropertyName { get; init; }
         public string? ParameterNamePrefix { get; init; }
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
         public System.Type? ParameterType { get; init; }
         public string? ProductName { get; init; }
         public bool UseParameterNamePrefixInParameterCollection { get; init; }
@@ -3199,6 +3211,8 @@ namespace Quartz.Impl
         public override System.Threading.Tasks.ValueTask<Quartz.Extensibility.JobScope> CreateJob(Quartz.Extensibility.TriggerFiredBundle bundle, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual System.Threading.Tasks.ValueTask<Quartz.Extensibility.JobScope> CreateJobInstance(Quartz.Extensibility.TriggerFiredBundle bundle, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual void SetObjectProperties(object obj, Quartz.JobDataMap data) { }
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification="The job instance is of the job detail\'s declared type or of a registered implemen" +
+            "tation of it, and both are annotated where they enter Quartz. See the remarks.")]
         protected virtual void SetObjectProperty(object job, string name, object? value) { }
     }
     public sealed class RAMJobStore : Quartz.Extensibility.IJobStore

--- a/src/Quartz/Configuration/ITriggerConfigurator.cs
+++ b/src/Quartz/Configuration/ITriggerConfigurator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 namespace Quartz;
@@ -36,7 +37,7 @@ public interface ITriggerConfigurator
 /// job's own properties.
 /// </summary>
 /// <typeparam name="TJob">the type of job the trigger fires.</typeparam>
-public interface ITriggerConfigurator<TJob> : ITriggerConfigurator where TJob : IJob
+public interface ITriggerConfigurator<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob> : ITriggerConfigurator where TJob : IJob
 {
     /// <summary>
     /// Use a <see cref="TriggerKey" /> with the given name and default group to

--- a/src/Quartz/Configuration/QuartzBuilderExtensions.cs
+++ b/src/Quartz/Configuration/QuartzBuilderExtensions.cs
@@ -81,7 +81,7 @@ public static class QuartzBuilderExtensions
     /// generated one, which a persistent store cannot recognise again on the next start.
     /// </param>
     public static IQuartzBuilder AddJob<
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
+            [DynamicallyAccessedMembers(JobTypeMembers.Required)]
     T>(
         this IQuartzBuilder builder,
         Action<IJobConfigurator<T>> configure) where T : IJob
@@ -92,7 +92,7 @@ public static class QuartzBuilderExtensions
 
     /// <inheritdoc cref="AddJob{T}(IQuartzBuilder, Action{IJobConfigurator{T}})" />
     public static IQuartzBuilder AddJob<
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
+            [DynamicallyAccessedMembers(JobTypeMembers.Required)]
     T>(
         this IQuartzBuilder builder,
         Action<IServiceProvider, IJobConfigurator<T>> configure) where T : IJob
@@ -121,7 +121,7 @@ public static class QuartzBuilderExtensions
     /// </param>
     public static IQuartzBuilder AddJob(
         this IQuartzBuilder builder,
-           [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
+           [DynamicallyAccessedMembers(JobTypeMembers.Required)]
         Type jobType,
         Action<IJobConfigurator<IJob>> configure)
     {
@@ -132,7 +132,7 @@ public static class QuartzBuilderExtensions
     /// <inheritdoc cref="AddJob(IQuartzBuilder, Type, Action{IJobConfigurator{IJob}})" />
     public static IQuartzBuilder AddJob(
         this IQuartzBuilder builder,
-           [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
+           [DynamicallyAccessedMembers(JobTypeMembers.Required)]
         Type jobType,
         Action<IServiceProvider, IJobConfigurator<IJob>> configure)
     {
@@ -166,7 +166,7 @@ public static class QuartzBuilderExtensions
     /// <typeparam name="TJob">The type of job the trigger fires.</typeparam>
     /// <param name="builder">The builder.</param>
     /// <param name="configure">Configures the trigger.</param>
-    public static IQuartzBuilder AddTrigger<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] TJob>(
+    public static IQuartzBuilder AddTrigger<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(
         this IQuartzBuilder builder,
         Action<ITriggerConfigurator<TJob>> configure) where TJob : IJob
     {
@@ -175,7 +175,7 @@ public static class QuartzBuilderExtensions
     }
 
     /// <inheritdoc cref="AddTrigger{TJob}(IQuartzBuilder, Action{ITriggerConfigurator{TJob}})" />
-    public static IQuartzBuilder AddTrigger<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] TJob>(
+    public static IQuartzBuilder AddTrigger<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(
         this IQuartzBuilder builder,
         Action<IServiceProvider, ITriggerConfigurator<TJob>> configure) where TJob : IJob
     {
@@ -215,7 +215,7 @@ public static class QuartzBuilderExtensions
     /// <param name="trigger">Configures the trigger.</param>
     /// <param name="job">Configures the job, which most schedules do not need to.</param>
     public static IQuartzBuilder ScheduleJob<
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
+            [DynamicallyAccessedMembers(JobTypeMembers.Required)]
     T>(
         this IQuartzBuilder builder,
         Action<ITriggerConfigurator<T>> trigger,
@@ -227,7 +227,7 @@ public static class QuartzBuilderExtensions
 
     /// <inheritdoc cref="ScheduleJob{T}(IQuartzBuilder, Action{ITriggerConfigurator{T}}, Action{IJobConfigurator{T}})" />
     public static IQuartzBuilder ScheduleJob<
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)]
+            [DynamicallyAccessedMembers(JobTypeMembers.Required)]
     T>(
         this IQuartzBuilder builder,
         Action<IServiceProvider, ITriggerConfigurator<T>> trigger,
@@ -281,7 +281,7 @@ public static class QuartzBuilderExtensions
         return builder;
     }
 
-    private static IJobDetail ConfigureAndBuildJobDetail<TJob>(
+    private static IJobDetail ConfigureAndBuildJobDetail<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(
         IServiceProvider serviceProvider,
         JobBuilder<TJob> builder,
         Action<IServiceProvider, IJobConfigurator<TJob>> configure) where TJob : IJob
@@ -325,7 +325,7 @@ public static class QuartzBuilderExtensions
     /// <typeparam name="TJob">The job type, as named on the job detail.</typeparam>
     /// <param name="builder">The builder.</param>
     public static IQuartzBuilder AddJobType<
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TJob>(
+            [DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(
         this IQuartzBuilder builder) where TJob : class, IJob
     {
         return builder.AddJobType<TJob, TJob>(ServiceLifetime.Scoped);
@@ -335,7 +335,7 @@ public static class QuartzBuilderExtensions
     /// <param name="builder">The builder.</param>
     /// <param name="lifetime">How long one instance lives.</param>
     public static IQuartzBuilder AddJobType<
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TJob>(
+            [DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(
         this IQuartzBuilder builder,
         ServiceLifetime lifetime) where TJob : class, IJob
     {
@@ -351,7 +351,7 @@ public static class QuartzBuilderExtensions
     /// <param name="builder">The builder.</param>
     public static IQuartzBuilder AddJobType<
             TJob,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(
+            [DynamicallyAccessedMembers(JobTypeMembers.Required)] TImplementation>(
         this IQuartzBuilder builder)
         where TJob : class, IJob
         where TImplementation : class, TJob
@@ -364,7 +364,7 @@ public static class QuartzBuilderExtensions
     /// <param name="lifetime">How long one instance lives.</param>
     public static IQuartzBuilder AddJobType<
             TJob,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(
+            [DynamicallyAccessedMembers(JobTypeMembers.Required)] TImplementation>(
         this IQuartzBuilder builder,
         ServiceLifetime lifetime)
         where TJob : class, IJob

--- a/src/Quartz/HttpApiContract/JobDetailDto.cs
+++ b/src/Quartz/HttpApiContract/JobDetailDto.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
+
 // ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract - Can be null when received from Web API
 // ReSharper disable NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
 
@@ -64,6 +66,7 @@ internal record JobDetailDto(
         }
     }
 
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in an HTTP API request is not guaranteed to survive trimming.")]
     public (IJobDetail? JobDetail, string? ErrorReason) AsIJobDetail()
     {
         if (JobType is null || !IsWellFormedTypeName(JobType))

--- a/src/Quartz/IJobConfigurator.cs
+++ b/src/Quartz/IJobConfigurator.cs
@@ -1,8 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 namespace Quartz;
 
-public interface IJobConfigurator<TJob> where TJob : IJob
+public interface IJobConfigurator<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob> where TJob : IJob
 {
     /// <summary>
     /// Use a <see cref="JobKey" /> with the given name and default group to

--- a/src/Quartz/ILLink.Suppressions.xml
+++ b/src/Quartz/ILLink.Suppressions.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-  The ILLink half of the trim baseline recorded in issue #3341. It lists exactly the same types as
-  TrimAnalysisBaseline.cs beside it, for exactly the same reasons — read that file first; the reasoning
-  lives there and is not repeated here.
+  The ILLink half of the trim baseline recorded in issue #3341. It lists the same types as
+  TrimAnalysisBaseline.cs beside it, for the same reasons — read that file first; the reasoning lives
+  there and is not repeated here.
+
+  It is not entry-for-entry identical, and one difference is deliberate: ILLink sees through calls the
+  Roslyn analyzer does not, so JsonSchedulingHelper needs an IL2057 here that the C# baseline has no
+  warning to silence. Removing an entry that looks unused because the analyzer is quiet about it fails
+  the publish; verify against a clean `dotnet fallout PublishTrimmed`, not against the compile.
 
   Two files are needed because the two tools cannot be told the same way. SuppressMessageAttribute is
   [Conditional("CODE_ANALYSIS")], so the C# baseline never reaches metadata and ILLink cannot see it;
@@ -29,7 +34,7 @@
 <linker>
   <assembly fullname="Quartz">
 
-    <!-- Types named by string -->
+    <!-- Types and properties named by string -->
     <type fullname="Quartz.Impl.SimpleTypeLoader*">
       <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
         <argument>Trimming</argument>
@@ -63,8 +68,13 @@
         <property name="Justification">An ADO.NET provider's connection type is named by the driver description, so the provider assembly need not be referenced.</property>
       </attribute>
     </type>
-
-    <!-- Types constructed at runtime -->
+    <type fullname="Quartz.Impl.AdoJobStore.Common.ConfigurationBasedDbMetadataFactory*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">A driver described by quartz.dbprovider.* keys has those keys applied to its DbMetadata by name.</property>
+      </attribute>
+    </type>
     <type fullname="Quartz.Configuration.QuartzPropertyBridge*">
       <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
         <argument>Trimming</argument>
@@ -76,12 +86,22 @@
         <argument>IL2072</argument>
         <property name="Justification">Translating legacy quartz.* keys means constructing the component each key names.</property>
       </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">A component with no typed options of its own takes the leftover quartz.* keys as properties set by name.</property>
+      </attribute>
     </type>
     <type fullname="Quartz.Configuration.SchedulerPluginFactory*">
       <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
         <argument>Trimming</argument>
         <argument>IL2067</argument>
         <property name="Justification">A plugin registered by type is constructed through the container from that Type.</property>
+      </attribute>
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">A plugin's quartz.plugin.&lt;name&gt;.* keys are applied to it as properties set by name.</property>
       </attribute>
     </type>
     <type fullname="Quartz.Configuration.PropertyListenerFactory*">
@@ -95,12 +115,10 @@
         <argument>IL2075</argument>
         <property name="Justification">A listener's Name is set through the property of that name, on a type known only at runtime.</property>
       </attribute>
-    </type>
-    <type fullname="Quartz.Impl.JobActivatorCache*">
       <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
         <argument>Trimming</argument>
-        <argument>IL2067</argument>
-        <property name="Justification">A job type reaches the activator as a Type; that is the whole point of the cache.</property>
+        <argument>IL2026</argument>
+        <property name="Justification">A listener's quartz.*.listener.&lt;name&gt;.* keys are applied to it as properties set by name.</property>
       </attribute>
     </type>
     <type fullname="Quartz.Configuration.JsonSchedulingHelper*">
@@ -115,78 +133,18 @@
         <property name="Justification">Jobs declared in configuration name their type as a string.</property>
       </attribute>
     </type>
-    <type fullname="Quartz.Xml.XmlSchedulingDataProcessor*">
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2072</argument>
-        <property name="Justification">Jobs declared in job_scheduling_data XML name their type as a string.</property>
-      </attribute>
-    </type>
 
-    <!-- Properties bound by name -->
+    <!-- Values converted onto a property the compiler cannot see -->
     <type fullname="Quartz.Util.ObjectUtils*">
       <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
         <argument>Trimming</argument>
         <argument>IL2026</argument>
-        <property name="Justification">TypeDescriptor.GetConverter is how a configuration string becomes a property's value.</property>
-      </attribute>
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2057</argument>
-        <property name="Justification">A property typed as Type takes its value from a type name in configuration.</property>
+        <property name="Justification">TypeDescriptor.GetConverter is how a value becomes a property's value, and the property's type is not annotatable.</property>
       </attribute>
       <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
         <argument>Trimming</argument>
         <argument>IL2067</argument>
-        <property name="Justification">The conversion target arrives as a Type read off the property being set.</property>
-      </attribute>
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2070</argument>
-        <property name="Justification">The conversion target arrives as a Type read off the property being set.</property>
-      </attribute>
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2072</argument>
-        <property name="Justification">The conversion target arrives as a Type read off the property being set.</property>
-      </attribute>
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2075</argument>
-        <property name="Justification">Setting a property named by a configuration key means looking it up on the target's runtime type.</property>
-      </attribute>
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2080</argument>
-        <property name="Justification">Setting a property named by a configuration key means looking it up on the target's runtime type.</property>
-      </attribute>
-    </type>
-    <type fullname="Quartz.Impl.PropertySettingJobFactory*">
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2075</argument>
-        <property name="Justification">Pushing a JobDataMap onto a job means finding properties by the map's keys.</property>
-      </attribute>
-    </type>
-    <type fullname="Quartz.Util.JobDataExpression*">
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2070</argument>
-        <property name="Justification">The check that the job factory will find the property is itself a property lookup by name.</property>
-      </attribute>
-    </type>
-    <type fullname="Quartz.Impl.AdoJobStore.Common.DbProvider*">
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2075</argument>
-        <property name="Justification">A provider's connection string and command properties are named by its DbMetadata, not referenced.</property>
-      </attribute>
-    </type>
-    <type fullname="Quartz.Impl.AdoJobStore.Common.DbMetadata*">
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2075</argument>
-        <property name="Justification">A provider's connection string and command properties are named by its DbMetadata, not referenced.</property>
+        <property name="Justification">The default for a missing value is Activator.CreateInstance of the target type, which is only ever reached for a value type.</property>
       </attribute>
     </type>
 

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -3691,7 +3691,7 @@ public abstract class AdoJobStoreBase : IJobStore
                     Type jobType;
                     try
                     {
-                        jobType = typeLoader.LoadType(result.JobTypeName)!;
+                        jobType = JobType.Resolve(result.JobTypeName, typeLoader)!;
                     }
                     catch (Exception e)
                     {
@@ -3712,7 +3712,10 @@ public abstract class AdoJobStoreBase : IJobStore
                         continue;
                     }
 
-                    if (ObjectUtils.IsAttributePresent(jobType, typeof(DisallowConcurrentExecutionAttribute)))
+                    // The same question JobDetailImpl answers, answered the same way: the attribute is
+                    // inherited from an interface as readily as from a base class, and this loop used to
+                    // consult the non-walking check and so let an interface-inherited one fire twice.
+                    if (JobTypeInformation.GetOrCreate(jobType).ConcurrentExecutionDisallowed)
                     {
                         if (!acquiredJobKeysForNoConcurrentExec.Add(nextTrigger.JobKey))
                         {

--- a/src/Quartz/Impl/AdoJobStore/Common/BuiltInDbMetadataFactory.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/BuiltInDbMetadataFactory.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Quartz.Impl.AdoJobStore.Common;
 
@@ -45,6 +46,13 @@ namespace Quartz.Impl.AdoJobStore.Common;
 /// </remarks>
 internal sealed class BuiltInDbMetadataFactory : DbMetadataFactory
 {
+    /// <summary>
+    /// What <see cref="DbProvider" /> does with a driver type: construct a connection or a command, and
+    /// read the properties a <see cref="DbMetadata" /> names on them.
+    /// </summary>
+    private const DynamicallyAccessedMemberTypes DriverTypeMembers =
+        DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties;
+
     /// <summary>
     /// Provider names in the order the old resource listed them, which is the order they are reported
     /// back to somebody who named one that does not exist.
@@ -236,5 +244,6 @@ internal sealed class BuiltInDbMetadataFactory : DbMetadataFactory
     /// filled is what the reflective binder did, and it is the right answer: a driver assembly the
     /// application did not bring along is a configuration mistake, not a description that half works.
     /// </summary>
+    [return: DynamicallyAccessedMembers(DriverTypeMembers)]
     private static Type LoadType(string typeName) => Type.GetType(typeName, throwOnError: true)!;
 }

--- a/src/Quartz/Impl/AdoJobStore/Common/DbMetadata.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/DbMetadata.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -61,18 +62,32 @@ public sealed record DbMetadata
     /// Gets the type of the connection.
     /// </summary>
     /// <value>The type of the connection.</value>
+    /// <remarks>
+    /// <see cref="DbProvider" /> constructs one of these per connection it opens, so the type has to
+    /// keep its public constructors through trimming.
+    /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public Type? ConnectionType { get; init; }
 
     /// <summary>
     /// Gets the type of the command.
     /// </summary>
     /// <value>The type of the command.</value>
+    /// <remarks>
+    /// <see cref="DbProvider" /> constructs one of these per command it runs and, for a driver that
+    /// binds parameters by name, sets <c>BindByName</c> on it.
+    /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
     public Type? CommandType { get; init; }
 
     /// <summary>
     /// Gets the type of the parameter.
     /// </summary>
     /// <value>The type of the parameter.</value>
+    /// <remarks>
+    /// The property <see cref="ParameterDbTypePropertyName" /> names is looked up on this type.
+    /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
     public Type? ParameterType { get; init; }
 
     /// <summary>

--- a/src/Quartz/Impl/JobActivatorCache.cs
+++ b/src/Quartz/Impl/JobActivatorCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -7,15 +8,24 @@ namespace Quartz.Impl;
 internal sealed class JobActivatorCache
 {
     private readonly ConcurrentDictionary<Type, ObjectFactory> activatorCache = new();
-    private readonly Func<Type, ObjectFactory> createFactory = type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes);
 
-    public IJob CreateInstance(IServiceProvider serviceProvider, Type jobType)
+    public IJob CreateInstance(
+        IServiceProvider serviceProvider,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type jobType)
     {
         ArgumentNullException.ThrowIfNull(serviceProvider);
 
         ArgumentNullException.ThrowIfNull(jobType);
 
-        var factory = activatorCache.GetOrAdd(jobType, createFactory);
+        // Looked up before it is built rather than through a GetOrAdd factory, because a lambda's
+        // parameter carries no annotation and the job type would reach ActivatorUtilities with nothing
+        // said about its constructors. The caching is the same: a race builds two factories, stores one.
+        if (activatorCache.TryGetValue(jobType, out var factory))
+        {
+            return (IJob) factory(serviceProvider, null);
+        }
+
+        factory = activatorCache.GetOrAdd(jobType, ActivatorUtilities.CreateFactory(jobType, Type.EmptyTypes));
         return (IJob) factory(serviceProvider, null);
     }
 }

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 using Quartz.Util;
 
@@ -49,12 +50,20 @@ internal sealed class JobTypeInformation
     /// <returns>
     /// An <see cref="JobTypeInformation"/> object that describe specified type
     /// </returns>
-    public static JobTypeInformation GetOrCreate(Type jobType)
+    public static JobTypeInformation GetOrCreate([DynamicallyAccessedMembers(JobTypeMembers.Required)] Type jobType)
     {
-        return jobTypeCache.GetOrAdd(jobType, jt => Create(jt));
+        // Looked up before it is built, rather than through a GetOrAdd factory: a lambda's parameter
+        // carries no annotation, so the type would arrive at Create with nothing said about it. The
+        // memoization is the same - a race builds the information twice and stores it once.
+        if (jobTypeCache.TryGetValue(jobType, out var cached))
+        {
+            return cached;
+        }
+
+        return jobTypeCache.GetOrAdd(jobType, Create(jobType));
     }
 
-    private static JobTypeInformation Create(Type jobType)
+    private static JobTypeInformation Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type jobType)
     {
         var concurrentExecutionDisallowed = ObjectUtils.IsAnyInterfaceAttributePresent(jobType, typeof(DisallowConcurrentExecutionAttribute));
         var persistJobDataAfterExecution = ObjectUtils.IsAnyInterfaceAttributePresent(jobType, typeof(PersistJobDataAfterExecutionAttribute));
@@ -109,7 +118,7 @@ internal sealed class JobDetailImpl : IJobDetail
     /// <exception cref="ArgumentException">
     /// If name is null or empty, or the group is an empty string.
     /// </exception>
-    public JobDetailImpl(string name, Type jobType) : this(name, JobKey.DefaultGroup, jobType)
+    public JobDetailImpl(string name, [DynamicallyAccessedMembers(JobTypeMembers.Required)] Type jobType) : this(name, JobKey.DefaultGroup, jobType)
     {
     }
 
@@ -121,7 +130,7 @@ internal sealed class JobDetailImpl : IJobDetail
     /// <exception cref="ArgumentException">
     /// If name is null or empty, or the group is an empty string.
     /// </exception>
-    public JobDetailImpl(string name, string group, Type jobType)
+    public JobDetailImpl(string name, string group, [DynamicallyAccessedMembers(JobTypeMembers.Required)] Type jobType)
     {
         Name = name;
         Group = group;
@@ -140,7 +149,7 @@ internal sealed class JobDetailImpl : IJobDetail
     /// <exception cref="ArgumentException">
     /// ArgumentException if name is null or empty, or the group is an empty string.
     /// </exception>
-    public JobDetailImpl(string name, string group, Type jobType, bool isDurable, bool requestsRecovery)
+    public JobDetailImpl(string name, string group, [DynamicallyAccessedMembers(JobTypeMembers.Required)] Type jobType, bool isDurable, bool requestsRecovery)
     {
         Name = name;
         Group = group;
@@ -342,7 +351,7 @@ internal sealed class JobDetailImpl : IJobDetail
         {
             if (!persistJobDataAfterExecution.HasValue)
             {
-                persistJobDataAfterExecution = JobTypeInformation.GetOrCreate(JobType.Type).PersistJobDataAfterExecution;
+                persistJobDataAfterExecution = JobTypeInformation.GetOrCreate(JobType.ResolvedType).PersistJobDataAfterExecution;
             }
 
             return persistJobDataAfterExecution.GetValueOrDefault();
@@ -362,7 +371,7 @@ internal sealed class JobDetailImpl : IJobDetail
         {
             if (!disallowConcurrentExecution.HasValue)
             {
-                disallowConcurrentExecution = JobTypeInformation.GetOrCreate(JobType.Type).ConcurrentExecutionDisallowed;
+                disallowConcurrentExecution = JobTypeInformation.GetOrCreate(JobType.ResolvedType).ConcurrentExecutionDisallowed;
             }
 
             return disallowConcurrentExecution.GetValueOrDefault();

--- a/src/Quartz/Impl/MicrosoftDependencyInjectionJobFactory.cs
+++ b/src/Quartz/Impl/MicrosoftDependencyInjectionJobFactory.cs
@@ -164,7 +164,7 @@ public class MicrosoftDependencyInjectionJobFactory : PropertySettingJobFactory
     /// </remarks>
     private (IJob Job, bool FromContainer) ResolveJob(TriggerFiredBundle bundle, IServiceProvider serviceProvider)
     {
-        var jobType = bundle.JobDetail.JobType.Type;
+        var jobType = bundle.JobDetail.JobType.ResolvedType;
 
         var job = schedulerKey is null ? null : (IJob?) serviceProvider.GetKeyedService(jobType, schedulerKey);
         job ??= (IJob?) serviceProvider.GetService(jobType);

--- a/src/Quartz/Impl/PropertySettingJobFactory.cs
+++ b/src/Quartz/Impl/PropertySettingJobFactory.cs
@@ -17,6 +17,7 @@
  */
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 
@@ -249,6 +250,16 @@ public class PropertySettingJobFactory : SimpleJobFactory
     /// <param name="job">Job instance to set property value to.</param>
     /// <param name="name">Property name to set.</param>
     /// <param name="value">Value to set.</param>
+    /// <remarks>
+    /// The property is found on the instance's own type rather than on the job detail's declared one,
+    /// because a factory is allowed to hand back something else — <c>AddJobType&lt;TJob, TImpl&gt;</c>
+    /// registers exactly that — and the data belongs to whatever was built. Both of those types are
+    /// annotated where they enter Quartz, so their public properties survive trimming; the analyzer
+    /// cannot see the link because the instance arrives here as an <see cref="object" />. A job factory
+    /// written from scratch that returns a type nothing else references is the one case this does not
+    /// cover, and such a factory has to root its own jobs.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "The job instance is of the job detail's declared type or of a registered implementation of it, and both are annotated where they enter Quartz. See the remarks.")]
     protected virtual void SetObjectProperty(object job, string name, object? value)
     {
         string propName = name;

--- a/src/Quartz/Impl/SimpleJobFactory.cs
+++ b/src/Quartz/Impl/SimpleJobFactory.cs
@@ -75,7 +75,7 @@ public class SimpleJobFactory : IJobFactory
     protected IJob InstantiateJobCore(TriggerFiredBundle bundle)
     {
         IJobDetail jobDetail = bundle.JobDetail;
-        Type jobType = jobDetail.JobType.Type;
+        Type jobType = jobDetail.JobType.ResolvedType;
         try
         {
             if (logger.IsEnabled(LogLevel.Debug))

--- a/src/Quartz/JobBuilder.cs
+++ b/src/Quartz/JobBuilder.cs
@@ -84,7 +84,7 @@ public static class JobBuilder
     /// their keys.
     /// </remarks>
     /// <returns>a new JobBuilder</returns>
-    public static JobBuilder<T> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] T>() where T : IJob
+    public static JobBuilder<T> Create<[DynamicallyAccessedMembers(JobTypeMembers.Required)] T>() where T : IJob
     {
         var b = new JobBuilder<T>();
         b.OfType<T>();
@@ -101,7 +101,7 @@ public static class JobBuilder
 /// name; <c>JobBuilder.Create&lt;TJob&gt;()</c> gives one that does.
 /// </remarks>
 /// <seealso cref="JobBuilder" />
-public sealed class JobBuilder<TJob> : IJobConfigurator<TJob> where TJob : IJob
+public sealed class JobBuilder<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob> : IJobConfigurator<TJob> where TJob : IJob
 {
     private JobKey? _key;
     private string? _description;
@@ -285,6 +285,7 @@ public sealed class JobBuilder<TJob> : IJobConfigurator<TJob> where TJob : IJob
     /// </summary>
     /// <param name="typeName">the Type name</param>
     /// <returns>the updated JobBuilder</returns>
+    [RequiresUnreferencedCode(JobType.NamedTypeIsNotGuaranteedToSurviveTrimming)]
     public JobBuilder<TJob> OfType(string typeName)
     {
         _jobType = new JobType(typeName);
@@ -314,7 +315,7 @@ public sealed class JobBuilder<TJob> : IJobConfigurator<TJob> where TJob : IJob
     /// </summary>
     /// <returns>the updated JobBuilder</returns>
     /// <seealso cref="IJobDetail.JobType" />
-    public JobBuilder<TJob> OfType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] T>() where T : TJob
+    public JobBuilder<TJob> OfType<[DynamicallyAccessedMembers(JobTypeMembers.Required)] T>() where T : TJob
     {
         return OfType(typeof(T));
     }
@@ -325,7 +326,7 @@ public sealed class JobBuilder<TJob> : IJobConfigurator<TJob> where TJob : IJob
     /// </summary>
     /// <returns>the updated JobBuilder</returns>
     /// <seealso cref="IJobDetail.JobType" />
-    public JobBuilder<TJob> OfType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+    public JobBuilder<TJob> OfType([DynamicallyAccessedMembers(JobTypeMembers.Required)] Type type)
     {
         // The type is known here, so the mismatch is reported at the call that caused it rather than at
         // the build - which, configured through the container, happens somewhere else entirely.

--- a/src/Quartz/JobType.cs
+++ b/src/Quartz/JobType.cs
@@ -18,6 +18,13 @@ namespace Quartz;
 public sealed class JobType : IEquatable<JobType>
 {
     /// <summary>
+    /// What every API that turns a type <i>name</i> into a job says, in the same words. Named as a
+    /// constant so the sentence cannot drift between the constructor, the cast and the builder.
+    /// </summary>
+    internal const string NamedTypeIsNotGuaranteedToSurviveTrimming =
+        "Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in configuration or in the database is not guaranteed to survive trimming.";
+
+    /// <summary>
     /// How a name becomes a type when the caller had nothing better to offer: the runtime's own lookup.
     /// </summary>
     private static readonly Func<string, Type?> defaultResolver = static name => Type.GetType(name);
@@ -32,6 +39,7 @@ public sealed class JobType : IEquatable<JobType>
     /// <summary>
     /// The type this was constructed from, when it was constructed from one at all.
     /// </summary>
+    [DynamicallyAccessedMembers(JobTypeMembers.Required)]
     private readonly Type? declaredType;
 
     /// <summary>
@@ -40,6 +48,7 @@ public sealed class JobType : IEquatable<JobType>
     /// </summary>
     /// <param name="fullName">Type full name</param>
     /// <exception cref="ArgumentNullException"><paramref name="fullName"/> is <see langword="null" /></exception>
+    [RequiresUnreferencedCode(NamedTypeIsNotGuaranteedToSurviveTrimming)]
     public JobType(string fullName) : this(fullName, defaultResolver)
     {
     }
@@ -83,7 +92,7 @@ public sealed class JobType : IEquatable<JobType>
     /// <param name="type">The Job Type</param>
     /// <exception cref="ArgumentException"><paramref name="type"/> is not assignable from  <see cref="IJob"/></exception>
     /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null" /></exception>
-    public JobType(Type type)
+    public JobType([DynamicallyAccessedMembers(JobTypeMembers.Required)] Type type)
     {
         if (type is null)
         {
@@ -109,6 +118,62 @@ public sealed class JobType : IEquatable<JobType>
     public Type Type => type.Value;
 
     /// <summary>
+    /// The type this was constructed from, or <see langword="null" /> when it was constructed from a
+    /// name. Annotated truthfully: the only way to set it is the constructor that takes a
+    /// <see cref="System.Type" />, and that constructor asks its caller for the same members.
+    /// </summary>
+    [DynamicallyAccessedMembers(JobTypeMembers.Required)]
+    internal Type? DeclaredType => declaredType;
+
+    /// <summary>
+    /// The job's type, carrying the annotation the reflection Quartz does on it requires.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="JobType" /> built from a <see cref="System.Type" /> took that type from a caller who
+    /// declared these members, so the annotation is earned. One built from a name goes through
+    /// <see cref="FoundByName" />, which is where the difference between the two is admitted.
+    /// </remarks>
+    [DynamicallyAccessedMembers(JobTypeMembers.Required)]
+    internal Type ResolvedType => DeclaredType ?? FoundByName(type.Value)!;
+
+    /// <summary>
+    /// Hands a type that was found by name on as one Quartz may reflect over.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the fork the whole of issue #3341, step 3 turns on: the single place in Quartz where a
+    /// type nobody declared statically is given the annotation the fire path asks for. Everything
+    /// downstream — the attribute checks, both job factories, the ADO store's acquisition loop — reads
+    /// an annotated type and needs no suppression of its own.
+    /// </para>
+    /// <para>
+    /// The suppression costs an application that never names a job by string nothing, because every way
+    /// of producing a name-constructed <see cref="JobType" /> that Quartz offers a caller is itself
+    /// <see cref="RequiresUnreferencedCodeAttribute" />: <see cref="JobType(string)" />, the explicit
+    /// cast from <see cref="string" />, and <c>JobBuilder&lt;TJob&gt;.OfType(string)</c>. The rest are
+    /// Quartz's own persistence and configuration readers, whose string contracts are recorded in
+    /// <c>TrimAnalysisBaseline.cs</c>: an application that keeps jobs in a database or names them in
+    /// <c>quartz.*</c> keys is naming types by string and has to root them itself.
+    /// </para>
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2068", Justification = "A name-constructed JobType has no annotation to carry; every API that produces one is itself RequiresUnreferencedCode. See the remarks.")]
+    [return: DynamicallyAccessedMembers(JobTypeMembers.Required)]
+    private static Type? FoundByName(Type? resolved) => resolved;
+
+    /// <summary>
+    /// Resolves a stored job type name through a scheduler's type loader, for a caller that wants the
+    /// type and not a <see cref="JobType" />.
+    /// </summary>
+    /// <remarks>
+    /// The ADO store's acquisition loop asks this per trigger, purely to find out whether the job
+    /// carries <see cref="DisallowConcurrentExecutionAttribute" />, and would otherwise build a
+    /// <see cref="JobType" /> it immediately throws away. It goes through <see cref="FoundByName" />,
+    /// so it is the same fork and not a second one.
+    /// </remarks>
+    [return: DynamicallyAccessedMembers(JobTypeMembers.Required)]
+    internal static Type? Resolve(string fullName, Extensibility.ITypeLoader typeLoader) => FoundByName(typeLoader.LoadType(fullName));
+
+    /// <summary>
     /// Resolves the type for a caller that can carry on without it, without throwing and without settling
     /// <see cref="Type" />.
     /// </summary>
@@ -125,24 +190,24 @@ public sealed class JobType : IEquatable<JobType>
     /// permanently unresolvable. A speculative caller must not be able to poison the real one.
     /// </para>
     /// </remarks>
-    public bool TryResolve([NotNullWhen(true)] out Type? resolved)
+    public bool TryResolve([NotNullWhen(true)][DynamicallyAccessedMembers(JobTypeMembers.Required)] out Type? resolved)
     {
-        if (declaredType is not null)
+        if (DeclaredType is { } declared)
         {
-            resolved = declaredType;
+            resolved = declared;
             return true;
         }
 
         if (type.IsValueCreated)
         {
-            resolved = type.Value;
+            resolved = ResolvedType;
             return true;
         }
 
         try
         {
             // Suppressing not-found does not suppress an assembly that is found but cannot be loaded.
-            resolved = resolver(FullName);
+            resolved = FoundByName(resolver(FullName));
         }
         catch (Exception e) when (e is ArgumentException or FileLoadException or BadImageFormatException or TypeLoadException or TargetInvocationException)
         {
@@ -168,7 +233,7 @@ public sealed class JobType : IEquatable<JobType>
     /// </summary>
     /// <exception cref="ArgumentException"><paramref name="type"/> does not implement <see cref="IJob"/>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="type"/> is <see langword="null" />.</exception>
-    public static implicit operator JobType(Type type) => new(type);
+    public static implicit operator JobType([DynamicallyAccessedMembers(JobTypeMembers.Required)] Type type) => new(type);
 
     /// <summary>
     /// Explicit on purpose: a name is accepted unvalidated, and resolving it is deferred to the
@@ -176,6 +241,7 @@ public sealed class JobType : IEquatable<JobType>
     /// of faith visible at the call site.
     /// </summary>
     /// <exception cref="ArgumentNullException"><paramref name="fullName"/> is <see langword="null" />.</exception>
+    [RequiresUnreferencedCode(NamedTypeIsNotGuaranteedToSurviveTrimming)]
     public static explicit operator JobType(string fullName) => new(fullName);
 
     public bool Equals(JobType? other)

--- a/src/Quartz/JobTypeMembers.cs
+++ b/src/Quartz/JobTypeMembers.cs
@@ -1,0 +1,56 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Quartz;
+
+/// <summary>
+/// What Quartz reflects over on a job type, spelled once so that every API which accepts one asks for
+/// the same thing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three sets, and each is something Quartz already does today:
+/// <see cref="DynamicallyAccessedMemberTypes.PublicConstructors" /> because a job factory activates the
+/// type, <see cref="DynamicallyAccessedMemberTypes.PublicProperties" /> because
+/// <see cref="Impl.PropertySettingJobFactory" /> pushes the <see cref="JobDataMap" /> onto its
+/// properties, and <see cref="DynamicallyAccessedMemberTypes.Interfaces" /> because
+/// <see cref="DisallowConcurrentExecutionAttribute" /> and
+/// <see cref="PersistJobDataAfterExecutionAttribute" /> are inherited from an interface as readily as
+/// from a base class.
+/// </para>
+/// <para>
+/// <see cref="DynamicallyAccessedMemberTypes.PublicMethods" /> is deliberately absent. It was on the
+/// job-type parameters until issue #3341, step 3, and nothing needed it: a kept property keeps its
+/// accessors, and <see cref="IJob.Execute" /> is reached through the interface rather than by name.
+/// </para>
+/// </remarks>
+internal static class JobTypeMembers
+{
+    /// <summary>
+    /// The members a job type must keep for Quartz to be able to run it.
+    /// </summary>
+    public const DynamicallyAccessedMemberTypes Required =
+        DynamicallyAccessedMemberTypes.PublicConstructors
+        | DynamicallyAccessedMemberTypes.PublicProperties
+        | DynamicallyAccessedMemberTypes.Interfaces;
+}

--- a/src/Quartz/TriggerBuilder.cs
+++ b/src/Quartz/TriggerBuilder.cs
@@ -91,7 +91,7 @@ public static class TriggerBuilder
     /// </remarks>
     /// <param name="timeProvider">Time provider instance to use, defaults to <see cref="TimeProvider.System"/></param>
     /// <returns>the new TriggerBuilder</returns>
-    public static TriggerBuilder<TJob> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] TJob>(TimeProvider? timeProvider = null) where TJob : IJob
+    public static TriggerBuilder<TJob> Create<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(TimeProvider? timeProvider = null) where TJob : IJob
     {
         return new TriggerBuilder<TJob>(timeProvider ?? TimeProvider.System);
     }
@@ -106,7 +106,7 @@ public static class TriggerBuilder
 /// to name; <c>TriggerBuilder.Create&lt;TJob&gt;()</c> gives one that does.
 /// </remarks>
 /// <seealso cref="TriggerBuilder" />
-public sealed class TriggerBuilder<TJob> : ITriggerConfigurator<TJob> where TJob : IJob
+public sealed class TriggerBuilder<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob> : ITriggerConfigurator<TJob> where TJob : IJob
 {
     private readonly TimeProvider timeProvider;
     private TriggerKey? key;

--- a/src/Quartz/TrimAnalysisBaseline.cs
+++ b/src/Quartz/TrimAnalysisBaseline.cs
@@ -21,21 +21,29 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-// The recorded set of trim-analysis warnings Quartz produced when EnableTrimAnalyzer was first turned
-// on (https://github.com/quartznet/quartznet/issues/3341). It is a baseline, not an all-clear: none of
-// these call sites is trim-safe, and every one of them is work still to do. What the baseline buys is
+// The trim-analysis warnings Quartz still produces (https://github.com/quartznet/quartznet/issues/3341).
+// It is a baseline, not an all-clear: none of these call sites is trim-safe. What the baseline buys is
 // that a *new* one fails the build, because TreatWarningsAsErrors makes IL2xxx an error and nothing
 // suppresses a warning that is not listed here.
+//
+// Step 3 of that issue took the fire path out of this file. A job type that reached Quartz as a type -
+// JobBuilder.Create<T>(), OfType<T>(), AddJob<T>() - now carries [DynamicallyAccessedMembers] all the
+// way to the attribute checks, the job factories and the ADO store's acquisition loop, and the APIs
+// that accept a type *name* instead say [RequiresUnreferencedCode] out loud. What is left below is what
+// that redesign could not reach, and each group says which wall it ran into.
 //
 // Adding an entry is the wrong first move. Reach for it only after establishing that the reflection is
 // genuinely unavoidable, and then say in the group comment why. The preferred fixes, in order:
 //
 //   1. Resolve the type statically — a generic parameter or a typed option instead of a type name.
 //   2. Annotate with [DynamicallyAccessedMembers], so the requirement travels to the caller that does
-//      know the type. Check where it propagates to first, and whether it can travel at all: on the fire
-//      path it cannot, because JobType.Type erases the annotation — a job named by a string has no
-//      annotatable type. That is why ObjectUtils is left alone here (issue #3341, step 3).
+//      know the type. Check where it propagates to first: it has to reach a caller that can satisfy it.
 //   3. Mark the API [RequiresUnreferencedCode], for opt-in surface a trimmed app can avoid entirely.
+//      Check where *that* propagates to as well. It cannot cross a member that implements an interface
+//      Quartz does not own both sides of (IJobStore, IDriverDelegate, ISchedulerFactory all forbid it,
+//      because IL2046 wants the attribute to match on both sides and RAMJobStore must stay clean), and
+//      it must stop before AddQuartz — which every application calls, including the trim canary, and
+//      which is trimmable when it is configured in code.
 //
 // Scope is deliberately the type rather than the member. ILLink reports these against compiler-
 // generated closure types whose names change whenever a lambda is added to or removed from the file, so
@@ -47,49 +55,46 @@ using System.Diagnostics.CodeAnalysis;
 // SuppressMessageAttribute is [Conditional("CODE_ANALYSIS")] and never reaches metadata, so this file
 // silences the analyzer during Quartz's own compile and nothing else. Consumers publishing a trimmed
 // application still see every warning below, which is honest: their app really is affected. The
-// unconditional form would hide it from them too, and that would be a lie until step 3 lands.
+// unconditional form would hide it from them too. Where Quartz *has* reasoned an application's way out
+// of a warning, it says so in an [UnconditionalSuppressMessage] at the call site instead — there are two,
+// on JobType.FoundByName and PropertySettingJobFactory.SetObjectProperty, and each carries the argument.
 
-// --- Types named by string --------------------------------------------------------------------------
+// --- Types and properties named by string -----------------------------------------------------------
 // Configuration and persistence both store types as text: the flat quartz.* keys, the JOB_CLASS_NAME
-// column, job_scheduling_data XML, and JobType's name-constructed form. A type resolved from a string
-// cannot be proven reachable, so the trimmer cannot keep it.
+// column, and JobType's name-constructed form. A type resolved from a string cannot be proven
+// reachable, so the trimmer cannot keep it — nor the properties a key then sets on it.
+//
+// The APIs an application calls to name a job type by string say [RequiresUnreferencedCode] instead,
+// so a trimmed application is told; the job_scheduling_data XML loader left this file that way. What
+// remains is Quartz reading its own configuration and its own tables, on paths that reach AddQuartz or
+// an interface Quartz does not own both sides of, and so cannot carry the attribute themselves.
 
 [assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.Impl.SimpleTypeLoader", Justification = "The default ITypeLoader exists to resolve a configured type name; that is its contract.")]
 [assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.JobType", Justification = "A name-constructed JobType resolves through Type.GetType when the caller supplied no resolver.")]
 [assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.StdAdoDelegate", Justification = "A persisted job's type is the JOB_CLASS_NAME column, which is a string by the time it is read back.")]
+[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.StdAdoDelegate", Justification = "A persisted job's type reaches JobBuilder.OfType as a Type resolved from JOB_CLASS_NAME.")]
 [assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.Common.BuiltInDbMetadataFactory", Justification = "An ADO.NET provider's connection type is named by the driver description, so the provider assembly need not be referenced.")]
-
-// --- Types constructed at runtime -------------------------------------------------------------------
-// Once a type arrives as a Type rather than a generic argument, Activator/ActivatorUtilities cannot
-// promise its constructor survives, and JobBuilder.OfType wants its members annotated.
-
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.Common.ConfigurationBasedDbMetadataFactory", Justification = "A driver described by quartz.dbprovider.* keys has those keys applied to its DbMetadata by name.")]
 [assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Configuration.QuartzPropertyBridge", Justification = "Translating legacy quartz.* keys means constructing the component each key names.")]
 [assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Configuration.QuartzPropertyBridge", Justification = "Translating legacy quartz.* keys means constructing the component each key names.")]
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Configuration.QuartzPropertyBridge", Justification = "A component with no typed options of its own takes the leftover quartz.* keys as properties set by name.")]
 [assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Configuration.SchedulerPluginFactory", Justification = "A plugin registered by type is constructed through the container from that Type.")]
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Configuration.SchedulerPluginFactory", Justification = "A plugin's quartz.plugin.<name>.* keys are applied to it as properties set by name.")]
 [assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Configuration.PropertyListenerFactory", Justification = "A listener registered by quartz.*.listener.* keys is constructed from the type the key names.")]
-[assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Impl.JobActivatorCache", Justification = "A job type reaches the activator as a Type; that is the whole point of the cache.")]
-[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Configuration.JsonSchedulingHelper", Justification = "Jobs declared in configuration name their type as a string.")]
-[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Xml.XmlSchedulingDataProcessor", Justification = "Jobs declared in job_scheduling_data XML name their type as a string.")]
-[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.StdAdoDelegate", Justification = "A persisted job's type reaches JobBuilder.OfType as a Type resolved from JOB_CLASS_NAME.")]
-
-// --- Properties bound by name -----------------------------------------------------------------------
-// The flat quartz.* keys and JobDataMap both set properties on a target the compiler cannot see the
-// type of. ObjectUtils is the shared implementation and the structural blocker for the whole track:
-// annotating it would reach IJobDetail and out into every consumer's code, so it stays as it is until
-// issue #3341, step 3 redesigns it.
-
-[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "TypeDescriptor.GetConverter is how a configuration string becomes a property's value.")]
-[assembly: SuppressMessage("Trimming", "IL2057", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "A property typed as Type takes its value from a type name in configuration.")]
-[assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "The conversion target arrives as a Type read off the property being set.")]
-[assembly: SuppressMessage("Trimming", "IL2070", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "The conversion target arrives as a Type read off the property being set.")]
-[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "The conversion target arrives as a Type read off the property being set.")]
-[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "Setting a property named by a configuration key means looking it up on the target's runtime type.")]
-[assembly: SuppressMessage("Trimming", "IL2080", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "Setting a property named by a configuration key means looking it up on the target's runtime type.")]
-[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Impl.PropertySettingJobFactory", Justification = "Pushing a JobDataMap onto a job means finding properties by the map's keys.")]
 [assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Configuration.PropertyListenerFactory", Justification = "A listener's Name is set through the property of that name, on a type known only at runtime.")]
-[assembly: SuppressMessage("Trimming", "IL2070", Scope = "type", Target = "T:Quartz.Util.JobDataExpression", Justification = "The check that the job factory will find the property is itself a property lookup by name.")]
-[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.Common.DbProvider", Justification = "A provider's connection string and command properties are named by its DbMetadata, not referenced.")]
-[assembly: SuppressMessage("Trimming", "IL2075", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.Common.DbMetadata.DerivedMetadata", Justification = "A provider's connection string and command properties are named by its DbMetadata, not referenced.")]
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Configuration.PropertyListenerFactory", Justification = "A listener's quartz.*.listener.<name>.* keys are applied to it as properties set by name.")]
+[assembly: SuppressMessage("Trimming", "IL2072", Scope = "type", Target = "T:Quartz.Configuration.JsonSchedulingHelper", Justification = "Jobs declared in configuration name their type as a string.")]
+
+// --- Values converted onto a property the compiler cannot see -----------------------------------------
+// Not a string contract, and the one wall step 3 could not move. ConvertValueIfNecessary answers the two
+// questions that need no converter itself, and hands the rest to a RequiresUnreferencedCode helper: a
+// converter is found by reflecting over the target type, and the target arrives as
+// PropertyInfo.PropertyType or as a setter's parameter type. The framework annotates neither, and could
+// not — so there is no [DynamicallyAccessedMembers] chain to build, and the callers that would have to
+// carry [RequiresUnreferencedCode] instead are the default job factory and everything that runs a job.
+
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "TypeDescriptor.GetConverter is how a value becomes a property's value, and the property's type is not annotatable.")]
+[assembly: SuppressMessage("Trimming", "IL2067", Scope = "type", Target = "T:Quartz.Util.ObjectUtils", Justification = "The default for a missing value is Activator.CreateInstance of the target type, which is only ever reached for a value type.")]
 
 // --- Duck-typed exception inspection ------------------------------------------------------------------
 // Whether a database error is worth retrying lives in provider-specific properties (SqlException.Number,

--- a/src/Quartz/Util/JobDataExpression.cs
+++ b/src/Quartz/Util/JobDataExpression.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -37,7 +38,7 @@ internal static class JobDataExpression
     /// <summary>
     /// Returns the property the expression reads, after checking that job data can actually be bound to it.
     /// </summary>
-    internal static PropertyInfo GetProperty<TJob, TValue>(Expression<Func<TJob, TValue>> jobProperty)
+    internal static PropertyInfo GetProperty<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TJob, TValue>(Expression<Func<TJob, TValue>> jobProperty)
     {
         if (jobProperty is null)
         {
@@ -102,7 +103,7 @@ internal static class JobDataExpression
     /// job runs rather than silently binding the wrong thing.
     /// </para>
     /// </remarks>
-    private static void VerifyTheJobFactoryFindsIt(Type jobType, PropertyInfo property, string paramName)
+    private static void VerifyTheJobFactoryFindsIt([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type jobType, PropertyInfo property, string paramName)
     {
         // Exactly what PropertySettingJobFactory.SetObjectProperty does to a key before looking it up.
         var name = property.Name;

--- a/src/Quartz/Util/ObjectUtils.cs
+++ b/src/Quartz/Util/ObjectUtils.cs
@@ -22,6 +22,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 
@@ -37,6 +38,14 @@ internal static class ObjectUtils
     /// <summary>
     /// Convert the value to the required <see cref="System.Type"/> (if necessary from a string).
     /// </summary>
+    /// <remarks>
+    /// The two answers that need no <see cref="TypeConverter" /> are given here — a value that is
+    /// already what the target takes, and the target's own default for a missing one — and only the
+    /// conversion itself sits behind <see cref="ConvertUsingTypeConverter" />, which is
+    /// <see cref="RequiresUnreferencedCodeAttribute" /> because <see cref="TypeDescriptor" /> finds a
+    /// converter by reflecting over the target type. Most of what a <see cref="JobDataMap" /> carries
+    /// is answered by the first of the two and never reaches it.
+    /// </remarks>
     /// <param name="newValue">The proposed change value.</param>
     /// <param name="requiredType">
     /// The <see cref="System.Type"/> we must convert to.
@@ -44,53 +53,25 @@ internal static class ObjectUtils
     /// <returns>The new value, possibly the result of type conversion.</returns>
     public static object? ConvertValueIfNecessary(Type requiredType, object? newValue)
     {
-        if (newValue is not null)
+        if (newValue is null)
         {
-            // if it is assignable, return the value right away
-            if (requiredType.IsInstanceOfType(newValue))
-            {
-                return newValue;
-            }
-
-            // try to convert using type converter
-            TypeConverter typeConverter = TypeDescriptor.GetConverter(requiredType);
-            if (typeConverter.CanConvertFrom(newValue.GetType()))
-            {
-                return typeConverter.ConvertFrom(null, CultureInfo.InvariantCulture, newValue);
-            }
-
-            typeConverter = TypeDescriptor.GetConverter(newValue.GetType());
-            if (typeConverter.CanConvertTo(requiredType))
-            {
-                return typeConverter.ConvertTo(null, CultureInfo.InvariantCulture, newValue, requiredType);
-            }
-
-            if (requiredType == typeof(Type))
-            {
-                return Type.GetType(newValue.ToString()!, throwOnError: true);
-            }
-
-            if (newValue.GetType().IsEnum)
-            {
-                // If we couldn't convert the type, but it's an enum type, try convert it as an int
-                return ConvertValueIfNecessary(requiredType, Convert.ChangeType(newValue, Convert.GetTypeCode(newValue), null));
-            }
-
-            if (requiredType.IsEnum)
-            {
-                // if JSON serializer creates numbers from enums, be prepared for that
-                try
-                {
-                    return Enum.ToObject(requiredType, newValue);
-                }
-                catch
-                {
-                }
-            }
-
-            Throw.NotSupportedException($"{newValue} is no a supported value for a target of type {requiredType}");
+            return DefaultValue(requiredType);
         }
 
+        // if it is assignable, return the value right away
+        if (requiredType.IsInstanceOfType(newValue))
+        {
+            return newValue;
+        }
+
+        return ConvertUsingTypeConverter(requiredType, newValue);
+    }
+
+    /// <summary>
+    /// The value a target of this type holds when there is nothing to put in it.
+    /// </summary>
+    private static object? DefaultValue(Type requiredType)
+    {
         if (requiredType.IsValueType)
         {
             return Activator.CreateInstance(requiredType);
@@ -101,15 +82,67 @@ internal static class ObjectUtils
     }
 
     /// <summary>
+    /// Converts through <see cref="TypeDescriptor" />, in the order this has always tried things.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in here can be annotated instead. A converter is found by reflecting over the target
+    /// type, which arrives as <see cref="PropertyInfo.PropertyType" /> or as a setter's parameter type —
+    /// neither of which the framework annotates, or could. Splitting it out at least keeps the
+    /// requirement off the values that never need converting.
+    /// </remarks>
+    [RequiresUnreferencedCode("A value whose type does not match the target's is converted through TypeDescriptor, which finds the converter by reflecting over the target type; neither that type nor its converter is guaranteed to survive trimming.")]
+    private static object? ConvertUsingTypeConverter(Type requiredType, object newValue)
+    {
+        // try to convert using type converter
+        TypeConverter typeConverter = TypeDescriptor.GetConverter(requiredType);
+        if (typeConverter.CanConvertFrom(newValue.GetType()))
+        {
+            return typeConverter.ConvertFrom(null, CultureInfo.InvariantCulture, newValue);
+        }
+
+        typeConverter = TypeDescriptor.GetConverter(newValue.GetType());
+        if (typeConverter.CanConvertTo(requiredType))
+        {
+            return typeConverter.ConvertTo(null, CultureInfo.InvariantCulture, newValue, requiredType);
+        }
+
+        if (requiredType == typeof(Type))
+        {
+            return Type.GetType(newValue.ToString()!, throwOnError: true);
+        }
+
+        if (newValue.GetType().IsEnum)
+        {
+            // If we couldn't convert the type, but it's an enum type, try convert it as an int
+            return ConvertValueIfNecessary(requiredType, Convert.ChangeType(newValue, Convert.GetTypeCode(newValue), null));
+        }
+
+        if (requiredType.IsEnum)
+        {
+            // if JSON serializer creates numbers from enums, be prepared for that
+            try
+            {
+                return Enum.ToObject(requiredType, newValue);
+            }
+            catch
+            {
+            }
+        }
+
+        Throw.NotSupportedException($"{newValue} is no a supported value for a target of type {requiredType}");
+        return null;
+    }
+
+    /// <summary>
     /// Instantiates an instance of the type specified.
     /// </summary>
-    public static T InstantiateType<T>(Type? type)
+    public static T InstantiateType<T>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type)
     {
         ConstructorInfo ci = GetDefaultConstructor(type);
         return (T) ci.Invoke([]);
     }
 
-    public static ConstructorInfo GetDefaultConstructor(Type? type)
+    public static ConstructorInfo GetDefaultConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type)
     {
         if (type is null)
         {
@@ -128,6 +161,7 @@ internal static class ObjectUtils
     /// <summary>
     /// Sets the object properties using reflection.
     /// </summary>
+    [RequiresUnreferencedCode("Component properties are set by name on a type Quartz is handed at run time; a component named by a quartz.* configuration key, and the properties that key sets, are not guaranteed to survive trimming.")]
     public static void SetObjectProperties(object obj, string[] propertyNames, object[] propertyValues)
     {
         for (int i = 0; i < propertyNames.Length; i++)
@@ -149,6 +183,7 @@ internal static class ObjectUtils
     /// </summary>
     /// <param name="obj">The object to set values to.</param>
     /// <param name="props">The properties to set to object.</param>
+    [RequiresUnreferencedCode("Component properties are set by name on a type Quartz is handed at run time; a component named by a quartz.* configuration key, and the properties that key sets, are not guaranteed to survive trimming.")]
     public static void SetObjectProperties(object obj, NameValueCollection props)
     {
         // remove the type
@@ -182,6 +217,7 @@ internal static class ObjectUtils
     private const BindingFlags Bindings =
         BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
+    [RequiresUnreferencedCode("Component properties are set by name on a type Quartz is handed at run time; a component named by a quartz.* configuration key, and the properties that key sets, are not guaranteed to survive trimming.")]
     public static void SetPropertyValue(object target, string propertyName, object? value)
     {
         var pi = propertyResolutionCache.GetOrAdd((target.GetType(), propertyName), static tuple =>
@@ -263,12 +299,31 @@ internal static class ObjectUtils
         }
     }
 
+    /// <summary>
+    /// Whether the type, or anything it inherits from, carries the attribute.
+    /// </summary>
+    /// <remarks>
+    /// No annotation is needed on <paramref name="typeToExamine" />: an attribute is part of the
+    /// metadata of a type that survives trimming at all, so the trimmer has nothing to preserve on its
+    /// account.
+    /// </remarks>
     public static bool IsAttributePresent(Type typeToExamine, Type attributeType)
     {
         return typeToExamine.GetCustomAttributes(attributeType, inherit: true).Length > 0;
     }
 
-    public static bool IsAnyInterfaceAttributePresent(Type typeToExamine, Type attributeType)
+    /// <summary>
+    /// Whether the type, anything it inherits from, or any interface it implements carries the attribute.
+    /// </summary>
+    /// <remarks>
+    /// The interfaces are walked flat rather than recursively, because <see cref="Type.GetInterfaces" />
+    /// already reports the ones an interface itself inherits — the recursion asked the same question
+    /// twice, and asking it once is what lets the requirement stop at
+    /// <see cref="DynamicallyAccessedMemberTypes.Interfaces" /> instead of travelling.
+    /// </remarks>
+    public static bool IsAnyInterfaceAttributePresent(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type typeToExamine,
+        Type attributeType)
     {
         if (IsAttributePresent(typeToExamine, attributeType))
         {
@@ -277,7 +332,7 @@ internal static class ObjectUtils
 
         foreach (var type in typeToExamine.GetInterfaces())
         {
-            if (IsAnyInterfaceAttributePresent(type, attributeType))
+            if (IsAttributePresent(type, attributeType))
             {
                 return true;
             }

--- a/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
@@ -15,6 +15,7 @@
  *
  */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Xml;
 using System.Xml.Schema;
@@ -133,6 +134,7 @@ internal class XmlSchedulingDataProcessor
     /// "quartz_jobs.xml" in the current working directory).
     /// </summary>
     /// <param name="cancellationToken">The cancellation instruction.</param>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public virtual ValueTask ProcessFile(CancellationToken cancellationToken = default)
     {
         return ProcessFile(QuartzXmlFileName, cancellationToken);
@@ -143,6 +145,7 @@ internal class XmlSchedulingDataProcessor
     /// </summary>
     /// <param name="fileName">meta data file name.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public virtual ValueTask ProcessFile(
         string fileName,
         CancellationToken cancellationToken = default)
@@ -157,6 +160,7 @@ internal class XmlSchedulingDataProcessor
     /// <param name="fileName">Name of the file.</param>
     /// <param name="systemId">The system id.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public virtual async ValueTask ProcessFile(
         string fileName,
         string systemId,
@@ -181,6 +185,7 @@ internal class XmlSchedulingDataProcessor
     /// <param name="stream">The stream.</param>
     /// <param name="systemId">The system id.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public virtual async ValueTask ProcessStream(
         Stream stream,
         string? systemId,
@@ -208,6 +213,7 @@ internal class XmlSchedulingDataProcessor
         loadedTriggers.Clear();
     }
 
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     protected virtual void ProcessInternal(string xml)
     {
         PrepareForProcessing();
@@ -561,6 +567,7 @@ internal class XmlSchedulingDataProcessor
     /// Process the xml file in the default location, and schedule all of the jobs defined within it.
     /// </summary>
     /// <remarks>Note that we will set overwriteExistingJobs after the default xml is parsed.</remarks>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public async ValueTask ProcessFileAndScheduleJobs(
         IScheduler scheduler,
         bool overwriteExistingJobs,
@@ -578,6 +585,7 @@ internal class XmlSchedulingDataProcessor
     /// Process the xml file in the default location, and schedule all of the
     /// jobs defined within it.
     /// </summary>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public virtual ValueTask ProcessFileAndScheduleJobs(
         IScheduler scheduler,
         CancellationToken cancellationToken = default)
@@ -592,6 +600,7 @@ internal class XmlSchedulingDataProcessor
     /// <param name="fileName">meta data file name.</param>
     /// <param name="scheduler">The scheduler.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public virtual ValueTask ProcessFileAndScheduleJobs(
         string fileName,
         IScheduler scheduler,
@@ -608,6 +617,7 @@ internal class XmlSchedulingDataProcessor
     /// <param name="systemId">The system id.</param>
     /// <param name="scheduler">The scheduler.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public virtual async ValueTask ProcessFileAndScheduleJobs(
         string fileName,
         string systemId,
@@ -626,6 +636,7 @@ internal class XmlSchedulingDataProcessor
     /// <param name="stream">stream to read XML data from.</param>
     /// <param name="scheduler">The scheduler.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
+    [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
     public virtual async ValueTask ProcessStreamAndScheduleJobs(
         Stream stream,
         IScheduler scheduler,


### PR DESCRIPTION
Step 3 of #3341: the statically-known job type stays statically known through the fire path, the
string-named path is honestly `[RequiresUnreferencedCode]`, and the trim baseline shrinks to the
contracts that cannot carry either attribute.

Part of #3341 — steps 4 (source-generated JSON) and 5 (`IsAotCompatible`) are still open, so the issue
stays open.

## What was annotated

One internal constant, `JobTypeMembers.Required`, spells what Quartz reflects over on a job type:
`PublicConstructors | PublicProperties | Interfaces` — what a job factory constructs, what a
`JobDataMap` binds onto, and where `[DisallowConcurrentExecution]` may be inherited from. It is
declared on:

- `JobType(Type)` and the implicit `Type` → `JobType` conversion;
- `JobBuilder.Create<T>()`, `JobBuilder<TJob>` and its `OfType<T>()` / `OfType(Type)`,
  `TriggerBuilder.Create<TJob>()` and `TriggerBuilder<TJob>`;
- `IJobConfigurator<TJob>` and `ITriggerConfigurator<TJob>`;
- `AddJob<T>()`, `AddJob(Type, …)`, `AddJobType<TJob>()`, `AddJobType<TJob, TImplementation>()`,
  `AddTrigger<TJob>()`, `ScheduleJob<T>()`;
- `JobDetailImpl`'s `Type`-taking constructors.

`PublicMethods` leaves that set, as the spec asked — nothing needed it. A kept property keeps its
accessors, and `IJob.Execute` is reached through the interface rather than by name; dropping it is
visible in the public API baseline and does not weaken anything.

`DbMetadata.ConnectionType`, `.CommandType` and `.ParameterType` are annotated too, with what
`DbProvider` actually does with each. That is what removed `DbProvider` and `DbMetadata.DerivedMetadata`
from the baseline entirely.

## Where the single fork is, and its justification

`JobType.FoundByName` — one `private static Type? FoundByName(Type?)` that hands a type found by name
on as one Quartz may reflect over, carrying one `[UnconditionalSuppressMessage("Trimming", "IL2068")]`.
`ResolvedType`, `TryResolve` and `JobType.Resolve(name, typeLoader)` all go through it, so the four
fire-path consumers the spec names — `JobTypeInformation.Create`, `SimpleJobFactory.InstantiateJobCore`,
`MicrosoftDependencyInjectionJobFactory.ResolveJob` and `AdoJobStoreBase`'s acquisition-time
`[DisallowConcurrentExecution]` check — read an annotated type and need no suppression of their own.
`JobTypeInformation` stays memoized per `Type` (`TryGetValue` before `GetOrAdd`, because a `GetOrAdd`
factory's lambda parameter carries no annotation).

The justification is that every API Quartz offers a caller for producing a name-constructed `JobType`
is itself `[RequiresUnreferencedCode]`, so a trimmed application that avoids those entry points never
reaches the branch. The remaining producers are Quartz's own persistence and configuration readers,
which are in the baseline as string contracts.

There is a **second** `[UnconditionalSuppressMessage]`, on `PropertySettingJobFactory.SetObjectProperty`
(IL2075). The job instance arrives there as an `object`, and looking its properties up on the job
detail's declared type instead would stop binding data to an `AddJobType<TJob, TImplementation>`
implementation's own properties — a silent behaviour change. Both types are annotated where they enter
Quartz, so the properties do survive; the analyzer just cannot see the link. `SetObjectProperty` stays
`protected virtual`, and so does `ConvertValueIfNecessary`.

## What became `[RequiresUnreferencedCode]`

`JobType(string)`, the explicit `string` → `JobType` cast and `JobBuilder<TJob>.OfType(string)` carry
the message verbatim; `JobDetailDto.AsIJobDetail` and `XmlSchedulingDataProcessor`'s nine public entry
points carry it with the second half adjusted to the site. `ObjectUtils.SetObjectProperties` /
`SetPropertyValue` carry a parallel sentence about `quartz.*` keys.

`ConvertValueIfNecessary` is split: the two answers that need no converter — a value already of the
target's type, and the target's default for a missing one — are given in front, and only the
`TypeDescriptor.GetConverter` fallback sits behind a `[RequiresUnreferencedCode]` helper. The order the
fallback tries things in is untouched, so `JobDataExpression`'s round-trip check still rejects lossy
conversions.

## Which baseline entries left, and which stayed

**28 entries over 19 types → 21 entries over 14 types.** Gone entirely:
`Quartz.Impl.JobActivatorCache`, `Quartz.Impl.PropertySettingJobFactory`, `Quartz.Util.JobDataExpression`,
`Quartz.Impl.AdoJobStore.Common.DbProvider`, `Quartz.Impl.AdoJobStore.Common.DbMetadata`,
`Quartz.Xml.XmlSchedulingDataProcessor`. `Quartz.Util.ObjectUtils` went from seven codes to two.
One type joined: `ConfigurationBasedDbMetadataFactory`, for the `quartz.dbprovider.*` keys it binds by
name — the same contract as its neighbours, which now show as IL2026 because the binder says so.

What stayed, in the groups the file names:

- **the string contracts** — `SimpleTypeLoader`, `JobType`'s `Type.GetType`, `StdAdoDelegate`,
  `BuiltInDbMetadataFactory`, `ConfigurationBasedDbMetadataFactory`, `QuartzPropertyBridge`,
  `SchedulerPluginFactory`, `PropertyListenerFactory`, `JsonSchedulingHelper`;
- **the `PropertyInfo.PropertyType` wall** — `ObjectUtils`, two codes;
- **duck-typed provider error codes** — `TransientErrorDetector`;
- **the reflective serializer** — step 4;
- **the configuration binder** — `QuartzTypedOptions`.

## One behaviour change

`AdoJobStoreBase`'s acquisition decided `[DisallowConcurrentExecution]` with the non-walking
`ObjectUtils.IsAttributePresent` while `IJobDetail.ConcurrentExecutionDisallowed` walked interfaces, so
a job inheriting the attribute from an interface was serialized when it fired but not when it was
acquired — a batch could hold two of its triggers, and the surplus was released again. Both ask
`JobTypeInformation` now. `AdoJobStoreBaseTest` pins it, and fails without the fix.
`IsAnyInterfaceAttributePresent` also walks flat rather than recursively, because `Type.GetInterfaces`
already reports the interfaces an interface itself inherits; `ObjectUtilsTest` pins that.

## Docs

A short **Trimming** section on `tutorial/more-about-jobs.md` — register job types, avoid string-named
ones, and what the analyzer will say — plus a migration-guide section carrying the API delta, as
`AGENTS.md` requires for a public-API baseline change.

## What a reviewer has to decide

Three places where the spec's letter and the codebase's shape disagreed. Each is argued in
`TrimAnalysisBaseline.cs`'s header, but they are the review's real questions:

1. **`ITypeLoader.LoadType` and `SimpleTypeLoader` are *not* `[RequiresUnreferencedCode]`.** IL2046
   requires the attribute to match across an interface implementation, and `LoadType` is implemented by
   `SimpleTypeLoader`, by `AdoJobStoreBase`'s own null loader and by user loaders; its callers are
   `IJobStore` and `IDriverDelegate` members, which cannot carry it without dragging `RAMJobStore` in.
   Their `Type.GetType` stays in the baseline as the string contract it always was.
2. **`QuartzPropertyBridge`, `SchedulerPluginFactory`, `PropertyListenerFactory` and
   `ConfigurationBasedDbMetadataFactory` are not `[RequiresUnreferencedCode]` either.** Propagating from
   there reaches `AddQuartz` (every overload, including the `IConfiguration` one the trim canary calls)
   and `ISchedulerFactory.GetScheduler`. Marking `AddQuartz` would both fail the `PublishTrimmed` leg and
   be untrue — a code-only configuration trims fine. They stay baselined.
3. **The "cheap cut" is narrower than specified.** Handling the primitives and enums in front of the
   converter cannot be done without changing tested coercion: `BaseNumberConverter` accepts `0x`/`#`
   prefixes, `Convert.ChangeType` allows thousands separators where the converters do not, `CharConverter`
   trims and `Convert.ToChar` does not, and `EnumConverter` wraps failures in `FormatException`. The front
   therefore covers only the cases that need no converter at all; everything else keeps the exact old
   order behind the RUC helper.

## Verification

```
dotnet build src/Quartz/Quartz.csproj      0 Warning(s), 0 Error(s)
dotnet build Quartz.slnx                   0 Warning(s), 0 Error(s)
dotnet test  Quartz.Tests.Unit             Passed: 3098, Skipped: 4, Total: 3102
dotnet test  Quartz.Tests.AspNetCore       Passed:  314, Total: 314
dotnet test  Quartz.Tests.Integration     Passed:  316, Total: 316 (8m41s, Docker 29.5.3)
dotnet fallout PublishTrimmed              Succeeded (link step re-run from clean; "Optimizing assemblies for size")
dotnet fallout VerifyDocsSnippets          Succeeded (89 markdown files checked)
npm run docs:check-links                   211 pages, 698 internal links, 393 fragments; no dead links or anchors
```

The public API baseline moved through the Verify workflow and the delta is in the migration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
