### PR TITLE
The standalone tutorial builds its scheduler in one expression

### DIFF
--- a/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
+++ b/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
@@ -32,10 +32,11 @@ gives you. Every configuration verb is therefore the same verb:
 `AddSchedulerListener<T>`, `AddJobListener<T>`, `AddTriggerListener<T>` — plus the extension methods
 `AddJob<T>`, `AddTrigger<TJob>`, `ScheduleJob<T>` and `AddCalendar`.
 
-Learn the configuration API once and it works in both places. Only three members are the builder's own:
+Learn the configuration API once and it works in both places. Only five members are the builder's own:
 `Build()`, `BuildScheduler()`, `UseConfiguration(IConfiguration)` and the two `UseProperties` overloads.
 
-Every configuration member returns `QuartzSchedulerBuilder`, so the whole thing is one expression:
+Every configuration member returns `QuartzSchedulerBuilder`, and so does every builder extension, so
+the whole thing is one expression whatever is in the chain:
 
 <!-- snippet: sample_standalone_one_expression -->
 ```csharp
@@ -47,9 +48,11 @@ await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
 <!-- endSnippet -->
 
 ::: warning Changed in 4.x
-In the 4.0 previews the configuration members returned `IQuartzBuilder`, so a chain had to be broken up
-and the builder held in a variable to reach `Build()`. The returns are covariant now and
-`Create()…Build()` is one statement.
+In the 4.0 previews a chain had to be broken up and the builder held in a variable to reach `Build()`:
+the configuration members returned `IQuartzBuilder`, and so did the extension methods that add jobs,
+triggers and calendars. The configuration members are covariant now, and every extension is mirrored on
+the builder as an instance method that returns it, so `Create()…Build()` is one statement no matter
+which of them the chain is made of.
 :::
 
 ## Build, or BuildScheduler
@@ -138,28 +141,21 @@ new factory instead. `Standby()` / `Start()` is the pause-and-resume pair.
 
 ## Jobs, triggers and calendars
 
-The `IQuartzBuilder` extension methods work here unchanged:
+The `IQuartzBuilder` extension methods work here unchanged, and chain with the rest:
 
 <!-- snippet: sample_standalone_jobs_triggers_and_calendars -->
 ```csharp
-QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create().UseInMemoryStore();
-
-builder
+await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
+    .UseInMemoryStore()
     .AddJob<ReportJob>(j => j.WithIdentity("nightly", "reports").StoreDurably())
     .AddTrigger<ReportJob>(t => t
         .ForJob("nightly", "reports")
         .WithIdentity("nightly-trigger", "reports")
         .WithCronSchedule("0 30 2 * * ?"))
-    .AddCalendar<HolidayCalendar>("holidays", configure: c => c.AddExcludedDay(new DateOnly(2026, 12, 25)));
-
-await using StandaloneSchedulerFactory factory = builder.Build();
+    .AddCalendar<HolidayCalendar>("holidays", configure: c => c.AddExcludedDay(new DateOnly(2026, 12, 25)))
+    .Build();
 ```
 <!-- endSnippet -->
-
-`AddJob`, `AddTrigger`, `ScheduleJob` and `AddCalendar` are extension methods over `IQuartzBuilder`, and
-they return `IQuartzBuilder` rather than the builder's own type — so `Build()` comes off the variable
-rather than off the end of that chain. The interface's own members are covariant, so a chain made only
-of those still ends in `Build()`.
 
 Jobs declared this way are registered with the container, so they can take constructor dependencies:
 

--- a/src/Quartz.Documentation.Samples/Tutorial/StandaloneSchedulerSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/StandaloneSchedulerSamples.cs
@@ -93,17 +93,15 @@ public static class StandaloneSchedulerSamples
     {
         #region sample_standalone_jobs_triggers_and_calendars
 
-        QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create().UseInMemoryStore();
-
-        builder
+        await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
+            .UseInMemoryStore()
             .AddJob<ReportJob>(j => j.WithIdentity("nightly", "reports").StoreDurably())
             .AddTrigger<ReportJob>(t => t
                 .ForJob("nightly", "reports")
                 .WithIdentity("nightly-trigger", "reports")
                 .WithCronSchedule("0 30 2 * * ?"))
-            .AddCalendar<HolidayCalendar>("holidays", configure: c => c.AddExcludedDay(new DateOnly(2026, 12, 25)));
-
-        await using StandaloneSchedulerFactory factory = builder.Build();
+            .AddCalendar<HolidayCalendar>("holidays", configure: c => c.AddExcludedDay(new DateOnly(2026, 12, 25)))
+            .Build();
 
         #endregion
     }


### PR DESCRIPTION
The standalone tutorial's own promise is that `Create()…Build()` is one expression. Its jobs, triggers
and calendars sample did not keep it: the builder went into a variable and `Build()` came off that,
with a paragraph underneath explaining why it had to. That was true when the page was written —
`AddJob`, `AddTrigger`, `ScheduleJob` and `AddCalendar` are extension methods over `IQuartzBuilder` and
returned the interface — and #3396 made it false by mirroring each of them on `QuartzSchedulerBuilder`
as an instance method that returns the builder.

So:

- **The sample chains.** `sample_standalone_jobs_triggers_and_calendars` in
  `src/Quartz.Documentation.Samples/Tutorial/StandaloneSchedulerSamples.cs` is now
  `await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create().UseInMemoryStore().AddJob<ReportJob>(…).AddTrigger<ReportJob>(…).AddCalendar<HolidayCalendar>(…).Build();`,
  regenerated into the page with `dotnet fallout DocsSnippets`. It is a compiled sample, so the page is
  claiming something the compiler agrees with.
- **The paragraph explaining why `Build()` came off a variable is deleted.** There is nothing left for
  it to say.
- **The "Changed in 4.x" warning is true again.** It said the configuration members used to return
  `IQuartzBuilder` and are covariant now; it now also says the extensions were the other half of that
  problem and are mirrored on the builder, so the chain keeps its type whatever it is made of. The
  lead-in above the one-expression sample says the same in one line.

Follow-up to #3396, on a page that came from #3357.

## Verification

```
dotnet build Quartz.slnx            Build succeeded. 0 Warning(s) 0 Error(s)
dotnet fallout DocsSnippets         Updated docs\documentation\quartz-4.x	utorial\standalone-scheduler.md
dotnet fallout VerifyDocsSnippets   Documentation snippets are up to date (89 markdown files checked)
npm run docs:check-links            docs: 211 pages, 718 internal links, 413 fragments — no dead links or anchors
```

Two files changed, no BOMs (`head -c3` reads `---` and `usi`).

## Also here

Two lines above the warning the page said "Only three members are the builder's own" and then listed
five — `Build()`, `BuildScheduler()`, `UseConfiguration(IConfiguration)` and the two `UseProperties`
overloads. The list is right, so the count is five now. Those five really are the whole of it:
`QuartzSchedulerBuilder` declares nothing else of its own beyond the static `Create()` that hands you
one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
