### PR TITLE
Every listener callback is told which scheduler is calling it

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2986,6 +2986,133 @@ exception:
 + IJobListener? listener = listenerManager.GetJobListener(name);
 ```
 
+### Listeners are told which scheduler is calling
+
+The listener callbacks that run inside a firing have always been able to say who was calling:
+`IJobExecutionContext.Scheduler`. The rest could not. A listener registered with two schedulers in one
+host — which `AddQuartz("acme", …)` and `AddQuartz("initech", …)` make an ordinary thing to do — was told
+that *a* trigger had been paused, or that *a* scheduler had failed, with no way to ask which one (#3063).
+
+There is one rule now, and it holds for all three listener interfaces: **a listener reaches the scheduler
+it serves through its execution context, or as its first argument when there is no execution.** That makes
+`IScheduler` the first parameter of every one of `ISchedulerListener`'s twenty-three members, and of
+`ITriggerListener.TriggerMisfired` — the one trigger callback with no context to carry it, because a
+misfire is noticed rather than executed.
+
+```diff
+- public ValueTask SchedulerStarted(CancellationToken cancellationToken = default)
++ public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default)
+  {
+-     logger.LogInformation("Scheduler started");
++     logger.LogInformation("Scheduler {SchedulerName} started", scheduler.SchedulerName);
+      return default;
+  }
+```
+
+It is the `IScheduler` rather than a name or an identity record, because a listener that knows *which*
+scheduler usually wants to *act* on it — pause the trigger it was just told about, read `Status`. Identity
+is `SchedulerName` and `SchedulerInstanceId` on the same object.
+
+The instance handed over is the one `ISchedulerFactory.GetScheduler()` returns, and the very one
+`IJobExecutionContext.Scheduler` carries, so those two compare by reference. An `IScheduler` injected from
+the container does not: that is a proxy that resolves the scheduler on first use, so compare a
+`SchedulerName` there rather than the objects.
+
+#### `SchedulerError` says what the error was about
+
+`SchedulerError` took a message and an exception, which said what happened but never what it happened to.
+Most of the places that raise it know: a job that threw is reported from its execution context, a job that
+could not be built from the bundle that was fired. Those facts now travel in a `SchedulerErrorContext`:
+
+```diff
+- ValueTask SchedulerError(string msg, SchedulerException cause, CancellationToken cancellationToken = default);
++ ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default);
+```
+
+```csharp
+public sealed record SchedulerErrorContext
+{
+    public required string Message { get; init; }
+    public required SchedulerException Exception { get; init; }
+    public TriggerKey? TriggerKey { get; init; }
+    public JobKey? JobKey { get; init; }
+    public string? FireInstanceId { get; init; }
+}
+```
+
+`Message` and `Exception` are the two old parameters, so a listener that only logged needs one rename:
+
+```diff
+- public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
++ public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
+  {
+-     logger.LogError(exception, "{Message}", message);
++     logger.LogError(errorContext.Exception, "{Message}", errorContext.Message);
+      return default;
+  }
+```
+
+The three keys are nullable because some errors genuinely have no subject: a scan for the next trigger to
+fire that never reached a trigger, a job store retrying a failed connection, a schedule file that names
+many jobs. Read a null as "the scheduler could not say", not as "this concerns no trigger". Where the
+scheduler does know — every failure inside a firing, and a misfire notification that a listener broke —
+all three are filled in, which is what discussion #3211 asked for: the trigger behind a `SchedulerError`.
+
+`ISchedulerSignaler.NotifySchedulerListenersError` takes the record for the same reason, so a job store of
+your own can report the trigger it failed for:
+
+```diff
+- ValueTask NotifySchedulerListenersError(string message, SchedulerException exception, CancellationToken cancellationToken = default);
++ ValueTask NotifySchedulerListenersError(SchedulerErrorContext errorContext, CancellationToken cancellationToken = default);
+```
+
+#### The compiler will not point at every callback you have to change
+
+Every member of these interfaces has a default implementation, which is what lets a listener implement only
+the notifications it cares about — and it is also why a listener that keeps an old signature still compiles.
+It simply stops being an implementation of anything: the default runs instead, and the method becomes dead
+code that is never called.
+
+So the build will not fail. Search your listeners for the twenty-four names in the table below rather than
+waiting to be told, and note that `#pragma`-free hints do exist: a callback that no longer overrides
+anything and does not touch instance state trips CA1822 ("can be marked as static"), and an
+`<inheritdoc />` on it trips MA0196. Both fired on Quartz's own listeners while this change was made.
+
+#### Every signature that changed
+
+| 3.x | 4.x |
+|---|---|
+| `ISchedulerListener.JobScheduled(ITrigger, ct)` | `JobScheduled(IScheduler, ITrigger, ct)` |
+| `ISchedulerListener.JobUnscheduled(TriggerKey, ct)` | `JobUnscheduled(IScheduler, TriggerKey, ct)` |
+| `ISchedulerListener.TriggerFinalized(ITrigger, ct)` | `TriggerFinalized(IScheduler, ITrigger, ct)` |
+| `ISchedulerListener.TriggerPaused(TriggerKey, ct)` | `TriggerPaused(IScheduler, TriggerKey, ct)` |
+| `ISchedulerListener.TriggersPaused(string?, ct)` | `TriggersPaused(IScheduler, string?, ct)` |
+| `ISchedulerListener.TriggerResumed(TriggerKey, ct)` | `TriggerResumed(IScheduler, TriggerKey, ct)` |
+| `ISchedulerListener.TriggersResumed(string?, ct)` | `TriggersResumed(IScheduler, string?, ct)` |
+| `ISchedulerListener.TriggerInError(TriggerKey, ct)` | `TriggerInError(IScheduler, TriggerKey, ct)` |
+| `ISchedulerListener.TriggersInError(JobKey, ct)` | `TriggersInError(IScheduler, JobKey, ct)` |
+| `ISchedulerListener.JobAdded(IJobDetail, ct)` | `JobAdded(IScheduler, IJobDetail, ct)` |
+| `ISchedulerListener.JobDeleted(JobKey, ct)` | `JobDeleted(IScheduler, JobKey, ct)` |
+| `ISchedulerListener.JobPaused(JobKey, ct)` | `JobPaused(IScheduler, JobKey, ct)` |
+| `ISchedulerListener.JobsPaused(string?, ct)` | `JobsPaused(IScheduler, string?, ct)` |
+| `ISchedulerListener.JobResumed(JobKey, ct)` | `JobResumed(IScheduler, JobKey, ct)` |
+| `ISchedulerListener.JobsResumed(string?, ct)` | `JobsResumed(IScheduler, string?, ct)` |
+| `ISchedulerListener.JobInterrupted(JobKey, ct)` | `JobInterrupted(IScheduler, JobKey, ct)` |
+| `ISchedulerListener.SchedulerError(string, SchedulerException, ct)` | `SchedulerError(IScheduler, SchedulerErrorContext, ct)` |
+| `ISchedulerListener.SchedulerStarting(ct)` | `SchedulerStarting(IScheduler, ct)` |
+| `ISchedulerListener.SchedulerStarted(ct)` | `SchedulerStarted(IScheduler, ct)` |
+| `ISchedulerListener.SchedulerInStandbyMode(ct)` | `SchedulerInStandbyMode(IScheduler, ct)` |
+| `ISchedulerListener.SchedulerShuttingDown(ct)` | `SchedulerShuttingDown(IScheduler, ct)` |
+| `ISchedulerListener.SchedulerShutdown(ct)` | `SchedulerShutdown(IScheduler, ct)` |
+| `ISchedulerListener.SchedulingDataCleared(ct)` | `SchedulingDataCleared(IScheduler, ct)` |
+| `ITriggerListener.TriggerMisfired(ITrigger, ct)` | `TriggerMisfired(IScheduler, ITrigger, ct)` |
+
+`BroadcastSchedulerListener` and `BroadcastTriggerListener` forward the scheduler they were handed, so a
+listener behind one is told the same thing it would have been told directly.
+
+`IJobListener`'s members and `ITriggerListener`'s other three are unchanged: they all receive an
+`IJobExecutionContext`, which is how they reach the scheduler already.
+
 ### The three `*Support` base classes are gone
 
 `JobListenerSupport`, `TriggerListenerSupport` and `SchedulerListenerSupport` existed so that a listener could
@@ -3050,8 +3177,8 @@ A.CallTo(() => listener.Name).Returns("myListener");
 ```diff
 - ValueTask JobsPaused(string jobGroup, CancellationToken cancellationToken = default);
 - ValueTask JobsResumed(string jobGroup, CancellationToken cancellationToken = default);
-+ ValueTask JobsPaused(string? jobGroup, CancellationToken cancellationToken = default);
-+ ValueTask JobsResumed(string? jobGroup, CancellationToken cancellationToken = default);
++ ValueTask JobsPaused(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default);
++ ValueTask JobsResumed(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default);
 ```
 
 Null means every group, matching `TriggersPaused` and `TriggersResumed`, which were already nullable. The
@@ -3069,8 +3196,11 @@ unscheduled there is no trigger left to hand out.
 + ValueTask SchedulerShuttingDown(CancellationToken cancellationToken = default);
 
 - ValueTask SchedulerError(string msg, SchedulerException cause, CancellationToken cancellationToken = default);
-+ ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default);
++ ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default);
 ```
+
+`SchedulerError`'s two parameters became one record on the way — see [Listeners are told which scheduler is
+calling](#listeners-are-told-which-scheduler-is-calling).
 
 ### Instantiation failures name the trigger
 
@@ -3079,15 +3209,16 @@ reason — the trigger has already fired, but there is no `IJobExecutionContext`
 `IJobListener` callback can be raised. `SchedulerError` is the only notification, and it used to carry the job
 key as interpolated message text and the trigger nowhere at all.
 
-It now receives a `JobInstantiationException`:
+It now receives a `JobInstantiationException`, and the `SchedulerErrorContext` around it names the same
+firing without any unwrapping:
 
 ```csharp
-public override ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
 {
-    if (exception is JobInstantiationException failure)
+    if (errorContext.Exception is JobInstantiationException failure)
     {
         logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}",
-            failure.JobDetail.Key, failure.Trigger.Key, failure.FireInstanceId);
+            errorContext.JobKey, errorContext.TriggerKey, errorContext.FireInstanceId);
     }
 
     return default;
@@ -3114,8 +3245,8 @@ log — and two of the ADO store's transitions, a job type that will not load wh
 cannot be read back in `TriggersFired`, did not reach the scheduler at all.
 
 ```csharp
-ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
-ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+ValueTask TriggerInError(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+ValueTask TriggersInError(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 ```
 
 Following the singular/plural pair `ISchedulerListener` already has for pause and resume. Both are
@@ -3246,6 +3377,7 @@ already have them.
 * **`TriggerState.Executing`** — tell whether a trigger's job is running, across the whole cluster (see [Executing is a trigger state](#executing-is-a-trigger-state))
 * **`JobInstantiationException`** — a job that could not be built names the trigger, the job and the fire instance instead of only interpolating the job key into a message (see [Instantiation failures name the trigger](#instantiation-failures-name-the-trigger))
 * **`ISchedulerListener.TriggerInError` / `TriggersInError`** — observe a trigger being moved to `TriggerState.Error`, including two ADO store transitions that reached nothing at all before (see [Triggers entering the error state are reported](#triggers-entering-the-error-state-are-reported))
+* **Every listener callback names its scheduler** — one listener can serve several schedulers in one host and still say which of them paused a trigger or failed, and `SchedulerError` carries the trigger, job and firing it was raised for (see [Listeners are told which scheduler is calling](#listeners-are-told-which-scheduler-is-calling))
 * **Joining a transaction the application owns** — the ADO job store can take part in a transaction you started, so saving your own data and scheduling the job that acts on it commit together or not at all. Turn it on with `store.Configure(o => o.AcceptEnlistedTransactions = true)`, `JobStore:AcceptEnlistedTransactions`, or `quartz.jobStore.acceptEnlistedTransactions`, then hand the store a connection for the duration of a scope with `IScheduler.EnlistTransaction` / `EnlistConnection`. Handing over a connection is the only way to take part: a connection the job store opens for itself is deliberately kept out of any ambient `TransactionScope`, since a second connection in that transaction would require promoting it to a distributed one. See [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction)
 * **Builder methods for three more plugins** — `UseJobHistoryLogging()`, `UseTriggerHistoryLogging()` and `UseShutdownHook()`. Only the structured-logging variants had one, so the classic history plugins and the shutdown hook could previously be reached only through `quartz.plugin.*` property keys
 * **An `IJobDetail` of your own** — the interface no longer declares a member only Quartz can implement, so an application can supply its own job detail type and have `RAMJobStore` hand it back rather than quietly swapping it for Quartz's (see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own))
@@ -6960,9 +7092,11 @@ moved there too, and `Quartz.Core` is now internal from top to bottom: nothing i
 ```diff
 - using Quartz.Core;
 -
-  public ValueTask SchedulerError(string msg, SchedulerException cause, CancellationToken ct = default)
+- public ValueTask SchedulerError(string msg, SchedulerException cause, CancellationToken ct = default)
++ public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext error, CancellationToken ct = default)
   {
-      if (cause is JobInstantiationException failure) { … }
+-     if (cause is JobInstantiationException failure) { … }
++     if (error.Exception is JobInstantiationException failure) { … }
       return default;
   }
 ```

--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -131,18 +131,19 @@ called.
 Jobs that are not registered — those named by an XML or JSON schedule, or built by a job factory of
 your own — can still fail that way. If you need to react to such a failure at fire time rather than
 prevent it — to fail whatever scheduled the work, for instance — `ISchedulerListener.SchedulerError`
-receives a `JobInstantiationException` naming the trigger, the job and the fire instance:
+receives a `SchedulerErrorContext` naming the trigger, the job and the fire instance, wrapped around a
+`JobInstantiationException` that carries the same three:
 
 <!-- snippet: sample_di_instantiation_failure_listener -->
 ```csharp
 public sealed class InstantiationFailureListener(ILogger<InstantiationFailureListener> logger) : ISchedulerListener
 {
-    public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+    public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
     {
-        if (exception is JobInstantiationException failure)
+        if (errorContext.Exception is JobInstantiationException failure)
         {
-            logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}",
-                failure.JobDetail.Key, failure.Trigger.Key, failure.FireInstanceId);
+            logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}, on scheduler {SchedulerName}",
+                errorContext.JobKey, errorContext.TriggerKey, errorContext.FireInstanceId, scheduler.SchedulerName);
         }
 
         return default;

--- a/docs/documentation/quartz-4.x/tutorial/scheduler-listeners.md
+++ b/docs/documentation/quartz-4.x/tutorial/scheduler-listeners.md
@@ -23,29 +23,83 @@ public interface ISchedulerListener
 {
     string Name => GetType().Name;
 
-    ValueTask JobScheduled(ITrigger trigger, CancellationToken cancellationToken = default);
+    ValueTask JobScheduled(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default);
 
-    ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default);
+    ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default);
 
-    ValueTask TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken = default);
+    ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default);
 
-    ValueTask TriggersPaused(string? triggerGroup, CancellationToken cancellationToken = default);
+    ValueTask TriggersPaused(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default);
 
-    ValueTask TriggersResumed(string? triggerGroup, CancellationToken cancellationToken = default);
+    ValueTask TriggersResumed(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default);
 
-    ValueTask JobsPaused(string? jobGroup, CancellationToken cancellationToken = default);
+    ValueTask JobsPaused(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default);
 
-    ValueTask JobsResumed(string? jobGroup, CancellationToken cancellationToken = default);
+    ValueTask JobsResumed(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default);
 
-    ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default);
+    ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default);
 
-    ValueTask SchedulerShutdown(CancellationToken cancellationToken = default);
+    ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default);
 
     // ...and the rest; every member has a do-nothing default implementation, so implement only what you care about
 }
 ```
 
 A null group in `JobsPaused`, `JobsResumed`, `TriggersPaused` or `TriggersResumed` means every group.
+
+## Every callback names its scheduler
+
+A listener reaches the scheduler it serves through its execution context, or as its first argument when there
+is no execution. Nothing here runs inside a firing, so every member takes the scheduler — which is what lets
+one listener instance serve several schedulers in one host and still say which of them it is hearing from:
+
+```csharp
+public sealed class AuditSchedulerListener : ISchedulerListener
+{
+    public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("{SchedulerName} paused {TriggerKey}", scheduler.SchedulerName, triggerKey);
+        return default;
+    }
+}
+```
+
+It is the scheduler itself rather than its name, so a listener that wants to act on what it heard can: pause
+the trigger, read `Status`, ask for the job. `SchedulerName` and `SchedulerInstanceId` are on it when identity
+is all you need.
+
+## Reporting an error
+
+`SchedulerError` is raised when something goes seriously wrong — a job that could not be built, a job store
+that keeps failing, a job that threw. It receives a `SchedulerErrorContext`, which says what went wrong and,
+where the scheduler knew it, what it went wrong for:
+
+```csharp
+public sealed record SchedulerErrorContext
+{
+    public required string Message { get; init; }
+    public required SchedulerException Exception { get; init; }
+    public TriggerKey? TriggerKey { get; init; }
+    public JobKey? JobKey { get; init; }
+    public string? FireInstanceId { get; init; }
+}
+```
+
+The three keys are null when there is nothing to name — a scan that never reached a trigger, a store retrying
+a connection. Every failure inside a firing fills in all three:
+
+```csharp
+public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
+{
+    if (errorContext.TriggerKey is { } triggerKey)
+    {
+        return scheduler.PauseTrigger(triggerKey, cancellationToken);
+    }
+
+    logger.LogError(errorContext.Exception, "{Message}", errorContext.Message);
+    return default;
+}
+```
 
 SchedulerListeners are registered with the scheduler's `ListenerManager`.
 SchedulerListeners can be virtually any object that implements the `ISchedulerListener` interface.

--- a/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
+++ b/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
@@ -27,7 +27,7 @@ public interface ITriggerListener
 
     ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default);
 
-    ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default);
+    ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default);
 
     ValueTask TriggerComplete(ITrigger trigger, IJobExecutionContext context, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default);
 }
@@ -35,6 +35,19 @@ public interface ITriggerListener
 
 `triggerInstructionCode` is the `SchedulerInstruction` the trigger returned for this fire — what the scheduler
 is about to do with the trigger, from `NoInstruction` through `SetTriggerComplete` to `DeleteTrigger`.
+
+A listener reaches the scheduler it serves through its execution context, or as its first argument when there
+is no execution. Three of these four callbacks happen inside a firing, so they read `context.Scheduler`;
+`TriggerMisfired` is the exception, because a misfire is noticed rather than executed, and it takes the
+scheduler directly:
+
+```csharp
+public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
+{
+    logger.LogWarning("{SchedulerName} missed {TriggerKey}", scheduler.SchedulerName, trigger.Key);
+    return default;
+}
+```
 
 Job-related events include: a notification that the job is about to be executed, and a notification when the job has completed execution.
 

--- a/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/QuartSchedulerBenchmark.cs
@@ -501,7 +501,7 @@ public class QuartSchedulerBenchmark
             return default;
         }
 
-        public ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        public ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
             return default;
         }
@@ -511,37 +511,37 @@ public class QuartSchedulerBenchmark
             return default;
         }
 
-        public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+        public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask SchedulerInStandbyMode(CancellationToken cancellationToken = default)
+        public ValueTask SchedulerInStandbyMode(IScheduler scheduler, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask SchedulerShutdown(CancellationToken cancellationToken = default)
+        public ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask SchedulerShuttingDown(CancellationToken cancellationToken = default)
+        public ValueTask SchedulerShuttingDown(IScheduler scheduler, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask SchedulerStarted(CancellationToken cancellationToken = default)
+        public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask SchedulerStarting(CancellationToken cancellationToken = default)
+        public ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask SchedulingDataCleared(CancellationToken cancellationToken = default)
+        public ValueTask SchedulingDataCleared(IScheduler scheduler, CancellationToken cancellationToken = default)
         {
             return default;
         }
@@ -551,7 +551,7 @@ public class QuartSchedulerBenchmark
             return default;
         }
 
-        public ValueTask TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken = default)
+        public ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
         {
             return default;
         }
@@ -561,27 +561,27 @@ public class QuartSchedulerBenchmark
             return default;
         }
 
-        public ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default)
+        public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask TriggerResumed(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        public ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask TriggersPaused(string? triggerGroup, CancellationToken cancellationToken = default)
+        public ValueTask TriggersPaused(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask TriggersResumed(string? triggerGroup, CancellationToken cancellationToken = default)
+        public ValueTask TriggersResumed(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default)
         {
             return default;
         }
@@ -591,42 +591,42 @@ public class QuartSchedulerBenchmark
             return new ValueTask<bool>(false);
         }
 
-        public ValueTask JobAdded(IJobDetail jobDetail, CancellationToken cancellationToken = default)
+        public ValueTask JobAdded(IScheduler scheduler, IJobDetail jobDetail, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask JobDeleted(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask JobDeleted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask JobInterrupted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask JobPaused(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask JobResumed(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask JobScheduled(ITrigger trigger, CancellationToken cancellationToken = default)
+        public ValueTask JobScheduled(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask JobsPaused(string? jobGroup, CancellationToken cancellationToken = default)
+        public ValueTask JobsPaused(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default)
         {
             return default;
         }
 
-        public ValueTask JobsResumed(string? jobGroup, CancellationToken cancellationToken = default)
+        public ValueTask JobsResumed(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default)
         {
             return default;
         }

--- a/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
+++ b/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
@@ -504,7 +504,7 @@ public class RAMJobStoreBenchmark
 
     public class NoOpSignaler : ISchedulerSignaler
     {
-        public ValueTask NotifySchedulerListenersError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+        public ValueTask NotifySchedulerListenersError(SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
         {
             return default;
         }

--- a/src/Quartz.Dashboard/Hubs/IQuartzDashboardHubClient.cs
+++ b/src/Quartz.Dashboard/Hubs/IQuartzDashboardHubClient.cs
@@ -96,4 +96,13 @@ public sealed record TriggerEventDto(
 /// </remarks>
 public sealed record SchedulerStateDto(string SchedulerName, SchedulerStatus Status);
 
-public sealed record SchedulerErrorDto(string SchedulerName, string Message, string? Cause);
+/// <remarks>
+/// <see cref="TriggerKey" /> and <see cref="JobKey" /> are null when the scheduler could not say what
+/// the error was about — a store retrying a failed operation names neither.
+/// </remarks>
+public sealed record SchedulerErrorDto(
+    string SchedulerName,
+    string Message,
+    string? Cause,
+    TriggerKeyDto? TriggerKey,
+    JobKeyDto? JobKey);

--- a/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
@@ -30,7 +30,6 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
 {
     private IScheduler? scheduler;
     private IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>? hubContext;
-    private string schedulerName = string.Empty;
 
     public string Name { get; private set; } = "QuartzDashboardLiveEvents";
 
@@ -38,7 +37,6 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     {
         Name = pluginName;
         this.scheduler = scheduler;
-        schedulerName = scheduler.SchedulerName;
 
         scheduler.ListenerManager.AddJobListener(this, Matchers.AllJobs());
         scheduler.ListenerManager.AddTriggerListener(this, Matchers.AllTriggers());
@@ -103,14 +101,14 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return ValueTask.FromResult(false);
     }
 
-    public ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default)
+    public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
     {
         TriggerEventDto payload = new(
             TriggerKey: new TriggerKeyDto(trigger.Key.Group, trigger.Key.Name),
             JobKey: trigger.JobKey is null ? null : new JobKeyDto(trigger.JobKey.Group, trigger.JobKey.Name),
             FireTimeUtc: null);
 
-        return BroadcastToScheduler(schedulerName, client => client.TriggerMisfired(payload));
+        return BroadcastToScheduler(scheduler.SchedulerName, client => client.TriggerMisfired(payload));
     }
 
     public ValueTask TriggerComplete(
@@ -127,64 +125,70 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(context.Scheduler.SchedulerName, client => client.TriggerCompleted(payload));
     }
 
-    public ValueTask JobScheduled(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+    public ValueTask JobScheduled(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+    public ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+    public ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         TriggerKeyDto payload = new(triggerKey.Group, triggerKey.Name);
-        return BroadcastToScheduler(schedulerName, client => client.TriggerPaused(payload));
+        return BroadcastToScheduler(scheduler.SchedulerName, client => client.TriggerPaused(payload));
     }
 
-    public ValueTask TriggersPaused(string? triggerGroup, CancellationToken cancellationToken = default) => default;
+    public ValueTask TriggersPaused(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask TriggerResumed(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         TriggerKeyDto payload = new(triggerKey.Group, triggerKey.Name);
-        return BroadcastToScheduler(schedulerName, client => client.TriggerResumed(payload));
+        return BroadcastToScheduler(scheduler.SchedulerName, client => client.TriggerResumed(payload));
     }
 
-    public ValueTask TriggersResumed(string? triggerGroup, CancellationToken cancellationToken = default) => default;
+    public ValueTask TriggersResumed(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask JobAdded(IJobDetail jobDetail, CancellationToken cancellationToken = default) => default;
+    public ValueTask JobAdded(IScheduler scheduler, IJobDetail jobDetail, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask JobDeleted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+    public ValueTask JobDeleted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask JobPaused(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
         JobKeyDto payload = new(jobKey.Group, jobKey.Name);
-        return BroadcastToScheduler(schedulerName, client => client.JobPaused(payload));
+        return BroadcastToScheduler(scheduler.SchedulerName, client => client.JobPaused(payload));
     }
 
-    public ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+    public ValueTask JobInterrupted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask JobsPaused(string? jobGroup, CancellationToken cancellationToken = default) => default;
+    public ValueTask JobsPaused(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask JobResumed(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
         JobKeyDto payload = new(jobKey.Group, jobKey.Name);
-        return BroadcastToScheduler(schedulerName, client => client.JobResumed(payload));
+        return BroadcastToScheduler(scheduler.SchedulerName, client => client.JobResumed(payload));
     }
 
-    public ValueTask JobsResumed(string? jobGroup, CancellationToken cancellationToken = default) => default;
+    public ValueTask JobsResumed(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+    public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
     {
-        SchedulerErrorDto payload = new(schedulerName, message, exception.Message);
-        return BroadcastToScheduler(schedulerName, client => client.SchedulerError(payload));
+        SchedulerErrorDto payload = new(
+            SchedulerName: scheduler.SchedulerName,
+            Message: errorContext.Message,
+            Cause: errorContext.Exception.Message,
+            TriggerKey: errorContext.TriggerKey is null ? null : new TriggerKeyDto(errorContext.TriggerKey.Group, errorContext.TriggerKey.Name),
+            JobKey: errorContext.JobKey is null ? null : new JobKeyDto(errorContext.JobKey.Group, errorContext.JobKey.Name));
+
+        return BroadcastToScheduler(scheduler.SchedulerName, client => client.SchedulerError(payload));
     }
 
-    public ValueTask SchedulerInStandbyMode(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerInStandbyMode(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return BroadcastState(SchedulerStatus.Standby);
+        return BroadcastState(scheduler, SchedulerStatus.Standby);
     }
 
-    public ValueTask SchedulerStarted(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return BroadcastState(SchedulerStatus.Running);
+        return BroadcastState(scheduler, SchedulerStatus.Running);
     }
 
     /// <summary>
@@ -195,28 +199,28 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     /// "starting" first only gave a browser a value that is not a <see cref="SchedulerStatus" /> to
     /// render in the meantime.
     /// </remarks>
-    public ValueTask SchedulerStarting(CancellationToken cancellationToken = default) => default;
+    public ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask SchedulerShutdown(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return BroadcastState(SchedulerStatus.Shutdown);
+        return BroadcastState(scheduler, SchedulerStatus.Shutdown);
     }
 
-    public ValueTask SchedulerShuttingDown(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerShuttingDown(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return BroadcastState(SchedulerStatus.ShuttingDown);
+        return BroadcastState(scheduler, SchedulerStatus.ShuttingDown);
     }
 
     /// <summary>
     /// Pushes the state the scheduler is now in, which is what a listener event means.
     /// </summary>
-    private ValueTask BroadcastState(SchedulerStatus status)
+    private ValueTask BroadcastState(IScheduler scheduler, SchedulerStatus status)
     {
-        SchedulerStateDto payload = new(schedulerName, status);
-        return BroadcastToScheduler(schedulerName, client => client.SchedulerStateChanged(payload));
+        SchedulerStateDto payload = new(scheduler.SchedulerName, status);
+        return BroadcastToScheduler(scheduler.SchedulerName, client => client.SchedulerStateChanged(payload));
     }
 
-    public ValueTask SchedulingDataCleared(CancellationToken cancellationToken = default) => default;
+    public ValueTask SchedulingDataCleared(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
     private async ValueTask BroadcastToScheduler(string schedulerName, Func<IQuartzDashboardHubClient, Task> send)
     {

--- a/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
@@ -75,12 +75,12 @@ public static class MicrosoftDiIntegrationSamples
 
     public sealed class InstantiationFailureListener(ILogger<InstantiationFailureListener> logger) : ISchedulerListener
     {
-        public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+        public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
         {
-            if (exception is JobInstantiationException failure)
+            if (errorContext.Exception is JobInstantiationException failure)
             {
-                logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}",
-                    failure.JobDetail.Key, failure.Trigger.Key, failure.FireInstanceId);
+                logger.LogError(failure, "Job {Job} could not be built for trigger {Trigger}, fire {FireInstanceId}, on scheduler {SchedulerName}",
+                    errorContext.JobKey, errorContext.TriggerKey, errorContext.FireInstanceId, scheduler.SchedulerName);
             }
 
             return default;

--- a/src/Quartz.Examples.AspNetCore/SampleSchedulerListener.cs
+++ b/src/Quartz.Examples.AspNetCore/SampleSchedulerListener.cs
@@ -11,9 +11,9 @@ public class SampleSchedulerListener : ISchedulerListener
         this.logger = logger;
     }
 
-    public ValueTask SchedulerStarted(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Observed scheduler start");
+        logger.LogInformation("Observed start of scheduler {SchedulerName}", scheduler.SchedulerName);
         return default;
     }
 }

--- a/src/Quartz.Examples.AspNetCore/SampleTriggerListener.cs
+++ b/src/Quartz.Examples.AspNetCore/SampleTriggerListener.cs
@@ -13,9 +13,12 @@ public class SampleTriggerListener : ITriggerListener
 
     public string Name => "Sample Trigger Listener";
 
-    public ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default)
+    public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Observed trigger fire by trigger {TriggerKey}", trigger.Key);
+        logger.LogInformation(
+            "Observed misfire of trigger {TriggerKey} on scheduler {SchedulerName}",
+            trigger.Key,
+            scheduler.SchedulerName);
         return default;
     }
 }

--- a/src/Quartz.Examples.Worker/Listeners.cs
+++ b/src/Quartz.Examples.Worker/Listeners.cs
@@ -9,9 +9,9 @@ public class TestSchedulerListener : ISchedulerListener
         this.logger = logger;
     }
 
-    public ValueTask SchedulerStarting(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Scheduler starting");
+        logger.LogInformation("Scheduler {SchedulerName} starting", scheduler.SchedulerName);
         return ValueTask.CompletedTask;
     }
 }

--- a/src/Quartz.Plugins/Plugins/History/LoggingTriggerHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/LoggingTriggerHistoryPlugin.cs
@@ -335,9 +335,11 @@ public sealed class LoggingTriggerHistoryPlugin : ISchedulerPlugin, ITriggerList
     /// does a lot.
     /// </para>
     /// </summary>
+    /// <param name="scheduler">The scheduler raising the notification.</param>
     /// <param name="trigger">The <see cref="ITrigger" /> that has misfired.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     public ValueTask TriggerMisfired(
+        IScheduler scheduler,
         ITrigger trigger,
         CancellationToken cancellationToken = default)
     {

--- a/src/Quartz.Plugins/Plugins/History/StructuredLoggingTriggerHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/StructuredLoggingTriggerHistoryPlugin.cs
@@ -146,6 +146,7 @@ public sealed class StructuredLoggingTriggerHistoryPlugin : ISchedulerPlugin, IT
 
     /// <inheritdoc />
     public ValueTask TriggerMisfired(
+        IScheduler scheduler,
         ITrigger trigger,
         CancellationToken cancellationToken = default)
     {

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
@@ -212,11 +212,19 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
 
             logger.LogError(e, "Could not schedule jobs and triggers from JSON file {FileName}", jobFile.FileName);
 
+            // No keys: the file names many jobs and triggers, and the failure is the file rather than
+            // any one of them.
+            SchedulerErrorContext errorContext = new()
+            {
+                Message = message,
+                Exception = schedulerException,
+            };
+
             foreach (var listener in Scheduler.ListenerManager.GetSchedulerListeners())
             {
                 try
                 {
-                    await listener.SchedulerError(message, schedulerException, cancellationToken).ConfigureAwait(false);
+                    await listener.SchedulerError(Scheduler, errorContext, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
                 catch (Exception ex)

--- a/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
@@ -277,11 +277,19 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
     {
         var listeners = Scheduler.ListenerManager.GetSchedulerListeners();
 
+        // No keys: the file names many jobs and triggers, and the failure is the file rather than any
+        // one of them.
+        SchedulerErrorContext errorContext = new()
+        {
+            Message = message,
+            Exception = schedulerException,
+        };
+
         foreach (var listener in listeners)
         {
             try
             {
-                await listener.SchedulerError(message, schedulerException, cancellationToken).ConfigureAwait(false);
+                await listener.SchedulerError(Scheduler, errorContext, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardSchedulerStateEventsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardSchedulerStateEventsTest.cs
@@ -22,12 +22,12 @@ public class DashboardSchedulerStateEventsTest
     [Test]
     public async Task EachListenerEventPushesTheStateTheSchedulerIsNowIn()
     {
-        (DashboardLiveEventsPlugin plugin, List<SchedulerStateDto> pushed) = await Plugin();
+        (DashboardLiveEventsPlugin plugin, List<SchedulerStateDto> pushed, IScheduler scheduler) = await Plugin();
 
-        await plugin.SchedulerStarted();
-        await plugin.SchedulerInStandbyMode();
-        await plugin.SchedulerShuttingDown();
-        await plugin.SchedulerShutdown();
+        await plugin.SchedulerStarted(scheduler);
+        await plugin.SchedulerInStandbyMode(scheduler);
+        await plugin.SchedulerShuttingDown(scheduler);
+        await plugin.SchedulerShutdown(scheduler);
 
         pushed.Select(state => state.Status).Should().Equal(
             [
@@ -44,16 +44,16 @@ public class DashboardSchedulerStateEventsTest
     [Test]
     public async Task ASchedulerThatIsStartingPushesNothing()
     {
-        (DashboardLiveEventsPlugin plugin, List<SchedulerStateDto> pushed) = await Plugin();
+        (DashboardLiveEventsPlugin plugin, List<SchedulerStateDto> pushed, IScheduler scheduler) = await Plugin();
 
-        await plugin.SchedulerStarting();
+        await plugin.SchedulerStarting(scheduler);
 
         pushed.Should().BeEmpty(
             "starting is an event rather than a state, and the state it leads to arrives a moment later as "
             + "SchedulerStarted - pushing 'Starting' only gave a browser a value that is not a status to render");
     }
 
-    private static async Task<(DashboardLiveEventsPlugin Plugin, List<SchedulerStateDto> Pushed)> Plugin()
+    private static async Task<(DashboardLiveEventsPlugin Plugin, List<SchedulerStateDto> Pushed, IScheduler Scheduler)> Plugin()
     {
         List<SchedulerStateDto> pushed = [];
 
@@ -83,7 +83,7 @@ public class DashboardSchedulerStateEventsTest
         DashboardLiveEventsPlugin plugin = new();
         await plugin.Initialize("live", scheduler);
 
-        return (plugin, pushed);
+        return (plugin, pushed, scheduler);
     }
 
     private sealed class CapturingHubContext : IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -35,10 +35,12 @@ namespace Quartz.Dashboard.Hubs
     }
     public sealed class SchedulerErrorDto : System.IEquatable<Quartz.Dashboard.Hubs.SchedulerErrorDto>
     {
-        public SchedulerErrorDto(string SchedulerName, string Message, string? Cause) { }
+        public SchedulerErrorDto(string SchedulerName, string Message, string? Cause, Quartz.Dashboard.Services.TriggerKeyDto? TriggerKey, Quartz.Dashboard.Services.JobKeyDto? JobKey) { }
         public string? Cause { get; init; }
+        public Quartz.Dashboard.Services.JobKeyDto? JobKey { get; init; }
         public string Message { get; init; }
         public string SchedulerName { get; init; }
+        public Quartz.Dashboard.Services.TriggerKeyDto? TriggerKey { get; init; }
     }
     public sealed class SchedulerStateDto : System.IEquatable<Quartz.Dashboard.Hubs.SchedulerStateDto>
     {
@@ -72,35 +74,35 @@ namespace Quartz.Dashboard.Plugins
         public DashboardLiveEventsPlugin() { }
         public string Name { get; }
         public System.Threading.Tasks.ValueTask Initialize(string pluginName, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobAdded(Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobDeleted(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobAdded(Quartz.IScheduler scheduler, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobDeleted(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask JobExecutionVetoed(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobInterrupted(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobPaused(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobResumed(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobScheduled(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobInterrupted(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobPaused(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobResumed(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobScheduled(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask JobToBeExecuted(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobUnscheduled(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobUnscheduled(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask JobWasExecuted(Quartz.IJobExecutionContext context, Quartz.JobExecutionException? jobException, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobsPaused(string? jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobsResumed(string? jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerError(string message, Quartz.SchedulerException exception, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerInStandbyMode(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerShutdown(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerShuttingDown(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerStarted(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerStarting(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulingDataCleared(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobsPaused(Quartz.IScheduler scheduler, string? jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobsResumed(Quartz.IScheduler scheduler, string? jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerError(Quartz.IScheduler scheduler, Quartz.SchedulerErrorContext errorContext, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerInStandbyMode(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerShutdown(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerShuttingDown(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerStarted(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerStarting(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulingDataCleared(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Shutdown(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Start(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerComplete(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, Quartz.SchedulerInstruction triggerInstructionCode, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerFired(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerPaused(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerResumed(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggersPaused(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggersResumed(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerPaused(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerResumed(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggersPaused(Quartz.IScheduler scheduler, string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggersResumed(Quartz.IScheduler scheduler, string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> VetoJobExecution(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/TriggerInErrorNotificationAdoTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/TriggerInErrorNotificationAdoTest.cs
@@ -104,7 +104,7 @@ public sealed class TriggerInErrorNotificationAdoTest
 
         public Task<JobKey> JobTriggers => jobTriggers.Task;
 
-        public ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask TriggersInError(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             jobTriggers.TrySetResult(jobKey);
             return default;

--- a/src/Quartz.Tests.Unit/Configuration/ListenerRegistrationTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ListenerRegistrationTest.cs
@@ -260,7 +260,7 @@ public class ListenerRegistrationTest
 
         public ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default) => new(false);
 
-        public ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+        public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
 
         public ValueTask TriggerComplete(ITrigger trigger, IJobExecutionContext context, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default) => default;
     }

--- a/src/Quartz.Tests.Unit/Core/BulkKeySetOperationsTest.cs
+++ b/src/Quartz.Tests.Unit/Core/BulkKeySetOperationsTest.cs
@@ -385,61 +385,61 @@ public class BulkKeySetOperationsTest
             ResumedJobGroups.Clear();
         }
 
-        public ValueTask JobDeleted(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask JobDeleted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             DeletedJobs.Add(jobKey);
             return default;
         }
 
-        public ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        public ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
             UnscheduledTriggers.Add(triggerKey);
             return default;
         }
 
-        public ValueTask TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
             PausedTriggers.Add(triggerKey);
             return default;
         }
 
-        public ValueTask TriggersPaused(string? triggerGroup, CancellationToken cancellationToken = default)
+        public ValueTask TriggersPaused(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default)
         {
             PausedTriggerGroups.Add(triggerGroup);
             return default;
         }
 
-        public ValueTask TriggerResumed(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        public ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
             ResumedTriggers.Add(triggerKey);
             return default;
         }
 
-        public ValueTask TriggersResumed(string? triggerGroup, CancellationToken cancellationToken = default)
+        public ValueTask TriggersResumed(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default)
         {
             ResumedTriggerGroups.Add(triggerGroup);
             return default;
         }
 
-        public ValueTask JobPaused(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             PausedJobs.Add(jobKey);
             return default;
         }
 
-        public ValueTask JobsPaused(string? jobGroup, CancellationToken cancellationToken = default)
+        public ValueTask JobsPaused(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default)
         {
             PausedJobGroups.Add(jobGroup);
             return default;
         }
 
-        public ValueTask JobResumed(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             ResumedJobs.Add(jobKey);
             return default;
         }
 
-        public ValueTask JobsResumed(string? jobGroup, CancellationToken cancellationToken = default)
+        public ValueTask JobsResumed(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default)
         {
             ResumedJobGroups.Add(jobGroup);
             return default;

--- a/src/Quartz.Tests.Unit/Core/JobInstantiationExceptionTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobInstantiationExceptionTest.cs
@@ -19,16 +19,21 @@ public class JobInstantiationExceptionTest
         // InvalidOperationException out unwrapped, so it lands in JobRunShell's generic catch.
         InvalidOperationException cause = new InvalidOperationException("Unable to resolve service for type 'ITaskTracker'");
 
-        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(cause);
+        (SchedulerErrorContext reported, IScheduler scheduler) = await RunFailingJob(cause);
 
         try
         {
-            JobInstantiationException failure = reported.Should().BeOfType<JobInstantiationException>().Subject;
+            JobInstantiationException failure = reported.Exception.Should().BeOfType<JobInstantiationException>().Subject;
 
             failure.Trigger.Key.Should().Be(new TriggerKey("trigger1", "instantiation"));
             failure.JobDetail.Key.Should().Be(new JobKey("job1", "instantiation"));
             failure.FireInstanceId.Should().NotBeNullOrEmpty();
             failure.InnerException.Should().BeSameAs(cause);
+
+            reported.TriggerKey.Should().Be(new TriggerKey("trigger1", "instantiation"),
+                "the same identity has to be reachable without unwrapping the exception");
+            reported.JobKey.Should().Be(new JobKey("job1", "instantiation"));
+            reported.FireInstanceId.Should().Be(failure.FireInstanceId);
         }
         finally
         {
@@ -43,11 +48,11 @@ public class JobInstantiationExceptionTest
         // so enriching only the generic catch would leave these users where they were.
         SchedulerException cause = new SchedulerException("Problem instantiating class 'MyJob'", new MissingMethodException());
 
-        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(cause);
+        (SchedulerErrorContext reported, IScheduler scheduler) = await RunFailingJob(cause);
 
         try
         {
-            JobInstantiationException failure = reported.Should().BeOfType<JobInstantiationException>().Subject;
+            JobInstantiationException failure = reported.Exception.Should().BeOfType<JobInstantiationException>().Subject;
 
             failure.Trigger.Key.Should().Be(new TriggerKey("trigger1", "instantiation"));
             failure.InnerException.Should().BeSameAs(cause,
@@ -64,11 +69,11 @@ public class JobInstantiationExceptionTest
     public async Task FactoryThrowingOperationCanceled_LeavesTriggerOutOfErrorState()
     {
         // Shutdown races must not poison the schedule; only real failures set Error.
-        (SchedulerException reported, IScheduler scheduler) = await RunFailingJob(new OperationCanceledException());
+        (SchedulerErrorContext reported, IScheduler scheduler) = await RunFailingJob(new OperationCanceledException());
 
         try
         {
-            reported.Should().BeOfType<JobInstantiationException>();
+            reported.Exception.Should().BeOfType<JobInstantiationException>();
 
             TriggerState state = await scheduler.GetTriggerState(new TriggerKey("trigger1", "instantiation"));
             state.Should().NotBe(TriggerState.Error,
@@ -82,10 +87,10 @@ public class JobInstantiationExceptionTest
 
     /// <summary>
     /// Schedules a single job whose instantiation fails with <paramref name="cause"/> and returns the
-    /// exception handed to <see cref="ISchedulerListener.SchedulerError"/>. The scheduler is returned
+    /// error handed to <see cref="ISchedulerListener.SchedulerError"/>. The scheduler is returned
     /// still running so that trigger state can be inspected before shutdown.
     /// </summary>
-    private static async Task<(SchedulerException Reported, IScheduler Scheduler)> RunFailingJob(Exception cause)
+    private static async Task<(SchedulerErrorContext Reported, IScheduler Scheduler)> RunFailingJob(Exception cause)
     {
         ErrorCapturingListener listener = new ErrorCapturingListener();
 
@@ -109,7 +114,7 @@ public class JobInstantiationExceptionTest
         await scheduler.ScheduleJob(job, trigger);
         await scheduler.Start();
 
-        SchedulerException reported = await listener.Reported.WaitAsync(TimeSpan.FromSeconds(30));
+        SchedulerErrorContext reported = await listener.Reported.WaitAsync(TimeSpan.FromSeconds(30));
         return (reported, scheduler);
     }
 
@@ -129,16 +134,14 @@ public class JobInstantiationExceptionTest
 
     private sealed class ErrorCapturingListener : ISchedulerListener
     {
-        private readonly TaskCompletionSource<SchedulerException> reported = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<SchedulerErrorContext> reported = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task<SchedulerException> Reported => reported.Task;
+        public Task<SchedulerErrorContext> Reported => reported.Task;
 
-        public ValueTask SchedulerError(
-            string message,
-            SchedulerException exception,
+        public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext,
             CancellationToken cancellationToken = default)
         {
-            reported.TrySetResult(exception);
+            reported.TrySetResult(errorContext);
             return default;
         }
     }

--- a/src/Quartz.Tests.Unit/Core/ListenerSenderTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerSenderTest.cs
@@ -1,0 +1,214 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Listeners;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// A listener is told which scheduler is calling it — through its execution context where there is one,
+/// and as the first argument of every callback where there is not (#3063).
+/// </summary>
+[NonParallelizable]
+public sealed class ListenerSenderTest
+{
+    [Test]
+    public async Task OneListenerServingTwoSchedulers_IsToldWhichOneCalled()
+    {
+        // An ISchedulerListener registered as a plain unkeyed service reaches every scheduler in the
+        // container, which is exactly the case that used to be unanswerable: the callbacks said what
+        // happened but never where.
+        RecordingSchedulerListener listener = new();
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddSingleton<ISchedulerListener>(listener);
+
+        services.AddQuartz("acme", q => Schedule(q, "acme"));
+        services.AddQuartz("initech", q => Schedule(q, "initech"));
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler acme = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+        IScheduler initech = await provider.GetRequiredKeyedService<ISchedulerFactory>("initech").GetScheduler();
+
+        await acme.PauseTrigger(new TriggerKey("trigger", "acme"));
+        await initech.PauseTrigger(new TriggerKey("trigger", "initech"));
+
+        listener.Paused.Should().Equal(
+            [("acme", new TriggerKey("trigger", "acme")), ("initech", new TriggerKey("trigger", "initech"))],
+            "one listener shared by two schedulers has to be able to tell which of them paused a trigger");
+
+        listener.PausedBy.Should().Equal([acme, initech],
+            "the scheduler handed to a callback is the very instance the application holds, not a stand-in");
+    }
+
+    [Test]
+    public async Task JobThatThrows_ReportsTheTriggerJobAndFiringItThrewFor()
+    {
+        ErrorRecordingListener listener = new();
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create().BuildScheduler();
+
+        try
+        {
+            scheduler.ListenerManager.AddSchedulerListener(listener);
+
+            IJobDetail job = JobBuilder.Create<ThrowingJob>()
+                .WithIdentity("job", "sender")
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger", "sender")
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            (IScheduler reportedBy, SchedulerErrorContext error) = await listener.Reported.WaitAsync(TimeSpan.FromSeconds(30));
+
+            reportedBy.Should().BeSameAs(scheduler);
+            error.Message.Should().Contain("threw an exception");
+            error.TriggerKey.Should().Be(new TriggerKey("trigger", "sender"));
+            error.JobKey.Should().Be(new JobKey("job", "sender"));
+            error.FireInstanceId.Should().NotBeNullOrEmpty(
+                "the firing is what distinguishes this failure from the next one of the same job");
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    [Test]
+    public async Task Misfire_IsReportedByTheSchedulerThatNoticedIt()
+    {
+        // A misfire is noticed by the job store rather than executed, so this is the one trigger-listener
+        // callback with no IJobExecutionContext to reach the scheduler through.
+        MisfireRecordingListener listener = new();
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "misfires")
+            .UseInMemoryStore(store => store.MisfireThreshold = TimeSpan.FromMilliseconds(1))
+            .BuildScheduler();
+
+        try
+        {
+            scheduler.ListenerManager.AddTriggerListener(listener, Quartz.Matchers.AllTriggers());
+
+            IJobDetail job = JobBuilder.Create<HarmlessJob>()
+                .WithIdentity("job", "misfire")
+                .Build();
+
+            // Scheduled while the scheduler is in standby and dated well into the past, so the trigger is
+            // already past its misfire threshold by the time acquisition first looks at it.
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger", "misfire")
+                .ForJob(job)
+                .StartAt(DateTimeOffset.UtcNow.AddMinutes(-5))
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            (IScheduler reportedBy, TriggerKey misfired) = await listener.Reported.WaitAsync(TimeSpan.FromSeconds(30));
+
+            reportedBy.Should().BeSameAs(scheduler);
+            reportedBy.SchedulerName.Should().Be("misfires");
+            misfired.Should().Be(new TriggerKey("trigger", "misfire"));
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    [Test]
+    public async Task BroadcastSchedulerListener_ForwardsTheSchedulerItWasGiven()
+    {
+        RecordingSchedulerListener first = new();
+        RecordingSchedulerListener second = new();
+
+        BroadcastSchedulerListener broadcast = new("broadcast", [first, second]);
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create().BuildScheduler();
+
+        try
+        {
+            await broadcast.TriggerPaused(scheduler, new TriggerKey("trigger", "broadcast"));
+
+            first.PausedBy.Should().Equal([scheduler],
+                "a broadcast has nothing of its own to say about who is calling, so it passes on what it was told");
+            second.PausedBy.Should().Equal([scheduler]);
+        }
+        finally
+        {
+            await scheduler.Shutdown(true);
+        }
+    }
+
+    private static void Schedule(IQuartzBuilder builder, string group)
+    {
+        builder.AddJob<HarmlessJob>(j => j.WithIdentity("job", group));
+        builder.AddTrigger<IJob>(t => t
+            .ForJob("job", group)
+            .WithIdentity("trigger", group)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1)));
+    }
+
+    private sealed class RecordingSchedulerListener : ISchedulerListener
+    {
+        public List<(string SchedulerName, TriggerKey TriggerKey)> Paused { get; } = [];
+
+        public List<IScheduler> PausedBy { get; } = [];
+
+        public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        {
+            Paused.Add((scheduler.SchedulerName, triggerKey));
+            PausedBy.Add(scheduler);
+            return default;
+        }
+    }
+
+    private sealed class ErrorRecordingListener : ISchedulerListener
+    {
+        private readonly TaskCompletionSource<(IScheduler, SchedulerErrorContext)> reported = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<(IScheduler Scheduler, SchedulerErrorContext Error)> Reported => reported.Task;
+
+        public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
+        {
+            reported.TrySetResult((scheduler, errorContext));
+            return default;
+        }
+    }
+
+    private sealed class MisfireRecordingListener : ITriggerListener
+    {
+        private readonly TaskCompletionSource<(IScheduler, TriggerKey)> reported = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<(IScheduler Scheduler, TriggerKey TriggerKey)> Reported => reported.Task;
+
+        public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
+        {
+            reported.TrySetResult((scheduler, trigger.Key));
+            return default;
+        }
+    }
+
+    public sealed class HarmlessJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public sealed class ThrowingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("the report has to name this firing");
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -141,8 +141,10 @@ public class QuartzSchedulerTest
 
         // assert
         // expect unschedule and schedule
-        A.CallTo(() => listener.JobUnscheduled(new TriggerKey(TriggerName, TriggerGroup), A<CancellationToken>._)).MustHaveHappened();
-        A.CallTo(() => listener.JobScheduled(jobTrigger, A<CancellationToken>._)).MustHaveHappened();
+        // The scheduler argument is the very instance the caller holds, so it is matched by reference
+        // rather than by any property of it.
+        A.CallTo(() => listener.JobUnscheduled(scheduler, new TriggerKey(TriggerName, TriggerGroup), A<CancellationToken>._)).MustHaveHappened();
+        A.CallTo(() => listener.JobScheduled(scheduler, jobTrigger, A<CancellationToken>._)).MustHaveHappened();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Core/SchedulerLifecycleStatusTest.cs
+++ b/src/Quartz.Tests.Unit/Core/SchedulerLifecycleStatusTest.cs
@@ -280,15 +280,15 @@ public class SchedulerLifecycleStatusTest
             }
         }
 
-        public ValueTask SchedulerStarting(CancellationToken cancellationToken = default) => Record(nameof(SchedulerStarting));
+        public ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken = default) => Record(nameof(SchedulerStarting));
 
-        public ValueTask SchedulerStarted(CancellationToken cancellationToken = default) => Record(nameof(SchedulerStarted));
+        public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default) => Record(nameof(SchedulerStarted));
 
-        public ValueTask SchedulerInStandbyMode(CancellationToken cancellationToken = default) => Record(nameof(SchedulerInStandbyMode));
+        public ValueTask SchedulerInStandbyMode(IScheduler scheduler, CancellationToken cancellationToken = default) => Record(nameof(SchedulerInStandbyMode));
 
-        public ValueTask SchedulerShuttingDown(CancellationToken cancellationToken = default) => Record(nameof(SchedulerShuttingDown));
+        public ValueTask SchedulerShuttingDown(IScheduler scheduler, CancellationToken cancellationToken = default) => Record(nameof(SchedulerShuttingDown));
 
-        public ValueTask SchedulerShutdown(CancellationToken cancellationToken = default) => Record(nameof(SchedulerShutdown));
+        public ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default) => Record(nameof(SchedulerShutdown));
 
         private ValueTask Record(string what)
         {

--- a/src/Quartz.Tests.Unit/Core/ShutdownDrainTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ShutdownDrainTest.cs
@@ -194,7 +194,7 @@ public class ShutdownDrainTest
     {
         public bool ShutDown { get; private set; }
 
-        public ValueTask SchedulerShutdown(CancellationToken cancellationToken = default)
+        public ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default)
         {
             ShutDown = true;
             return default;

--- a/src/Quartz.Tests.Unit/Core/TriggerInErrorNotificationTest.cs
+++ b/src/Quartz.Tests.Unit/Core/TriggerInErrorNotificationTest.cs
@@ -118,7 +118,7 @@ public class TriggerInErrorNotificationTest
 
         public ValueTask SignalSchedulingChange(DateTimeOffset? candidateNewNextFireTimeUtc, CancellationToken cancellationToken = default) => default;
 
-        public ValueTask NotifySchedulerListenersError(string message, SchedulerException exception, CancellationToken cancellationToken = default) => default;
+        public ValueTask NotifySchedulerListenersError(SchedulerErrorContext errorContext, CancellationToken cancellationToken = default) => default;
 
         public ValueTask NotifySchedulerListenersTriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
@@ -167,13 +167,13 @@ public class TriggerInErrorNotificationTest
 
         public Task<TriggerKey> SingleTrigger => singleTrigger.Task;
 
-        public ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask TriggersInError(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             jobTriggers.TrySetResult(jobKey);
             return default;
         }
 
-        public ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        public ValueTask TriggerInError(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
         {
             singleTrigger.TrySetResult(triggerKey);
             return default;

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/MultipleSchedulerTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/MultipleSchedulerTests.cs
@@ -647,33 +647,33 @@ public sealed class MultipleSchedulerTests
         public string Name => nameof(TestTriggerListenerA);
         public ValueTask TriggerFired(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
         public ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default) => new(false);
-        public ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+        public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
         public ValueTask TriggerComplete(ITrigger trigger, IJobExecutionContext context, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default) => default;
     }
 
     private sealed class TestSchedulerListenerA : ISchedulerListener
     {
-        public ValueTask JobScheduled(ITrigger trigger, CancellationToken cancellationToken = default) => default;
-        public ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
-        public ValueTask TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken = default) => default;
-        public ValueTask TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
-        public ValueTask TriggersPaused(string triggerGroup, CancellationToken cancellationToken = default) => default;
-        public ValueTask TriggerResumed(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
-        public ValueTask TriggersResumed(string triggerGroup, CancellationToken cancellationToken = default) => default;
-        public ValueTask JobAdded(IJobDetail jobDetail, CancellationToken cancellationToken = default) => default;
-        public ValueTask JobDeleted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
-        public ValueTask JobPaused(JobKey jobKey, CancellationToken cancellationToken = default) => default;
-        public ValueTask JobsPaused(string jobGroup, CancellationToken cancellationToken = default) => default;
-        public ValueTask JobResumed(JobKey jobKey, CancellationToken cancellationToken = default) => default;
-        public ValueTask JobsResumed(string jobGroup, CancellationToken cancellationToken = default) => default;
-        public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default) => default;
-        public ValueTask SchedulerInStandbyMode(CancellationToken cancellationToken = default) => default;
-        public ValueTask SchedulerStarted(CancellationToken cancellationToken = default) => default;
-        public ValueTask SchedulerStarting(CancellationToken cancellationToken = default) => default;
-        public ValueTask SchedulerShutdown(CancellationToken cancellationToken = default) => default;
-        public ValueTask SchedulerShuttingDown(CancellationToken cancellationToken = default) => default;
-        public ValueTask SchedulingDataCleared(CancellationToken cancellationToken = default) => default;
-        public ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobScheduled(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+        public ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
+        public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+        public ValueTask TriggersPaused(IScheduler scheduler, string triggerGroup, CancellationToken cancellationToken = default) => default;
+        public ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+        public ValueTask TriggersResumed(IScheduler scheduler, string triggerGroup, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobAdded(IScheduler scheduler, IJobDetail jobDetail, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobDeleted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobsPaused(IScheduler scheduler, string jobGroup, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobsResumed(IScheduler scheduler, string jobGroup, CancellationToken cancellationToken = default) => default;
+        public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default) => default;
+        public ValueTask SchedulerInStandbyMode(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+        public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+        public ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+        public ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+        public ValueTask SchedulerShuttingDown(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+        public ValueTask SchedulingDataCleared(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+        public ValueTask JobInterrupted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
     }
 
     #endregion

--- a/src/Quartz.Tests.Unit/InterrubtableJobTest.cs
+++ b/src/Quartz.Tests.Unit/InterrubtableJobTest.cs
@@ -137,7 +137,7 @@ public class InterruptableJobTest
     {
         public TaskCompletionSource<JobKey> Interrupted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = default)
+        public ValueTask JobInterrupted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
         {
             Interrupted.TrySetResult(jobKey);
             return default;

--- a/src/Quartz.Tests.Unit/NodeAffinityTest.cs
+++ b/src/Quartz.Tests.Unit/NodeAffinityTest.cs
@@ -245,6 +245,6 @@ public sealed class NodeAffinityTest
         public ValueTask NotifySchedulerListenersFinalized(ITrigger trigger, CancellationToken cancellationToken = default) => default;
         public ValueTask NotifySchedulerListenersJobDeleted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
         public ValueTask SignalSchedulingChange(DateTimeOffset? candidateNewNextFireTimeUtc, CancellationToken cancellationToken = default) => default;
-        public ValueTask NotifySchedulerListenersError(string message, SchedulerException jpe, CancellationToken cancellationToken = default) => default;
+        public ValueTask NotifySchedulerListenersError(SchedulerErrorContext errorContext, CancellationToken cancellationToken = default) => default;
     }
 }

--- a/src/Quartz.Tests.Unit/Plugins/History/LoggingTriggerHistoryPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/History/LoggingTriggerHistoryPluginTest.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using FakeItEasy;
+
 using Microsoft.Extensions.Logging;
 
 using Quartz.Impl;
@@ -76,7 +78,7 @@ public class LoggingTriggerHistoryPluginTest
 
         t.JobKey = new JobKey("name", "group");
 
-        await plugin.TriggerMisfired(t);
+        await plugin.TriggerMisfired(A.Fake<IScheduler>(), t);
 
         loggerProvider.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Information);
     }

--- a/src/Quartz.Tests.Unit/Plugins/History/StructuredLoggingTriggerHistoryPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/History/StructuredLoggingTriggerHistoryPluginTest.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using FakeItEasy;
+
 using Microsoft.Extensions.Logging;
 
 using Quartz.Impl;
@@ -77,7 +79,7 @@ public class StructuredLoggingTriggerHistoryPluginTest
 
         t.JobKey = new JobKey("name", "group");
 
-        await plugin.TriggerMisfired(t);
+        await plugin.TriggerMisfired(A.Fake<IScheduler>(), t);
 
         Assert.That(loggerProvider.Entries, Has.Count.EqualTo(1));
         Assert.That(loggerProvider.Entries[0].Level, Is.EqualTo(LogLevel.Information));

--- a/src/Quartz.Tests.Unit/Plugins/Xml/XmlSchedulingDataProcessorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/Xml/XmlSchedulingDataProcessorPluginTest.cs
@@ -99,8 +99,8 @@ public class XmlSchedulingDataProcessorPluginTest
 
         // Verify that SchedulerListener.SchedulerError was called
         A.CallTo(() => mockSchedulerListener.SchedulerError(
-                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
-                A<SchedulerException>._,
+                mockScheduler,
+                A<SchedulerErrorContext>.That.Matches(e => e.Message.Contains("Could not schedule jobs and triggers from file")),
                 A<System.Threading.CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
@@ -128,8 +128,8 @@ public class XmlSchedulingDataProcessorPluginTest
 
         // Verify that SchedulerListener.SchedulerError was called even when not throwing
         A.CallTo(() => mockSchedulerListener.SchedulerError(
-                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
-                A<SchedulerException>._,
+                mockScheduler,
+                A<SchedulerErrorContext>.That.Matches(e => e.Message.Contains("Could not schedule jobs and triggers from file")),
                 A<System.Threading.CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
@@ -152,8 +152,8 @@ public class XmlSchedulingDataProcessorPluginTest
 
         // Configure the throwing listener to throw when SchedulerError is called
         A.CallTo(() => throwingListener.SchedulerError(
-                A<string>._,
-                A<SchedulerException>._,
+                A<IScheduler>._,
+                A<SchedulerErrorContext>._,
                 A<System.Threading.CancellationToken>._))
             .Throws(new Exception("Listener failed to process error"));
 
@@ -168,21 +168,21 @@ public class XmlSchedulingDataProcessorPluginTest
 
         // Assert - verify that all listeners had SchedulerError called, including the throwing one
         A.CallTo(() => throwingListener.SchedulerError(
-                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
-                A<SchedulerException>._,
+                mockScheduler,
+                A<SchedulerErrorContext>.That.Matches(e => e.Message.Contains("Could not schedule jobs and triggers from file")),
                 A<System.Threading.CancellationToken>._))
             .MustHaveHappenedOnceExactly();
 
         // Verify that the non-throwing listeners were still notified despite the first one throwing
         A.CallTo(() => successListener1.SchedulerError(
-                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
-                A<SchedulerException>._,
+                mockScheduler,
+                A<SchedulerErrorContext>.That.Matches(e => e.Message.Contains("Could not schedule jobs and triggers from file")),
                 A<System.Threading.CancellationToken>._))
             .MustHaveHappenedOnceExactly();
 
         A.CallTo(() => successListener2.SchedulerError(
-                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
-                A<SchedulerException>._,
+                mockScheduler,
+                A<SchedulerErrorContext>.That.Matches(e => e.Message.Contains("Could not schedule jobs and triggers from file")),
                 A<System.Threading.CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }

--- a/src/Quartz.Tests.Unit/SchedulerListenerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerListenerTest.cs
@@ -47,7 +47,7 @@ public class SchedulerListenerTest
             return new ValueTask<bool>(false);
         }
 
-        public ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken)
+        public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken)
         {
             return default;
         }
@@ -65,109 +65,109 @@ public class SchedulerListenerTest
     {
         public int TriggerFinalizedCount { get; private set; }
 
-        public ValueTask JobScheduled(ITrigger trigger, CancellationToken cancellationToken)
+        public ValueTask JobScheduled(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken)
+        public ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken)
+        public ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken)
         {
             TriggerFinalizedCount++;
             logger.LogInformation("triggerFinalized {Trigger}", trigger);
             return default;
         }
 
-        public ValueTask TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken)
+        public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask TriggersPaused(string triggerGroup, CancellationToken cancellationToken)
+        public ValueTask TriggersPaused(IScheduler scheduler, string triggerGroup, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask TriggerResumed(TriggerKey triggerKey, CancellationToken cancellationToken)
+        public ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask TriggersResumed(string triggerGroup, CancellationToken cancellationToken)
+        public ValueTask TriggersResumed(IScheduler scheduler, string triggerGroup, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask JobAdded(IJobDetail jobDetail, CancellationToken cancellationToken)
+        public ValueTask JobAdded(IScheduler scheduler, IJobDetail jobDetail, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask JobDeleted(JobKey jobKey, CancellationToken cancellationToken)
+        public ValueTask JobDeleted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask JobPaused(JobKey jobKey, CancellationToken cancellationToken)
+        public ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = new())
+        public ValueTask JobInterrupted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = new())
         {
             return default;
         }
 
-        public ValueTask JobsPaused(string jobGroup, CancellationToken cancellationToken)
+        public ValueTask JobsPaused(IScheduler scheduler, string jobGroup, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask JobResumed(JobKey jobKey, CancellationToken cancellationToken)
+        public ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask JobsResumed(string jobGroup, CancellationToken cancellationToken)
+        public ValueTask JobsResumed(IScheduler scheduler, string jobGroup, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken)
+        public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask SchedulerInStandbyMode(CancellationToken cancellationToken)
+        public ValueTask SchedulerInStandbyMode(IScheduler scheduler, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask SchedulerStarted(CancellationToken cancellationToken)
+        public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask SchedulerStarting(CancellationToken cancellationToken)
+        public ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask SchedulerShutdown(CancellationToken cancellationToken)
+        public ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask SchedulerShuttingDown(CancellationToken cancellationToken)
+        public ValueTask SchedulerShuttingDown(IScheduler scheduler, CancellationToken cancellationToken)
         {
             return default;
         }
 
-        public ValueTask SchedulingDataCleared(CancellationToken cancellationToken)
+        public ValueTask SchedulingDataCleared(IScheduler scheduler, CancellationToken cancellationToken)
         {
             return default;
         }

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -1355,8 +1355,7 @@ public class RAMJobStoreTest
         }
 
         public ValueTask NotifySchedulerListenersError(
-            string message,
-            SchedulerException jpe,
+            SchedulerErrorContext errorContext,
             CancellationToken cancellationToken = default)
         {
             return default;

--- a/src/Quartz.Tests.Unit/TestJobStores.cs
+++ b/src/Quartz.Tests.Unit/TestJobStores.cs
@@ -172,5 +172,5 @@ public sealed class NoOpSchedulerSignaler : ISchedulerSignaler
 
     public ValueTask SignalSchedulingChange(DateTimeOffset? candidateNewNextFireTimeUtc, CancellationToken cancellationToken = default) => default;
 
-    public ValueTask NotifySchedulerListenersError(string message, SchedulerException jpe, CancellationToken cancellationToken = default) => default;
+    public ValueTask NotifySchedulerListenersError(SchedulerErrorContext errorContext, CancellationToken cancellationToken = default) => default;
 }

--- a/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
+++ b/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
@@ -512,7 +512,7 @@ public class UpdateTriggerDetailsTest
         public ValueTask NotifyTriggerListenersMisfired(ITrigger trigger, CancellationToken cancellationToken = default) => default;
         public ValueTask NotifySchedulerListenersFinalized(ITrigger trigger, CancellationToken cancellationToken = default) => default;
         public ValueTask SignalSchedulingChange(DateTimeOffset? candidateNewNextFireTimeUtc, CancellationToken cancellationToken = default) => default;
-        public ValueTask NotifySchedulerListenersError(string message, SchedulerException jpe, CancellationToken cancellationToken = default) => default;
+        public ValueTask NotifySchedulerListenersError(SchedulerErrorContext errorContext, CancellationToken cancellationToken = default) => default;
         public ValueTask NotifySchedulerListenersJobDeleted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
     }
 }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Plugins.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Plugins.verified.txt
@@ -77,7 +77,7 @@ namespace Quartz.Plugins.History
         public System.Threading.Tasks.ValueTask Start(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerComplete(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, Quartz.SchedulerInstruction triggerInstructionCode, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerFired(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> VetoJobExecution(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public sealed class StructuredLoggingJobHistoryPlugin : Quartz.Extensibility.ISchedulerPlugin, Quartz.IJobListener
@@ -109,7 +109,7 @@ namespace Quartz.Plugins.History
         public System.Threading.Tasks.ValueTask Start(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerComplete(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, Quartz.SchedulerInstruction triggerInstructionCode, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerFired(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> VetoJobExecution(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -712,29 +712,29 @@ namespace Quartz
     public interface ISchedulerListener
     {
         string Name { get; }
-        System.Threading.Tasks.ValueTask JobAdded(Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask JobDeleted(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask JobInterrupted(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask JobPaused(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask JobResumed(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask JobScheduled(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask JobUnscheduled(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask JobsPaused(string? jobGroup, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask JobsResumed(string? jobGroup, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask SchedulerError(string message, Quartz.SchedulerException exception, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask SchedulerInStandbyMode(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask SchedulerShutdown(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask SchedulerShuttingDown(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask SchedulerStarted(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask SchedulerStarting(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask SchedulingDataCleared(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggerInError(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggerPaused(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggerResumed(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggersInError(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggersPaused(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggersResumed(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobAdded(Quartz.IScheduler scheduler, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobDeleted(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobInterrupted(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobPaused(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobResumed(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobScheduled(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobUnscheduled(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobsPaused(Quartz.IScheduler scheduler, string? jobGroup, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask JobsResumed(Quartz.IScheduler scheduler, string? jobGroup, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask SchedulerError(Quartz.IScheduler scheduler, Quartz.SchedulerErrorContext errorContext, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask SchedulerInStandbyMode(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask SchedulerShutdown(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask SchedulerShuttingDown(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask SchedulerStarted(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask SchedulerStarting(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask SchedulingDataCleared(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggerInError(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggerPaused(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggerResumed(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggersInError(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggersPaused(Quartz.IScheduler scheduler, string? triggerGroup, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggersResumed(Quartz.IScheduler scheduler, string? triggerGroup, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface ISchedulerRegistry
     {
@@ -801,7 +801,7 @@ namespace Quartz
         string Name { get; }
         System.Threading.Tasks.ValueTask TriggerComplete(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, Quartz.SchedulerInstruction triggerInstructionCode, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggerFired(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> VetoJobExecution(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default);
     }
     public sealed class InMemoryJobStoreOptions
@@ -1360,6 +1360,15 @@ namespace Quartz
         public static System.IDisposable EnlistConnection(this Quartz.IScheduler scheduler, System.Data.Common.DbConnection connection, System.Data.Common.DbTransaction? transaction = null) { }
         public static System.IDisposable EnlistTransaction(this Quartz.IScheduler scheduler, System.Data.Common.DbTransaction transaction) { }
     }
+    public sealed class SchedulerErrorContext : System.IEquatable<Quartz.SchedulerErrorContext>
+    {
+        public SchedulerErrorContext() { }
+        public required Quartz.SchedulerException Exception { get; init; }
+        public string? FireInstanceId { get; init; }
+        public Quartz.JobKey? JobKey { get; init; }
+        public required string Message { get; init; }
+        public Quartz.TriggerKey? TriggerKey { get; init; }
+    }
     public class SchedulerException : System.Exception
     {
         public SchedulerException() { }
@@ -1868,7 +1877,7 @@ namespace Quartz.Extensibility
     }
     public interface ISchedulerSignaler
     {
-        System.Threading.Tasks.ValueTask NotifySchedulerListenersError(string message, Quartz.SchedulerException exception, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask NotifySchedulerListenersError(Quartz.SchedulerErrorContext errorContext, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask NotifySchedulerListenersFinalized(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask NotifySchedulerListenersJobDeleted(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask NotifySchedulerListenersTriggerInError(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
@@ -3511,31 +3520,31 @@ namespace Quartz.Listeners
         public System.Collections.Generic.IReadOnlyList<Quartz.ISchedulerListener> Listeners { get; }
         public string Name { get; }
         public void AddListener(Quartz.ISchedulerListener listener) { }
-        public System.Threading.Tasks.ValueTask JobAdded(Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobDeleted(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobInterrupted(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobPaused(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobResumed(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobScheduled(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobUnscheduled(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobsPaused(string? jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask JobsResumed(string? jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobAdded(Quartz.IScheduler scheduler, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobDeleted(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobInterrupted(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobPaused(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobResumed(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobScheduled(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobUnscheduled(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobsPaused(Quartz.IScheduler scheduler, string? jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask JobsResumed(Quartz.IScheduler scheduler, string? jobGroup, System.Threading.CancellationToken cancellationToken = default) { }
         public bool RemoveListener(Quartz.ISchedulerListener listener) { }
         public bool RemoveListener(string listenerName) { }
-        public System.Threading.Tasks.ValueTask SchedulerError(string message, Quartz.SchedulerException exception, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerInStandbyMode(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerShutdown(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerShuttingDown(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerStarted(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulerStarting(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask SchedulingDataCleared(System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerInError(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerPaused(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerResumed(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggersInError(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggersPaused(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggersResumed(string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerError(Quartz.IScheduler scheduler, Quartz.SchedulerErrorContext errorContext, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerInStandbyMode(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerShutdown(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerShuttingDown(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerStarted(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulerStarting(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask SchedulingDataCleared(Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerFinalized(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerInError(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerPaused(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerResumed(Quartz.IScheduler scheduler, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggersInError(Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggersPaused(Quartz.IScheduler scheduler, string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggersResumed(Quartz.IScheduler scheduler, string? triggerGroup, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public sealed class BroadcastTriggerListener : Quartz.ITriggerListener
     {
@@ -3548,7 +3557,7 @@ namespace Quartz.Listeners
         public bool RemoveListener(string listenerName) { }
         public System.Threading.Tasks.ValueTask TriggerComplete(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, Quartz.SchedulerInstruction triggerInstructionCode, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerFired(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> VetoJobExecution(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public sealed class JobChainingJobListener : Quartz.IJobListener

--- a/src/Quartz/Core/ErrorLogger.cs
+++ b/src/Quartz/Core/ErrorLogger.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using Quartz.Diagnostics;
-using Quartz.Listeners;
 
 namespace Quartz.Core;
 
@@ -12,13 +11,34 @@ internal sealed class ErrorLogger : ISchedulerListener
     private readonly ILogger<ErrorLogger> logger = LogProvider.CreateLogger<ErrorLogger>();
 
     public ValueTask SchedulerError(
-        string message,
-        SchedulerException exception,
+        IScheduler scheduler,
+        SchedulerErrorContext error,
         CancellationToken cancellationToken = default)
     {
-#pragma warning disable CA2254
-        logger.LogError(exception, message);
-#pragma warning restore CA2254
+        // Named placeholders rather than an interpolated string, so a host running several schedulers
+        // can filter its log by SchedulerName or by the keys instead of reading prose. Two templates
+        // because most errors carry no keys, and a line ending in three empty fields reads as though
+        // the scheduler had lost them rather than never having had them.
+        if (error.TriggerKey is null && error.JobKey is null && error.FireInstanceId is null)
+        {
+            logger.LogError(
+                error.Exception,
+                "{Message} (scheduler: {SchedulerName})",
+                error.Message,
+                scheduler.SchedulerName);
+        }
+        else
+        {
+            logger.LogError(
+                error.Exception,
+                "{Message} (scheduler: {SchedulerName}, trigger: {TriggerKey}, job: {JobKey}, fire instance: {FireInstanceId})",
+                error.Message,
+                scheduler.SchedulerName,
+                error.TriggerKey,
+                error.JobKey,
+                error.FireInstanceId);
+        }
+
         return default;
     }
 }

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -131,7 +131,9 @@ internal sealed class JobRunShell
             // The factory said what went wrong; the exception handed to listeners adds which trigger
             // and which firing it went wrong for, which the message text alone never carried.
             JobInstantiationException failure = new JobInstantiationException(se.Message, firedTriggerBundle, se);
-            await qs!.NotifySchedulerListenersError($"An error occurred instantiating job to be executed. job='{jobDetail.Key}'", failure, cancellationToken).ConfigureAwait(false);
+            await qs!.NotifySchedulerListenersError(
+                ErrorFor(firedTriggerBundle, $"An error occurred instantiating job to be executed. job='{jobDetail.Key}'", failure),
+                cancellationToken).ConfigureAwait(false);
 
             IOperableTrigger errorTrigger = (IOperableTrigger) firedTriggerBundle.Trigger;
             SchedulerInstruction instruction = se.InnerException is ObjectDisposedException or OperationCanceledException
@@ -200,7 +202,7 @@ internal sealed class JobRunShell
                     catch (SchedulerException se)
                     {
                         string msg = $"Error during veto of Job {context.JobDetail.Key}: couldn't finalize execution.";
-                        await qs.NotifySchedulerListenersError(msg, se, cancellationToken).ConfigureAwait(false);
+                        await qs.NotifySchedulerListenersError(ErrorFor(context, msg, se), cancellationToken).ConfigureAwait(false);
                     }
                     break;
                 }
@@ -241,7 +243,9 @@ internal sealed class JobRunShell
                     endTimestamp = timeProvider.GetTimestamp();
                     logger.LogError(e, "Job {JobDetailKey} threw an unhandled Exception: ", jobDetail.Key);
                     SchedulerException se = new JobExecutionProcessException(context, e);
-                    await qs.NotifySchedulerListenersError($"Job {context.JobDetail.Key} threw an exception.", se, cancellationToken).ConfigureAwait(false);
+                    await qs.NotifySchedulerListenersError(
+                        ErrorFor(context, $"Job {context.JobDetail.Key} threw an exception.", se),
+                        cancellationToken).ConfigureAwait(false);
                     jobExEx = new JobExecutionException(se);
                     jobExEx.JobDetail = jobDetail;
                 }
@@ -267,7 +271,9 @@ internal sealed class JobRunShell
                 {
                     // If this happens, there's a bug in the trigger...
                     SchedulerException se = new SchedulerException("Trigger threw an unhandled exception.", e);
-                    await qs.NotifySchedulerListenersError("Please report this error to the Quartz developers.", se, cancellationToken).ConfigureAwait(false);
+                    await qs.NotifySchedulerListenersError(
+                        ErrorFor(context, "Please report this error to the Quartz developers.", se),
+                        cancellationToken).ConfigureAwait(false);
                 }
 
                 // re-Execute job — skip listener notifications so that listeners like
@@ -304,7 +310,9 @@ internal sealed class JobRunShell
                     catch (Exception e)
                     {
                         SchedulerException se2 = new SchedulerException("Error notifying scheduler listeners of finalized trigger.", e);
-                        await qs.NotifySchedulerListenersError("Error notifying scheduler listeners of finalized trigger.", se2, cancellationToken).ConfigureAwait(false);
+                        await qs.NotifySchedulerListenersError(
+                            ErrorFor(context, "Error notifying scheduler listeners of finalized trigger.", se2),
+                            cancellationToken).ConfigureAwait(false);
                     }
 
                     await qs.NotifyJobStoreJobComplete(trigger, jobDetail, instructionCode, cancellationToken).ConfigureAwait(false);
@@ -327,8 +335,10 @@ internal sealed class JobRunShell
                 // Run is handed to the thread pool and nobody awaits it, so letting this escape would
                 // lose it entirely. Report it and carry on to the context disposal below.
                 await qs.NotifySchedulerListenersError(
-                    $"An error occurred returning job to the job factory. job='{jobDetail.Key}'",
-                    new SchedulerException($"Problem returning job '{jobDetail.Key}' to the job factory: {e.Message}", e),
+                    ErrorFor(
+                        firedTriggerBundle,
+                        $"An error occurred returning job to the job factory. job='{jobDetail.Key}'",
+                        new SchedulerException($"Problem returning job '{jobDetail.Key}' to the job factory: {e.Message}", e)),
                     cancellationToken).ConfigureAwait(false);
             }
             finally
@@ -344,7 +354,9 @@ internal sealed class JobRunShell
         async ValueTask NotifyInstantiationFailed(Exception e)
         {
             SchedulerException se = new JobInstantiationException($"Problem instantiating type '{jobDetail.JobType.FullName}': {e.Message}", firedTriggerBundle, e);
-            await qs!.NotifySchedulerListenersError($"An error occurred instantiating job to be executed. job='{jobDetail.Key}', message='{e.Message}'", se, cancellationToken).ConfigureAwait(false);
+            await qs!.NotifySchedulerListenersError(
+                ErrorFor(firedTriggerBundle, $"An error occurred instantiating job to be executed. job='{jobDetail.Key}', message='{e.Message}'", se),
+                cancellationToken).ConfigureAwait(false);
 
             IOperableTrigger errorTrigger = (IOperableTrigger) firedTriggerBundle.Trigger;
             SchedulerInstruction instruction = e is ObjectDisposedException or OperationCanceledException
@@ -368,7 +380,7 @@ internal sealed class JobRunShell
         catch (SchedulerException se)
         {
             var msg = $"Unable to notify TriggerListener(s) while firing trigger (Trigger and Job will NOT be fired!). trigger= {ctx.Trigger.Key} job= {ctx.JobDetail.Key}";
-            await qs!.NotifySchedulerListenersError(msg, se, cancellationToken).ConfigureAwait(false);
+            await qs!.NotifySchedulerListenersError(ErrorFor(ctx, msg, se), cancellationToken).ConfigureAwait(false);
             return false;
         }
 
@@ -384,7 +396,7 @@ internal sealed class JobRunShell
             catch (SchedulerException se)
             {
                 var msg = $"Unable to notify JobListener(s) of vetoed execution while firing trigger (Trigger and Job will NOT be fired!). trigger= {ctx.Trigger.Key} job= {ctx.JobDetail.Key}";
-                await qs.NotifySchedulerListenersError(msg, se, cancellationToken).ConfigureAwait(false);
+                await qs.NotifySchedulerListenersError(ErrorFor(ctx, msg, se), cancellationToken).ConfigureAwait(false);
             }
             throw new VetoedException(this);
         }
@@ -397,7 +409,7 @@ internal sealed class JobRunShell
         catch (SchedulerException se)
         {
             string msg = $"Unable to notify JobListener(s) of Job to be executed: (Job will NOT be executed!). trigger= {ctx.Trigger.Key} job= {ctx.JobDetail.Key}";
-            await qs.NotifySchedulerListenersError(msg, se, cancellationToken).ConfigureAwait(false);
+            await qs.NotifySchedulerListenersError(ErrorFor(ctx, msg, se), cancellationToken).ConfigureAwait(false);
 
             return false;
         }
@@ -417,7 +429,7 @@ internal sealed class JobRunShell
         catch (SchedulerException se)
         {
             string msg = $"Unable to notify JobListener(s) of Job that was executed: (error will be ignored). trigger= {ctx.Trigger.Key} job= {ctx.JobDetail.Key}";
-            await qs.NotifySchedulerListenersError(msg, se, cancellationToken).ConfigureAwait(false);
+            await qs.NotifySchedulerListenersError(ErrorFor(ctx, msg, se), cancellationToken).ConfigureAwait(false);
 
             return false;
         }
@@ -479,9 +491,43 @@ internal sealed class JobRunShell
             CancellationToken cancellationToken)
         {
             string msg = $"Unable to notify TriggerListener(s) of Job that was executed: (error will be ignored). trigger= {ctx.Trigger.Key} job= {ctx.JobDetail.Key}";
-            await qs.NotifySchedulerListenersError(msg, se, cancellationToken).ConfigureAwait(false);
+            await qs.NotifySchedulerListenersError(ErrorFor(ctx, msg, se), cancellationToken).ConfigureAwait(false);
             return false;
         }
+    }
+
+    /// <summary>
+    /// The error context for a failure inside this firing, taken from the bundle the store fired.
+    /// </summary>
+    /// <remarks>
+    /// Used before the execution context exists — a job that could not be built has no context, but the
+    /// trigger, the job and the fire instance are all known regardless.
+    /// </remarks>
+    private static SchedulerErrorContext ErrorFor(TriggerFiredBundle bundle, string message, SchedulerException exception)
+    {
+        return new SchedulerErrorContext
+        {
+            Message = message,
+            Exception = exception,
+            TriggerKey = bundle.Trigger.Key,
+            JobKey = bundle.JobDetail.Key,
+            FireInstanceId = bundle.Trigger.FireInstanceId,
+        };
+    }
+
+    /// <summary>
+    /// The error context for a failure inside this firing, taken from the execution context.
+    /// </summary>
+    private static SchedulerErrorContext ErrorFor(JobExecutionContextImpl context, string message, SchedulerException exception)
+    {
+        return new SchedulerErrorContext
+        {
+            Message = message,
+            Exception = exception,
+            TriggerKey = context.Trigger.Key,
+            JobKey = context.JobDetail.Key,
+            FireInstanceId = context.FireInstanceId,
+        };
     }
 
     internal sealed class VetoedException : Exception

--- a/src/Quartz/Core/LazySchedulerSignaler.cs
+++ b/src/Quartz/Core/LazySchedulerSignaler.cs
@@ -63,8 +63,8 @@ internal sealed class LazySchedulerSignaler : ISchedulerSignaler
         return signaler.Value.SignalSchedulingChange(candidateNewNextFireTimeUtc, cancellationToken);
     }
 
-    public ValueTask NotifySchedulerListenersError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+    public ValueTask NotifySchedulerListenersError(SchedulerErrorContext error, CancellationToken cancellationToken = default)
     {
-        return signaler.Value.NotifySchedulerListenersError(message, exception, cancellationToken);
+        return signaler.Value.NotifySchedulerListenersError(error, cancellationToken);
     }
 }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -115,6 +115,18 @@ internal sealed class QuartzScheduler
     public ISchedulerSignaler SchedulerSignaler { get; } = null!;
 
     /// <summary>
+    /// The <see cref="IScheduler" /> facade this scheduler is seen through — the one handed to every
+    /// listener callback and to every <see cref="IJobExecutionContext" />.
+    /// </summary>
+    /// <remarks>
+    /// Built once here rather than by whoever assembles the scheduler, so that there is exactly one
+    /// facade per scheduler and it exists from the moment the scheduler does. A notification must
+    /// never construct one: two facades over one scheduler would compare unequal, and a listener that
+    /// remembers the scheduler it was told about would remember a different object each time.
+    /// </remarks>
+    public IScheduler Scheduler { get; } = null!;
+
+    /// <summary>
     /// Returns the name of the <see cref="QuartzScheduler" />.
     /// </summary>
     public string SchedulerName => resources.Name;
@@ -265,6 +277,7 @@ internal sealed class QuartzScheduler
         AddInternalSchedulerListener(errLogger);
 
         SchedulerSignaler = new SchedulerSignalerImpl(this, schedThread);
+        Scheduler = new StdScheduler(this);
 
         logger.LogInformation("Quartz Scheduler created");
     }
@@ -1917,9 +1930,10 @@ internal sealed class QuartzScheduler
         var listeners = ListenerManager.GetTriggerListeners();
 
         return listeners.Count == 0 ? default
-            : NotifyAwaited(ListenerManager, listeners, trigger, cancellationToken);
+            : NotifyAwaited(Scheduler, ListenerManager, listeners, trigger, cancellationToken);
 
         static async ValueTask NotifyAwaited(
+            IScheduler scheduler,
             IListenerManager listenerManager,
             IReadOnlyList<ITriggerListener> listeners,
             ITrigger trigger,
@@ -1934,7 +1948,7 @@ internal sealed class QuartzScheduler
 
                 try
                 {
-                    await tl.TriggerMisfired(trigger, cancellationToken).ConfigureAwait(false);
+                    await tl.TriggerMisfired(scheduler, trigger, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -2105,12 +2119,10 @@ internal sealed class QuartzScheduler
     /// <summary>
     /// Notifies the scheduler listeners about scheduler error.
     /// </summary>
-    /// <param name="message">A description of what went wrong.</param>
-    /// <param name="exception">The error itself.</param>
+    /// <param name="error">What went wrong, and what it went wrong for.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     public async ValueTask NotifySchedulerListenersError(
-        string message,
-        SchedulerException exception,
+        SchedulerErrorContext error,
         CancellationToken cancellationToken = default)
     {
         // build a list of all scheduler listeners that are to be notified...
@@ -2121,12 +2133,12 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.SchedulerError(message, exception, cancellationToken).ConfigureAwait(false);
+                await sl.SchedulerError(Scheduler, error, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
                 logger.LogError(e, "Error while notifying SchedulerListener of error");
-                logger.LogError(exception, "  Original error (for notification) was: {Message}", message);
+                logger.LogError(error.Exception, "  Original error (for notification) was: {Message}", error.Message);
             }
         }
     }
@@ -2140,7 +2152,7 @@ internal sealed class QuartzScheduler
         ITrigger trigger,
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.JobScheduled(trigger, cancellationToken), $"scheduled job. Trigger={trigger.Key}");
+        return NotifySchedulerListeners(l => l.JobScheduled(Scheduler, trigger, cancellationToken), $"scheduled job. Trigger={trigger.Key}");
     }
 
     /// <summary>
@@ -2160,11 +2172,11 @@ internal sealed class QuartzScheduler
             {
                 if (triggerKey is null)
                 {
-                    await sl.SchedulingDataCleared(cancellationToken).ConfigureAwait(false);
+                    await sl.SchedulingDataCleared(Scheduler, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    await sl.JobUnscheduled(triggerKey, cancellationToken).ConfigureAwait(false);
+                    await sl.JobUnscheduled(Scheduler, triggerKey, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -2185,7 +2197,7 @@ internal sealed class QuartzScheduler
         ITrigger trigger,
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.TriggerFinalized(trigger, cancellationToken), $"finalized trigger. Trigger={trigger.Key}");
+        return NotifySchedulerListeners(l => l.TriggerFinalized(Scheduler, trigger, cancellationToken), $"finalized trigger. Trigger={trigger.Key}");
     }
 
     /// <summary>
@@ -2205,7 +2217,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.TriggersPaused(@group, cancellationToken).ConfigureAwait(false);
+                await sl.TriggersPaused(Scheduler, @group, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2227,7 +2239,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.TriggerInError(triggerKey, cancellationToken).ConfigureAwait(false);
+                await sl.TriggerInError(Scheduler, triggerKey, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2249,7 +2261,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.TriggersInError(jobKey, cancellationToken).ConfigureAwait(false);
+                await sl.TriggersInError(Scheduler, jobKey, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2273,7 +2285,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.TriggerPaused(triggerKey, cancellationToken).ConfigureAwait(false);
+                await sl.TriggerPaused(Scheduler, triggerKey, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2291,7 +2303,7 @@ internal sealed class QuartzScheduler
         string? group,
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.TriggersResumed(group, cancellationToken), $"resumed group: {group}");
+        return NotifySchedulerListeners(l => l.TriggersResumed(Scheduler, group, cancellationToken), $"resumed group: {group}");
     }
 
     /// <summary>
@@ -2309,7 +2321,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.TriggerResumed(triggerKey, cancellationToken).ConfigureAwait(false);
+                await sl.TriggerResumed(Scheduler, triggerKey, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2332,7 +2344,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.JobPaused(jobKey, cancellationToken).ConfigureAwait(false);
+                await sl.JobPaused(Scheduler, jobKey, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2356,7 +2368,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.JobsPaused(@group, cancellationToken).ConfigureAwait(false);
+                await sl.JobsPaused(Scheduler, @group, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2380,7 +2392,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.JobResumed(jobKey, cancellationToken).ConfigureAwait(false);
+                await sl.JobResumed(Scheduler, jobKey, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2404,7 +2416,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await sl.JobsResumed(@group, cancellationToken).ConfigureAwait(false);
+                await sl.JobsResumed(Scheduler, @group, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -2416,19 +2428,19 @@ internal sealed class QuartzScheduler
     public ValueTask NotifySchedulerListenersInStandbyMode(
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.SchedulerInStandbyMode(cancellationToken), "inStandByMode");
+        return NotifySchedulerListeners(l => l.SchedulerInStandbyMode(Scheduler, cancellationToken), "inStandByMode");
     }
 
     public ValueTask NotifySchedulerListenersStarted(
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.SchedulerStarted(cancellationToken), "startup");
+        return NotifySchedulerListeners(l => l.SchedulerStarted(Scheduler, cancellationToken), "startup");
     }
 
     public ValueTask NotifySchedulerListenersStarting(
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.SchedulerStarting(cancellationToken), "scheduler starting");
+        return NotifySchedulerListeners(l => l.SchedulerStarting(Scheduler, cancellationToken), "scheduler starting");
     }
 
     /// <summary>
@@ -2437,27 +2449,27 @@ internal sealed class QuartzScheduler
     public ValueTask NotifySchedulerListenersShutdown(
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.SchedulerShutdown(cancellationToken), "shutdown");
+        return NotifySchedulerListeners(l => l.SchedulerShutdown(Scheduler, cancellationToken), "shutdown");
     }
 
     public ValueTask NotifySchedulerListenersShuttingDown(
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.SchedulerShuttingDown(cancellationToken), "shutting down");
+        return NotifySchedulerListeners(l => l.SchedulerShuttingDown(Scheduler, cancellationToken), "shutting down");
     }
 
     public ValueTask NotifySchedulerListenersJobAdded(
         IJobDetail jobDetail,
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.JobAdded(jobDetail, cancellationToken), "job addition");
+        return NotifySchedulerListeners(l => l.JobAdded(Scheduler, jobDetail, cancellationToken), "job addition");
     }
 
     public ValueTask NotifySchedulerListenersJobDeleted(
         JobKey jobKey,
         CancellationToken cancellationToken = default)
     {
-        return NotifySchedulerListeners(l => l.JobDeleted(jobKey, cancellationToken), "job deletion");
+        return NotifySchedulerListeners(l => l.JobDeleted(Scheduler, jobKey, cancellationToken), "job deletion");
     }
 
     private async ValueTask NotifySchedulerListeners(
@@ -2504,7 +2516,7 @@ internal sealed class QuartzScheduler
 
         if (interrupted)
         {
-            await NotifySchedulerListeners(l => l.JobInterrupted(jobKey, cancellationToken), "job interruption").ConfigureAwait(false);
+            await NotifySchedulerListeners(l => l.JobInterrupted(Scheduler, jobKey, cancellationToken), "job interruption").ConfigureAwait(false);
         }
 
         return interrupted;
@@ -2537,7 +2549,7 @@ internal sealed class QuartzScheduler
 
         interruptableContext.Interrupt();
         var jobKey = interruptableContext.JobDetail.Key;
-        await NotifySchedulerListeners(l => l.JobInterrupted(jobKey, cancellationToken), "job interruption").ConfigureAwait(false);
+        await NotifySchedulerListeners(l => l.JobInterrupted(Scheduler, jobKey, cancellationToken), "job interruption").ConfigureAwait(false);
         return true;
     }
 

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -356,8 +356,14 @@ internal sealed class QuartzSchedulerThread
                     {
                         if (acquiresFailed == 0)
                         {
-                            var msg = "An error occurred while scanning for the next trigger to fire.";
-                            await qs.NotifySchedulerListenersError(msg, jpe, CancellationToken.None).ConfigureAwait(false);
+                            // No keys: the scan never got as far as a trigger, so there is nothing this
+                            // failure is about beyond the store it came from.
+                            SchedulerErrorContext error = new()
+                            {
+                                Message = "An error occurred while scanning for the next trigger to fire.",
+                                Exception = jpe,
+                            };
+                            await qs.NotifySchedulerListenersError(error, CancellationToken.None).ConfigureAwait(false);
                         }
 
                         if (acquiresFailed < int.MaxValue)
@@ -457,7 +463,18 @@ internal sealed class QuartzSchedulerThread
                         catch (SchedulerException se)
                         {
                             var msg = "An error occurred while firing triggers '" + string.Join(", ", triggers.Select(t => t.Key)) + "'";
-                            await qs.NotifySchedulerListenersError(msg, se, CancellationToken.None).ConfigureAwait(false);
+
+                            // The whole batch failed, so the trigger key is only reported when the batch
+                            // held one trigger. Naming one of several would say the failure was about
+                            // that trigger, which it is not — the message enumerates them all instead.
+                            SchedulerErrorContext error = new()
+                            {
+                                Message = msg,
+                                Exception = se,
+                                TriggerKey = triggers.Count == 1 ? triggers[0].Key : null,
+                                JobKey = triggers.Count == 1 ? triggers[0].JobKey : null,
+                            };
+                            await qs.NotifySchedulerListenersError(error, CancellationToken.None).ConfigureAwait(false);
                             // QTZ-179 : a problem occurred interacting with the triggers from the db
                             // we release them and loop again
                             foreach (IOperableTrigger t in triggers)

--- a/src/Quartz/Core/SchedulerSignalerImpl.cs
+++ b/src/Quartz/Core/SchedulerSignalerImpl.cs
@@ -61,7 +61,17 @@ internal sealed class SchedulerSignalerImpl : ISchedulerSignaler
         catch (SchedulerException se)
         {
             logger.LogError(se, "Error notifying listeners of trigger misfire.");
-            await scheduler.NotifySchedulerListenersError("Error notifying listeners of trigger misfire.", se, cancellationToken).ConfigureAwait(false);
+
+            // The trigger travels with the failure: a listener that throws on one trigger's misfire
+            // should not leave the report saying only that some misfire notification failed.
+            SchedulerErrorContext error = new()
+            {
+                Message = "Error notifying listeners of trigger misfire.",
+                Exception = se,
+                TriggerKey = trigger.Key,
+                JobKey = trigger.JobKey,
+            };
+            await scheduler.NotifySchedulerListenersError(error, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -111,10 +121,9 @@ internal sealed class SchedulerSignalerImpl : ISchedulerSignaler
     }
 
     public ValueTask NotifySchedulerListenersError(
-        string message,
-        SchedulerException exception,
+        SchedulerErrorContext error,
         CancellationToken cancellationToken = default)
     {
-        return scheduler.NotifySchedulerListenersError(message, exception, cancellationToken);
+        return scheduler.NotifySchedulerListenersError(error, cancellationToken);
     }
 }

--- a/src/Quartz/Extensibility/ISchedulerSignaler.cs
+++ b/src/Quartz/Extensibility/ISchedulerSignaler.cs
@@ -85,8 +85,14 @@ public interface ISchedulerSignaler
     /// <summary>
     /// Informs scheduler listeners about an exception that has occurred.
     /// </summary>
+    /// <remarks>
+    /// The context is how a job store reports which trigger, job or firing the failure was for; a store
+    /// that knows none of them fills in <see cref="SchedulerErrorContext.Message" /> and
+    /// <see cref="SchedulerErrorContext.Exception" /> alone.
+    /// </remarks>
+    /// <param name="errorContext">What went wrong, and what it went wrong for.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
     ValueTask NotifySchedulerListenersError(
-        string message,
-        SchedulerException exception,
+        SchedulerErrorContext errorContext,
         CancellationToken cancellationToken = default);
 }

--- a/src/Quartz/ISchedulerListener.cs
+++ b/src/Quartz/ISchedulerListener.cs
@@ -28,8 +28,14 @@ namespace Quartz;
 /// <see cref="IScheduler" /> events.
 /// </summary>
 /// <remarks>
+/// Every callback is told which scheduler is calling it: a listener reaches the scheduler it serves
+/// through its execution context, or as its first argument when there is no execution. No member here
+/// is handed an execution context, so every one of them takes the scheduler. One listener instance can
+/// therefore serve several schedulers in one host and still say which of them paused a trigger or failed.
+/// <para>
 /// Every member has a default implementation, so an implementation only has to write the
 /// notifications it cares about. <see cref="Name" /> defaults to the implementing type's name.
+/// </para>
 /// </remarks>
 /// <seealso cref="IScheduler" />
 /// <seealso cref="IJobListener" />
@@ -53,25 +59,37 @@ public interface ISchedulerListener
     /// Called by the <see cref="IScheduler" /> when a <see cref="IJobDetail" />
     /// is scheduled.
     /// </summary>
-    ValueTask JobScheduled(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="trigger">The trigger the job was scheduled with.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask JobScheduled(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> when a <see cref="IJobDetail" />
     /// is unscheduled.
     /// </summary>
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="triggerKey">The trigger that was removed.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <seealso cref="SchedulingDataCleared"/>
-    ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+    ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> when a <see cref="ITrigger" />
     /// has reached the condition in which it will never fire again.
     /// </summary>
-    ValueTask TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="trigger">The trigger that will never fire again.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler"/> a <see cref="ITrigger"/>s has been paused.
     /// </summary>
-    ValueTask TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="triggerKey">The trigger that was paused.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler"/> a group of
@@ -80,15 +98,19 @@ public interface ISchedulerListener
     /// <remarks>
     /// A null <paramref name="triggerGroup" /> means every group.
     /// </remarks>
+    /// <param name="scheduler">The scheduler raising the notification.</param>
     /// <param name="triggerGroup">The trigger group, or null for all groups.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    ValueTask TriggersPaused(string? triggerGroup, CancellationToken cancellationToken = default) => default;
+    ValueTask TriggersPaused(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler"/> when a <see cref="ITrigger"/>
     /// has been un-paused.
     /// </summary>
-    ValueTask TriggerResumed(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="triggerKey">The trigger that was resumed.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler"/> when a
@@ -97,33 +119,46 @@ public interface ISchedulerListener
     /// <remarks>
     /// A null <paramref name="triggerGroup" /> means every group.
     /// </remarks>
+    /// <param name="scheduler">The scheduler raising the notification.</param>
     /// <param name="triggerGroup">The trigger group, or null for all groups.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    ValueTask TriggersResumed(string? triggerGroup, CancellationToken cancellationToken = default) => default;
+    ValueTask TriggersResumed(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> when a <see cref="IJobDetail" />
     /// has been added.
     /// </summary>
-    ValueTask JobAdded(IJobDetail jobDetail, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="jobDetail">The job that was added.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask JobAdded(IScheduler scheduler, IJobDetail jobDetail, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> when a <see cref="IJobDetail" />
     /// has been deleted.
     /// </summary>
-    ValueTask JobDeleted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="jobKey">The job that was deleted.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask JobDeleted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler"/> when a <see cref="IJobDetail"/>
     /// has been  paused.
     /// </summary>
-    ValueTask JobPaused(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="jobKey">The job that was paused.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler"/> when a <see cref="IJobDetail"/>
     /// has been interrupted.
     /// </summary>
-    ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="jobKey">The job that was interrupted.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask JobInterrupted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler"/> when a
@@ -135,15 +170,19 @@ public interface ISchedulerListener
     /// group rather than once with no group, but a job store or a caller raising the event itself
     /// may report all groups that way.
     /// </remarks>
+    /// <param name="scheduler">The scheduler raising the notification.</param>
     /// <param name="jobGroup">The job group, or null for all groups.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    ValueTask JobsPaused(string? jobGroup, CancellationToken cancellationToken = default) => default;
+    ValueTask JobsPaused(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> when a <see cref="IJobDetail" />
     /// has been  un-paused.
     /// </summary>
-    ValueTask JobResumed(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="jobKey">The job that was resumed.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> when a group of <see cref="IJobDetail" />s has
@@ -153,9 +192,10 @@ public interface ISchedulerListener
     /// A null <paramref name="jobGroup" /> means every group, matching
     /// <see cref="TriggersResumed" />.
     /// </remarks>
+    /// <param name="scheduler">The scheduler raising the notification.</param>
     /// <param name="jobGroup">The job group, or null for all groups.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    ValueTask JobsResumed(string? jobGroup, CancellationToken cancellationToken = default) => default;
+    ValueTask JobsResumed(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> when a serious error has
@@ -163,9 +203,17 @@ public interface ISchedulerListener
     /// or the inability to instantiate a <see cref="IJob" /> instance when its
     /// <see cref="ITrigger" /> has fired.
     /// </summary>
+    /// <remarks>
+    /// <see cref="SchedulerErrorContext" /> carries the trigger, job and firing the error was raised
+    /// for wherever the scheduler knew them, so a listener can pause the offending trigger rather than
+    /// read the keys out of the message text.
+    /// </remarks>
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="errorContext">What went wrong, and what it went wrong for.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
     ValueTask SchedulerError(
-        string message,
-        SchedulerException exception,
+        IScheduler scheduler,
+        SchedulerErrorContext errorContext,
         CancellationToken cancellationToken = default) => default;
 
     /// <summary>
@@ -182,7 +230,10 @@ public interface ISchedulerListener
     /// The default implementation does nothing.
     /// </para>
     /// </remarks>
-    ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="triggerKey">The trigger that was parked in the error state.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask TriggerInError(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> when every <see cref="ITrigger" /> of a job has moved
@@ -197,40 +248,55 @@ public interface ISchedulerListener
     /// The default implementation does nothing.
     /// </para>
     /// </remarks>
-    ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="jobKey">The job whose triggers were parked in the error state.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask TriggersInError(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> to inform the listener
     /// that it has move to standby mode.
     /// </summary>
-    ValueTask SchedulerInStandbyMode(CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask SchedulerInStandbyMode(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> to inform the listener
     /// that it has started.
     /// </summary>
-    ValueTask SchedulerStarted(CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> to inform the listener that it is starting.
     /// </summary>
-    ValueTask SchedulerStarting(CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> to inform the listener
     /// that it has Shutdown.
     /// </summary>
-    ValueTask SchedulerShutdown(CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> to inform the listener
     /// that it has begun the shutdown sequence.
     /// </summary>
-    ValueTask SchedulerShuttingDown(CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask SchedulerShuttingDown(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
     /// <summary>
     /// Called by the <see cref="IScheduler" /> to inform the listener
     /// that all jobs, triggers and calendars were deleted.
     /// </summary>
-    ValueTask SchedulingDataCleared(CancellationToken cancellationToken = default) => default;
+    /// <param name="scheduler">The scheduler raising the notification.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask SchedulingDataCleared(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 }

--- a/src/Quartz/ITriggerListener.cs
+++ b/src/Quartz/ITriggerListener.cs
@@ -29,8 +29,14 @@ namespace Quartz;
 /// <see cref="IScheduler" /> will not have use for this mechanism.
 /// </summary>
 /// <remarks>
+/// Every callback is told which scheduler is calling it: a listener reaches the scheduler it serves
+/// through its execution context, or as its first argument when there is no execution. Only
+/// <see cref="TriggerMisfired" /> is of the second kind — a misfire is noticed rather than executed,
+/// so it has no context to carry one.
+/// <para>
 /// Every member has a default implementation, so an implementation only has to write the
 /// notifications it cares about. <see cref="Name" /> defaults to the implementing type's name.
+/// </para>
 /// </remarks>
 /// <seealso cref="IListenerManager" />
 /// <seealso cref="IMatcher{T}" />
@@ -107,12 +113,18 @@ public interface ITriggerListener
     /// does a lot.
     /// </para>
     /// </summary>
+    /// <param name="scheduler">The scheduler raising the notification.</param>
     /// <param name="trigger">The <see cref="ITrigger" /> that has misfired.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <remarks>
+    /// The scheduler is passed because a misfire is noticed outside any execution, so there is no
+    /// <see cref="IJobExecutionContext" /> here to reach it through.
+    /// <para>
     /// The default implementation does nothing.
+    /// </para>
     /// </remarks>
     ValueTask TriggerMisfired(
+        IScheduler scheduler,
         ITrigger trigger,
         CancellationToken cancellationToken = default) => default;
 

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -5149,7 +5149,14 @@ public abstract class AdoJobStoreBase : IJobStore
             {
                 if (retry % RetryableActionErrorLogThreshold == 0)
                 {
-                    await schedSignaler.NotifySchedulerListenersError("An error occurred during retry", jpe, cancellationToken).ConfigureAwait(false);
+                    // No keys: the callback being retried is an arbitrary unit of store work, and the
+                    // failure is the connection rather than anything the work was about.
+                    SchedulerErrorContext error = new()
+                    {
+                        Message = "An error occurred during retry",
+                        Exception = jpe,
+                    };
+                    await schedSignaler.NotifySchedulerListenersError(error, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception e)

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -155,7 +155,10 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
                 quartzScheduler.SetExecutionLimits(executionLimits);
             }
 
-            var scheduler = new StdScheduler(quartzScheduler);
+            // The scheduler's own facade, not a fresh one: it is what every listener callback and every
+            // execution context is handed, so anything that compares the scheduler it was told about
+            // with the one it holds must be comparing the same object.
+            IScheduler scheduler = quartzScheduler.Scheduler;
 
             foreach (var pair in options.Context)
             {

--- a/src/Quartz/Listeners/BroadcastSchedulerListener.cs
+++ b/src/Quartz/Listeners/BroadcastSchedulerListener.cs
@@ -99,119 +99,119 @@ public sealed class BroadcastSchedulerListener : ISchedulerListener
 
     public IReadOnlyList<ISchedulerListener> Listeners => listeners;
 
-    public ValueTask JobAdded(IJobDetail jobDetail, CancellationToken cancellationToken = default)
+    public ValueTask JobAdded(IScheduler scheduler, IJobDetail jobDetail, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.JobAdded(jobDetail, cancellationToken), nameof(JobAdded));
+        return IterateListenersInGuard(l => l.JobAdded(scheduler, jobDetail, cancellationToken), nameof(JobAdded));
     }
 
-    public ValueTask JobDeleted(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask JobDeleted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.JobDeleted(jobKey, cancellationToken), nameof(JobDeleted));
+        return IterateListenersInGuard(l => l.JobDeleted(scheduler, jobKey, cancellationToken), nameof(JobDeleted));
     }
 
-    public ValueTask JobScheduled(ITrigger trigger, CancellationToken cancellationToken = default)
+    public ValueTask JobScheduled(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.JobScheduled(trigger, cancellationToken), nameof(JobScheduled));
+        return IterateListenersInGuard(l => l.JobScheduled(scheduler, trigger, cancellationToken), nameof(JobScheduled));
     }
 
-    public ValueTask JobUnscheduled(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.JobUnscheduled(triggerKey, cancellationToken), nameof(JobUnscheduled));
+        return IterateListenersInGuard(l => l.JobUnscheduled(scheduler, triggerKey, cancellationToken), nameof(JobUnscheduled));
     }
 
-    public ValueTask TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken = default)
+    public ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.TriggerFinalized(trigger, cancellationToken), nameof(TriggerFinalized));
+        return IterateListenersInGuard(l => l.TriggerFinalized(scheduler, trigger, cancellationToken), nameof(TriggerFinalized));
     }
 
-    public ValueTask TriggersPaused(string? triggerGroup, CancellationToken cancellationToken = default)
+    public ValueTask TriggersPaused(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.TriggersPaused(triggerGroup, cancellationToken), nameof(TriggersPaused));
+        return IterateListenersInGuard(l => l.TriggersPaused(scheduler, triggerGroup, cancellationToken), nameof(TriggersPaused));
     }
 
-    public ValueTask TriggerPaused(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.TriggerPaused(triggerKey, cancellationToken), nameof(TriggerPaused));
+        return IterateListenersInGuard(l => l.TriggerPaused(scheduler, triggerKey, cancellationToken), nameof(TriggerPaused));
     }
 
-    public ValueTask TriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask TriggerInError(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.TriggerInError(triggerKey, cancellationToken), nameof(TriggerInError));
+        return IterateListenersInGuard(l => l.TriggerInError(scheduler, triggerKey, cancellationToken), nameof(TriggerInError));
     }
 
-    public ValueTask TriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask TriggersInError(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.TriggersInError(jobKey, cancellationToken), nameof(TriggersInError));
+        return IterateListenersInGuard(l => l.TriggersInError(scheduler, jobKey, cancellationToken), nameof(TriggersInError));
     }
 
-    public ValueTask TriggersResumed(string? triggerGroup, CancellationToken cancellationToken = default)
+    public ValueTask TriggersResumed(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.TriggersResumed(triggerGroup, cancellationToken), nameof(TriggerResumed));
+        return IterateListenersInGuard(l => l.TriggersResumed(scheduler, triggerGroup, cancellationToken), nameof(TriggerResumed));
     }
 
-    public ValueTask SchedulingDataCleared(CancellationToken cancellationToken = default)
+    public ValueTask SchedulingDataCleared(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.SchedulingDataCleared(cancellationToken), nameof(SchedulingDataCleared));
+        return IterateListenersInGuard(l => l.SchedulingDataCleared(scheduler, cancellationToken), nameof(SchedulingDataCleared));
     }
 
-    public ValueTask TriggerResumed(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.TriggerResumed(triggerKey, cancellationToken), nameof(TriggerResumed));
+        return IterateListenersInGuard(l => l.TriggerResumed(scheduler, triggerKey, cancellationToken), nameof(TriggerResumed));
     }
 
-    public ValueTask JobInterrupted(JobKey jobKey, CancellationToken cancellationToken = new CancellationToken())
+    public ValueTask JobInterrupted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = new CancellationToken())
     {
-        return IterateListenersInGuard(l => l.JobInterrupted(jobKey, cancellationToken), nameof(JobInterrupted));
+        return IterateListenersInGuard(l => l.JobInterrupted(scheduler, jobKey, cancellationToken), nameof(JobInterrupted));
     }
 
-    public ValueTask JobsPaused(string? jobGroup, CancellationToken cancellationToken = default)
+    public ValueTask JobsPaused(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.JobsPaused(jobGroup, cancellationToken), nameof(JobsPaused));
+        return IterateListenersInGuard(l => l.JobsPaused(scheduler, jobGroup, cancellationToken), nameof(JobsPaused));
     }
 
-    public ValueTask JobPaused(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.JobPaused(jobKey, cancellationToken), nameof(JobPaused));
+        return IterateListenersInGuard(l => l.JobPaused(scheduler, jobKey, cancellationToken), nameof(JobPaused));
     }
 
-    public ValueTask JobsResumed(string? jobGroup, CancellationToken cancellationToken = default)
+    public ValueTask JobsResumed(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.JobsResumed(jobGroup, cancellationToken), nameof(JobsResumed));
+        return IterateListenersInGuard(l => l.JobsResumed(scheduler, jobGroup, cancellationToken), nameof(JobsResumed));
     }
 
-    public ValueTask JobResumed(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.JobResumed(jobKey, cancellationToken), nameof(JobResumed));
+        return IterateListenersInGuard(l => l.JobResumed(scheduler, jobKey, cancellationToken), nameof(JobResumed));
     }
 
-    public ValueTask SchedulerError(string message, SchedulerException exception, CancellationToken cancellationToken = default)
+    public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.SchedulerError(message, exception, cancellationToken), nameof(SchedulerError));
+        return IterateListenersInGuard(l => l.SchedulerError(scheduler, errorContext, cancellationToken), nameof(SchedulerError));
     }
 
-    public ValueTask SchedulerStarted(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.SchedulerStarted(cancellationToken), nameof(SchedulerStarted));
+        return IterateListenersInGuard(l => l.SchedulerStarted(scheduler, cancellationToken), nameof(SchedulerStarted));
     }
 
-    public ValueTask SchedulerStarting(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.SchedulerStarting(cancellationToken), nameof(SchedulerStarting));
+        return IterateListenersInGuard(l => l.SchedulerStarting(scheduler, cancellationToken), nameof(SchedulerStarting));
     }
 
-    public ValueTask SchedulerInStandbyMode(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerInStandbyMode(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.SchedulerInStandbyMode(cancellationToken), nameof(SchedulerInStandbyMode));
+        return IterateListenersInGuard(l => l.SchedulerInStandbyMode(scheduler, cancellationToken), nameof(SchedulerInStandbyMode));
     }
 
-    public ValueTask SchedulerShutdown(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.SchedulerShutdown(cancellationToken), nameof(SchedulerShutdown));
+        return IterateListenersInGuard(l => l.SchedulerShutdown(scheduler, cancellationToken), nameof(SchedulerShutdown));
     }
 
-    public ValueTask SchedulerShuttingDown(CancellationToken cancellationToken = default)
+    public ValueTask SchedulerShuttingDown(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.SchedulerShuttingDown(cancellationToken), nameof(SchedulerShuttingDown));
+        return IterateListenersInGuard(l => l.SchedulerShuttingDown(scheduler, cancellationToken), nameof(SchedulerShuttingDown));
     }
 
     private async ValueTask IterateListenersInGuard(Func<ISchedulerListener, ValueTask> action, string methodName)

--- a/src/Quartz/Listeners/BroadcastTriggerListener.cs
+++ b/src/Quartz/Listeners/BroadcastTriggerListener.cs
@@ -125,9 +125,9 @@ public sealed class BroadcastTriggerListener : ITriggerListener
         return false;
     }
 
-    public ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default)
+    public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
     {
-        return IterateListenersInGuard(l => l.TriggerMisfired(trigger, cancellationToken), nameof(TriggerMisfired));
+        return IterateListenersInGuard(l => l.TriggerMisfired(scheduler, trigger, cancellationToken), nameof(TriggerMisfired));
     }
 
     public ValueTask TriggerComplete(

--- a/src/Quartz/SchedulerErrorContext.cs
+++ b/src/Quartz/SchedulerErrorContext.cs
@@ -1,0 +1,69 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// What went wrong, and — where the scheduler knew it — what it went wrong for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ISchedulerListener.SchedulerError" /> used to take a message and an exception, which said
+/// what happened but never which trigger or job it happened to. Most of the places that raise the event
+/// know: a job that threw is reported from its execution context, and a misfire notification that failed
+/// is reported from the trigger that misfired. Those facts arrive here rather than only inside the
+/// message text, so a listener can act on them instead of parsing prose.
+/// </para>
+/// <para>
+/// The three keys are optional because some errors genuinely have no subject — a job store retrying a
+/// failed operation, or a scan for the next trigger to fire that never got as far as a trigger. A
+/// listener should treat a null as "the scheduler could not say", not as "this concerns no trigger".
+/// </para>
+/// </remarks>
+/// <seealso cref="ISchedulerListener.SchedulerError" />
+public sealed record SchedulerErrorContext
+{
+    /// <summary>
+    /// A description of what went wrong, written for a human reading a log.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// The error itself.
+    /// </summary>
+    public required SchedulerException Exception { get; init; }
+
+    /// <summary>
+    /// The trigger the error concerns, or <see langword="null" /> when the scheduler could not say.
+    /// </summary>
+    public TriggerKey? TriggerKey { get; init; }
+
+    /// <summary>
+    /// The job the error concerns, or <see langword="null" /> when the scheduler could not say.
+    /// </summary>
+    public JobKey? JobKey { get; init; }
+
+    /// <summary>
+    /// The firing the error concerns, matching <see cref="IJobExecutionContext.FireInstanceId" />, or
+    /// <see langword="null" /> when the error happened outside a firing.
+    /// </summary>
+    public string? FireInstanceId { get; init; }
+}


### PR DESCRIPTION
Closes #3063. Also answers discussion #3211 — the trigger behind a `SchedulerError`.

## The rule

**A listener reaches the scheduler it serves through its execution context, or as its first argument when there is no execution.**

`IJobListener`'s members and three of `ITriggerListener`'s four already receive an `IJobExecutionContext`, whose `.Scheduler` says who is calling. `ISchedulerListener`'s twenty-three members and `ITriggerListener.TriggerMisfired` received nothing, so a listener shared by several schedulers in one host — which `AddQuartz("acme", …)` plus `AddQuartz("initech", …)` makes ordinary — was told that *a* trigger had been paused and could not ask which scheduler paused it.

Those twenty-four members now take `IScheduler` first. The interfaces state the rule in their XML docs, and so do the two tutorial pages.

It is the `IScheduler` rather than a name or an identity record because a listener that knows *which* scheduler usually wants to *act* on it — pause the trigger it just heard about, read `Status`; identity is `SchedulerName`/`SchedulerInstanceId` on the same object.

## The record

`SchedulerError(string, SchedulerException, ct)` becomes `SchedulerError(IScheduler, SchedulerErrorContext, ct)`:

```csharp
public sealed record SchedulerErrorContext
{
    public required string Message { get; init; }
    public required SchedulerException Exception { get; init; }
    public TriggerKey? TriggerKey { get; init; }
    public JobKey? JobKey { get; init; }
    public string? FireInstanceId { get; init; }
}
```

Filled in where the facts are known:

| Site | What it fills in |
|---|---|
| `JobRunShell` (12 raise sites) | trigger, job and fire instance, from the execution context or — before one exists — from the `TriggerFiredBundle` |
| `SchedulerSignalerImpl`, misfire-notification failure | the trigger that misfired, and its job |
| `QuartzSchedulerThread`, acquisition scan failed | nothing; the scan never reached a trigger |
| `QuartzSchedulerThread`, `TriggersFired` failed | the trigger **only when the batch held one** — see "for a reviewer" below |
| `AdoJobStoreBase`, retry | nothing; the failure is the connection |
| `Xml`/`JsonSchedulingDataProcessorPlugin` | nothing; the failure is the file, which names many jobs |

`ISchedulerSignaler.NotifySchedulerListenersError` takes the record too, so a job store of somebody's own can report the trigger it failed for.

## How `QuartzScheduler` gets its facade

`QuartzScheduler` builds its `StdScheduler` once, in its constructor, and exposes it as `QuartzScheduler.Scheduler`. `DefaultSchedulerFactory.Create` now hands out *that* instance instead of `new StdScheduler(quartzScheduler)`, so the facade the factory returns, the one `IJobExecutionContext.Scheduler` carries, the one `StdJobRunShellFactory.Initialize` receives and the one every listener callback is handed are all the same object. No notification constructs a facade and none resolves one from a container.

*(Deviation from the spec, deliberately: the spec said to hand the facade to `QuartzScheduler` from `DefaultSchedulerFactory`. Constructing it in `QuartzScheduler` instead means it is never null — benchmarks and several unit tests construct `QuartzScheduler` directly and drive the scheduler thread, and a null facade would have been an NRE on the first error notification. Same single instance, same construction point, one fewer way to get it wrong.)*

## Implementers updated

`Core/ErrorLogger` (logs the scheduler name and the keys as structured fields, with a second template for the common no-keys case so a line does not end in three empty fields), `Listeners/BroadcastSchedulerListener`, `Listeners/BroadcastTriggerListener`, `Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin`, `Quartz.Plugins`' `LoggingTriggerHistoryPlugin`, `StructuredLoggingTriggerHistoryPlugin`, `XmlSchedulingDataProcessorPlugin` and `JsonSchedulingDataProcessorPlugin`, `Quartz.Examples.Worker/Listeners`, `Quartz.Examples.AspNetCore`'s `SampleSchedulerListener` and `SampleTriggerListener`, `Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples`, `Quartz.Benchmark`, and every test implementer the grep found.

`DashboardLiveEventsPlugin` now keys its broadcasts on the *passed* scheduler's name rather than the one it was initialized with (#3389 made it one instance per scheduler anyway), and its `schedulerName` field is gone. `SchedulerErrorDto` gained `TriggerKey` and `JobKey` — added to the existing positional record, no new wire type; `LiveLogs.razor` receives the payload as `object`, so the extra members render without a change there.

## Baselines moved

Three, all through the Verify workflow (run the tests, review the diff, promote `.received.txt`):

- `PublicApiTest_Quartz.verified.txt` — the 23 `ISchedulerListener` members and `BroadcastSchedulerListener`'s 23, `ITriggerListener.TriggerMisfired` and `BroadcastTriggerListener`'s, `ISchedulerSignaler.NotifySchedulerListenersError`, and the new `Quartz.SchedulerErrorContext`.
- `PublicApiTest_Quartz.Plugins.verified.txt` — `TriggerMisfired` on the two trigger-history plugins.
- `PublicApiTest_Quartz.Dashboard.verified.txt` — `DashboardLiveEventsPlugin`'s listener members and `SchedulerErrorDto`'s two new members.

The same delta is in `docs/documentation/quartz-4.x/migration-guide.md`, as a new section with an exhaustive twenty-four-row before/after table.

## For a reviewer to decide

1. **The migration experience is not what the spec assumed, and the guide says so.** The spec expected a listener that overrides a changed member to get a compile error naming it. It does not: every member of these interfaces has a default implementation, so a listener keeping an old signature still compiles — it silently stops implementing anything and its method becomes dead code. Nothing in the language warns. Two analyzers happened to catch Quartz's own (CA1822 on a callback that no longer touches instance state, MA0196 on an `<inheritdoc />` that no longer inherits), and the guide names both, but neither is a guarantee. The guide tells readers to search for the twenty-four names rather than wait to be told. If that is too weak a migration story, the alternative is dropping the default implementations, which would undo [The three `*Support` base classes are gone].

2. **`QuartzSchedulerThread`'s batch-fire failure reports a trigger only when the batch held one.** The spec said this site "sets the trigger", but `TriggersFired` fails for a whole batch and the record has room for one key. Naming one of five would claim the failure was about that trigger. The message still enumerates them all. Say the word if you would rather it were always null, or always `triggers[0]`.

3. **The parameter is `errorContext`, not `error`.** CA1716 rejects `error` on a virtual or interface member — it is a VB keyword — and the rule is on as an error here. Internal implementations still call it `error` where that reads better.

4. **A container-injected `IScheduler` is not reference-equal to the one a callback is handed.** The container hands out `DeferredScheduler`, a proxy that resolves on first use; the callback gets the `StdScheduler` behind it, which is also what `ISchedulerFactory.GetScheduler()` and `IJobExecutionContext.Scheduler` return. That asymmetry predates this PR; the guide now spells it out and says to compare `SchedulerName` in that case.

## Left alone deliberately

- `IJobListener`'s members and `ITriggerListener`'s other three — they already receive an execution context.
- `ISchedulerListener` member *names*.
- `multi-tenancy.md`'s note that a listener "is told which scheduler it is hearing from on every callback" — it now reads literally true.
- `docs/documentation/quartz-3.x/`.

## Verification

```
dotnet build Quartz.slnx                                   Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit                          Passed! 0 failed, 3120 passed, 4 skipped
dotnet test src/Quartz.Tests.AspNetCore                    Passed! 0 failed, 328 passed
dotnet test src/Quartz.Tests.Integration -f db-sqlite      Passed! 0 failed, 7 passed      (Docker up)
dotnet test … ~TriggerInErrorNotificationAdoTest           Passed! 0 failed, 1 passed      (Docker up, Postgres)
dotnet fallout VerifyDocsSnippets                          up to date (89 markdown files checked)
npm run docs:check-links                                   211 pages, 712 links, 407 fragments; no dead links or anchors
```
