### PR TITLE
A scheduler under Aspire is two lines and a data source

### DIFF
--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -142,6 +142,7 @@ export const sidebarEn: SidebarConfig = [
               "/documentation/quartz-4.x/how-tos/rescheduling-jobs",
               "/documentation/quartz-4.x/how-tos/multiple-triggers",
               "/documentation/quartz-4.x/how-tos/job-template",
+              "/documentation/quartz-4.x/how-tos/aspire",
               "/documentation/quartz-4.x/how-tos/custom-job-store",
               "/documentation/quartz-4.x/how-tos/dialect-delegate",
               "/documentation/quartz-4.x/how-tos/trigger-persistence-delegate",

--- a/docs/documentation/quartz-4.x/how-tos/README.md
+++ b/docs/documentation/quartz-4.x/how-tos/README.md
@@ -14,6 +14,7 @@ Short, task-shaped recipes. Each page answers one question; the
 * [Rescheduling Jobs](rescheduling-jobs.md) — change a live schedule, retry a firing, recover a failed trigger
 * [Multiple Triggers](multiple-triggers.md) — drive one job from several triggers, and give each its own data
 * [Job Template](job-template.md) — the recommended skeleton for a job class
+* [Running Quartz under Aspire](aspire.md) — telemetry, health and the database, wired to an AppHost
 
 Extending Quartz — the four seams the `Quartz.Impl.AdoJobStore` types exist for:
 

--- a/docs/documentation/quartz-4.x/how-tos/aspire.md
+++ b/docs/documentation/quartz-4.x/how-tos/aspire.md
@@ -1,0 +1,335 @@
+---
+title: 'Running Quartz under Aspire'
+---
+
+# Running Quartz under Aspire
+
+[Aspire](https://aspire.dev/) — formerly ".NET Aspire", renamed in Aspire 13 — is an orchestrator for a
+local application and the shared configuration that goes with it. Two of its pieces matter to a scheduler:
+the **AppHost**, which declares the databases and projects and wires them to each other, and
+**ServiceDefaults**, a project every service references that turns on OpenTelemetry, health checks, service
+discovery and HTTP resilience in one call.
+
+A Quartz scheduler needs almost nothing to fit. Quartz already publishes on a `System.Diagnostics`
+`ActivitySource` and `Meter`, its health check already registers on the standard `IHealthChecksBuilder`, its
+components already take their loggers from the container's `ILoggerFactory`, and its store already takes
+connections from a `DbDataSource` the container holds. What is left is naming the two telemetry signals to
+the pipeline ServiceDefaults built, and pointing the store at the database the AppHost started. This page is
+exactly that list, and it is short.
+
+There is no Quartz integration for Aspire — no `Aspire.Hosting.Quartz` package, no `AddQuartz` resource for
+the AppHost. Everything here is ordinary Quartz configuration in an application that Aspire happens to be
+running.
+
+## The two lines that do the integration
+
+`AddServiceDefaults()` builds an OpenTelemetry pipeline and then exports it. What the template subscribes to
+is a fixed list: runtime, ASP.NET Core and `HttpClient` metrics; ASP.NET Core and `HttpClient` traces; and
+one `ActivitySource` named after the application itself. Quartz is not on it, and could not be — the file is
+generated before anyone knows what the project will reference.
+
+So name it. Anywhere in the application's own startup will do:
+
+<!-- snippet: sample_aspire_subscribe -->
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddSource(QuartzInstrumentation.ActivitySourceName))
+    .WithMetrics(metrics => metrics.AddMeter(QuartzInstrumentation.MeterName));
+```
+<!-- endSnippet -->
+
+Both constants are in `Quartz.Diagnostics` and both are `"Quartz"`. A second `AddOpenTelemetry()` composes
+with the first rather than replacing it — OpenTelemetry keeps one `TracerProvider` and one `MeterProvider`
+per container — so this can go before or after `AddServiceDefaults()`.
+
+::: warning Do not add an exporter here
+ServiceDefaults calls `UseOtlpExporter()` whenever `OTEL_EXPORTER_OTLP_ENDPOINT` is set, and the AppHost
+sets it. That method may be called only once, and it cannot be combined with a signal-specific
+`AddOtlpExporter()` — either mistake throws `NotSupportedException`. The
+[Observability](../packages/opentelemetry-integration.md) page shows the same subscription *with* an
+exporter, for an application that has no ServiceDefaults to inherit one from.
+:::
+
+That is the whole of the telemetry integration. Everything below is about the database, the health probe and
+the logs.
+
+## The AppHost
+
+A Postgres server, a database on it, and the worker that uses them:
+
+<!-- Not a compiled sample: `Aspire.Hosting.PostgreSQL` and the generated `Projects` class come from the
+     AppHost project, neither of which this repository references. -->
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgres = builder.AddPostgres("postgres")
+    .WithDataVolume()
+    .WithLifetime(ContainerLifetime.Persistent);
+
+var quartzDb = postgres.AddDatabase("quartz");
+
+builder.AddProject<Projects.Orders_Worker>("orders")
+    .WithReference(quartzDb)
+    .WaitFor(quartzDb);
+
+builder.Build().Run();
+```
+
+`AddDatabase("quartz")` names both the Aspire resource and, because the second argument was left out, the
+database itself. `WithReference` hands the worker that resource's connection string as the environment
+variable `ConnectionStrings__quartz`, which the default configuration builder reads back as
+`ConnectionStrings:quartz` — so the name in the AppHost is the name the worker asks for, on every path
+below. `WaitFor` holds the worker until Postgres reports healthy, which spares the scheduler a first
+connection attempt against a container that is still starting.
+
+`WithDataVolume()` and `WithLifetime(ContainerLifetime.Persistent)` are worth having for a scheduler in
+particular: without them every restart is a fresh database, and a persistent job store whose rows disappear
+between runs is an in-memory store with more moving parts.
+
+## The worker
+
+Aspire's side is two calls:
+
+<!-- Not a compiled sample: `AddServiceDefaults` comes from the generated ServiceDefaults project and
+     `AddNpgsqlDataSource` from `Aspire.Npgsql`, neither of which this repository references. -->
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults();
+builder.AddNpgsqlDataSource("quartz");
+```
+
+`AddServiceDefaults` is generic over `IHostApplicationBuilder`, so a worker gets it as readily as a web
+application does. `AddNpgsqlDataSource("quartz")` reads the connection string that `WithReference` injected
+and registers Npgsql's data source; among the services it registers is an unkeyed `DbDataSource`, which is
+the one Quartz asks for.
+
+Quartz's side is then a persistent store that takes its connections from the container:
+
+<!-- snippet: sample_aspire_persistent_store -->
+```csharp
+builder.AddQuartz(q =>
+{
+    q.ConfigureScheduler(options =>
+    {
+        options.InstanceName = "orders";
+        options.GenerateInstanceId = true;
+    });
+
+    q.UsePersistentStore(store =>
+    {
+        store.UsePostgres(db => db.UseRegisteredDataSource = true);
+        store.UseClustering();
+    });
+});
+
+builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+```
+<!-- endSnippet -->
+
+`UseRegisteredDataSource` is a setting on `DataSourceOptions` rather than a method, because it answers the
+same question `ConnectionString` and `ConnectionStringName` answer — where connections come from — and it
+wins over both. It resolves the container's one unkeyed `DbDataSource`. The dialect call is still needed and
+is not redundant with it: `UsePostgres` selects `PostgreSQLDelegate` and the Npgsql driver description,
+which decide the SQL and the parameter shape, while the data source decides the connection.
+
+Whatever the data source was built with is in play for Quartz's own statements — its type mappers, its
+logging, its connection multiplexing — because commands are made by the connection rather than from a driver
+description. That is the practical reason to prefer this over a connection string when the application
+already has an `NpgsqlDataSource`.
+
+`GenerateInstanceId` and `UseClustering` are here because Aspire makes replicas cheap; see
+[Clustering](../tutorial/advanced-enterprise-features.md) for what they mean. A single-node scheduler needs
+neither.
+
+### More than one database
+
+An application that talks to two databases cannot have one unkeyed data source stand for both.
+`AddKeyedNpgsqlDataSource("quartz")` registers its `DbDataSource` under that string as a service key rather
+than unkeyed, and `DataSourceServiceKey` says which key is this store's. Setting it implies
+`UseRegisteredDataSource`, so the two are never written together:
+
+<!-- snippet: sample_aspire_keyed_data_source -->
+```csharp
+builder.AddQuartz(q => q.UsePersistentStore(store =>
+    store.UsePostgres(db => db.DataSourceServiceKey = "quartz")));
+```
+<!-- endSnippet -->
+
+### SQL Server takes the connection-string path
+
+`Microsoft.Data.SqlClient` ships no `DbDataSource` implementation, and Aspire's SQL Server client
+integration registers a scoped `SqlConnection` rather than a data source. `UseRegisteredDataSource` has
+nothing to resolve there, and fails at first use rather than at startup validation. Read the injected
+connection string by name instead — which needs no client integration at all, only `WithReference` in the
+AppHost:
+
+<!-- snippet: sample_aspire_sql_server -->
+```csharp
+builder.AddQuartz(q => q.UsePersistentStore(store =>
+    store.UseSqlServer(db => db.ConnectionStringName = "quartz")));
+```
+<!-- endSnippet -->
+
+The same shape works for Postgres, and is the right one whenever the application has no data source of its
+own to share.
+
+## The tables are still yours to create
+
+Quartz does not create or migrate its schema, under Aspire or anywhere else — see
+[Database Schema](../db/) for what has to exist and
+[`database/tables`](https://github.com/quartznet/quartznet/tree/main/database/tables) for the scripts.
+Aspire does not close that gap either. `AddDatabase` creates the *database* when the server becomes ready,
+and the two hooks that look like they would run the DDL do not:
+
+* `WithInitFiles` copies files into the container's `/docker-entrypoint-initdb.d`, which Postgres runs while
+  first initializing its data directory — before the `AddDatabase` database exists, and against the server's
+  default database.
+* `WithCreationScript` runs against the server too. Its own documentation says it is for statements that
+  apply to the default database, such as `CREATE DATABASE`, and that table creation is not supported
+  "since they require a distinct connection to the newly created database".
+
+What does work is the shape Aspire already teaches for Entity Framework Core migrations: a small project
+that connects to the database, applies the schema and exits, which the worker waits for with
+`WaitForCompletion`. Whatever applies your schema in production applies it here.
+
+## Health
+
+`AddQuartzHealthChecks` registers the scheduler's check with the same `IHealthChecksBuilder` that
+ServiceDefaults put its own `self` check on, so `MapDefaultEndpoints()` serves both from `/health` with no
+further wiring:
+
+<!-- snippet: sample_aspire_health_checks -->
+```csharp
+builder.Services.AddQuartzHealthChecks();
+```
+<!-- endSnippet -->
+
+It comes from the `Quartz.AspNetCore` package; see
+[ASP.NET Core Integration](../packages/aspnet-core-integration.md). Point the AppHost at the endpoint to
+have the result reach the dashboard — which means a web project, since the probe is an HTTP request:
+
+<!-- Not a compiled sample: `WithHttpHealthCheck` is an `Aspire.Hosting` method. -->
+
+```csharp
+builder.AddProject<Projects.Orders_Api>("api")
+    .WithHttpHealthCheck("/health")
+    .WithReference(quartzDb)
+    .WaitFor(quartzDb);
+```
+
+The check reports the scheduler's own state, and a scheduler has more than two. What survives the trip to
+the dashboard is less:
+
+| Scheduler | Quartz reports | `/health` answers | Dashboard shows |
+|---|---|---|---|
+| Running, and its store answers | Healthy | 200 | Running |
+| In standby | Degraded | **200** | Running |
+| Running, but the store threw `SchedulerException` | Unhealthy | 503 | Running (Unhealthy) |
+| Created but never started, shutting down, or shut down | Unhealthy | 503 | Running (Unhealthy) |
+
+Standby is the interesting state and the one that gets lost. A scheduler deliberately put in standby is
+alive, reachable and firing nothing: reporting it healthy would hide an application that never started its
+scheduler, and reporting it unhealthy would take a node out of rotation for doing what it was told, so the
+check reports degraded. But ASP.NET Core's health middleware maps `Degraded` to **200** by default, exactly
+as it maps `Healthy`, and Aspire's `WithHttpHealthCheck` compares the response to a single status code and
+reports anything else as unhealthy. So an HTTP probe cannot produce the dashboard's `Running (Degraded)`
+rendering at all — a degraded scheduler simply looks healthy.
+
+If that distinction matters, it has to be made deliberately. Mapping `Degraded` to 503 in
+`HealthCheckOptions.ResultStatusCodes` puts a standby scheduler in the dashboard's unhealthy set, which is a
+different claim from "degraded" but at least a visible one; the alternative is to read `/health`'s body,
+where the default response writer already writes the aggregate status as text.
+
+Three more limits worth knowing before you rely on any of this:
+
+* **The Quartz check carries no tags**, so it is part of `/health` but not of `/alive`, whose predicate
+  keeps only checks tagged `live`. That is the right default — a scheduler in standby should not fail a
+  liveness probe — and `options.Tags.Add("live")` changes it if you disagree.
+* **A worker project has no health endpoint at all.** `MapDefaultEndpoints` takes a `WebApplication`. Aspire
+  has no documented recipe for exposing one from a non-web worker; the check is still registered and still
+  resolvable from the container, but nothing serves it, so `WithHttpHealthCheck` has nothing to poll.
+* **ServiceDefaults maps both endpoints only when `IsDevelopment()`**, on the grounds that exposing them
+  elsewhere has security implications. Running under the AppHost locally is development, so this is a
+  deployment concern rather than a local one — but a `WithHttpHealthCheck("/health")` that works on your
+  machine will poll a 404 wherever that guard holds.
+
+## Logs
+
+Nothing. The container's logging *is* Quartz's logging: everything a scheduler is built from takes its
+logger from the `ILoggerFactory` that built it — the scheduling loop, the job store with its cluster
+manager, misfire handler, driver delegate and lock handler, and the thread pool, job factory, type loader
+and instance id generator that `Use*<T>()` chose. ServiceDefaults has already put an OpenTelemetry logging
+provider on that factory, so those lines reach the dashboard because the application configured logging at
+all, not because it said anything about Quartz.
+
+`LogProvider.SetLogProvider` is still in the API, and under Aspire it is worth writing for one narrower
+reason: the handful of types no container ever builds. A listener or a trigger you constructed and handed
+over, `CronTriggerImpl`, the static helpers such as `TimeZones`, and the jobs in `Quartz.Jobs` cannot be
+injected anything, so they read the ambient factory instead of going unlogged. Forwarding the host's factory
+to it once brings them onto the same pipeline as everything else. The
+[migration guide](../migration-guide.md#the-ambient-logger-factory-stays-ambient) has the complete list and
+the reason the slot stays ambient.
+
+The scheduling loop also opens one logging scope for the lifetime of its run, carrying
+`quartz.scheduler.name` and `quartz.scheduler.id` — the same attribute names the spans and the measurements
+use. ServiceDefaults sets `IncludeScopes = true` on the OpenTelemetry logging provider, so those become
+attributes on every line the loop writes, and the dashboard's advanced log filter can select on them. Job
+log lines inherit the scope through the execution context their thread-pool dispatch captured, which is why
+the loop opens it once rather than the run shell opening one per firing.
+
+## What the dashboard shows
+
+**Traces.** One `Quartz.Job.Execute` span per firing, `ActivityKind.Internal`, covering the whole fire; a
+`Quartz.Job.Veto` span where a trigger listener said no. Selecting **View details** on a span opens a
+property grid of its attributes, which is where `quartz.job.name`, `quartz.job.group`,
+`quartz.trigger.name` and `quartz.trigger.group` appear. `quartz.scheduler.name`, `quartz.scheduler.id`,
+`quartz.job.type` and `quartz.fire.instance.id` are added only when the span is sampled for full data, so a
+sampler that records without collecting all data will not show them. A failed firing sets the span's status
+to error, attaches an exception event and tags it `error.type` with the exception the job threw.
+
+A persistent store adds one `Quartz.JobStore.*` span per operation —
+`Quartz.JobStore.AcquireNextTriggers`, `.TriggersFired`, `.ScheduleJob` and the rest. The in-memory store
+emits none of them, so a scheduler on `UseInMemoryStore` shows firings and nothing underneath.
+
+**Metrics.** The `Quartz` meter appears in the Metrics page's selection pane with two instruments under it.
+`quartz.job.execution.duration` is a histogram in **seconds**, which the dashboard charts as P50, P90 and
+P99; `quartz.job.execution.active` is an up-down counter of jobs currently running. Both carry
+`quartz.scheduler.name` and the four job and trigger identity attributes, and the histogram additionally
+carries `error.type` on a failed execution — so the failure rate is the part of the histogram's count that
+has that attribute, and it says which exception. The metric attributes are deliberately a smaller set than
+the span attributes: `quartz.fire.instance.id` is unique per firing and has no business on a time series.
+
+The full attribute and instrument tables are on the [Observability](../packages/opentelemetry-integration.md)
+page rather than repeated here.
+
+**Structured logs.** The loop's lines carry `quartz.scheduler.name`, which the advanced filter dialog can
+select on — useful the moment a process runs more than one scheduler, since the logger category is a type
+name and says nothing about which.
+
+## What Aspire does not do for you
+
+Aspire orchestrates processes and hands them configuration. It has no view of what a scheduler is, so
+everything that makes one correct is still Quartz's to say:
+
+* **Clustering.** `WithReplicas(2)` in the AppHost starts two copies of the worker; it does not make them a
+  cluster. `UseClustering()` and a distinct `InstanceId` per node do — `GenerateInstanceId = true` derives
+  one from host name and a timestamp, which stays distinct across replicas on one machine. Without it every
+  replica keeps the default id, `NON_CLUSTERED`, and the id is how a node recognises its own check-in row
+  and its own fired triggers.
+* **The table prefix, the serializer, the misfire threshold and the lock strategy.** All store settings,
+  all in [Configuration Reference](../configuration/reference.md#persistent-job-store).
+* **Startup order beyond the container.** `WaitFor` waits on the database resource's health check, not on
+  the Quartz tables existing. If the schema is applied by a migration step, the worker has to wait for
+  that step, not for the database.
+* **The dashboard's data.** Aspire's dashboard is a local OTLP viewer; it holds telemetry in memory for the
+  session. It is not a place to look for last week's failed job. Point the same OTLP export at a collector
+  for that — nothing about the Quartz side changes, because ServiceDefaults owns the exporter.
+
+::: tip
+None of this is Aspire-specific. `AddServiceDefaults()` is a project template you own, not a framework
+call — everything on this page works in any generic-host application that configures OpenTelemetry, and the
+[Observability](../packages/opentelemetry-integration.md) page is the version without Aspire in the way.
+:::

--- a/src/Quartz.Documentation.Samples/HowTos/AspireSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/AspireSamples.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+using Quartz.Diagnostics;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/aspire.md.
+/// </summary>
+/// <remarks>
+/// Only the Quartz half of that page is compiled. The Aspire calls beside these — <c>AddServiceDefaults</c>,
+/// <c>AddNpgsqlDataSource</c>, and everything in the AppHost — come from packages this repository does not
+/// reference, so the page carries them as plain fences.
+/// </remarks>
+public static class AspireSamples
+{
+    public static void SubscribeToQuartzSignals(IHostApplicationBuilder builder)
+    {
+        #region sample_aspire_subscribe
+
+        builder.Services.AddOpenTelemetry()
+            .WithTracing(tracing => tracing.AddSource(QuartzInstrumentation.ActivitySourceName))
+            .WithMetrics(metrics => metrics.AddMeter(QuartzInstrumentation.MeterName));
+
+        #endregion
+    }
+
+    public static void PersistentStoreOverRegisteredDataSource(IHostApplicationBuilder builder)
+    {
+        #region sample_aspire_persistent_store
+
+        builder.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = "orders";
+                options.GenerateInstanceId = true;
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UsePostgres(db => db.UseRegisteredDataSource = true);
+                store.UseClustering();
+            });
+        });
+
+        builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
+    public static void PersistentStoreOverKeyedDataSource(IHostApplicationBuilder builder)
+    {
+        #region sample_aspire_keyed_data_source
+
+        builder.AddQuartz(q => q.UsePersistentStore(store =>
+            store.UsePostgres(db => db.DataSourceServiceKey = "quartz")));
+
+        #endregion
+    }
+
+    public static void PersistentStoreOverConnectionString(IHostApplicationBuilder builder)
+    {
+        #region sample_aspire_sql_server
+
+        builder.AddQuartz(q => q.UsePersistentStore(store =>
+            store.UseSqlServer(db => db.ConnectionStringName = "quartz")));
+
+        #endregion
+    }
+
+    public static void HealthChecks(IHostApplicationBuilder builder)
+    {
+        #region sample_aspire_health_checks
+
+        builder.Services.AddQuartzHealthChecks();
+
+        #endregion
+    }
+}


### PR DESCRIPTION
A new how-to, `docs/documentation/quartz-4.x/how-tos/aspire.md`, registered in the 4.x sidebar and in the
how-tos index. It answers one question: what does an Aspire application actually have to write to get a
Quartz scheduler's traces, metrics, health and database wiring, and what does it *not* get.

The short answer is two `AddSource`/`AddMeter` lines plus a data source, which would make for a thin page.
What makes it worth having is the three places where the seams do not meet, each of which is a real trap and
none of which is written down anywhere today.

Rebased onto `2f067d502`, so it is written against #3392 having landed: the **Logs** section now says that
the container's logging is Quartz's logging and there is nothing to write, and the
`sample_aspire_log_provider` snippet that told you otherwise is gone.

## What the page claims about Quartz, and what decides it

Every one of these was read in this tree at `2f067d502`, not recalled.

| Claim on the page | Decided by |
|---|---|
| `QuartzInstrumentation.ActivitySourceName` and `.MeterName` are `public const`, both `"Quartz"`, in the core package | `src/Quartz/Diagnostics/QuartzInstrumentation.cs:23,34` |
| One `Quartz.Job.Execute` span per firing, `ActivityKind.Internal`, created only when a listener is subscribed | `src/Quartz/Diagnostics/QuartzActivitySource.cs:13-17`, `src/Quartz/Diagnostics/OperationName.cs:7` |
| `quartz.job.name/group` and `quartz.trigger.name/group` are unconditional; `quartz.scheduler.name/id`, `quartz.job.type`, `quartz.fire.instance.id` only under `IsAllDataRequested` | `src/Quartz/Diagnostics/QuartzActivitySource.cs:33-44` |
| A failed firing sets error status, adds the exception and tags `error.type` | `src/Quartz/Diagnostics/QuartzActivitySource.cs:66-74` |
| A `Quartz.Job.Veto` span exists | `src/Quartz/Diagnostics/OperationName.cs:18` |
| `Quartz.JobStore.*` spans come from the ADO store only — `RAMJobStore` emits none | `src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs` (the sole `JobStoreActivityTracer`) |
| Exactly two instruments: `quartz.job.execution.duration` (`Histogram<double>`, unit `s`) and `quartz.job.execution.active` (`UpDownCounter<long>`, unit `{job}`) | `src/Quartz/Diagnostics/Meters.cs:47,52` |
| Duration is recorded in seconds | `src/Quartz/Diagnostics/Meters.cs:102` (`duration.TotalSeconds`) |
| Measurement tags are `quartz.scheduler.name` + the four identity tags — *not* the span's set | `src/Quartz/Diagnostics/Meters.cs:66-75` |
| `error.type` is on the histogram only, never on the up-down counter | `src/Quartz/Diagnostics/Meters.cs:90-97` |
| `AddQuartzHealthChecks` is in `Quartz.AspNetCore` and delegates to `AddHealthChecks().AddQuartz(…)` | `src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs:31-38` |
| Running → healthy *after* a store probe; Standby → degraded; Created/ShuttingDown/Shutdown → unhealthy; store failure under Running → unhealthy | `src/Quartz.AspNetCore/AspNetCore/HealthChecks/QuartzHealthCheck.cs:52-86` |
| The check carries no tags by default, so it is in `/health` but not `/alive` | `QuartzHealthCheckOptions.cs:32` (empty `Tags`), and ServiceDefaults' `/alive` predicate |
| `UseRegisteredDataSource` is a `bool` on `DataSourceOptions`, not a builder method | `src/Quartz/Configuration/DataSourceOptions.cs:86` |
| Resolution order: `DataSourceFactory` > `DataSourceServiceKey` (keyed `DbDataSource`) > `UseRegisteredDataSource` (unkeyed `DbDataSource`) > connection string | `src/Quartz/Configuration/PersistentStoreBuilder.cs:73-100` |
| Nothing registered → passes startup validation and throws at first resolution, not at startup | `src/Quartz/Configuration/QuartzOptionsValidators.cs` (`DataSourceOptionsValidator`) vs `PersistentStoreBuilder.cs:83-86` |
| The dialect call is still required — it is what sets `Provider` and the driver delegate | `src/Quartz/Configuration/PersistentStoreBuilderExtensions.cs:37-41` |
| `ConnectionStringName` resolves through `IConfiguration.GetConnectionString`, which is how `ConnectionStrings__quartz` arrives | `src/Quartz/Configuration/PersistentStoreBuilder.cs:88-97` |
| **The container's `ILoggerFactory` is what the scheduler core, the store and the `Use*<T>()` components log through** | `src/Quartz/Core/QuartzSchedulerResources.cs:126`, `src/Quartz/Impl/AdoJobStore/DriverDelegateContext.cs:85`, `src/Quartz/Impl/AdoJobStore/SemaphoreContext.cs:77`, fed by `src/Quartz/Configuration/QuartzServiceRegistration.cs:202,315` |
| `LogProvider` is still for the types no container builds | migration guide, [The ambient logger factory stays ambient](https://github.com/quartznet/quartznet/blob/main/docs/documentation/quartz-4.x/migration-guide.md#the-ambient-logger-factory-stays-ambient) — the page names the same set and links there |
| The loop's scope carries `quartz.scheduler.name` / `quartz.scheduler.id`, opened once per run | `src/Quartz/Diagnostics/SchedulerLogScope.cs:55-56`, `src/Quartz/Core/QuartzSchedulerThread.cs:274` |
| Job lines inherit the scope through the captured execution context | `src/Quartz/Core/JobRunShell.cs:99-107` |
| A clustered node with no `GenerateInstanceId` keeps `NON_CLUSTERED`; the default generator is host name + timestamp | `src/Quartz/Impl/DefaultSchedulerFactory.cs:134,241-252`, `src/Quartz/Impl/SimpleInstanceIdGenerator.cs:43-47`, `QuartzSchedulerOptions.cs:20,34,40` |
| `UseClustering()` turns on database locking and does *not* set `GenerateInstanceId` | `src/Quartz/Configuration/PersistentStoreBuilder.cs:212-230` |
| Quartz never creates or migrates its schema | `docs/documentation/quartz-4.x/db/index.md` and the absence of any DDL execution path |

Also verified: this repository contains no Aspire reference of any kind (one unrelated prose mention in
`.github/agents/squad.agent.md`), so the page says plainly that no Quartz integration for Aspire exists.

## The three findings the page exists for

1. **`UseRegisteredDataSource` works for Postgres because of Npgsql, not because of Aspire.**
   `Aspire.Npgsql`'s `AddNpgsqlDataSource(connectionName)` delegates to Npgsql's own
   `services.AddNpgsqlDataSource(…, serviceKey: null)`, and Npgsql's `AddCommonServices` `TryAdd`s
   `typeof(DbDataSource)` resolving to the `NpgsqlDataSource` — unkeyed when there is no key, keyed when
   there is. That is exactly the shape `PersistentStoreBuilder` asks for, and it is what makes
   `AddKeyedNpgsqlDataSource("quartz")` pair with `DataSourceServiceKey = "quartz"`.

2. **SQL Server cannot use that path at all.** `Aspire.Microsoft.Data.SqlClient`'s `AddSqlServerClient`
   registers `services.AddScoped(_ => new SqlConnection(…))` and nothing else; `Microsoft.Data.SqlClient`
   ships no `DbDataSource`. `UseRegisteredDataSource` there passes startup validation and then throws on
   first resolution. The page routes SQL Server through `ConnectionStringName` instead, which needs no
   client integration — only `WithReference` in the AppHost.

3. **A scheduler in standby looks healthy in the Aspire dashboard.** Quartz reports `Degraded`;
   ASP.NET Core's `HealthCheckOptions.DefaultStatusCodesMapping` maps `Degraded` to **200**, the same as
   `Healthy`; Aspire's `WithHttpHealthCheck` compares the response to one status code and registers with
   `failureStatus: default`, so it can only produce `Healthy` or `Unhealthy`. The dashboard's
   `Running (Degraded)` rendering exists — `ResourceStateViewModel.GetStateText` composes it — but an HTTP
   probe can never reach it. The page says so and gives the two ways to make the distinction visible.

And a fourth, about the database rather than the wiring: **neither Aspire hook creates Quartz's tables.**
`WithInitFiles` copies into `/docker-entrypoint-initdb.d`, which runs at first data-directory
initialization, against the server's default database, before `AddDatabase` has created anything.
`WithCreationScript`'s own XML documentation says it is for default-database statements and that "table
creation and data insertion are not supported since they require a distinct connection to the newly created
database". The page recommends the migration-project shape Aspire already teaches for EF Core, waited on
with `WaitForCompletion`.

## Logging, after #3392

The **Logs** section is now three paragraphs and no code. It says the container's logging is Quartz's
logging, lists what that covers (the scheduling loop, the store with its cluster manager, misfire handler,
driver delegate and lock handler, and the `Use*<T>()` components), and keeps `LogProvider.SetLogProvider`
only for the types no container builds — matching the wording #3404 landed on
`tutorial/configuration-resource-usage-and-scheduler-factory.md` and
`packages/opentelemetry-integration.md`. The scheduler-name log-scope paragraph is #3389's and is unchanged
apart from dropping the "with the ambient logger factory set" conditional, which is no longer a condition.

## Sources

Aspire — note that `dotnet/aspire` now redirects to **`microsoft/aspire`**, `learn.microsoft.com/dotnet/aspire/*`
301s to **`aspire.dev`**, and the product dropped ".NET" from its name in Aspire 13. Current stable is
**13.5.2** (`v13.5.2`, 2026-08-21).

* `microsoft/aspire` — `src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs` (the
  whole of `AddServiceDefaults`, `ConfigureOpenTelemetry`, `AddDefaultHealthChecks`, `MapDefaultEndpoints`)
* `microsoft/aspire` — `src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs`
* `microsoft/aspire` — `src/Components/Aspire.Microsoft.Data.SqlClient/AspireSqlServerSqlClientExtensions.cs`
* `microsoft/aspire` — `src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs` (`AddPostgres`,
  `AddDatabase`, `WithInitFiles`, `WithCreationScript`, `WithDataVolume`)
* `microsoft/aspire` — `src/Aspire.Hosting/ResourceBuilderExtensions.cs`
  (`ConnectionStringEnvironmentName = "ConnectionStrings__"`, `WithReference`, `WaitFor`,
  `WaitForCompletion`, `WithHttpHealthCheck`), `src/Aspire.Hosting/api/Aspire.Hosting.cs` (`WithReplicas`)
* `microsoft/aspire` — `src/Aspire.Dashboard/Model/ResourceStateViewModel.cs` (the `Running (Degraded)`
  rendering), `src/Aspire.Dashboard/Components/Controls/SpanDetails.razor` (span attributes as a property
  grid), `src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs` (histograms charted as
  P50/P90/P99)
* <https://aspire.dev/get-started/csharp-service-defaults/>
* <https://aspire.dev/dashboard/explore/> — structured-log filtering by any log property; span **View details**
* <https://aspire.dev/fundamentals/health-checks/> — the `IsDevelopment()` guard and why it is there
* <https://aspire.dev/integrations/databases/postgres/postgres-host/>,
  <https://aspire.dev/integrations/databases/sql-server/sql-server-connect/>
* <https://aspire.dev/integrations/databases/efcore/migrations/> — the migration-service shape, and the
  canonical `AddServiceDefaults()` + `AddOpenTelemetry().WithTracing(t => t.AddSource(…))` on a worker
* `open-telemetry/opentelemetry-dotnet` — `src/OpenTelemetry.Extensions.Hosting/README.md` ("Multiple calls
  to `AddOpenTelemetry` will **NOT** result in multiple providers"),
  `src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md` (`UseOtlpExporter` once only, and never
  beside `AddOtlpExporter`)
* `npgsql/npgsql` — `src/Npgsql/NpgsqlServiceCollectionExtensions.cs`, `AddCommonServices`
* `dotnet/aspnetcore` — `src/Middleware/HealthChecks/src/HealthCheckOptions.cs`
  (`Degraded → 200`)

## Sample convention

The Quartz half of every block is a compiled snippet in
`src/Quartz.Documentation.Samples/HowTos/AspireSamples.cs`. The Aspire half — `AddServiceDefaults`,
`AddNpgsqlDataSource`, and everything in the AppHost — is a plain fence with a
`<!-- Not a compiled sample: … -->` comment above it, since this repository references none of those
packages and should not take a dependency to compile a documentation sample.

## A naming decision worth a second opinion

The page is titled **"Running Quartz under Aspire"**, not ".NET Aspire". The product renamed in Aspire 13,
the repository is `microsoft/aspire`, and `aspire.dev` uses the bare name throughout. The first sentence
says 'formerly ".NET Aspire"' so the old name is still on the page for anyone searching it.

## Deliberately left out

* **Deployment.** `aspire publish`, Azure Container Apps, Kubernetes. Nothing about a deployed Quartz is
  different from a deployed anything, and the one Aspire-specific note that is true — data volumes not
  working after deployment to ACA — belongs on Aspire's page, not this one.
* **`WithPgAdmin` / `WithPgWeb` / `WithPostgresMcp`.** Real and useful, nothing to do with Quartz.
* **A ready/live tag split for the Quartz check.** The page says the check is untagged and how to change it;
  choosing a probe topology for the reader would be guessing at their orchestrator.
* **Repeating the attribute and instrument tables.** They are on
  `packages/opentelemetry-integration.md` and the page links there.
* **Any claim about the dashboard's metric percentiles from the docs.** The current `aspire.dev` dashboard
  page does not mention histograms or percentiles at all; the P50/P90/P99 claim on the page comes from
  `ChartDataCalculator.cs` instead.

## Verification

Rebased onto `2f067d502` (never merged), head `e50206b38`.

```text
dotnet build Quartz.slnx            Build succeeded. 0 Warning(s) 0 Error(s)
dotnet fallout DocsSnippets         Succeeded
dotnet fallout VerifyDocsSnippets   Succeeded — snippets are up to date (90 markdown files checked)
npm ci                              exit 0
npm run docs:check-links            212 pages, 733 internal links, 421 fragments — no dead links or anchors
npm run docs:build                  Rendering 213 pages — VuePress build completed
markdownlint-cli2 (new files)       Summary: 0 error(s)
```

`markdownlint-cli2 "docs/**/*.md"` over the whole tree reports five errors, all pre-existing on `main` in
`docs/documentation/quartz-4.x/tutorial/more-about-jobs.md` and `docs/README.md`, neither of which this
branch touches.

Related: #2718 (asked for an Aspire integration; there is still no package, and the page says so), #3392
(the logging change this page is written against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
