### PR TITLE
The HTTP wire contract is source-generated

### DIFF
--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -380,6 +380,21 @@ The wire format is the one documented on this page, so any HTTP client speaks it
 convenience of not writing that yourself. [HTTP Client](http-client.md) covers registration,
 authentication, serializer matching and what does not travel.
 
+## The wire contract is source-generated
+
+The bodies on this page are a closed set, and Quartz states them as a source-generated
+`JsonSerializerContext`: a scheduler, a job detail, a page of triggers, a problem-details error and every
+request that goes the other way are described at compile time rather than discovered by reflecting over
+the type. The server and `Quartz.HttpClient` share the one context, so both ends of a call are generated,
+and adding a body to the API means adding it there too.
+
+Three things on the wire are deliberately left open. An `ITrigger` and an `ICalendar` are read and
+written by converters that consult the scheduler's serializer registry — which is what lets a custom
+trigger or calendar type travel at all — and the values inside a `JobDataMap` are whatever the
+application put there, so nothing generated can name them ahead of time. The generated contract is asked
+first and reflection second, so a body never reflects on its way to those converters, and the reflection
+that remains is over the payload rather than over the contract.
+
 ## Production hardening
 
 - Require authentication/authorization on `MapQuartzHttpApi()`

--- a/src/Quartz.HttpClient/HttpClientExtensions.cs
+++ b/src/Quartz.HttpClient/HttpClientExtensions.cs
@@ -22,7 +22,6 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 using Quartz.HttpApiContract;
 using Quartz.Impl.AdoJobStore;
@@ -138,11 +137,11 @@ internal static class HttpClientExtensions
             return true;
         }
 
-        ProblemDetails? problemDetails = null;
+        ProblemDetailsDto? problemDetails = null;
 
         try
         {
-            problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>(serializerOptions, cancellationToken).ConfigureAwait(false);
+            problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetailsDto>(serializerOptions, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -207,27 +206,5 @@ internal static class HttpClientExtensions
     {
         var result = await content.ReadFromJsonAsync<T>(serializerOptions, cancellationToken).ConfigureAwait(false);
         return result ?? throw new HttpClientException("Could not deserialize response");
-    }
-
-    // Copy & paste from: https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetails.cs
-    private sealed class ProblemDetails
-    {
-        [JsonPropertyName("type")]
-        public string? Type { get; set; }
-
-        [JsonPropertyName("title")]
-        public string? Title { get; set; }
-
-        [JsonPropertyName("status")]
-        public int? Status { get; set; }
-
-        [JsonPropertyName("detail")]
-        public string? Detail { get; set; }
-
-        [JsonPropertyName("instance")]
-        public string? Instance { get; set; }
-
-        [JsonExtensionData]
-        public IDictionary<string, JsonElement>? Extensions { get; set; }
     }
 }

--- a/src/Quartz.Tests.AspNetCore/HttpApi/QuartzHttpApiJsonOptionsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/QuartzHttpApiJsonOptionsTest.cs
@@ -1,6 +1,11 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+
+using Quartz.HttpApiContract;
 
 namespace Quartz.Tests.AspNetCore.HttpApi;
 
@@ -37,11 +42,44 @@ public class QuartzHttpApiJsonOptionsTest
             "the JSON options belong to the container rather than to one scheduler, so serving a second scheduler over HTTP must not stack the same converters onto them twice");
     }
 
+    [Test]
+    public void RegistrationAsksTheGeneratedContractBeforeReflection()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("first");
+        services.AddQuartzHttpApi();
+
+        IList<IJsonTypeInfoResolver> resolvers = SerializerOptions(services).TypeInfoResolverChain;
+
+        resolvers[0].Should().BeOfType<HttpApiJsonContext>(
+            "a contract body must be answered from generated metadata rather than reflected over");
+        resolvers[^1].Should().BeOfType<DefaultJsonTypeInfoResolver>(
+            "the options are the whole application's, so the host's own bodies must keep resolving the way they did");
+    }
+
+    [Test]
+    public void SecondRegistrationDoesNotAddTheSameResolverAgain()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("first");
+        services.AddQuartz("second");
+        services.AddQuartzHttpApi();
+        services.AddQuartzHttpApi();
+
+        SerializerOptions(services).TypeInfoResolverChain.Count(resolver => resolver is HttpApiJsonContext).Should().Be(1,
+            "serving a second scheduler over HTTP must not stack the contract onto the container's options twice, any more than it stacks the converters");
+    }
+
     private static int QuartzConverterCount(IServiceCollection services)
+    {
+        return SerializerOptions(services).Converters.Count(converter => converter.GetType().Assembly == typeof(IScheduler).Assembly);
+    }
+
+    private static JsonSerializerOptions SerializerOptions(IServiceCollection services)
     {
         using ServiceProvider provider = services.BuildServiceProvider();
         JsonOptions options = provider.GetRequiredService<IOptions<JsonOptions>>().Value;
 
-        return options.SerializerOptions.Converters.Count(converter => converter.GetType().Assembly == typeof(IScheduler).Assembly);
+        return options.SerializerOptions;
     }
 }

--- a/src/Quartz.Tests.Unit/HttpApi/WireFormatSourceGenerationTest.cs
+++ b/src/Quartz.Tests.Unit/HttpApi/WireFormatSourceGenerationTest.cs
@@ -1,0 +1,131 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+using Quartz.HttpApiContract;
+using Quartz.Serialization.SystemTextJson;
+using Quartz.Serialization.SystemTextJson.Converters;
+
+namespace Quartz.Tests.Unit.HttpApi;
+
+/// <summary>
+/// The wire contract's closed shapes are answered from generated metadata, and its open ones from the
+/// converters that know the scheduler's serializer registry.
+/// </summary>
+/// <remarks>
+/// A contract type that is not listed in <c>HttpApiJsonContext</c> still serializes — the chain falls
+/// through to reflection behind the context — so nothing else would notice it was left out. This is
+/// what notices.
+/// </remarks>
+public class WireFormatSourceGenerationTest
+{
+    private static JsonSerializerOptions WireOptions()
+    {
+        return new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            .ConfigureWireFormat(new SystemTextJsonSerializerRegistry());
+    }
+
+    /// <summary>
+    /// Every non-generic type in the contract's namespace, which is the set the API can put on the wire.
+    /// </summary>
+    private static IEnumerable<Type> ContractTypes()
+    {
+        return typeof(SchedulerDto).Assembly.GetTypes()
+            .Where(type => type.Namespace == "Quartz.HttpApiContract")
+            .Where(type => !type.IsNested && !type.IsInterface && !type.IsAbstract && !type.IsGenericTypeDefinition)
+            .Where(type => type.GetCustomAttribute<CompilerGeneratedAttribute>() is null)
+            .Where(type => type != typeof(HttpApiJsonContext))
+            .OrderBy(type => type.Name, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The page envelope is generic, so it is on the wire once per thing it carries and each closed
+    /// form has to be listed on its own.
+    /// </summary>
+    private static IEnumerable<Type> PagedBodies()
+    {
+        yield return typeof(PagedResultDto<FireInstanceDto>);
+        yield return typeof(PagedResultDto<JobGroupDto>);
+        yield return typeof(PagedResultDto<JobHeaderDto>);
+        yield return typeof(PagedResultDto<string>);
+        yield return typeof(PagedResultDto<TriggerGroupDto>);
+        yield return typeof(PagedResultDto<TriggerHeaderDto>);
+    }
+
+    [TestCaseSource(nameof(ContractTypes))]
+    public void ContractTypeIsAnsweredByTheGeneratedContext(Type contractType)
+    {
+        JsonTypeInfo typeInfo = WireOptions().GetTypeInfo(contractType);
+
+        typeInfo.OriginatingResolver.Should().BeOfType<HttpApiJsonContext>(
+            $"{contractType.Name} is part of the wire contract, so it needs a [JsonSerializable] entry in HttpApiJsonContext; without one it falls through to reflection and no longer survives trimming");
+    }
+
+    [TestCaseSource(nameof(PagedBodies))]
+    public void PagedBodyIsAnsweredByTheGeneratedContext(Type pagedBody)
+    {
+        JsonTypeInfo typeInfo = WireOptions().GetTypeInfo(pagedBody);
+
+        typeInfo.OriginatingResolver.Should().BeOfType<HttpApiJsonContext>(
+            "a page of a listing is a body like any other, and the generator only sees the closed forms it is given");
+    }
+
+    [Test]
+    public void TheGeneratedContextIsAskedFirst()
+    {
+        JsonSerializerOptions options = WireOptions();
+
+        options.TypeInfoResolverChain[0].Should().BeOfType<HttpApiJsonContext>(
+            "a contract type must never reach the reflection resolver, and the chain is consulted in order");
+        options.TypeInfoResolverChain[^1].Should().BeOfType<DefaultJsonTypeInfoResolver>(
+            "the values inside a JobDataMap are whatever the application put there, so the chain has to end in reflection");
+    }
+
+    [Test]
+    public void TypesOutsideTheContractStillReachReflection()
+    {
+        JsonTypeInfo typeInfo = WireOptions().GetTypeInfo(typeof(Uri));
+
+        typeInfo.OriginatingResolver.Should().BeOfType<DefaultJsonTypeInfoResolver>(
+            "putting the contract in front of the reflection resolver must not take the reflection resolver away");
+    }
+
+    [Test]
+    public void ConfiguringTwiceDoesNotStackTheContext()
+    {
+        JsonSerializerOptions options = WireOptions().ConfigureWireFormat(new SystemTextJsonSerializerRegistry());
+
+        options.TypeInfoResolverChain.Count(resolver => resolver is HttpApiJsonContext).Should().Be(1,
+            "the options are the whole container's on the server, and asking twice must leave them as one ask does");
+    }
+
+    [TestCase(typeof(ITrigger), typeof(TriggerConverter))]
+    [TestCase(typeof(ICalendar), typeof(CalendarConverter))]
+    [TestCase(typeof(JobDataMap), typeof(JobDataMapConverter))]
+    public void OpenTypesStillGoThroughTheirConverter(Type openType, Type converterType)
+    {
+        JsonTypeInfo typeInfo = WireOptions().GetTypeInfo(openType);
+
+        typeInfo.Converter.Should().BeOfType(converterType,
+            $"{openType.Name} is whatever the application made it, so it is read and written by the converter that consults the scheduler's serializer registry rather than by a contract the generator could write");
+    }
+
+    [Test]
+    public void GeneratedMetadataObeysTheOptionsRatherThanTheContext()
+    {
+        SchedulerDto dto = new(
+            SchedulerInstanceId: "NON_CLUSTERED",
+            Name: "TestScheduler",
+            Status: SchedulerStatus.Running,
+            ThreadPool: new SchedulerThreadPoolDto("Quartz.Impl.DefaultThreadPool, Quartz", 10),
+            JobStore: new SchedulerJobStoreDto("Quartz.Impl.RAMJobStore, Quartz", Clustered: false, Persistent: false),
+            Statistics: new SchedulerStatisticsDto("1.2.3", RunningSince: null, JobsExecuted: 7, LocalExecutingJobs: 1));
+
+        string json = JsonSerializer.Serialize(dto, WireOptions());
+
+        json.Should().Be(
+            """{"schedulerInstanceId":"NON_CLUSTERED","name":"TestScheduler","status":"Running","threadPool":{"type":"Quartz.Impl.DefaultThreadPool, Quartz","size":10},"jobStore":{"type":"Quartz.Impl.RAMJobStore, Quartz","clustered":false,"persistent":false},"statistics":{"version":"1.2.3","runningSince":null,"jobsExecuted":7,"localExecutingJobs":1}}""",
+            "the generated metadata carries no naming policy and no enum spelling of its own - both come from the options in use, which is what keeps the wire snapshots where they were");
+    }
+}

--- a/src/Quartz/HttpApiContract/HttpApiJson.cs
+++ b/src/Quartz/HttpApiContract/HttpApiJson.cs
@@ -19,8 +19,10 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 using Quartz.Serialization.SystemTextJson;
 
@@ -34,7 +36,8 @@ internal static class HttpApiJson
 {
     /// <summary>
     /// Teaches <paramref name="options" /> the wire contract: Quartz's trigger, calendar, key and
-    /// job-data-map converters, plus the contract's enums as their names.
+    /// job-data-map converters, the contract's enums as their names, and the generated metadata for the
+    /// contract's own shapes.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -49,6 +52,14 @@ internal static class HttpApiJson
     /// application: a host's own endpoints must keep rendering their own enums the way they always did.
     /// The typed form is also the trimming- and AOT-safe one.
     /// </para>
+    /// <para>
+    /// <see cref="HttpApiJsonContext" /> goes in front of whatever resolver the options already had, so
+    /// a contract type is answered from generated metadata and everything else — the host's own bodies
+    /// on the server, the values inside a <see cref="JobDataMap" /> everywhere — still reaches the
+    /// resolver behind it. Converters registered above win over both: generated metadata for a type the
+    /// options carry a converter for is metadata that defers to that converter, which is what keeps an
+    /// <see cref="ITrigger" /> going through <c>TriggerConverter</c> either way.
+    /// </para>
     /// </remarks>
     public static JsonSerializerOptions ConfigureWireFormat(
         this JsonSerializerOptions options,
@@ -59,6 +70,58 @@ internal static class HttpApiJson
         options.Converters.Add(new JsonStringEnumConverter<SchedulerStatus>());
         options.Converters.Add(new JsonStringEnumConverter<FireInstanceState>());
         options.Converters.Add(new JsonStringEnumConverter<ExecutionLimitScope>());
+
+        // Asking twice must leave the chain as asking once does: on the server these options belong to
+        // the whole container, and every AddQuartzHttpApi call wants the same contract in front of it.
+        IList<IJsonTypeInfoResolver> resolvers = options.TypeInfoResolverChain;
+        if (!resolvers.Contains(HttpApiJsonContext.Default))
+        {
+            if (resolvers.Count == 0)
+            {
+                // Options carrying no resolver of their own fall back to reflection lazily, but only for
+                // as long as the chain stays empty - and putting the contract in it ends that. So the
+                // fallback has to be named here, or the values inside a JobDataMap, whose types the
+                // contract cannot know, would stop resolving at all.
+                DefaultJsonTypeInfoResolver? reflection = ReflectionResolver();
+                if (reflection is not null)
+                {
+                    resolvers.Add(reflection);
+                }
+            }
+
+            resolvers.Insert(0, HttpApiJsonContext.Default);
+        }
+
         return options;
+    }
+
+    /// <summary>
+    /// The reflection-based resolver the wire's open half needs, or <see langword="null" /> where
+    /// reflection-based serialization is switched off.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The chain has to end in reflection because the contract does: a <see cref="JobDataMap" /> holds
+    /// whatever the application put in it, and no generated metadata can describe that. The same guard
+    /// <c>Microsoft.AspNetCore.Http.Json.JsonOptions</c> builds its own default resolver behind is what
+    /// makes naming <see cref="DefaultJsonTypeInfoResolver" /> here safe: a trimmed publish sets
+    /// <c>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault</c> to false — the SDK does it by
+    /// default, as the trim canary's runtimeconfig shows — so the trimmer substitutes the property,
+    /// drops this branch and never sees the resolver. What such an application is left with is the
+    /// generated contract, which is more than it had: options carrying no resolver at all threw on the
+    /// first body either way.
+    /// </para>
+    /// <para>
+    /// The suppression therefore hides nothing an application is not told. The reflection it silences is
+    /// already reported against
+    /// <c>Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions</c>, which every caller of this
+    /// method reaches through <c>JobDataMapConverter</c>, and which is deliberately not suppressed for
+    /// consumers.
+    /// </para>
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Guarded by IsReflectionEnabledByDefault, which a trimmed publish substitutes away along with this branch. See the remarks.")]
+    private static DefaultJsonTypeInfoResolver? ReflectionResolver()
+    {
+        return JsonSerializer.IsReflectionEnabledByDefault ? new DefaultJsonTypeInfoResolver() : null;
     }
 }

--- a/src/Quartz/HttpApiContract/HttpApiJsonContext.cs
+++ b/src/Quartz/HttpApiContract/HttpApiJsonContext.cs
@@ -1,0 +1,98 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Text.Json.Serialization;
+
+namespace Quartz.HttpApiContract;
+
+/// <summary>
+/// The wire contract as metadata the compiler wrote: every request body, response body and page
+/// envelope the HTTP API exchanges, listed so that reading or writing one needs no reflection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="HttpApiJson.ConfigureWireFormat" /> puts this in front of the reflection resolver, so a
+/// listed type is answered here and never reflects. The open half of the contract is deliberately not
+/// closed by it: an <see cref="ITrigger" />, an <see cref="ICalendar" /> and a <see cref="JobDataMap" />
+/// are whatever the application made them, and they keep going through the converters that consult the
+/// scheduler's <c>SystemTextJsonSerializerRegistry</c>. They are named below all the same, because the
+/// generator follows the closure of the bodies that carry them anyway; what it writes for them is
+/// metadata that defers to the converter the options carry, which is what a generated type does with
+/// any converter registered at runtime.
+/// </para>
+/// <para>
+/// A body that gains a type has to be listed here too. Nothing breaks if it is not — the chain falls
+/// through to reflection, which is exactly why it would go unnoticed. <c>WireFormatSourceGenerationTest</c>
+/// is what notices.
+/// </para>
+/// <para>
+/// <see cref="JsonSourceGenerationMode.Metadata" /> rather than the default, because the generated
+/// write path bakes in the naming and number handling of the options the context was declared with, and
+/// System.Text.Json will only take it when those options match the ones in use. The wire options never
+/// do — they carry Quartz's converters — so the generated writers would be dead code. Asking for
+/// metadata alone keeps the generated source to what is actually reached.
+/// </para>
+/// </remarks>
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+
+// Request bodies.
+[JsonSerializable(typeof(AddCalendarRequest))]
+[JsonSerializable(typeof(AddJobRequest))]
+[JsonSerializable(typeof(DeleteJobsRequest))]
+[JsonSerializable(typeof(JobKeySetRequest))]
+[JsonSerializable(typeof(KeyDto[]))]
+[JsonSerializable(typeof(RescheduleJobRequest))]
+[JsonSerializable(typeof(ScheduleJobRequest))]
+[JsonSerializable(typeof(ScheduleJobsRequest))]
+[JsonSerializable(typeof(SetExecutionLimitsRequest))]
+[JsonSerializable(typeof(TriggerJobRequest))]
+[JsonSerializable(typeof(TriggerKeySetRequest))]
+[JsonSerializable(typeof(UnscheduleJobsRequest))]
+
+// Response bodies.
+[JsonSerializable(typeof(AffectedGroupsResponse))]
+[JsonSerializable(typeof(AppliedJobKeysResponse))]
+[JsonSerializable(typeof(AppliedTriggerKeysResponse))]
+[JsonSerializable(typeof(ExecutionLimitsResponse))]
+[JsonSerializable(typeof(ExistsResponse))]
+[JsonSerializable(typeof(GroupPausedResponse))]
+[JsonSerializable(typeof(JobDetailDto))]
+[JsonSerializable(typeof(JobDetailDto[]))]
+[JsonSerializable(typeof(OperationAppliedResponse))]
+[JsonSerializable(typeof(PagedResultDto<FireInstanceDto>))]
+[JsonSerializable(typeof(PagedResultDto<JobGroupDto>))]
+[JsonSerializable(typeof(PagedResultDto<JobHeaderDto>))]
+[JsonSerializable(typeof(PagedResultDto<string>))]
+[JsonSerializable(typeof(PagedResultDto<TriggerGroupDto>))]
+[JsonSerializable(typeof(PagedResultDto<TriggerHeaderDto>))]
+[JsonSerializable(typeof(ProblemDetailsDto))]
+[JsonSerializable(typeof(RescheduleJobResponse))]
+[JsonSerializable(typeof(ScheduleJobResponse))]
+[JsonSerializable(typeof(SchedulerContextDto))]
+[JsonSerializable(typeof(SchedulerDto))]
+[JsonSerializable(typeof(SchedulerHeaderDto[]))]
+[JsonSerializable(typeof(TriggerStateDto))]
+
+// The open types, which are bodies of their own as well as members of the ones above.
+[JsonSerializable(typeof(ICalendar))]
+[JsonSerializable(typeof(ITrigger))]
+[JsonSerializable(typeof(List<ITrigger>))]
+internal sealed partial class HttpApiJsonContext : JsonSerializerContext;

--- a/src/Quartz/HttpApiContract/ProblemDetailsDto.cs
+++ b/src/Quartz/HttpApiContract/ProblemDetailsDto.cs
@@ -1,0 +1,63 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Quartz.HttpApiContract;
+
+/// <summary>
+/// The error body every failing request answers with — RFC 9457 problem details, as the API's clients
+/// read them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server writes ASP.NET Core's own <c>ProblemDetails</c>; this is the same shape stated where the
+/// rest of the contract is stated, so that a client need not reference ASP.NET Core to read an error.
+/// It carries the member names explicitly rather than leaning on a naming policy, because the wire
+/// spells them in lower case whatever policy the caller's options happen to have.
+/// </para>
+/// <para>
+/// A class with settable properties rather than a record, because <see cref="Extensions" /> is filled
+/// after construction: that is how <see cref="JsonExtensionDataAttribute" /> works, and it is where
+/// <see cref="HttpApiConstants.ProblemDetailsExceptionType" /> arrives.
+/// </para>
+/// </remarks>
+internal sealed class ProblemDetailsDto
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("status")]
+    public int? Status { get; set; }
+
+    [JsonPropertyName("detail")]
+    public string? Detail { get; set; }
+
+    [JsonPropertyName("instance")]
+    public string? Instance { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? Extensions { get; set; }
+}

--- a/src/Quartz/ILLink.Suppressions.xml
+++ b/src/Quartz/ILLink.Suppressions.xml
@@ -157,19 +157,19 @@
       </attribute>
     </type>
 
-    <!-- Reflection-based serialization; issue #3341, step 4 -->
+    <!-- Reflection-based serialization -->
     <type fullname="Quartz.Impl.SystemTextJsonObjectSerializer*">
       <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
         <argument>Trimming</argument>
         <argument>IL2026</argument>
-        <property name="Justification">Job data is serialized as whatever the application stored; issue #3341, step 4.</property>
+        <property name="Justification">Job data is serialized as whatever the application stored, which no generated contract can name.</property>
       </attribute>
     </type>
     <type fullname="Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions*">
       <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
         <argument>Trimming</argument>
         <argument>IL2026</argument>
-        <property name="Justification">Job data is serialized as whatever the application stored; issue #3341, step 4.</property>
+        <property name="Justification">Job data is serialized as whatever the application stored, which no generated contract can name.</property>
       </attribute>
     </type>
 

--- a/src/Quartz/TrimAnalysisBaseline.cs
+++ b/src/Quartz/TrimAnalysisBaseline.cs
@@ -32,6 +32,11 @@ using System.Diagnostics.CodeAnalysis;
 // that accept a type *name* instead say [RequiresUnreferencedCode] out loud. What is left below is what
 // that redesign could not reach, and each group says which wall it ran into.
 //
+// Step 4 closed the HTTP wire contract without adding a line here: HttpApiJsonContext states every body
+// the API exchanges, and HttpApiJson.ConfigureWireFormat asks it before it asks reflection. That change
+// removed no entry either, because the contract's reflection was never Quartz's own warning to record -
+// it lived in System.Text.Json's lazy fallback, which nothing reports.
+//
 // Adding an entry is the wrong first move. Reach for it only after establishing that the reflection is
 // genuinely unavoidable, and then say in the group comment why. The preferred fixes, in order:
 //
@@ -104,11 +109,12 @@ using System.Diagnostics.CodeAnalysis;
 
 // --- Reflection-based serialization ---------------------------------------------------------------------
 // A JobDataMap holds whatever the application put in it, so the payload's types are not known until it
-// is serialized. Issue #3341, step 4 replaces the closed set of wire DTOs with a source-generated
-// JsonSerializerContext; the open part of the registry stays reflective on purpose.
+// is serialized. Everything around it is closed now - the wire contract by HttpApiJsonContext, the
+// trigger and calendar shapes by their serializers - and these two are the open middle that is left:
+// the values themselves, which no generated contract can name because the application chose them.
 
-[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Impl.SystemTextJsonObjectSerializer", Justification = "Job data is serialized as whatever the application stored; issue #3341, step 4.")]
-[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions", Justification = "Job data is serialized as whatever the application stored; issue #3341, step 4.")]
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Impl.SystemTextJsonObjectSerializer", Justification = "Job data is serialized as whatever the application stored, which no generated contract can name.")]
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions", Justification = "Job data is serialized as whatever the application stored, which no generated contract can name.")]
 
 // --- Configuration binding ------------------------------------------------------------------------------
 // IServiceCollection.Configure<TOptions>(name, section) is RequiresUnreferencedCode: the binder reflects


### PR DESCRIPTION
Part of #3341 (step 4). The issue stays open — step 5 remains.

## What changed

The HTTP API's wire contract is a closed set of shapes, and until now every one of them was discovered
at runtime: `System.Text.Json` reflected over the DTO the first time a body went through it, on the
server and in `Quartz.HttpClient` alike. `HttpApiJsonContext` states them instead — a
`[JsonSerializable]`-annotated `JsonSerializerContext` in `src/Quartz/HttpApiContract/`, listing every
request body, response body and page envelope the API exchanges.

`HttpApiJson.ConfigureWireFormat` is the one place that installs it, which is also the one place that
already installed the converters, so the server (`QuartzJsonOptionsSetup` → the container's
`JsonOptions`), `HttpScheduler` and the endpoint tests all pick it up without a line of their own.

### Resolver order

```
TypeInfoResolverChain = [ HttpApiJsonContext.Default, <whatever the options already had> ]
```

The context goes in front. On the server the options already carry ASP.NET Core's
`DefaultJsonTypeInfoResolver`, so the host's own bodies keep resolving exactly as they did and only get
a generated answer for types the host cannot have. On options that carry no resolver — a bare
`new HttpScheduler(...)` — the reflection resolver is appended first and the context inserted in front
of it, because options with an empty chain fall back to reflection only for as long as the chain stays
empty, and putting the contract in it ends that.

Prepending is idempotent (`SecondRegistrationDoesNotAddTheSameResolverAgain`), matching what
`QuartzHttpApiJsonOptionsTest` already pinned for the converters.

### What stays reflective, and why

`ITrigger`, `ICalendar` and `JobDataMap` are the open half of the contract. The first two are read and
written by converters that consult the scheduler's `SystemTextJsonSerializerRegistry` — which is what
lets a *custom* trigger or calendar type travel at all — and the values inside a job data map are
whatever the application put there, so nothing generated can name them ahead of time.

They are still named in the context, because the generator follows the closure of the bodies that carry
them. What it writes for them is metadata that defers to the converter the options carry
(`TryGetTypeInfoForRuntimeCustomConverter` is the generator's first move for every type), which is how
a generated type treats any converter registered at runtime. `OpenTypesStillGoThroughTheirConverter`
pins that: `options.GetTypeInfo(typeof(ITrigger)).Converter` is Quartz's `TriggerConverter`.

That the generated write path is not used is also deliberate: the context asks for
`JsonSourceGenerationMode.Metadata`. The generated writers bake in the naming and number handling of
the options the context was declared with, and System.Text.Json only takes them when those match the
options in use — which the wire options never do, since they carry Quartz's converters. Metadata mode
keeps the generated source to what is actually reached, and makes it structural rather than lucky that
naming policy, ignore condition and enums-as-names still come from the options.

### The error body moved into the contract

`Quartz.HttpClient` carried a private copy of ASP.NET Core's `ProblemDetails`, pasted from that
repository into `HttpClientExtensions`. It is a body like the others, so it is now
`Quartz.HttpApiContract.ProblemDetailsDto` and generated with the rest. Member names stay explicit
(`type`, `title`, `status`, `detail`, `instance` plus `[JsonExtensionData]`), so the bytes are
unchanged.

## Trim-warning delta

**Zero, in both directions.** `dotnet build src/Quartz/Quartz.csproj` (trim analyzer on) is 0 warnings
before and after, and `dotnet fallout PublishTrimmed` from a deleted publish output is 0 warnings
before and after. Neither `TrimAnalysisBaseline.cs` nor `ILLink.Suppressions.xml` gains or loses an
entry — the contract's reflection was never a warning either tool reported, because it lived in
System.Text.Json's lazy fallback, which nothing reports. Both files' comments are updated to say that
rather than to promise step 4 as future work.

**One thing a reviewer should decide.** Naming a resolver means naming
`DefaultJsonTypeInfoResolver`, whose constructor is `[RequiresUnreferencedCode]`. It sits behind
`JsonSerializer.IsReflectionEnabledByDefault` with an `[UnconditionalSuppressMessage]` on the helper —
the same construction `Microsoft.AspNetCore.Http.Json.JsonOptions` uses for its own default resolver.
Two things make that honest rather than convenient, and both were checked rather than assumed:

- The guard is load-bearing. The trim canary's published `runtimeconfig.json` carries
  `"System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault": false` — the SDK sets it for a
  trimmed publish — so ILLink substitutes the property, drops the branch and never sees the resolver.
  With the attribute downgraded to a plain `[SuppressMessage]` (compile-only, invisible to ILLink), a
  clean `PublishTrimmed` still reported nothing. For contrast: deleting the `Utf8JsonWriterExtensions`
  entry from `ILLink.Suppressions.xml` made the same publish fail with 2×IL2026, so the canary is
  demonstrably watching.
- What it silences, the application is told anyway. Every caller of this helper reaches
  `Utf8JsonWriterExtensions` through `JobDataMapConverter`, and that IL2026 is deliberately *not*
  suppressed for consumers.

The net effect for a trimmed application is strictly better than before: options with no resolver
threw on the first body either way, and now the whole closed contract plus the trigger, calendar and
job-data converters survive.

## No snapshot moved

`git status --porcelain src/Quartz.Tests.AspNetCore/Verify` is empty after the run, and no
`*.received.*` file was produced anywhere. Every `WireFormatSnapshotTest` baseline and both OpenAPI
schema tests pass untouched — which is the point: the generated metadata carries no naming policy or
enum spelling of its own.

## Verification

Run at `9db9509a0`, rebased onto `main` at `b0263ab29`:

```
dotnet build src/Quartz/Quartz.csproj          0 Warning(s)  0 Error(s)
dotnet build Quartz.slnx                       0 Warning(s)  0 Error(s)
dotnet test  Quartz.Tests.Unit                 Passed! - Failed: 0, Passed: 3216, Skipped: 4
dotnet test  Quartz.Tests.AspNetCore           Passed! - Failed: 0, Passed: 427,  Skipped: 0
dotnet fallout PublishTrimmed (output deleted) PublishTrimmed Succeeded, 0 Warning(s)
dotnet fallout VerifyDocsSnippets              Succeeded
npm run docs:check-links                       211 pages, 718 internal links, 413 fragments,
                                               no dead links or anchors
git status --porcelain src/…/Verify            (empty)
```

Each of the three commits was also built on its own; all three are green.

`Quartz.Tests.Integration` was run against the pre-rebase tree with Docker available: 189 passed, 1
failed — `AdoJobStoreSmokeTest.TestSQLite("newtonsoft")`, `GenericJobType.TriggeredCount` 0 rather than
1. That is a timing-sensitive ADO smoke test with the *Newtonsoft* serializer, and the integration
project has no reference to `HttpApiContract` or `HttpScheduler` at all; re-running
`AdoJobStoreSmokeTest.TestSQLite` on its own passes 4/4, so it is a flake under the load of the full
container-backed run rather than anything this branch does.

## Tests

- `WireFormatSourceGenerationTest` (Quartz.Tests.Unit) — reflects over the whole
  `Quartz.HttpApiContract` namespace and asserts each type's `JsonTypeInfo.OriginatingResolver` is
  `HttpApiJsonContext`, so a body added to the API without a `[JsonSerializable]` entry fails rather
  than silently falling back to reflection. Verified to fail as intended by removing one entry. Also
  pins the chain order, that types outside the contract still reach reflection, idempotency, the three
  open types' converters, and one byte-for-byte `SchedulerDto` body.
- `QuartzHttpApiJsonOptionsTest` gains the resolver counterparts of its converter tests.

## Deviations from the brief

- **Step 3 of the brief** asked for the context to be added to
  `JsonOptions.SerializerOptions.TypeInfoResolverChain` inside `AddQuartzHttpApi`. That registration
  already routes through `ConfigureWireFormat` (via `QuartzJsonOptionsSetup`), so doing it there as well
  would insert the context twice — the very thing `QuartzHttpApiJsonOptionsTest` exists to prevent.
  `ConfigureWireFormat` is the single place.
- **`ProblemDetails`** — the brief said "if Quartz owns it". It did not; `Quartz.HttpClient` owned a
  private copy. Moving it into the contract was the smallest way to make the claim "every closed body
  is generated" true, and it is a separate commit so it can be dropped on its own.
- **`options.GetTypeInfo(typeof(ITrigger))`** does not resolve to the *reflection* resolver, because
  `ScheduleJobRequest` carries an `ITrigger` and the generator follows the closure regardless. The test
  asserts the thing that actually matters — that its converter is `TriggerConverter`.
- **Rebased.** The brief's base, `9a549413a`, is 20 commits behind `main` now, and one of them —
  `60ff36bb6 The HTTP API is registered where it takes effect` — removed the `IQuartzBuilder` overload
  of `AddQuartzHttpApi` that the new tests were written against. CI builds the merge commit, so the
  first push failed to compile on that overload alone. The branch is rebased onto `b0263ab29` and the
  two new tests use the current registration shape.

## Left alone deliberately

- `Quartz.AspNetCore`'s `RequestDelegateFactory` warnings are app-level and out of scope; the trim
  analyzer was not enabled there, locally or in this branch.
- The dashboard needed no change: `dashboard-bunit-and-client-removal` has since landed and deleted
  `QuartzApiClient`/`DashboardSerializerOptions`, which were the one pair of wire options built from
  `AddQuartzConverters` rather than `ConfigureWireFormat`. `ConfigureWireFormat` is now the only seam.
