### PR TITLE
The scheduler context endpoint answers for a container-built scheduler

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1630,6 +1630,29 @@ configures it under — some plugins derive persisted job and trigger keys from 
 deployment's identity rather than a label. Left unset, the plugin's type name is used, exactly as
 before.
 
+### The container is not in the scheduler context
+
+3.x's `ServiceCollectionSchedulerFactory` put the `IServiceProvider` into
+`scheduler.Context["Quartz.ServiceProvider"]`, and a plugin that needed the container read it back out
+of there. 4.0 writes no such entry. Plugins and listeners are constructed by the container, so they
+take what they need by constructor — and a job takes its dependencies the same way:
+
+```diff
+- private IServiceProvider? services;
+-
+- public ValueTask Initialize(string name, IScheduler scheduler, CancellationToken cancellationToken = default)
+- {
+-     services = (IServiceProvider) scheduler.Context["Quartz.ServiceProvider"]!;
++ private readonly IMyService service;
++
++ public MyPlugin(IMyService service) => this.service = service;
+```
+
+The entry was Quartz's plumbing in a map that belongs to the application, and the HTTP API's
+`GET …/schedulers/{name}/context` answered `500` for every container-built scheduler because of it
+([#3408](https://github.com/quartznet/quartznet/issues/3408)). That endpoint renders every value as
+text now, so a context entry of any type reads back.
+
 ## Registered schedulers can be listed without being started
 
 `ISchedulerFactory.GetAllSchedulers()` — `GetAllSchedulers()` on 3.x too — lists the schedulers
@@ -5135,10 +5158,11 @@ public class ContextMergingJobFactory : MicrosoftDependencyInjectionJobFactory
 }
 ```
 
-The merge was also defective in ways the removal fixes: the DI integration seeds a service-provider
+The merge was also defective in ways the removal fixes: 3.x's DI integration seeded a service-provider
 entry into every scheduler context, which no job has a property for, so every container-hosted fire
 logged a property miss — and threw, with `PropertyMismatchBehavior.Throw`; and the factory
-enumerated the context while plugins could still be writing to it.
+enumerated the context while plugins could still be writing to it. 4.0 seeds no such entry either —
+see [The container is not in the scheduler context](#the-container-is-not-in-the-scheduler-context).
 
 ### One setting says what a property miss does
 

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -109,6 +109,39 @@ That parameter was `?delayMilliseconds=30000` in the 4.0 previews. `TimeSpan` ma
 duration the API carries and does not round a sub-millisecond delay away.
 :::
 
+## The scheduler context travels as text
+
+`GET {ApiPath}/schedulers/{name}/context` answers with the scheduler's context, and **every value in it
+goes out as a string**. The context is the application's own map of `string` to `object`, so a value
+that is not one is rendered as its invariant text; a null stays null.
+
+```json
+{
+  "context": {
+    "activeFrom": "2025-06-01T12:30:00.0000000+00:00",
+    "nothing": null,
+    "retries": "4352",
+    "tenant": "acme"
+  }
+}
+```
+
+Two rules make that body the same one everywhere: an instant — a `DateTimeOffset` or a `DateTime` —
+is rendered in the round-trip `"O"` format, the ISO-8601 spelling every other instant on this wire
+carries, and the entries are ordered by key ordinally rather than in the order a concurrent dictionary
+happens to enumerate them.
+
+Text is all a remote reader has — the endpoint hands out a snapshot of a live in-process map, and a
+client reading it back gets every entry as a string whatever it was in the scheduler's process. An
+entry whose type a caller has to act on belongs in an endpoint of its own rather than in the context.
+
+::: warning Changed in 4.x
+This endpoint answered `500` for every container-built scheduler in the 4.0 previews: the DI
+integration seeded the `IServiceProvider` into `scheduler.Context["Quartz.ServiceProvider"]`, and the
+endpoint refused any value that was not a string. Both are gone — nothing writes the container to the
+context, and no value is refused.
+:::
+
 ## Response-shape conventions
 
 **A `200` carries a body exactly when the operation has something to say that the caller could not

--- a/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
@@ -26,14 +26,28 @@ namespace Quartz.Dashboard.Plugins;
 
 public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
 {
-    private IScheduler? scheduler;
+    private readonly IServiceProvider serviceProvider;
+
+    /// <summary>
+    /// Takes the container the history store is resolved from.
+    /// </summary>
+    /// <remarks>
+    /// A plugin is constructed by the container — this one is registered for every scheduler by
+    /// <c>AddQuartzDashboard</c> — so it asks for what it needs the way any other component does. It used
+    /// to read the container back out of <c>scheduler.Context["Quartz.ServiceProvider"]</c>, which put
+    /// Quartz's plumbing into the application's own map, and left the scheduler-context endpoint of the
+    /// HTTP API answering <c>500</c> for every scheduler a container had built.
+    /// </remarks>
+    public DashboardHistoryPlugin(IServiceProvider serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
 
     public string Name { get; private set; } = "QuartzDashboardHistory";
 
     public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         Name = pluginName;
-        this.scheduler = scheduler;
         scheduler.ListenerManager.AddJobListener(this, Matchers.AllJobs());
         return default;
     }
@@ -50,14 +64,11 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
     {
         try
         {
-            if (scheduler?.Context is not { } ctx
-                || !ctx.TryGetValue(DashboardPluginKeys.ServiceProvider, out var value)
-                || value is not IServiceProvider sp)
-            {
-                return default;
-            }
-
-            IDashboardHistoryStore? store = sp.GetService<IDashboardHistoryStore>();
+            // Resolved per execution and allowed to be absent, as when this went through the scheduler
+            // context: a dashboard that was never registered is a reason to record nothing, not a reason
+            // to fail the execution that just finished. Nor is a container the host has begun disposing,
+            // which is what the catch below is for.
+            IDashboardHistoryStore? store = serviceProvider.GetService<IDashboardHistoryStore>();
             if (store is null)
             {
                 return default;

--- a/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
@@ -28,15 +28,25 @@ namespace Quartz.Dashboard.Plugins;
 
 public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, ITriggerListener, ISchedulerListener
 {
-    private IScheduler? scheduler;
+    private readonly IServiceProvider serviceProvider;
     private IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>? hubContext;
+
+    /// <summary>
+    /// Takes the container the dashboard's SignalR hub is resolved from.
+    /// </summary>
+    /// <remarks>
+    /// <inheritdoc cref="DashboardHistoryPlugin(IServiceProvider)" path="/remarks" />
+    /// </remarks>
+    public DashboardLiveEventsPlugin(IServiceProvider serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
 
     public string Name { get; private set; } = "QuartzDashboardLiveEvents";
 
     public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         Name = pluginName;
-        this.scheduler = scheduler;
 
         scheduler.ListenerManager.AddJobListener(this, Matchers.AllJobs());
         scheduler.ListenerManager.AddTriggerListener(this, Matchers.AllTriggers());
@@ -231,13 +241,10 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
 
         try
         {
-            if (hubContext is null
-                && scheduler?.Context is { } ctx
-                && ctx.TryGetValue(DashboardPluginKeys.ServiceProvider, out var value)
-                && value is IServiceProvider sp)
-            {
-                hubContext = sp.GetService<IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>>();
-            }
+            // Resolved on the first event and kept, as when this went through the scheduler context. An
+            // application with no hub registered has none to broadcast to, so the event is dropped
+            // rather than the execution failed.
+            hubContext ??= serviceProvider.GetService<IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>>();
 
             if (hubContext is null)
             {

--- a/src/Quartz.Dashboard/Plugins/DashboardPluginKeys.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardPluginKeys.cs
@@ -1,6 +1,0 @@
-namespace Quartz.Dashboard.Plugins;
-
-internal static class DashboardPluginKeys
-{
-    public const string ServiceProvider = "Quartz.ServiceProvider";
-}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/CapturingHubContext.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/CapturingHubContext.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.SignalR;
+
+using Quartz.Dashboard.Hubs;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// A hub context that hands out the clients it was given, so a test can read what the live-events
+/// plugin pushed.
+/// </summary>
+/// <remarks>
+/// Written out rather than faked: the hub is internal, so a dynamic proxy over
+/// <see cref="IHubContext{THub, T}" /> closed over it cannot be emitted.
+/// </remarks>
+internal sealed class CapturingHubContext : IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>
+{
+    public CapturingHubContext(IHubClients<IQuartzDashboardHubClient> clients)
+    {
+        Clients = clients;
+    }
+
+    public IHubClients<IQuartzDashboardHubClient> Clients { get; }
+
+    public IGroupManager Groups => throw new NotSupportedException("the plugin sends to groups, it does not manage them");
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardDurationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardDurationTest.cs
@@ -25,9 +25,9 @@ public class DashboardDurationTest
     public async Task HistoryPluginRecordsTheRunTimeItWasGiven()
     {
         DashboardHistoryStore store = new();
-        IScheduler scheduler = SchedulerWith(store);
+        IScheduler scheduler = FakeScheduler();
 
-        DashboardHistoryPlugin plugin = new();
+        DashboardHistoryPlugin plugin = new(ProviderWith(store));
         await plugin.Initialize("history", scheduler);
         await plugin.JobWasExecuted(ExecutionContext(scheduler, SubMillisecond), jobException: null);
 
@@ -45,9 +45,9 @@ public class DashboardDurationTest
     public async Task HistoryPluginRecordsTheFailureAndItsMessage()
     {
         DashboardHistoryStore store = new();
-        IScheduler scheduler = SchedulerWith(store);
+        IScheduler scheduler = FakeScheduler();
 
-        DashboardHistoryPlugin plugin = new();
+        DashboardHistoryPlugin plugin = new(ProviderWith(store));
         await plugin.Initialize("history", scheduler);
         await plugin.JobWasExecuted(
             ExecutionContext(scheduler, TimeSpan.FromSeconds(2)),
@@ -68,9 +68,9 @@ public class DashboardDurationTest
     [Test]
     public async Task LiveEventsPluginSurvivesHavingNoHubToBroadcastTo()
     {
-        IScheduler scheduler = SchedulerWith(new DashboardHistoryStore());
+        IScheduler scheduler = FakeScheduler();
 
-        DashboardLiveEventsPlugin plugin = new();
+        DashboardLiveEventsPlugin plugin = new(ProviderWith(new DashboardHistoryStore()));
         await plugin.Initialize("live", scheduler);
 
         Func<Task> executed = async () =>
@@ -130,20 +130,20 @@ public class DashboardDurationTest
         ExceptionMessage: null);
 
     /// <remarks>
-    /// The plugins reach their services through the scheduler context, the way the dashboard's own
-    /// registration puts them there.
+    /// The plugins take the container by constructor, the way the dashboard's own registration builds
+    /// them.
     /// </remarks>
-    private static IScheduler SchedulerWith(IDashboardHistoryStore store)
+    private static ServiceProvider ProviderWith(IDashboardHistoryStore store)
     {
         ServiceCollection services = new();
         services.AddSingleton(store);
-        ServiceProvider provider = services.BuildServiceProvider();
+        return services.BuildServiceProvider();
+    }
 
-        SchedulerContext context = new() { ["Quartz.ServiceProvider"] = provider };
-
+    private static IScheduler FakeScheduler()
+    {
         IScheduler scheduler = A.Fake<IScheduler>();
         A.CallTo(() => scheduler.SchedulerName).Returns("TestScheduler");
-        A.CallTo(() => scheduler.Context).Returns(context);
         A.CallTo(() => scheduler.ListenerManager).Returns(A.Fake<IListenerManager>());
         return scheduler;
     }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardPluginRegistrationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardPluginRegistrationTest.cs
@@ -1,8 +1,14 @@
+using FakeItEasy;
+
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 
 using Quartz.Configuration;
+using Quartz.Dashboard.Hubs;
 using Quartz.Dashboard.Plugins;
+using Quartz.Dashboard.Services;
 using Quartz.Extensibility;
+using Quartz.Tests.AspNetCore.Support;
 
 namespace Quartz.Tests.AspNetCore.Dashboard;
 
@@ -86,6 +92,107 @@ public class DashboardPluginRegistrationTest
         live.Distinct().Should().HaveCount(3,
             "a plugin is told which scheduler it extends when it is initialized, so one instance shared "
             + "between three schedulers would broadcast every scheduler's events under the last name");
+    }
+
+    /// <summary>
+    /// The history plugin a named scheduler's container builds records to that container's store.
+    /// </summary>
+    /// <remarks>
+    /// Two things at once, because they fail in the same place. The plugin takes the container by
+    /// constructor now — it used to read it back out of
+    /// <c>scheduler.Context["Quartz.ServiceProvider"]</c> — and a constructor the container cannot
+    /// satisfy shows up nowhere until the first <c>GetScheduler()</c>, which no registration test
+    /// reaches. For a named scheduler the parameter is resolved through the scheduler-scoped provider
+    /// rather than the container itself, so this is also what says that wrapper answers a request for
+    /// <see cref="IServiceProvider" />.
+    /// </remarks>
+    [Test]
+    public async Task TheHistoryPluginBuiltForANamedSchedulerRecordsToThatContainersStore()
+    {
+        DashboardHistoryStore store = new();
+
+        ServiceCollection services = new();
+        // registered before the dashboard, whose own store registration is a TryAdd, so this is the
+        // store the plugin has to find
+        services.AddSingleton<IDashboardHistoryStore>(store);
+        services.AddQuartzDashboard();
+        services.AddQuartz("acme");
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        DashboardHistoryPlugin plugin = Plugins(provider, "acme").OfType<DashboardHistoryPlugin>().Single();
+        IScheduler scheduler = FakeScheduler("acme");
+
+        await plugin.Initialize("quartzDashboardHistory", scheduler);
+        await plugin.JobWasExecuted(ExecutionContext(scheduler), jobException: null);
+
+        PagedResult<DashboardHistoryEntry> page = await store.GetPage(new DashboardHistoryQuery { SchedulerName = "acme" });
+        page.Items.Should().ContainSingle("the plugin resolves its store from the container it was built with")
+            .Which.JobName.Should().Be("DummyJob");
+    }
+
+    /// <summary>
+    /// The live-events plugin a named scheduler's container builds broadcasts through that container's
+    /// hub.
+    /// </summary>
+    /// <remarks>
+    /// <inheritdoc cref="TheHistoryPluginBuiltForANamedSchedulerRecordsToThatContainersStore" path="/remarks" />
+    /// </remarks>
+    [Test]
+    public async Task TheLiveEventsPluginBuiltForANamedSchedulerBroadcastsThroughThatContainersHub()
+    {
+        List<SchedulerStateDto> pushed = [];
+
+        IQuartzDashboardHubClient client = A.Fake<IQuartzDashboardHubClient>();
+        A.CallTo(() => client.SchedulerStateChanged(A<SchedulerStateDto>._))
+            .Invokes((SchedulerStateDto state) => pushed.Add(state))
+            .Returns(Task.CompletedTask);
+
+        IHubClients<IQuartzDashboardHubClient> clients = A.Fake<IHubClients<IQuartzDashboardHubClient>>();
+        A.CallTo(() => clients.Group(A<string>._)).Returns(client);
+
+        ServiceCollection services = new();
+        // an exact registration wins over the open generic AddSignalR registers, so the plugin's lazy
+        // hub lookup finds this one
+        services.AddSingleton<IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>>(new CapturingHubContext(clients));
+        services.AddQuartzDashboard();
+        services.AddQuartz("acme");
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        DashboardLiveEventsPlugin plugin = Plugins(provider, "acme").OfType<DashboardLiveEventsPlugin>().Single();
+        IScheduler scheduler = FakeScheduler("acme");
+
+        await plugin.Initialize("quartzDashboardLiveEvents", scheduler);
+        await plugin.SchedulerStarted(scheduler);
+
+        pushed.Should().ContainSingle("the plugin resolves its hub from the container it was built with")
+            .Which.Should().BeEquivalentTo(new SchedulerStateDto("acme", SchedulerStatus.Running));
+    }
+
+    private static IScheduler FakeScheduler(string name)
+    {
+        IScheduler scheduler = A.Fake<IScheduler>();
+        A.CallTo(() => scheduler.SchedulerName).Returns(name);
+        A.CallTo(() => scheduler.ListenerManager).Returns(A.Fake<IListenerManager>());
+        return scheduler;
+    }
+
+    private static IJobExecutionContext ExecutionContext(IScheduler scheduler)
+    {
+        IJobExecutionContext context = A.Fake<IJobExecutionContext>();
+        A.CallTo(() => context.Scheduler).Returns(scheduler);
+        A.CallTo(() => context.JobDetail).Returns(
+            JobBuilder.Create<DummyJob>().WithIdentity("DummyJob", "DummyGroup").Build());
+        A.CallTo(() => context.Trigger).Returns(
+            TriggerBuilder.Create()
+                .WithIdentity("DummyTrigger", "DummyTriggerGroup")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)))
+                .Build());
+        A.CallTo(() => context.FireTimeUtc).Returns(new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        A.CallTo(() => context.JobRunTime).Returns(TimeSpan.FromSeconds(1));
+        A.CallTo(() => context.FireInstanceId).Returns("fire-1");
+        return context;
     }
 
     private static List<(string Name, Type Type)> DashboardPlugins(IServiceProvider provider, object? schedulerKey)

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardSchedulerStateEventsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardSchedulerStateEventsTest.cs
@@ -65,36 +65,19 @@ public class DashboardSchedulerStateEventsTest
         IHubClients<IQuartzDashboardHubClient> clients = A.Fake<IHubClients<IQuartzDashboardHubClient>>();
         A.CallTo(() => clients.Group(A<string>._)).Returns(client);
 
-        // Written out rather than faked: the hub is internal, so a dynamic proxy over
-        // IHubContext<QuartzDashboardHub, …> cannot be emitted.
         IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient> hubContext = new CapturingHubContext(clients);
 
         ServiceCollection services = new();
         services.AddSingleton(hubContext);
         ServiceProvider provider = services.BuildServiceProvider();
 
-        SchedulerContext context = new() { ["Quartz.ServiceProvider"] = provider };
-
         IScheduler scheduler = A.Fake<IScheduler>();
         A.CallTo(() => scheduler.SchedulerName).Returns("TestScheduler");
-        A.CallTo(() => scheduler.Context).Returns(context);
         A.CallTo(() => scheduler.ListenerManager).Returns(A.Fake<IListenerManager>());
 
-        DashboardLiveEventsPlugin plugin = new();
+        DashboardLiveEventsPlugin plugin = new(provider);
         await plugin.Initialize("live", scheduler);
 
         return (plugin, pushed, scheduler);
-    }
-
-    private sealed class CapturingHubContext : IHubContext<QuartzDashboardHub, IQuartzDashboardHubClient>
-    {
-        public CapturingHubContext(IHubClients<IQuartzDashboardHubClient> clients)
-        {
-            Clients = clients;
-        }
-
-        public IHubClients<IQuartzDashboardHubClient> Clients { get; }
-
-        public IGroupManager Groups => throw new NotSupportedException("the plugin sends to groups, it does not manage them");
     }
 }

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
@@ -92,13 +92,23 @@ public class SchedulerEndpointsTest : WebApiTest
             "the job store type name passes through as a string - the remote type need not exist in the client process");
     }
 
+    /// <summary>
+    /// The context endpoint reads a context holding what a context holds: whatever the application put
+    /// in it.
+    /// </summary>
+    /// <remarks>
+    /// The non-string entry is the point. This test passed for as long as the endpoint refused one,
+    /// because the fixture's scheduler is a fake whose context the test filled with strings — while
+    /// every scheduler a container had built carried a value that made the endpoint answer <c>500</c>.
+    /// </remarks>
     [Test]
     public async Task GetSchedulerContextShouldWork()
     {
-        var testContext = new SchedulerContext
+        SchedulerContext testContext = new()
         {
             { "TestKey1", "TestValue" },
-            { "TestKey2", "4352" }
+            { "TestKey2", "4352" },
+            { "TestKey3", 4352 }
         };
 
         A.CallTo(() => FakeScheduler.Context).Returns(testContext);
@@ -114,7 +124,12 @@ public class SchedulerEndpointsTest : WebApiTest
             serializerOptions,
             CancellationToken.None);
 
-        dto.AsContext().Should().BeEquivalentTo(testContext);
+        dto.Context.Should().Equal(new Dictionary<string, string?>
+        {
+            ["TestKey1"] = "TestValue",
+            ["TestKey2"] = "4352",
+            ["TestKey3"] = "4352"
+        }, "a value that is not a string arrives as its invariant text - text is all a remote reader has");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
@@ -113,29 +113,26 @@ public sealed class TenantSchedulerRoutingTest
     }
 
     /// <summary>
-    /// A defect this fixture walked into, kept as the failing test rather than fixed here: the
-    /// scheduler-context endpoint answers <c>500</c> for every scheduler a container built.
+    /// A container-built scheduler's context reads back over the API, holding what the application put
+    /// there and nothing else.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <c>SchedulerContentInitializer.Initialize</c> puts the <see cref="IServiceProvider" /> into
-    /// <c>scheduler.Context["Quartz.ServiceProvider"]</c> so that plugins can reach the container, and
-    /// <c>SchedulerContextDto.Create</c> throws <see cref="NotSupportedException" /> when any context value
-    /// is not a string. Every scheduler built by <c>AddQuartz</c> — and by
-    /// <c>QuartzSchedulerBuilder</c>, which builds a container of its own — therefore has exactly one
-    /// entry the endpoint refuses, so <c>GET …/schedulers/{name}/context</c> is unusable in every real
-    /// deployment while <c>SchedulerEndpointsTest.GetSchedulerContextShouldWork</c> passes: that fixture's
-    /// scheduler is a fake whose context the test filled with strings.
+    /// Nothing here is specific to a tenant; it is that a real container-built scheduler had never been
+    /// driven through this route, and doing so answered <c>500</c> every time (#3408). Two things made
+    /// it: <c>SchedulerContentInitializer</c> wrote the <see cref="IServiceProvider" /> into
+    /// <c>scheduler.Context["Quartz.ServiceProvider"]</c> so that plugins could reach the container, and
+    /// <c>SchedulerContextDto.Create</c> threw on any value that was not a string — so every scheduler
+    /// from <c>AddQuartz</c> carried exactly one entry the endpoint refused, while
+    /// <c>SchedulerEndpointsTest.GetSchedulerContextShouldWork</c> passed against a fake whose context
+    /// the test had filled with strings.
     /// </para>
     /// <para>
-    /// Nothing about it is specific to a tenant; it is only that a real container-built scheduler had
-    /// never been driven through this route. Which way to fix it is a product decision — skip
-    /// non-serializable entries, report them as their type name, or move the service provider off the
-    /// context — so this test is <c>[Explicit]</c> and states the failure rather than choosing.
+    /// Both halves are asserted: the container is absent from the context, and a value the application
+    /// put there that is not a string is rendered rather than refused.
     /// </para>
     /// </remarks>
     [Test]
-    [Explicit("Fails: GET /schedulers/{name}/context is 500 for any container-built scheduler. See the remarks.")]
     public async Task TheContextOfAContainerBuiltSchedulerCanBeRead()
     {
         WebApplicationFactory<Program> application = CreateApplication("Acme");
@@ -146,12 +143,29 @@ public sealed class TenantSchedulerRoutingTest
 
         try
         {
+            scheduler.Context["tenant"] = "Acme";
+            scheduler.Context["retries"] = 3;
+
             using HttpClient client = application.CreateClient();
 
-            using HttpResponseMessage context = await client.GetAsync("schedulers/Acme/context");
-            context.StatusCode.Should().Be(HttpStatusCode.OK,
-                "a scheduler's context is readable over the API, and every container-built scheduler carries "
-                + "the container in it - so an endpoint that refuses a non-string value refuses them all");
+            using HttpResponseMessage response = await client.GetAsync("schedulers/Acme/context");
+            response.StatusCode.Should().Be(HttpStatusCode.OK,
+                "a scheduler's context is readable over the API, and an application may put any object in it");
+
+            JsonSerializerOptions serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+                .ConfigureWireFormat(new SystemTextJsonSerializerRegistry());
+
+            string body = await response.Content.ReadAsStringAsync();
+            SchedulerContextDto dto = JsonSerializer.Deserialize<SchedulerContextDto>(body, serializerOptions)!;
+
+            dto.Context.Should().Equal(
+                new Dictionary<string, string?>
+                {
+                    ["tenant"] = "Acme",
+                    ["retries"] = "3"
+                },
+                "the context carries what the application put in it - the container is not application data, "
+                + "and a value that is not a string arrives as its invariant text");
         }
         finally
         {

--- a/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
@@ -125,6 +125,31 @@ public class WireFormatSnapshotTest : WebApiTest
         await VerifyBody(body);
     }
 
+    /// <summary>
+    /// The scheduler context, which is the one body whose values the application chose the types of.
+    /// </summary>
+    /// <remarks>
+    /// Every one of them goes out as a JSON string: the context is a <c>Map&lt;String, Object&gt;</c> in
+    /// the scheduler's own process, and text is what a remote reader can use. The number and the instant
+    /// are here to pin the rendering as invariant — an <c>int</c> must not pick up a group separator and
+    /// a <c>DateTimeOffset</c> must not pick up the server's date format — and the null to say an absent
+    /// value stays absent rather than becoming the empty string.
+    /// </remarks>
+    [Test]
+    public async Task SchedulerContextBody()
+    {
+        A.CallTo(() => FakeScheduler.Context).Returns(new SchedulerContext
+        {
+            { "tenant", "acme" },
+            { "retries", 4352 },
+            { "activeFrom", new DateTimeOffset(2025, 6, 1, 12, 30, 0, TimeSpan.Zero) },
+            { "nothing", null }
+        });
+
+        string body = await Get($"{SchedulerUrl}/context");
+        await VerifyBody(body);
+    }
+
     [Test]
     public async Task AppliedJobKeysBody()
     {

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -60,7 +60,7 @@ namespace Quartz.Dashboard.Plugins
 {
     public sealed class DashboardHistoryPlugin : Quartz.Extensibility.ISchedulerPlugin, Quartz.IJobListener
     {
-        public DashboardHistoryPlugin() { }
+        public DashboardHistoryPlugin(System.IServiceProvider serviceProvider) { }
         public string Name { get; }
         public System.Threading.Tasks.ValueTask Initialize(string pluginName, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask JobExecutionVetoed(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
@@ -71,7 +71,7 @@ namespace Quartz.Dashboard.Plugins
     }
     public sealed class DashboardLiveEventsPlugin : Quartz.Extensibility.ISchedulerPlugin, Quartz.IJobListener, Quartz.ISchedulerListener, Quartz.ITriggerListener
     {
-        public DashboardLiveEventsPlugin() { }
+        public DashboardLiveEventsPlugin(System.IServiceProvider serviceProvider) { }
         public string Name { get; }
         public System.Threading.Tasks.ValueTask Initialize(string pluginName, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask JobAdded(Quartz.IScheduler scheduler, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SchedulerContextBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SchedulerContextBody.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "context": {
+    "activeFrom": "2025-06-01T12:30:00.0000000+00:00",
+    "nothing": null,
+    "retries": "4352",
+    "tenant": "acme"
+  }
+}

--- a/src/Quartz/Configuration/SchedulerContentInitializer.cs
+++ b/src/Quartz/Configuration/SchedulerContentInitializer.cs
@@ -21,14 +21,18 @@ namespace Quartz.Configuration;
 /// scheduler is therefore never even seen by another, and a listener arrives together with the matchers
 /// it was registered with instead of being re-joined to them by type.
 /// </para>
+/// <para>
+/// The container is deliberately not among the content. It used to be written into
+/// <c>scheduler.Context["Quartz.ServiceProvider"]</c> so that plugins could reach it, but the scheduler
+/// context is the application's own map and Quartz's plumbing is not application data — an entry no
+/// application put there is one every reader of the context has to know about to skip, and the HTTP
+/// API's context endpoint answered <c>500</c> for every container-built scheduler because of it.
+/// Plugins, listeners and jobs are constructed by the container, so they take what they need by
+/// constructor.
+/// </para>
 /// </remarks>
 internal sealed class SchedulerContentInitializer
 {
-    /// <summary>
-    /// The scheduler context entry through which plugins reach the container.
-    /// </summary>
-    internal const string ServiceProviderContextKey = "Quartz.ServiceProvider";
-
     private readonly IServiceProvider serviceProvider;
     private readonly SchedulerKey schedulerKey;
     private readonly NameValueCollection properties;
@@ -56,9 +60,6 @@ internal sealed class SchedulerContentInitializer
 
     public async ValueTask Initialize(IScheduler scheduler, CancellationToken cancellationToken)
     {
-        // Plugins reach the container through the scheduler context.
-        scheduler.Context[ServiceProviderContextKey] = serviceProvider;
-
         AddSchedulerListeners(scheduler);
         AddJobListeners(scheduler);
         AddTriggerListeners(scheduler);

--- a/src/Quartz/HttpApiContract/Dtos.cs
+++ b/src/Quartz/HttpApiContract/Dtos.cs
@@ -21,6 +21,8 @@
 
 // ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract - Can be null when received from Web API
 
+using System.Globalization;
+
 namespace Quartz.HttpApiContract;
 
 internal record KeyDto(string Name, string Group) : IValidatable
@@ -61,17 +63,63 @@ internal record KeyDto(string Name, string Group) : IValidatable
 
 internal record SchedulerContextDto(Dictionary<string, string?> Context)
 {
+    /// <summary>
+    /// Renders a scheduler's context as text. A <see langword="string" /> passes through; any other
+    /// value becomes its invariant text, and <see langword="null" /> stays <see langword="null" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Nothing here throws. The scheduler context is the application's own <c>Map&lt;String, Object&gt;</c>
+    /// and an application may put whatever it likes in it, so a value that is not a string is ordinary
+    /// rather than exceptional — this used to answer one with a <see cref="NotSupportedException" />,
+    /// which the endpoint turned into a <c>500</c> for the whole context.
+    /// </para>
+    /// <para>
+    /// Text is all a remote reader can use in any case: the values arrive as JSON strings and
+    /// <see cref="AsContext" /> hands every one of them back as a <see langword="string" />, whatever it
+    /// was in the scheduler's own process. Rendering with
+    /// <see cref="CultureInfo.InvariantCulture" /> is what makes that reading the same one wherever the
+    /// server happens to be running.
+    /// </para>
+    /// <para>
+    /// An instant is the one value rendered by name rather than by <c>Convert.ToString</c>: a
+    /// <see cref="DateTimeOffset" /> or a <see cref="DateTime" /> goes out in the round-trip <c>"O"</c>
+    /// format, so a context entry reads as the ISO-8601 instant every other instant this API emits is.
+    /// Nothing else needs a case — a <see cref="TimeSpan" /> already renders in its constant form and a
+    /// <see cref="Guid" /> in its <c>"D"</c> one.
+    /// </para>
+    /// <para>
+    /// The entries are ordered by key, ordinally. A <see cref="SchedulerContext" /> is backed by a
+    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}" />, whose enumeration
+    /// order is where the keys landed in a hash table rather than anything the application chose, so
+    /// ordering them here is what makes the body the same one on every server and on every run. The
+    /// order is part of the contract rather than an accident, and a snapshot can pin it.
+    /// </para>
+    /// </remarks>
     public static SchedulerContextDto Create(SchedulerContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (context.Values.Any(x => x is not string))
-        {
-            throw new NotSupportedException("Only string values are supported in SchedulerContext");
-        }
+        Dictionary<string, string?> data = context
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .ToDictionary(x => x.Key, x => Render(x.Value));
 
-        var data = context.ToDictionary(x => x.Key, x => (string?) x.Value);
         return new SchedulerContextDto(data);
+    }
+
+    /// <summary>
+    /// One context value as the text a remote reader gets.
+    /// </summary>
+    private static string? Render(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string text => text,
+            DateTimeOffset instant => instant.ToString("O", CultureInfo.InvariantCulture),
+            DateTime instant => instant.ToString("O", CultureInfo.InvariantCulture),
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+        };
     }
 
     public SchedulerContext AsContext()


### PR DESCRIPTION
`GET /schedulers/{name}/context` answered **500 for every scheduler a container built**, which in 4.0 is
every scheduler. Two things made it, and both are fixed here.

## The container is no longer kept in the application's scheduler context

`SchedulerContentInitializer` wrote the `IServiceProvider` into
`scheduler.Context["Quartz.ServiceProvider"]` so that the dashboard's plugins could reach the container.
The scheduler context is the application's own `Map<String, Object>` (Java parity) and Quartz's plumbing
is not application data: an entry no application put there is one every reader of the context has to
know to skip.

`DashboardHistoryPlugin` and `DashboardLiveEventsPlugin` take an `IServiceProvider` by constructor
instead, and keep resolving the history store and the hub context lazily exactly as before — a missing
store or a missing hub is still a reason to record/broadcast nothing rather than to fail an execution.
Both are container-built per scheduler since #3389, and for a *named* scheduler the constructor is
satisfied by `SchedulerScopedServiceProvider`, which answers a request for `IServiceProvider` with
itself. `DashboardPluginKeys` is gone with the key.

A constructor the container cannot satisfy fails only at the first `GetScheduler()`, which no
registration test reaches, so `DashboardPluginRegistrationTest` now resolves each plugin **for a named
scheduler** and drives one event through it — a job execution into a history store the container holds,
a `SchedulerStarted` into a capturing hub context.

## The context DTO renders rather than refuses

`SchedulerContextDto.Create` threw `NotSupportedException` on any non-string value, which the endpoint
turned into a 500 for the whole context. An application may put any object in its context — that is what
the context is for — so a string passes through, anything else becomes
`Convert.ToString(value, CultureInfo.InvariantCulture)`, and a null stays null. Text is all a remote
reader has in any case: the values arrive as JSON strings and `SchedulerContextDto.AsContext` hands every
one of them back as a `string`.

Two rules keep that body the same one everywhere:

- **An instant is ISO-8601.** A `DateTimeOffset` or a `DateTime` is rendered with the round-trip `"O"`
  format, so a context entry reads as the instant every other instant this API emits is. No other type
  needs a case: `TimeSpan` already renders in its constant form and `Guid` in its `"D"` one.
- **Member order is a contract.** The entries are ordered by key with `StringComparer.Ordinal`. A
  `SchedulerContext` is backed by a `ConcurrentDictionary`, whose enumeration order is where the keys
  landed in a hash table rather than anything the application chose; ordering makes the body identical
  on every server and every run, and worth pinning.

## Tests

- `SchedulerEndpointsTest.GetSchedulerContextShouldWork` gets a non-string entry. It passed only because
  the fixture's scheduler is a fake whose context the test had filled with strings.
- `WireFormatSnapshotTest.SchedulerContextBody` pins a body holding a string, an `int`, a
  `DateTimeOffset` and a null — sorted, with `"activeFrom": "2025-06-01T12:30:00.0000000+00:00"`. No
  existing snapshot moved.
- `TenantSchedulerRoutingTest.TheContextOfAContainerBuiltSchedulerCanBeRead` (#3407) loses its
  `[Explicit]`, states the behaviour, and asserts the body rather than only the status — the two entries
  the test put there, and nothing else.
- `PublicApiTest_Quartz.Dashboard.verified.txt` regenerated by running the tests: the two plugins' `()`
  constructors became `(IServiceProvider)`. The migration guide carries the same delta.

## Worth a reviewer's eye

The plugins' parameterless constructors are gone. Anyone constructing them by hand — not something
`AddQuartzDashboard` does — now passes an `IServiceProvider`.

Closes #3408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
