### PR TITLE
The four untested tenancy combinations are tested

### DIFF
--- a/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.HttpApiContract;
+using Quartz.Serialization.SystemTextJson;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// How the HTTP API answers for a tenant, where "registered" and "running" come apart.
+/// </summary>
+/// <remarks>
+/// The routes resolve through <see cref="ISchedulerRepository" />, which holds the schedulers something
+/// has already created. That is what <c>multi-tenancy.md</c> says in its "the dashboard and the HTTP API
+/// list the repository, not the registry" box, and nothing had gone through the wire to check it.
+/// </remarks>
+[NonParallelizable]
+public sealed class TenantSchedulerRoutingTest
+{
+    private readonly List<WebApplicationFactory<Program>> factories = [];
+
+    [TearDown]
+    public async Task DisposeApplications()
+    {
+        foreach (WebApplicationFactory<Program> factory in factories)
+        {
+            await factory.DisposeAsync();
+        }
+
+        factories.Clear();
+    }
+
+    /// <summary>
+    /// The window <c>AddQuartzHostedService()</c> closes and everything else leaves open: the container
+    /// knows the tenant, nothing has built it, and the two views of "what schedulers are there" disagree
+    /// on purpose. The API answering <c>404</c> here is not "unknown name" — it is "nothing has built it
+    /// yet", and <see cref="ISchedulerRegistry" /> is the read that can tell the two apart.
+    /// </summary>
+    [Test]
+    public async Task ATenantNothingHasBuiltIsMissingFromTheApiAndPresentInTheRegistry()
+    {
+        WebApplicationFactory<Program> application = CreateApplication("acme");
+
+        using HttpClient client = application.CreateClient();
+
+        using HttpResponseMessage response = await client.GetAsync("schedulers/acme");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "the route resolves through the repository, which holds schedulers something has created - and "
+            + "answering it by building one would make an operator's dashboard start every tenant it lists");
+
+        SchedulerHeaderDto[] listed = await ReadSchedulers(client);
+        listed.Should().NotContain(x => x.Name == "acme",
+            "the listing reads the same repository the lookup does, so a tenant absent from one is absent from both");
+
+        List<SchedulerRegistration> registrations =
+            await application.Services.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        SchedulerRegistration registration = registrations.Should().ContainSingle(x => x.Name == "acme",
+            "the registry reads the registrations, which is where a tenant nobody has asked for still exists").Subject;
+        registration.Status.Should().BeNull(
+            "null is the answer this query exists to give - the registration is there, nothing was built from "
+            + "it, and asking did not build it");
+        registration.IsCreated.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Builds the test application with one named scheduler registered beside the default one, and
+    /// records it for disposal. Per test rather than per fixture, because whether the tenant has been
+    /// created is exactly what these tests differ on.
+    /// </summary>
+    private WebApplicationFactory<Program> CreateApplication(string tenantName)
+    {
+        TestContentRoot.Apply();
+
+        WebApplicationFactory<Program> root = new();
+        factories.Add(root);
+
+        WebApplicationFactory<Program> application = root.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services => services.AddQuartz(tenantName, q => q.UseInMemoryStore())));
+        factories.Add(application);
+
+        return application;
+    }
+
+    private static async Task<SchedulerHeaderDto[]> ReadSchedulers(HttpClient client)
+    {
+        // This endpoint is not one HttpScheduler calls, so the reader is built here - off the same wire
+        // contract the endpoint writes with.
+        JsonSerializerOptions serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            .ConfigureWireFormat(new SystemTextJsonSerializerRegistry());
+
+        using HttpResponseMessage response = await client.GetAsync("schedulers");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<SchedulerHeaderDto[]>(body, serializerOptions)!;
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
@@ -12,12 +12,16 @@ using Quartz.Tests.AspNetCore.Support;
 namespace Quartz.Tests.AspNetCore.HttpApi;
 
 /// <summary>
-/// How the HTTP API answers for a tenant, where "registered" and "running" come apart.
+/// How the HTTP API answers for a tenant, on the two questions where "registered" and "running" come
+/// apart: a tenant nothing has built yet, and a tenant asked for under a different casing than it was
+/// registered with.
 /// </summary>
 /// <remarks>
-/// The routes resolve through <see cref="ISchedulerRepository" />, which holds the schedulers something
-/// has already created. That is what <c>multi-tenancy.md</c> says in its "the dashboard and the HTTP API
-/// list the repository, not the registry" box, and nothing had gone through the wire to check it.
+/// Both routes resolve through <see cref="ISchedulerRepository" />, which holds the schedulers something
+/// has already created and indexes them ignoring case. That is two separate statements in
+/// <c>multi-tenancy.md</c> — the "the dashboard and the HTTP API list the repository, not the registry"
+/// box, and the scheduler name being compared case-insensitively there while the container compares
+/// service keys ordinally — and neither had gone through the wire.
 /// </remarks>
 [NonParallelizable]
 public sealed class TenantSchedulerRoutingTest
@@ -66,6 +70,93 @@ public sealed class TenantSchedulerRoutingTest
             "null is the answer this query exists to give - the registration is there, nothing was built from "
             + "it, and asking did not build it");
         registration.IsCreated.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The same name spelled two ways. The repository indexes ignoring case, so the route finds the
+    /// scheduler; the container compares service keys ordinally, which
+    /// <c>SchedulerNameComparisonTest</c> covers on the other side of the same registration.
+    /// </summary>
+    [Test]
+    public async Task ATenantRegisteredAsAcmeIsReachableAtTheAcmeRoute()
+    {
+        WebApplicationFactory<Program> application = CreateApplication("Acme");
+
+        // Created explicitly: until something builds it, the route would answer 404 for either spelling,
+        // and the casing would not be what the test was measuring.
+        IScheduler scheduler = await application.Services
+            .GetRequiredKeyedService<ISchedulerFactory>("Acme")
+            .GetScheduler();
+
+        try
+        {
+            using HttpClient client = application.CreateClient();
+
+            using HttpResponseMessage details = await client.GetAsync("schedulers/acme");
+            details.StatusCode.Should().Be(HttpStatusCode.OK,
+                "every ISchedulerRepository lookup compares names ignoring case, and the API route is one");
+
+            using HttpResponseMessage jobs = await client.GetAsync("schedulers/acme/jobs");
+            jobs.StatusCode.Should().Be(HttpStatusCode.OK,
+                "the casing is forgiven by the lookup rather than by one endpoint group, so a route under a "
+                + "different one resolves the same scheduler the same way");
+
+            SchedulerHeaderDto[] listed = await ReadSchedulers(client);
+            listed.Should().ContainSingle(x => x.Name == "Acme",
+                "a scheduler is listed under the name it was registered with, whatever spelling the caller used "
+                + "to reach it");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// A defect this fixture walked into, kept as the failing test rather than fixed here: the
+    /// scheduler-context endpoint answers <c>500</c> for every scheduler a container built.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>SchedulerContentInitializer.Initialize</c> puts the <see cref="IServiceProvider" /> into
+    /// <c>scheduler.Context["Quartz.ServiceProvider"]</c> so that plugins can reach the container, and
+    /// <c>SchedulerContextDto.Create</c> throws <see cref="NotSupportedException" /> when any context value
+    /// is not a string. Every scheduler built by <c>AddQuartz</c> — and by
+    /// <c>QuartzSchedulerBuilder</c>, which builds a container of its own — therefore has exactly one
+    /// entry the endpoint refuses, so <c>GET …/schedulers/{name}/context</c> is unusable in every real
+    /// deployment while <c>SchedulerEndpointsTest.GetSchedulerContextShouldWork</c> passes: that fixture's
+    /// scheduler is a fake whose context the test filled with strings.
+    /// </para>
+    /// <para>
+    /// Nothing about it is specific to a tenant; it is only that a real container-built scheduler had
+    /// never been driven through this route. Which way to fix it is a product decision — skip
+    /// non-serializable entries, report them as their type name, or move the service provider off the
+    /// context — so this test is <c>[Explicit]</c> and states the failure rather than choosing.
+    /// </para>
+    /// </remarks>
+    [Test]
+    [Explicit("Fails: GET /schedulers/{name}/context is 500 for any container-built scheduler. See the remarks.")]
+    public async Task TheContextOfAContainerBuiltSchedulerCanBeRead()
+    {
+        WebApplicationFactory<Program> application = CreateApplication("Acme");
+
+        IScheduler scheduler = await application.Services
+            .GetRequiredKeyedService<ISchedulerFactory>("Acme")
+            .GetScheduler();
+
+        try
+        {
+            using HttpClient client = application.CreateClient();
+
+            using HttpResponseMessage context = await client.GetAsync("schedulers/Acme/context");
+            context.StatusCode.Should().Be(HttpStatusCode.OK,
+                "a scheduler's context is readable over the API, and every container-built scheduler carries "
+                + "the container in it - so an endpoint that refuses a non-string value refuses them all");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
     }
 
     /// <summary>

--- a/src/Quartz.Tests.AspNetCore/HttpApi/WebApiTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WebApiTest.cs
@@ -13,7 +13,7 @@ public abstract class WebApiTest
     [OneTimeSetUp]
     public void OneTimeSetup()
     {
-        Environment.SetEnvironmentVariable("ASPNETCORE_TEST_CONTENTROOT_QUARTZ_TESTS_ASPNETCORE", ResolveContentRoot());
+        TestContentRoot.Apply();
         WebApplicationFactory = new WebApplicationFactory<Program>();
         HttpScheduler = new HttpScheduler(TestData.SchedulerName, WebApplicationFactory.CreateClient());
     }
@@ -69,20 +69,4 @@ public abstract class WebApiTest
         }
     }
 
-    private static string ResolveContentRoot()
-    {
-        DirectoryInfo? directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null)
-        {
-            string projectFilePath = Path.Combine(directory.FullName, "src", "Quartz.Tests.AspNetCore", "Quartz.Tests.AspNetCore.csproj");
-            if (File.Exists(projectFilePath))
-            {
-                return Path.Combine(directory.FullName, "src", "Quartz.Tests.AspNetCore");
-            }
-
-            directory = directory.Parent;
-        }
-
-        throw new InvalidOperationException($"Could not locate content root from base path {AppContext.BaseDirectory}.");
-    }
 }

--- a/src/Quartz.Tests.AspNetCore/Support/TestContentRoot.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestContentRoot.cs
@@ -1,0 +1,44 @@
+namespace Quartz.Tests.AspNetCore.Support;
+
+/// <summary>
+/// Where <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}" /> should think
+/// this test assembly's application lives.
+/// </summary>
+/// <remarks>
+/// The factory otherwise derives the content root from a build-time manifest, which does not survive
+/// every way this suite is run. Setting
+/// <c>ASPNETCORE_TEST_CONTENTROOT_QUARTZ_TESTS_ASPNETCORE</c> to the answer is the documented override,
+/// and the answer is found by walking up to the project rather than hard-coded, so it holds whatever the
+/// output path is.
+/// </remarks>
+internal static class TestContentRoot
+{
+    internal const string EnvironmentVariable = "ASPNETCORE_TEST_CONTENTROOT_QUARTZ_TESTS_ASPNETCORE";
+
+    /// <summary>
+    /// Points the factory's content root at this test project, and answers where that is.
+    /// </summary>
+    public static string Apply()
+    {
+        string contentRoot = Resolve();
+        Environment.SetEnvironmentVariable(EnvironmentVariable, contentRoot);
+        return contentRoot;
+    }
+
+    private static string Resolve()
+    {
+        DirectoryInfo? directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            string projectFilePath = Path.Combine(directory.FullName, "src", "Quartz.Tests.AspNetCore", "Quartz.Tests.AspNetCore.csproj");
+            if (File.Exists(projectFilePath))
+            {
+                return Path.Combine(directory.FullName, "src", "Quartz.Tests.AspNetCore");
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException($"Could not locate content root from base path {AppContext.BaseDirectory}.");
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExecutionCeilingPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExecutionCeilingPostgresTest.cs
@@ -1,0 +1,14 @@
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The cluster-scoped ceiling against PostgreSQL, whose acquisition locks through
+/// <c>PostgreSqlSelectForUpdateSemaphore</c> and whose <c>COUNT(*)</c> comes back as a 64-bit integer.
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class ClusteredExecutionCeilingPostgresTest : ClusteredExecutionCeilingTestBase
+{
+    public ClusteredExecutionCeilingPostgresTest() : base(TestConstants.PostgresProvider)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExecutionCeilingSqlServerTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExecutionCeilingSqlServerTest.cs
@@ -1,0 +1,15 @@
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The cluster-scoped ceiling against SQL Server, whose acquisition locks through
+/// <c>SelectForUpdateSemaphore</c> with the <c>(UPDLOCK,ROWLOCK)</c> hint and whose <c>COUNT(*)</c>
+/// comes back as a 32-bit integer.
+/// </summary>
+[Category("db-sqlserver")]
+[NonParallelizable]
+public sealed class ClusteredExecutionCeilingSqlServerTest : ClusteredExecutionCeilingTestBase
+{
+    public ClusteredExecutionCeilingSqlServerTest() : base(TestConstants.DefaultSqlServerProvider)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExecutionCeilingTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExecutionCeilingTestBase.cs
@@ -1,0 +1,267 @@
+using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Globalization;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// A cluster-scoped execution limit, measured across two real nodes sharing one database rather than
+/// against a single store's ledger.
+/// <para>
+/// <c>JobStoreContractTest</c> already holds both stores to what the ledger says — a reservation counts,
+/// a running execution counts, a node-scoped limit does not count either. None of that says what two
+/// nodes racing each other actually manage to run at the same instant, which is the number a tenant
+/// quota is bought for. The documented promise is deliberately not "never more than the limit": with
+/// <c>AcquireTriggersWithinLock</c> off — the default — two nodes can read the same in-flight count in
+/// the same instant and each take one trigger, so the ceiling holds within an acquisition round and the
+/// transient overshoot is bounded by <c>limit + (nodes - 1)</c>. Turning the lock on makes it exact.
+/// Both halves of that sentence are asserted here, because a bound nothing measures is a hope.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Run against every engine that has a fixture: the ceiling is one aggregate over
+/// <c>QRTZ_FIRED_TRIGGERS</c> evaluated beside the candidate select, under whichever lock the engine's
+/// semaphore implements, and neither the aggregate's <c>COUNT(*)</c> type nor the locking is the same on
+/// PostgreSQL as on SQL Server.
+/// </remarks>
+public abstract class ClusteredExecutionCeilingTestBase : ClusteredJobStoreTestBase
+{
+    /// <summary>The execution group the ceiling applies to — the "tenant" of a tenant quota.</summary>
+    private const string Tenant = "tenant-acme";
+
+    private const string Group = "clusterCeiling";
+
+    /// <summary>How many triggers of <see cref="Tenant" /> may run at once, cluster-wide.</summary>
+    private const int Limit = 2;
+
+    private const int NodeCount = 2;
+
+    /// <summary>
+    /// Enough due work that the ceiling, rather than the supply of triggers, is what decides how many
+    /// run: twenty against a ceiling of two leaves eighteen queued behind it for the whole measurement.
+    /// </summary>
+    private const int TriggerCount = 20;
+
+    protected ClusteredExecutionCeilingTestBase(string provider) : base(provider)
+    {
+    }
+
+    protected override string SchedulerName => "ClusterCeilingTest";
+
+    [SetUp]
+    public void ResetGate() => GatedJob.Reset();
+
+    [TearDown]
+    public void OpenGate() => GatedJob.Open();
+
+    /// <summary>
+    /// The default arrangement, and the one the bound is stated for: two nodes acquiring without the
+    /// cluster's <c>TRIGGER_ACCESS</c> lock, one trigger per round each.
+    /// </summary>
+    [Test]
+    public Task TwoNodesStayWithinTheStatedOvershootOfAClusterScopedCeiling()
+    {
+        // limit + (nodes - 1): each node acquiring lock-free can add at most one trigger over a ceiling
+        // it read before the other node's acquisition landed.
+        return AssertCeilingHolds(acquireTriggersWithinLock: false, allowedOvershoot: NodeCount - 1);
+    }
+
+    /// <summary>
+    /// The same two nodes with acquisition serialized cluster-wide, which is the trade the documentation
+    /// offers to anyone who needs the quota to be exact: the in-flight count and the acquisition that
+    /// spends it happen inside one lock, so no node can act on a count another node has already spent.
+    /// </summary>
+    [Test]
+    public Task WithAcquisitionUnderTheClusterLockTheCeilingIsExact()
+    {
+        return AssertCeilingHolds(acquireTriggersWithinLock: true, allowedOvershoot: 0);
+    }
+
+    private async Task AssertCeilingHolds(bool acquireTriggersWithinLock, int allowedOvershoot)
+    {
+        void ConfigureNode(NameValueCollection properties)
+        {
+            properties["quartz.clusterExecutionLimit." + Tenant] = Limit.ToString(CultureInfo.InvariantCulture);
+
+            // One trigger per round, which is the only arrangement in which the lock-free path exists at
+            // all: the store takes TRIGGER_ACCESS whenever it is asked for more than one trigger.
+            properties["quartz.scheduler.batchTriggerAcquisitionMaxCount"] = "1";
+            properties["quartz.jobStore.acquireTriggersWithinLock"] = acquireTriggersWithinLock ? "true" : "false";
+
+            // Comfortably more threads than the ceiling allows, so that what caps concurrency is the
+            // ceiling and not the thread pool - the failure mode where a green test proves nothing.
+            properties["quartz.threadPool.maxConcurrency"] = "8";
+
+            // Eighteen triggers sit behind the ceiling for as long as the gate is shut, and acquisition
+            // excludes anything older than the misfire threshold. At the one-minute default the backlog
+            // would be handed to RecoverMisfiredJobs partway through the measurement and the test would
+            // be measuring misfire policy instead.
+            properties["quartz.jobStore.misfireThreshold"] = "1800000";
+        }
+
+        IScheduler nodeA = await CreateScheduler("nodeA", configure: ConfigureNode);
+        IScheduler nodeB = await CreateScheduler("nodeB", configure: ConfigureNode);
+
+        try
+        {
+            IJobDetail job = JobBuilder.Create<GatedJob>()
+                .WithIdentity("gatedJob", Group)
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, new AddJobOptions { Replace = true });
+
+            // Stored before either node is running, and dated far enough back that all twenty are due the
+            // moment the nodes start: the contention this measures only exists while both nodes have more
+            // work than the ceiling allows.
+            DateTimeOffset start = DateTimeOffset.UtcNow.AddSeconds(-5);
+            string[] expected = new string[TriggerCount];
+            for (int i = 0; i < TriggerCount; i++)
+            {
+                expected[i] = "ceiling-" + i.ToString(CultureInfo.InvariantCulture);
+                await nodeA.ScheduleJob(TriggerBuilder.Create()
+                    .WithIdentity(expected[i], Group)
+                    .ForJob(job)
+                    .WithExecutionGroup(Tenant)
+                    .StartAt(start)
+                    .Build());
+            }
+
+            await nodeA.Start();
+            await nodeB.Start();
+
+            await WaitForCondition(
+                () => Task.FromResult(GatedJob.InFlight >= Limit),
+                timeoutMs: 60_000,
+                async () => $"the cluster to reach its ceiling of {Limit} concurrent executions; it reached "
+                            + $"{GatedJob.Peak}. State:\n{await DumpDatabaseState()}");
+
+            // An overshoot cannot be polled for, only waited out: it appears when two nodes acquire in the
+            // same instant, and with the gate shut it then persists, because nothing completes to give the
+            // slot back. Three idle-wait cycles of acquisition attempts by both nodes pass inside this.
+            await Task.Delay(6000);
+
+            int peak = GatedJob.Peak;
+            TestContext.Out.WriteLine(
+                $"Peak concurrent executions across {NodeCount} nodes: {peak} "
+                + $"(ceiling {Limit}, bound {Limit + allowedOvershoot}, acquireTriggersWithinLock={acquireTriggersWithinLock})");
+            TestContext.Out.WriteLine("Executions per node while held: " + string.Join(", ", GatedJob.Executions
+                .GroupBy(x => x.InstanceId)
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .Select(x => $"{x.Key}={x.Count()}")));
+
+            peak.Should().BeGreaterThanOrEqualTo(Limit,
+                "a ceiling that never let its own quota through would pass every upper-bound assertion below "
+                + "while serving the tenant less than it was promised");
+            peak.Should().BeLessThanOrEqualTo(Limit + allowedOvershoot,
+                "a cluster-scoped ceiling of {0} bounds what {1} nodes run at once by limit + (nodes - 1) when "
+                + "they acquire lock-free, and by the limit itself when acquisition takes the cluster lock - "
+                + "the numbers execution-groups.md states and a tenant quota is bought for",
+                Limit, NodeCount);
+
+            GatedJob.Open();
+
+            await WaitForCondition(
+                () => Task.FromResult(GatedJob.Completed >= TriggerCount),
+                timeoutMs: 120_000,
+                async () =>
+                {
+                    string[] missing = expected.Except(GatedJob.Executions.Select(x => x.TriggerName)).ToArray();
+                    return $"all {TriggerCount} triggers to run once the ceiling stopped holding them back; "
+                           + $"{missing.Length} never did ([{string.Join(", ", missing)}]). State:\n{await DumpDatabaseState()}";
+                });
+
+            GatedJob.Executions.Select(x => x.TriggerName).Should().BeEquivalentTo(expected,
+                "a ceiling holds work back, it does not drop it - a missing trigger means the limit consumed "
+                + "one instead of setting it aside, and a repeated one means two nodes ran the same trigger");
+
+            GatedJob.Peak.Should().BeLessThanOrEqualTo(Limit + allowedOvershoot,
+                "the ceiling applies to the drain as much as to the queue, so the peak over the whole run is "
+                + "bounded by the same number as the peak while the gate was shut");
+        }
+        finally
+        {
+            // Before the shutdowns: a job still parked at the gate would otherwise hold a thread the
+            // shutdown is waiting for, and the failure would be a hang rather than an assertion.
+            GatedJob.Open();
+
+            await nodeA.Shutdown(waitForJobsToComplete: false);
+            await nodeB.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    private sealed record Execution(string TriggerName, string InstanceId);
+
+    /// <summary>
+    /// Parks inside <c>Execute</c> until the test opens the gate, counting how many firings are inside it
+    /// at once. That count is what a ceiling is a promise about, and it is only observable while the
+    /// firings are held: a job that returns immediately never has a second one beside it to be counted
+    /// with, however badly the limit is enforced.
+    /// </summary>
+    /// <remarks>
+    /// The count is deliberately conservative at both ends — it rises after the store has already written
+    /// the fired-trigger row and falls before the row is deleted — so it can only ever be at or below what
+    /// the store's own ledger holds. That is the safe direction for an upper bound: this cannot report an
+    /// overshoot the store did not commit.
+    /// </remarks>
+    private sealed class GatedJob : IJob
+    {
+        private static volatile TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static volatile ConcurrentQueue<Execution> executions = new();
+        private static int inFlight;
+        private static int peak;
+        private static int completed;
+
+        public static ConcurrentQueue<Execution> Executions => executions;
+
+        public static int InFlight => Volatile.Read(ref inFlight);
+
+        /// <summary>The most firings this job has ever had inside it at one instant.</summary>
+        public static int Peak => Volatile.Read(ref peak);
+
+        /// <summary>How many firings have run to the end, which only happens once the gate is open.</summary>
+        public static int Completed => Volatile.Read(ref completed);
+
+        public static void Reset()
+        {
+            Interlocked.Exchange(ref gate, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+            Interlocked.Exchange(ref executions, new ConcurrentQueue<Execution>());
+            Interlocked.Exchange(ref inFlight, 0);
+            Interlocked.Exchange(ref peak, 0);
+            Interlocked.Exchange(ref completed, 0);
+        }
+
+        public static void Open() => gate.TrySetResult();
+
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            // Recorded on the way in rather than on the way out, so that the ledger says who is running
+            // what while the gate is still shut - which is the only moment at which it says anything.
+            Executions.Enqueue(new Execution(context.Trigger.Key.Name, context.Scheduler.SchedulerInstanceId));
+            RecordPeak(Interlocked.Increment(ref inFlight));
+            try
+            {
+                await gate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref inFlight);
+                Interlocked.Increment(ref completed);
+            }
+        }
+
+        private static void RecordPeak(int observed)
+        {
+            int highest = Volatile.Read(ref peak);
+            while (observed > highest)
+            {
+                int previous = Interlocked.CompareExchange(ref peak, observed, highest);
+                if (previous == highest)
+                {
+                    return;
+                }
+
+                highest = previous;
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancyPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancyPostgresTest.cs
@@ -1,0 +1,48 @@
+using System.Data.Common;
+
+using Npgsql;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Two tenants sharing the assembly-wide PostgreSQL database, which is where a real deployment of this
+/// arrangement would put them.
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class SharedDatabaseTenancyPostgresTest : SharedDatabaseTenancyTestBase
+{
+    protected override void UseDatabase(IPersistentStoreBuilder store)
+    {
+        store.UsePostgres(TestConstants.PostgresConnectionString);
+    }
+
+    protected override async Task CleanUpDatabase()
+    {
+        // The tenants share every table with the rest of this assembly's fixtures, so the cleanup names
+        // the two SCHED_NAMEs rather than truncating anything.
+        await using DbConnection connection = new NpgsqlConnection(TestConstants.PostgresConnectionString);
+        await connection.OpenAsync();
+
+        await using DbCommand command = connection.CreateCommand();
+        command.CommandText =
+            "DELETE FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME IN (@acme, @initech);"
+            + "DELETE FROM QRTZ_SIMPLE_TRIGGERS WHERE SCHED_NAME IN (@acme, @initech);"
+            + "DELETE FROM QRTZ_TRIGGERS WHERE SCHED_NAME IN (@acme, @initech);"
+            + "DELETE FROM QRTZ_JOB_DETAILS WHERE SCHED_NAME IN (@acme, @initech);"
+            + "DELETE FROM QRTZ_PAUSED_TRIGGER_GRPS WHERE SCHED_NAME IN (@acme, @initech);"
+            + "DELETE FROM QRTZ_SCHEDULER_STATE WHERE SCHED_NAME IN (@acme, @initech);";
+        AddParameter(command, "acme", Acme);
+        AddParameter(command, "initech", Initech);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static void AddParameter(DbCommand command, string name, string value)
+    {
+        DbParameter parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value;
+        command.Parameters.Add(parameter);
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancySqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancySqliteTest.cs
@@ -1,0 +1,72 @@
+using Microsoft.Data.Sqlite;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The same two tenants on a SQLite file, which needs no container and so runs wherever the unit tests
+/// do. "One database" is at its most literal here — one file, both schedulers — and SQLite forces
+/// <c>AcquireTriggersWithinLock</c> on, so the two tenants also contend for the store's own lock rather
+/// than merely for rows.
+/// </summary>
+[Category("db-sqlite")]
+[NonParallelizable]
+public sealed class SharedDatabaseTenancySqliteTest : SharedDatabaseTenancyTestBase
+{
+    private string databaseFile;
+
+    protected override void UseDatabase(IPersistentStoreBuilder store)
+    {
+        store.UseSqlite(ConnectionString);
+    }
+
+    protected override async Task PrepareDatabase()
+    {
+        databaseFile = $"tenancy-shared-{Guid.NewGuid():N}.db";
+
+        await using SqliteConnection connection = new SqliteConnection(ConnectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = new SqliteCommand(LoadTableScript(), connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    protected override Task CleanUpDatabase()
+    {
+        // The file is this fixture's alone, so it goes rather than its rows. Pools have to be cleared
+        // first or the handle the store left behind keeps the file locked on Windows.
+        SqliteConnection.ClearAllPools();
+
+        if (databaseFile is not null && File.Exists(databaseFile))
+        {
+            try
+            {
+                File.Delete(databaseFile);
+            }
+            catch (IOException)
+            {
+                // scratch space; leaving one behind is not worth failing a passing test over
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private string ConnectionString => $"Data Source={databaseFile};";
+
+    private static string LoadTableScript()
+    {
+        DirectoryInfo directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            string candidate = Path.Combine(directory.FullName, "database", "tables", "tables_sqlite.sql");
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate database/tables/tables_sqlite.sql from " + AppContext.BaseDirectory);
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancyTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancyTestBase.cs
@@ -1,0 +1,229 @@
+using System.Collections.Concurrent;
+
+using MELT;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The arrangement multi-tenancy is built on, actually running: two schedulers, one database, one table
+/// prefix, two <c>SCHED_NAME</c>s.
+/// <para>
+/// Every Quartz table has <c>SCHED_NAME</c> as the first column of its primary key and every statement
+/// filters on it, so the isolation is a property of the schema rather than of the code paths. That is a
+/// claim about every statement, which is why it is worth asserting against a database rather than a
+/// stub: the two tenants here schedule the <em>same job and trigger keys</em>, so a query that forgot its
+/// <c>SCHED_NAME</c> predicate would find the neighbour's row rather than nothing at all, and a scheduler
+/// that acquired across the boundary would fire it.
+/// </para>
+/// <para>
+/// The prefix is the same on both, deliberately. <see cref="Quartz.Configuration.SharedDatabaseValidator" />
+/// warns when two schedulers of one container share a database and <em>disagree</em> about the prefix;
+/// the supported arrangement has to stay silent, or the warning becomes noise every multi-tenant
+/// deployment learns to ignore. <c>SharedDatabaseValidatorTest</c> covers the prefix matrix with stub
+/// providers; this is the half that runs the arrangement.
+/// </para>
+/// </summary>
+public abstract class SharedDatabaseTenancyTestBase
+{
+    /// <summary>The two tenants, which are two <c>SCHED_NAME</c> values and nothing else.</summary>
+    protected const string Acme = "TenancyAcme";
+
+    protected const string Initech = "TenancyInitech";
+
+    /// <summary>
+    /// The key both tenants schedule under. Identical on purpose: distinct keys would pass even against a
+    /// store that ignored <c>SCHED_NAME</c> entirely.
+    /// </summary>
+    private const string SharedTriggerName = "nightly";
+
+    private const string Group = "tenancy";
+
+    [SetUp]
+    public void ResetTenantJob() => TenantJob.Reset();
+
+    /// <summary>
+    /// Configures the tenant's store to point at this fixture's database, with the default table prefix.
+    /// </summary>
+    protected abstract void UseDatabase(IPersistentStoreBuilder store);
+
+    /// <summary>
+    /// Creates the schema, if this fixture's database does not already have one.
+    /// </summary>
+    protected virtual Task PrepareDatabase() => Task.CompletedTask;
+
+    /// <summary>
+    /// Removes both tenants' rows, so a later run starts against a database that holds neither.
+    /// </summary>
+    protected abstract Task CleanUpDatabase();
+
+    [Test]
+    public async Task TwoTenantsInOneTableSetFireOnlyTheirOwnTriggers()
+    {
+        await PrepareDatabase();
+
+        ITestLoggerFactory loggerFactory = TestLoggerFactory.Create();
+
+        ServiceCollection services = new();
+
+        // Registered before AddQuartz, which only adds a factory when the container has none: this is
+        // what puts the shared-database check's own warnings within reach of the assertion below.
+        services.AddSingleton<ILoggerFactory>(loggerFactory);
+        services.AddQuartz(Acme, ConfigureTenant);
+        services.AddQuartz(Initech, ConfigureTenant);
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler acme = await provider.GetRequiredKeyedService<ISchedulerFactory>(Acme).GetScheduler();
+        IScheduler initech = await provider.GetRequiredKeyedService<ISchedulerFactory>(Initech).GetScheduler();
+
+        try
+        {
+            acme.SchedulerName.Should().Be(Acme);
+            initech.SchedulerName.Should().Be(Initech);
+
+            await ScheduleTenantWork(acme);
+            await ScheduleTenantWork(initech);
+
+            // Asserted before either scheduler starts, because the shared one-shot trigger is deleted the
+            // moment it fires and a listing taken afterwards could not tell "scoped correctly" from "gone".
+            (await TriggerNames(acme)).Should().BeEquivalentTo([SharedTriggerName, Acme + "-only"],
+                "a query is scoped to the scheduler that issues it, so a tenant lists its own trigger rows "
+                + "and no others - including the one whose key it shares with its neighbour");
+            (await TriggerNames(initech)).Should().BeEquivalentTo([SharedTriggerName, Initech + "-only"]);
+
+            await acme.Start();
+            await initech.Start();
+
+            await WaitForCondition(
+                () => TenantJob.Firings.Count >= 2,
+                timeoutMs: 60_000,
+                () => $"both tenants to fire their own copy of '{SharedTriggerName}'; so far: "
+                      + string.Join(", ", TenantJob.Firings.Select(x => $"{x.SchedulerName}/{x.Tenant}")));
+
+            // Absence cannot be polled for. A scheduler that acquired across the SCHED_NAME boundary
+            // would fire the neighbour's trigger as a third firing, which arrives after the two legitimate
+            // ones rather than before them.
+            await Task.Delay(3000);
+
+            TenantJob.Firings.Should().HaveCount(2,
+                "there are two trigger rows, one per tenant, and each belongs to exactly one scheduler - a "
+                + "third firing means one scheduler acquired a row that was not its own");
+
+            foreach (Firing firing in TenantJob.Firings)
+            {
+                firing.SchedulerName.Should().Be(firing.Tenant,
+                    "the tenant marker travels in the job data map of the row that was scheduled under that "
+                    + "SCHED_NAME, so a firing whose scheduler disagrees with it is a row read across the boundary");
+            }
+
+            TenantJob.Firings.Select(x => x.SchedulerName).Should().BeEquivalentTo([Acme, Initech]);
+
+            // What survives the firing is scoped too: each tenant's one-shot trigger is gone and its own
+            // future one is not, which is the same boundary read from the far side.
+            (await TriggerNames(acme)).Should().BeEquivalentTo([Acme + "-only"],
+                "the tenant's own one-shot trigger completed and was removed; the neighbour's is untouched "
+                + "and was never this tenant's to see");
+            (await TriggerNames(initech)).Should().BeEquivalentTo([Initech + "-only"]);
+
+            loggerFactory.Sink.LogEntries.Should().NotBeEmpty(
+                "the silence asserted next means nothing unless this is the factory Quartz actually logs "
+                + "through - a container that quietly built its own would make the check below vacuous");
+
+            loggerFactory.Sink.LogEntries
+                .Where(x => x.LoggerName.Contains("SharedDatabaseValidator", StringComparison.Ordinal))
+                .Should().BeEmpty(
+                    "one database, one table prefix and two scheduler names is the arrangement the check exists "
+                    + "to protect, so warning about it would teach every multi-tenant deployment to filter the "
+                    + "category out - and with it the mistyped prefix the warning is for");
+        }
+        finally
+        {
+            await acme.Shutdown(waitForJobsToComplete: false);
+            await initech.Shutdown(waitForJobsToComplete: false);
+            await CleanUpDatabase();
+        }
+    }
+
+    private void ConfigureTenant(IQuartzBuilder builder)
+    {
+        builder.UsePersistentStore(store =>
+        {
+            UseDatabase(store);
+            // The same prefix on both, which is the supported arrangement: SCHED_NAME is what separates
+            // the tenants, and a prefix is for separate table sets rather than for isolation.
+            store.Configure(options => options.TablePrefix = "QRTZ_");
+        });
+    }
+
+    /// <summary>
+    /// Schedules one trigger whose key both tenants use and one whose name only this tenant uses. The
+    /// second never fires — it exists so that a listing has something to be wrong about.
+    /// </summary>
+    private static async Task ScheduleTenantWork(IScheduler scheduler)
+    {
+        IJobDetail job = JobBuilder.Create<TenantJob>()
+            .WithIdentity("tenantJob", Group)
+            .UsingJobData("tenant", scheduler.SchedulerName)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(job, new AddJobOptions { Replace = true });
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SharedTriggerName, Group)
+            .ForJob(job)
+            .StartAt(DateTimeOffset.UtcNow.AddSeconds(1))
+            .Build());
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(scheduler.SchedulerName + "-only", Group)
+            .ForJob(job)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+            .Build());
+    }
+
+    private static async Task<string[]> TriggerNames(IScheduler scheduler)
+    {
+        PagedResult<TriggerHeader> triggers = await scheduler.QueryTriggers(new TriggerQuery());
+        return triggers.Items.Select(x => x.Key.Name).ToArray();
+    }
+
+    private static async Task WaitForCondition(Func<bool> condition, int timeoutMs, Func<string> message)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        Assert.Fail($"Timed out after {timeoutMs} ms waiting for {message()}");
+    }
+
+    private sealed record Firing(string SchedulerName, string Tenant);
+
+    /// <summary>
+    /// Records which scheduler ran it and which tenant's data map it was handed. The two agree exactly
+    /// when no row crossed the <c>SCHED_NAME</c> boundary.
+    /// </summary>
+    private sealed class TenantJob : IJob
+    {
+        private static volatile ConcurrentQueue<Firing> firings = new();
+
+        public static ConcurrentQueue<Firing> Firings => firings;
+
+        public static void Reset() => Interlocked.Exchange(ref firings, new ConcurrentQueue<Firing>());
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Firings.Enqueue(new Firing(context.Scheduler.SchedulerName, context.MergedJobDataMap.GetString("tenant")));
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerNameComparisonTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerNameComparisonTest.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// A scheduler name is compared two different ways, and knowing which is which saves an afternoon: the
+/// repository — and so every lookup, including the HTTP API's route — compares ignoring case, while
+/// keyed resolution out of the container compares ordinally, because a service key is compared by
+/// equality and string equality is ordinal.
+/// </summary>
+/// <remarks>
+/// Neither comparison is wrong for what it does, and neither is going to change: the repository's is what
+/// makes the duplicate-name check and the API route forgiving, and the container's is Microsoft's. What
+/// was missing is a test that says so, so that a future reader meeting one of the two halves does not
+/// conclude the other is a bug. <c>TenantSchedulerRoutingTest</c> is the same registration seen from the
+/// HTTP side.
+/// </remarks>
+[NonParallelizable]
+public sealed class SchedulerNameComparisonTest
+{
+    private const string RegisteredName = "Acme";
+    private const string OtherCasing = "acme";
+
+    [Test]
+    public async Task KeyedResolutionComparesTheNameOrdinally()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(RegisteredName, _ => { });
+
+        // Awaited disposal: resolving IScheduler hands back a DeferredScheduler, which the container can
+        // only dispose asynchronously.
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredKeyedService<IScheduler>(RegisteredName).Should().NotBeNull(
+            "the spelling the registration used is the service key, and resolving by it is the supported way in");
+
+        Action mismatched = () => provider.GetRequiredKeyedService<IScheduler>(OtherCasing);
+        mismatched.Should().Throw<InvalidOperationException>(
+            "the container compares service keys by equality and string equality is ordinal, so a name spelled "
+            + "with different casing is a different key rather than the same one leniently matched");
+    }
+
+    [Test]
+    public async Task TheRepositoryFindsTheSchedulerUnderEitherCasing()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(RegisteredName, _ => { });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler scheduler = await provider.GetRequiredKeyedService<ISchedulerFactory>(RegisteredName).GetScheduler();
+
+        try
+        {
+            ISchedulerRepository repository = provider.GetRequiredService<ISchedulerRepository>();
+
+            repository.Lookup(OtherCasing).Should().BeSameAs(scheduler,
+                "the repository indexes names ignoring case, which is what makes the duplicate-name check and "
+                + "the HTTP API's route forgiving about casing - and is the opposite of the container's rule");
+            repository.Lookup(RegisteredName).Should().BeSameAs(scheduler);
+
+            scheduler.SchedulerName.Should().Be(RegisteredName,
+                "the scheduler carries the spelling it was registered with, whichever spelling found it");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Covers the four untested tenancy combinations from the alpha-2 multi-tenancy audit. Tests only — no product code. Built on the clustered test base #3365 added.

## What each test pins

**1. A cluster-scoped ceiling, measured across two real ADO nodes** — `ClusteredExecutionCeilingTestBase`, with a sealed fixture per engine (PostgreSQL, SQL Server).

`JobStoreContractTest` already holds both stores to what the fired-triggers ledger says: a reservation counts, a running execution counts, a node-scoped limit does not. None of that says how many jobs two nodes racing each other actually run at the same instant, which is the number a tenant quota is bought for. `execution-groups.md` promises `limit + (nodes − 1)` while acquisition is lock-free and the limit exactly with `AcquireTriggersWithinLock = true`; a bound nothing measures is a hope.

Two schedulers share one `SCHED_NAME` and one database, twenty due one-shot triggers carry one execution group with a ceiling of two, `MaxBatchSize = 1`. The job parks inside `Execute` until the test opens a gate — concurrency is only observable while the firings are held, since a job that returns immediately never has a second one beside it to be counted with. The counter rises after the store has written the fired-trigger row and falls before the row is deleted, so it can only ever be at or below what the store committed: it cannot report an overshoot the store did not make.

`MisfireThreshold` is raised to half an hour. The eighteen triggers held behind the ceiling would otherwise pass the one-minute default partway through the measurement and be handed to `RecoverMisfiredJobs`, and the test would be measuring misfire policy.

**2. Two schedulers, one database, one prefix, two `SCHED_NAME`s, actually running** — `SharedDatabaseTenancyTestBase`, with a PostgreSQL fixture and a SQLite one that needs no container.

Both tenants schedule the *same job and trigger keys*, which is what makes the assertion sharp: a query that forgot its `SCHED_NAME` predicate would find the neighbour's row rather than nothing at all. Each tenant's job carries its own name in its data map, so a firing whose `IJobExecutionContext.Scheduler.SchedulerName` disagrees with the marker is a row read across the boundary. `QueryTriggers` is asserted before either scheduler starts — the shared one-shot trigger is deleted the moment it fires, and a listing taken afterwards cannot tell "scoped correctly" from "gone" — and again after, where each tenant sees its own surviving trigger and not its neighbour's.

`SharedDatabaseValidator` stays silent, which is the point: same prefix is the supported arrangement, and a warning there would teach every multi-tenant deployment to filter the category out. The fixture also asserts its sink caught *something*, so the silence is not the silence of a logger nobody wired up. (Checked while writing: with the prefixes deliberately made to disagree the warning does arrive in that same sink.)

**3. A registered-but-never-created scheduler on the HTTP API** — `TenantSchedulerRoutingTest`, in `Quartz.Tests.AspNetCore`.

`AddQuartz("acme", …)` behind the test application with nothing resolving `acme`'s factory: `GET …/schedulers/acme` answers `404`, `GET …/schedulers` does not list it, and `ISchedulerRegistry.QuerySchedulers()` does, with `Status == null`. That is the "the dashboard and the HTTP API list the repository, not the registry" box in `multi-tenancy.md`, which had nothing going through the wire behind it. The `404` here means "nothing has built it yet" rather than "no such tenant", and the registry is what can tell the two apart.

**4. Case-mismatched names** — the unit half in `SchedulerNameComparisonTest`, the route half in the same AspNetCore fixture.

One registration spelled `Acme` shows all three rules `multi-tenancy.md` states: `GetRequiredKeyedService<IScheduler>("acme")` throws, because the container compares service keys by equality and string equality is ordinal; `repository.Lookup("acme")` hands back the same scheduler the registered spelling does; and the route `…/schedulers/acme` resolves it — as does a route under a different endpoint group, because the casing is forgiven by the lookup rather than by one endpoint.

## Measured overshoot in test 1

Peak concurrent executions across the two nodes, sampled while the gate was shut, ceiling 2:

| Run | PostgreSQL lock-free (bound 3) | PostgreSQL locked (bound 2) | SQL Server lock-free (bound 3) | SQL Server locked (bound 2) |
|---|---|---|---|---|
| 1 | 2 | 2 | 2 | 2 |
| 2 | 2 | 2 | 2 | 2 |
| 3 | 2 | 2 | 2 | 2 |

Zero overshoot on all twelve measurements, and both nodes were genuinely contending in every one — `nodeA=1, nodeB=1` while held, rather than one node taking both slots. The lock-free test allows the documented `limit + (nodes − 1)` rather than asserting equality, because the overshoot is a race the documentation admits to and a test that forbade it would be flaky by construction; what is measured is that it stays inside the stated bound and that the quota is actually served.

## A product defect a test turned up

`GET /schedulers/{name}/context` answers `500` for **every** scheduler a container built.

`SchedulerContentInitializer.Initialize` puts the `IServiceProvider` into `scheduler.Context["Quartz.ServiceProvider"]` so plugins can reach the container, and `SchedulerContextDto.Create` throws `NotSupportedException` when any context value is not a string. Every scheduler from `AddQuartz` — and from `QuartzSchedulerBuilder`, which builds a container of its own — therefore carries exactly one entry the endpoint refuses. `SchedulerEndpointsTest.GetSchedulerContextShouldWork` passes because its scheduler is a fake whose context the test filled with strings; a real one had never been driven through the route.

Kept as a failing `[Explicit]` test, `TenantSchedulerRoutingTest.TheContextOfAContainerBuiltSchedulerCanBeRead`, with the finding in its remarks. **A reviewer has to decide the fix**: skip non-string entries, report them as their type name, or move the service provider off the scheduler context. Nothing about it is tenancy-specific, so it is left alone here.

## Also in this PR

`WebApiTest`'s private content-root resolution moves to `Quartz.Tests.AspNetCore.Support.TestContentRoot`, because the new fixture builds its own application and needs the same answer.

## Verification

- `dotnet build Quartz.slnx` — succeeded, 0 warnings, 0 errors.
- `Quartz.Tests.Unit` — 3255 passed, 0 failed, 4 skipped.
- `Quartz.Tests.AspNetCore` — 429 passed, 0 failed.
- Integration, `db-postgres` — 69 passed, 0 failed.
- Integration, `db-sqlserver` — 62 passed, 0 failed.
- Integration, `db-sqlite` — 9 passed, 0 failed.
- Test 1 run three times in a row on each engine: six runs, twelve measurements, all green (table above).

Docker 29.5.3 was up for every integration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
