### PR TITLE
The AOT and single-file analyzers are on, and the package still cannot claim AOT compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,13 @@ binds this repository.
 - **Explicit types over `var`** — prefer explicit types everywhere (`csharp_style_var_for_built_in_types = false`).
 - **Nullable enabled** globally; test projects may disable it.
 - **Warnings as errors** — `TreatWarningsAsErrors` is true; code style is enforced in build.
-- **`Quartz` builds with the trim analyzer on**, so an `IL2xxx` is an error. The known-reflective types are
-  recorded in `src/Quartz/TrimAnalysisBaseline.cs` (and mirrored for ILLink in `src/Quartz/ILLink.Suppressions.xml`,
-  which the worker example's trimmed publish applies). A warning in a type not listed there means new
+- **`Quartz` builds with the trim, AOT and single-file analyzers on**, so an `IL2xxx` or `IL3xxx` is an error.
+  The known-reflective types are recorded in `src/Quartz/TrimAnalysisBaseline.cs` (and mirrored for ILLink in
+  `src/Quartz/ILLink.Suppressions.xml`, which the worker example's trimmed publish applies; ILCompiler takes no
+  such file, so a native AOT publish still reports them). A warning in a type not listed there means new
   reflection — fix it rather than adding a line; that file explains the order to try fixes in. Neither file
-  ships, so consumers still see every warning. Tracked on #3341.
+  ships, so consumers still see every warning. The package does **not** say `IsAotCompatible`, and
+  `src/Quartz/Quartz.csproj` says why. Tracked on #3341.
 - **Allman brace style** — braces on new lines for methods, types, control blocks, properties, accessors, lambdas.
 - **No `DateTime.Now`/`DateTimeOffset.Now`** — banned via Roslyn analyzer (`BannedSymbols.txt`). Use `TimeProvider` instead.
 - **No implicit `DateTime` → `DateTimeOffset` cast** — also banned.

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -130,12 +130,23 @@ partial class Build : FalloutBuild, ICompile, IPack
     /// Publishes the example applications, one of which is the repository's trim canary.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Named <c>PublishAot</c> until issue #3341: nothing here has ever published native AOT, and
     /// leaving the misnomer in place would have collided with the real thing when it arrives.
     /// <c>Quartz.Examples.Worker</c> publishes fully trimmed over Quartz and nothing else, so an IL2xxx
     /// warning it reports is Quartz's own and fails this leg. <c>Quartz.Examples.AspNetCore</c> is a
     /// plain publish, because Razor Pages, MVC and Blazor Server are not trimmable and never will be —
     /// its csproj says so at length.
+    /// </para>
+    /// <para>
+    /// Still no native AOT publish here after step 5 of that issue, and the reason is a tooling one
+    /// rather than a scheduling one: ILCompiler takes no <c>--link-attributes</c>, so
+    /// <c>ILLink.Suppressions.xml</c> — which is what makes this leg green without silencing anything for
+    /// consumers — cannot be handed to it. An AOT publish of the worker therefore reports every recorded
+    /// warning as an error, and the only ways to quiet it are the two the issue has already refused: bake
+    /// the suppressions into the shipped assembly, or <c>NoWarn</c> the family and prove nothing. Step 5
+    /// ran the publish by hand and wrote down what it found; a leg here waits on step 6.
+    /// </para>
     /// </remarks>
     Target PublishTrimmed => _ => _
         .After<ICompile>()

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3655,7 +3655,10 @@ suppressed in the shipped assembly, deliberately — suppressing them would hide
 Configuration by flat `quartz.*` keys, jobs named as strings (`job_scheduling_data` XML, a persisted
 `JOB_CLASS_NAME`), and `JobDataMap` values bound onto job properties are the paths that need reflection;
 an application that configures in code, references its job types statically and keeps job data to
-primitives exercises far less of it. Progress is tracked on
+primitives exercises far less of it. One thing it does not get round: a **persistent job store** cannot
+be published trimmed at all yet, because a trimmed publish switches reflection-based `System.Text.Json`
+off and the default serializer has no generated contract to fall back on — see
+[Trimming](tutorial/more-about-jobs.md#trimming) for what that looks like. Progress is tracked on
 [#3341](https://github.com/quartznet/quartznet/issues/3341).
 
 ## Executing is a trigger state

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -447,10 +447,65 @@ rooted:
 Registering every job type with `AddJob<TJob>()` or `AddJobType<TJob>()` covers the first of those:
 those calls are what the trimmer follows, and the store then finds the type it needs.
 
-::: tip
-Native AOT is not supported yet — that work is tracked on
-[issue #3341](https://github.com/quartznet/quartznet/issues/3341).
+::: warning A trimmed publish switches reflection-based JSON off
+`PublishTrimmed` sets `System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault` to false, and the
+default `IObjectSerializer` has no source-generated contract to fall back on. An application that keeps
+its schedule in memory never notices; one with a **persistent job store** gets
+
+```
+System.InvalidOperationException: Reflection-based serialization has been disabled for this
+application. Either use the source generator APIs or explicitly configure the
+'JsonSerializerOptions.TypeInfoResolver' property.
+```
+
+the first time it writes a trigger. **Publish a persistent-store application untrimmed** until that is
+closed.
+
+Turning the switch back on with
+`<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` is not a
+way round it, and the failure it buys is a more confusing one: the trimmer has already removed what
+reflection would have needed, so the same write comes back as
+`FileNotFoundException: Could not load file or assembly 'System.Private.Uri'` instead. That holds for
+`TrimMode=partial` as much as for `full`.
 :::
+
+## Native AOT
+
+Everything above applies to `PublishAot` as well — it is a trimmed publish with an ahead-of-time
+compiler behind it — and native AOT adds one question of its own: what needs code to be *generated* at
+run time, which an AOT application has no way to do. Quartz builds with the AOT analyzer on, so those
+call sites are known rather than guessed at.
+
+**A scheduler over the in-memory store runs.** The worker example publishes and runs as a single native
+executable, with no runtime installed:
+
+```shell
+dotnet publish src/Quartz.Examples.Worker -c Release -r linux-x64 -p:PublishAot=true
+```
+
+It starts, initialises `RAMJobStore`, fires both its simple and its daily-time-interval trigger,
+executes and disposes job instances, applies flat `quartz.*` keys from `appsettings.json`, and shuts
+down cleanly on Ctrl+C with `WaitForJobsToComplete` honoured. Job types named as types, listeners and
+the DI graph all survive.
+
+**A scheduler over a persistent store does not, yet.** It is the serializer above, not the scheduler:
+`IObjectSerializer` writes triggers, calendars and `JobDataMap` values through reflection-based
+`System.Text.Json`, which is both switched off and uncompilable under AOT. This is what stops the
+`Quartz` package from declaring `IsAotCompatible`, and it is tracked on
+[issue #3341](https://github.com/quartznet/quartznet/issues/3341).
+
+**Publishing AOT reports Quartz's own warnings, and that is deliberate.** Quartz records its remaining
+reflective call sites in the repository rather than in the shipped assembly, so an
+`UnconditionalSuppressMessage` never hides them from you. Expect `IL2xxx` for the string-named
+configuration paths described above, and `IL3050` for two more:
+
+- **configuration binding** — `Configure<TOptions>(name, section)` binds the `Quartz` section by
+  reflecting over the options types. Configuring in code with `AddQuartz(q => …)` rather than from
+  `appsettings.json` avoids it;
+- **job data serialization** — the persistent-store path above.
+
+Neither is on the fire path of an in-memory scheduler, so an application that configures in code and
+schedules in memory publishes AOT with warnings it can read and dismiss.
 
 ## JobExecutionException
 

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -463,10 +463,11 @@ closed.
 
 Turning the switch back on with
 `<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` is not a
-way round it, and the failure it buys is a more confusing one: the trimmer has already removed what
-reflection would have needed, so the same write comes back as
-`FileNotFoundException: Could not load file or assembly 'System.Private.Uri'` instead. That holds for
-`TrimMode=partial` as much as for `full`.
+way round it either: the trimmer has already removed what reflection would have needed, and what
+remains fails later and less clearly. In the console application that produced the exception above,
+the same write came back as `FileNotFoundException: Could not load file or assembly
+'System.Private.Uri'`, under `TrimMode=partial` as much as `full`; a larger application keeps more
+and fails elsewhere. Reflection over a trimmed assembly is unsupported, not merely unreliable.
 :::
 
 ## Native AOT

--- a/src/Quartz/HttpApiContract/HttpApiJson.cs
+++ b/src/Quartz/HttpApiContract/HttpApiJson.cs
@@ -112,14 +112,21 @@ internal static class HttpApiJson
     /// first body either way.
     /// </para>
     /// <para>
-    /// The suppression therefore hides nothing an application is not told. The reflection it silences is
+    /// A native AOT publish is the same publish: it implies <c>PublishTrimmed</c>, so it sets the same
+    /// switch to false and ILCompiler substitutes the same property. That is why the AOT warning is
+    /// answered here rather than recorded — the resolver this branch would construct does not exist in
+    /// an AOT application to need constructing.
+    /// </para>
+    /// <para>
+    /// The suppressions therefore hide nothing an application is not told. The reflection they silence is
     /// already reported against
     /// <c>Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions</c>, which every caller of this
     /// method reaches through <c>JobDataMapConverter</c>, and which is deliberately not suppressed for
-    /// consumers.
+    /// consumers — as trimming-unsafe and as AOT-unsafe both.
     /// </para>
     /// </remarks>
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Guarded by IsReflectionEnabledByDefault, which a trimmed publish substitutes away along with this branch. See the remarks.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Guarded by IsReflectionEnabledByDefault, which an AOT publish substitutes away along with this branch. See the remarks.")]
     private static DefaultJsonTypeInfoResolver? ReflectionResolver()
     {
         return JsonSerializer.IsReflectionEnabledByDefault ? new DefaultJsonTypeInfoResolver() : null;

--- a/src/Quartz/ILLink.Suppressions.xml
+++ b/src/Quartz/ILLink.Suppressions.xml
@@ -9,6 +9,15 @@
   warning to silence. Removing an entry that looks unused because the analyzer is quiet about it fails
   the publish; verify against a clean `dotnet fallout PublishTrimmed`, not against the compile.
 
+  The other difference is that this file carries no IL3050, where TrimAnalysisBaseline.cs carries three.
+  That is not an omission. ILLink does not report IL3050 at all — dynamic code is ILCompiler's concern,
+  and ILCompiler cannot be handed this file: its command line offers a descriptor option and a
+  substitution option and no link-attributes option at all, and the SDK item below only ever reaches
+  ILLink. The only way to tell ILCompiler would be to bake UnconditionalSuppressMessage into the shipped
+  assembly, which is exactly the lie the paragraph below refuses to tell. So a native AOT publish of the
+  examples reports every one of these against Quartz and cannot be made a CI leg; step 5 of #3341 ran it
+  by hand instead, and its pull request records what it said.
+
   Two files are needed because the two tools cannot be told the same way. SuppressMessageAttribute is
   [Conditional("CODE_ANALYSIS")], so the C# baseline never reaches metadata and ILLink cannot see it;
   ILLink is told through its link-attributes option instead. The unconditional attribute would cover

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -7,6 +7,22 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <!--
+      IsAotCompatible would turn these two on as well, and it is deliberately not set. Step 5 of #3341
+      turned them on by themselves instead, so that the warnings could be counted before the claim was
+      made: twelve IL3050 call sites, of which one was fixed, one answered at the call site and ten are
+      recorded in TrimAnalysisBaseline.cs. That much would be the same standard IsTrimmable is held to.
+
+      What stops the claim is not a warning but a run. A native AOT publish switches reflection-based
+      System.Text.Json off, and the default IObjectSerializer has no resolver to fall back on when it is
+      — so a native AOT application over RAMJobStore starts, fires its triggers and shuts down cleanly,
+      while one over a persistent store throws "Reflection-based serialization has been disabled for
+      this application" the first time it writes a trigger. Saying IsAotCompatible here would claim
+      otherwise. (A trimmed publish switches the same thing off, so this predates AOT; the trim canary
+      never noticed because it is an in-memory application.)
+    -->
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz/TrimAnalysisBaseline.cs
+++ b/src/Quartz/TrimAnalysisBaseline.cs
@@ -21,10 +21,11 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-// The trim-analysis warnings Quartz still produces (https://github.com/quartznet/quartznet/issues/3341).
-// It is a baseline, not an all-clear: none of these call sites is trim-safe. What the baseline buys is
-// that a *new* one fails the build, because TreatWarningsAsErrors makes IL2xxx an error and nothing
-// suppresses a warning that is not listed here.
+// The trim- and AOT-analysis warnings Quartz still produces (https://github.com/quartznet/quartznet/issues/3341).
+// It is a baseline, not an all-clear: none of these call sites is trim-safe, and the IL3050 ones are not
+// AOT-safe either. What the baseline buys is that a *new* one fails the build, because
+// TreatWarningsAsErrors makes an IL2xxx or an IL3xxx an error and nothing suppresses a warning that is
+// not listed here.
 //
 // Step 3 of that issue took the fire path out of this file. A job type that reached Quartz as a type -
 // JobBuilder.Create<T>(), OfType<T>(), AddJob<T>() - now carries [DynamicallyAccessedMembers] all the
@@ -36,6 +37,17 @@ using System.Diagnostics.CodeAnalysis;
 // the API exchanges, and HttpApiJson.ConfigureWireFormat asks it before it asks reflection. That change
 // removed no entry either, because the contract's reflection was never Quartz's own warning to record -
 // it lived in System.Text.Json's lazy fallback, which nothing reports.
+//
+// Step 5 turned the AOT and single-file analyzers on beside the trim analyzer, which is where the IL3050
+// entries came from. The single-file analyzer found nothing at all: Quartz reads no file it did not
+// embed, so there is no Assembly.Location for it to object to. The AOT analyzer found twelve call sites
+// and not one new type - every IL3050 below is on a type this file already listed, because needing
+// runtime code generation and being untrimmable are the same three habits here: binding options,
+// serializing job data, and reading it back. Two of the twelve are gone rather than recorded, which is
+// the order this file asks for: XmlSchedulingDataProcessor asked Enum.GetValues for an array of a type
+// named at runtime and now asks the generic overload for the same array at compile time, and
+// HttpApiJson.ReflectionResolver answers at the call site, because a native AOT publish substitutes its
+// feature switch away exactly as a trimmed one does.
 //
 // Adding an entry is the wrong first move. Reach for it only after establishing that the reflection is
 // genuinely unavoidable, and then say in the group comment why. The preferred fixes, in order:
@@ -113,13 +125,33 @@ using System.Diagnostics.CodeAnalysis;
 // is serialized. Everything around it is closed now - the wire contract by HttpApiJsonContext, the
 // trigger and calendar shapes by their serializers - and these two are the open middle that is left:
 // the values themselves, which no generated contract can name because the application chose them.
+//
+// The same two types are where the AOT analyzer lands, and for the same reason one step further on: a
+// converter System.Text.Json has to work out at runtime is a converter it has to generate. Every
+// JsonSerializer overload taking a JsonSerializerOptions is RequiresDynamicCode wholesale, so this
+// covers the one closed shape among them - a job data value read back as Dictionary<string, string> -
+// as well as the open ones.
+//
+// These two are also the entries that keep Quartz.csproj from saying IsAotCompatible, and they are the
+// only ones this file records that a publish does not merely warn about. A trimmed or AOT publish
+// switches System.Text.Json's reflection fallback off, and CreateSerializerOptions builds options with
+// converters but no resolver - so serializing anything through them throws "Reflection-based
+// serialization has been disabled for this application" rather than losing a member. A persistent job
+// store hits that on the first trigger it writes. Closing it means giving these options a resolver that
+// survives with reflection off, which is a change of shape rather than a suppression, and is what step 6
+// of #3341 is for.
 
 [assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Impl.SystemTextJsonObjectSerializer", Justification = "Job data is serialized as whatever the application stored, which no generated contract can name.")]
 [assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions", Justification = "Job data is serialized as whatever the application stored, which no generated contract can name.")]
+[assembly: SuppressMessage("AOT", "IL3050", Scope = "type", Target = "T:Quartz.Impl.SystemTextJsonObjectSerializer", Justification = "Serializing a type chosen by the application is what System.Text.Json needs runtime code generation for.")]
+[assembly: SuppressMessage("AOT", "IL3050", Scope = "type", Target = "T:Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions", Justification = "Serializing a type chosen by the application is what System.Text.Json needs runtime code generation for.")]
 
 // --- Configuration binding ------------------------------------------------------------------------------
-// IServiceCollection.Configure<TOptions>(name, section) is RequiresUnreferencedCode: the binder reflects
-// over TOptions. The options types are ours and closed, so the source-generated binder is the fix; that
-// is a separate change from this baseline.
+// IServiceCollection.Configure<TOptions>(name, section) is RequiresUnreferencedCode and
+// RequiresDynamicCode both: the binder reflects over TOptions, and builds what it needs to set a
+// collection or a nullable property on it. The options types are ours and closed, so the
+// source-generated binder is the fix for both; that is a separate change from this baseline, and the
+// one entry here that a later step can expect to delete rather than argue for.
 
 [assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Configuration.QuartzTypedOptions", Justification = "Binding the quartz configuration section reflects over the options types; the source-generated binder is the fix.")]
+[assembly: SuppressMessage("AOT", "IL3050", Scope = "type", Target = "T:Quartz.Configuration.QuartzTypedOptions", Justification = "Binding the quartz configuration section generates code for the options types; the source-generated binder is the fix.")]

--- a/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
@@ -498,11 +498,16 @@ internal class XmlSchedulingDataProcessor
         return retValue;
     }
 
-    protected virtual bool TryParseEnum<T>(string value, out T result) where T : struct
+    /// <remarks>
+    /// The generic overloads of <see cref="Enum.GetNames{TEnum}" /> and <see cref="Enum.GetValues{TEnum}" />
+    /// rather than the ones taking a <see cref="Type" />: building an array of an enum type named at runtime
+    /// is code the AOT compiler would have to generate, and the constraint means it never has to.
+    /// </remarks>
+    protected virtual bool TryParseEnum<T>(string value, out T result) where T : struct, Enum
     {
-        var names = Enum.GetNames(typeof(T));
-        result = (T) Enum.GetValues(typeof(T)).GetValue(0)!;
-        foreach (var name in names)
+        string[] names = Enum.GetNames<T>();
+        result = Enum.GetValues<T>()[0];
+        foreach (string name in names)
         {
             if (name == value)
             {


### PR DESCRIPTION
Part of #3341 (step 5). `EnableAotAnalyzer` and `EnableSingleFileAnalyzer` are on for `Quartz`
beside the trim analyzer that step 1 turned on, everything they found is either fixed or recorded, and
a real `PublishAot` publish was run to check the analyzers against a scheduler that actually starts.

**`IsAotCompatible` is not set**, and the argument for that is below — it is a runtime finding rather
than a warning count, and it names step 6.

## The raw inventory

`dotnet build src/Quartz/Quartz.csproj` with the two analyzers on and nothing recorded: **twelve
warnings, all IL3050, in five types**. The single-file analyzer reported **nothing at all** — Quartz
reads no file it did not embed, so there is no `Assembly.Location` for it to object to. No IL3051,
IL3052, IL3053 or IL3054 either.

| Site | Type | What it uses | Fire path? | Outcome |
|---|---|---|---|---|
| `Configuration/QuartzTypedOptions.cs` 103, 104, 110, 111, 115, 121 | `Quartz.Configuration.QuartzTypedOptions` | `Configure<TOptions>(IServiceCollection, string, IConfiguration)` | no — registration only | recorded |
| `HttpApiContract/HttpApiJson.cs` 125 | `Quartz.HttpApiContract.HttpApiJson` | `new DefaultJsonTypeInfoResolver()` | no | **answered at the call site** |
| `Impl/SystemTextJsonObjectSerializer.cs` 74 | `Quartz.Impl.SystemTextJsonObjectSerializer` | `JsonSerializer.SerializeToUtf8Bytes<TValue>(TValue, JsonSerializerOptions)` | yes, persistent store | recorded |
| `Impl/SystemTextJsonObjectSerializer.cs` 85 | same | `JsonSerializer.Deserialize<TValue>(ReadOnlySpan<byte>, JsonSerializerOptions)` | yes | recorded |
| `Serialization/SystemTextJson/SerializationExtensions.cs` 293 | `Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions` | `JsonSerializer.Serialize<TValue>(Utf8JsonWriter, TValue, JsonSerializerOptions)` | yes | recorded |
| `Serialization/SystemTextJson/SerializationExtensions.cs` 335 | same | `JsonSerializer.Deserialize<TValue>(JsonElement, JsonSerializerOptions)` | yes | recorded |
| `Xml/XmlSchedulingDataProcessor.cs` 504 | `Quartz.Xml.XmlSchedulingDataProcessor` | `Enum.GetValues(Type)` | no | **fixed** |

Not one *new* type: every IL3050 lands on a type `TrimAnalysisBaseline.cs` already listed for
trimming. Needing runtime code generation and being untrimmable turn out to be the same three habits
here — binding options, serializing job data, and reading it back.

The spec's likely suspects did not appear, and it is worth saying so: there is no `MakeGenericType`,
`MakeGenericMethod`, `Expression.Compile` or `Reflection.Emit` anywhere in `Quartz`.
`JobDataExpression` only ever *inspects* the expression tree it is handed, exactly as its remarks
claim, so it is AOT-clean. `ObjectUtils`'s `TypeDescriptor` and `Activator.CreateInstance(Type)` and
`Enum.ToObject(Type, object)` are trimming concerns but not dynamic-code ones, and the analyzer agrees.

## Fixed versus recorded

**Fixed (1).** `XmlSchedulingDataProcessor.TryParseEnum<T>` asked `Enum.GetValues(typeof(T))` for an
array of a type named at runtime. The constraint is now `where T : struct, Enum` and the call is
`Enum.GetValues<T>()`, which asks for the same array at compile time. Behaviour is unchanged line for
line — the type is `internal`, the method has one caller, and the public API baselines do not move.

**Answered at the call site (1).** `HttpApiJson.ReflectionResolver` already carried an
`[UnconditionalSuppressMessage]` for IL2026 with the argument that a trimmed publish substitutes
`JsonSerializer.IsReflectionEnabledByDefault` to `false` and drops the branch entirely. A native AOT
publish implies `PublishTrimmed`, sets the same switch and substitutes the same property, so the
identical argument covers IL3050; it now carries both attributes and the remarks say why. No baseline
entry.

**Recorded (10 warnings, 3 entries).** `TrimAnalysisBaseline.cs` goes from **21 entries to 24**, all
three type-scoped like the rest, in the two groups that already existed:

- `Quartz.Configuration.QuartzTypedOptions` — `Configure<TOptions>(name, section)` is
  `RequiresDynamicCode` as well as `RequiresUnreferencedCode`. The options types are ours and closed,
  so the source-generated binder is the fix for both. This is the one entry a later step can expect to
  *delete* rather than argue for.
- `Quartz.Impl.SystemTextJsonObjectSerializer` and
  `Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions` — every `JsonSerializer` overload
  taking a `JsonSerializerOptions` is `RequiresDynamicCode` wholesale, which catches the one closed
  shape among them (a job data value read back as `Dictionary<string, string>`) along with the open ones.

I did not add `[RequiresDynamicCode]` to the string-contract entry points that carry
`[RequiresUnreferencedCode]`. The evidence refuses it: not one of them produced an IL3050, because
`Type.GetType`, `Activator.CreateInstance(Type)` and `TypeDescriptor` are all things a native AOT
application can do. Marking them would warn consumers about paths that work.

### No AOT entries in `ILLink.Suppressions.xml`, deliberately

ILLink does not report IL3050 at all, and ILCompiler — which does — is given no link-attributes file
by the SDK and offers no option to take one. The only way to tell ILCompiler would be to bake
`UnconditionalSuppressMessage` into the shipped assembly, which is the exact lie that file's header
refuses to tell. **So an AOT publish of the examples cannot be made a CI leg**, and `build/Build.cs`
now says so beside the `PublishTrimmed` target instead of leaving the next person to rediscover it.
The XML header explains the asymmetry so nobody "completes" the mirror.

## The AOT publish, verbatim

```
dotnet publish src/Quartz.Examples.Worker -c Release -r win-x64 -p:PublishAot=true -p:TreatWarningsAsErrors=false
```

The native toolchain is present on this machine (VS 2022 Community, MSVC 14.44). One
17.1 MB `Quartz.Examples.Worker.exe`, no runtime, no managed assemblies beside it. ILCompiler reported
39 warnings against Quartz — `IL2072`×12, `IL2026`×9, `IL2057`×6, `IL2070`×4, **`IL3050`×4**,
`IL2067`×2, `IL2075`×1, `IL2078`×1 — which is the recorded set, unsuppressed, for the reason above.
`-p:TreatWarningsAsErrors=false` is what makes them warnings rather than a failed publish.

Run for thirty seconds and then sent Ctrl+C (thirty rather than ten because the example sets
`StartDelay = TimeSpan.FromSeconds(10)` of its own, so a ten-second run only ever watches the host come
up):

```
[19:11:31 INF] Initialized Scheduler Signaller of type: Quartz.Core.SchedulerSignalerImpl
[19:11:31 INF] Quartz Scheduler created
[19:11:31 INF] JobFactory set to: Quartz.Impl.MicrosoftDependencyInjectionJobFactory
[19:11:31 INF] RAMJobStore initialized.
[19:11:31 INF] Adding 2 jobs, 2 triggers
[19:11:31 INF] Adding job: DEFAULT.Combined Configuration Trigger
[19:11:31 INF] Adding job: awesome group.awesome job
[19:11:31 INF] Quartz Scheduler 4.0.0.0 - 'Quartz Worker Service Sample Scheduler' with instanceId 'Scheduler-Core' initialized
[19:11:31 INF] Using thread pool 'Quartz.Impl.DefaultThreadPool', size: 10
[19:11:31 INF] Using job store 'Quartz.Impl.RAMJobStore', supports persistence: False, clustered: False
[19:11:31 INF] Application started. Press Ctrl+C to shut down.
[19:11:31 INF] Hosting environment: Production
[19:11:41 INF] Scheduler Quartz Worker Service Sample Scheduler starting
[19:11:41 INF] Scheduler Quartz Worker Service Sample Scheduler_$_Scheduler-Core started.
[19:11:41 INF] Trigger DEFAULT.Combined Configuration Trigger fired
[19:11:41 INF] Job DEFAULT.Combined Configuration Trigger to be executed
[19:11:41 INF] DEFAULT.Combined Configuration Trigger job executing, triggered by DEFAULT.Combined Configuration Trigger
[19:11:42 INF] Example job disposing
[19:11:50 INF] Trigger DEFAULT.Combined Configuration Trigger fired
[19:11:50 INF] Job DEFAULT.Combined Configuration Trigger to be executed
[19:11:50 INF] DEFAULT.Combined Configuration Trigger job executing, triggered by DEFAULT.Combined Configuration Trigger
[19:11:51 INF] Example job disposing
[19:11:51 INF] Trigger DEFAULT.Simple Trigger fired
[19:11:51 INF] Job awesome group.awesome job to be executed
[19:11:51 INF] awesome group.awesome job job executing, triggered by DEFAULT.Simple Trigger
[19:11:52 INF] Example job disposing
[19:12:00 INF] Trigger DEFAULT.Combined Configuration Trigger fired
[19:12:00 INF] Job DEFAULT.Combined Configuration Trigger to be executed
[19:12:00 INF] DEFAULT.Combined Configuration Trigger job executing, triggered by DEFAULT.Combined Configuration Trigger
[19:12:01 INF] Example job disposing
[19:12:01 INF] Application is shutting down...
[19:12:01 INF] Scheduler Quartz Worker Service Sample Scheduler_$_Scheduler-Core shutting down.
[19:12:01 INF] Scheduler Quartz Worker Service Sample Scheduler_$_Scheduler-Core paused.
[19:12:01 INF] Scheduler Quartz Worker Service Sample Scheduler_$_Scheduler-Core Shutdown complete.
---- exit code: 0
```

Nothing reflective broke: no `MissingMethodException`, no `NotSupportedException`. The DI graph, the
job factory, the listeners, both triggers and the job type all survive, and so does the flat
`quartz.scheduler.instanceName` key the example puts in `appsettings.json` — which is `QuartzPropertyBridge`,
one of the loudest entries in the trim baseline, working correctly under AOT. The worker needed no
change to its `Program.cs`.

## The `IsAotCompatible` decision, and why it is no

If the warning count were the whole story I would set it: ten recorded warnings, every one of them
avoidable by an application that configures in code and keeps job data simple, which is the same
standard `IsTrimmable` is already held to.

What stops it is a run, not a warning. **A native AOT publish switches reflection-based
`System.Text.Json` off, and the default `IObjectSerializer` has no resolver to fall back on.** A
throwaway AOT console app over `SystemTextJsonObjectSerializer` — the serializer every persistent job
store uses, and the one DI constructs — gives:

```
IsReflectionEnabledByDefault = False
THREW: System.InvalidOperationException: Reflection-based serialization has been disabled for this
application. Either use the source generator APIs or explicitly configure the
'JsonSerializerOptions.TypeInfoResolver' property.
TRIGGER THREW: System.InvalidOperationException: Reflection-based serialization has been disabled ...
```

for a `JobDataMap` *and* for a plain `SimpleTrigger`. That is not a string contract an application can
route around; it is the first thing an ADO.NET store writes. Declaring `IsAotCompatible` would say
otherwise.

Two things a reviewer should know about that finding:

1. **It predates AOT.** A plain `PublishTrimmed` sets the same switch, and the same probe fails the
   same way trimmed. The trim canary never noticed because `Quartz.Examples.Worker` is an in-memory
   application. So the marking we already ship, `IsTrimmable`, is arguably ahead of the evidence too —
   I have left it alone, since it is the correct opt-in for trim *analysis* and unsetting it is a
   separate argument.
2. **Turning reflection back on does not rescue it.** With
   `JsonSerializerIsReflectionEnabledByDefault=true` the trimmer has already removed what reflection
   needs, so the same write comes back as
   `FileNotFoundException: Could not load file or assembly 'System.Private.Uri'` — under
   `TrimMode=partial` as much as `full`. Only an untrimmed publish round-trips today (verified).

**Step 6 is therefore: give `SystemTextJsonObjectSerializer.CreateSerializerOptions` a
`TypeInfoResolver` that survives with reflection off** — a source-generated context for the trigger and
calendar shapes, which are closed and ours, plus a decided story for the `JobDataMap` values, which are
not. That is a change of shape rather than a suppression, and it is what the package needs before it
can claim AOT compatibility. With it done, the `QuartzTypedOptions` entry falls to the
source-generated configuration binder and the baseline's IL3050 section empties out.

## Documentation

`docs/documentation/quartz-4.x/tutorial/more-about-jobs.md` loses the `::: tip Native AOT is not
supported yet :::` placeholder and gains a `## Native AOT` section saying what a publish actually does,
plus a warning box on the trimming section carrying the persistent-store finding — it is a trimming
fact first. `migration-guide.md`'s trimming paragraph gains one sentence for the same reason; it
currently reads more optimistically than the evidence supports. No new C# is shown, so the page's
hand-written fences stay hand-written rather than being converted halfway.

## Found and deliberately left alone

- **`Quartz.Configuration.ListenerRegistration<T>` produces `IL2078` under ILCompiler and nothing under
  ILLink**, so it is in neither baseline and does not fail `PublishTrimmed`. It is a real gap in the
  mirror's coverage rather than a new regression, and recording it would mean recording it in a file
  that ILCompiler cannot read. Left for step 6, which will have to decide how ILC's extra findings are
  tracked at all.
- The missing scheduler-shutdown log lines I saw while working against the original base
  (`8556a9b33`) are **already fixed** by #3404 on `main`; the run above shows all three.

## Verification

All run on `8ae5b850`, rebased onto `origin/main` at `8a0e9f9f8`.

| Command | Result |
|---|---|
| `dotnet build src/Quartz/Quartz.csproj` | 0 Warning(s), 0 Error(s) — no unlisted IL2xxx/IL3xxx |
| `dotnet build Quartz.slnx` | 0 Warning(s), 0 Error(s) |
| `dotnet test src/Quartz.Tests.Unit` | Passed — Failed: 0, Passed: 3253, Skipped: 4 |
| `dotnet test src/Quartz.Tests.AspNetCore` | Passed — Failed: 0, Passed: 427, Skipped: 0 |
| `dotnet fallout PublishTrimmed` (clean publish dir) | Succeeded |
| `dotnet publish -p:PublishAot=true` + 30s run | exit code 0, log above |
| `dotnet fallout VerifyDocsSnippets` | Succeeded — 90 markdown files checked |
| `npm run docs:check-links` | 212 pages, 734 internal links, 422 fragments — no dead links or anchors |

Integration tests were not run: they need Docker, and nothing here touches a job store's SQL.
