### PR TITLE
A persistent job store's serializer survives a trimmed publish

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -91,6 +91,14 @@ jobs:
           # coverage any more; if a component test cannot be written, that is a seam to add rather
           # than a line to put back here.
           #
+          # src/Quartz.Trimming.Canary is excused from coverage for the opposite reason to the usual
+          # one: it is not code a test covers, it is a test. `dotnet fallout PublishTrimmed` publishes
+          # it fully trimmed and then runs it, and a non-zero exit fails that leg — which is the only
+          # way to prove what it proves, since the failure it guards against (#3341, step 6) produced
+          # no compile-time warning of its own. No coverage instrumentation sees any of it: the run
+          # happens out of process, in a different leg, over a trimmed self-contained publish. It
+          # stays in analysis like everything else here.
+          #
           # database/ is excused from copy-paste detection and from two PL/SQL rules, and from
           # nothing else. Its bug and security rules still apply; these three are the ones that
           # have nothing true to say about it.
@@ -121,7 +129,7 @@ jobs:
             /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml" \
             /d:sonar.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**" \
             /d:sonar.cpd.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**,database/**" \
-            /d:sonar.coverage.exclusions="docs/.vuepress/**" \
+            /d:sonar.coverage.exclusions="docs/.vuepress/**,src/Quartz.Trimming.Canary/**" \
             /d:sonar.issue.ignore.multicriteria="generatedOracleGuards,wholeTableByDesign" \
             /d:sonar.issue.ignore.multicriteria.generatedOracleGuards.ruleKey="plsql:S1523" \
             /d:sonar.issue.ignore.multicriteria.generatedOracleGuards.resourceKey="database/migrations/**/*.sql" \

--- a/Quartz.slnx
+++ b/Quartz.slnx
@@ -47,5 +47,6 @@
   <Project Path="src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj" />
   <Project Path="src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj" />
   <Project Path="src/Quartz.Server/Quartz.Server.csproj" />
+  <Project Path="src/Quartz.Trimming.Canary/Quartz.Trimming.Canary.csproj" />
   <Project Path="src/Quartz/Quartz.csproj" />
 </Solution>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -127,7 +127,8 @@ partial class Build : FalloutBuild, ICompile, IPack
         .SetVersionSuffix(VersionSuffix);
 
     /// <summary>
-    /// Publishes the example applications, one of which is the repository's trim canary.
+    /// Publishes the example applications, one of which is a trim canary, and runs the trim canary that
+    /// is not an example.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -139,13 +140,25 @@ partial class Build : FalloutBuild, ICompile, IPack
     /// its csproj says so at length.
     /// </para>
     /// <para>
-    /// Still no native AOT publish here after step 5 of that issue, and the reason is a tooling one
-    /// rather than a scheduling one: ILCompiler takes no <c>--link-attributes</c>, so
-    /// <c>ILLink.Suppressions.xml</c> — which is what makes this leg green without silencing anything for
-    /// consumers — cannot be handed to it. An AOT publish of the worker therefore reports every recorded
-    /// warning as an error, and the only ways to quiet it are the two the issue has already refused: bake
-    /// the suppressions into the shipped assembly, or <c>NoWarn</c> the family and prove nothing. Step 5
-    /// ran the publish by hand and wrote down what it found; a leg here waits on step 6.
+    /// <c>Quartz.Trimming.Canary</c> is published for the runner's own RID and then <em>started</em>, and
+    /// a non-zero exit fails the leg. That is step 6's addition, and the reason for it is what step 6
+    /// fixed: a persistent job store's serializer threw on the first trigger it wrote in any trimmed
+    /// application, and the two warnings that hinted at it were already in the baseline, so a publish
+    /// that only compiles could never have found it. The canary asserts that
+    /// <c>JsonSerializer.IsReflectionEnabledByDefault</c> really is false and then round-trips every blob
+    /// a job store writes through the ordinary serializer. Publishing it for the runner's RID is what
+    /// makes it runnable — a trimmed publish is a self-contained one — and it is why this leg gets a
+    /// clean output directory rather than reusing an earlier run's.
+    /// </para>
+    /// <para>
+    /// Still no native AOT publish here after step 6, and the reason is a tooling one rather than a
+    /// scheduling one: ILCompiler takes no <c>--link-attributes</c>, so <c>ILLink.Suppressions.xml</c> —
+    /// which is what makes this leg green without silencing anything for consumers — cannot be handed to
+    /// it. An AOT publish of the worker therefore reports every recorded warning as an error, and the
+    /// only ways to quiet it are the two the issue has already refused: bake the suppressions into the
+    /// shipped assembly, or <c>NoWarn</c> the family and prove nothing. The canary applies no
+    /// suppressions at all, so it is the one project here that could carry a native AOT leg; whether it
+    /// should is a decision that belongs with <c>IsAotCompatible</c>, and both are still open.
     /// </para>
     /// </remarks>
     Target PublishTrimmed => _ => _
@@ -164,6 +177,21 @@ partial class Build : FalloutBuild, ICompile, IPack
                 .SetProject(solution.AllProjects.First(x => x.Name == "Quartz.Examples.AspNetCore"))
                 .SetConfiguration(configuration)
             );
+
+            AbsolutePath canaryDirectory = ArtifactsDirectory / "trim-canary";
+            canaryDirectory.CreateOrCleanDirectory();
+
+            DotNetPublish(s => s
+                .SetProject(solution.AllProjects.First(x => x.Name == "Quartz.Trimming.Canary"))
+                .SetConfiguration(configuration)
+                .SetRuntime(RuntimeInformation.RuntimeIdentifier)
+                .SetOutput(canaryDirectory)
+            );
+
+            AbsolutePath canary = canaryDirectory / (IsRunningOnWindows ? "Quartz.Trimming.Canary.exe" : "Quartz.Trimming.Canary");
+            Log.Information("Running the trim canary: {Canary}", canary);
+
+            ProcessTasks.StartProcess(canary, logOutput: true).AssertZeroExitCode();
         });
 
     /// <summary>

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3655,10 +3655,12 @@ suppressed in the shipped assembly, deliberately — suppressing them would hide
 Configuration by flat `quartz.*` keys, jobs named as strings (`job_scheduling_data` XML, a persisted
 `JOB_CLASS_NAME`), and `JobDataMap` values bound onto job properties are the paths that need reflection;
 an application that configures in code, references its job types statically and keeps job data to
-primitives exercises far less of it. One thing it does not get round: a **persistent job store** cannot
-be published trimmed at all yet, because a trimmed publish switches reflection-based `System.Text.Json`
-off and the default serializer has no generated contract to fall back on — see
-[Trimming](tutorial/more-about-jobs.md#trimming) for what that looks like. Progress is tracked on
+primitives exercises far less of it. A **persistent job store** publishes trimmed: the default
+System.Text.Json serializer carries a source-generated contract for every blob a store writes, and a
+custom trigger or calendar type is answered by the registry it was registered with. The one thing left
+open is a job-data value of a type of your own, which the registry is handed metadata for through
+`SystemTextJsonSerializerRegistry.AddTypeInfoResolver` — see
+[Trimming](tutorial/more-about-jobs.md#trimming) for the shape of that. Progress is tracked on
 [#3341](https://github.com/quartznet/quartznet/issues/3341).
 
 ## Executing is a trigger state
@@ -7570,6 +7572,7 @@ Parameters and behavior are unchanged:
 | `IQuartzApiClient` speaks Quartz's vocabulary | See [The dashboard's client speaks one currency](#the-dashboard-s-client-speaks-one-currency) |
 | The dashboard's HTTP-backed API client is gone | `QuartzApiClient` was never registered; the dashboard renders the schedulers in its own process, and `QuartzDashboardOptions.BaseUrl` and `.ApiPath` went with it — see [The dashboard reads the schedulers in its own process](#the-dashboard-reads-the-schedulers-in-its-own-process) |
 | Serializers outside a scheduler read a container-wide registry | Because the serializer maps are per-serializer, the HTTP API and `Quartz.HttpClient` read a `SystemTextJsonSerializerRegistry` registered in the container. Register it as a singleton to make a custom serializer visible to them. The dashboard no longer registers one of its own: it passes triggers and calendars through as themselves |
+| `SystemTextJsonSerializerRegistry` gained `AddTypeInfoResolver(IJsonTypeInfoResolver)` | Where reflection-based serialization is off — a `PublishTrimmed` or `PublishAot` application — this is how job-data values of the application's own types are answered for. Hand it a generated `JsonSerializerContext`'s `Default`. Everything Quartz writes, and every custom trigger or calendar registered with the registry, is already covered; with reflection on it changes nothing — see [Trimming annotations](#trimming-annotations) |
 | `IDriverDelegate` trigger states are `StoredTriggerState` | Eighteen members took the state as a `string`; the database still stores the same values — see [Trigger states are typed on the driver delegate](#trigger-states-are-typed-on-the-driver-delegate) |
 | The `…FromOtherStates` members take a state collection | Two or three fixed old-state parameters became one `IReadOnlyCollection<StoredTriggerState>` |
 | `FiredTriggerQuery.InstanceName` is `InstanceId` | With the `instanceName` parameters of the scheduler-state members; the `INSTANCE_NAME` column is unchanged |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3655,7 +3655,9 @@ suppressed in the shipped assembly, deliberately — suppressing them would hide
 Configuration by flat `quartz.*` keys, jobs named as strings (`job_scheduling_data` XML, a persisted
 `JOB_CLASS_NAME`), and `JobDataMap` values bound onto job properties are the paths that need reflection;
 an application that configures in code, references its job types statically and keeps job data to
-primitives exercises far less of it. A **persistent job store** publishes trimmed: the default
+primitives exercises far less of it. A **persistent job store** publishes trimmed, given a registered
+`DbDataSource` to reach its provider through (a `TrimMode=full` publish does not keep a connection type
+that is only named by string): the default
 System.Text.Json serializer carries a source-generated contract for every blob a store writes, and a
 custom trigger or calendar type is answered by the registry it was registered with. The one thing left
 open is a job-data value of a type of your own, which the registry is handed metadata for through

--- a/docs/documentation/quartz-4.x/packages/system-text-json.md
+++ b/docs/documentation/quartz-4.x/packages/system-text-json.md
@@ -230,3 +230,35 @@ services.AddKeyedSingleton("reporting", new SystemTextJsonSerializerRegistry()
 `AddQuartzHttpClient`; when a `HttpScheduler` is constructed by hand, pass one to its `serializerRegistry`
 parameter. A remote scheduler's own registrations cannot be discovered over HTTP, so custom types are only
 readable if this process knows their serializers.
+
+## Publishing trimmed or native AOT
+
+`PublishTrimmed` and `PublishAot` set `System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault` to
+false, so a type nobody has written metadata for cannot be serialized at all. This serializer carries a
+source-generated contract for everything Quartz writes — every trigger type, every calendar type,
+`CronExpression`, `NameValueCollection`, and a `JobDataMap` holding any of the value types
+`DataMapExtensions` declares an accessor for — and the registry answers for every custom trigger and
+calendar type registered with it, because `AddTriggerSerializer<TTrigger>` and
+`AddCalendarSerializer<TCalendar>` know the type statically.
+
+What is left is a **job-data value of a type of your own**. Hand the registry the metadata for it, as a
+generated `JsonSerializerContext`:
+
+<!-- snippet: sample_stj_type_info_resolver -->
+```csharp
+// The metadata for this application's own job-data value types. Only a trimmed or native AOT
+// publish needs it: with reflection on, the resolver chain still ends in reflection.
+services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer("my connection string");
+    store.UseSystemTextJsonSerializer(json => json.AddTypeInfoResolver(JobDataContext.Default));
+}));
+```
+<!-- endSnippet -->
+
+Resolvers are asked in the order they were added, behind Quartz's own contract and in front of
+reflection, so `AddTypeInfoResolver` can be called more than once and is safe to configure whether or
+not the application is published trimmed.
+
+The `Quartz.Serialization.Newtonsoft` serializer has no equivalent: it is reflection by nature, so an
+application that publishes trimmed uses this one.

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -447,27 +447,67 @@ rooted:
 Registering every job type with `AddJob<TJob>()` or `AddJobType<TJob>()` covers the first of those:
 those calls are what the trimmer follows, and the store then finds the type it needs.
 
-::: warning A trimmed publish switches reflection-based JSON off
-`PublishTrimmed` sets `System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault` to false, and the
-default `IObjectSerializer` has no source-generated contract to fall back on. An application that keeps
-its schedule in memory never notices; one with a **persistent job store** gets
+### A persistent store under trimming
 
+`PublishTrimmed` sets `System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault` to false. An
+application that keeps its schedule in memory never notices; one with a **persistent job store** writes
+every trigger, calendar and `JobDataMap` through `IObjectSerializer`, and so depends on what
+`System.Text.Json` can still resolve.
+
+The default System.Text.Json serializer carries a source-generated contract for everything Quartz
+itself writes, so **the built-in shapes need nothing from you**: every trigger type, every calendar
+type, `CronExpression`, the `NameValueCollection` written under `useProperties`, and a `JobDataMap`
+holding a `string`, `bool`, `char`, `int`, `long`, `float`, `double`, `decimal`, `DateTime`,
+`DateTimeOffset`, `TimeSpan`, `Guid` or a `Dictionary<string, string>` — which is to say every type
+`DataMapExtensions` declares an accessor for. A **custom trigger or calendar type** needs nothing
+either: `AddTriggerSerializer<TTrigger>` and `AddCalendarSerializer<TCalendar>` know the type, so the
+registry answers for it.
+
+What is left open is a job-data value of a type of your own — an enum, or anything else you put in the
+map. With reflection off there is no metadata for it, and the write fails naming it. Hand the registry
+your own generated context:
+
+<!-- snippet: sample_more_about_jobs_trimmed_job_data_context -->
+```csharp
+// A job data value type of this application's own, which no contract of Quartz's can name.
+public enum ReportFormat
+{
+    Csv,
+    Pdf
+}
+
+// The metadata the registry is handed. Only a trimmed or native AOT publish needs it: with reflection
+// on, the resolver chain still ends in reflection and this changes nothing.
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(ReportFormat))]
+internal sealed partial class ReportJobDataContext : JsonSerializerContext;
 ```
-System.InvalidOperationException: Reflection-based serialization has been disabled for this
-application. Either use the source generator APIs or explicitly configure the
-'JsonSerializerOptions.TypeInfoResolver' property.
+<!-- endSnippet -->
+
+<!-- snippet: sample_more_about_jobs_trimmed_job_data_metadata -->
+```csharp
+services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer(connectionString);
+    store.UseSystemTextJsonSerializer(registry => registry.AddTypeInfoResolver(ReportJobDataContext.Default));
+}));
 ```
+<!-- endSnippet -->
 
-the first time it writes a trigger. **Publish a persistent-store application untrimmed** until that is
-closed.
+`AddTypeInfoResolver` can be called more than once, and resolvers are asked in the order they were
+added, behind Quartz's own contract and in front of reflection. With reflection on it changes nothing,
+so it is safe to configure unconditionally.
 
-Turning the switch back on with
-`<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` is not a
-way round it either: the trimmer has already removed what reflection would have needed, and what
-remains fails later and less clearly. In the console application that produced the exception above,
-the same write came back as `FileNotFoundException: Could not load file or assembly
-'System.Private.Uri'`, under `TrimMode=partial` as much as `full`; a larger application keeps more
-and fails elsewhere. Reflection over a trimmed assembly is unsupported, not merely unreliable.
+::: warning Turning reflection back on is not a way round anything
+`<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` looks
+like an escape hatch and is not one: the trimmer has already removed what reflection would have needed,
+and what remains fails later and less clearly. In one console application the same write came back as
+`FileNotFoundException: Could not load file or assembly 'System.Private.Uri'`, under `TrimMode=partial`
+as much as `full`; a larger application keeps more and fails elsewhere. Reflection over a trimmed
+assembly is unsupported, not merely unreliable.
+
+The `Quartz.Serialization.Newtonsoft` serializer is reflection by nature and has no source-generated
+form to fall back on, so an application that publishes trimmed uses the System.Text.Json one.
 :::
 
 ## Native AOT
@@ -489,24 +529,23 @@ executes and disposes job instances, applies flat `quartz.*` keys from `appsetti
 down cleanly on Ctrl+C with `WaitForJobsToComplete` honoured. Job types named as types, listeners and
 the DI graph all survive.
 
-**A scheduler over a persistent store does not, yet.** It is the serializer above, not the scheduler:
-`IObjectSerializer` writes triggers, calendars and `JobDataMap` values through reflection-based
-`System.Text.Json`, which is both switched off and uncompilable under AOT. This is what stops the
-`Quartz` package from declaring `IsAotCompatible`, and it is tracked on
-[issue #3341](https://github.com/quartznet/quartznet/issues/3341).
+**The store serializer runs too.** A native AOT publish is a trimmed publish, so it switches the same
+reflection off, and the source-generated contract described above is what answers instead. The
+repository's `Quartz.Trimming.Canary` round-trips every blob a job store writes — every trigger, every
+calendar including a chained one, a `JobDataMap`, a `NameValueCollection` and a `CronExpression` —
+out of a fully trimmed publish on every build, and out of a native AOT publish when run by hand.
 
 **Publishing AOT reports Quartz's own warnings, and that is deliberate.** Quartz records its remaining
 reflective call sites in the repository rather than in the shipped assembly, so an
 `UnconditionalSuppressMessage` never hides them from you. Expect `IL2xxx` for the string-named
-configuration paths described above, and `IL3050` for two more:
+configuration paths described above, and `IL3050` for one more: **configuration binding**.
+`Configure<TOptions>(name, section)` binds the `Quartz` section by reflecting over the options types;
+configuring in code with `AddQuartz(q => …)` rather than from `appsettings.json` avoids it.
 
-- **configuration binding** — `Configure<TOptions>(name, section)` binds the `Quartz` section by
-  reflecting over the options types. Configuring in code with `AddQuartz(q => …)` rather than from
-  `appsettings.json` avoids it;
-- **job data serialization** — the persistent-store path above.
-
-Neither is on the fire path of an in-memory scheduler, so an application that configures in code and
-schedules in memory publishes AOT with warnings it can read and dismiss.
+That warning is not on the fire path of any scheduler, so an application that configures in code
+publishes AOT with warnings it can read and dismiss. The `Quartz` package still does not declare
+`IsAotCompatible` — the remaining warnings are what that claim would have to answer for, and the
+question is tracked on [issue #3341](https://github.com/quartznet/quartznet/issues/3341).
 
 ## JobExecutionException
 

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -498,6 +498,15 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
 added, behind Quartz's own contract and in front of reflection. With reflection on it changes nothing,
 so it is safe to configure unconditionally.
 
+**The provider's connection type is the one thing a `TrimMode=full` publish still has to be told
+about.** An ADO.NET store resolves its provider's `DbConnection` type from the driver description by
+name, and the trimmer does not follow a name: `UseSqlite(connectionString)` published `TrimMode=full`
+fails while the container is being built, with `Cannot instantiate type which has no empty constructor`.
+Either register a `DbDataSource` in the container and set `UseRegisteredDataSource`, as
+[Job stores](job-stores.md) describes, or root the provider assembly with
+`<TrimmerRootAssembly Include="Microsoft.Data.Sqlite" />`. Making the store need neither is the open
+step on [#3341](https://github.com/quartznet/quartznet/issues/3341).
+
 ::: warning Turning reflection back on is not a way round anything
 `<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` looks
 like an escape hatch and is not one: the trimmer has already removed what reflection would have needed,

--- a/src/Quartz.Documentation.Samples/Packages/SystemTextJsonSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/SystemTextJsonSamples.cs
@@ -1,5 +1,6 @@
 using System.Collections.Specialized;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -146,4 +147,30 @@ public static class SystemTextJsonSamples
 
         #endregion
     }
+
+    public static void TypeInfoResolver(IServiceCollection services)
+    {
+        #region sample_stj_type_info_resolver
+
+        // The metadata for this application's own job-data value types. Only a trimmed or native AOT
+        // publish needs it: with reflection on, the resolver chain still ends in reflection.
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer("my connection string");
+            store.UseSystemTextJsonSerializer(json => json.AddTypeInfoResolver(JobDataContext.Default));
+        }));
+
+        #endregion
+    }
 }
+
+/// <summary>A job-data value type of the application's own, which no contract of Quartz's can name.</summary>
+public enum Severity
+{
+    Routine,
+    Urgent
+}
+
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(Severity))]
+internal sealed partial class JobDataContext : JsonSerializerContext;

--- a/src/Quartz.Documentation.Samples/Tutorial/MoreAboutJobsSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/MoreAboutJobsSamples.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Quartz.Documentation.Samples.Tutorial;
@@ -214,7 +216,37 @@ public static class MoreAboutJobsSamples
         }
         #endregion
     }
+
+    public static void JobDataMetadataForATrimmedPublish(IServiceCollection services, string connectionString)
+    {
+        #region sample_more_about_jobs_trimmed_job_data_metadata
+
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(connectionString);
+            store.UseSystemTextJsonSerializer(registry => registry.AddTypeInfoResolver(ReportJobDataContext.Default));
+        }));
+
+        #endregion
+    }
 }
+
+#region sample_more_about_jobs_trimmed_job_data_context
+
+// A job data value type of this application's own, which no contract of Quartz's can name.
+public enum ReportFormat
+{
+    Csv,
+    Pdf
+}
+
+// The metadata the registry is handed. Only a trimmed or native AOT publish needs it: with reflection
+// on, the resolver chain still ends in reflection and this changes nothing.
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(ReportFormat))]
+internal sealed partial class ReportJobDataContext : JsonSerializerContext;
+
+#endregion
 
 #region sample_more_about_jobs_custom_job_detail
 

--- a/src/Quartz.Tests.Unit/HttpApi/WireFormatSourceGenerationTest.cs
+++ b/src/Quartz.Tests.Unit/HttpApi/WireFormatSourceGenerationTest.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization.Metadata;
 using Quartz.HttpApiContract;
 using Quartz.Serialization.SystemTextJson;
 using Quartz.Serialization.SystemTextJson.Converters;
+using Quartz.Tests.Unit.Simpl;
 
 namespace Quartz.Tests.Unit.HttpApi;
 
@@ -80,6 +81,22 @@ public class WireFormatSourceGenerationTest
             "a contract type must never reach the reflection resolver, and the chain is consulted in order");
         options.TypeInfoResolverChain[^1].Should().BeOfType<DefaultJsonTypeInfoResolver>(
             "the values inside a JobDataMap are whatever the application put there, so the chain has to end in reflection");
+    }
+
+    /// <summary>
+    /// The wire has the same open half the store format does — the values inside a
+    /// <see cref="JobDataMap" /> — so it is given the same seam, assembled by the same method.
+    /// </summary>
+    [Test]
+    public void TheSchedulersRegistryIsAskedBehindTheContract()
+    {
+        SystemTextJsonSerializerRegistry registry = new();
+        registry.AddTypeInfoResolver(JobDataValueContext.Default);
+
+        JsonSerializerOptions options = new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureWireFormat(registry);
+
+        options.TypeInfoResolverChain[2].Should().BeSameAs(JobDataValueContext.Default,
+            "an application publishing trimmed answers for its own job-data value types once, and both formats read the same registry");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Simpl/StoreFormatSourceGenerationTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/StoreFormatSourceGenerationTest.cs
@@ -1,0 +1,308 @@
+#nullable enable
+
+using System.Collections.Specialized;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.Calendar;
+using Quartz.Impl.Triggers;
+using Quartz.Serialization.SystemTextJson;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// The store format resolves every type it writes without reflection, which is what lets a persistent
+/// job store survive a trimmed or native-AOT publish.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A test host always has reflection on, and <c>JsonSerializer.IsReflectionEnabledByDefault</c> cannot
+/// be flipped in a running process — it is a feature switch a publish substitutes away. So the
+/// serializer under test here is the real one with the reflection resolver taken back out of its chain,
+/// which is precisely the chain a trimmed publish leaves behind. A type nobody named then has no
+/// answer at all, and the round trip throws instead of quietly reflecting.
+/// </para>
+/// <para>
+/// <c>Quartz.Trimming.Canary</c> proves the same thing the other way round, out of an actual trimmed
+/// publish. This test is the one that fails on a laptop.
+/// </para>
+/// </remarks>
+public class StoreFormatSourceGenerationTest
+{
+    private static IEnumerable<TestCaseData> BuiltInTriggers()
+    {
+        yield return Trigger("SimpleTrigger", SimpleScheduleBuilder.Create()
+            .WithInterval(TimeSpan.FromMinutes(5))
+            .WithRepeatCount(3));
+
+        yield return Trigger("CronTrigger", CronScheduleBuilder.Create("0/5 * * * * ?"));
+
+        yield return Trigger("CalendarIntervalTrigger", CalendarIntervalScheduleBuilder.Create()
+            .WithInterval(2, IntervalUnit.Day));
+
+        yield return Trigger("DailyTimeIntervalTrigger", DailyTimeIntervalScheduleBuilder.Create()
+            .WithInterval(30, IntervalUnit.Minute)
+            .StartingDailyAt(new TimeOnly(8, 0))
+            .EndingDailyAt(new TimeOnly(17, 0)));
+
+        yield return Trigger("RecurrenceTrigger", RecurrenceScheduleBuilder.Create("FREQ=DAILY")
+            .InTimeZone(TimeZoneInfo.Utc));
+
+        static TestCaseData Trigger(string name, IScheduleBuilder schedule)
+        {
+            IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+                .WithSchedule(schedule)
+                .WithIdentity(name, "StoreFormat")
+                .ForJob("Job", "StoreFormat")
+                .StartAt(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero))
+                .UsingJobData("value", "kept")
+                .Build();
+
+            return new TestCaseData(trigger).SetArgDisplayNames(name);
+        }
+    }
+
+    private static IEnumerable<TestCaseData> BuiltInCalendars()
+    {
+        yield return Calendar("BaseCalendar", new BaseCalendar());
+        yield return Calendar("AnnualCalendar", new AnnualCalendar());
+        yield return Calendar("CronCalendar", new CronCalendar("0/5 * * * * ?"));
+        yield return Calendar("DailyCalendar", new DailyCalendar(new TimeOnly(1, 0), new TimeOnly(2, 0)));
+        yield return Calendar("HolidayCalendar", new HolidayCalendar());
+        yield return Calendar("MonthlyCalendar", new MonthlyCalendar());
+        yield return Calendar("WeeklyCalendar", new WeeklyCalendar());
+        yield return Calendar("ChainedCalendars", new CronCalendar("0/5 * * * * ?")
+        {
+            CalendarBase = new AnnualCalendar { Description = "the base of the chain" }
+        });
+
+        static TestCaseData Calendar(string name, ICalendar calendar)
+        {
+            calendar.Description = calendar.Description ?? name;
+            return new TestCaseData(calendar).SetArgDisplayNames(name);
+        }
+    }
+
+    [TestCaseSource(nameof(BuiltInTriggers))]
+    public void BuiltInTriggerRoundTripsWithoutReflection(IOperableTrigger trigger)
+    {
+        IObjectSerializer serializer = ReflectionlessSerializer();
+
+        IOperableTrigger? restored = serializer.Deserialize<IOperableTrigger>(serializer.Serialize(trigger));
+
+        restored.Should().BeEquivalentTo(trigger,
+            $"{trigger.GetType().Name} is written by every persistent job store, so its metadata has to be answerable with reflection off");
+    }
+
+    [TestCaseSource(nameof(BuiltInCalendars))]
+    public void BuiltInCalendarRoundTripsWithoutReflection(ICalendar calendar)
+    {
+        IObjectSerializer serializer = ReflectionlessSerializer();
+
+        ICalendar? restored = serializer.Deserialize<ICalendar>(serializer.Serialize(calendar));
+
+        restored.Should().BeEquivalentTo(calendar,
+            $"{calendar.GetType().Name} is stored as a blob of its own, and a chained one carries a second calendar inside it");
+    }
+
+    [Test]
+    public void JobDataMapRoundTripsEveryValueTheReadSideCanProduce()
+    {
+        // Exactly the set SerializationExtensions.GetJobDataMap can hand back: past these, a stored
+        // value has no reading, whatever it was written from.
+        JobDataMap map = new()
+        {
+            { "string", "value" },
+            { "bool", true },
+            { "int", 42 },
+            { "long", 9_000_000_000L },
+            { "double", 12.34 },
+            { "null", null },
+            { "dictionary", new Dictionary<string, string> { ["inner"] = "value" } }
+        };
+
+        IObjectSerializer serializer = ReflectionlessSerializer();
+        JobDataMap? restored = serializer.Deserialize<JobDataMap>(serializer.Serialize(map));
+
+        restored.Should().NotBeNull();
+        restored!["string"].Should().Be("value");
+        restored["bool"].Should().Be(true);
+        restored["int"].Should().Be(42);
+        restored["long"].Should().Be(9_000_000_000L);
+        restored["double"].Should().Be(12.34);
+        restored["null"].Should().BeNull();
+        restored["dictionary"].Should().BeEquivalentTo(new Dictionary<string, string> { ["inner"] = "value" },
+            "an object-valued entry comes back as Dictionary<string, string>, which is why that closed form is named in the context");
+    }
+
+    [Test]
+    public void JobDataMapWritesEveryValueTypeQuartzDeclaresAnAccessorFor()
+    {
+        // DataMapExtensions is what tells an application which types a job data map holds, so the write
+        // side has to answer for each of them with reflection off. Several read back as a string or a
+        // number rather than as themselves - that is the store format, not this test's concern.
+        JobDataMap map = new()
+        {
+            { "char", 'q' },
+            { "float", 1.5f },
+            { "decimal", 9.99m },
+            { "dateTime", new DateTime(1982, 6, 28, 1, 1, 1, DateTimeKind.Utc) },
+            { "dateTimeOffset", new DateTimeOffset(1982, 6, 28, 1, 1, 1, TimeSpan.FromHours(3)) },
+            { "timeSpan", TimeSpan.FromMinutes(90) },
+            { "guid", Guid.Parse("6f9619ff-8b86-d011-b42d-00c04fc964ff") }
+        };
+
+        IObjectSerializer serializer = ReflectionlessSerializer();
+        Action write = () => serializer.Serialize(map);
+
+        write.Should().NotThrow(
+            "every type DataMapExtensions declares an accessor for is a type Quartz teaches an application to store, so a trimmed application must be able to write it");
+    }
+
+    [Test]
+    public void CronExpressionAndNameValueCollectionRoundTripWithoutReflection()
+    {
+        IObjectSerializer serializer = ReflectionlessSerializer();
+
+        CronExpression expression = new("0/5 * * * * ?", TimeZoneInfo.Utc);
+        CronExpression? restoredExpression = serializer.Deserialize<CronExpression>(serializer.Serialize(expression));
+        restoredExpression.Should().BeEquivalentTo(expression, "a cron expression has a converter of its own and so needs metadata of its own");
+
+        NameValueCollection properties = new() { { "key", "value" } };
+        NameValueCollection? restoredProperties = serializer.Deserialize<NameValueCollection>(serializer.Serialize(properties));
+        restoredProperties.Should().BeEquivalentTo(properties,
+            "under useProperties the store writes a job data map as a NameValueCollection, so that is a blob shape too");
+    }
+
+    [Test]
+    public void TheChainIsTheContractThenTheRegistryThenReflection()
+    {
+        JsonSerializerOptions options = new TestSerializer(new SystemTextJsonSerializerRegistry()).Options();
+
+        options.TypeInfoResolverChain[0].Should().BeOfType<QuartzStoreJsonContext>(
+            "a type Quartz names must never reach reflection, and the chain is consulted in order");
+        options.TypeInfoResolverChain[^1].Should().BeOfType<DefaultJsonTypeInfoResolver>(
+            "the values inside a JobDataMap are whatever the application put there, so where reflection exists the chain still ends in it");
+        options.TypeInfoResolverChain.Should().HaveCount(3,
+            "the registry sits between the two: the trigger and calendar types registered with it, and whatever the application handed to AddTypeInfoResolver");
+    }
+
+    [Test]
+    public void ApplicationResolversAreAskedAfterQuartzAndBeforeReflection()
+    {
+        SystemTextJsonSerializerRegistry registry = new();
+        registry.AddTypeInfoResolver(JobDataValueContext.Default);
+
+        JsonSerializerOptions options = new TestSerializer(registry).Options();
+
+        options.TypeInfoResolverChain[2].Should().BeSameAs(JobDataValueContext.Default,
+            "an application's own metadata answers for what Quartz cannot name, and is still asked before reflection");
+        options.TypeInfoResolverChain[^1].Should().BeOfType<DefaultJsonTypeInfoResolver>(
+            "handing in a resolver must not take the reflection fallback away from everything else");
+    }
+
+    [Test]
+    public void CustomTriggerRoundTripsWithoutReflectionAndWithoutASeam()
+    {
+        SystemTextJsonSerializerRegistry registry = new();
+        registry.AddTriggerSerializer<JsonSerializationTestTrigger>(new JsonSerializationTestTrigger.SystemTextJsonSerializer());
+
+        JsonSerializationTestTrigger trigger = new()
+        {
+            Key = new TriggerKey("Custom", "StoreFormat"),
+            JobKey = new JobKey("Job", "StoreFormat"),
+            StartTimeUtc = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            RepeatInterval = TimeSpan.FromHours(1),
+            RepeatCount = 5,
+            CustomProperty = 56
+        };
+
+        IObjectSerializer serializer = ReflectionlessSerializer(registry);
+        IOperableTrigger? restored = serializer.Deserialize<IOperableTrigger>(serializer.Serialize(trigger));
+
+        restored.Should().BeEquivalentTo(trigger,
+            "AddTriggerSerializer<TTrigger> knows the type statically, so the registry can answer for a custom trigger itself and the application needs no JsonSerializerContext for it");
+    }
+
+    [Test]
+    public void AJobDataValueTypeQuartzCannotNameNeedsTheApplicationsOwnMetadata()
+    {
+        JobDataMap map = new() { { "mode", JobDataValue.Fast } };
+
+        Action withoutResolver = () => ReflectionlessSerializer().Serialize(map);
+
+        withoutResolver.Should().Throw<JsonSerializationException>(
+                "with reflection off, a value type neither Quartz nor the application named has no metadata at all")
+            .WithInnerException<NotSupportedException>()
+            .WithMessage($"*{typeof(JobDataValue).FullName}*",
+                "the failure has to name the type the application has to answer for");
+
+        SystemTextJsonSerializerRegistry registry = new();
+        registry.AddTypeInfoResolver(JobDataValueContext.Default);
+
+        IObjectSerializer serializer = ReflectionlessSerializer(registry);
+        JobDataMap? restored = serializer.Deserialize<JobDataMap>(serializer.Serialize(map));
+
+        restored.Should().NotBeNull();
+        restored!["mode"].Should().Be((int) JobDataValue.Fast,
+            "an enum goes out as its number and comes back as one, which is what GetInt reads - handing in the context is what makes the write possible at all");
+    }
+
+    private static IObjectSerializer ReflectionlessSerializer()
+    {
+        return ReflectionlessSerializer(new SystemTextJsonSerializerRegistry());
+    }
+
+    private static IObjectSerializer ReflectionlessSerializer(SystemTextJsonSerializerRegistry registry)
+    {
+        return new TestSerializer(registry, withoutReflection: true);
+    }
+
+    /// <summary>
+    /// The production serializer, with its options reachable and — where asked — with the reflection
+    /// resolver taken out of the chain, exactly as a trimmed publish takes it out.
+    /// </summary>
+    private sealed class TestSerializer(SystemTextJsonSerializerRegistry registry, bool withoutReflection = false)
+        : SystemTextJsonObjectSerializer(registry)
+    {
+        public JsonSerializerOptions Options() => CreateSerializerOptions();
+
+        protected override JsonSerializerOptions CreateSerializerOptions()
+        {
+            JsonSerializerOptions options = base.CreateSerializerOptions();
+            if (!withoutReflection)
+            {
+                return options;
+            }
+
+            IList<IJsonTypeInfoResolver> chain = options.TypeInfoResolverChain;
+            for (int i = chain.Count - 1; i >= 0; i--)
+            {
+                if (chain[i] is DefaultJsonTypeInfoResolver)
+                {
+                    chain.RemoveAt(i);
+                }
+            }
+
+            return options;
+        }
+    }
+}
+
+/// <summary>A job-data value type of the application's own, which no contract of Quartz's can name.</summary>
+public enum JobDataValue
+{
+    Slow = 0,
+    Fast = 1
+}
+
+/// <summary>
+/// The metadata an application hands to <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" />
+/// for its own job-data value types.
+/// </summary>
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(JobDataValue))]
+internal sealed partial class JobDataValueContext : JsonSerializerContext;

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -3659,6 +3659,7 @@ namespace Quartz.Serialization.SystemTextJson
             where TCalendar : Quartz.ICalendar { }
         public Quartz.Serialization.SystemTextJson.SystemTextJsonSerializerRegistry AddTriggerSerializer<TTrigger>(Quartz.Serialization.SystemTextJson.Triggers.ITriggerSerializer serializer)
             where TTrigger : Quartz.ITrigger { }
+        public Quartz.Serialization.SystemTextJson.SystemTextJsonSerializerRegistry AddTypeInfoResolver(System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver resolver) { }
     }
 }
 namespace Quartz.Serialization.SystemTextJson.Triggers

--- a/src/Quartz.Trimming.Canary/Program.cs
+++ b/src/Quartz.Trimming.Canary/Program.cs
@@ -1,0 +1,201 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Specialized;
+using System.Text;
+using System.Text.Json;
+
+using Quartz;
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Trimming.Canary;
+
+/// <summary>
+/// Round-trips everything a persistent job store writes, out of a trimmed publish, through the ordinary
+/// <see cref="SystemTextJsonObjectSerializer" /> with no test seam of any kind.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A trimmed or native-AOT publish sets <c>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault</c>
+/// to false, and that is the whole point: with it false, options carrying no resolver have nothing to
+/// answer <c>GetTypeInfo</c> with, and before issue #3341's step 6 every ADO store threw on the first
+/// trigger it wrote. The first check below asserts the switch really is off, so a green run cannot be a
+/// run that happened to keep reflection.
+/// </para>
+/// <para>
+/// Each check serializes, deserializes, and serializes again, then compares the two payloads byte for
+/// byte. That catches both halves at once — a shape that cannot be written, and a shape that comes back
+/// different — and it needs no equality implementation on the types involved.
+/// </para>
+/// </remarks>
+internal static class Program
+{
+    private static readonly DateTimeOffset StartTime = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    public static int Main()
+    {
+        List<string> failures = [];
+
+        Console.WriteLine($"IsReflectionEnabledByDefault: {JsonSerializer.IsReflectionEnabledByDefault}");
+        if (JsonSerializer.IsReflectionEnabledByDefault)
+        {
+            failures.Add("FAIL reflection-is-off: JsonSerializer.IsReflectionEnabledByDefault is true, so this run proves nothing. Publish with PublishTrimmed=true.");
+        }
+
+        SystemTextJsonObjectSerializer serializer = new();
+
+        foreach ((string name, object value) in Payloads())
+        {
+            string? failure = RoundTrip(serializer, name, value);
+            if (failure is null)
+            {
+                Console.WriteLine($"PASS {name}");
+            }
+            else
+            {
+                failures.Add(failure);
+            }
+        }
+
+        foreach (string failure in failures)
+        {
+            Console.WriteLine(failure);
+        }
+
+        Console.WriteLine(failures.Count == 0
+            ? "Quartz.Trimming.Canary: the store format round-trips with reflection-based serialization off."
+            : $"Quartz.Trimming.Canary: {failures.Count} check(s) failed.");
+
+        return failures.Count == 0 ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Everything a persistent job store hands the serializer: every built-in trigger, every built-in
+    /// calendar and a chained one, a job data map holding each value the read side can produce, the
+    /// property collection <c>useProperties</c> writes, and a cron expression.
+    /// </summary>
+    private static IEnumerable<(string Name, object Value)> Payloads()
+    {
+        yield return ("SimpleTrigger", Trigger("SimpleTrigger", SimpleScheduleBuilder.Create()
+            .WithInterval(TimeSpan.FromMinutes(5))
+            .WithRepeatCount(3)));
+
+        yield return ("CronTrigger", Trigger("CronTrigger", CronScheduleBuilder.Create("0/5 * * * * ?")));
+
+        yield return ("CalendarIntervalTrigger", Trigger("CalendarIntervalTrigger", CalendarIntervalScheduleBuilder.Create()
+            .WithInterval(2, IntervalUnit.Day)));
+
+        yield return ("DailyTimeIntervalTrigger", Trigger("DailyTimeIntervalTrigger", DailyTimeIntervalScheduleBuilder.Create()
+            .WithInterval(30, IntervalUnit.Minute)
+            .StartingDailyAt(new TimeOnly(8, 0))
+            .EndingDailyAt(new TimeOnly(17, 0))));
+
+        yield return ("RecurrenceTrigger", Trigger("RecurrenceTrigger", RecurrenceScheduleBuilder.Create("FREQ=DAILY")
+            .InTimeZone(TimeZoneInfo.Utc)));
+
+        yield return ("BaseCalendar", new BaseCalendar { Description = "BaseCalendar" });
+        yield return ("AnnualCalendar", new AnnualCalendar { Description = "AnnualCalendar" });
+        yield return ("CronCalendar", new CronCalendar("0/5 * * * * ?") { Description = "CronCalendar" });
+        yield return ("DailyCalendar", new DailyCalendar(new TimeOnly(1, 0), new TimeOnly(2, 0)) { Description = "DailyCalendar" });
+        yield return ("HolidayCalendar", new HolidayCalendar { Description = "HolidayCalendar" });
+        yield return ("MonthlyCalendar", new MonthlyCalendar { Description = "MonthlyCalendar" });
+        yield return ("WeeklyCalendar", new WeeklyCalendar { Description = "WeeklyCalendar" });
+
+        yield return ("ChainedCalendars", new CronCalendar("0/5 * * * * ?")
+        {
+            Description = "ChainedCalendars",
+            CalendarBase = new AnnualCalendar { Description = "the base of the chain" }
+        });
+
+        yield return ("JobDataMap", new JobDataMap
+        {
+            { "string", "value" },
+            { "bool", true },
+            { "int", 42 },
+            { "long", 9_000_000_000L },
+            { "double", 12.34 },
+            { "null", null },
+            { "dictionary", new Dictionary<string, string> { ["inner"] = "value" } }
+        });
+
+        yield return ("NameValueCollection", new NameValueCollection { { "key", "value" } });
+
+        yield return ("CronExpression", new CronExpression("0/5 * * * * ?", TimeZoneInfo.Utc));
+    }
+
+    private static IOperableTrigger Trigger(string name, IScheduleBuilder schedule)
+    {
+        return (IOperableTrigger) TriggerBuilder.Create()
+            .WithSchedule(schedule)
+            .WithIdentity(name, "Canary")
+            .ForJob("Job", "Canary")
+            .StartAt(StartTime)
+            .UsingJobData("value", "kept")
+            .Build();
+    }
+
+    /// <summary>
+    /// Writes the value, reads it back through the type the store names for it, and writes it again.
+    /// </summary>
+    private static string? RoundTrip(SystemTextJsonObjectSerializer serializer, string name, object value)
+    {
+        try
+        {
+            byte[] written = serializer.Serialize(value);
+            object? restored = Read(serializer, value, written);
+
+            if (restored is null)
+            {
+                return $"FAIL {name}: came back as null.";
+            }
+
+            byte[] rewritten = serializer.Serialize(restored);
+            if (!written.AsSpan().SequenceEqual(rewritten))
+            {
+                return $"FAIL {name}: came back different.{Environment.NewLine}  wrote:   {Encoding.UTF8.GetString(written)}{Environment.NewLine}  rewrote: {Encoding.UTF8.GetString(rewritten)}";
+            }
+
+            return null;
+        }
+        catch (Exception e)
+        {
+            return $"FAIL {name}: {e.GetType().FullName}: {e.Message}{Environment.NewLine}{e}";
+        }
+    }
+
+    /// <summary>
+    /// Reads a blob back under the very type <c>StdAdoDelegate</c> asks <c>GetObjectFromBlob</c> for.
+    /// </summary>
+    private static object? Read(SystemTextJsonObjectSerializer serializer, object value, byte[] written)
+    {
+        return value switch
+        {
+            ITrigger => serializer.Deserialize<IOperableTrigger>(written),
+            ICalendar => serializer.Deserialize<ICalendar>(written),
+            JobDataMap => serializer.Deserialize<JobDataMap>(written),
+            NameValueCollection => serializer.Deserialize<NameValueCollection>(written),
+            CronExpression => serializer.Deserialize<CronExpression>(written),
+            _ => throw new InvalidOperationException($"No job store reads a {value.GetType()} back, so this payload does not belong in the canary.")
+        };
+    }
+}

--- a/src/Quartz.Trimming.Canary/Quartz.Trimming.Canary.csproj
+++ b/src/Quartz.Trimming.Canary/Quartz.Trimming.Canary.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+  </PropertyGroup>
+
+  <!--
+    The trim canary that runs. Quartz.Examples.Worker is published trimmed and never started, so it can
+    only prove the absence of a warning; this one starts, and proves that a persistent job store's
+    serializer still works when System.Text.Json's reflection fallback is gone. That distinction is not
+    academic — issue #3341's step 6 fixed a failure that produced no warning at all beyond the two
+    already recorded, and that a compile could not have found.
+
+    No TrimmerRootAssembly here, deliberately. The worker roots Quartz so that the trim analyzer walks
+    every path in it and any IL2xxx is reported; this project wants the opposite, an application trimmed
+    down to what it actually reaches, because that is the shape in which a missing JsonTypeInfo shows up.
+
+    ILLink.Suppressions.xml is not applied either, and must not be needed: the store serializer's own
+    path is warning-free after step 6, so a warning here is news. It does not ship — see the header of
+    that file — so applying it would only hide something.
+  -->
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz/HttpApiContract/HttpApiJson.cs
+++ b/src/Quartz/HttpApiContract/HttpApiJson.cs
@@ -19,10 +19,8 @@
 
 #endregion
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 
 using Quartz.Serialization.SystemTextJson;
 
@@ -60,6 +58,14 @@ internal static class HttpApiJson
     /// options carry a converter for is metadata that defers to that converter, which is what keeps an
     /// <see cref="ITrigger" /> going through <c>TriggerConverter</c> either way.
     /// </para>
+    /// <para>
+    /// The registry goes in behind the contract, which is what puts the wire and the store format on the
+    /// same footing: a custom trigger or calendar type is answered because
+    /// <c>AddTriggerSerializer&lt;TTrigger&gt;</c> knew the type, and an application's own job-data value
+    /// types are answered by whatever it handed to
+    /// <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" />. The two formats have the same
+    /// open half, so they are assembled by the same method.
+    /// </para>
     /// </remarks>
     public static JsonSerializerOptions ConfigureWireFormat(
         this JsonSerializerOptions options,
@@ -71,64 +77,8 @@ internal static class HttpApiJson
         options.Converters.Add(new JsonStringEnumConverter<FireInstanceState>());
         options.Converters.Add(new JsonStringEnumConverter<ExecutionLimitScope>());
 
-        // Asking twice must leave the chain as asking once does: on the server these options belong to
-        // the whole container, and every AddQuartzHttpApi call wants the same contract in front of it.
-        IList<IJsonTypeInfoResolver> resolvers = options.TypeInfoResolverChain;
-        if (!resolvers.Contains(HttpApiJsonContext.Default))
-        {
-            if (resolvers.Count == 0)
-            {
-                // Options carrying no resolver of their own fall back to reflection lazily, but only for
-                // as long as the chain stays empty - and putting the contract in it ends that. So the
-                // fallback has to be named here, or the values inside a JobDataMap, whose types the
-                // contract cannot know, would stop resolving at all.
-                DefaultJsonTypeInfoResolver? reflection = ReflectionResolver();
-                if (reflection is not null)
-                {
-                    resolvers.Add(reflection);
-                }
-            }
-
-            resolvers.Insert(0, HttpApiJsonContext.Default);
-        }
+        options.UseQuartzContract(HttpApiJsonContext.Default, registry);
 
         return options;
-    }
-
-    /// <summary>
-    /// The reflection-based resolver the wire's open half needs, or <see langword="null" /> where
-    /// reflection-based serialization is switched off.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The chain has to end in reflection because the contract does: a <see cref="JobDataMap" /> holds
-    /// whatever the application put in it, and no generated metadata can describe that. The same guard
-    /// <c>Microsoft.AspNetCore.Http.Json.JsonOptions</c> builds its own default resolver behind is what
-    /// makes naming <see cref="DefaultJsonTypeInfoResolver" /> here safe: a trimmed publish sets
-    /// <c>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault</c> to false — the SDK does it by
-    /// default, as the trim canary's runtimeconfig shows — so the trimmer substitutes the property,
-    /// drops this branch and never sees the resolver. What such an application is left with is the
-    /// generated contract, which is more than it had: options carrying no resolver at all threw on the
-    /// first body either way.
-    /// </para>
-    /// <para>
-    /// A native AOT publish is the same publish: it implies <c>PublishTrimmed</c>, so it sets the same
-    /// switch to false and ILCompiler substitutes the same property. That is why the AOT warning is
-    /// answered here rather than recorded — the resolver this branch would construct does not exist in
-    /// an AOT application to need constructing.
-    /// </para>
-    /// <para>
-    /// The suppressions therefore hide nothing an application is not told. The reflection they silence is
-    /// already reported against
-    /// <c>Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions</c>, which every caller of this
-    /// method reaches through <c>JobDataMapConverter</c>, and which is deliberately not suppressed for
-    /// consumers — as trimming-unsafe and as AOT-unsafe both.
-    /// </para>
-    /// </remarks>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Guarded by IsReflectionEnabledByDefault, which a trimmed publish substitutes away along with this branch. See the remarks.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Guarded by IsReflectionEnabledByDefault, which an AOT publish substitutes away along with this branch. See the remarks.")]
-    private static DefaultJsonTypeInfoResolver? ReflectionResolver()
-    {
-        return JsonSerializer.IsReflectionEnabledByDefault ? new DefaultJsonTypeInfoResolver() : null;
     }
 }

--- a/src/Quartz/ILLink.Suppressions.xml
+++ b/src/Quartz/ILLink.Suppressions.xml
@@ -9,7 +9,7 @@
   warning to silence. Removing an entry that looks unused because the analyzer is quiet about it fails
   the publish; verify against a clean `dotnet fallout PublishTrimmed`, not against the compile.
 
-  The other difference is that this file carries no IL3050, where TrimAnalysisBaseline.cs carries three.
+  The other difference is that this file carries no IL3050, where TrimAnalysisBaseline.cs carries one.
   That is not an omission. ILLink does not report IL3050 at all — dynamic code is ILCompiler's concern,
   and ILCompiler cannot be handed this file: its command line offers a descriptor option and a
   substitution option and no link-attributes option at all, and the SDK item below only ever reaches
@@ -163,22 +163,6 @@
         <argument>Trimming</argument>
         <argument>IL2070</argument>
         <property name="Justification">Retry classification reads provider error codes off exception types Quartz deliberately does not reference.</property>
-      </attribute>
-    </type>
-
-    <!-- Reflection-based serialization -->
-    <type fullname="Quartz.Impl.SystemTextJsonObjectSerializer*">
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2026</argument>
-        <property name="Justification">Job data is serialized as whatever the application stored, which no generated contract can name.</property>
-      </attribute>
-    </type>
-    <type fullname="Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions*">
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2026</argument>
-        <property name="Justification">Job data is serialized as whatever the application stored, which no generated contract can name.</property>
       </attribute>
     </type>
 

--- a/src/Quartz/Impl/SystemTextJsonObjectSerializer.cs
+++ b/src/Quartz/Impl/SystemTextJsonObjectSerializer.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 using Quartz.Serialization.SystemTextJson;
 using Quartz.Extensibility;
@@ -59,9 +60,22 @@ public class SystemTextJsonObjectSerializer : IObjectSerializer
         }
     }
 
+    /// <summary>
+    /// Builds the options this serializer reads and writes with: Quartz's converters, and the resolver
+    /// chain that lets them work where reflection-based serialization is switched off.
+    /// </summary>
+    /// <remarks>
+    /// The chain is <see cref="QuartzStoreJsonContext" />, then the scheduler's registry — the trigger
+    /// and calendar types registered with it, and whatever the application handed to
+    /// <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" /> — then reflection, where a
+    /// publish has left any. A resolver decides only how a type is answered; the payload is still
+    /// written by the converters, byte for byte as every earlier version of Quartz wrote it.
+    /// </remarks>
     protected virtual JsonSerializerOptions CreateSerializerOptions()
     {
-        return new JsonSerializerOptions().AddQuartzConverters(Registry, newtonsoftCompatibilityMode: true);
+        JsonSerializerOptions options = new JsonSerializerOptions().AddQuartzConverters(Registry, newtonsoftCompatibilityMode: true);
+        options.UseQuartzContract(QuartzStoreJsonContext.Default, Registry);
+        return options;
     }
 
     /// <summary>
@@ -69,9 +83,18 @@ public class SystemTextJsonObjectSerializer : IObjectSerializer
     /// that can be stored to permanent stores.
     /// </summary>
     /// <param name="obj">Object to serialize.</param>
+    /// <remarks>
+    /// Written as <see cref="object" /> so that the payload names the runtime type, which is what every
+    /// stored blob has always said. Asking the options for that type's metadata and handing the result
+    /// to <see cref="JsonSerializer" /> is the same call the overload taking
+    /// <see cref="JsonSerializerOptions" /> would make internally, minus that overload's blanket
+    /// <c>RequiresUnreferencedCode</c> — it is what a trimmed application needs and what keeps this
+    /// class out of the trim-analysis baseline.
+    /// </remarks>
     public byte[] Serialize<T>(T obj) where T : class
     {
-        return JsonSerializer.SerializeToUtf8Bytes<object>(obj, Options);
+        JsonTypeInfo typeInfo = Options.GetTypeInfo(typeof(object));
+        return JsonSerializer.SerializeToUtf8Bytes(obj, typeInfo);
     }
 
     /// <summary>
@@ -82,7 +105,8 @@ public class SystemTextJsonObjectSerializer : IObjectSerializer
     {
         try
         {
-            return JsonSerializer.Deserialize<T?>(data, Options);
+            JsonTypeInfo<T> typeInfo = (JsonTypeInfo<T>) Options.GetTypeInfo(typeof(T));
+            return JsonSerializer.Deserialize(data, typeInfo);
         }
         // Quartz's exception comes from Quartz's own converters; System.Text.Json's comes from the
         // reader, which rejects a payload whose very first token is malformed before any converter is

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -10,16 +10,21 @@
     <!--
       IsAotCompatible would turn these two on as well, and it is deliberately not set. Step 5 of #3341
       turned them on by themselves instead, so that the warnings could be counted before the claim was
-      made: twelve IL3050 call sites, of which one was fixed, one answered at the call site and ten are
-      recorded in TrimAnalysisBaseline.cs. That much would be the same standard IsTrimmable is held to.
+      made: twelve IL3050 call sites, of which one was fixed and one answered at the call site. Step 6
+      took six more away rather than recording them, and the six that are left are one entry in
+      TrimAnalysisBaseline.cs — the configuration binder, whose fix is the source-generated one.
 
-      What stops the claim is not a warning but a run. A native AOT publish switches reflection-based
-      System.Text.Json off, and the default IObjectSerializer has no resolver to fall back on when it is
-      — so a native AOT application over RAMJobStore starts, fires its triggers and shuts down cleanly,
-      while one over a persistent store throws "Reflection-based serialization has been disabled for
-      this application" the first time it writes a trigger. Saying IsAotCompatible here would claim
-      otherwise. (A trimmed publish switches the same thing off, so this predates AOT; the trim canary
-      never noticed because it is an in-memory application.)
+      What stopped the claim was not a warning but a run, and step 6 fixed the run. A native AOT publish
+      switches reflection-based System.Text.Json off, and the default IObjectSerializer used to have no
+      resolver to fall back on when it was — so a native AOT application over RAMJobStore started, fired
+      its triggers and shut down cleanly, while one over a persistent store threw "Reflection-based
+      serialization has been disabled for this application" the first time it wrote a trigger. It no
+      longer does: Quartz.Trimming.Canary round-trips every blob a job store writes out of a trimmed
+      publish on every build, and out of a native AOT publish when run by hand.
+
+      What is left is the recorded set above, which is what an application publishing native AOT would
+      see reported against Quartz. Setting IsAotCompatible is therefore a judgement about those, not
+      about the store any more, and it is the one decision this file is still waiting on.
     -->
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>

--- a/src/Quartz/Serialization/SystemTextJson/QuartzStoreJsonContext.cs
+++ b/src/Quartz/Serialization/SystemTextJson/QuartzStoreJsonContext.cs
@@ -1,0 +1,126 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Specialized;
+using System.Text.Json.Serialization;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Serialization.SystemTextJson;
+
+/// <summary>
+/// The store format as metadata the compiler wrote: every type a persistent job store can ask
+/// <see cref="Quartz.Impl.SystemTextJsonObjectSerializer" /> to resolve, listed so that writing a
+/// trigger needs no reflection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is what makes an ADO job store survive a trimmed publish. <c>PublishTrimmed</c> sets
+/// <c>JsonSerializer.IsReflectionEnabledByDefault</c> to false, and options carrying converters but no
+/// resolver then have nothing to answer <c>GetTypeInfo</c> with — so the first trigger written threw
+/// <c>Reflection-based serialization has been disabled for this application</c>. Listing the types
+/// here answers them from generated metadata instead.
+/// </para>
+/// <para>
+/// A listed type that the options carry a converter for is answered by that converter: the generated
+/// code asks <c>options.Converters</c> before it reaches for the metadata it wrote, which is how a
+/// <see cref="JobDataMap" /> still goes through <c>JobDataMapConverter</c>. So this list is not a
+/// second description of the store format — the converters and serializers are still the only
+/// description. It is the set of types that have to be answerable at all.
+/// </para>
+/// <para>
+/// Three groups, each derived from a call site rather than from memory:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// What the store hands the serializer. <c>StdAdoDelegate.SerializeObject</c> goes through
+/// <c>Serialize&lt;T&gt;</c>, which writes as <see cref="object" />, so the runtime type of every blob
+/// has to be answerable; the reads name their type instead, and are
+/// <c>GetObjectFromBlob&lt;JobDataMap&gt;</c>, <c>&lt;NameValueCollection&gt;</c>,
+/// <c>&lt;ICalendar&gt;</c> and <c>&lt;IOperableTrigger&gt;</c>. <see cref="ITrigger" /> is here beside
+/// them because <c>IObjectSerializer</c> is public and a caller may name the interface it holds.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// What the converters dispatch on. <c>CronExpressionConverter</c>, <c>JobKeyConverter</c> and
+/// <c>TriggerKeyConverter</c> own a type each, and those three are here. <c>TriggerConverter</c> and
+/// <c>CalendarConverter</c> are asked for the <em>concrete</em> type at write time, and those are
+/// <em>not</em> here: <see cref="SystemTextJsonSerializerRegistry" /> already holds the one list of
+/// them, and answers for each out of the same generic registration that adds its serializer. A second
+/// list here would be a list that can drift, and drift silently — a new built-in trigger left off it
+/// would go back to reflecting with nothing to say so.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// What a <see cref="JobDataMap" /> holds. The read side is closed —
+/// <c>SerializationExtensions.GetJobDataMap</c> produces a string, a bool, an int, a long, a double,
+/// null or a <c>Dictionary&lt;string, string&gt;</c> and nothing else — and the write side is not, but
+/// the types <c>DataMapExtensions</c> declares an accessor for are the ones Quartz teaches an
+/// application to store. Anything past them is the application's own choice, and reaches Quartz
+/// through <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" />.
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// <see cref="JsonSourceGenerationMode.Metadata" /> rather than the default, for the reason
+/// <c>HttpApiJsonContext</c> gives: the generated write path bakes in the options it was declared with,
+/// the store options never match them because they carry Quartz's converters, and so the generated
+/// writers would be dead code.
+/// </para>
+/// <para>
+/// <c>StoreFormatSourceGenerationTest</c> is what notices a type left out. Nothing else would: with
+/// reflection on — which is every test host and every untrimmed application — the chain falls through
+/// and the omission only shows up in a trimmed publish, which is where it hurts.
+/// </para>
+/// </remarks>
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+
+// What the store hands the serializer.
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(JobDataMap))]
+[JsonSerializable(typeof(NameValueCollection))]
+[JsonSerializable(typeof(ICalendar))]
+[JsonSerializable(typeof(ITrigger))]
+[JsonSerializable(typeof(IOperableTrigger))]
+
+// What the converters dispatch on, minus the trigger and calendar types, which the registry answers for.
+[JsonSerializable(typeof(CronExpression))]
+[JsonSerializable(typeof(JobKey))]
+[JsonSerializable(typeof(TriggerKey))]
+
+// What a JobDataMap holds.
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(char))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(decimal))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(TimeSpan))]
+[JsonSerializable(typeof(Guid))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal sealed partial class QuartzStoreJsonContext : JsonSerializerContext;

--- a/src/Quartz/Serialization/SystemTextJson/QuartzTypeInfoResolvers.cs
+++ b/src/Quartz/Serialization/SystemTextJson/QuartzTypeInfoResolvers.cs
@@ -1,0 +1,125 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Quartz.Serialization.SystemTextJson;
+
+/// <summary>
+/// The resolver chain both of Quartz's JSON formats are built out of: the generated contract in front,
+/// the scheduler's own registry behind it, and reflection last where reflection still exists.
+/// </summary>
+/// <remarks>
+/// The store format and the HTTP wire format have the same shape and the same open half — the values
+/// inside a <see cref="JobDataMap" />, which the application chose and no generated contract can name.
+/// They are assembled here once so that the two cannot drift, and so that the argument for naming
+/// <see cref="DefaultJsonTypeInfoResolver" /> is written down in one place.
+/// </remarks>
+internal static class QuartzTypeInfoResolvers
+{
+    /// <summary>
+    /// Puts <paramref name="contract" /> and the scheduler's registry in front of
+    /// <paramref name="options" />'s resolver chain, leaving the chain ending in reflection.
+    /// </summary>
+    /// <param name="options">The options being taught the chain.</param>
+    /// <param name="contract">The generated metadata for the format's closed shapes.</param>
+    /// <param name="registry">
+    /// The scheduler's registry, which answers for the trigger and calendar types registered with it and
+    /// carries whatever resolvers the application handed in.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// Asking twice leaves the chain as asking once does. On the server the options belong to the whole
+    /// container, and every <c>AddQuartzHttpApi</c> call wants the same contract in front of them.
+    /// </para>
+    /// <para>
+    /// Options carrying no resolver of their own fall back to reflection lazily, but only for as long as
+    /// the chain stays empty — and putting anything in it ends that. So the fallback has to be named
+    /// here, or the values inside a <see cref="JobDataMap" />, whose types no contract can know, would
+    /// stop resolving at all.
+    /// </para>
+    /// </remarks>
+    public static void UseQuartzContract(
+        this JsonSerializerOptions options,
+        IJsonTypeInfoResolver contract,
+        SystemTextJsonSerializerRegistry registry)
+    {
+        IList<IJsonTypeInfoResolver> chain = options.TypeInfoResolverChain;
+        if (chain.Contains(contract))
+        {
+            return;
+        }
+
+        if (chain.Count == 0)
+        {
+            DefaultJsonTypeInfoResolver? reflection = Reflection();
+            if (reflection is not null)
+            {
+                chain.Add(reflection);
+            }
+        }
+
+        int index = 0;
+        chain.Insert(index++, contract);
+        foreach (IJsonTypeInfoResolver resolver in registry.TypeInfoResolvers)
+        {
+            chain.Insert(index++, resolver);
+        }
+    }
+
+    /// <summary>
+    /// The reflection-based resolver the open half needs, or <see langword="null" /> where
+    /// reflection-based serialization is switched off.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The chain has to end in reflection because both formats do: a <see cref="JobDataMap" /> holds
+    /// whatever the application put in it, and no generated metadata can describe that. The same guard
+    /// <c>Microsoft.AspNetCore.Http.Json.JsonOptions</c> builds its own default resolver behind is what
+    /// makes naming <see cref="DefaultJsonTypeInfoResolver" /> here safe: a trimmed publish sets
+    /// <c>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault</c> to false — the SDK does it by
+    /// default, as the trim canary's runtimeconfig shows — so the trimmer substitutes the property,
+    /// drops this branch and never sees the resolver. What such an application is left with is the
+    /// generated contract plus whatever it registered itself, which is enough for a job data map holding
+    /// the types Quartz's own accessors name.
+    /// </para>
+    /// <para>
+    /// A native AOT publish is the same publish: it implies <c>PublishTrimmed</c>, so it sets the same
+    /// switch to false and ILCompiler substitutes the same property. That is why the AOT warning is
+    /// answered here rather than recorded — the resolver this branch would construct does not exist in
+    /// an AOT application to need constructing.
+    /// </para>
+    /// <para>
+    /// The suppressions therefore hide nothing an application is not told. An application whose job data
+    /// holds a type of its own, published trimmed, gets a <c>NotSupportedException</c> naming that type
+    /// on the first write rather than a silently wrong payload, and
+    /// <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" /> is how it answers for it.
+    /// </para>
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Guarded by IsReflectionEnabledByDefault, which a trimmed publish substitutes away along with this branch. See the remarks.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Guarded by IsReflectionEnabledByDefault, which an AOT publish substitutes away along with this branch. See the remarks.")]
+    public static DefaultJsonTypeInfoResolver? Reflection()
+    {
+        return JsonSerializer.IsReflectionEnabledByDefault ? new DefaultJsonTypeInfoResolver() : null;
+    }
+}

--- a/src/Quartz/Serialization/SystemTextJson/SerializationExtensions.cs
+++ b/src/Quartz/Serialization/SystemTextJson/SerializationExtensions.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Quartz.Serialization.SystemTextJson;
 
@@ -283,14 +284,26 @@ internal static class Utf8JsonWriterExtensions
         return new JobKey(name!, group!);
     }
 
+    /// <summary>
+    /// Writes a job data map's entries, each value as whatever the application stored.
+    /// </summary>
+    /// <remarks>
+    /// The value is written as <see cref="object" />, so its runtime type is looked up through the
+    /// options' resolver chain — the closed set Quartz names, then the scheduler's registry, then
+    /// reflection where a publish left any. Asking for that metadata here rather than passing the
+    /// options to <see cref="JsonSerializer" /> is what makes this method trimming- and AOT-clean: the
+    /// overloads taking <see cref="JsonSerializerOptions" /> are <c>RequiresUnreferencedCode</c> and
+    /// <c>RequiresDynamicCode</c> wholesale, whatever they are handed.
+    /// </remarks>
     public static void WriteJobDataMapValue(this Utf8JsonWriter writer, JobDataMap jobDataMap, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
 
+        JsonTypeInfo valueTypeInfo = options.GetTypeInfo(typeof(object));
         foreach (var pair in jobDataMap)
         {
             writer.WritePropertyName(pair.Key);
-            JsonSerializer.Serialize(writer, pair.Value, options);
+            JsonSerializer.Serialize(writer, pair.Value, valueTypeInfo);
         }
 
         writer.WriteEndObject();
@@ -332,7 +345,9 @@ internal static class Utf8JsonWriterExtensions
                     }
                     break;
                 case JsonValueKind.Object:
-                    value = property.Value.Deserialize<Dictionary<string, string>>(options);
+                    // The one shape past the primitives a job data value comes back as, and the reason
+                    // Dictionary<string, string> is named in QuartzStoreJsonContext.
+                    value = property.Value.Deserialize((JsonTypeInfo<Dictionary<string, string>>) options.GetTypeInfo(typeof(Dictionary<string, string>)));
                     break;
                 default:
                     throw new JsonException($"Unsupported value kind: {property.Value.ValueKind}");

--- a/src/Quartz/Serialization/SystemTextJson/SystemTextJsonSerializerRegistry.cs
+++ b/src/Quartz/Serialization/SystemTextJson/SystemTextJsonSerializerRegistry.cs
@@ -1,3 +1,7 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
 using Quartz.Serialization.SystemTextJson.Calendars;
@@ -22,17 +26,29 @@ namespace Quartz.Serialization.SystemTextJson;
 /// Registrations are expected to be complete before the owning serializer is initialized; the maps are
 /// not synchronized for concurrent writes, exactly as the statics they replace were not.
 /// </para>
+/// <para>
+/// A registry is also where the serializer's <see cref="JsonSerializerOptions" /> get the metadata a
+/// trimmed or native-AOT application has instead of reflection. It answers for every trigger and
+/// calendar type registered with it, built-in or custom, because
+/// <see cref="AddTriggerSerializer{TTrigger}" /> and <see cref="AddCalendarSerializer{TCalendar}" />
+/// know the type statically; anything else the application puts in a <see cref="JobDataMap" /> is what
+/// <see cref="AddTypeInfoResolver" /> is for.
+/// </para>
 /// </remarks>
 public sealed class SystemTextJsonSerializerRegistry
 {
     private readonly SerializerMap<ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
     private readonly SerializerMap<ICalendarSerializer> calendarSerializers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<Type, Func<JsonSerializerOptions, JsonConverter, JsonTypeInfo>> registeredTypeInfos = [];
+    private readonly List<IJsonTypeInfoResolver> resolvers;
 
     /// <summary>
     /// Creates a registry holding the serializers for the built-in trigger and calendar types.
     /// </summary>
     public SystemTextJsonSerializerRegistry()
     {
+        resolvers = [new RegisteredTypeResolver(registeredTypeInfos)];
+
         AddTriggerSerializer<CalendarIntervalTriggerImpl>(new CalendarIntervalTriggerSerializer());
         AddTriggerSerializer<CronTriggerImpl>(new CronTriggerSerializer());
         AddTriggerSerializer<DailyTimeIntervalTriggerImpl>(new DailyTimeIntervalTriggerSerializer());
@@ -57,6 +73,7 @@ public sealed class SystemTextJsonSerializerRegistry
 
         // Found by its JSON discriminator, and also by its type name.
         triggerSerializers.Add(serializer, serializer.TriggerTypeName, typeof(TTrigger).AssemblyQualifiedNameWithoutVersion());
+        RegisterTypeInfo<TTrigger>();
         return this;
     }
 
@@ -74,8 +91,53 @@ public sealed class SystemTextJsonSerializerRegistry
         ArgumentNullException.ThrowIfNull(serializer);
 
         calendarSerializers.Add(serializer, typeof(TCalendar).AssemblyQualifiedNameWithoutVersion(), serializer.CalendarTypeName);
+        RegisterTypeInfo<TCalendar>();
         return this;
     }
+
+    /// <summary>
+    /// Adds the metadata for the application's own job-data value types, needed only where
+    /// reflection-based serialization is off.
+    /// </summary>
+    /// <param name="resolver">
+    /// A <see cref="JsonSerializerContext" /> the application generated — a partial class deriving from
+    /// it with a <c>[JsonSerializable]</c> attribute per type — or any other
+    /// <see cref="IJsonTypeInfoResolver" />. Its <c>Default</c> instance is what to hand in.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// A <see cref="JobDataMap" /> holds whatever the application put in it, so the store format has an
+    /// open half no contract of Quartz's can close. With reflection on — every test host, every
+    /// untrimmed application — that half is answered by reflection and this method is unnecessary. A
+    /// <c>PublishTrimmed</c> or <c>PublishAot</c> application has no reflection to fall back to, and a
+    /// value type Quartz cannot name reaches the writer as a <see cref="NotSupportedException" /> naming
+    /// it. This is how the application answers for it.
+    /// </para>
+    /// <para>
+    /// Custom trigger and calendar types need nothing here:
+    /// <see cref="AddTriggerSerializer{TTrigger}" /> and <see cref="AddCalendarSerializer{TCalendar}" />
+    /// know the type statically, so the registry already answers for them.
+    /// </para>
+    /// <para>
+    /// Resolvers are asked in the order they were added, behind Quartz's own contract and in front of
+    /// reflection. A resolver that does not know a type returns nothing and the next one is asked, so
+    /// handing in a context that names a type Quartz already covers changes nothing.
+    /// </para>
+    /// </remarks>
+    public SystemTextJsonSerializerRegistry AddTypeInfoResolver(IJsonTypeInfoResolver resolver)
+    {
+        ArgumentNullException.ThrowIfNull(resolver);
+
+        resolvers.Add(resolver);
+        return this;
+    }
+
+    /// <summary>
+    /// The resolvers this registry contributes to a serializer's options, in the order they are asked:
+    /// the types registered here first, then whatever the application handed to
+    /// <see cref="AddTypeInfoResolver" />.
+    /// </summary>
+    internal IReadOnlyList<IJsonTypeInfoResolver> TypeInfoResolvers => resolvers;
 
     internal ITriggerSerializer GetTriggerSerializer(string? typeName)
     {
@@ -85,5 +147,77 @@ public sealed class SystemTextJsonSerializerRegistry
     internal ICalendarSerializer GetCalendarSerializer(string? typeName)
     {
         return calendarSerializers.Get(typeName, "Don't know how to handle");
+    }
+
+    /// <summary>
+    /// Remembers how to build the metadata for a registered type, while the type is still a type
+    /// argument.
+    /// </summary>
+    /// <remarks>
+    /// This is the whole reason the registration methods are generic in the type rather than taking a
+    /// <see cref="Type" />. A trigger is written through <c>TriggerConverter</c> and a calendar through
+    /// <c>CalendarConverter</c>, so the metadata for either is
+    /// <see cref="JsonMetadataServices.CreateValueInfo{T}" /> over that converter — but that call needs
+    /// <typeparamref name="T" /> at compile time, and reaching it from a <see cref="Type" /> would mean
+    /// <c>MakeGenericMethod</c>, which is the very thing an AOT publish cannot do. Captured here, the
+    /// closure is compiled like any other generic instantiation.
+    /// </remarks>
+    private void RegisterTypeInfo<T>()
+    {
+        registeredTypeInfos[typeof(T)] = static (options, converter) => JsonMetadataServices.CreateValueInfo<T>(options, converter);
+    }
+
+    /// <summary>
+    /// Answers for the trigger and calendar types registered with a registry, out of the converter the
+    /// options carry for each.
+    /// </summary>
+    /// <remarks>
+    /// The converter is looked up by walking <see cref="JsonSerializerOptions.Converters" /> rather than
+    /// by calling <c>GetConverter</c>, which is <c>RequiresUnreferencedCode</c> and
+    /// <c>RequiresDynamicCode</c> both. It is the same walk a generated
+    /// <see cref="JsonSerializerContext" /> does before it reaches for the metadata it wrote, which is
+    /// what makes a runtime-registered converter win over generated metadata; this resolver has no
+    /// metadata of its own to fall back to, so options without Quartz's converters get nothing from it
+    /// and the chain moves on.
+    /// </remarks>
+    private sealed class RegisteredTypeResolver(
+        Dictionary<Type, Func<JsonSerializerOptions, JsonConverter, JsonTypeInfo>> registeredTypeInfos) : IJsonTypeInfoResolver
+    {
+        public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options)
+        {
+            if (!registeredTypeInfos.TryGetValue(type, out Func<JsonSerializerOptions, JsonConverter, JsonTypeInfo>? create))
+            {
+                return null;
+            }
+
+            JsonConverter? converter = FindConverter(type, options);
+            if (converter is null)
+            {
+                return null;
+            }
+
+            JsonTypeInfo typeInfo = create(options, converter);
+            typeInfo.OriginatingResolver = this;
+            return typeInfo;
+        }
+
+        private static JsonConverter? FindConverter(Type type, JsonSerializerOptions options)
+        {
+            IList<JsonConverter> converters = options.Converters;
+            for (int i = 0; i < converters.Count; i++)
+            {
+                JsonConverter converter = converters[i];
+                if (!converter.CanConvert(type))
+                {
+                    continue;
+                }
+
+                // A factory is asked for the converter it would make; Quartz registers none, but an
+                // application is free to, and handing the factory itself to CreateValueInfo would throw.
+                return converter is JsonConverterFactory factory ? factory.CreateConverter(type, options) : converter;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Quartz/TrimAnalysisBaseline.cs
+++ b/src/Quartz/TrimAnalysisBaseline.cs
@@ -49,6 +49,17 @@ using System.Diagnostics.CodeAnalysis;
 // HttpApiJson.ReflectionResolver answers at the call site, because a native AOT publish substitutes its
 // feature switch away exactly as a trimmed one does.
 //
+// Step 6 deleted four entries - the IL2026 and IL3050 on SystemTextJsonObjectSerializer and on
+// Utf8JsonWriterExtensions - and they are the only ones this file has ever recorded that a publish did
+// not merely warn about. The store serializer built options with converters and no resolver, and a
+// trimmed publish switches System.Text.Json's reflection fallback off, so a persistent job store threw
+// "Reflection-based serialization has been disabled for this application" on the first trigger it wrote.
+// QuartzStoreJsonContext names the closed set, SystemTextJsonSerializerRegistry answers for the trigger
+// and calendar types registered with it and for whatever context the application handed in, and the
+// call sites ask options.GetTypeInfo and pass the JsonTypeInfo - which is the overload that carries
+// neither attribute. Quartz.Trimming.Canary runs the round trip out of a trimmed publish, so the leg
+// proves the fix rather than the absence of a warning.
+//
 // Adding an entry is the wrong first move. Reach for it only after establishing that the reflection is
 // genuinely unavoidable, and then say in the group comment why. The preferred fixes, in order:
 //
@@ -119,32 +130,6 @@ using System.Diagnostics.CodeAnalysis;
 // SqliteException.SqliteErrorCode). Quartz must not reference the provider assemblies to read them.
 
 [assembly: SuppressMessage("Trimming", "IL2070", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.TransientErrorDetector", Justification = "Retry classification reads provider error codes off exception types Quartz deliberately does not reference.")]
-
-// --- Reflection-based serialization ---------------------------------------------------------------------
-// A JobDataMap holds whatever the application put in it, so the payload's types are not known until it
-// is serialized. Everything around it is closed now - the wire contract by HttpApiJsonContext, the
-// trigger and calendar shapes by their serializers - and these two are the open middle that is left:
-// the values themselves, which no generated contract can name because the application chose them.
-//
-// The same two types are where the AOT analyzer lands, and for the same reason one step further on: a
-// converter System.Text.Json has to work out at runtime is a converter it has to generate. Every
-// JsonSerializer overload taking a JsonSerializerOptions is RequiresDynamicCode wholesale, so this
-// covers the one closed shape among them - a job data value read back as Dictionary<string, string> -
-// as well as the open ones.
-//
-// These two are also the entries that keep Quartz.csproj from saying IsAotCompatible, and they are the
-// only ones this file records that a publish does not merely warn about. A trimmed or AOT publish
-// switches System.Text.Json's reflection fallback off, and CreateSerializerOptions builds options with
-// converters but no resolver - so serializing anything through them throws "Reflection-based
-// serialization has been disabled for this application" rather than losing a member. A persistent job
-// store hits that on the first trigger it writes. Closing it means giving these options a resolver that
-// survives with reflection off, which is a change of shape rather than a suppression, and is what step 6
-// of #3341 is for.
-
-[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Impl.SystemTextJsonObjectSerializer", Justification = "Job data is serialized as whatever the application stored, which no generated contract can name.")]
-[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions", Justification = "Job data is serialized as whatever the application stored, which no generated contract can name.")]
-[assembly: SuppressMessage("AOT", "IL3050", Scope = "type", Target = "T:Quartz.Impl.SystemTextJsonObjectSerializer", Justification = "Serializing a type chosen by the application is what System.Text.Json needs runtime code generation for.")]
-[assembly: SuppressMessage("AOT", "IL3050", Scope = "type", Target = "T:Quartz.Serialization.SystemTextJson.Utf8JsonWriterExtensions", Justification = "Serializing a type chosen by the application is what System.Text.Json needs runtime code generation for.")]
 
 // --- Configuration binding ------------------------------------------------------------------------------
 // IServiceCollection.Configure<TOptions>(name, section) is RequiresUnreferencedCode and


### PR DESCRIPTION
Step 6 of #3341. `SystemTextJsonObjectSerializer.CreateSerializerOptions` built `new JsonSerializerOptions().AddQuartzConverters(...)` — converters, no resolver. `PublishTrimmed` (and so `PublishAot`) sets `JsonSerializer.IsReflectionEnabledByDefault` to false, and options with no resolver then have nothing to answer `GetTypeInfo` with, so **every ADO job store threw on the first trigger it wrote** in any trimmed application, alpha.1 included, while the package said `IsTrimmable`. This closes that.

## The shape

The store options now carry the chain `ConfigureWireFormat` already had:

1. **`QuartzStoreJsonContext`** — an internal `JsonSerializerContext` in metadata mode, stating the closed set. Its remarks derive each group from a call site rather than from memory.
2. **The scheduler's registry**, which answers for every trigger and calendar type registered with it — built-in *and* custom. `AddTriggerSerializer<TTrigger>` knows the type statically, so a `JsonMetadataServices.CreateValueInfo<TTrigger>` factory is captured there; no `MakeGenericMethod`, and the converter is found by walking `options.Converters` rather than calling `GetConverter`, which is `RequiresUnreferencedCode`/`RequiresDynamicCode` both.
3. **`SystemTextJsonSerializerRegistry.AddTypeInfoResolver(IJsonTypeInfoResolver)`** — the one new public member. The open half of the format is a job-data value of the application's own type; this is where its generated context goes.
4. **Reflection last**, and only where `IsReflectionEnabledByDefault`. `HttpApiJson.ReflectionResolver` moved to `QuartzTypeInfoResolvers`, suppressions and remarks intact, and both formats are assembled by the same `UseQuartzContract` — so the wire got the same seam, which it wanted for the same reason.

`Serialize`/`Deserialize` and `WriteJobDataMapValue`/`GetJobDataMap` ask `options.GetTypeInfo` and pass the `JsonTypeInfo`, which is the overload carrying neither attribute.

**The stored JSON does not move.** Every `JsonObjectSerializerTest_*.verified.txt` and every `WireFormatSnapshotTest_*.verified.json` is unchanged; a resolver decides how a type is answered, never what is written.

## The closed set, and the evidence for it

| Entry | Why |
|---|---|
| `object` | `StdAdoDelegate.SerializeObject` goes through `Serialize<T>`, which writes as `object`, so every blob's runtime type is resolved through it |
| `JobDataMap` | `StdAdoDelegate.SerializeJobData`, `GetObjectFromBlob<JobDataMap>` (`StdAdoDelegate.cs:316,328`) |
| `NameValueCollection` | `SerializeProperties` under `useProperties`, `GetJobDataFromBlob<NameValueCollection>` (`StdAdoDelegate.cs:353`) |
| `ICalendar` | `GetObjectFromBlob<ICalendar>` (`StdAdoDelegate.Calendars.cs:71`) |
| `IOperableTrigger` | `GetObjectFromBlob<IOperableTrigger>` (`StdAdoDelegate.Triggers.cs:1080,2088`) |
| `ITrigger` | `IObjectSerializer` is public; a caller may name the interface it holds |
| `CronExpression`, `JobKey`, `TriggerKey` | the three converters `AddQuartzConverters` registers that own exactly one type each |
| `string`, `bool`, `char`, `int`, `long`, `float`, `double`, `decimal`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid` | every type `DataMapExtensions` declares an accessor for — which is Quartz's own statement of what a job data map holds |
| `Dictionary<string, string>` | the one non-primitive `SerializationExtensions.GetJobDataMap` can hand back |

**The built-in trigger and calendar impls are deliberately *not* listed** — a deviation from the spec, described below.

## Baseline delta

```
$ git diff 507acd716 -- src/Quartz/TrimAnalysisBaseline.cs src/Quartz/ILLink.Suppressions.xml --stat
 src/Quartz/ILLink.Suppressions.xml | 18 +-----------------
 src/Quartz/TrimAnalysisBaseline.cs | 37 ++++++++-----------------------------
 2 files changed, 11 insertions(+), 44 deletions(-)
```

All four entries are gone (`IL2026` + `IL3050` on `SystemTextJsonObjectSerializer` and `Utf8JsonWriterExtensions`), and their two ILLink mirrors. `dotnet build src/Quartz/Quartz.csproj` is warning-free without them. Six IL3050 call sites went with them; the six left are the configuration binder's, in one entry.

## The proof that runs

`Quartz.Trimming.Canary` — a small console project, not packable, not an example — is published `TrimMode=full` by the `PublishTrimmed` leg and then **started**, with a non-zero exit failing the leg. It asserts `IsReflectionEnabledByDefault` is false, then round-trips every blob a job store writes through the ordinary `SystemTextJsonObjectSerializer` (no test seam), comparing the payload before and after. It applies no `ILLink.Suppressions.xml` and roots no assembly, so it is trimmed down to what it actually reaches.

Verified that it fails without the fix: with the resolver chain removed it reports `FAIL SimpleTrigger: System.NotSupportedException: JsonTypeInfo metadata for type 'System.Object' was not provided by TypeInfoResolver of type '<null>'` and exits non-zero.

## What a reviewer has to decide

- **`IsAotCompatible`.** Not set here. The canary publishes and runs under `-p:PublishAot=true` with **no ILC warnings at all**, so the store is no longer the obstacle; what the claim would have to answer for is the recorded baseline, which is a judgement rather than something this PR settles. `Quartz.csproj`'s comment says so.
- **Whether the built-in impls should be in the context anyway.** The spec asked for them; see below.

## Deviations from the spec

1. **The built-in trigger and calendar impls are not `[JsonSerializable]` entries.** Listing them generated ~535 KB of source — full property metadata for `CronTriggerImpl` and transitively for `TimeProvider`, `TimeZoneInfo`, `MonthDay`, `TimeRange` and more — every byte of it dead, because a runtime-registered converter always wins, and all of it rooted in every trimmed application. It would also be a *second* list of the built-in types beside the one `SystemTextJsonSerializerRegistry`'s constructor already is, and the kind that drifts silently: a new built-in trigger left off it would quietly go back to reflecting. So the registry answers for them, by the same mechanism that answers for a custom one. Warning-free, and covered by the round-trip tests and the canary.
2. **The unit test's options are the production chain minus the reflection resolver**, rather than a chain whose only member is the context — because with (1) that is exactly the chain a trimmed publish leaves, and a hand-built one would be testing something else. A type nobody named still has no answer, which is what `AJobDataValueTypeQuartzCannotNameNeedsTheApplicationsOwnMetadata` asserts.
3. **"A custom trigger registered through the seam"** became "a custom trigger needs no seam" — `AddTriggerSerializer<TTrigger>` covers it — plus a separate test for a job-data value type that genuinely does need one.
4. The `more-about-jobs.md` trimming warning box became a section (`### A persistent store under trimming`) rather than a `::: warning`, because it is no longer a warning. The `#trimming` anchor other pages link to is unaffected.
5. Not in the spec at all: `src/Quartz.Trimming.Canary/**` joins `sonar.coverage.exclusions`. The canary is a test rather than code a test covers, and it runs out of process in a different leg over a self-contained trimmed publish, so no instrumentation sees a line of it — Sonar failed the new-code coverage condition on the one file whose whole job is to fail a leg when it breaks. It stays in analysis; the comment beside the exclusion says all this.

## Left alone: the ADO path itself under trimming

Not this PR's scope — step 7's input. What a trimmed (`TrimMode=full`) console application over `UseSqlite` does today, on this branch:

- **Publish warnings**: no serializer warnings at all. Everything reported is a type already in `TrimAnalysisBaseline.cs` — `SimpleTypeLoader`, `JobType`, `StdAdoDelegate`, `BuiltInDbMetadataFactory`, `ConfigurationBasedDbMetadataFactory`, `QuartzPropertyBridge`, `SchedulerPluginFactory`, `PropertyListenerFactory`, `TransientErrorDetector`, `ObjectUtils`.
- **`store.UseSqlite(connectionString)` does not run**: `System.ArgumentException: Cannot instantiate type which has no empty constructor (Parameter 'SqliteConnection')`, from `ObjectUtils.GetDefaultConstructor` via `DbProvider..ctor`. The provider's connection type is resolved from the driver description by name (the `BuiltInDbMetadataFactory` IL2057), so the trimmer removes its constructor. It fails building the container, before a single blob is serialized. The same program published untrimmed runs.
- **Two things make it run, fully trimmed**: `<TrimmerRootAssembly Include="Microsoft.Data.Sqlite" />`, or — with no rooting at all — `store.UseSqlite(db => db.UseRegisteredDataSource = true)` over a `DbDataSource` in the container. Either way the probe schedules a trigger, reads it back as `SimpleTriggerImpl` with its job data intact, and fires it twice. One IL2057 remains, `SimpleTypeLoader.LoadType`, for the `JOB_CLASS_NAME` column.

So the serializer was the part that could not be worked around; the connection type can be, and step 7 gets to decide whether it should have to be.

## Verification

| | |
|---|---|
| `dotnet build src/Quartz/Quartz.csproj` | 0 warnings, 0 errors (with the four baseline entries deleted) |
| `dotnet build Quartz.slnx` | 0 warnings, 0 errors |
| `dotnet test src/Quartz.Tests.Unit` | 3277 passed, 0 failed, 4 skipped |
| `dotnet test src/Quartz.Tests.AspNetCore` | 429 passed, 0 failed |
| `dotnet test src/Quartz.Tests.Integration --filter TestCategory=db-sqlite` | 9 passed |
| `dotnet test src/Quartz.Tests.Integration --filter TestCategory=db-postgres` | 69 passed (Docker) |
| `dotnet fallout PublishTrimmed` (clean publish dir) | Succeeded, canary output below |
| `dotnet fallout VerifyDocsSnippets` | up to date (90 markdown files checked) |
| `npm run docs:check-links` | 212 pages, 735 internal links, 423 fragments, no dead links or anchors |

The canary, out of `dotnet fallout PublishTrimmed`:

```
Running the trim canary: ...\artifacts\trim-canary\Quartz.Trimming.Canary.exe
IsReflectionEnabledByDefault: False
PASS SimpleTrigger
PASS CronTrigger
PASS CalendarIntervalTrigger
PASS DailyTimeIntervalTrigger
PASS RecurrenceTrigger
PASS BaseCalendar
PASS AnnualCalendar
PASS CronCalendar
PASS DailyCalendar
PASS HolidayCalendar
PASS MonthlyCalendar
PASS WeeklyCalendar
PASS ChainedCalendars
PASS JobDataMap
PASS NameValueCollection
PASS CronExpression
Quartz.Trimming.Canary: the store format round-trips with reflection-based serialization off.
```

And by hand, native AOT (`dotnet publish src/Quartz.Trimming.Canary -c Release -r win-x64 -p:PublishAot=true`) — the publish itself reported no ILC warnings:

```
IsReflectionEnabledByDefault: False
PASS SimpleTrigger
PASS CronTrigger
PASS CalendarIntervalTrigger
PASS DailyTimeIntervalTrigger
PASS RecurrenceTrigger
PASS BaseCalendar
PASS AnnualCalendar
PASS CronCalendar
PASS DailyCalendar
PASS HolidayCalendar
PASS MonthlyCalendar
PASS WeeklyCalendar
PASS ChainedCalendars
PASS JobDataMap
PASS NameValueCollection
PASS CronExpression
Quartz.Trimming.Canary: the store format round-trips with reflection-based serialization off.
EXIT CODE: 0
```

Part of #3341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfNtYcGzWFwJXJNHubegfg
