### PR TITLE
A listener with a stale signature is refused where it is registered

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2041,6 +2041,12 @@ public async ValueTask Execute(IJobExecutionContext context, CancellationToken c
 `Execute` also gained a `CancellationToken`. See [Jobs take a CancellationToken](#jobs-take-a-cancellationtoken)
 below for why, and for what to do with it.
 
+Listeners are the one place where a missed `Task` → `ValueTask` does not fail the build. Every member of
+`IJobListener`, `ITriggerListener` and `ISchedulerListener` has a default implementation, so a 3.x signature
+still compiles and simply stops implementing anything — the default runs, and the method is never called.
+Quartz refuses a listener in that shape when it is registered, naming the member; see
+[The compiler will not point at the callbacks you have to change, but the registration will](#the-compiler-will-not-point-at-the-callbacks-you-have-to-change-but-the-registration-will).
+
 ::: warning
 The following operations should never be performed on a `ValueTask<TResult>` instance:
 
@@ -3114,17 +3120,44 @@ your own can report the trigger it failed for:
 + ValueTask NotifySchedulerListenersError(SchedulerErrorContext errorContext, CancellationToken cancellationToken = default);
 ```
 
-#### The compiler will not point at every callback you have to change
+#### The compiler will not point at the callbacks you have to change, but the registration will
 
 Every member of these interfaces has a default implementation, which is what lets a listener implement only
 the notifications it cares about — and it is also why a listener that keeps an old signature still compiles.
 It simply stops being an implementation of anything: the default runs instead, and the method becomes dead
 code that is never called.
 
-So the build will not fail. Search your listeners for the twenty-four names in the table below rather than
-waiting to be told, and note that `#pragma`-free hints do exist: a callback that no longer overrides
-anything and does not touch instance state trips CA1822 ("can be marked as static"), and an
-`<inheritdoc />` on it trips MA0196. Both fired on Quartz's own listeners while this change was made.
+So the build does not fail. Registering the listener does. Quartz reads the shape of a listener as it is
+registered and refuses one that carries a public method with a notification's name but not its signature,
+naming both signatures in a `SchedulerConfigException` (#3398):
+
+```text
+MyListener declares 'ValueTask SchedulerError(String, SchedulerException, CancellationToken)', which does
+not implement ISchedulerListener.SchedulerError. The interface member is
+'ValueTask SchedulerError(IScheduler, SchedulerErrorContext, CancellationToken)': the names match but the
+signatures do not, and every member of ISchedulerListener has a default implementation, so this compiles
+and the default runs instead. The scheduler never calls SchedulerError. Listener callbacks take
+IScheduler scheduler first since 4.0.0-alpha.2. Correct the signature, or rename the method if it is not
+meant to be that notification. See
+https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html#listeners-are-told-which-scheduler-is-calling.
+```
+
+Where that lands depends on how the listener was registered. `q.AddJobListener<MyListener>()` and the
+instance overload throw from the `AddQuartz` call itself, since the listener's type is known while the
+configuration is still being written. Everything else — a factory overload declared as the interface, a
+listener registered as a plain service, a `quartz.jobListener.*` key, and
+`scheduler.ListenerManager.AddJobListener(…)` — throws when the listener is attached to a scheduler, which
+for a hosted application is host start.
+
+A method that deliberately overloads a notification's name for an unrelated purpose is refused as well.
+Rename it: the alternative is letting the far commoner stale signature through in silence. A listener that
+implements the interface explicitly is never examined, because an explicit implementation is not a public
+method of the class.
+
+The table below is the whole list of what moved. The compile-time hints are worth knowing too: a callback
+that no longer overrides anything and does not touch instance state trips CA1822 ("can be marked as
+static"), and an `<inheritdoc />` on it trips MA0196. Both fired on Quartz's own listeners while this change
+was made.
 
 #### Every signature that changed
 
@@ -3185,6 +3218,12 @@ Implement the interface instead, and drop `override`:
 
 `Name` can go: it defaults to the type's name. Keep it only when several instances of one type are registered
 with the same scheduler, since the later registration would otherwise replace the earlier one.
+
+A listener that derived from one of these base classes fails to compile, which is the outcome you want. A 3.x
+listener that implemented the interface directly has the silent version of the same problem: its `Task`-returning
+members compile against 4.x and implement nothing. Quartz refuses such a listener when it is registered and
+names the member — see
+[The compiler will not point at the callbacks you have to change, but the registration will](#the-compiler-will-not-point-at-the-callbacks-you-have-to-change-but-the-registration-will).
 
 One consequence is easy to miss: **a default interface member is not a class member**. Code that reads `Name`
 off the concrete type no longer compiles unless the listener declares `Name` itself, so read it through the
@@ -3425,7 +3464,7 @@ already have them.
 * **`TriggerState.Executing`** — tell whether a trigger's job is running, across the whole cluster (see [Executing is a trigger state](#executing-is-a-trigger-state))
 * **`JobInstantiationException`** — a job that could not be built names the trigger, the job and the fire instance instead of only interpolating the job key into a message (see [Instantiation failures name the trigger](#instantiation-failures-name-the-trigger))
 * **`ISchedulerListener.TriggerInError` / `TriggersInError`** — observe a trigger being moved to `TriggerState.Error`, including two ADO store transitions that reached nothing at all before (see [Triggers entering the error state are reported](#triggers-entering-the-error-state-are-reported))
-* **Every listener callback names its scheduler** — one listener can serve several schedulers in one host and still say which of them paused a trigger or failed, and `SchedulerError` carries the trigger, job and firing it was raised for (see [Listeners are told which scheduler is calling](#listeners-are-told-which-scheduler-is-calling))
+* **Every listener callback names its scheduler** — one listener can serve several schedulers in one host and still say which of them paused a trigger or failed, and `SchedulerError` carries the trigger, job and firing it was raised for. A listener still carrying a signature from 3.x or from alpha.1 is refused when it is registered, with a message naming the member, rather than being attached and never called (see [Listeners are told which scheduler is calling](#listeners-are-told-which-scheduler-is-calling))
 * **Joining a transaction the application owns** — the ADO job store can take part in a transaction you started, so saving your own data and scheduling the job that acts on it commit together or not at all. Turn it on with `store.Configure(o => o.AcceptEnlistedTransactions = true)`, `JobStore:AcceptEnlistedTransactions`, or `quartz.jobStore.acceptEnlistedTransactions`, then hand the store a connection for the duration of a scope with `IScheduler.EnlistTransaction` / `EnlistConnection`. Handing over a connection is the only way to take part: a connection the job store opens for itself is deliberately kept out of any ambient `TransactionScope`, since a second connection in that transaction would require promoting it to a distributed one. See [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction)
 * **Builder methods for three more plugins** — `UseJobHistoryLogging()`, `UseTriggerHistoryLogging()` and `UseShutdownHook()`. Only the structured-logging variants had one, so the classic history plugins and the shutdown hook could previously be reached only through `quartz.plugin.*` property keys
 * **An `IJobDetail` of your own** — the interface no longer declares a member only Quartz can implement, so an application can supply its own job detail type and have `RAMJobStore` hand it back rather than quietly swapping it for Quartz's (see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own))

--- a/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
+++ b/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
@@ -84,6 +84,13 @@ Every member of both interfaces has a default implementation — the notificatio
 the type's name — so implement only the events you're interested in, and only declare `Name` when you register
 several instances of one type with the same scheduler.
 
+::: warning
+The price of those defaults is that a method whose *signature* does not match the interface's is not a
+compile error. It simply stops implementing anything, and the default runs in its place — the method is
+never called. Quartz refuses a listener in that shape when it is registered, naming the method and the
+signature it should have, rather than attaching one that will be silent.
+:::
+
 Listeners are registered with the scheduler's `ListenerManager` along with a Matcher that describes which Jobs/Triggers the listener wants to receive events for.
 
 ::: tip

--- a/src/Quartz.Tests.Unit/Core/ListenerShapeTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ListenerShapeTest.cs
@@ -1,0 +1,358 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Core;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// Guards the refusal of a listener whose public method has a notification's name but not its signature.
+/// </summary>
+/// <remarks>
+/// Every listener member has a default implementation, so a stale signature is not a compile error: the
+/// method stops implementing anything, the default runs, and the listener is silently never called. The
+/// cases below are the two migrations that produce that shape — a 3.x listener returning
+/// <see cref="Task" />, and a 4.0.0-alpha.1 listener whose callbacks do not lead with the scheduler — plus
+/// the shapes that must keep working, since a check that refuses a sound listener is worse than no check.
+/// </remarks>
+public class ListenerShapeTest
+{
+    private ListenerManagerImpl manager;
+
+    [SetUp]
+    public void SetUp()
+    {
+        manager = new ListenerManagerImpl();
+    }
+
+    [Test]
+    public void AJobListenerWithTheCurrentShapeIsAccepted()
+    {
+        Action act = () => manager.AddJobListener(new SoundJobListener());
+
+        act.Should().NotThrow("a listener whose members implement the interface is what the check is for");
+        manager.GetJobListeners().Should().ContainSingle();
+    }
+
+    [Test]
+    public void ATriggerListenerWithTheCurrentShapeIsAccepted()
+    {
+        Action act = () => manager.AddTriggerListener(new SoundTriggerListener());
+
+        act.Should().NotThrow(
+            "TriggerMisfired leads with the scheduler and TriggerFired does not, and both are implemented here");
+        manager.GetTriggerListeners().Should().ContainSingle();
+    }
+
+    [Test]
+    public void ASchedulerListenerWithTheCurrentShapeIsAccepted()
+    {
+        Action act = () => manager.AddSchedulerListener(new SoundSchedulerListener());
+
+        act.Should().NotThrow(
+            "SchedulerError takes the scheduler and a SchedulerErrorContext here, which is the 4.0.0-alpha.2 shape");
+        manager.GetSchedulerListeners().Should().ContainSingle();
+    }
+
+    [Test]
+    public void AListenerThatLeavesEveryNotificationToItsDefaultIsAccepted()
+    {
+        Action act = () => manager.AddJobListener(new SilentJobListener());
+
+        act.Should().NotThrow(
+            "implementing only the notifications you care about is the whole point of the default members");
+    }
+
+    [Test]
+    public void AMethodWhoseNameIsNotANotificationIsLeftAlone()
+    {
+        Action act = () => manager.AddJobListener(new HelpfulJobListener());
+
+        act.Should().NotThrow("a listener's own methods are its own business");
+    }
+
+    [Test]
+    public void AnExplicitImplementationIsAccepted()
+    {
+        Action act = () => manager.AddSchedulerListener(new ExplicitSchedulerListener());
+
+        act.Should().NotThrow(
+            "an explicit implementation is not a public method of the class, so there is nothing to mistake it for");
+    }
+
+    [Test]
+    public void AListenerInheritingItsNotificationsIsAccepted()
+    {
+        Action act = () => manager.AddJobListener(new InheritingJobListener());
+
+        act.Should().NotThrow(
+            "a notification implemented on a base class implements it for every listener that derives from it");
+    }
+
+    [Test]
+    public void AStaleMemberInheritedFromABaseIsRefused()
+    {
+        Action act = () => manager.AddJobListener(new InheritsAThreeXBase());
+
+        act.Should().Throw<SchedulerConfigException>(
+            "where the dead method was written does not change that it is dead")
+            .Which.Message.Should().Contain(nameof(IJobListener.JobToBeExecuted));
+    }
+
+    [Test]
+    public void AThreeXJobListenerIsRefusedAndToldAboutValueTask()
+    {
+        Action act = () => manager.AddJobListener(new ThreeXJobListener());
+
+        act.Should().Throw<SchedulerConfigException>()
+            .Which.Message.Should()
+            .Contain(nameof(IJobListener.JobToBeExecuted), "the refusal is worth nothing unless it names the dead member")
+            .And.Contain(nameof(ThreeXJobListener), "and the listener that carries it")
+            .And.Contain("return ValueTask rather than Task", "which is what a 3.x listener has to change");
+    }
+
+    [Test]
+    public void AThreeXTriggerListenerIsRefusedAndToldAboutValueTask()
+    {
+        Action act = () => manager.AddTriggerListener(new ThreeXTriggerListener());
+
+        act.Should().Throw<SchedulerConfigException>()
+            .Which.Message.Should()
+            .Contain(nameof(ITriggerListener.VetoJobExecution))
+            .And.Contain("return ValueTask rather than Task");
+    }
+
+    [Test]
+    public void AThreeXSchedulerListenerIsRefusedAndToldAboutValueTask()
+    {
+        Action act = () => manager.AddSchedulerListener(new ThreeXSchedulerListener());
+
+        act.Should().Throw<SchedulerConfigException>()
+            .Which.Message.Should()
+            .Contain(nameof(ISchedulerListener.SchedulerStarted))
+            .And.Contain("return ValueTask rather than Task");
+    }
+
+    [Test]
+    public void AnAlphaOneSchedulerErrorIsRefusedAndToldAboutTheScheduler()
+    {
+        Action act = () => manager.AddSchedulerListener(new AlphaOneSchedulerErrorListener());
+
+        act.Should().Throw<SchedulerConfigException>()
+            .Which.Message.Should()
+            .Contain("SchedulerError(String, SchedulerException, CancellationToken)",
+                "the signature that was written is how the reader finds the method")
+            .And.Contain("SchedulerError(IScheduler, SchedulerErrorContext, CancellationToken)",
+                "and the signature it has to become is the fix")
+            .And.Contain("take IScheduler scheduler first since 4.0.0-alpha.2");
+    }
+
+    [Test]
+    public void AnAlphaOneLifecycleCallbackIsRefusedAndToldAboutTheScheduler()
+    {
+        Action act = () => manager.AddSchedulerListener(new AlphaOneLifecycleListener());
+
+        act.Should().Throw<SchedulerConfigException>()
+            .Which.Message.Should()
+            .Contain(nameof(ISchedulerListener.SchedulerShuttingDown))
+            .And.Contain("take IScheduler scheduler first since 4.0.0-alpha.2");
+    }
+
+    [Test]
+    public void AnAlphaOneTriggerMisfiredIsRefusedAndToldAboutTheScheduler()
+    {
+        Action act = () => manager.AddTriggerListener(new AlphaOneTriggerListener());
+
+        act.Should().Throw<SchedulerConfigException>()
+            .Which.Message.Should()
+            .Contain(nameof(ITriggerListener.TriggerMisfired))
+            .And.Contain("take IScheduler scheduler first since 4.0.0-alpha.2",
+                "TriggerMisfired is the one trigger callback that gained the scheduler");
+    }
+
+    [Test]
+    public void ARefusalPointsAtTheMigrationGuide()
+    {
+        Action act = () => manager.AddSchedulerListener(new AlphaOneLifecycleListener());
+
+        act.Should().Throw<SchedulerConfigException>()
+            .Which.Message.Should()
+            .Contain("migration-guide.html#listeners-are-told-which-scheduler-is-calling",
+                "a reader who has never heard of this change needs somewhere to go");
+    }
+
+    [Test]
+    public void ARefusalIsRepeatedForEveryRegistration()
+    {
+        Action act = () => manager.AddJobListener(new ThreeXJobListener());
+
+        act.Should().Throw<SchedulerConfigException>();
+        act.Should().Throw<SchedulerConfigException>(
+            "the answer is remembered only for a listener that passed, so a second registration is refused too");
+    }
+
+    [Test]
+    public void AListenerRegisteredByTypeIsRefusedWhereItIsWritten()
+    {
+        Action act = () => new ServiceCollection().AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.InstanceName = "listener-shape-by-type");
+            q.AddJobListener<ThreeXJobListener>();
+        });
+
+        act.Should().Throw<SchedulerConfigException>(
+            "the type is known while the application is still writing its configuration, which is the earliest anyone can be told")
+            .Which.Message.Should().Contain(nameof(IJobListener.JobToBeExecuted));
+    }
+
+    [Test]
+    public void AListenerRegisteredByInstanceIsRefusedWhereItIsWritten()
+    {
+        Action act = () => new ServiceCollection().AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.InstanceName = "listener-shape-by-instance");
+            q.AddSchedulerListener(new AlphaOneSchedulerErrorListener());
+        });
+
+        act.Should().Throw<SchedulerConfigException>()
+            .Which.Message.Should().Contain("take IScheduler scheduler first since 4.0.0-alpha.2");
+    }
+
+    [Test]
+    public async Task AListenerRegisteredByFactoryIsRefusedWhenTheSchedulerIsBuilt()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.InstanceName = "listener-shape-by-factory");
+
+            // Declared as the interface, so the registration names no methods to check: what the factory
+            // produces is not known until there is a scheduler to attach it to.
+            q.AddJobListener<IJobListener>(_ => new ThreeXJobListener());
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        Func<Task> act = async () => await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        (await act.Should().ThrowAsync<SchedulerConfigException>(
+            "a listener whose type only the factory knows is still refused, at the moment it is attached"))
+            .Which.Message.Should().Contain(nameof(IJobListener.JobToBeExecuted));
+    }
+
+    [Test]
+    public async Task ASoundListenerRegistersThroughTheContainer()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options => options.InstanceName = "listener-shape-sound");
+            q.AddJobListener<SoundJobListener>();
+            q.AddTriggerListener<SoundTriggerListener>();
+            q.AddSchedulerListener<SoundSchedulerListener>();
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        try
+        {
+            scheduler.ListenerManager.GetJobListeners().Should().ContainSingle();
+            scheduler.ListenerManager.GetTriggerListeners().Should().ContainSingle();
+            scheduler.ListenerManager.GetSchedulerListeners().Should().ContainSingle(
+                "the check must let through every listener that does implement the interface");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    private sealed class SoundJobListener : IJobListener
+    {
+        public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException jobException, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class SilentJobListener : IJobListener;
+
+    private sealed class HelpfulJobListener : IJobListener
+    {
+        public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+
+        public Task Flush() => Task.CompletedTask;
+    }
+
+    private sealed class InheritingJobListener : SoundJobListenerBase;
+
+    private class SoundJobListenerBase : IJobListener
+    {
+        public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// A 3.x job listener: it implemented the interface directly, and the members returned <see cref="Task" />.
+    /// </summary>
+    private sealed class ThreeXJobListener : IJobListener
+    {
+        public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class InheritsAThreeXBase : ThreeXJobListenerBase;
+
+    private class ThreeXJobListenerBase : IJobListener
+    {
+        public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class SoundTriggerListener : ITriggerListener
+    {
+        public ValueTask TriggerFired(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class ThreeXTriggerListener : ITriggerListener
+    {
+        public Task<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default) => Task.FromResult(false);
+    }
+
+    /// <summary>
+    /// A 4.0.0-alpha.1 trigger listener: <c>TriggerMisfired</c> is the one trigger callback that gained the
+    /// scheduler, because a misfire is noticed rather than executed.
+    /// </summary>
+    private sealed class AlphaOneTriggerListener : ITriggerListener
+    {
+        public ValueTask TriggerMisfired(ITrigger trigger, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class SoundSchedulerListener : ISchedulerListener
+    {
+        public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
+
+        public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class ExplicitSchedulerListener : ISchedulerListener
+    {
+        ValueTask ISchedulerListener.SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken) => default;
+    }
+
+    private sealed class ThreeXSchedulerListener : ISchedulerListener
+    {
+        public Task SchedulerStarted(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// A 4.0.0-alpha.1 scheduler listener: the error arrived as a message and an exception rather than as a
+    /// <see cref="SchedulerErrorContext" />, and nothing said which scheduler had failed.
+    /// </summary>
+    private sealed class AlphaOneSchedulerErrorListener : ISchedulerListener
+    {
+        public ValueTask SchedulerError(string message, SchedulerException cause, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class AlphaOneLifecycleListener : ISchedulerListener
+    {
+        public ValueTask SchedulerShuttingDown(CancellationToken cancellationToken = default) => default;
+    }
+}

--- a/src/Quartz/Configuration/IQuartzBuilder.cs
+++ b/src/Quartz/Configuration/IQuartzBuilder.cs
@@ -335,30 +335,58 @@ public interface IQuartzBuilder
         where T : class, ISchedulerPlugin
         where TOptions : class;
 
+    /// <summary>
+    /// Adds a scheduler listener the container builds.
+    /// </summary>
+    /// <remarks>
+    /// The listener's shape is checked here, while the application is still writing its configuration.
+    /// Every member of <see cref="ISchedulerListener" />, <see cref="IJobListener" /> and
+    /// <see cref="ITriggerListener" /> has a default implementation, so a public method that carries a
+    /// notification's name but not its signature still compiles — it just stops implementing anything,
+    /// and the default runs in its place with nothing to say the method is dead. Such a listener is
+    /// refused with a <see cref="SchedulerConfigException" /> naming the member and the signature it
+    /// should have.
+    /// <para>
+    /// What is examined is <typeparamref name="T" />: for an instance overload that is the type the call
+    /// was written with rather than the instance's own, so a listener handed over as its base type is
+    /// checked as that base, and a factory overload declared as the interface has nothing to examine at
+    /// all. Neither escapes — the listener's runtime type is checked again when it is attached to a
+    /// scheduler, which is only a later moment to hear about it.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The listener's type.</typeparam>
     IQuartzBuilder AddSchedulerListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>()
         where T : class, ISchedulerListener;
 
+    /// <inheritdoc cref="AddSchedulerListener{T}()" path="/remarks" />
     IQuartzBuilder AddSchedulerListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         T listener) where T : class, ISchedulerListener;
 
+    /// <inheritdoc cref="AddSchedulerListener{T}()" path="/remarks" />
     IQuartzBuilder AddSchedulerListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         Func<IServiceProvider, T> factory) where T : class, ISchedulerListener;
 
+    /// <inheritdoc cref="AddSchedulerListener{T}()" path="/remarks" />
     IQuartzBuilder AddJobListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         params IReadOnlyCollection<IMatcher<JobKey>> matchers) where T : class, IJobListener;
 
+    /// <inheritdoc cref="AddSchedulerListener{T}()" path="/remarks" />
     IQuartzBuilder AddJobListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         T listener, params IReadOnlyCollection<IMatcher<JobKey>> matchers) where T : class, IJobListener;
 
+    /// <inheritdoc cref="AddSchedulerListener{T}()" path="/remarks" />
     IQuartzBuilder AddJobListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         Func<IServiceProvider, T> factory, params IReadOnlyCollection<IMatcher<JobKey>> matchers) where T : class, IJobListener;
 
+    /// <inheritdoc cref="AddSchedulerListener{T}()" path="/remarks" />
     IQuartzBuilder AddTriggerListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         params IReadOnlyCollection<IMatcher<TriggerKey>> matchers) where T : class, ITriggerListener;
 
+    /// <inheritdoc cref="AddSchedulerListener{T}()" path="/remarks" />
     IQuartzBuilder AddTriggerListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         T listener, params IReadOnlyCollection<IMatcher<TriggerKey>> matchers) where T : class, ITriggerListener;
 
+    /// <inheritdoc cref="AddSchedulerListener{T}()" path="/remarks" />
     IQuartzBuilder AddTriggerListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         Func<IServiceProvider, T> factory, params IReadOnlyCollection<IMatcher<TriggerKey>> matchers) where T : class, ITriggerListener;
 

--- a/src/Quartz/Configuration/ListenerRegistration.cs
+++ b/src/Quartz/Configuration/ListenerRegistration.cs
@@ -2,6 +2,8 @@ using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Extensions.DependencyInjection;
 
+using Quartz.Core;
+
 namespace Quartz.Configuration;
 
 /// <summary>
@@ -20,7 +22,9 @@ namespace Quartz.Configuration;
 /// own, the same way its job store and thread pool are.
 /// </para>
 /// </remarks>
-internal abstract class ListenerRegistration<TListener> where TListener : class
+internal abstract class ListenerRegistration<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] TListener>
+    where TListener : class
 {
     private readonly Func<IServiceProvider, TListener>? listenerFactory;
     private readonly TListener? listenerInstance;
@@ -31,6 +35,12 @@ internal abstract class ListenerRegistration<TListener> where TListener : class
         Func<IServiceProvider, TListener>? listenerFactory,
         TListener? listenerInstance)
     {
+        // Said while the application is still writing its configuration, which is the earliest moment
+        // the listener's type is known. A factory overload is checked here too, but only against the
+        // type it was declared with; whatever it actually produces is checked when it reaches the
+        // listener manager, at the latest.
+        ListenerShape.Verify(listenerType, typeof(TListener));
+
         ListenerType = listenerType;
         this.listenerFactory = listenerFactory;
         this.listenerInstance = listenerInstance;

--- a/src/Quartz/Core/ListenerManagerImpl.cs
+++ b/src/Quartz/Core/ListenerManagerImpl.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Quartz.Core;
 
 /// <summary>
@@ -22,6 +24,8 @@ internal sealed class ListenerManagerImpl : IListenerManager
         {
             Throw.ArgumentNullException(nameof(jobListener));
         }
+
+        VerifyShape(jobListener, typeof(IJobListener));
 
         if (string.IsNullOrEmpty(jobListener.Name))
         {
@@ -251,6 +255,8 @@ internal sealed class ListenerManagerImpl : IListenerManager
         {
             Throw.ArgumentNullException(nameof(triggerListener));
         }
+
+        VerifyShape(triggerListener, typeof(ITriggerListener));
 
         if (string.IsNullOrEmpty(triggerListener.Name))
         {
@@ -483,6 +489,8 @@ internal sealed class ListenerManagerImpl : IListenerManager
             Throw.ArgumentNullException(nameof(schedulerListener));
         }
 
+        VerifyShape(schedulerListener, typeof(ISchedulerListener));
+
         if (string.IsNullOrEmpty(schedulerListener.Name))
         {
             Throw.ArgumentException($"{nameof(schedulerListener.Name)} cannot be null or empty.", nameof(schedulerListener));
@@ -556,6 +564,25 @@ internal sealed class ListenerManagerImpl : IListenerManager
 
             return schedulerListener;
         }
+    }
+
+    /// <summary>
+    /// Refuses a listener whose public methods say it implements a notification it does not.
+    /// </summary>
+    /// <remarks>
+    /// This is the last gate every listener passes through, whatever registered it: the builder, a plain
+    /// service registration, a <c>quartz.*Listener.*</c> key, a plugin, or an application calling
+    /// <see cref="IListenerManager" /> itself. A listener the builder registered by type or by instance
+    /// was already refused at registration, which is the better moment to hear about it;
+    /// <see cref="ListenerShape" /> remembers the types it has passed, so arriving here twice costs a
+    /// dictionary lookup.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "The methods read are the public methods of a listener the application constructed and handed over, so the type is rooted. Trimming can only take away a member nothing calls, which is exactly the stale member being looked for: the check can then find nothing, never the wrong thing. The registration paths that do know the type statically annotate it and keep those members.")]
+    private static void VerifyShape(
+        object listener,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type listenerInterface)
+    {
+        ListenerShape.Verify(listener.GetType(), listenerInterface);
     }
 
     private void RemoveJobListenerMatchers(string listenerName)

--- a/src/Quartz/Core/ListenerShape.cs
+++ b/src/Quartz/Core/ListenerShape.cs
@@ -1,0 +1,230 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text;
+
+namespace Quartz.Core;
+
+/// <summary>
+/// Refuses a listener that carries a public method with a notification's name but not its signature.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every member of <see cref="IJobListener" />, <see cref="ITriggerListener" /> and
+/// <see cref="ISchedulerListener" /> has a default implementation, which is what lets a listener write
+/// only the notifications it cares about. The price is that a member with the wrong signature is not a
+/// compile error: it simply stops being an implementation of anything. The default body runs instead,
+/// and the method becomes dead code the scheduler never calls. Two migrations produce exactly that
+/// shape — a 3.x listener whose members return <see cref="Task" />, and a 4.0.0-alpha.1 listener whose
+/// callbacks do not take the scheduler first — and nothing in the build names the dead member.
+/// </para>
+/// <para>
+/// So the shape is checked once, where the listener is registered, and a method whose name matches a
+/// notification but which does not implement it is refused by name and by signature.
+/// </para>
+/// <para>
+/// A method that deliberately overloads a notification's name for an unrelated purpose is refused too.
+/// That is accepted: it is a rare thing to write, a rename settles it, and the alternative is letting
+/// the far commoner stale signature through in silence. Explicit interface implementations are not
+/// public methods of the class, so a listener that implements the interface explicitly is never
+/// examined and never refused.
+/// </para>
+/// </remarks>
+internal static class ListenerShape
+{
+    private const string MigrationGuide = "https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html";
+
+    /// <summary>
+    /// What <see cref="Type.GetInterfaceMap" /> asks of the interface it is given. Only the three listener
+    /// interfaces are ever passed, each as a <c>typeof</c> of a type this assembly declares, so nothing has
+    /// to be kept that would not be kept anyway.
+    /// </summary>
+    private const DynamicallyAccessedMemberTypes ListenerInterfaceMembers =
+        DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
+
+    /// <summary>
+    /// The pairs already found sound. A listener registered through the container is checked where it is
+    /// registered and again when it reaches the listener manager, and a host with many schedulers
+    /// registers the same listener type once per scheduler; the shape of a type does not change between
+    /// those moments, so it is worked out once.
+    /// </summary>
+    private static readonly ConcurrentDictionary<(Type ListenerType, Type ListenerInterface), bool> verified = new();
+
+    /// <summary>
+    /// Refuses <paramref name="listenerType" /> if it shadows a member of <paramref name="listenerInterface" />.
+    /// </summary>
+    /// <param name="listenerType">
+    /// The listener's type. For a registration made by type or by instance this is the type the
+    /// application named, which is the one whose methods it wrote.
+    /// </param>
+    /// <param name="listenerInterface">
+    /// <see cref="IJobListener" />, <see cref="ITriggerListener" /> or <see cref="ISchedulerListener" />.
+    /// </param>
+    /// <exception cref="SchedulerConfigException">
+    /// A public instance method of <paramref name="listenerType" /> has an interface member's name but
+    /// does not implement it.
+    /// </exception>
+    public static void Verify(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type listenerType,
+        [DynamicallyAccessedMembers(ListenerInterfaceMembers)] Type listenerInterface)
+    {
+        // A registration naming an interface or a type that is not a listener of this kind - which
+        // AddJobListener<IJobListener>(factory) is - describes no methods to check. What the factory
+        // actually produces is checked when it reaches the listener manager.
+        if (listenerType.IsInterface || !listenerInterface.IsAssignableFrom(listenerType))
+        {
+            return;
+        }
+
+        if (verified.ContainsKey((listenerType, listenerInterface)))
+        {
+            return;
+        }
+
+        Check(listenerType, listenerInterface);
+        verified[(listenerType, listenerInterface)] = true;
+    }
+
+    private static void Check(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type listenerType,
+        [DynamicallyAccessedMembers(ListenerInterfaceMembers)] Type listenerInterface)
+    {
+        InterfaceMapping mapping = listenerType.GetInterfaceMap(listenerInterface);
+
+        // The methods that really do implement the interface. A notification the listener leaves to its
+        // default maps to the interface's own method, which is never a member of the listener class, so
+        // nothing the loop below looks at can match it by accident.
+        HashSet<MethodInfo> implementing = new(mapping.TargetMethods);
+
+        foreach (MethodInfo method in listenerType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (implementing.Contains(method))
+            {
+                continue;
+            }
+
+            MethodInfo? shadowed = Array.Find(
+                mapping.InterfaceMethods,
+                candidate => string.Equals(candidate.Name, method.Name, StringComparison.Ordinal));
+
+            if (shadowed is null)
+            {
+                continue;
+            }
+
+            Throw.SchedulerConfigException(Describe(listenerType, listenerInterface, method, shadowed));
+        }
+    }
+
+    private static string Describe(Type listenerType, Type listenerInterface, MethodInfo method, MethodInfo shadowed)
+    {
+        StringBuilder message = new();
+        message.Append(listenerType)
+            .Append(" declares '")
+            .Append(Signature(method))
+            .Append("', which does not implement ")
+            .Append(listenerInterface.Name)
+            .Append('.')
+            .Append(shadowed.Name)
+            .Append(". The interface member is '")
+            .Append(Signature(shadowed))
+            .Append("': the names match but the signatures do not, and every member of ")
+            .Append(listenerInterface.Name)
+            .Append(" has a default implementation, so this compiles and the default runs instead. The scheduler never calls ")
+            .Append(method.Name)
+            .Append(". ");
+
+        string? section = null;
+
+        if (ReturnsTask(method))
+        {
+            message.Append("Listener members return ValueTask rather than Task since 4.0. ");
+            section = "#tasks-changed-to-valuetask";
+        }
+
+        if (MissesTheScheduler(method, shadowed))
+        {
+            message.Append("Listener callbacks take IScheduler scheduler first since 4.0.0-alpha.2. ");
+            section ??= "#listeners-are-told-which-scheduler-is-calling";
+        }
+
+        message.Append("Correct the signature, or rename the method if it is not meant to be that notification. See ")
+            .Append(MigrationGuide)
+            .Append(section)
+            .Append('.');
+
+        return message.ToString();
+    }
+
+    /// <summary>
+    /// Whether the method has the return type a 3.x listener had.
+    /// </summary>
+    private static bool ReturnsTask(MethodInfo method)
+    {
+        Type returnType = method.ReturnType;
+        return returnType == typeof(Task)
+            || (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>));
+    }
+
+    /// <summary>
+    /// Whether the notification leads with the scheduler and the method does not, which is the shape a
+    /// listener written against 4.0.0-alpha.1 has.
+    /// </summary>
+    private static bool MissesTheScheduler(MethodInfo method, MethodInfo shadowed)
+    {
+        ParameterInfo[] expected = shadowed.GetParameters();
+        if (expected.Length == 0 || expected[0].ParameterType != typeof(IScheduler))
+        {
+            return false;
+        }
+
+        ParameterInfo[] actual = method.GetParameters();
+        return actual.Length == 0 || actual[0].ParameterType != typeof(IScheduler);
+    }
+
+    private static string Signature(MethodInfo method)
+    {
+        StringBuilder signature = new();
+        signature.Append(TypeName(method.ReturnType)).Append(' ').Append(method.Name).Append('(');
+
+        ParameterInfo[] parameters = method.GetParameters();
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                signature.Append(", ");
+            }
+
+            signature.Append(TypeName(parameters[i].ParameterType));
+        }
+
+        return signature.Append(')').ToString();
+    }
+
+    private static string TypeName(Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            return type.Name;
+        }
+
+        string name = type.Name;
+        int arity = name.IndexOf('`', StringComparison.Ordinal);
+
+        StringBuilder formatted = new();
+        formatted.Append(arity < 0 ? name : name[..arity]).Append('<');
+
+        Type[] arguments = type.GetGenericArguments();
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            if (i > 0)
+            {
+                formatted.Append(", ");
+            }
+
+            formatted.Append(TypeName(arguments[i]));
+        }
+
+        return formatted.Append('>').ToString();
+    }
+}

--- a/src/Quartz/IListenerManager.cs
+++ b/src/Quartz/IListenerManager.cs
@@ -54,7 +54,18 @@ public interface IListenerManager
     /// If a <see cref="IJobListener" /> with the same name is already registered, that listener
     /// and the associated matchers will be replaced.
     /// </para>
+    /// <para>
+    /// The listener's shape is checked as it is added. Every member of <see cref="IJobListener" /> has a
+    /// default implementation, so a public method carrying a notification's name but not its signature
+    /// still compiles — it just stops implementing anything, and the default runs in its place with
+    /// nothing to say the method is dead. Such a listener is refused rather than attached and never
+    /// called.
+    /// </para>
     /// </remarks>
+    /// <exception cref="SchedulerConfigException">
+    /// <paramref name="jobListener" /> has a public method with an <see cref="IJobListener" /> member's
+    /// name but not its signature, so that member is not implemented.
+    /// </exception>
     /// <seealso cref="IMatcher{T}" />
     /// <seealso cref="EverythingMatcher{T}" />
     void AddJobListener(IJobListener jobListener, params IReadOnlyCollection<IMatcher<JobKey>> matchers);
@@ -164,7 +175,18 @@ public interface IListenerManager
     /// If a <see cref="ITriggerListener" /> with the same name is already registered, that listener
     /// and the associated matchers will be replaced.
     /// </para>
+    /// <para>
+    /// The listener's shape is checked as it is added. Every member of <see cref="ITriggerListener" /> has
+    /// a default implementation, so a public method carrying a notification's name but not its signature
+    /// still compiles — it just stops implementing anything, and the default runs in its place with
+    /// nothing to say the method is dead. Such a listener is refused rather than attached and never
+    /// called.
+    /// </para>
     /// </remarks>
+    /// <exception cref="SchedulerConfigException">
+    /// <paramref name="triggerListener" /> has a public method with an <see cref="ITriggerListener" />
+    /// member's name but not its signature, so that member is not implemented.
+    /// </exception>
     /// <seealso cref="IMatcher{T}" />
     /// <seealso cref="EverythingMatcher{T}" />
     void AddTriggerListener(ITriggerListener triggerListener, params IReadOnlyCollection<IMatcher<TriggerKey>> matchers);
@@ -243,9 +265,22 @@ public interface IListenerManager
     /// <see cref="IScheduler" />.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// If a <see cref="ISchedulerListener" /> with the same <see cref="ISchedulerListener.Name" />
     /// is already registered, that listener will be replaced.
+    /// </para>
+    /// <para>
+    /// The listener's shape is checked as it is added. Every member of <see cref="ISchedulerListener" />
+    /// has a default implementation, so a public method carrying a notification's name but not its
+    /// signature still compiles — it just stops implementing anything, and the default runs in its place
+    /// with nothing to say the method is dead. Such a listener is refused rather than attached and never
+    /// called.
+    /// </para>
     /// </remarks>
+    /// <exception cref="SchedulerConfigException">
+    /// <paramref name="schedulerListener" /> has a public method with an <see cref="ISchedulerListener" />
+    /// member's name but not its signature, so that member is not implemented.
+    /// </exception>
     void AddSchedulerListener(ISchedulerListener schedulerListener);
 
     /// <summary>

--- a/src/Quartz/TrimAnalysisBaseline.cs
+++ b/src/Quartz/TrimAnalysisBaseline.cs
@@ -56,8 +56,9 @@ using System.Diagnostics.CodeAnalysis;
 // silences the analyzer during Quartz's own compile and nothing else. Consumers publishing a trimmed
 // application still see every warning below, which is honest: their app really is affected. The
 // unconditional form would hide it from them too. Where Quartz *has* reasoned an application's way out
-// of a warning, it says so in an [UnconditionalSuppressMessage] at the call site instead — there are two,
-// on JobType.FoundByName and PropertySettingJobFactory.SetObjectProperty, and each carries the argument.
+// of a warning, it says so in an [UnconditionalSuppressMessage] at the call site instead — there are three,
+// on JobType.FoundByName, PropertySettingJobFactory.SetObjectProperty and ListenerManagerImpl.VerifyShape,
+// and each carries the argument.
 
 // --- Types and properties named by string -----------------------------------------------------------
 // Configuration and persistence both store types as text: the flat quartz.* keys, the JOB_CLASS_NAME


### PR DESCRIPTION
`ISchedulerListener`, `IJobListener` and `ITriggerListener` are default-interface-member interfaces, which
is what lets a listener implement only the notifications it cares about. The price is that a member with the
wrong signature is not a compile error: it stops being an implementation of anything, the default body runs
instead, and the method becomes dead code the scheduler never calls. A 3.x listener that implemented the
interface directly (`Task JobToBeExecuted(…)`) and an alpha.1 listener written before #3397
(`SchedulerError(string, SchedulerException, …)`) both have exactly that shape, and nothing in the build
names the dead member.

`Quartz.Core.ListenerShape` reads a listener's type once and refuses one that carries a public instance
method with a notification's name but not its signature.

## Where the check runs

| Registration | Refused at |
|---|---|
| `q.AddJobListener<MyListener>()` and the instance overloads | the `AddQuartz(…)` call itself — `ListenerRegistration`'s constructor, which all nine builder overloads funnel through |
| a factory overload declared as the interface, a listener registered as a plain service, a `quartz.jobListener.*` key, a plugin, `scheduler.ListenerManager.AddJobListener(…)` | when the listener is attached to a scheduler — `ListenerManagerImpl.Add*Listener`, which every listener passes through whatever registered it |

Verified answers are remembered per `(listener type, listener interface)` in a
`ConcurrentDictionary`, so a listener checked at registration and again at attachment costs a dictionary
lookup the second time. A refusal is never cached, so it is repeated for every registration.

The mechanism is `GetInterfaceMap(interface).TargetMethods` as the set of methods that really do implement
the interface, against `GetMethods(Public | Instance)`. A notification left to its default maps to the
interface's own method, which is never a class member, so it cannot match by accident. Explicit
implementations are not public methods of the class, so a listener that implements the interface explicitly
is never examined. A stale member inherited from a base class is caught; a sound one inherited from a base
class is accepted (both are tested).

## The message

```text
MyListener declares 'ValueTask SchedulerError(String, SchedulerException, CancellationToken)', which does
not implement ISchedulerListener.SchedulerError. The interface member is
'ValueTask SchedulerError(IScheduler, SchedulerErrorContext, CancellationToken)': the names match but the
signatures do not, and every member of ISchedulerListener has a default implementation, so this compiles
and the default runs instead. The scheduler never calls SchedulerError. Listener callbacks take
IScheduler scheduler first since 4.0.0-alpha.2. Correct the signature, or rename the method if it is not
meant to be that notification. See
https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html#listeners-are-told-which-scheduler-is-calling
```

Both signatures are always named. Two diagnoses are recognised and change the sentence and the guide
section linked:

* a `Task`- or `Task<T>`-returning method — "Listener members return ValueTask rather than Task since 4.0",
  linking `#tasks-changed-to-valuetask`;
* an interface member that leads with `IScheduler` where the method does not — "Listener callbacks take
  IScheduler scheduler first since 4.0.0-alpha.2", linking
  `#listeners-are-told-which-scheduler-is-calling`.

A 3.x listener trips both, and is told both.

## Trimming

`dotnet build src/Quartz/Quartz.csproj` adds no `IL2xxx`, and the trim canary
(`dotnet publish src/Quartz.Examples.Worker -r win-x64`, `TrimMode=full`) publishes clean, so no
`TrimAnalysisBaseline.cs` or `ILLink.Suppressions.xml` entry was needed.

`Type.GetInterfaceMap` turns out to carry no trim annotation at all — neither `RequiresUnreferencedCode` nor
a `DynamicallyAccessedMembers` requirement on the receiver; it only asks `PublicMethods | NonPublicMethods`
of the *interface* argument, which is always a `typeof` of one of the three interfaces this assembly
declares. `GetMethods(Public | Instance)` asks `PublicMethods` of the listener type, which the nine
`IQuartzBuilder.Add*Listener<T>` overloads **already** annotate `T` with — that is what keeps the stale
member visible to the check in a trimmed application, and it is why no public API baseline moved.

One suppression was needed: `ListenerManagerImpl.VerifyShape` sees a runtime type
(`listener.GetType()`), which is IL2072. It carries an `[UnconditionalSuppressMessage]` whose argument is
that trimming can only remove a member nothing calls, which is exactly the stale member being looked for —
so under trimming the check can find nothing, never the wrong thing. `TrimAnalysisBaseline.cs`'s header
comment, which counts the call-site suppressions, is updated from two to three.

## Decisions a reviewer may want to overturn

* **`DynamicallyAccessedMemberTypes.Interfaces` was *not* added to the generic parameters.** #3398 suggests
  `PublicMethods | Interfaces`. The analyzer does not ask for it (`GetInterfaceMap` carries no receiver
  annotation), the interface implementation of a type the scheduler stores and invokes as `IJobListener`
  cannot be trimmed away, and adding it would have moved nine rows of `PublicApiTest_Quartz.verified.txt`
  and forced an edit to `QuartzSchedulerBuilder.cs`, which mirrors those annotations and is being changed on
  another branch right now. Say so and it goes in.
* **A method that overloads a notification's name for an unrelated purpose is refused.** #3398 accepts this;
  it is documented in `ListenerShape`'s remarks, in `IQuartzBuilder`'s, and in the guide. A rename settles
  it, and the alternative is letting the far commoner stale signature through in silence.
* **The instance overloads check `typeof(T)`, not `listener.GetType()`**, so a listener handed over as its
  base type is checked as that base. Documented on `IQuartzBuilder.AddSchedulerListener{T}()`. It is closed
  in practice: the runtime type is checked when the listener reaches the listener manager, so only the
  moment differs.
* **The check runs in `ListenerRegistration`'s constructor** rather than in nine `QuartzBuilder` methods.
  All nine funnel through it, and the registration object is constructed synchronously inside the
  `AddQuartz` callback, so the throw lands on the line that wrote it.

## Documentation

`docs/documentation/quartz-4.x/migration-guide.md`: the "search your listeners for the twenty-four names"
advice becomes "the registration tells you", with the message, where it lands for each way of registering,
and the two rules that are worth knowing (overloads refused, explicit implementations exempt). The same
point is added to "Tasks Changed to ValueTask" and beside "The three `*Support` base classes are gone",
which is where a 3.x listener is migrated from, and to the highlights bullet. The heading changed from
"The compiler will not point at every callback you have to change" to
"…at the callbacks you have to change, but the registration will"; nothing linked to the old anchor.

`docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md`, which is where the default members
are taught, gains a warning about the same trap.

`docs/documentation/quartz-3.x/` is untouched.

## Verification

* `dotnet build src/Quartz/Quartz.csproj` — 0 warnings, 0 errors
* `dotnet build Quartz.slnx` — 0 warnings, 0 errors
* `dotnet test src/Quartz.Tests.Unit` — 3144 passed, 0 failed, 4 skipped (20 of them new)
* `dotnet test src/Quartz.Tests.AspNetCore` — 328 passed, 0 failed
* `dotnet publish src/Quartz.Examples.Worker -c Release -r win-x64` (the trim canary) — clean
* `npm run docs:check-links` — 211 pages, 715 internal links, 410 fragments, no dead links or anchors
* `npm run docs:lint` — 127 pre-existing errors before and after these changes, none in the edited regions
* `dotnet test src/Quartz.Tests.Integration` (Docker 29.5.3) — 316 passed, 0 failed, 9 m 17 s

Closes #3398
