### PR TITLE
The instructions name both public-API baseline locations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,9 @@ Pluggable serialization for job store persistence:
   404s. `PackageReadmeTest` fails on each of those, on a packable project with no readme, and on a csproj
   that packs anything out of `docs/`. The readmes carry the same `<!-- snippet: … -->` markers as the
   documentation, so keep them short and let the site hold the prose.
-- **`src/Quartz.Tests.Unit/Verify/PublicApiTest_*.verified.txt` are the public API baselines.**
+- **`src/Quartz.Tests.Unit/Verify/PublicApiTest_*.verified.txt` are the public API baselines**, and
+  `src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_*.verified.txt` are the same thing for
+  `Quartz.AspNetCore` and `Quartz.Dashboard`, whose dependencies only that project has.
   Any change to public API fails those tests; review the diff, and if the change is intended,
   accept the new baseline and carry the same diff into
   `docs/documentation/quartz-4.x/migration-guide.md`. Never hand-edit them.


### PR DESCRIPTION
## The premise was already three-quarters true

`Quartz.AspNetCore` and `Quartz.Dashboard` do have a public-API baseline. `src/Quartz.Tests.AspNetCore/PublicApiTest.cs` and both snapshots under `src/Quartz.Tests.AspNetCore/Verify/` were added in a34a84312 ("Make the extensibility API coherent for 4.0", #3194) and shipped in `v4.0.0-alpha.2` — which is this branch's base. Three of the issue's four bullets were therefore already satisfied when it was filed.

The fourth was not, and that is what this changes.

## What changes

`AGENTS.md`'s public-API-baselines bullet named only `src/Quartz.Tests.Unit/Verify/`. An agent that read it and then touched `QuartzHttpApiOptions`, an endpoint DTO, `QuartzDashboardOptions` or `IQuartzApiClient` met a failing snapshot the instructions did not account for, with nothing to tell it that the same diff belongs in the migration guide. The bullet now names both locations and says why the second one exists.

The cross-branch `git diff` recipe further down the same file already named `src/Quartz.Tests.AspNetCore/Verify`, so the two halves of that section now agree.

`CLAUDE.md` and the other pointer files are untouched, as they should be.

## What was verified rather than written

- The test is built the way `src/Quartz.Tests.Unit/PublicApiTest.cs` builds the core ones: same nine `ExcludeAttributes`, same `UseDirectory("Verify")` / `UseFileName($"PublicApiTest_{name}")` / `DisableRequireUniquePrefix()`. It adds an `ExcludeTypes` filter for `ComponentBase` subclasses and `_Imports`, which the core assemblies have no need of.
- Both projects are single-target `net10.0`, and the generated names carry no TFM suffix: `PublicApiTest_Quartz.AspNetCore.verified.txt` and `PublicApiTest_Quartz.Dashboard.verified.txt`.
- `origin/3.x` carries both file names at the same path, so `git diff origin/3.x origin/main -- src/Quartz.Tests.AspNetCore/Verify` works as documented.
- Both snapshots are current: the test passes unmodified, so alpha.2's surface is what is recorded. Nothing in either assembly changed.

## For the reviewer to decide — not changed here

Reading the freshly-reviewed snapshot turned up surface that looks unintentional. None of it is touched in this PR; file what you agree with.

**The two dashboard plugins look accidentally public.** `Quartz.Dashboard.Plugins.DashboardHistoryPlugin` and `DashboardLiveEventsPlugin` are `public sealed`, carry no XML documentation, and are registered only by `AddQuartzDashboard` through `quartz.AddPlugin<T>`. The only other references are in `Quartz.Tests.AspNetCore`, which `Quartz.Dashboard` already grants `InternalsVisibleTo` — the sibling `DashboardHistoryStore` is `internal sealed` behind a public `IDashboardHistoryStore`, which is the pattern these two do not follow. `AddPlugin<T>`'s constraint is a `DynamicallyAccessedMembers` annotation about trimming, not accessibility, so an internal type with public members satisfies it. Together they contribute roughly 40 members to the baseline, and `DashboardLiveEventsPlugin` implements `IJobListener`, `ITriggerListener` and `ISchedulerListener` in full — so every listener method added to core would churn this baseline as though a dashboard contract had moved.

**`IQuartzApiClient` is a judgement call, not a bug.** Its 37 members and the ~15 DTO and request records they reference are most of the 314-line Dashboard baseline, and its only implementation is `internal sealed InProcessQuartzApiClient`. That is either a deliberate extension point (a consumer pointing the dashboard at a remote scheduler) or a leaked internal seam. Worth settling before alpha.3's fleet view adds to it. Note that `JobKeyDto` and `TriggerKeyDto` are pinned public regardless: `IQuartzDashboardHubClient`, which `AGENTS.md` records as necessarily public for SignalR, has them in its signatures.

**A small asymmetry the baseline makes visible.** `AddQuartzHealthChecks` has both an `IServiceCollection` and an `IQuartzBuilder` overload; `AddQuartzHttpApi` has only the `IServiceCollection` one.

**A 3.x follow-up.** `3.x`'s copy of this test lacks the `_Imports` exclusion, so its Dashboard baseline still records two `public class _Imports` entries that this branch's does not. The cross-branch diff for these two files consequently opens with a delta that is not one. Porting the one-clause filter to `3.x` would clear it; out of scope on this branch.

Closes #3413

## Verification

```
dotnet build Quartz.slnx
  Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
  Passed! - Failed: 0, Passed: 433, Skipped: 0, Total: 433

dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
  Passed! - Failed: 0, Passed: 3292, Skipped: 4, Total: 3296
```

`AgentInstructionsTest` and `SourceEncodingTest` pass (13 tests); `AGENTS.md` is 21,038 bytes against the 32,768-byte cap, still UTF-8 without a BOM and still CRLF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
