### PR TITLE
The core logs through source-generated events with a pinned catalogue

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2286,10 +2286,18 @@ Ids are allocated in ranges by area, and are stable from 4.0 onwards:
 | 6000–8999 | Reserved for `Quartz.Plugins`, `Quartz.Jobs` and `Quartz.Extensions.Redis`, which are converting to the same shape |
 
 Levels and message templates are otherwise **unchanged from 3.x**, so a log query that matched a
-message before still matches it. The one exception is `JobStoreSupport.LogWarnIfNonZero`, which wrote
-the cluster recovery counts at Information when the count was non-zero and at Debug when it was zero,
-whatever its name said: those six messages are Warning events now, raised only when the count is
-non-zero. If you filtered them at Information, filter them at Warning.
+message before still matches it. Two exceptions:
+
+* `JobStoreSupport.LogWarnIfNonZero` wrote the cluster recovery counts at Information when the count
+  was non-zero and at Debug when it was zero, whatever its name said. Those six messages are Warning
+  events now, raised only when the count is non-zero. If you filtered them at Information, filter them
+  at Warning.
+* Four messages carried a typo, corrected while their ids were new: `Removed  {Count} 'complete'
+  triggers.` lost a double space, `complete triggers(s)` became `complete trigger(s)`, `Found
+  {TriggerGroupDeleteCount}delete trigger group commands.` gained the missing space, and the message
+  about a trigger that already existed — spelled with double spaces in one place and single spaces in
+  the other — is one event with the single-space spelling. A query matching those on text needs
+  updating; one matching on event id does not, which is rather the point.
 
 ## The ambient logger factory stays ambient
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2264,6 +2264,33 @@ inject, which the next section lists.
 
 Further information on configuring Microsoft.Logging can be found [at Microsoft docs](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging).
 
+### Every message carries an event id
+
+The `Quartz` package logs through source-generated `[LoggerMessage]` methods rather than
+`logger.LogInformation(…)` and its siblings. Two things follow. Nothing is formatted or boxed when the
+level is off, including on the scheduling loop. And every message has a stable event id, so an operator
+can filter or alert on the event rather than on its text.
+
+Ids are allocated in ranges by area, and are stable from 4.0 onwards:
+
+| Range | Area |
+|---|---|
+| 1000–1999 | Scheduler core — the scheduler, its firing loop, the job run shell, the signaler, the error listener |
+| 2000–2999 | `RAMJobStore` |
+| 3000–3499 | ADO.NET store, its connections and its driver delegate |
+| 3500–3599 | Clustering — check-in, failed-instance detection and recovery |
+| 3600–3699 | Misfire handling |
+| 3700–3799 | Lock handlers |
+| 4000–4999 | Configuration, dependency injection and hosting, including the thread pools and job factories |
+| 5000–5999 | Serialization, type loading, triggers, calendars, XML scheduling data and the utilities |
+| 6000–8999 | Reserved for `Quartz.Plugins`, `Quartz.Jobs` and `Quartz.Extensions.Redis`, which are converting to the same shape |
+
+Levels and message templates are otherwise **unchanged from 3.x**, so a log query that matched a
+message before still matches it. The one exception is `JobStoreSupport.LogWarnIfNonZero`, which wrote
+the cluster recovery counts at Information when the count was non-zero and at Debug when it was zero,
+whatever its name said: those six messages are Warning events now, raised only when the count is
+non-zero. If you filtered them at Information, filter them at Warning.
+
 ## The ambient logger factory stays ambient
 
 `LogProvider.SetLogProvider(ILoggerFactory)` is the one piece of mutable process-wide state left in
@@ -4571,10 +4598,11 @@ Two properties that nothing read are gone rather than made read-only: `DriverDel
 injected, not loaded from a type name here) and `DontSetAutoCommitFalse` (never consulted).
 `AdoJobStoreOptions.DontSetAutoCommitFalse` went with the store property: no code path ever read it and no
 configuration key ever set it, so an application that set it was configuring nothing.
-`LastCheckin` and `LogWarnIfNonZero` are internal and private respectively — cluster check-in bookkeeping
-and a log helper, neither of which a subclass has any business in. The `[TimeSpanParseRule]` attributes on
-these properties are gone too; they are read only when a component's settings arrive as strings, which for
-this store they no longer do.
+`LastCheckin` is internal — cluster check-in bookkeeping a subclass has no business in — and
+`LogWarnIfNonZero` is gone: its callers raise source-generated events instead, at the level its name always
+claimed, as [Every message carries an event id](#every-message-carries-an-event-id) describes. The
+`[TimeSpanParseRule]` attributes on these properties are gone too; they are read only when a component's
+settings arrive as strings, which for this store they no longer do.
 
 ### `AdoJobStoreBase`'s overridable surface is a decision now
 
@@ -7632,7 +7660,7 @@ Parameters and behavior are unchanged:
 | `AdoJobStoreBase`'s virtual surface is a curated seam | Only `Initialize`, `Shutdown`, `GetConnection`, `GetLocalTransactionConnection`, `ExecuteInLock<T>`, `IsTransient`, `AcquireNextTriggers`, `CreateAcquisitionCriteria` and `GetFiredTriggerRecordId` remain overridable; the other ~75 members were virtual by default, not by design, and freezing the store's internal call order as a behavior contract would have made it unrefactorable |
 | `AdoJobStoreBase.DriverDelegateType` and `.DontSetAutoCommitFalse` removed | Nothing read either one; the driver delegate is injected |
 | `AdoJobStoreOptions.DontSetAutoCommitFalse` removed | The option the deleted store property mirrored. No code path read it and no `quartz.*` key set it, so setting it configured nothing |
-| `AdoJobStoreBase.LastCheckin` is internal, `LogWarnIfNonZero` is private | Cluster check-in bookkeeping and a logging helper, neither of them an extension point |
+| `AdoJobStoreBase.LastCheckin` is internal, `LogWarnIfNonZero` is removed | Cluster check-in bookkeeping and a logging helper, neither of them an extension point. The helper's callers raise source-generated events, at the level its name always claimed — see [Every message carries an event id](#every-message-carries-an-event-id) |
 | `AdoJobStoreBase.RecoverJobs(CancellationToken)` returns `ValueTask` | The `bool` it returned was the constant `true` |
 | `DbSemaphore.LockSql` (was `Sql`) and `InsertSql` are get-only, fed by the constructor | Assigning one after construction left it un-prefixed relative to its pair — see [The semaphores were tidied](#the-semaphores-were-tidied) |
 | The row-lock semaphores are named for the SQL they issue | `StdRowLockSemaphore` is `SelectForUpdateSemaphore`, `UpdateLockRowSemaphore` is `UpdateRowSemaphore`, `PostgreSQLRowLockSemaphore` is `PostgreSqlSelectForUpdateSemaphore`, `UpdateLockRowSemaphoreMOT` is `SqlServerMemoryOptimizedUpdateRowSemaphore`. `quartz.jobStore.lockHandler.type` naming an old one still resolves, with a warning — see [The semaphores were tidied](#the-semaphores-were-tidied) |

--- a/src/Quartz.Tests.Unit/LogCallSiteTest.cs
+++ b/src/Quartz.Tests.Unit/LogCallSiteTest.cs
@@ -1,0 +1,116 @@
+using System.Text.RegularExpressions;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// How a call site logs: through a source-generated <c>[LoggerMessage]</c> method, never through
+/// <c>ILogger.LogInformation</c> and its siblings.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A plain <c>Log*</c> call formats and boxes its arguments whether or not the level is on, carries no
+/// event id an operator can filter, and puts its message somewhere no snapshot can see. The conversion
+/// away from them is worth nothing if it can come back one call at a time, which is what this test is
+/// for — the same job <c>SourceEncodingTest</c> does for byte-order marks.
+/// </para>
+/// <para>
+/// Only <c>src/Quartz/</c> is covered so far. <c>Quartz.Plugins</c>, <c>Quartz.Jobs</c> and
+/// <c>Quartz.Extensions.Redis</c> join <see cref="Converted" /> as their own conversions land (#3414);
+/// tests, examples and the documentation samples are deliberately never covered, because a plain call
+/// is the right thing to write in all three.
+/// </para>
+/// </remarks>
+public class LogCallSiteTest
+{
+    /// <summary>
+    /// The projects whose logging has been converted, relative to the repository root.
+    /// </summary>
+    private static readonly string[] Converted = ["src/Quartz"];
+
+    /// <summary>
+    /// Build output and tool caches, which hold the generator's own output among other things.
+    /// </summary>
+    private static readonly string[] NotSearched = ["bin", "obj", "node_modules", "TestResults", ".vs"];
+
+    /// <summary>
+    /// Call sites that may keep a plain call, each with the reason it is allowed one. Empty, and
+    /// meant to stay that way — an entry here is a promise that the site has been looked at, not a
+    /// place to put one that has not.
+    /// </summary>
+    private static readonly (string Path, string Reason)[] Allowed = [];
+
+    /// <summary>
+    /// The generated classes themselves, whose whole job is to hold the logging.
+    /// </summary>
+    private const string GeneratedLoggingSuffix = "Log.cs";
+
+    private static readonly Regex PlainLogCall = new(
+        @"\.Log(Trace|Debug|Information|Warning|Error|Critical)\(|\.Log\(LogLevel",
+        RegexOptions.Compiled);
+
+    [Test]
+    public void NoConvertedProjectCallsILoggerDirectly()
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+
+        List<string> offenders = [];
+
+        foreach (string project in Converted)
+        {
+            DirectoryInfo directory = new(Path.Combine(root.FullName, project.Replace('/', Path.DirectorySeparatorChar)));
+
+            directory.Exists.Should().BeTrue(
+                $"{project} is listed as converted, so the tree this test walks must reach it");
+
+            foreach (FileInfo file in Discover(directory))
+            {
+                string relative = Path.GetRelativePath(root.FullName, file.FullName).Replace('\\', '/');
+
+                if (Allowed.Any(x => x.Path == relative))
+                {
+                    continue;
+                }
+
+                foreach (Match match in PlainLogCall.Matches(File.ReadAllText(file.FullName)))
+                {
+                    offenders.Add($"{relative}: {match.Value}");
+                }
+            }
+        }
+
+        offenders.Should().BeEmpty(
+            "logging goes through a [LoggerMessage] method on the area's *Log class, which costs nothing "
+            + "when the level is off and gives the message an event id that LogEventCatalogTest pins. These "
+            + "call ILogger directly:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, offenders.Order(StringComparer.Ordinal).Select(x => "    " + x))
+            + Environment.NewLine
+            + "Add the event to the *Log class beside the caller, taking the next id in that area's range, "
+            + "and call it. A site that genuinely cannot go through one belongs in this test's allow-list, "
+            + "with the reason written down");
+    }
+
+    private static IEnumerable<FileInfo> Discover(DirectoryInfo directory)
+    {
+        foreach (FileInfo file in directory.EnumerateFiles("*.cs"))
+        {
+            if (!file.Name.EndsWith(GeneratedLoggingSuffix, StringComparison.Ordinal))
+            {
+                yield return file;
+            }
+        }
+
+        foreach (DirectoryInfo child in directory.EnumerateDirectories())
+        {
+            if (NotSearched.Contains(child.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (FileInfo file in Discover(child))
+            {
+                yield return file;
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/LogEventCatalogTest.cs
+++ b/src/Quartz.Tests.Unit/LogEventCatalogTest.cs
@@ -1,0 +1,137 @@
+using System.Reflection;
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The catalogue of log events a package raises: every <c>[LoggerMessage]</c> method, its event id,
+/// its level and its message template.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An event id is what an operator filters and alerts on, and a message template is what a
+/// structured-logging consumer matches. Both are contract once shipped, and neither shows up in the
+/// public API baseline, because the generated classes are internal. The snapshot is what makes adding
+/// an event, renumbering one, or rewording a message a reviewed diff instead of an invisible one.
+/// </para>
+/// <para>
+/// Ids are allocated in ranges, one set per package, so two packages loaded into the same process
+/// never disagree about what an id means. The ranges live in <see cref="Ranges" />; a package may only
+/// use its own.
+/// </para>
+/// </remarks>
+public class LogEventCatalogTest
+{
+    /// <summary>
+    /// Who owns which event ids. Every id an assembly raises must fall inside a range recorded here
+    /// against that assembly, which is also what keeps it out of another package's reserved range.
+    /// </summary>
+    private static readonly EventIdRange[] Ranges =
+    [
+        new("Quartz", 1000, 1999, "scheduler core"),
+        new("Quartz", 2000, 2999, "in-memory store"),
+        new("Quartz", 3000, 3499, "ADO.NET store"),
+        new("Quartz", 3500, 3599, "clustering"),
+        new("Quartz", 3600, 3699, "misfire handling"),
+        new("Quartz", 3700, 3799, "lock handlers"),
+        new("Quartz", 4000, 4999, "configuration, dependency injection and hosting"),
+        new("Quartz", 5000, 5999, "serialization, type loading, triggers, calendars and utilities"),
+        new("Quartz.Plugins", 6000, 6999, "plugins"),
+        new("Quartz.Jobs", 7000, 7999, "jobs"),
+        new("Quartz.Extensions.Redis", 8000, 8999, "Redis"),
+    ];
+
+    /// <summary>
+    /// The assemblies whose catalogue is snapshotted. A package joins this list on the day its
+    /// <c>Log*</c> calls become <c>[LoggerMessage]</c> methods — one line, and a snapshot of its own.
+    /// </summary>
+    private static readonly Assembly[] Catalogued =
+    [
+        typeof(global::Quartz.IScheduler).Assembly,
+    ];
+
+    private static IEnumerable<TestCaseData> Assemblies()
+    {
+        foreach (Assembly assembly in Catalogued)
+        {
+            yield return new TestCaseData(assembly).SetName(assembly.GetName().Name);
+        }
+    }
+
+    [TestCaseSource(nameof(Assemblies))]
+    public async Task LogEventCatalogHasNotChangedUnintentionally(Assembly assembly)
+    {
+        string name = assembly.GetName().Name!;
+        List<LogEvent> events = Read(assembly);
+
+        events.Should().NotBeEmpty(
+            $"{name} is listed as having a catalogue, so reflecting over it must find [LoggerMessage] methods "
+            + "- an empty result means the query stopped working, not that the package stopped logging");
+
+        List<IGrouping<int, LogEvent>> collisions = events.GroupBy(x => x.EventId).Where(x => x.Count() > 1).ToList();
+
+        collisions.Should().BeEmpty(
+            "an event id identifies one event to whoever filters on it, so two events cannot share one:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, collisions.Select(x => $"    {x.Key}: {string.Join(", ", x.Select(y => y.Method))}")));
+
+        List<LogEvent> outside = events.Where(x => !Ranges.Any(r => r.Owner == name && r.Contains(x.EventId))).ToList();
+
+        outside.Should().BeEmpty(
+            $"every id {name} raises has to be in a range allocated to {name}, which is what keeps it out of "
+            + "another package's range when both are loaded into one process. These are not:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, outside.Select(x => $"    {x.EventId} {x.Method}"))
+            + Environment.NewLine
+            + $"Ranges for {name}: "
+            + string.Join(", ", Ranges.Where(x => x.Owner == name).Select(x => $"{x.From}-{x.To} ({x.Area})")));
+
+        await Verify(Format(events), extension: "txt")
+            .UseDirectory("Verify")
+            .UseFileName($"LogEventCatalogTest_{name}")
+            .DisableRequireUniquePrefix();
+    }
+
+    private static List<LogEvent> Read(Assembly assembly)
+    {
+        List<LogEvent> events = [];
+
+        foreach (Type type in assembly.GetTypes())
+        {
+            foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            {
+                LoggerMessageAttribute attribute = method.GetCustomAttribute<LoggerMessageAttribute>();
+                if (attribute is null)
+                {
+                    continue;
+                }
+
+                events.Add(new LogEvent(attribute.EventId, $"{type.Name}.{method.Name}", attribute.Level, attribute.Message));
+            }
+        }
+
+        events.Sort((x, y) => x.EventId != y.EventId
+            ? x.EventId.CompareTo(y.EventId)
+            : string.CompareOrdinal(x.Method, y.Method));
+
+        return events;
+    }
+
+    /// <summary>
+    /// The message is quoted because trailing whitespace is part of a template and would otherwise be
+    /// invisible in the snapshot and in its diff.
+    /// </summary>
+    private static string Format(List<LogEvent> events)
+    {
+        return string.Join(Environment.NewLine, events.Select(x =>
+            $"{x.EventId}  {x.Level}  {x.Method}{Environment.NewLine}    \"{x.Message}\""));
+    }
+
+    private sealed record LogEvent(int EventId, string Method, LogLevel Level, string Message);
+
+    private sealed record EventIdRange(string Owner, int From, int To, string Area)
+    {
+        public bool Contains(int eventId) => eventId >= From && eventId <= To;
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
@@ -129,7 +129,7 @@
 3020  Information  AdoJobStoreLog.RecoveryComplete
     "Recovery complete."
 3021  Information  AdoJobStoreLog.CompleteTriggersRemoved
-    "Removed  {Count} 'complete' triggers."
+    "Removed {Count} 'complete' triggers."
 3022  Information  AdoJobStoreLog.StaleFiredJobEntriesRemoved
     "Removed {Count} stale fired job entries."
 3023  Error  AdoJobStoreLog.StaleAcquiredTriggerRecoveryFailed
@@ -211,7 +211,7 @@
 3507  Warning  ClusterLog.AcquiredTriggersFreed
     "ClusterManager: ......Freed {Count} acquired trigger(s)."
 3508  Warning  ClusterLog.CompleteTriggersDeleted
-    "ClusterManager: ......Deleted {Count} complete triggers(s)."
+    "ClusterManager: ......Deleted {Count} complete trigger(s)."
 3509  Warning  ClusterLog.RecoverableJobsScheduled
     "ClusterManager: ......Scheduled {Count} recoverable job(s) for recovery."
 3510  Warning  ClusterLog.OtherFailedJobsCleanedUp
@@ -319,7 +319,7 @@
 5002  Debug  XmlSchedulingLog.FoundDeleteJobGroupCommands
     "Found {JobGroupCount} delete job group commands."
 5003  Debug  XmlSchedulingLog.FoundDeleteTriggerGroupCommands
-    "Found {TriggerGroupDeleteCount}delete trigger group commands."
+    "Found {TriggerGroupDeleteCount} delete trigger group commands."
 5004  Debug  XmlSchedulingLog.FoundDeleteJobCommands
     "Found {JobsToDeleteCount} delete job commands."
 5005  Debug  XmlSchedulingLog.FoundDeleteTriggerCommands
@@ -365,8 +365,6 @@
 5025  Debug  XmlSchedulingLog.SchedulingJob
     "Scheduling job: {JobKey} with trigger: {TriggerKey}"
 5026  Debug  XmlSchedulingLog.TriggerAlreadyExistedWillReschedule
-    "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed.  This is likely due to a race condition between multiple instances in the cluster.  Will try to reschedule instead."
-5027  Debug  XmlSchedulingLog.TriggerAlreadyExistedWillRescheduleJob
     "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed. This is likely due to a race condition between multiple instances in the cluster. Will try to reschedule instead."
 5028  Information  XmlSchedulingLog.NotOverwritingExistingTrigger
     "Not overwriting existing trigger: {JobKey}"

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
@@ -1,0 +1,410 @@
+﻿1000  Information  CoreLog.JobFactorySet
+    "JobFactory set to: {Value}"
+1001  Information  CoreLog.SchedulerCreated
+    "Quartz Scheduler created"
+1002  Information  CoreLog.SchedulerStarted
+    "Scheduler {SchedulerIdentifier} started."
+1003  Error  CoreLog.DelayedStartFailed
+    "Unable to start scheduler after startup delay."
+1004  Information  CoreLog.SchedulerPaused
+    "Scheduler {SchedulerIdentifier} paused."
+1005  Information  CoreLog.SchedulerShuttingDown
+    "Scheduler {SchedulerIdentifier} shutting down."
+1006  Warning  CoreLog.GaveUpWaitingForRunningJobs
+    "Scheduler {SchedulerIdentifier} gave up waiting for its running jobs, which are still executing. Their job store updates may not complete, and the store is about to be shut down under them."
+1007  Information  CoreLog.SchedulerShutdownComplete
+    "Scheduler {SchedulerIdentifier} Shutdown complete."
+1008  Error  CoreLog.ListenerNotificationOfErrorFailed
+    "Error while notifying SchedulerListener of error"
+1009  Error  CoreLog.OriginalErrorForNotification
+    "  Original error (for notification) was: {Message}"
+1010  Error  CoreLog.ListenerNotificationOfUnscheduledJobFailed
+    "Error while notifying SchedulerListener of unscheduled job. Trigger={TriggerKey}"
+1011  Error  CoreLog.ListenerNotificationOfPausedGroupFailed
+    "Error while notifying SchedulerListener of paused group: {Group}"
+1012  Error  CoreLog.ListenerNotificationOfTriggerInErrorFailed
+    "Error while notifying SchedulerListener of trigger in error state. Trigger={TriggerKey}"
+1013  Error  CoreLog.ListenerNotificationOfJobTriggersInErrorFailed
+    "Error while notifying SchedulerListener of job triggers in error state. Job={JobKey}"
+1014  Error  CoreLog.ListenerNotificationOfPausedTriggerFailed
+    "Error while notifying SchedulerListener of paused trigger. Trigger={TriggerKey}"
+1015  Error  CoreLog.ListenerNotificationOfResumedTriggerFailed
+    "Error while notifying SchedulerListener of resumed trigger. Trigger={TriggerKey}"
+1016  Error  CoreLog.ListenerNotificationOfPausedJobFailed
+    "Error while notifying SchedulerListener of paused job. Job={JobKey}"
+1017  Error  CoreLog.ListenerNotificationOfResumedJobFailed
+    "Error while notifying SchedulerListener of resumed job: {JobKey}"
+1018  Error  CoreLog.ListenerNotificationOfResumedGroupFailed
+    "Error while notifying SchedulerListener of resumed group: {Group}"
+1019  Error  CoreLog.ListenerNotificationFailed
+    "Error while notifying SchedulerListener of {Action}"
+1030  Debug  CoreLog.TriggerBatchAcquired
+    "Batch acquisition of {TriggerCount} triggers"
+1031  Error  CoreLog.SchedulerThreadLoopFailed
+    "quartzSchedulerThreadLoop: RuntimeException {Message}"
+1032  Error  CoreLog.TriggerFireFailedWithDbException
+    "DbException while firing trigger {Trigger}"
+1033  Debug  CoreLog.ThreadPoolRefusedWorkDuringShutdown
+    "ThreadPool.TryRun() returned false due to scheduler shutdown, completing trigger"
+1034  Error  CoreLog.ThreadPoolRefusedWork
+    "ThreadPool.TryRun() returned false"
+1035  Error  CoreLog.TriggerFiringLoopFailed
+    "Runtime error occurred in main trigger firing loop."
+1036  Error  CoreLog.AcquiredTriggerReleaseFailed
+    "Error releasing acquired trigger '{TriggerKey}' {Context}"
+1050  Debug  CoreLog.JobExecuting
+    "Calling Execute on job {JobKey}"
+1051  Information  CoreLog.JobCancelled
+    "Job {JobDetailKey} was cancelled"
+1052  Error  CoreLog.JobThrewJobExecutionException
+    "Job {JobDetailKey} threw a JobExecutionException: "
+1053  Error  CoreLog.JobThrewUnhandledException
+    "Job {JobDetailKey} threw an unhandled Exception: "
+1054  Debug  CoreLog.TriggerInstructionDecided
+    "Trigger instruction : {InstructionCode}"
+1055  Debug  CoreLog.TriggerRefiring
+    "Rescheduling trigger to reexecute"
+1070  Information  CoreLog.SchedulerSignalerInitialized
+    "Initialized Scheduler Signaller of type: {Type}"
+1071  Error  CoreLog.ListenerNotificationOfMisfireFailed
+    "Error notifying listeners of trigger misfire."
+1080  Error  CoreLog.SchedulerError
+    "{Message} (scheduler: {SchedulerName})"
+1081  Error  CoreLog.SchedulerErrorForFire
+    "{Message} (scheduler: {SchedulerName}, trigger: {TriggerKey}, job: {JobKey}, fire instance: {FireInstanceId})"
+2000  Information  RAMJobStoreLog.StoreInitialized
+    "RAMJobStore initialized."
+2001  Warning  RAMJobStoreLog.TriggerSkippedJobMissing
+    "Skipping trigger {TriggerKey}: its job {JobKey} no longer exists"
+2002  Warning  RAMJobStoreLog.TriggerReferencesMissingCalendar
+    "Trigger {TriggerKey} references calendar '{CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared."
+2003  Debug  RAMJobStoreLog.TriggerDeleting
+    "Deleting trigger"
+2004  Debug  RAMJobStoreLog.TriggerDeletionCancelled
+    "Deleting cancelled - trigger still active"
+2005  Information  RAMJobStoreLog.TriggerSetToError
+    "Trigger {TriggerKey} set to ERROR state."
+2006  Information  RAMJobStoreLog.JobTriggersSetToError
+    "All triggers of Job {JobKey} set to ERROR state."
+3000  Information  AdoJobStoreLog.SqliteSemaphoreSubstituted
+    "Detected SQLite usage, changing to use SQLiteSemaphore for in-memory locking"
+3001  Information  AdoJobStoreLog.SqliteAcquireTriggersWithinLockForced
+    "With SQLite we need to set AcquireTriggersWithinLock to true, changing"
+3002  Information  AdoJobStoreLog.SqliteSerializableIsolationForced
+    "Detected usage of SQLiteDelegate - forcing transaction isolation level to 'Serializable'"
+3003  Information  AdoJobStoreLog.SqliteLockAllOperationsForced
+    "With SQLite all operations must be serialized, setting LockAllOperations to true"
+3004  Warning  AdoJobStoreLog.IsolationLevelIgnoredForEnlistedTransactions
+    "The configured transaction isolation level applies only to connections the job store opens itself: an operation running on a connection enlisted by the application uses that transaction's isolation level instead."
+3005  Information  AdoJobStoreLog.SqlServerLockSqlDefaulted
+    "Detected usage of SqlServerDelegate - defaulting 'selectWithLockSQL' to '{DefaultLockSql}'."
+3006  Information  AdoJobStoreLog.UsingDatabaseLocking
+    "Using db table-based data access locking (synchronization) via {LockHandlerType}."
+3007  Information  AdoJobStoreLog.UsingMonitorLocking
+    "Using thread monitor-based data access locking (synchronization) via {LockHandlerType}."
+3008  Warning  AdoJobStoreLog.RowLockStatementIgnoredBySqlite
+    "A row-lock statement is configured, but SQLite serializes callers in process rather than by locking a row, so the statement is ignored."
+3009  Warning  AdoJobStoreLog.RowLockStatementIgnoredBySuppliedHandler
+    "A row-lock statement is configured, but lock handler {LockHandlerType} was supplied rather than built by the job store, so the statement is ignored. Pass it to the handler's constructor, or remove the lock handler and let the store choose one."
+3010  Warning  AdoJobStoreLog.EnlistedTransactionsWithSqlite
+    "Accepting enlisted transactions with SQLite keeps in-process locking: SQLiteSemaphore releases the lock when the scheduling call returns, while the application transaction still holds the SQLite writer lock, so a concurrent scheduler operation can fail with 'database is locked' until that transaction completes. Keep enlisted transactions short, or use a database that supports row locking."
+3011  Warning  AdoJobStoreLog.EnlistedTransactionsWithInProcessLocking
+    "Accepting enlisted transactions with lock handler {LockHandlerType}, which does not lock in the database. Its locks are released before the application commits its transaction, so concurrent callers can act on scheduling data that is not visible to them yet."
+3012  Warning  AdoJobStoreLog.SqlServerCouldUseRowLocking
+    "Detected usage of SqlServerDelegate and UpdateRowSemaphore, removing 'quartz.jobStore.lockHandler.type' would allow more efficient SQL Server specific (UPDLOCK,ROWLOCK) row access"
+3013  Warning  AdoJobStoreLog.SqlServerProviderWithoutSqlServerDelegate
+    "Detected usage of SQL Server provider without SqlServerDelegate, SqlServerDelegate would provide better performance"
+3014  Information  AdoJobStoreLog.SchemaValidated
+    "Successfully validated presence of {SchemaObjectCount} schema objects"
+3015  Error  AdoJobStoreLog.JobRecoveryFailed
+    "Failure occurred during job recovery: {ExceptionMessage}"
+3016  Warning  AdoJobStoreLog.DatabaseShutdownFailed
+    "Database connection Shutdown unsuccessful."
+3017  Error  AdoJobStoreLog.LockReleaseFailed
+    "Error returning lock: {ExceptionMessage}"
+3018  Information  AdoJobStoreLog.TriggersFreedFromAcquiredOrBlocked
+    "Freed {Count} triggers from 'acquired' / 'blocked' state."
+3019  Information  AdoJobStoreLog.RecoveringInProgressJobs
+    "Recovering {Count} jobs that were in-progress at the time of the last shut-down."
+3020  Information  AdoJobStoreLog.RecoveryComplete
+    "Recovery complete."
+3021  Information  AdoJobStoreLog.CompleteTriggersRemoved
+    "Removed  {Count} 'complete' triggers."
+3022  Information  AdoJobStoreLog.StaleFiredJobEntriesRemoved
+    "Removed {Count} stale fired job entries."
+3023  Error  AdoJobStoreLog.StaleAcquiredTriggerRecoveryFailed
+    "Error recovering stale acquired trigger '{TriggerKey}'"
+3024  Information  AdoJobStoreLog.StaleAcquiredTriggersRecovered
+    "Recovered {RecoveredCount} trigger(s) stuck in ACQUIRED state (stale threshold: {StaleThreshold})"
+3025  Information  AdoJobStoreLog.TriggerResetFromError
+    "Trigger {TriggerKey} reset from ERROR state to: {NewState}"
+3026  Error  AdoJobStoreLog.JobRetrievalFailed
+    "Error retrieving job, setting trigger state to ERROR."
+3027  Error  AdoJobStoreLog.TriggerErrorStateUpdateFailed
+    "Unable to set trigger state to ERROR."
+3028  Warning  AdoJobStoreLog.TriggerHasNoNextFireTime
+    "Trigger {TriggerKey} returned null on nextFireTime and yet still exists in DB!"
+3029  Error  AdoJobStoreLog.JobPersistenceExceptionCaught
+    "Caught job persistence exception: {ExceptionMessage}"
+3030  Error  AdoJobStoreLog.ExceptionCaught
+    "Caught exception: {ExceptionMessage}"
+3031  Information  AdoJobStoreLog.ConcurrentExecutionDeclined
+    "Not firing trigger {TriggerKey} for [DisallowConcurrentExecution] job {JobKey} - already executing on another node."
+3032  Warning  AdoJobStoreLog.TriggerReferencesMissingCalendar
+    "Trigger {TriggerKey} references calendar '{CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared."
+3033  Information  AdoJobStoreLog.TriggerSetToError
+    "Trigger {Trigger} set to ERROR state."
+3034  Information  AdoJobStoreLog.JobTriggersSetToError
+    "All triggers of Job {Job} set to ERROR state."
+3035  Information  AdoJobStoreLog.RollbackWithoutConnectionHolder
+    "ConnectionAndTransactionHolder passed to RollbackConnection was null, ignoring"
+3036  Debug  AdoJobStoreLog.CommitWithoutConnectionHolder
+    "ConnectionAndTransactionHolder passed to CommitConnection was null, ignoring"
+3037  Error  AdoJobStoreLog.RetryInLocalTransactionLockFailed
+    "RetryExecuteInLocalTransactionLock: RuntimeException {ExceptionMessage}"
+3038  Warning  AdoJobStoreLog.TransientFailureInLocalTransactionLock
+    "Transient exception on attempt {Attempt} of {TotalAttempts} in ExecuteInLocalTransactionLock, will retry after {RetryInterval}"
+3100  Debug  AdoJobStoreLog.SqlPrepared
+    "Prepared SQL: {Sql}"
+3110  Error  AdoJobStoreLog.ConnectionCloseFailed
+    "Unexpected exception closing Connection.  This is often due to a Connection being returned after or during shutdown."
+3111  Debug  AdoJobStoreLog.ConnectionDisposeFailed
+    "Exception disposing connection or transaction. This is often due to a connection being returned after or during shutdown."
+3112  Debug  AdoJobStoreLog.RollbackSkippedTransactionDisconnected
+    "Rollback skipped - transaction is no longer connected, database will have aborted it"
+3113  Debug  AdoJobStoreLog.RollbackFailedTransiently
+    "Rollback failed due to transient error"
+3114  Error  AdoJobStoreLog.RollbackFailed
+    "Couldn't rollback ADO.NET connection. {ExceptionMessage}"
+3130  Information  AdoJobStoreLog.ExternalTransactionStoreInitialized
+    "ExternalTransactionJobStore initialized."
+3131  Warning  AdoJobStoreLog.ExternalTransactionStoreShutdownFailed
+    "Database connection shutdown unsuccessful."
+3140  Information  AdoJobStoreLog.LocalTransactionStoreInitialized
+    "LocalTransactionJobStore initialized."
+3150  Warning  AdoJobStoreLog.CalendarNotFound
+    "Couldn't find calendar with name '{CalendarName}'"
+3151  Debug  AdoJobStoreLog.JobDeleting
+    "Deleting job: {JobKey}"
+3152  Debug  AdoJobStoreLog.NoJobForTrigger
+    "No job for trigger '{TriggerKey}'"
+3153  Debug  AdoJobStoreLog.TriggerPersistenceDelegateAdded
+    "Adding TriggerPersistenceDelegate of type: {Type}"
+3154  Warning  AdoJobStoreLog.MisfiredTriggerHasNoTypeRow
+    "Misfired trigger '{TriggerKey}' has no {TriggerType} row and is skipped"
+3155  Warning  AdoJobStoreLog.BatchedStatementExecutionFailed
+    "Batched statement execution failed, retrying {StatementCount} statement(s) individually"
+3500  Warning  ClusterLog.TransientFailureInCheckIn
+    "Transient exception on attempt {Attempt} of {TotalAttempts} in DoCheckin, will retry after {RetryInterval}"
+3501  Warning  ClusterLog.RecoveredByAnotherInstance
+    "This scheduler instance ({InstanceId}) is still active but was recovered by another instance in the cluster.  This may cause inconsistent behavior."
+3502  Warning  ClusterLog.OrphanedFiredTriggersFound
+    "Found orphaned fired triggers for instance: {SchedulerInstanceId}"
+3503  Warning  ClusterLog.FailedInstancesDetected
+    "ClusterManager: detected {Count} failed or restarted instances."
+3504  Information  ClusterLog.ScanningFailedInstance
+    "ClusterManager: Scanning for instance {SchedulerInstanceId}'s failed in-progress jobs."
+3505  Information  ClusterLog.RecoveryDeferred
+    "ClusterManager: Deferring recovery of [DisallowConcurrentExecution] job {JobKey} (fired trigger {FireInstanceId}) — may still be executing on instance {SchedulerInstanceId}."
+3506  Warning  ClusterLog.FailedJobNoLongerExists
+    "ClusterManager: failed job {JobKey} no longer exists, cannot schedule recovery."
+3507  Warning  ClusterLog.AcquiredTriggersFreed
+    "ClusterManager: ......Freed {Count} acquired trigger(s)."
+3508  Warning  ClusterLog.CompleteTriggersDeleted
+    "ClusterManager: ......Deleted {Count} complete triggers(s)."
+3509  Warning  ClusterLog.RecoverableJobsScheduled
+    "ClusterManager: ......Scheduled {Count} recoverable job(s) for recovery."
+3510  Warning  ClusterLog.OtherFailedJobsCleanedUp
+    "ClusterManager: ......Cleaned-up {Count} other failed job(s)."
+3511  Warning  ClusterLog.ExecutingJobRecoveriesDeferred
+    "ClusterManager: ......Deferred recovery of {Count} executing [DisallowConcurrentExecution] job(s)."
+3512  Information  ClusterLog.AutoPinnedTriggersReleased
+    "ClusterManager: Released {Count} auto-pinned trigger(s) from dead node '{InstanceId}' for re-acquisition."
+3513  Debug  ClusterLog.CheckInComplete
+    "Check-in complete."
+3514  Error  ClusterLog.ClusterManagementFailed
+    "Error managing cluster: {ExceptionMessage}"
+3600  Information  MisfireLog.HandlingFirstMisfiredTriggers
+    "Handling the first {Count} triggers that missed their scheduled fire-time. More misfired triggers remain to be processed."
+3601  Information  MisfireLog.HandlingMisfiredTriggers
+    "Handling {Count} trigger(s) that missed their scheduled fire-time."
+3602  Debug  MisfireLog.NoMisfiredTriggers
+    "Found 0 triggers that missed their scheduled fire-time."
+3603  Error  MisfireLog.MisfireUpdatePreparationFailed
+    "Error preparing misfire update for trigger: '{TriggerKey}'"
+3604  Error  MisfireLog.MisfiredTriggerUpdateFailed
+    "Error updating {Count} misfired trigger(s)"
+3605  Debug  MisfireLog.MisfiredTriggersCounted
+    "Found {MisfireCount} triggers that missed their scheduled fire-time."
+3606  Debug  MisfireLog.ScanningForMisfires
+    "Scanning for misfires..."
+3607  Error  MisfireLog.MisfireHandlingFailed
+    "Error handling misfires: {ExceptionMessage}"
+3700  Debug  LockHandlerLog.LockDesired
+    "Lock '{LockName}' is desired by: {RequestorId}"
+3701  Debug  LockHandlerLog.LockGiven
+    "Lock '{LockName}' given to: {RequestorId}"
+3702  Debug  LockHandlerLog.LockAlreadyHeld
+    "Lock '{LockName}' Is already owned by: {RequestorId}"
+3703  Debug  LockHandlerLog.LockReturned
+    "Lock '{LockName}' returned by: {RequestorId}"
+3704  Warning  LockHandlerLog.LockReturnedByNonOwner
+    "Lock '{LockName}' attempt to return by: {RequestorId} -- but not owner!"
+3705  Warning  LockHandlerLog.WrongfulReturnerStack
+    "stack-trace of wrongful returner: {Stacktrace}"
+3706  Debug  LockHandlerLog.LockBeingObtained
+    "Lock '{LockName}' is being obtained: {RequestorId}"
+3707  Debug  LockHandlerLog.LockRowInsertingForThread
+    "Inserting new lock row for lock: '{LockName}' being obtained by thread: {RequestorId}"
+3708  Debug  LockHandlerLog.LockNotObtainedWithRetryNote
+    "Lock '{LockName}' was not obtained by: {RequestorId}{RetryMessage}"
+3709  Debug  LockHandlerLog.LockAlreadyOwnedByOther
+    "Lock '{LockName}' already owned by: {RequestorId} -- but not owner!"
+3710  Debug  LockHandlerLog.WrongfulReturnerStackDebug
+    "stack-trace of wrongful returner: {StackTrace}"
+3711  Debug  LockHandlerLog.LockNotObtained
+    "Lock '{LockName}' was not obtained by: {RequestorId}"
+3712  Debug  LockHandlerLog.LockReentrantAcquisition
+    "Lock '{LockName}' reentrant acquisition by: {RequestorId} (count: {LockCount})"
+3713  Debug  LockHandlerLog.LockReentrantRelease
+    "Lock '{LockName}' reentrant release by: {RequestorId} (remaining: {LockCount})"
+3714  Debug  LockHandlerLog.LockNotObtainedWillRetry
+    "Lock '{LockName}' was not obtained by: {RequestorId} - will try again."
+3715  Debug  LockHandlerLog.LockRowInserting
+    "Inserting new lock row for lock: '{LockName}' being obtained: {RequestorId}"
+4000  Debug  ConfigurationLog.SharedDatabaseCheckUnavailable
+    "The shared-database check could not read what database scheduler '{SchedulerName}' talks to."
+4001  Warning  ConfigurationLog.SchedulersShareDatabaseWithDifferentPrefixes
+    "Scheduler '{SchedulerName}' (data source '{DataSource}', table prefix '{TablePrefix}') and scheduler '{OtherSchedulerName}' (data source '{OtherDataSource}', table prefix '{OtherTablePrefix}') use the same database with different table prefixes, so neither can see the other's rows. Schedulers sharing a database are normally told apart by SCHED_NAME and share one table prefix; separate table sets are legal, and if that is what you meant this warning is expected. If it is not, the scheduler with the wrong prefix starts cleanly, passes schema validation against the tables it was pointed at, and never sees its own data."
+4002  Information  ConfigurationLog.SchedulerInitialized
+    "Quartz Scheduler {Version} - '{SchedulerName}' with instanceId '{SchedulerInstanceId}' initialized"
+4003  Information  ConfigurationLog.UsingThreadPool
+    "Using thread pool '{ThreadPoolType}', size: {ThreadPoolSize}"
+4004  Information  ConfigurationLog.UsingJobStore
+    "Using job store '{JobStoreType}', supports persistence: {SupportsPersistence}, clustered: {Clustered}"
+4005  Error  ConfigurationLog.InstanceIdGenerationFailed
+    "Couldn't generate instance id"
+4006  Error  ConfigurationLog.ShutdownAfterInstantiationFailureFailed
+    "Got another exception while shutting down after instantiation exception"
+4007  Information  ConfigurationLog.HostNameShortened
+    "Host name '{HostName}' was too long, shortened to '{Newname}'"
+4008  Warning  ConfigurationLog.JobReturnAfterFailedCreationFailed
+    "Failed to return a job after its creation failed; the original error follows"
+4009  Warning  ConfigurationLog.JobPropertyNotSet
+    "{Problem}"
+4010  Debug  ConfigurationLog.ProducingJobInstance
+    "Producing instance of Job '{JobKey}', class={JobFullName}"
+4011  Debug  ConfigurationLog.TaskSchedulingThreadPoolConfigured
+    "TaskSchedulingThreadPool configured with max concurrency of {MaxConcurrency} and TaskScheduler {SchedulerName}."
+4012  Error  ConfigurationLog.ThreadPoolTaskFaulted
+    "A task handed to the thread pool faulted."
+4013  Debug  ConfigurationLog.ThreadPoolShuttingDown
+    "Shutting down threadpool..."
+4014  Debug  ConfigurationLog.ThreadPoolDrained
+    "No executing jobs remaining, all threads stopped."
+4015  Debug  ConfigurationLog.ThreadPoolDraining
+    "Draining threadpool..."
+4016  Debug  ConfigurationLog.ThreadPoolDrainGivenUp
+    "Gave up waiting for the thread pool to drain; work is still running."
+4017  Debug  ConfigurationLog.ThreadPoolClosedToNewWork
+    "Thread pool closed to new work with {RunningTaskCount} running tasks remaining."
+4018  Debug  ConfigurationLog.ThreadPoolShutdownComplete
+    "Shutdown of threadpool complete."
+4019  Debug  ConfigurationLog.ZeroSizeThreadPoolShutdownComplete
+    "Shutdown complete"
+5000  Information  XmlSchedulingLog.ParsingFile
+    "Parsing XML file: {FileName} with systemId: {SystemId}"
+5001  Information  XmlSchedulingLog.ParsingStream
+    "Parsing XML from stream with systemId: {SystemId}"
+5002  Debug  XmlSchedulingLog.FoundDeleteJobGroupCommands
+    "Found {JobGroupCount} delete job group commands."
+5003  Debug  XmlSchedulingLog.FoundDeleteTriggerGroupCommands
+    "Found {TriggerGroupDeleteCount}delete trigger group commands."
+5004  Debug  XmlSchedulingLog.FoundDeleteJobCommands
+    "Found {JobsToDeleteCount} delete job commands."
+5005  Debug  XmlSchedulingLog.FoundDeleteTriggerCommands
+    "Found {TriggersToDelete} delete trigger commands."
+5006  Debug  XmlSchedulingLog.OverwriteExistingDataSpecified
+    "Directive 'overwrite-existing-data' specified as: {Overwrite}"
+5007  Debug  XmlSchedulingLog.IgnoreDuplicatesSpecified
+    "Directive 'ignore-duplicates' specified as: {IgnoreDuplicates}"
+5008  Debug  XmlSchedulingLog.ScheduleTriggerRelativeSpecified
+    "Directive 'schedule-trigger-relative-to-replaced-trigger' specified as: {ScheduleRelative}"
+5009  Debug  XmlSchedulingLog.OverwriteExistingDataDefaulted
+    "Directive 'overwrite-existing-data' not specified, defaulting to {Overwrite}"
+5010  Debug  XmlSchedulingLog.IgnoreDuplicatesDefaulted
+    "Directive 'ignore-duplicates' not specified, defaulting to {IgnoreDuplicates}"
+5011  Debug  XmlSchedulingLog.ScheduleTriggerRelativeDefaulted
+    "Directive 'schedule-trigger-relative-to-replaced-trigger' not specified, defaulting to {ScheduleTriggerRelativeToReplacedTrigger}"
+5012  Debug  XmlSchedulingLog.FoundJobDefinitions
+    "Found {Count} job definitions."
+5013  Debug  XmlSchedulingLog.ParsedJobDefinition
+    "Parsed job definition: {JobDetail}"
+5014  Debug  XmlSchedulingLog.FoundTriggerDefinitions
+    "Found {TriggerCount} trigger definitions."
+5015  Debug  XmlSchedulingLog.ParsedTriggerDefinition
+    "Parsed trigger definition: {Trigger}"
+5016  Warning  XmlSchedulingLog.SchemaValidationUnavailable
+    "Unable to validate XML with schema: {Message}"
+5017  Warning  XmlSchedulingLog.SchemaValidationWarning
+    "{ValidationMessage}"
+5018  Information  XmlSchedulingLog.AddingJobsAndTriggers
+    "Adding {JobCount} jobs, {TriggerCount} triggers"
+5019  Information  XmlSchedulingLog.RemovingJob
+    "Removing job: {JobKey}"
+5020  Information  XmlSchedulingLog.NotOverwritingExistingJob
+    "Not overwriting existing job: {JobKey}"
+5021  Information  XmlSchedulingLog.ReplacingJob
+    "Replacing job: {JobKey}"
+5022  Information  XmlSchedulingLog.AddingJob
+    "Adding job: {JobKey}"
+5023  Debug  XmlSchedulingLog.ReschedulingJob
+    "Rescheduling job: {JobKey} with updated trigger: {TriggerKey}"
+5024  Information  XmlSchedulingLog.NotOverwritingExistingTriggerByKey
+    "Not overwriting existing trigger: {Key}"
+5025  Debug  XmlSchedulingLog.SchedulingJob
+    "Scheduling job: {JobKey} with trigger: {TriggerKey}"
+5026  Debug  XmlSchedulingLog.TriggerAlreadyExistedWillReschedule
+    "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed.  This is likely due to a race condition between multiple instances in the cluster.  Will try to reschedule instead."
+5027  Debug  XmlSchedulingLog.TriggerAlreadyExistedWillRescheduleJob
+    "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed. This is likely due to a race condition between multiple instances in the cluster. Will try to reschedule instead."
+5028  Information  XmlSchedulingLog.NotOverwritingExistingTrigger
+    "Not overwriting existing trigger: {JobKey}"
+5029  Warning  XmlSchedulingLog.DuplicatelyNamedTrigger
+    "Possibly duplicately named ({TriggerKey}) trigger in configuration, this can be caused by not having a fixed job key for targeted jobs"
+5030  Debug  XmlSchedulingLog.UsingRelativeScheduling
+    "Using relative scheduling for trigger with key {TriggerKey}"
+5031  Information  XmlSchedulingLog.DeletingAllJobsInAllGroups
+    "Deleting all jobs in ALL groups."
+5032  Information  XmlSchedulingLog.DeletingAllJobsInGroup
+    "Deleting all jobs in group: {Group}"
+5033  Information  XmlSchedulingLog.DeletingAllTriggersInAllGroups
+    "Deleting all triggers in ALL groups."
+5034  Information  XmlSchedulingLog.DeletingAllTriggersInGroup
+    "Deleting all triggers in group: {Group}"
+5035  Information  XmlSchedulingLog.DeletingJob
+    "Deleting job: {Key}"
+5036  Information  XmlSchedulingLog.DeletingTrigger
+    "Deleting trigger: {Key}"
+5100  Warning  UtilityLog.MisfireInstructionFromAnotherFamily
+    "Misfire instruction '{MisfireInstruction}' is not one of the {Family} trigger names. It resolves to code {Code}, which for this trigger means {Policy}; spell it '{Canonical}'"
+5101  Error  UtilityLog.TimeZoneAliasNotFound
+    "Could not find time zone using alias id {AliasId}"
+5102  Warning  UtilityLog.TypeFoundUnderNewName
+    "Type '{OldName}' was found as '{NewName}'; the type moved in Quartz 4.0. Update the configuration, as this fallback will not last forever."
+5103  Warning  UtilityLog.UnrecognizedCronMisfirePolicy
+    "Unrecognized misfire policy {MisfireInstruction}. Derived builder will use the default cron trigger behavior (FireOnceNow)"
+5104  Error  UtilityLog.ListenerRaisedException
+    "Listener {ListenerName} - method {MethodName} raised an exception: {ExceptionMessage}"
+5105  Error  UtilityLog.SchedulerListenerRaisedException
+    "Listener method {MethodName} raised an exception: {ExceptionMessage}"
+5106  Information  UtilityLog.ChainingToJob
+    "Job '{JobKey}' will now chain to Job '{Job}'"
+5107  Error  UtilityLog.ChainingToJobFailed
+    "Error encountered during chaining to Job '{Job}'"
+5108  Warning  UtilityLog.FilePathResolutionDenied
+    "Unable to resolve file path '{FileName}' due to security exception, probably running under medium trust"
+5109  Warning  UtilityLog.EnvironmentVariableReadDenied
+    "Unable to read environment variable '{Key}' due to security exception, probably running under medium trust"
+5110  Warning  UtilityLog.EnvironmentVariablesReadDenied
+    "Unable to read environment variables due to security exception, probably running under medium trust"

--- a/src/Quartz/Configuration/ConfigurationLog.cs
+++ b/src/Quartz/Configuration/ConfigurationLog.cs
@@ -1,0 +1,116 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// Every event configuration, dependency injection and hosting log — the parts a container builds a
+/// scheduler out of — as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 4000-4999 belong to this area and are allocated in file order: the configuration
+/// diagnostics themselves first, then the scheduler factory, the instance id generator, the job
+/// factories and the thread pools. Those last live in <c>Quartz.Impl</c> and reach these methods
+/// through a <c>using Quartz.Configuration;</c>: one class per area is what makes an id range mean
+/// something, and the area spans two namespaces.
+/// </para>
+/// <para>
+/// An id, once given out, is what an operator filters and alerts on, so it is never reused for a
+/// different event and never renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed
+/// diff.
+/// </para>
+/// </remarks>
+internal static partial class ConfigurationLog
+{
+    [LoggerMessage(EventId = 4000, Level = LogLevel.Debug, Message = "The shared-database check could not read what database scheduler '{SchedulerName}' talks to.")]
+    public static partial void SharedDatabaseCheckUnavailable(this ILogger logger, string schedulerName, Exception exception);
+
+    [LoggerMessage(EventId = 4001, Level = LogLevel.Warning, Message = "Scheduler '{SchedulerName}' (data source '{DataSource}', table prefix '{TablePrefix}') and scheduler '{OtherSchedulerName}' (data source '{OtherDataSource}', table prefix '{OtherTablePrefix}') use the same database with different table prefixes, so neither can see the other's rows. Schedulers sharing a database are normally told apart by SCHED_NAME and share one table prefix; separate table sets are legal, and if that is what you meant this warning is expected. If it is not, the scheduler with the wrong prefix starts cleanly, passes schema validation against the tables it was pointed at, and never sees its own data.")]
+    public static partial void SchedulersShareDatabaseWithDifferentPrefixes(
+        this ILogger logger,
+        string schedulerName,
+        string dataSource,
+        string tablePrefix,
+        string otherSchedulerName,
+        string otherDataSource,
+        string otherTablePrefix);
+
+    [LoggerMessage(EventId = 4002, Level = LogLevel.Information, Message = "Quartz Scheduler {Version} - '{SchedulerName}' with instanceId '{SchedulerInstanceId}' initialized")]
+    public static partial void SchedulerInitialized(this ILogger logger, string version, string schedulerName, string schedulerInstanceId);
+
+    [LoggerMessage(EventId = 4003, Level = LogLevel.Information, Message = "Using thread pool '{ThreadPoolType}', size: {ThreadPoolSize}")]
+    public static partial void UsingThreadPool(this ILogger logger, string? threadPoolType, int threadPoolSize);
+
+    [LoggerMessage(EventId = 4004, Level = LogLevel.Information, Message = "Using job store '{JobStoreType}', supports persistence: {SupportsPersistence}, clustered: {Clustered}")]
+    public static partial void UsingJobStore(this ILogger logger, string? jobStoreType, bool supportsPersistence, bool clustered);
+
+    [LoggerMessage(EventId = 4005, Level = LogLevel.Error, Message = "Couldn't generate instance id")]
+    public static partial void InstanceIdGenerationFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 4006, Level = LogLevel.Error, Message = "Got another exception while shutting down after instantiation exception")]
+    public static partial void ShutdownAfterInstantiationFailureFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 4007, Level = LogLevel.Information, Message = "Host name '{HostName}' was too long, shortened to '{Newname}'")]
+    public static partial void HostNameShortened(this ILogger logger, string hostName, string newname);
+
+    [LoggerMessage(EventId = 4008, Level = LogLevel.Warning, Message = "Failed to return a job after its creation failed; the original error follows")]
+    public static partial void JobReturnAfterFailedCreationFailed(this ILogger logger, Exception exception);
+
+    /// <remarks>
+    /// The whole message is one placeholder because it is assembled at the call site out of the job
+    /// type, the property and the value that would not go into it, and there are nine call sites that
+    /// each word it differently. The text an operator reads is unchanged, the event id is what they
+    /// filter on, and the <c>CA2254</c> pragma that used to stand here is gone.
+    /// </remarks>
+    [LoggerMessage(EventId = 4009, Level = LogLevel.Warning, Message = "{Problem}")]
+    public static partial void JobPropertyNotSet(this ILogger logger, string problem, Exception? exception);
+
+    [LoggerMessage(EventId = 4010, Level = LogLevel.Debug, Message = "Producing instance of Job '{JobKey}', class={JobFullName}")]
+    public static partial void ProducingJobInstance(this ILogger logger, JobKey jobKey, string? jobFullName);
+
+    [LoggerMessage(EventId = 4011, Level = LogLevel.Debug, Message = "TaskSchedulingThreadPool configured with max concurrency of {MaxConcurrency} and TaskScheduler {SchedulerName}.")]
+    public static partial void TaskSchedulingThreadPoolConfigured(this ILogger logger, int maxConcurrency, string schedulerName);
+
+    [LoggerMessage(EventId = 4012, Level = LogLevel.Error, Message = "A task handed to the thread pool faulted.")]
+    public static partial void ThreadPoolTaskFaulted(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 4013, Level = LogLevel.Debug, Message = "Shutting down threadpool...")]
+    public static partial void ThreadPoolShuttingDown(this ILogger logger);
+
+    [LoggerMessage(EventId = 4014, Level = LogLevel.Debug, Message = "No executing jobs remaining, all threads stopped.")]
+    public static partial void ThreadPoolDrained(this ILogger logger);
+
+    [LoggerMessage(EventId = 4015, Level = LogLevel.Debug, Message = "Draining threadpool...")]
+    public static partial void ThreadPoolDraining(this ILogger logger);
+
+    [LoggerMessage(EventId = 4016, Level = LogLevel.Debug, Message = "Gave up waiting for the thread pool to drain; work is still running.")]
+    public static partial void ThreadPoolDrainGivenUp(this ILogger logger);
+
+    [LoggerMessage(EventId = 4017, Level = LogLevel.Debug, Message = "Thread pool closed to new work with {RunningTaskCount} running tasks remaining.")]
+    public static partial void ThreadPoolClosedToNewWork(this ILogger logger, int runningTaskCount);
+
+    [LoggerMessage(EventId = 4018, Level = LogLevel.Debug, Message = "Shutdown of threadpool complete.")]
+    public static partial void ThreadPoolShutdownComplete(this ILogger logger);
+
+    [LoggerMessage(EventId = 4019, Level = LogLevel.Debug, Message = "Shutdown complete")]
+    public static partial void ZeroSizeThreadPoolShutdownComplete(this ILogger logger);
+}

--- a/src/Quartz/Configuration/SharedDatabaseValidator.cs
+++ b/src/Quartz/Configuration/SharedDatabaseValidator.cs
@@ -72,10 +72,7 @@ internal sealed class SharedDatabaseValidator
             // A diagnostic must never be the reason a scheduler fails to start. The one thing below that
             // can throw is a job store of somebody else's answering for its connection details, and a
             // provider that refuses to say could not have been compared with anything anyway.
-            logger.LogDebug(
-                e,
-                "The shared-database check could not read what database scheduler '{SchedulerName}' talks to.",
-                schedulerName);
+            logger.SharedDatabaseCheckUnavailable(schedulerName, e);
         }
     }
 
@@ -120,13 +117,7 @@ internal sealed class SharedDatabaseValidator
 
         foreach (Arrangement other in disagreeing)
         {
-            logger.LogWarning(
-                "Scheduler '{SchedulerName}' (data source '{DataSource}', table prefix '{TablePrefix}') and scheduler "
-                + "'{OtherSchedulerName}' (data source '{OtherDataSource}', table prefix '{OtherTablePrefix}') use the same "
-                + "database with different table prefixes, so neither can see the other's rows. Schedulers sharing a database "
-                + "are normally told apart by SCHED_NAME and share one table prefix; separate table sets are legal, and if that "
-                + "is what you meant this warning is expected. If it is not, the scheduler with the wrong prefix starts cleanly, "
-                + "passes schema validation against the tables it was pointed at, and never sees its own data.",
+            logger.SchedulersShareDatabaseWithDifferentPrefixes(
                 arrangement.SchedulerName,
                 arrangement.DataSource,
                 arrangement.TablePrefix,

--- a/src/Quartz/Core/CoreLog.cs
+++ b/src/Quartz/Core/CoreLog.cs
@@ -1,0 +1,157 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Core;
+
+/// <summary>
+/// Every event the scheduler core logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 1000-1999 belong to this area and are allocated in file order: the scheduler itself
+/// (1000-1029), its firing loop (1030-1049), the job run shell (1050-1069), the signaler (1070-1079)
+/// and the error listener of last resort (1080-1089). An id, once given out, is what an operator
+/// filters and alerts on, so it is never reused for a different event and never renumbered;
+/// <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// </remarks>
+internal static partial class CoreLog
+{
+    [LoggerMessage(EventId = 1000, Level = LogLevel.Information, Message = "JobFactory set to: {Value}")]
+    public static partial void JobFactorySet(this ILogger logger, IJobFactory value);
+
+    [LoggerMessage(EventId = 1001, Level = LogLevel.Information, Message = "Quartz Scheduler created")]
+    public static partial void SchedulerCreated(this ILogger logger);
+
+    [LoggerMessage(EventId = 1002, Level = LogLevel.Information, Message = "Scheduler {SchedulerIdentifier} started.")]
+    public static partial void SchedulerStarted(this ILogger logger, string schedulerIdentifier);
+
+    [LoggerMessage(EventId = 1003, Level = LogLevel.Error, Message = "Unable to start scheduler after startup delay.")]
+    public static partial void DelayedStartFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 1004, Level = LogLevel.Information, Message = "Scheduler {SchedulerIdentifier} paused.")]
+    public static partial void SchedulerPaused(this ILogger logger, string schedulerIdentifier);
+
+    [LoggerMessage(EventId = 1005, Level = LogLevel.Information, Message = "Scheduler {SchedulerIdentifier} shutting down.")]
+    public static partial void SchedulerShuttingDown(this ILogger logger, string schedulerIdentifier);
+
+    [LoggerMessage(EventId = 1006, Level = LogLevel.Warning, Message = "Scheduler {SchedulerIdentifier} gave up waiting for its running jobs, which are still executing. Their job store updates may not complete, and the store is about to be shut down under them.")]
+    public static partial void GaveUpWaitingForRunningJobs(this ILogger logger, string schedulerIdentifier);
+
+    [LoggerMessage(EventId = 1007, Level = LogLevel.Information, Message = "Scheduler {SchedulerIdentifier} Shutdown complete.")]
+    public static partial void SchedulerShutdownComplete(this ILogger logger, string schedulerIdentifier);
+
+    [LoggerMessage(EventId = 1008, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of error")]
+    public static partial void ListenerNotificationOfErrorFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 1009, Level = LogLevel.Error, Message = "  Original error (for notification) was: {Message}")]
+    public static partial void OriginalErrorForNotification(this ILogger logger, string? message, Exception? exception);
+
+    [LoggerMessage(EventId = 1010, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of unscheduled job. Trigger={TriggerKey}")]
+    public static partial void ListenerNotificationOfUnscheduledJobFailed(this ILogger logger, string triggerKey, Exception exception);
+
+    [LoggerMessage(EventId = 1011, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of paused group: {Group}")]
+    public static partial void ListenerNotificationOfPausedGroupFailed(this ILogger logger, string? group, Exception exception);
+
+    [LoggerMessage(EventId = 1012, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of trigger in error state. Trigger={TriggerKey}")]
+    public static partial void ListenerNotificationOfTriggerInErrorFailed(this ILogger logger, TriggerKey triggerKey, Exception exception);
+
+    [LoggerMessage(EventId = 1013, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of job triggers in error state. Job={JobKey}")]
+    public static partial void ListenerNotificationOfJobTriggersInErrorFailed(this ILogger logger, JobKey jobKey, Exception exception);
+
+    [LoggerMessage(EventId = 1014, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of paused trigger. Trigger={TriggerKey}")]
+    public static partial void ListenerNotificationOfPausedTriggerFailed(this ILogger logger, TriggerKey triggerKey, Exception exception);
+
+    [LoggerMessage(EventId = 1015, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of resumed trigger. Trigger={TriggerKey}")]
+    public static partial void ListenerNotificationOfResumedTriggerFailed(this ILogger logger, TriggerKey triggerKey, Exception exception);
+
+    [LoggerMessage(EventId = 1016, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of paused job. Job={JobKey}")]
+    public static partial void ListenerNotificationOfPausedJobFailed(this ILogger logger, JobKey jobKey, Exception exception);
+
+    [LoggerMessage(EventId = 1017, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of resumed job: {JobKey}")]
+    public static partial void ListenerNotificationOfResumedJobFailed(this ILogger logger, JobKey jobKey, Exception exception);
+
+    [LoggerMessage(EventId = 1018, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of resumed group: {Group}")]
+    public static partial void ListenerNotificationOfResumedGroupFailed(this ILogger logger, string group, Exception exception);
+
+    [LoggerMessage(EventId = 1019, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of {Action}")]
+    public static partial void ListenerNotificationFailed(this ILogger logger, string action, Exception exception);
+
+    [LoggerMessage(EventId = 1030, Level = LogLevel.Debug, Message = "Batch acquisition of {TriggerCount} triggers")]
+    public static partial void TriggerBatchAcquired(this ILogger logger, int triggerCount);
+
+    [LoggerMessage(EventId = 1031, Level = LogLevel.Error, Message = "quartzSchedulerThreadLoop: RuntimeException {Message}")]
+    public static partial void SchedulerThreadLoopFailed(this ILogger logger, string message, Exception exception);
+
+    [LoggerMessage(EventId = 1032, Level = LogLevel.Error, Message = "DbException while firing trigger {Trigger}")]
+    public static partial void TriggerFireFailedWithDbException(this ILogger logger, IOperableTrigger trigger, Exception exception);
+
+    [LoggerMessage(EventId = 1033, Level = LogLevel.Debug, Message = "ThreadPool.TryRun() returned false due to scheduler shutdown, completing trigger")]
+    public static partial void ThreadPoolRefusedWorkDuringShutdown(this ILogger logger);
+
+    [LoggerMessage(EventId = 1034, Level = LogLevel.Error, Message = "ThreadPool.TryRun() returned false")]
+    public static partial void ThreadPoolRefusedWork(this ILogger logger);
+
+    [LoggerMessage(EventId = 1035, Level = LogLevel.Error, Message = "Runtime error occurred in main trigger firing loop.")]
+    public static partial void TriggerFiringLoopFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 1036, Level = LogLevel.Error, Message = "Error releasing acquired trigger '{TriggerKey}' {Context}")]
+    public static partial void AcquiredTriggerReleaseFailed(this ILogger logger, TriggerKey triggerKey, string context, Exception exception);
+
+    [LoggerMessage(EventId = 1050, Level = LogLevel.Debug, Message = "Calling Execute on job {JobKey}")]
+    public static partial void JobExecuting(this ILogger logger, JobKey jobKey);
+
+    [LoggerMessage(EventId = 1051, Level = LogLevel.Information, Message = "Job {JobDetailKey} was cancelled")]
+    public static partial void JobCancelled(this ILogger logger, JobKey jobDetailKey);
+
+    [LoggerMessage(EventId = 1052, Level = LogLevel.Error, Message = "Job {JobDetailKey} threw a JobExecutionException: ")]
+    public static partial void JobThrewJobExecutionException(this ILogger logger, JobKey jobDetailKey, Exception exception);
+
+    [LoggerMessage(EventId = 1053, Level = LogLevel.Error, Message = "Job {JobDetailKey} threw an unhandled Exception: ")]
+    public static partial void JobThrewUnhandledException(this ILogger logger, JobKey jobDetailKey, Exception exception);
+
+    [LoggerMessage(EventId = 1054, Level = LogLevel.Debug, Message = "Trigger instruction : {InstructionCode}")]
+    public static partial void TriggerInstructionDecided(this ILogger logger, SchedulerInstruction instructionCode);
+
+    [LoggerMessage(EventId = 1055, Level = LogLevel.Debug, Message = "Rescheduling trigger to reexecute")]
+    public static partial void TriggerRefiring(this ILogger logger);
+
+    [LoggerMessage(EventId = 1070, Level = LogLevel.Information, Message = "Initialized Scheduler Signaller of type: {Type}")]
+    public static partial void SchedulerSignalerInitialized(this ILogger logger, Type type);
+
+    [LoggerMessage(EventId = 1071, Level = LogLevel.Error, Message = "Error notifying listeners of trigger misfire.")]
+    public static partial void ListenerNotificationOfMisfireFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 1080, Level = LogLevel.Error, Message = "{Message} (scheduler: {SchedulerName})")]
+    public static partial void SchedulerError(this ILogger logger, string? message, string schedulerName, Exception? exception);
+
+    [LoggerMessage(EventId = 1081, Level = LogLevel.Error, Message = "{Message} (scheduler: {SchedulerName}, trigger: {TriggerKey}, job: {JobKey}, fire instance: {FireInstanceId})")]
+    public static partial void SchedulerErrorForFire(
+        this ILogger logger,
+        string? message,
+        string schedulerName,
+        TriggerKey? triggerKey,
+        JobKey? jobKey,
+        string? fireInstanceId,
+        Exception? exception);
+}

--- a/src/Quartz/Core/ErrorLogger.cs
+++ b/src/Quartz/Core/ErrorLogger.cs
@@ -31,22 +31,20 @@ internal sealed class ErrorLogger : ISchedulerListener
         // the scheduler had lost them rather than never having had them.
         if (error.TriggerKey is null && error.JobKey is null && error.FireInstanceId is null)
         {
-            logger.LogError(
-                error.Exception,
-                "{Message} (scheduler: {SchedulerName})",
+            logger.SchedulerError(
                 error.Message,
-                scheduler.SchedulerName);
+                scheduler.SchedulerName,
+                error.Exception);
         }
         else
         {
-            logger.LogError(
-                error.Exception,
-                "{Message} (scheduler: {SchedulerName}, trigger: {TriggerKey}, job: {JobKey}, fire instance: {FireInstanceId})",
+            logger.SchedulerErrorForFire(
                 error.Message,
                 scheduler.SchedulerName,
                 error.TriggerKey,
                 error.JobKey,
-                error.FireInstanceId);
+                error.FireInstanceId,
+                error.Exception);
         }
 
         return default;

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -208,7 +208,7 @@ internal sealed class JobRunShell
 
                 if (logger.IsEnabled(LogLevel.Debug))
                 {
-                    logger.LogDebug("Calling Execute on job {JobKey}", jobDetail.Key);
+                    logger.JobExecuting(jobDetail.Key);
                 }
 
                 TimeProvider timeProvider = qs.resources.TimeProvider;
@@ -228,19 +228,19 @@ internal sealed class JobRunShell
                 catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
                 {
                     endTimestamp = timeProvider.GetTimestamp();
-                    logger.LogInformation("Job {JobDetailKey} was cancelled", jobDetail.Key);
+                    logger.JobCancelled(jobDetail.Key);
                 }
                 catch (JobExecutionException jee)
                 {
                     endTimestamp = timeProvider.GetTimestamp();
                     jee.JobDetail = jobDetail;
                     jobExEx = jee;
-                    logger.LogError(jee, "Job {JobDetailKey} threw a JobExecutionException: ", jobDetail.Key);
+                    logger.JobThrewJobExecutionException(jobDetail.Key, jee);
                 }
                 catch (Exception e)
                 {
                     endTimestamp = timeProvider.GetTimestamp();
-                    logger.LogError(e, "Job {JobDetailKey} threw an unhandled Exception: ", jobDetail.Key);
+                    logger.JobThrewUnhandledException(jobDetail.Key, e);
                     SchedulerException se = new JobExecutionProcessException(context, e);
                     await qs.NotifySchedulerListenersError(
                         ErrorFor(context, $"Job {context.JobDetail.Key} threw an exception.", se),
@@ -263,7 +263,7 @@ internal sealed class JobRunShell
                     instructionCode = trigger.ExecutionComplete(context, jobExEx);
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.LogDebug("Trigger instruction : {InstructionCode}", instructionCode);
+                        logger.TriggerInstructionDecided(instructionCode);
                     }
                 }
                 catch (Exception e)
@@ -281,7 +281,7 @@ internal sealed class JobRunShell
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.LogDebug("Rescheduling trigger to reexecute");
+                        logger.TriggerRefiring();
                     }
                     context.IncrementRefireCount();
                     continue;

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -242,7 +242,7 @@ internal sealed class QuartzScheduler
                 Throw.ArgumentException("JobFactory cannot be set to null!");
             }
 
-            logger.LogInformation("JobFactory set to: {Value}", value);
+            logger.JobFactorySet(value);
 
             jobFactory = value;
         }
@@ -282,7 +282,7 @@ internal sealed class QuartzScheduler
         SchedulerSignaler = new SchedulerSignalerImpl(this, schedThread, loggerFactory.CreateLogger<SchedulerSignalerImpl>());
         Scheduler = new StdScheduler(this);
 
-        logger.LogInformation("Quartz Scheduler created");
+        logger.SchedulerCreated();
     }
 
     /// <summary>
@@ -360,7 +360,7 @@ internal sealed class QuartzScheduler
 
         status = SchedulerStatus.Running;
 
-        logger.LogInformation("Scheduler {SchedulerIdentifier} started.", resources.GetUniqueIdentifier());
+        logger.SchedulerStarted(resources.GetUniqueIdentifier());
 
         await NotifySchedulerListenersStarted(cancellationToken).ConfigureAwait(false);
     }
@@ -385,7 +385,7 @@ internal sealed class QuartzScheduler
             }
             catch (SchedulerException se)
             {
-                logger.LogError(se, "Unable to start scheduler after startup delay.");
+                logger.DelayedStartFailed(se);
             }
         }, cancellationToken);
 #pragma warning restore MA0134
@@ -431,7 +431,7 @@ internal sealed class QuartzScheduler
     {
         await resources.JobStore.SchedulerPaused(cancellationToken).ConfigureAwait(false);
         schedThread.TogglePause(pause: true);
-        logger.LogInformation("Scheduler {SchedulerIdentifier} paused.", resources.GetUniqueIdentifier());
+        logger.SchedulerPaused(resources.GetUniqueIdentifier());
     }
 
     /// <summary>
@@ -495,7 +495,7 @@ internal sealed class QuartzScheduler
 
         try
         {
-            logger.LogInformation("Scheduler {SchedulerIdentifier} shutting down.", resources.GetUniqueIdentifier());
+            logger.SchedulerShuttingDown(resources.GetUniqueIdentifier());
 
             // Firing stops here, but the scheduler does not pass through standby on its way down and no
             // listener is told that it did: a scheduler being torn down is not one waiting to be started
@@ -542,10 +542,7 @@ internal sealed class QuartzScheduler
                 // handed the whole of the execution, of which that update is the last act.
                 if (!await resources.ThreadPool.Drain(cancellationToken).ConfigureAwait(false))
                 {
-                    logger.LogWarning(
-                        "Scheduler {SchedulerIdentifier} gave up waiting for its running jobs, which are still executing. "
-                        + "Their job store updates may not complete, and the store is about to be shut down under them.",
-                        resources.GetUniqueIdentifier());
+                    logger.GaveUpWaitingForRunningJobs(resources.GetUniqueIdentifier());
                 }
             }
             else
@@ -585,7 +582,7 @@ internal sealed class QuartzScheduler
             holdToPreventGc.Clear();
         }
 
-        logger.LogInformation("Scheduler {SchedulerIdentifier} Shutdown complete.", resources.GetUniqueIdentifier());
+        logger.SchedulerShutdownComplete(resources.GetUniqueIdentifier());
     }
 
     /// <summary>
@@ -2140,8 +2137,8 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of error");
-                logger.LogError(error.Exception, "  Original error (for notification) was: {Message}", error.Message);
+                logger.ListenerNotificationOfErrorFailed(e);
+                logger.OriginalErrorForNotification(error.Message, error.Exception);
             }
         }
     }
@@ -2184,9 +2181,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e,
-                    "Error while notifying SchedulerListener of unscheduled job. Trigger={TriggerKey}",
-                    triggerKey?.ToString() ?? "ALL DATA");
+                logger.ListenerNotificationOfUnscheduledJobFailed(triggerKey?.ToString() ?? "ALL DATA", e);
             }
         }
     }
@@ -2224,7 +2219,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of paused group: {Group}", group);
+                logger.ListenerNotificationOfPausedGroupFailed(group, e);
             }
         }
     }
@@ -2246,7 +2241,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of trigger in error state. Trigger={TriggerKey}", triggerKey);
+                logger.ListenerNotificationOfTriggerInErrorFailed(triggerKey, e);
             }
         }
     }
@@ -2268,7 +2263,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of job triggers in error state. Job={JobKey}", jobKey);
+                logger.ListenerNotificationOfJobTriggersInErrorFailed(jobKey, e);
             }
         }
     }
@@ -2292,7 +2287,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of paused trigger. Trigger={TriggerKey}", triggerKey);
+                logger.ListenerNotificationOfPausedTriggerFailed(triggerKey, e);
             }
         }
     }
@@ -2328,7 +2323,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of resumed trigger. Trigger={TriggerKey}", triggerKey);
+                logger.ListenerNotificationOfResumedTriggerFailed(triggerKey, e);
             }
         }
     }
@@ -2351,7 +2346,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of paused job. Job={JobKey}", jobKey);
+                logger.ListenerNotificationOfPausedJobFailed(jobKey, e);
             }
         }
     }
@@ -2375,7 +2370,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of paused group: {Group}", group);
+                logger.ListenerNotificationOfPausedGroupFailed(group, e);
             }
         }
     }
@@ -2399,7 +2394,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of resumed job: {JobKey}", jobKey);
+                logger.ListenerNotificationOfResumedJobFailed(jobKey, e);
             }
         }
     }
@@ -2423,7 +2418,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of resumed group: {Group}", group);
+                logger.ListenerNotificationOfResumedGroupFailed(group, e);
             }
         }
     }
@@ -2489,7 +2484,7 @@ internal sealed class QuartzScheduler
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error while notifying SchedulerListener of {Action}", action);
+                logger.ListenerNotificationFailed(action, e);
             }
         }
     }

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -351,7 +351,7 @@ internal sealed class QuartzSchedulerThread
                         acquiresFailed = 0;
                         if (logger.IsEnabled(LogLevel.Debug))
                         {
-                            logger.LogDebug("Batch acquisition of {TriggerCount} triggers", triggers.Count);
+                            logger.TriggerBatchAcquired(triggers.Count);
                         }
                     }
                     catch (JobPersistenceException jpe)
@@ -379,7 +379,7 @@ internal sealed class QuartzSchedulerThread
                     {
                         if (acquiresFailed == 0)
                         {
-                            logger.LogError(e, "quartzSchedulerThreadLoop: RuntimeException {Message}", e.Message);
+                            logger.SchedulerThreadLoopFailed(e.Message, e);
                         }
                         if (acquiresFailed < int.MaxValue)
                         {
@@ -496,7 +496,7 @@ internal sealed class QuartzSchedulerThread
                             // TODO SQL exception?
                             if (exception is not null && (exception is DbException || exception.InnerException is DbException))
                             {
-                                logger.LogError(exception, "DbException while firing trigger {Trigger}", trigger);
+                                logger.TriggerFireFailedWithDbException(trigger, exception);
                                 await SafeReleaseAcquiredTrigger(trigger, "after DbException").ConfigureAwait(false);
                                 continue;
                             }
@@ -580,14 +580,14 @@ internal sealed class QuartzSchedulerThread
                                     // Scheduler is shutting down, complete the trigger gracefully
                                     // Use TriggeredJobComplete to properly unblock other triggers
                                     // for DisallowConcurrentExecution jobs (TriggersFired already ran)
-                                    logger.LogDebug("ThreadPool.TryRun() returned false due to scheduler shutdown, completing trigger");
+                                    logger.ThreadPoolRefusedWorkDuringShutdown();
                                     await qsRsrcs.JobStore.TriggeredJobComplete(trigger, bndle.JobDetail, SchedulerInstruction.NoInstruction, CancellationToken.None).ConfigureAwait(false);
                                 }
                                 else
                                 {
                                     // this case should never happen, as it is indicative of a bug in the thread pool or
                                     // a thread pool being used concurrently - which the docs say not to do...
-                                    logger.LogError("ThreadPool.TryRun() returned false");
+                                    logger.ThreadPoolRefusedWork();
                                     await qsRsrcs.JobStore.TriggeredJobComplete(trigger, bndle.JobDetail, SchedulerInstruction.SetAllJobTriggersError, CancellationToken.None).ConfigureAwait(false);
                                 }
                             }
@@ -620,7 +620,7 @@ internal sealed class QuartzSchedulerThread
             }
             catch (Exception re)
             {
-                logger.LogError(re, "Runtime error occurred in main trigger firing loop.");
+                logger.TriggerFiringLoopFailed(re);
             }
         } // while (!halted)
     }
@@ -704,7 +704,7 @@ internal sealed class QuartzSchedulerThread
         }
         catch (Exception releaseEx)
         {
-            logger.LogError(releaseEx, "Error releasing acquired trigger '{TriggerKey}' {Context}", trigger.Key, context);
+            logger.AcquiredTriggerReleaseFailed(trigger.Key, context, releaseEx);
         }
     }
 

--- a/src/Quartz/Core/SchedulerSignalerImpl.cs
+++ b/src/Quartz/Core/SchedulerSignalerImpl.cs
@@ -44,7 +44,7 @@ internal sealed class SchedulerSignalerImpl : ISchedulerSignaler
         this.schedThread = schedThread;
         this.logger = logger;
 
-        logger.LogInformation("Initialized Scheduler Signaller of type: {Type}", GetType());
+        logger.SchedulerSignalerInitialized(GetType());
     }
 
 
@@ -63,7 +63,7 @@ internal sealed class SchedulerSignalerImpl : ISchedulerSignaler
         }
         catch (SchedulerException se)
         {
-            logger.LogError(se, "Error notifying listeners of trigger misfire.");
+            logger.ListenerNotificationOfMisfireFailed(se);
 
             // The trigger travels with the failure: a listener that throws on one trigger's misfire
             // should not leave the report saying only that some misfire notification failed.

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -717,7 +717,7 @@ public abstract class AdoJobStoreBase : IJobStore
 
         if (Delegate is SQLiteDelegate && LockHandler is not SQLiteSemaphore)
         {
-            Logger.LogInformation("Detected SQLite usage, changing to use SQLiteSemaphore for in-memory locking");
+            Logger.SqliteSemaphoreSubstituted();
             LockHandler = new SQLiteSemaphore();
         }
 
@@ -729,19 +729,19 @@ public abstract class AdoJobStoreBase : IJobStore
             }
             if (!AcquireTriggersWithinLock)
             {
-                Logger.LogInformation("With SQLite we need to set AcquireTriggersWithinLock to true, changing");
+                Logger.SqliteAcquireTriggersWithinLockForced();
                 AcquireTriggersWithinLock = true;
             }
             if (TransactionIsolationLevel != IsolationLevel.Serializable)
             {
                 // Not a default but a requirement: concurrent SQLite transactions at a lower level fail
                 // with "database is locked", so an explicit lower level is overridden rather than kept.
-                Logger.LogInformation("Detected usage of SQLiteDelegate - forcing transaction isolation level to 'Serializable'");
+                Logger.SqliteSerializableIsolationForced();
                 TransactionIsolationLevel = IsolationLevel.Serializable;
             }
             if (!LockAllOperations)
             {
-                Logger.LogInformation("With SQLite all operations must be serialized, setting LockAllOperations to true");
+                Logger.SqliteLockAllOperationsForced();
                 LockAllOperations = true;
             }
         }
@@ -750,7 +750,7 @@ public abstract class AdoJobStoreBase : IJobStore
         // begun at whatever level the application chose, and cannot be changed after the fact.
         if (AcceptEnlistedTransactions && TransactionIsolationLevel is not null && Delegate is not SQLiteDelegate)
         {
-            Logger.LogWarning("The configured transaction isolation level applies only to connections the job store opens itself: an operation running on a connection enlisted by the application uses that transaction's isolation level instead.");
+            Logger.IsolationLevelIgnoredForEnlistedTransactions();
         }
 
         // If the user hasn't specified an explicit lock handler, then
@@ -779,7 +779,7 @@ public abstract class AdoJobStoreBase : IJobStore
                     if (SelectWithLockSql is null)
                     {
                         const string DefaultLockSql = "SELECT * FROM {0}LOCKS WITH (UPDLOCK,ROWLOCK) WHERE " + AdoConstants.ColumnSchedulerName + " = @schedulerName AND LOCK_NAME = @lockName";
-                        Logger.LogInformation("Detected usage of SqlServerDelegate - defaulting 'selectWithLockSQL' to '{DefaultLockSql}'.", DefaultLockSql);
+                        Logger.SqlServerLockSqlDefaulted(DefaultLockSql);
                         SelectWithLockSql = DefaultLockSql;
                     }
                 }
@@ -793,12 +793,12 @@ public abstract class AdoJobStoreBase : IJobStore
                     LockHandler = new SelectForUpdateSemaphore(TablePrefix, InstanceName, SelectWithLockSql, DbProvider);
                 }
 
-                Logger.LogInformation("Using db table-based data access locking (synchronization) via {LockHandlerType}.", LockHandler.GetType().Name);
+                Logger.UsingDatabaseLocking(LockHandler.GetType().Name);
             }
             else
             {
                 LockHandler = new SimpleSemaphore();
-                Logger.LogInformation("Using thread monitor-based data access locking (synchronization) via {LockHandlerType}.", LockHandler.GetType().Name);
+                Logger.UsingMonitorLocking(LockHandler.GetType().Name);
             }
         }
         else
@@ -812,11 +812,11 @@ public abstract class AdoJobStoreBase : IJobStore
                 {
                     // SQLite arrives here with a handler the store installed rather than one the caller
                     // chose, so this is a property of the database rather than a configuration to undo.
-                    Logger.LogWarning("A row-lock statement is configured, but SQLite serializes callers in process rather than by locking a row, so the statement is ignored.");
+                    Logger.RowLockStatementIgnoredBySqlite();
                 }
                 else
                 {
-                    Logger.LogWarning("A row-lock statement is configured, but lock handler {LockHandlerType} was supplied rather than built by the job store, so the statement is ignored. Pass it to the handler's constructor, or remove the lock handler and let the store choose one.", LockHandler.GetType().Name);
+                    Logger.RowLockStatementIgnoredBySuppliedHandler(LockHandler.GetType().Name);
                 }
             }
 
@@ -828,18 +828,18 @@ public abstract class AdoJobStoreBase : IJobStore
                     // SQLite gets this handler unconditionally, before the upgrade to database locks
                     // can be applied, and it cannot be swapped for one - so this is a property of the
                     // combination rather than something to reconfigure away.
-                    Logger.LogWarning("Accepting enlisted transactions with SQLite keeps in-process locking: SQLiteSemaphore releases the lock when the scheduling call returns, while the application transaction still holds the SQLite writer lock, so a concurrent scheduler operation can fail with 'database is locked' until that transaction completes. Keep enlisted transactions short, or use a database that supports row locking.");
+                    Logger.EnlistedTransactionsWithSqlite();
                 }
                 else
                 {
-                    Logger.LogWarning("Accepting enlisted transactions with lock handler {LockHandlerType}, which does not lock in the database. Its locks are released before the application commits its transaction, so concurrent callers can act on scheduling data that is not visible to them yet.", LockHandler.GetType().Name);
+                    Logger.EnlistedTransactionsWithInProcessLocking(LockHandler.GetType().Name);
                 }
             }
 
             // be ready to give a friendly warning if SQL Server is used and sub-optimal locking
             if (LockHandler is UpdateRowSemaphore and not SqlServerMemoryOptimizedUpdateRowSemaphore && Delegate is SqlServerDelegate)
             {
-                Logger.LogWarning("Detected usage of SqlServerDelegate and UpdateRowSemaphore, removing 'quartz.jobStore.lockHandler.type' would allow more efficient SQL Server specific (UPDLOCK,ROWLOCK) row access");
+                Logger.SqlServerCouldUseRowLocking();
             }
             // be ready to give a friendly warning if SQL Server provider and wrong delegate
             if (DbProvider.Metadata.ConnectionType?.Namespace is not null
@@ -847,7 +847,7 @@ public abstract class AdoJobStoreBase : IJobStore
                 && DbProvider.Metadata.ConnectionType.Name == "SqlConnection"
                 && !(Delegate is SqlServerDelegate))
             {
-                Logger.LogWarning("Detected usage of SQL Server provider without SqlServerDelegate, SqlServerDelegate would provide better performance");
+                Logger.SqlServerProviderWithoutSqlServerDelegate();
             }
         }
 
@@ -872,7 +872,7 @@ public abstract class AdoJobStoreBase : IJobStore
             try
             {
                 var objectCount = await ExecuteWithoutLock<int>(conn => Delegate.ValidateSchema(conn, cancellationToken), cancellationToken).ConfigureAwait(false);
-                Logger.LogInformation("Successfully validated presence of {SchemaObjectCount} schema objects", objectCount);
+                Logger.SchemaValidated(objectCount);
             }
             catch (Exception ex)
             {
@@ -921,7 +921,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
             catch (SchedulerException se)
             {
-                Logger.LogError(se, "Failure occurred during job recovery: {ExceptionMessage}", se.Message);
+                Logger.JobRecoveryFailed(se.Message, se);
                 Throw.SchedulerConfigException("Failure occurred during job recovery.", se);
             }
         }
@@ -976,7 +976,7 @@ public abstract class AdoJobStoreBase : IJobStore
         }
         catch (Exception sqle)
         {
-            Logger.LogWarning(sqle, "Database connection Shutdown unsuccessful.");
+            Logger.DatabaseShutdownFailed(sqle);
         }
     }
 
@@ -1001,7 +1001,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
             catch (LockException le)
             {
-                Logger.LogError(le, "Error returning lock: {ExceptionMessage}", le.Message);
+                Logger.LockReleaseFailed(le.Message, le);
             }
         }
     }
@@ -1033,14 +1033,14 @@ public abstract class AdoJobStoreBase : IJobStore
 
             rows += await Delegate.UpdateTriggerStatesFromOtherStates(conn, StoredTriggerState.Paused, [StoredTriggerState.PausedBlocked], cancellationToken).ConfigureAwait(false);
 
-            Logger.LogInformation("Freed {Count} triggers from 'acquired' / 'blocked' state.", rows);
+            Logger.TriggersFreedFromAcquiredOrBlocked(rows);
 
             // clean up misfired jobs
             await RecoverMisfiredJobs(conn, true, cancellationToken).ConfigureAwait(false);
 
             // recover jobs marked for recovery that were not fully executed
             var recoveringJobTriggers = await Delegate.SelectTriggersForRecoveringJobs(conn, cancellationToken).ConfigureAwait(false);
-            Logger.LogInformation("Recovering {Count} jobs that were in-progress at the time of the last shut-down.", recoveringJobTriggers.Count);
+            Logger.RecoveringInProgressJobs(recoveringJobTriggers.Count);
 
             foreach (IOperableTrigger trigger in recoveringJobTriggers)
             {
@@ -1050,7 +1050,7 @@ public abstract class AdoJobStoreBase : IJobStore
                     await AddTrigger(conn, trigger, null, false, StoredTriggerState.Waiting, false, true, cancellationToken).ConfigureAwait(false);
                 }
             }
-            Logger.LogInformation("Recovery complete.");
+            Logger.RecoveryComplete();
 
             // remove lingering 'complete' triggers...
             var triggersInState = await Delegate.SelectTriggersInState(conn, StoredTriggerState.Complete, cancellationToken).ConfigureAwait(false);
@@ -1058,11 +1058,11 @@ public abstract class AdoJobStoreBase : IJobStore
             {
                 await DeleteTrigger(conn, trigger, cancellationToken).ConfigureAwait(false);
             }
-            Logger.LogInformation("Removed  {Count} 'complete' triggers.", triggersInState.Count);
+            Logger.CompleteTriggersRemoved(triggersInState.Count);
 
             // clean up any fired trigger entries
             int n = await Delegate.DeleteFiredTriggers(conn, new FiredTriggerQuery(), cancellationToken).ConfigureAwait(false);
-            Logger.LogInformation("Removed {Count} stale fired job entries.", n);
+            Logger.StaleFiredJobEntriesRemoved(n);
         }
         catch (JobPersistenceException)
         {
@@ -1097,22 +1097,18 @@ public abstract class AdoJobStoreBase : IJobStore
 
         if (hasMoreMisfiredTriggers)
         {
-            Logger.LogInformation(
-                "Handling the first {Count} triggers that missed their scheduled fire-time. More misfired triggers remain to be processed.",
-                misfiredTriggers.Count);
+            Logger.HandlingFirstMisfiredTriggers(misfiredTriggers.Count);
         }
         else if (misfiredTriggers.Count > 0)
         {
-            Logger.LogInformation(
-                "Handling {Count} trigger(s) that missed their scheduled fire-time.", misfiredTriggers.Count);
+            Logger.HandlingMisfiredTriggers(misfiredTriggers.Count);
         }
         else
         {
             // A healthy scheduler takes this branch on every misfire scan, forever, so it is Debug -
             // "nothing happened" is not news. The branches above, where something did misfire, stay
             // at Information.
-            Logger.LogDebug(
-                "Found 0 triggers that missed their scheduled fire-time.");
+            Logger.NoMisfiredTriggers();
             return RecoverMisfiredJobsResult.NoOp;
         }
 
@@ -1131,7 +1127,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
             catch (Exception e)
             {
-                Logger.LogError(e, "Error preparing misfire update for trigger: '{TriggerKey}'", trig.Key);
+                Logger.MisfireUpdatePreparationFailed(trig.Key, e);
                 continue;
             }
 
@@ -1155,7 +1151,7 @@ public abstract class AdoJobStoreBase : IJobStore
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "Error updating {Count} misfired trigger(s)", updates.Count);
+            Logger.MisfiredTriggerUpdateFailed(updates.Count, e);
             return new RecoverMisfiredJobsResult(hasMoreMisfiredTriggers, misfiredTriggers.Count, earliestNewTime);
         }
 
@@ -1262,14 +1258,14 @@ public abstract class AdoJobStoreBase : IJobStore
                 }
                 catch (Exception e)
                 {
-                    Logger.LogError(e, "Error recovering stale acquired trigger '{TriggerKey}'", rec.TriggerKey);
+                    Logger.StaleAcquiredTriggerRecoveryFailed(rec.TriggerKey, e);
                 }
             }
         }
 
         if (recoveredCount > 0)
         {
-            Logger.LogInformation("Recovered {RecoveredCount} trigger(s) stuck in ACQUIRED state (stale threshold: {StaleThreshold})", recoveredCount, staleThreshold);
+            Logger.StaleAcquiredTriggersRecovered(recoveredCount, staleThreshold);
         }
 
         return recoveredCount;
@@ -2294,7 +2290,7 @@ public abstract class AdoJobStoreBase : IJobStore
                 return false;
             }
 
-            Logger.LogInformation("Trigger {TriggerKey} reset from ERROR state to: {NewState}", triggerKey, newState);
+            Logger.TriggerResetFromError(triggerKey, newState);
             return true;
         }
         catch (Exception e)
@@ -3729,7 +3725,7 @@ public abstract class AdoJobStoreBase : IJobStore
                     {
                         try
                         {
-                            Logger.LogError(e, "Error retrieving job, setting trigger state to ERROR.");
+                            Logger.JobRetrievalFailed(e);
                             await Delegate.UpdateTriggerState(conn, triggerKey, StoredTriggerState.Error, cancellationToken).ConfigureAwait(false);
 
                             // A trigger whose job type will not load stops firing here and is reported
@@ -3739,7 +3735,7 @@ public abstract class AdoJobStoreBase : IJobStore
                         }
                         catch (Exception ex)
                         {
-                            Logger.LogError(ex, "Unable to set trigger state to ERROR.");
+                            Logger.TriggerErrorStateUpdateFailed(ex);
                         }
                         continue;
                     }
@@ -3775,7 +3771,7 @@ public abstract class AdoJobStoreBase : IJobStore
                     // able to be clean up by Quartz since we are not returning it to be processed.
                     if (nextFireTimeUtc is null)
                     {
-                        Logger.LogWarning("Trigger {TriggerKey} returned null on nextFireTime and yet still exists in DB!", nextTrigger.Key);
+                        Logger.TriggerHasNoNextFireTime(nextTrigger.Key);
                         continue;
                     }
 
@@ -3890,7 +3886,7 @@ public abstract class AdoJobStoreBase : IJobStore
                             {
                                 throw; // Let ExecuteInLocalTransactionLock retry the whole transaction
                             }
-                            Logger.LogError(jpe, "Caught job persistence exception: {ExceptionMessage}", jpe.Message);
+                            Logger.JobPersistenceExceptionCaught(jpe.Message, jpe);
                             result = TriggerFiredResult.Failed(jpe);
                         }
                         catch (Exception ex)
@@ -3900,7 +3896,7 @@ public abstract class AdoJobStoreBase : IJobStore
                                 // Wrap as JobPersistenceException so outer retry mechanism can handle it
                                 throw new JobPersistenceException("Transient error firing trigger: " + ex.Message, ex);
                             }
-                            Logger.LogError(ex, "Caught exception: {ExceptionMessage}", ex.Message);
+                            Logger.ExceptionCaught(ex.Message, ex);
                             result = TriggerFiredResult.Failed(ex);
                         }
 
@@ -3987,7 +3983,7 @@ public abstract class AdoJobStoreBase : IJobStore
         {
             try
             {
-                Logger.LogError(jpe, "Error retrieving job, setting trigger state to ERROR.");
+                Logger.JobRetrievalFailed(jpe);
                 await Delegate.UpdateTriggerState(conn, trigger.Key, StoredTriggerState.Error, cancellationToken).ConfigureAwait(false);
 
                 // Same as above: the trigger stops here and nothing else says so.
@@ -3995,7 +3991,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
             catch (Exception sqle)
             {
-                Logger.LogError(sqle, "Unable to set trigger state to ERROR.");
+                Logger.TriggerErrorStateUpdateFailed(sqle);
             }
             throw;
         }
@@ -4012,7 +4008,7 @@ public abstract class AdoJobStoreBase : IJobStore
                 bool alreadyExecuting = await Delegate.IsJobCurrentlyExecuting(conn, trigger.JobKey, cancellationToken).ConfigureAwait(false);
                 if (alreadyExecuting)
                 {
-                    Logger.LogInformation("Not firing trigger {TriggerKey} for [DisallowConcurrentExecution] job {JobKey} - already executing on another node.", trigger.Key, trigger.JobKey);
+                    Logger.ConcurrentExecutionDeclined(trigger.Key, trigger.JobKey);
                     return null;
                 }
             }
@@ -4027,7 +4023,7 @@ public abstract class AdoJobStoreBase : IJobStore
             calendar = await GetCalendar(conn, trigger.CalendarName, cancellationToken).ConfigureAwait(false);
             if (calendar is null)
             {
-                Logger.LogWarning("Trigger {TriggerKey} references calendar '{CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared.", trigger.Key, trigger.CalendarName);
+                Logger.TriggerReferencesMissingCalendar(trigger.Key, trigger.CalendarName);
                 return null;
             }
         }
@@ -4220,7 +4216,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
             else if (triggerInstructionCode == SchedulerInstruction.SetTriggerError)
             {
-                Logger.LogInformation("Trigger {Trigger} set to ERROR state.", trigger.Key);
+                Logger.TriggerSetToError(trigger.Key);
                 await Delegate.UpdateTriggerState(conn, trigger.Key, StoredTriggerState.Error, cancellationToken).ConfigureAwait(false);
                 conn.SignalSchedulingChangeOnTxCompletion = SchedulerConstants.SchedulingSignalDateTime;
             }
@@ -4231,7 +4227,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
             else if (triggerInstructionCode == SchedulerInstruction.SetAllJobTriggersError)
             {
-                Logger.LogInformation("All triggers of Job {Job} set to ERROR state.", trigger.JobKey);
+                Logger.JobTriggersSetToError(trigger.JobKey);
                 await Delegate.UpdateTriggerStatesForJob(conn, trigger.JobKey, StoredTriggerState.Error, cancellationToken).ConfigureAwait(false);
                 conn.SignalSchedulingChangeOnTxCompletion = SchedulerConstants.SchedulingSignalDateTime;
             }
@@ -4399,7 +4395,7 @@ public abstract class AdoJobStoreBase : IJobStore
 
                 if (Logger.IsEnabled(LogLevel.Debug))
                 {
-                    Logger.LogDebug("Found {MisfireCount} triggers that missed their scheduled fire-time.", misfireCount);
+                    Logger.MisfiredTriggersCounted(misfireCount);
                 }
 
                 if (misfireCount > 0)
@@ -4603,7 +4599,7 @@ public abstract class AdoJobStoreBase : IJobStore
                 await RollbackConnection(conn, jpe, cancellationToken).ConfigureAwait(false);
                 if (attempt < totalAttempts && IsTransient(jpe))
                 {
-                    Logger.LogWarning(jpe, "Transient exception on attempt {Attempt} of {TotalAttempts} in DoCheckin, will retry after {RetryInterval}", attempt, totalAttempts, TransientRetryInterval);
+                    Logger.TransientFailureInCheckIn(attempt, totalAttempts, TransientRetryInterval, jpe);
                 }
                 else
                 {
@@ -4684,10 +4680,7 @@ public abstract class AdoJobStoreBase : IJobStore
             if (!foundThisScheduler && !firstCheckIn)
             {
                 // TODO: revisit when handle self-failed-out impl'ed (see TODO in clusterCheckIn() below)
-                Logger.LogWarning(
-                    "This scheduler instance ({InstanceId}) is still " +
-                    "active but was recovered by another instance in the cluster.  " +
-                    "This may cause inconsistent behavior.", InstanceId);
+                Logger.RecoveredByAnotherInstance(InstanceId);
             }
 
             return failedInstances;
@@ -4729,7 +4722,7 @@ public abstract class AdoJobStoreBase : IJobStore
                 SchedulerStateRecord orphanedInstance = new(name, CheckinTimestamp: default, CheckinInterval: default);
                 orphanedInstances.Add(orphanedInstance);
 
-                Logger.LogWarning("Found orphaned fired triggers for instance: {SchedulerInstanceId}", orphanedInstance.SchedulerInstanceId);
+                Logger.OrphanedFiredTriggersFound(orphanedInstance.SchedulerInstanceId);
             }
         }
 
@@ -4777,13 +4770,12 @@ public abstract class AdoJobStoreBase : IJobStore
         {
             long recoverIds = timeProvider.GetTimestamp();
 
-            LogWarnIfNonZero(failedInstances.Count,
-                "ClusterManager: detected " + failedInstances.Count + " failed or restarted instances.");
+            Logger.FailedInstancesDetected(failedInstances.Count);
             try
             {
                 foreach (SchedulerStateRecord rec in failedInstances)
                 {
-                    Logger.LogInformation("ClusterManager: Scanning for instance {SchedulerInstanceId}'s failed in-progress jobs.", rec.SchedulerInstanceId);
+                    Logger.ScanningFailedInstance(rec.SchedulerInstanceId);
 
                     var firedTriggerRecs = await Delegate.SelectFiredTriggerRecords(conn, new FiredTriggerQuery { InstanceId = rec.SchedulerInstanceId }, cancellationToken).ConfigureAwait(false);
 
@@ -4832,10 +4824,7 @@ public abstract class AdoJobStoreBase : IJobStore
                             preservedFireInstanceIds ??= [];
                             preservedFireInstanceIds.Add(ftRec.FireInstanceId);
                             deferredCount++;
-                            Logger.LogInformation(
-                                "ClusterManager: Deferring recovery of [DisallowConcurrentExecution] job {JobKey} " +
-                                "(fired trigger {FireInstanceId}) — may still be executing on instance {SchedulerInstanceId}.",
-                                jKey, ftRec.FireInstanceId, rec.SchedulerInstanceId);
+                            Logger.RecoveryDeferred(jKey, ftRec.FireInstanceId, rec.SchedulerInstanceId);
                             continue;
                         }
 
@@ -4882,7 +4871,7 @@ public abstract class AdoJobStoreBase : IJobStore
                             }
                             else
                             {
-                                Logger.LogWarning("ClusterManager: failed job {JobKey} no longer exists, cannot schedule recovery.", jKey);
+                                Logger.FailedJobNoLongerExists(jKey);
                                 otherCount++;
                             }
                         }
@@ -4933,17 +4922,31 @@ public abstract class AdoJobStoreBase : IJobStore
                             }
                         }
                     }
-                    LogWarnIfNonZero(acquiredCount,
-                        "ClusterManager: ......Freed " + acquiredCount + " acquired trigger(s).");
-                    LogWarnIfNonZero(completeCount,
-                        "ClusterManager: ......Deleted " + completeCount + " complete triggers(s).");
-                    LogWarnIfNonZero(recoveredCount,
-                        "ClusterManager: ......Scheduled " + recoveredCount +
-                        " recoverable job(s) for recovery.");
-                    LogWarnIfNonZero(otherCount,
-                        "ClusterManager: ......Cleaned-up " + otherCount + " other failed job(s).");
-                    LogWarnIfNonZero(deferredCount,
-                        "ClusterManager: ......Deferred recovery of " + deferredCount + " executing [DisallowConcurrentExecution] job(s).");
+
+                    if (acquiredCount > 0)
+                    {
+                        Logger.AcquiredTriggersFreed(acquiredCount);
+                    }
+
+                    if (completeCount > 0)
+                    {
+                        Logger.CompleteTriggersDeleted(completeCount);
+                    }
+
+                    if (recoveredCount > 0)
+                    {
+                        Logger.RecoverableJobsScheduled(recoveredCount);
+                    }
+
+                    if (otherCount > 0)
+                    {
+                        Logger.OtherFailedJobsCleanedUp(otherCount);
+                    }
+
+                    if (deferredCount > 0)
+                    {
+                        Logger.ExecutingJobRecoveriesDeferred(deferredCount);
+                    }
 
                     if (rec.SchedulerInstanceId != InstanceId)
                     {
@@ -4966,7 +4969,7 @@ public abstract class AdoJobStoreBase : IJobStore
                                 conn, rec.SchedulerInstanceId, StdAdoConstants.AutoPinSentinel, cancellationToken).ConfigureAwait(false);
                             if (repinned > 0)
                             {
-                                Logger.LogInformation("ClusterManager: Released {Count} auto-pinned trigger(s) from dead node '{InstanceId}' for re-acquisition.", repinned, rec.SchedulerInstanceId);
+                                Logger.AutoPinnedTriggersReleased(repinned, rec.SchedulerInstanceId);
                             }
 
                             await Delegate.DeleteSchedulerState(conn, rec.SchedulerInstanceId, cancellationToken).ConfigureAwait(false);
@@ -4979,20 +4982,6 @@ public abstract class AdoJobStoreBase : IJobStore
                 Throw.JobPersistenceException("Failure recovering jobs: " + e.Message, e);
             }
         }
-    }
-
-    private void LogWarnIfNonZero(int val, string warning)
-    {
-#pragma warning disable CA2254
-        if (val > 0)
-        {
-            Logger.LogInformation(warning);
-        }
-        else
-        {
-            Logger.LogDebug(warning);
-        }
-#pragma warning restore CA2254
     }
 
     /// <summary>
@@ -5046,7 +5035,7 @@ public abstract class AdoJobStoreBase : IJobStore
         if (cth is null)
         {
             // db might be down or similar
-            Logger.LogInformation("ConnectionAndTransactionHolder passed to RollbackConnection was null, ignoring");
+            Logger.RollbackWithoutConnectionHolder();
             return;
         }
 
@@ -5082,7 +5071,7 @@ public abstract class AdoJobStoreBase : IJobStore
     {
         if (cth is null)
         {
-            Logger.LogDebug("ConnectionAndTransactionHolder passed to CommitConnection was null, ignoring");
+            Logger.CommitWithoutConnectionHolder();
             return;
         }
         await cth.Commit(openNewTransaction, cancellationToken).ConfigureAwait(false);
@@ -5201,7 +5190,7 @@ public abstract class AdoJobStoreBase : IJobStore
             }
             catch (Exception e)
             {
-                Logger.LogError(e, "RetryExecuteInLocalTransactionLock: RuntimeException {ExceptionMessage}", e.Message);
+                Logger.RetryInLocalTransactionLockFailed(e.Message, e);
             }
 
             // retry every N seconds (the db connection must be failed)
@@ -5345,7 +5334,7 @@ public abstract class AdoJobStoreBase : IJobStore
                 await RollbackConnection(conn, jpe, cancellationToken).ConfigureAwait(false);
                 if (attempt < totalAttempts && IsTransient(jpe))
                 {
-                    Logger.LogWarning(jpe, "Transient exception on attempt {Attempt} of {TotalAttempts} in ExecuteInLocalTransactionLock, will retry after {RetryInterval}", attempt, totalAttempts, TransientRetryInterval);
+                    Logger.TransientFailureInLocalTransactionLock(attempt, totalAttempts, TransientRetryInterval, jpe);
                 }
                 else
                 {

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreLog.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreLog.cs
@@ -106,7 +106,7 @@ internal static partial class AdoJobStoreLog
     [LoggerMessage(EventId = 3020, Level = LogLevel.Information, Message = "Recovery complete.")]
     public static partial void RecoveryComplete(this ILogger logger);
 
-    [LoggerMessage(EventId = 3021, Level = LogLevel.Information, Message = "Removed  {Count} 'complete' triggers.")]
+    [LoggerMessage(EventId = 3021, Level = LogLevel.Information, Message = "Removed {Count} 'complete' triggers.")]
     public static partial void CompleteTriggersRemoved(this ILogger logger, int count);
 
     [LoggerMessage(EventId = 3022, Level = LogLevel.Information, Message = "Removed {Count} stale fired job entries.")]

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreLog.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreLog.cs
@@ -1,0 +1,207 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// Every event the ADO.NET job store logs outside clustering, misfire handling and lock handling, as
+/// source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 3000-3499 belong to this area and are allocated in file order: the store itself
+/// (3000-3099), <c>AdoUtil</c> (3100-3109), the connection holder (3110-3129), the two store flavours
+/// (3130-3149) and the driver delegate (3150-3179). Clustering is 3500-3599 in <see cref="ClusterLog" />,
+/// misfire handling 3600-3699 in <see cref="MisfireLog" />, and lock handling 3700-3799 in
+/// <see cref="LockHandlerLog" />.
+/// </para>
+/// <para>
+/// An id, once given out, is what an operator filters and alerts on, so it is never reused for a
+/// different event and never renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed
+/// diff.
+/// </para>
+/// </remarks>
+internal static partial class AdoJobStoreLog
+{
+    [LoggerMessage(EventId = 3000, Level = LogLevel.Information, Message = "Detected SQLite usage, changing to use SQLiteSemaphore for in-memory locking")]
+    public static partial void SqliteSemaphoreSubstituted(this ILogger logger);
+
+    [LoggerMessage(EventId = 3001, Level = LogLevel.Information, Message = "With SQLite we need to set AcquireTriggersWithinLock to true, changing")]
+    public static partial void SqliteAcquireTriggersWithinLockForced(this ILogger logger);
+
+    [LoggerMessage(EventId = 3002, Level = LogLevel.Information, Message = "Detected usage of SQLiteDelegate - forcing transaction isolation level to 'Serializable'")]
+    public static partial void SqliteSerializableIsolationForced(this ILogger logger);
+
+    [LoggerMessage(EventId = 3003, Level = LogLevel.Information, Message = "With SQLite all operations must be serialized, setting LockAllOperations to true")]
+    public static partial void SqliteLockAllOperationsForced(this ILogger logger);
+
+    [LoggerMessage(EventId = 3004, Level = LogLevel.Warning, Message = "The configured transaction isolation level applies only to connections the job store opens itself: an operation running on a connection enlisted by the application uses that transaction's isolation level instead.")]
+    public static partial void IsolationLevelIgnoredForEnlistedTransactions(this ILogger logger);
+
+    [LoggerMessage(EventId = 3005, Level = LogLevel.Information, Message = "Detected usage of SqlServerDelegate - defaulting 'selectWithLockSQL' to '{DefaultLockSql}'.")]
+    public static partial void SqlServerLockSqlDefaulted(this ILogger logger, string defaultLockSql);
+
+    [LoggerMessage(EventId = 3006, Level = LogLevel.Information, Message = "Using db table-based data access locking (synchronization) via {LockHandlerType}.")]
+    public static partial void UsingDatabaseLocking(this ILogger logger, string lockHandlerType);
+
+    [LoggerMessage(EventId = 3007, Level = LogLevel.Information, Message = "Using thread monitor-based data access locking (synchronization) via {LockHandlerType}.")]
+    public static partial void UsingMonitorLocking(this ILogger logger, string lockHandlerType);
+
+    [LoggerMessage(EventId = 3008, Level = LogLevel.Warning, Message = "A row-lock statement is configured, but SQLite serializes callers in process rather than by locking a row, so the statement is ignored.")]
+    public static partial void RowLockStatementIgnoredBySqlite(this ILogger logger);
+
+    [LoggerMessage(EventId = 3009, Level = LogLevel.Warning, Message = "A row-lock statement is configured, but lock handler {LockHandlerType} was supplied rather than built by the job store, so the statement is ignored. Pass it to the handler's constructor, or remove the lock handler and let the store choose one.")]
+    public static partial void RowLockStatementIgnoredBySuppliedHandler(this ILogger logger, string lockHandlerType);
+
+    [LoggerMessage(EventId = 3010, Level = LogLevel.Warning, Message = "Accepting enlisted transactions with SQLite keeps in-process locking: SQLiteSemaphore releases the lock when the scheduling call returns, while the application transaction still holds the SQLite writer lock, so a concurrent scheduler operation can fail with 'database is locked' until that transaction completes. Keep enlisted transactions short, or use a database that supports row locking.")]
+    public static partial void EnlistedTransactionsWithSqlite(this ILogger logger);
+
+    [LoggerMessage(EventId = 3011, Level = LogLevel.Warning, Message = "Accepting enlisted transactions with lock handler {LockHandlerType}, which does not lock in the database. Its locks are released before the application commits its transaction, so concurrent callers can act on scheduling data that is not visible to them yet.")]
+    public static partial void EnlistedTransactionsWithInProcessLocking(this ILogger logger, string lockHandlerType);
+
+    [LoggerMessage(EventId = 3012, Level = LogLevel.Warning, Message = "Detected usage of SqlServerDelegate and UpdateRowSemaphore, removing 'quartz.jobStore.lockHandler.type' would allow more efficient SQL Server specific (UPDLOCK,ROWLOCK) row access")]
+    public static partial void SqlServerCouldUseRowLocking(this ILogger logger);
+
+    [LoggerMessage(EventId = 3013, Level = LogLevel.Warning, Message = "Detected usage of SQL Server provider without SqlServerDelegate, SqlServerDelegate would provide better performance")]
+    public static partial void SqlServerProviderWithoutSqlServerDelegate(this ILogger logger);
+
+    [LoggerMessage(EventId = 3014, Level = LogLevel.Information, Message = "Successfully validated presence of {SchemaObjectCount} schema objects")]
+    public static partial void SchemaValidated(this ILogger logger, int schemaObjectCount);
+
+    [LoggerMessage(EventId = 3015, Level = LogLevel.Error, Message = "Failure occurred during job recovery: {ExceptionMessage}")]
+    public static partial void JobRecoveryFailed(this ILogger logger, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 3016, Level = LogLevel.Warning, Message = "Database connection Shutdown unsuccessful.")]
+    public static partial void DatabaseShutdownFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 3017, Level = LogLevel.Error, Message = "Error returning lock: {ExceptionMessage}")]
+    public static partial void LockReleaseFailed(this ILogger logger, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 3018, Level = LogLevel.Information, Message = "Freed {Count} triggers from 'acquired' / 'blocked' state.")]
+    public static partial void TriggersFreedFromAcquiredOrBlocked(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3019, Level = LogLevel.Information, Message = "Recovering {Count} jobs that were in-progress at the time of the last shut-down.")]
+    public static partial void RecoveringInProgressJobs(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3020, Level = LogLevel.Information, Message = "Recovery complete.")]
+    public static partial void RecoveryComplete(this ILogger logger);
+
+    [LoggerMessage(EventId = 3021, Level = LogLevel.Information, Message = "Removed  {Count} 'complete' triggers.")]
+    public static partial void CompleteTriggersRemoved(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3022, Level = LogLevel.Information, Message = "Removed {Count} stale fired job entries.")]
+    public static partial void StaleFiredJobEntriesRemoved(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3023, Level = LogLevel.Error, Message = "Error recovering stale acquired trigger '{TriggerKey}'")]
+    public static partial void StaleAcquiredTriggerRecoveryFailed(this ILogger logger, TriggerKey triggerKey, Exception exception);
+
+    [LoggerMessage(EventId = 3024, Level = LogLevel.Information, Message = "Recovered {RecoveredCount} trigger(s) stuck in ACQUIRED state (stale threshold: {StaleThreshold})")]
+    public static partial void StaleAcquiredTriggersRecovered(this ILogger logger, int recoveredCount, TimeSpan staleThreshold);
+
+    [LoggerMessage(EventId = 3025, Level = LogLevel.Information, Message = "Trigger {TriggerKey} reset from ERROR state to: {NewState}")]
+    public static partial void TriggerResetFromError(this ILogger logger, TriggerKey triggerKey, StoredTriggerState newState);
+
+    [LoggerMessage(EventId = 3026, Level = LogLevel.Error, Message = "Error retrieving job, setting trigger state to ERROR.")]
+    public static partial void JobRetrievalFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 3027, Level = LogLevel.Error, Message = "Unable to set trigger state to ERROR.")]
+    public static partial void TriggerErrorStateUpdateFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 3028, Level = LogLevel.Warning, Message = "Trigger {TriggerKey} returned null on nextFireTime and yet still exists in DB!")]
+    public static partial void TriggerHasNoNextFireTime(this ILogger logger, TriggerKey triggerKey);
+
+    [LoggerMessage(EventId = 3029, Level = LogLevel.Error, Message = "Caught job persistence exception: {ExceptionMessage}")]
+    public static partial void JobPersistenceExceptionCaught(this ILogger logger, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 3030, Level = LogLevel.Error, Message = "Caught exception: {ExceptionMessage}")]
+    public static partial void ExceptionCaught(this ILogger logger, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 3031, Level = LogLevel.Information, Message = "Not firing trigger {TriggerKey} for [DisallowConcurrentExecution] job {JobKey} - already executing on another node.")]
+    public static partial void ConcurrentExecutionDeclined(this ILogger logger, TriggerKey triggerKey, JobKey jobKey);
+
+    [LoggerMessage(EventId = 3032, Level = LogLevel.Warning, Message = "Trigger {TriggerKey} references calendar '{CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared.")]
+    public static partial void TriggerReferencesMissingCalendar(this ILogger logger, TriggerKey triggerKey, string calendarName);
+
+    [LoggerMessage(EventId = 3033, Level = LogLevel.Information, Message = "Trigger {Trigger} set to ERROR state.")]
+    public static partial void TriggerSetToError(this ILogger logger, TriggerKey trigger);
+
+    [LoggerMessage(EventId = 3034, Level = LogLevel.Information, Message = "All triggers of Job {Job} set to ERROR state.")]
+    public static partial void JobTriggersSetToError(this ILogger logger, JobKey job);
+
+    [LoggerMessage(EventId = 3035, Level = LogLevel.Information, Message = "ConnectionAndTransactionHolder passed to RollbackConnection was null, ignoring")]
+    public static partial void RollbackWithoutConnectionHolder(this ILogger logger);
+
+    [LoggerMessage(EventId = 3036, Level = LogLevel.Debug, Message = "ConnectionAndTransactionHolder passed to CommitConnection was null, ignoring")]
+    public static partial void CommitWithoutConnectionHolder(this ILogger logger);
+
+    [LoggerMessage(EventId = 3037, Level = LogLevel.Error, Message = "RetryExecuteInLocalTransactionLock: RuntimeException {ExceptionMessage}")]
+    public static partial void RetryInLocalTransactionLockFailed(this ILogger logger, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 3038, Level = LogLevel.Warning, Message = "Transient exception on attempt {Attempt} of {TotalAttempts} in ExecuteInLocalTransactionLock, will retry after {RetryInterval}")]
+    public static partial void TransientFailureInLocalTransactionLock(this ILogger logger, int attempt, int totalAttempts, TimeSpan retryInterval, Exception exception);
+
+    [LoggerMessage(EventId = 3100, Level = LogLevel.Debug, Message = "Prepared SQL: {Sql}")]
+    public static partial void SqlPrepared(this ILogger logger, string sql);
+
+    [LoggerMessage(EventId = 3110, Level = LogLevel.Error, Message = "Unexpected exception closing Connection.  This is often due to a Connection being returned after or during shutdown.")]
+    public static partial void ConnectionCloseFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 3111, Level = LogLevel.Debug, Message = "Exception disposing connection or transaction. This is often due to a connection being returned after or during shutdown.")]
+    public static partial void ConnectionDisposeFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 3112, Level = LogLevel.Debug, Message = "Rollback skipped - transaction is no longer connected, database will have aborted it")]
+    public static partial void RollbackSkippedTransactionDisconnected(this ILogger logger);
+
+    [LoggerMessage(EventId = 3113, Level = LogLevel.Debug, Message = "Rollback failed due to transient error")]
+    public static partial void RollbackFailedTransiently(this ILogger logger);
+
+    [LoggerMessage(EventId = 3114, Level = LogLevel.Error, Message = "Couldn't rollback ADO.NET connection. {ExceptionMessage}")]
+    public static partial void RollbackFailed(this ILogger logger, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 3130, Level = LogLevel.Information, Message = "ExternalTransactionJobStore initialized.")]
+    public static partial void ExternalTransactionStoreInitialized(this ILogger logger);
+
+    [LoggerMessage(EventId = 3131, Level = LogLevel.Warning, Message = "Database connection shutdown unsuccessful.")]
+    public static partial void ExternalTransactionStoreShutdownFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 3140, Level = LogLevel.Information, Message = "LocalTransactionJobStore initialized.")]
+    public static partial void LocalTransactionStoreInitialized(this ILogger logger);
+
+    [LoggerMessage(EventId = 3150, Level = LogLevel.Warning, Message = "Couldn't find calendar with name '{CalendarName}'")]
+    public static partial void CalendarNotFound(this ILogger logger, string calendarName);
+
+    [LoggerMessage(EventId = 3151, Level = LogLevel.Debug, Message = "Deleting job: {JobKey}")]
+    public static partial void JobDeleting(this ILogger logger, JobKey jobKey);
+
+    [LoggerMessage(EventId = 3152, Level = LogLevel.Debug, Message = "No job for trigger '{TriggerKey}'")]
+    public static partial void NoJobForTrigger(this ILogger logger, TriggerKey triggerKey);
+
+    [LoggerMessage(EventId = 3153, Level = LogLevel.Debug, Message = "Adding TriggerPersistenceDelegate of type: {Type}")]
+    public static partial void TriggerPersistenceDelegateAdded(this ILogger logger, Type type);
+
+    [LoggerMessage(EventId = 3154, Level = LogLevel.Warning, Message = "Misfired trigger '{TriggerKey}' has no {TriggerType} row and is skipped")]
+    public static partial void MisfiredTriggerHasNoTypeRow(this ILogger logger, TriggerKey triggerKey, string triggerType);
+
+    [LoggerMessage(EventId = 3155, Level = LogLevel.Warning, Message = "Batched statement execution failed, retrying {StatementCount} statement(s) individually")]
+    public static partial void BatchedStatementExecutionFailed(this ILogger logger, int statementCount, Exception exception);
+}

--- a/src/Quartz/Impl/AdoJobStore/AdoUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoUtil.cs
@@ -562,7 +562,7 @@ internal sealed class AdoUtil : IAdoUtil
 
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug("Prepared SQL: {Sql}", cmd.CommandText);
+            logger.SqlPrepared(cmd.CommandText);
         }
 
         return cmd;

--- a/src/Quartz/Impl/AdoJobStore/ClusterLog.cs
+++ b/src/Quartz/Impl/AdoJobStore/ClusterLog.cs
@@ -68,7 +68,7 @@ internal static partial class ClusterLog
     [LoggerMessage(EventId = 3507, Level = LogLevel.Warning, Message = "ClusterManager: ......Freed {Count} acquired trigger(s).")]
     public static partial void AcquiredTriggersFreed(this ILogger logger, int count);
 
-    [LoggerMessage(EventId = 3508, Level = LogLevel.Warning, Message = "ClusterManager: ......Deleted {Count} complete triggers(s).")]
+    [LoggerMessage(EventId = 3508, Level = LogLevel.Warning, Message = "ClusterManager: ......Deleted {Count} complete trigger(s).")]
     public static partial void CompleteTriggersDeleted(this ILogger logger, int count);
 
     [LoggerMessage(EventId = 3509, Level = LogLevel.Warning, Message = "ClusterManager: ......Scheduled {Count} recoverable job(s) for recovery.")]

--- a/src/Quartz/Impl/AdoJobStore/ClusterLog.cs
+++ b/src/Quartz/Impl/AdoJobStore/ClusterLog.cs
@@ -1,0 +1,91 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// Every event clustering logs — check-in, failed-instance detection and recovery — as source-generated
+/// methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 3500-3599 belong to this area and are allocated in file order: the cluster region of
+/// <see cref="AdoJobStoreBase" /> first, then <see cref="ClusterManager" />.
+/// </para>
+/// <para>
+/// The six counting events (3503, 3507-3511) were <c>LogWarnIfNonZero</c>, which logged at Information
+/// when the count was non-zero and Debug when it was not, whatever its name said. They are Warning
+/// events now, raised only when the count is non-zero — the level the name always claimed, and the
+/// only one of the two branches that ever carried news.
+/// </para>
+/// <para>
+/// An id, once given out, is what an operator filters and alerts on, so it is never reused for a
+/// different event and never renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed
+/// diff.
+/// </para>
+/// </remarks>
+internal static partial class ClusterLog
+{
+    [LoggerMessage(EventId = 3500, Level = LogLevel.Warning, Message = "Transient exception on attempt {Attempt} of {TotalAttempts} in DoCheckin, will retry after {RetryInterval}")]
+    public static partial void TransientFailureInCheckIn(this ILogger logger, int attempt, int totalAttempts, TimeSpan retryInterval, Exception exception);
+
+    [LoggerMessage(EventId = 3501, Level = LogLevel.Warning, Message = "This scheduler instance ({InstanceId}) is still active but was recovered by another instance in the cluster.  This may cause inconsistent behavior.")]
+    public static partial void RecoveredByAnotherInstance(this ILogger logger, string instanceId);
+
+    [LoggerMessage(EventId = 3502, Level = LogLevel.Warning, Message = "Found orphaned fired triggers for instance: {SchedulerInstanceId}")]
+    public static partial void OrphanedFiredTriggersFound(this ILogger logger, string schedulerInstanceId);
+
+    [LoggerMessage(EventId = 3503, Level = LogLevel.Warning, Message = "ClusterManager: detected {Count} failed or restarted instances.")]
+    public static partial void FailedInstancesDetected(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3504, Level = LogLevel.Information, Message = "ClusterManager: Scanning for instance {SchedulerInstanceId}'s failed in-progress jobs.")]
+    public static partial void ScanningFailedInstance(this ILogger logger, string schedulerInstanceId);
+
+    [LoggerMessage(EventId = 3505, Level = LogLevel.Information, Message = "ClusterManager: Deferring recovery of [DisallowConcurrentExecution] job {JobKey} (fired trigger {FireInstanceId}) — may still be executing on instance {SchedulerInstanceId}.")]
+    public static partial void RecoveryDeferred(this ILogger logger, JobKey? jobKey, string fireInstanceId, string schedulerInstanceId);
+
+    [LoggerMessage(EventId = 3506, Level = LogLevel.Warning, Message = "ClusterManager: failed job {JobKey} no longer exists, cannot schedule recovery.")]
+    public static partial void FailedJobNoLongerExists(this ILogger logger, JobKey? jobKey);
+
+    [LoggerMessage(EventId = 3507, Level = LogLevel.Warning, Message = "ClusterManager: ......Freed {Count} acquired trigger(s).")]
+    public static partial void AcquiredTriggersFreed(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3508, Level = LogLevel.Warning, Message = "ClusterManager: ......Deleted {Count} complete triggers(s).")]
+    public static partial void CompleteTriggersDeleted(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3509, Level = LogLevel.Warning, Message = "ClusterManager: ......Scheduled {Count} recoverable job(s) for recovery.")]
+    public static partial void RecoverableJobsScheduled(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3510, Level = LogLevel.Warning, Message = "ClusterManager: ......Cleaned-up {Count} other failed job(s).")]
+    public static partial void OtherFailedJobsCleanedUp(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3511, Level = LogLevel.Warning, Message = "ClusterManager: ......Deferred recovery of {Count} executing [DisallowConcurrentExecution] job(s).")]
+    public static partial void ExecutingJobRecoveriesDeferred(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3512, Level = LogLevel.Information, Message = "ClusterManager: Released {Count} auto-pinned trigger(s) from dead node '{InstanceId}' for re-acquisition.")]
+    public static partial void AutoPinnedTriggersReleased(this ILogger logger, int count, string instanceId);
+
+    [LoggerMessage(EventId = 3513, Level = LogLevel.Debug, Message = "Check-in complete.")]
+    public static partial void CheckInComplete(this ILogger logger);
+
+    [LoggerMessage(EventId = 3514, Level = LogLevel.Error, Message = "Error managing cluster: {ExceptionMessage}")]
+    public static partial void ClusterManagementFailed(this ILogger logger, string exceptionMessage, Exception exception);
+}

--- a/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
+++ b/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
@@ -80,13 +80,13 @@ internal sealed class ClusterManager
             res = await jobStoreSupport.DoCheckin(requestorId).ConfigureAwait(false);
 
             numFails = 0;
-            logger.LogDebug("Check-in complete.");
+            logger.CheckInComplete();
         }
         catch (Exception e)
         {
             if (numFails % jobStoreSupport.RetryableActionErrorLogThreshold == 0)
             {
-                logger.LogError(e, "Error managing cluster: {ExceptionMessage}", e.Message);
+                logger.ClusterManagementFailed(e.Message, e);
             }
             numFails++;
         }

--- a/src/Quartz/Impl/AdoJobStore/ConnectionAndTransactionHolder.cs
+++ b/src/Quartz/Impl/AdoJobStore/ConnectionAndTransactionHolder.cs
@@ -203,9 +203,7 @@ public sealed class ConnectionAndTransactionHolder : IDisposable, IAsyncDisposab
         }
         catch (Exception e)
         {
-            logger.LogError(e,
-                "Unexpected exception closing Connection." +
-                "  This is often due to a Connection being returned after or during shutdown.");
+            logger.ConnectionCloseFailed(e);
         }
     }
 
@@ -279,7 +277,7 @@ public sealed class ConnectionAndTransactionHolder : IDisposable, IAsyncDisposab
     /// </summary>
     private void LogDisposeFailure(Exception e)
     {
-        logger.LogDebug(e, "Exception disposing connection or transaction. This is often due to a connection being returned after or during shutdown.");
+        logger.ConnectionDisposeFailed(e);
     }
 
     internal DateTimeOffset? SignalSchedulingChangeOnTxCompletion
@@ -322,7 +320,7 @@ public sealed class ConnectionAndTransactionHolder : IDisposable, IAsyncDisposab
                 // Transaction lost its connection - nothing to rollback, the database
                 // will have already aborted it. This commonly happens with transient
                 // connectivity issues (see https://github.com/quartznet/quartznet/issues/2290)
-                logger.LogDebug("Rollback skipped - transaction is no longer connected, database will have aborted it");
+                logger.RollbackSkippedTransactionDisconnected();
                 return;
             }
 
@@ -336,11 +334,11 @@ public sealed class ConnectionAndTransactionHolder : IDisposable, IAsyncDisposab
                 {
                     // original error was transient, ones we have in Azure, don't complain too much about it
                     // we will try again anyway
-                    logger.LogDebug("Rollback failed due to transient error");
+                    logger.RollbackFailedTransiently();
                 }
                 else
                 {
-                    logger.LogError(e, "Couldn't rollback ADO.NET connection. {ExceptionMessage}", e.Message);
+                    logger.RollbackFailed(e.Message, e);
                 }
             }
         }

--- a/src/Quartz/Impl/AdoJobStore/DbSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/DbSemaphore.cs
@@ -135,7 +135,7 @@ public abstract class DbSemaphore : ISemaphore
         var isDebugEnabled = logger.IsEnabled(LogLevel.Debug);
         if (isDebugEnabled)
         {
-            logger.LogDebug("Lock '{LockName}' is desired by: {RequestorId}", lockName, requestorId);
+            logger.LockDesired(lockName, requestorId);
         }
 
         var key = new ThreadLockKey(requestorId, lockKind);
@@ -146,7 +146,7 @@ public abstract class DbSemaphore : ISemaphore
 
             if (isDebugEnabled)
             {
-                logger.LogDebug("Lock '{LockName}' given to: {RequestorId}", lockName, requestorId);
+                logger.LockGiven(lockName, requestorId);
             }
 
             return locks.TryAdd(key, null);
@@ -155,7 +155,7 @@ public abstract class DbSemaphore : ISemaphore
         {
             if (isDebugEnabled)
             {
-                logger.LogDebug("Lock '{LockName}' Is already owned by: {RequestorId}", lockName, requestorId);
+                logger.LockAlreadyHeld(lockName, requestorId);
             }
             return false;
         }
@@ -177,13 +177,13 @@ public abstract class DbSemaphore : ISemaphore
 
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.LogDebug("Lock '{LockName}' returned by: {RequestorId}", lockKind.ToLockName(), requestorId);
+                logger.LockReturned(lockKind.ToLockName(), requestorId);
             }
         }
         else if (logger.IsEnabled(LogLevel.Warning))
         {
-            logger.LogWarning("Lock '{LockName}' attempt to return by: {RequestorId} -- but not owner!", lockKind.ToLockName(), requestorId);
-            logger.LogWarning("stack-trace of wrongful returner: {Stacktrace}", Environment.StackTrace);
+            logger.LockReturnedByNonOwner(lockKind.ToLockName(), requestorId);
+            logger.WrongfulReturnerStack(Environment.StackTrace);
         }
 
         return default;

--- a/src/Quartz/Impl/AdoJobStore/ExternalTransactionJobStore.cs
+++ b/src/Quartz/Impl/AdoJobStore/ExternalTransactionJobStore.cs
@@ -87,7 +87,7 @@ public class ExternalTransactionJobStore : AdoJobStoreBase
         }
 
         await base.Initialize(identity, cancellationToken).ConfigureAwait(false);
-        Logger.LogInformation("ExternalTransactionJobStore initialized.");
+        Logger.ExternalTransactionStoreInitialized();
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ public class ExternalTransactionJobStore : AdoJobStoreBase
         }
         catch (Exception ex)
         {
-            Logger.LogWarning(ex, "Database connection shutdown unsuccessful.");
+            Logger.ExternalTransactionStoreShutdownFailed(ex);
         }
     }
 

--- a/src/Quartz/Impl/AdoJobStore/LocalTransactionJobStore.cs
+++ b/src/Quartz/Impl/AdoJobStore/LocalTransactionJobStore.cs
@@ -68,7 +68,7 @@ public class LocalTransactionJobStore : AdoJobStoreBase
     public override async ValueTask Initialize(SchedulerIdentity identity, CancellationToken cancellationToken = default)
     {
         await base.Initialize(identity, cancellationToken).ConfigureAwait(false);
-        Logger.LogInformation("LocalTransactionJobStore initialized.");
+        Logger.LocalTransactionStoreInitialized();
     }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/LockHandlerLog.cs
+++ b/src/Quartz/Impl/AdoJobStore/LockHandlerLog.cs
@@ -1,0 +1,91 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// Every event the lock handlers log, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 3700-3799 belong to this area. The handlers share most of their vocabulary — a lock is
+/// desired, obtained, given, returned — so a message that several of them spell identically is one
+/// event here rather than one per handler: the event is what happened to the lock, and which handler
+/// implements it is the logger's category. Where two handlers word the same moment differently, the
+/// wording is preserved and they are two events, because the message text is what a structured-logging
+/// consumer already filters on.
+/// </para>
+/// <para>
+/// An id, once given out, is what an operator filters and alerts on, so it is never reused for a
+/// different event and never renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed
+/// diff.
+/// </para>
+/// </remarks>
+internal static partial class LockHandlerLog
+{
+    [LoggerMessage(EventId = 3700, Level = LogLevel.Debug, Message = "Lock '{LockName}' is desired by: {RequestorId}")]
+    public static partial void LockDesired(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3701, Level = LogLevel.Debug, Message = "Lock '{LockName}' given to: {RequestorId}")]
+    public static partial void LockGiven(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3702, Level = LogLevel.Debug, Message = "Lock '{LockName}' Is already owned by: {RequestorId}")]
+    public static partial void LockAlreadyHeld(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3703, Level = LogLevel.Debug, Message = "Lock '{LockName}' returned by: {RequestorId}")]
+    public static partial void LockReturned(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3704, Level = LogLevel.Warning, Message = "Lock '{LockName}' attempt to return by: {RequestorId} -- but not owner!")]
+    public static partial void LockReturnedByNonOwner(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3705, Level = LogLevel.Warning, Message = "stack-trace of wrongful returner: {Stacktrace}")]
+    public static partial void WrongfulReturnerStack(this ILogger logger, string stacktrace);
+
+    [LoggerMessage(EventId = 3706, Level = LogLevel.Debug, Message = "Lock '{LockName}' is being obtained: {RequestorId}")]
+    public static partial void LockBeingObtained(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3707, Level = LogLevel.Debug, Message = "Inserting new lock row for lock: '{LockName}' being obtained by thread: {RequestorId}")]
+    public static partial void LockRowInsertingForThread(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3708, Level = LogLevel.Debug, Message = "Lock '{LockName}' was not obtained by: {RequestorId}{RetryMessage}")]
+    public static partial void LockNotObtainedWithRetryNote(this ILogger logger, string lockName, Guid requestorId, string retryMessage);
+
+    [LoggerMessage(EventId = 3709, Level = LogLevel.Debug, Message = "Lock '{LockName}' already owned by: {RequestorId} -- but not owner!")]
+    public static partial void LockAlreadyOwnedByOther(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3710, Level = LogLevel.Debug, Message = "stack-trace of wrongful returner: {StackTrace}")]
+    public static partial void WrongfulReturnerStackDebug(this ILogger logger, string stackTrace);
+
+    [LoggerMessage(EventId = 3711, Level = LogLevel.Debug, Message = "Lock '{LockName}' was not obtained by: {RequestorId}")]
+    public static partial void LockNotObtained(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3712, Level = LogLevel.Debug, Message = "Lock '{LockName}' reentrant acquisition by: {RequestorId} (count: {LockCount})")]
+    public static partial void LockReentrantAcquisition(this ILogger logger, string lockName, Guid requestorId, int lockCount);
+
+    [LoggerMessage(EventId = 3713, Level = LogLevel.Debug, Message = "Lock '{LockName}' reentrant release by: {RequestorId} (remaining: {LockCount})")]
+    public static partial void LockReentrantRelease(this ILogger logger, string lockName, Guid requestorId, int lockCount);
+
+    [LoggerMessage(EventId = 3714, Level = LogLevel.Debug, Message = "Lock '{LockName}' was not obtained by: {RequestorId} - will try again.")]
+    public static partial void LockNotObtainedWillRetry(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 3715, Level = LogLevel.Debug, Message = "Inserting new lock row for lock: '{LockName}' being obtained: {RequestorId}")]
+    public static partial void LockRowInserting(this ILogger logger, string lockName, Guid requestorId);
+}

--- a/src/Quartz/Impl/AdoJobStore/MisfireHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/MisfireHandler.cs
@@ -145,7 +145,7 @@ internal sealed class MisfireHandler
     {
         try
         {
-            logger.LogDebug("Scanning for misfires...");
+            logger.ScanningForMisfires();
 
             RecoverMisfiredJobsResult res = await jobStoreSupport.DoRecoverMisfires(requestorId, CancellationToken.None).ConfigureAwait(false);
             numFails = 0;
@@ -155,7 +155,7 @@ internal sealed class MisfireHandler
         {
             if (numFails % jobStoreSupport.RetryableActionErrorLogThreshold == 0)
             {
-                logger.LogError(e, "Error handling misfires: {ExceptionMessage}", e.Message);
+                logger.MisfireHandlingFailed(e.Message, e);
             }
             numFails++;
         }

--- a/src/Quartz/Impl/AdoJobStore/MisfireLog.cs
+++ b/src/Quartz/Impl/AdoJobStore/MisfireLog.cs
@@ -1,0 +1,58 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// Every event misfire handling logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// Event ids 3600-3699 belong to this area and are allocated in file order: the misfire region of
+/// <see cref="AdoJobStoreBase" /> first, then <see cref="MisfireHandler" />. An id, once given out, is
+/// what an operator filters and alerts on, so it is never reused for a different event and never
+/// renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </remarks>
+internal static partial class MisfireLog
+{
+    [LoggerMessage(EventId = 3600, Level = LogLevel.Information, Message = "Handling the first {Count} triggers that missed their scheduled fire-time. More misfired triggers remain to be processed.")]
+    public static partial void HandlingFirstMisfiredTriggers(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3601, Level = LogLevel.Information, Message = "Handling {Count} trigger(s) that missed their scheduled fire-time.")]
+    public static partial void HandlingMisfiredTriggers(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 3602, Level = LogLevel.Debug, Message = "Found 0 triggers that missed their scheduled fire-time.")]
+    public static partial void NoMisfiredTriggers(this ILogger logger);
+
+    [LoggerMessage(EventId = 3603, Level = LogLevel.Error, Message = "Error preparing misfire update for trigger: '{TriggerKey}'")]
+    public static partial void MisfireUpdatePreparationFailed(this ILogger logger, TriggerKey triggerKey, Exception exception);
+
+    [LoggerMessage(EventId = 3604, Level = LogLevel.Error, Message = "Error updating {Count} misfired trigger(s)")]
+    public static partial void MisfiredTriggerUpdateFailed(this ILogger logger, int count, Exception exception);
+
+    [LoggerMessage(EventId = 3605, Level = LogLevel.Debug, Message = "Found {MisfireCount} triggers that missed their scheduled fire-time.")]
+    public static partial void MisfiredTriggersCounted(this ILogger logger, int misfireCount);
+
+    [LoggerMessage(EventId = 3606, Level = LogLevel.Debug, Message = "Scanning for misfires...")]
+    public static partial void ScanningForMisfires(this ILogger logger);
+
+    [LoggerMessage(EventId = 3607, Level = LogLevel.Error, Message = "Error handling misfires: {ExceptionMessage}")]
+    public static partial void MisfireHandlingFailed(this ILogger logger, string exceptionMessage, Exception exception);
+}

--- a/src/Quartz/Impl/AdoJobStore/SQLiteSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/SQLiteSemaphore.cs
@@ -86,7 +86,7 @@ internal sealed class SQLiteSemaphore : ISemaphore
 
         if (isDebugEnabled)
         {
-            logger.LogDebug("Lock '{LockName}' is desired by: {RequestorId}", lockName, requestorId);
+            logger.LockDesired(lockName, requestorId);
         }
 
         // Fast path: re-entrant acquisition by the same requestor avoids
@@ -98,7 +98,7 @@ internal sealed class SQLiteSemaphore : ISemaphore
                 lockCount++;
                 if (isDebugEnabled)
                 {
-                    logger.LogDebug("Lock '{LockName}' reentrant acquisition by: {RequestorId} (count: {LockCount})", lockName, requestorId, lockCount);
+                    logger.LockReentrantAcquisition(lockName, requestorId, lockCount);
                 }
                 return new ValueTask<bool>(true);
             }
@@ -115,7 +115,7 @@ internal sealed class SQLiteSemaphore : ISemaphore
     {
         if (isDebugEnabled)
         {
-            logger.LogDebug("Lock '{LockName}' is being obtained: {RequestorId}", lockName, requestorId);
+            logger.LockBeingObtained(lockName, requestorId);
         }
 
         try
@@ -126,7 +126,7 @@ internal sealed class SQLiteSemaphore : ISemaphore
         {
             if (isDebugEnabled)
             {
-                logger.LogDebug("Lock '{LockName}' was not obtained by: {RequestorId}", lockName, requestorId);
+                logger.LockNotObtained(lockName, requestorId);
             }
 
             return false;
@@ -140,7 +140,7 @@ internal sealed class SQLiteSemaphore : ISemaphore
 
         if (isDebugEnabled)
         {
-            logger.LogDebug("Lock '{LockName}' given to: {RequestorId}", lockName, requestorId);
+            logger.LockGiven(lockName, requestorId);
         }
 
         return true;
@@ -160,8 +160,8 @@ internal sealed class SQLiteSemaphore : ISemaphore
             {
                 if (logger.IsEnabled(LogLevel.Warning))
                 {
-                    logger.LogWarning("Lock '{LockName}' attempt to return by: {RequestorId} -- but not owner!", lockKind.ToLockName(), requestorId);
-                    logger.LogWarning("stack-trace of wrongful returner: {Stacktrace}", Environment.StackTrace);
+                    logger.LockReturnedByNonOwner(lockKind.ToLockName(), requestorId);
+                    logger.WrongfulReturnerStack(Environment.StackTrace);
                 }
 
                 return default;
@@ -172,7 +172,7 @@ internal sealed class SQLiteSemaphore : ISemaphore
             {
                 if (logger.IsEnabled(LogLevel.Debug))
                 {
-                    logger.LogDebug("Lock '{LockName}' reentrant release by: {RequestorId} (remaining: {LockCount})", lockKind.ToLockName(), requestorId, lockCount);
+                    logger.LockReentrantRelease(lockKind.ToLockName(), requestorId, lockCount);
                 }
 
                 return default;
@@ -185,7 +185,7 @@ internal sealed class SQLiteSemaphore : ISemaphore
 
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug("Lock '{LockName}' returned by: {RequestorId}", lockKind.ToLockName(), requestorId);
+            logger.LockReturned(lockKind.ToLockName(), requestorId);
         }
 
         return default;

--- a/src/Quartz/Impl/AdoJobStore/SelectForUpdateSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/SelectForUpdateSemaphore.cs
@@ -151,7 +151,7 @@ public class SelectForUpdateSemaphore : DbSemaphore
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.LogDebug("Lock '{LockName}' is being obtained: {RequestorId}", lockName, requestorId);
+                        logger.LockBeingObtained(lockName, requestorId);
                     }
 
                     found = await rs.ReadAsync(cancellationToken).ConfigureAwait(false);
@@ -161,7 +161,7 @@ public class SelectForUpdateSemaphore : DbSemaphore
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.LogDebug("Inserting new lock row for lock: '{LockName}' being obtained by thread: {RequestorId}", lockName, requestorId);
+                        logger.LockRowInsertingForThread(lockName, requestorId);
                     }
 
                     using DbCommand cmd2 = PrepareCommand(conn, expandedInsertSql);
@@ -197,7 +197,7 @@ public class SelectForUpdateSemaphore : DbSemaphore
 
                 if (logger.IsEnabled(LogLevel.Debug))
                 {
-                    logger.LogDebug("Lock '{LockName}' was not obtained by: {RequestorId}{RetryMessage}", lockName, requestorId, count < maxRetryLocal ? " - will try again." : "");
+                    logger.LockNotObtainedWithRetryNote(lockName, requestorId, count < maxRetryLocal ? " - will try again." : "");
                 }
 
                 if (count < maxRetryLocal)

--- a/src/Quartz/Impl/AdoJobStore/SimpleSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimpleSemaphore.cs
@@ -67,7 +67,7 @@ internal sealed class SimpleSemaphore : ISemaphore
 
         if (isDebugEnabled)
         {
-            logger.LogDebug("Lock '{LockName}' is desired by: {RequestorId}", lockName, requestorId);
+            logger.LockDesired(lockName, requestorId);
         }
 
         var gotLock = false;
@@ -76,7 +76,7 @@ internal sealed class SimpleSemaphore : ISemaphore
         {
             if (isDebugEnabled)
             {
-                logger.LogDebug("Lock '{LockName}' is being obtained: {RequestorId}", lockName, requestorId);
+                logger.LockBeingObtained(lockName, requestorId);
             }
 
             try
@@ -88,19 +88,19 @@ internal sealed class SimpleSemaphore : ISemaphore
             {
                 if (isDebugEnabled)
                 {
-                    logger.LogDebug("Lock '{LockName}' was not obtained by: {RequestorId}", lockName, requestorId);
+                    logger.LockNotObtained(lockName, requestorId);
                 }
             }
 
             if (isDebugEnabled)
             {
-                logger.LogDebug("Lock '{LockName}' given to: {RequestorId}", lockName, requestorId);
+                logger.LockGiven(lockName, requestorId);
             }
         }
         else if (isDebugEnabled)
         {
-            logger.LogDebug("Lock '{LockName}' already owned by: {RequestorId} -- but not owner!", lockName, requestorId);
-            logger.LogDebug("stack-trace of wrongful returner: {StackTrace}", Environment.StackTrace);
+            logger.LockAlreadyOwnedByOther(lockName, requestorId);
+            logger.WrongfulReturnerStackDebug(Environment.StackTrace);
         }
 
         return gotLock;
@@ -121,13 +121,13 @@ internal sealed class SimpleSemaphore : ISemaphore
 
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.LogDebug("Lock '{LockName}' returned by: {RequestorId}", lockKind.ToLockName(), requestorId);
+                logger.LockReturned(lockKind.ToLockName(), requestorId);
             }
         }
         else if (logger.IsEnabled(LogLevel.Warning))
         {
-            logger.LogWarning("Lock '{LockName}' attempt to return by: {RequestorId} -- but not owner!", lockKind.ToLockName(), requestorId);
-            logger.LogWarning("stack-trace of wrongful returner: {Stacktrace}", Environment.StackTrace);
+            logger.LockReturnedByNonOwner(lockKind.ToLockName(), requestorId);
+            logger.WrongfulReturnerStack(Environment.StackTrace);
         }
 
         return default;

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
@@ -73,7 +73,7 @@ public partial class StdAdoDelegate
 
         if (null == calendar)
         {
-            logger.LogWarning("Couldn't find calendar with name '{CalendarName}'", calendarName);
+            logger.CalendarNotFound(calendarName);
         }
 
         return calendar;

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -91,7 +91,7 @@ public partial class StdAdoDelegate
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlDeleteJobDetail));
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug("Deleting job: {JobKey}", jobKey);
+            logger.JobDeleting(jobKey);
         }
 
         AddCommandParameter(cmd, "schedulerName", schedulerName);
@@ -349,7 +349,7 @@ public partial class StdAdoDelegate
 
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug("No job for trigger '{TriggerKey}'", triggerKey);
+            logger.NoJobForTrigger(triggerKey);
         }
 
         return null;

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -1662,7 +1662,7 @@ public partial class StdAdoDelegate
 
     public virtual void AddTriggerPersistenceDelegate(ITriggerPersistenceDelegate persistenceDelegate)
     {
-        logger.LogDebug("Adding TriggerPersistenceDelegate of type: {Type}", persistenceDelegate.GetType());
+        logger.TriggerPersistenceDelegateAdded(persistenceDelegate.GetType());
         persistenceDelegate.Initialize(new TriggerPersistenceDelegateContext
         {
             SchedulerName = schedulerName,
@@ -1905,7 +1905,7 @@ public partial class StdAdoDelegate
             }
             else
             {
-                logger.LogWarning("Misfired trigger '{TriggerKey}' has no {TriggerType} row and is skipped", keys[i], rows[i].TriggerType);
+                logger.MisfiredTriggerHasNoTypeRow(keys[i], rows[i].TriggerType);
             }
         }
 
@@ -2336,7 +2336,7 @@ public partial class StdAdoDelegate
             // just dropped — or a transaction the server has already doomed, which is what Postgres does
             // to every statement after the first error — surfaces some later, unrecognisable failure
             // instead, and a retryable operation stops being retried.
-            logger.LogWarning(e, "Batched statement execution failed, retrying {StatementCount} statement(s) individually", length);
+            logger.BatchedStatementExecutionFailed(length, e);
             await ExecuteStatementsIndividually(conn, statements, offset, length, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/Quartz/Impl/AdoJobStore/UpdateRowSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/UpdateRowSemaphore.cs
@@ -118,14 +118,14 @@ public class UpdateRowSemaphore : DbSemaphore
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.LogDebug("Lock '{LockName}' was not obtained by: {RequestorId}", lockName, requestorId);
+                        logger.LockNotObtained(lockName, requestorId);
                     }
                 }
                 else
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.LogDebug("Lock '{LockName}' was not obtained by: {RequestorId} - will try again.", lockName, requestorId);
+                        logger.LockNotObtainedWillRetry(lockName, requestorId);
                     }
 
                     await Task.Delay(RetryPeriod, TimeProvider, cancellationToken).ConfigureAwait(false);
@@ -151,7 +151,7 @@ public class UpdateRowSemaphore : DbSemaphore
 
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug("Lock '{LockName}' is being obtained: {RequestorId}", lockName, requestorId);
+            logger.LockBeingObtained(lockName, requestorId);
         }
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false) >= 1;
     }
@@ -170,7 +170,7 @@ public class UpdateRowSemaphore : DbSemaphore
 
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug("Inserting new lock row for lock: '{LockName}' being obtained: {RequestorId}", lockName, requestorId);
+            logger.LockRowInserting(lockName, requestorId);
         }
 
         using var cmd = PrepareCommand(conn, sql);

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -192,14 +192,11 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
                 .Initialize(scheduler, cancellationToken)
                 .ConfigureAwait(false);
 
-            logger.LogInformation(
-                "Quartz Scheduler {Version} - '{SchedulerName}' with instanceId '{SchedulerInstanceId}' initialized",
+            logger.SchedulerInitialized(
                 quartzScheduler.Version, quartzScheduler.SchedulerName, quartzScheduler.SchedulerInstanceId);
-            logger.LogInformation(
-                "Using thread pool '{ThreadPoolType}', size: {ThreadPoolSize}",
+            logger.UsingThreadPool(
                 quartzScheduler.ThreadPoolType.FullName, quartzScheduler.ThreadPoolSize);
-            logger.LogInformation(
-                "Using job store '{JobStoreType}', supports persistence: {SupportsPersistence}, clustered: {Clustered}",
+            logger.UsingJobStore(
                 quartzScheduler.JobStoreType.FullName, quartzScheduler.SupportsPersistence, quartzScheduler.Clustered);
 
             return scheduler;
@@ -259,7 +256,7 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
         }
         catch (Exception e) when (e is not SchedulerException)
         {
-            logger.LogError(e, "Couldn't generate instance id");
+            logger.InstanceIdGenerationFailed(e);
             Throw.SchedulerException("Cannot run without an instance id.", e);
             return default!;
         }
@@ -275,7 +272,7 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
         }
         catch (Exception e)
         {
-            logger.LogError(e, "Got another exception while shutting down after instantiation exception");
+            logger.ShutdownAfterInstantiationFailureFailed(e);
         }
     }
 }

--- a/src/Quartz/Impl/HostNameBasedIdGenerator.cs
+++ b/src/Quartz/Impl/HostNameBasedIdGenerator.cs
@@ -23,6 +23,7 @@ using System.Net;
 
 using Microsoft.Extensions.Logging;
 
+using Quartz.Configuration;
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
 
@@ -67,7 +68,7 @@ public abstract class HostNameBasedIdGenerator : IInstanceIdGenerator
             if (hostName.Length > maxLength)
             {
                 string newName = hostName.Substring(0, maxLength);
-                logger.LogInformation("Host name '{HostName}' was too long, shortened to '{Newname}'", hostName, newName);
+                logger.HostNameShortened(hostName, newName);
                 hostName = newName;
             }
             return hostName;

--- a/src/Quartz/Impl/PropertySettingJobFactory.cs
+++ b/src/Quartz/Impl/PropertySettingJobFactory.cs
@@ -23,6 +23,7 @@ using System.Runtime.ExceptionServices;
 
 using Microsoft.Extensions.Logging;
 
+using Quartz.Configuration;
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
 using Quartz.Util;
@@ -155,7 +156,7 @@ public class PropertySettingJobFactory : SimpleJobFactory
             catch (Exception e)
             {
                 // Never let cleanup replace the failure that caused it.
-                factory.logger.LogWarning(e, "Failed to return a job after its creation failed; the original error follows");
+                factory.logger.JobReturnAfterFailedCreationFailed(e);
             }
 
             ExceptionDispatchInfo.Capture(failure).Throw();
@@ -343,16 +344,7 @@ public class PropertySettingJobFactory : SimpleJobFactory
 
         if (PropertyMismatchBehavior == PropertyMismatchBehavior.Warn)
         {
-#pragma warning disable CA2254
-            if (e is null)
-            {
-                logger.LogWarning(message);
-            }
-            else
-            {
-                logger.LogWarning(e, message);
-            }
-#pragma warning restore CA2254
+            logger.JobPropertyNotSet(message, e);
         }
     }
 }

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -151,7 +151,7 @@ public sealed class RAMJobStore : IJobStore
         ArgumentNullException.ThrowIfNull(identity);
 
         schedulerInstanceId = identity.InstanceId;
-        logger.LogInformation("RAMJobStore initialized.");
+        logger.StoreInitialized();
         return default;
     }
 
@@ -2541,7 +2541,7 @@ public sealed class RAMJobStore : IJobStore
                 // take down the acquisition loop and stop every other trigger from firing.
                 if (!jobsByKey.TryGetValue(jobKey, out var jobWrapper))
                 {
-                    logger.LogWarning("Skipping trigger {TriggerKey}: its job {JobKey} no longer exists", tw.TriggerKey, jobKey);
+                    logger.TriggerSkippedJobMissing(tw.TriggerKey, jobKey);
                     continue;
                 }
 
@@ -2696,7 +2696,7 @@ public sealed class RAMJobStore : IJobStore
                     calendarsByName.TryGetValue(tw.Trigger.CalendarName, out calendar);
                     if (calendar is null)
                     {
-                        logger.LogWarning("Trigger {TriggerKey} references calendar '{CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared.", tw.Trigger.Key, tw.Trigger.CalendarName);
+                        logger.TriggerReferencesMissingCalendar(tw.Trigger.Key, tw.Trigger.CalendarName);
                         results.Add(TriggerFiredResult.NotFired);
                         continue;
                     }
@@ -2893,7 +2893,7 @@ public sealed class RAMJobStore : IJobStore
             {
                 if (triggerInstructionCode == SchedulerInstruction.DeleteTrigger)
                 {
-                    logger.LogDebug("Deleting trigger");
+                    logger.TriggerDeleting();
                     DateTimeOffset? d = trigger.NextFireTimeUtc;
                     if (!d.HasValue)
                     {
@@ -2906,7 +2906,7 @@ public sealed class RAMJobStore : IJobStore
                         }
                         else
                         {
-                            logger.LogDebug("Deleting cancelled - trigger still active");
+                            logger.TriggerDeletionCancelled();
                         }
                     }
                     else
@@ -2923,14 +2923,14 @@ public sealed class RAMJobStore : IJobStore
                 }
                 else if (triggerInstructionCode == SchedulerInstruction.SetTriggerError)
                 {
-                    logger.LogInformation("Trigger {TriggerKey} set to ERROR state.", trigger.Key);
+                    logger.TriggerSetToError(trigger.Key);
                     tw.state = StoredTriggerState.Error;
                     errorNotification = ErrorNotification.Trigger;
                     await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
                 }
                 else if (triggerInstructionCode == SchedulerInstruction.SetAllJobTriggersError)
                 {
-                    logger.LogInformation("All triggers of Job {JobKey} set to ERROR state.", trigger.JobKey);
+                    logger.JobTriggersSetToError(trigger.JobKey);
                     SetAllTriggersOfJobToState(trigger.JobKey, StoredTriggerState.Error);
                     errorNotification = ErrorNotification.JobTriggers;
                     await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Impl/RAMJobStoreLog.cs
+++ b/src/Quartz/Impl/RAMJobStoreLog.cs
@@ -1,0 +1,54 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Impl;
+
+/// <summary>
+/// Every event the in-memory job store logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// Event ids 2000-2999 belong to this area and are allocated in file order. An id, once given out, is
+/// what an operator filters and alerts on, so it is never reused for a different event and never
+/// renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </remarks>
+internal static partial class RAMJobStoreLog
+{
+    [LoggerMessage(EventId = 2000, Level = LogLevel.Information, Message = "RAMJobStore initialized.")]
+    public static partial void StoreInitialized(this ILogger logger);
+
+    [LoggerMessage(EventId = 2001, Level = LogLevel.Warning, Message = "Skipping trigger {TriggerKey}: its job {JobKey} no longer exists")]
+    public static partial void TriggerSkippedJobMissing(this ILogger logger, TriggerKey triggerKey, JobKey jobKey);
+
+    [LoggerMessage(EventId = 2002, Level = LogLevel.Warning, Message = "Trigger {TriggerKey} references calendar '{CalendarName}', which does not exist - the fire was skipped and the trigger will not run until the calendar is added or the reference is cleared.")]
+    public static partial void TriggerReferencesMissingCalendar(this ILogger logger, TriggerKey triggerKey, string calendarName);
+
+    [LoggerMessage(EventId = 2003, Level = LogLevel.Debug, Message = "Deleting trigger")]
+    public static partial void TriggerDeleting(this ILogger logger);
+
+    [LoggerMessage(EventId = 2004, Level = LogLevel.Debug, Message = "Deleting cancelled - trigger still active")]
+    public static partial void TriggerDeletionCancelled(this ILogger logger);
+
+    [LoggerMessage(EventId = 2005, Level = LogLevel.Information, Message = "Trigger {TriggerKey} set to ERROR state.")]
+    public static partial void TriggerSetToError(this ILogger logger, TriggerKey triggerKey);
+
+    [LoggerMessage(EventId = 2006, Level = LogLevel.Information, Message = "All triggers of Job {JobKey} set to ERROR state.")]
+    public static partial void JobTriggersSetToError(this ILogger logger, JobKey jobKey);
+}

--- a/src/Quartz/Impl/SimpleJobFactory.cs
+++ b/src/Quartz/Impl/SimpleJobFactory.cs
@@ -19,6 +19,7 @@
 
 using Microsoft.Extensions.Logging;
 
+using Quartz.Configuration;
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
 using Quartz.Util;
@@ -87,7 +88,7 @@ public class SimpleJobFactory : IJobFactory
         {
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.LogDebug("Producing instance of Job '{JobKey}', class={JobFullName}", jobDetail.Key, jobType.FullName);
+                logger.ProducingJobInstance(jobDetail.Key, jobType.FullName);
             }
 
             return ObjectUtils.InstantiateType<IJob>(jobType);

--- a/src/Quartz/Impl/SimpleTypeLoader.cs
+++ b/src/Quartz/Impl/SimpleTypeLoader.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
+using Quartz.Util;
 
 namespace Quartz.Impl;
 
@@ -119,10 +120,7 @@ internal sealed class SimpleTypeLoader : ITypeLoader
             var type = Type.GetType(candidate, false);
             if (type is not null)
             {
-                logger.LogWarning(
-                    "Type '{OldName}' was found as '{NewName}'; the type moved in Quartz 4.0. " +
-                    "Update the configuration, as this fallback will not last forever.",
-                    name, candidate);
+                logger.TypeFoundUnderNewName(name, candidate);
                 return type;
             }
         }

--- a/src/Quartz/Impl/TaskSchedulingThreadPool.cs
+++ b/src/Quartz/Impl/TaskSchedulingThreadPool.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 
+using Quartz.Configuration;
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
 
@@ -175,8 +176,7 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
 
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug("TaskSchedulingThreadPool configured with max concurrency of {MaxConcurrency} and TaskScheduler {SchedulerName}.",
-                MaxConcurrency, Scheduler.GetType().Name);
+            logger.TaskSchedulingThreadPoolConfigured(MaxConcurrency, Scheduler.GetType().Name);
         }
 
         return default;
@@ -307,7 +307,7 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
         {
             // Observing the fault here keeps it off the UnobservedTaskException path; a failure
             // can reach this point only by escaping the job run shell's own error handling.
-            logger.LogError(completedTask.Exception, "A task handed to the thread pool faulted.");
+            logger.ThreadPoolTaskFaulted(completedTask.Exception);
         }
 
         concurrencySemaphore.Release();
@@ -337,7 +337,7 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
             return;
         }
 
-        logger.LogDebug("Shutting down threadpool...");
+        logger.ThreadPoolShuttingDown();
 
         Task drained = CloseToNewWork();
 
@@ -349,7 +349,7 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
             // tears down afterwards would run with jobs still writing to the store.
             await drained.ConfigureAwait(false);
 
-            logger.LogDebug("No executing jobs remaining, all threads stopped.");
+            logger.ThreadPoolDrained();
         }
 
         ReleaseResources();
@@ -364,7 +364,7 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
             return true;
         }
 
-        logger.LogDebug("Draining threadpool...");
+        logger.ThreadPoolDraining();
 
         Task drained = CloseToNewWork();
         bool drainedInTime = true;
@@ -386,11 +386,11 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
 
         if (drainedInTime)
         {
-            logger.LogDebug("No executing jobs remaining, all threads stopped.");
+            logger.ThreadPoolDrained();
         }
         else
         {
-            logger.LogDebug("Gave up waiting for the thread pool to drain; work is still running.");
+            logger.ThreadPoolDrainGivenUp();
         }
 
         ReleaseResources();
@@ -417,7 +417,7 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
                 ? Interlocked.Decrement(ref runningTasks)
                 : Volatile.Read(ref runningTasks);
 
-            logger.LogDebug("Thread pool closed to new work with {RunningTaskCount} running tasks remaining.", remaining);
+            logger.ThreadPoolClosedToNewWork(remaining);
 
             if (remaining == 0)
             {
@@ -435,6 +435,6 @@ public abstract class TaskSchedulingThreadPool : IThreadPool
         // Dispose the scheduler to release its resources (e.g. QueuedTaskScheduler threads)
         (scheduler as IDisposable)?.Dispose();
 
-        logger.LogDebug("Shutdown of threadpool complete.");
+        logger.ThreadPoolShutdownComplete();
     }
 }

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
+using Quartz.Util;
 
 namespace Quartz.Impl.Triggers;
 
@@ -447,8 +448,7 @@ public class CronTriggerImpl : TriggerBase, ICronTrigger
         else
         {
             var logger = LogProvider.CreateLogger<CronTriggerImpl>();
-            logger.LogWarning("Unrecognized misfire policy {MisfireInstruction}. Derived builder will use the default cron trigger behavior (FireOnceNow)",
-                MisfireInstructionCode);
+            logger.UnrecognizedCronMisfirePolicy(MisfireInstructionCode);
         }
 
         return cb;

--- a/src/Quartz/Impl/ZeroSizeThreadPool.cs
+++ b/src/Quartz/Impl/ZeroSizeThreadPool.cs
@@ -21,6 +21,7 @@
 
 using Microsoft.Extensions.Logging;
 
+using Quartz.Configuration;
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
 
@@ -85,7 +86,7 @@ public sealed class ZeroSizeThreadPool : IThreadPool
     /// <param name="cancellationToken">The cancellation instruction.</param>
     public ValueTask Shutdown(bool waitForJobsToComplete = true, CancellationToken cancellationToken = default)
     {
-        logger.LogDebug("Shutdown complete");
+        logger.ZeroSizeThreadPoolShutdownComplete();
         return default;
     }
 

--- a/src/Quartz/Listeners/BroadcastJobListener.cs
+++ b/src/Quartz/Listeners/BroadcastJobListener.cs
@@ -22,6 +22,7 @@
 using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
+using Quartz.Util;
 
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -134,8 +135,7 @@ public sealed class BroadcastJobListener : IJobListener
             {
                 if (logger.IsEnabled(LogLevel.Error))
                 {
-                    logger.LogError(e, "Listener {ListenerName} - method {MethodName} raised an exception: {ExceptionMessage}",
-                        listener.Name, methodName, e.Message);
+                    logger.ListenerRaisedException(listener.Name, methodName, e.Message, e);
                 }
             }
         }

--- a/src/Quartz/Listeners/BroadcastSchedulerListener.cs
+++ b/src/Quartz/Listeners/BroadcastSchedulerListener.cs
@@ -22,6 +22,7 @@
 using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
+using Quartz.Util;
 
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -226,7 +227,7 @@ public sealed class BroadcastSchedulerListener : ISchedulerListener
             {
                 if (logger.IsEnabled(LogLevel.Error))
                 {
-                    logger.LogError(e, "Listener method {MethodName} raised an exception: {ExceptionMessage}", methodName, e.Message);
+                    logger.SchedulerListenerRaisedException(methodName, e.Message, e);
                 }
             }
         }

--- a/src/Quartz/Listeners/BroadcastTriggerListener.cs
+++ b/src/Quartz/Listeners/BroadcastTriggerListener.cs
@@ -22,6 +22,7 @@
 using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
+using Quartz.Util;
 
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -151,8 +152,7 @@ public sealed class BroadcastTriggerListener : ITriggerListener
             {
                 if (logger.IsEnabled(LogLevel.Error))
                 {
-                    logger.LogError(e, "Listener {ListenerName} - method {MethodName} raised an exception: {ExceptionMessage}",
-                        listener.Name, methodName, e.Message);
+                    logger.ListenerRaisedException(listener.Name, methodName, e.Message, e);
                 }
             }
         }

--- a/src/Quartz/Listeners/JobChainingJobListener.cs
+++ b/src/Quartz/Listeners/JobChainingJobListener.cs
@@ -22,6 +22,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
+using Quartz.Util;
 
 namespace Quartz.Listeners;
 
@@ -185,7 +186,7 @@ public sealed class JobChainingJobListener : IJobListener
 
         foreach (JobKey followUpJob in followUpJobs)
         {
-            logger.LogInformation("Job '{JobKey}' will now chain to Job '{Job}'", context.JobDetail.Key, followUpJob);
+            logger.ChainingToJob(context.JobDetail.Key, followUpJob);
 
             try
             {
@@ -194,7 +195,7 @@ public sealed class JobChainingJobListener : IJobListener
             catch (SchedulerException se)
             {
                 // a follow-up that could not be triggered must not cost its siblings their firing
-                logger.LogError(se, "Error encountered during chaining to Job '{Job}'", followUpJob);
+                logger.ChainingToJobFailed(followUpJob, se);
             }
         }
     }

--- a/src/Quartz/MisfireInstructionNames.cs
+++ b/src/Quartz/MisfireInstructionNames.cs
@@ -161,8 +161,7 @@ internal static class MisfireInstructionNames
             if (IsValidFor(family, otherFamilyValue))
             {
                 ILogger log = logger ?? LogProvider.CreateLogger(typeof(MisfireInstructionNames).FullName!);
-                log.LogWarning(
-                    "Misfire instruction '{MisfireInstruction}' is not one of the {Family} trigger names. It resolves to code {Code}, which for this trigger means {Policy}; spell it '{Canonical}'",
+                log.MisfireInstructionFromAnotherFamily(
                     trimmed,
                     family.DisplayName(),
                     otherFamilyValue,

--- a/src/Quartz/TimeZones.cs
+++ b/src/Quartz/TimeZones.cs
@@ -309,7 +309,7 @@ public static class TimeZones
                 catch
                 {
                     var logger = LogProvider.CreateLogger(nameof(TimeZones));
-                    logger.LogError("Could not find time zone using alias id {AliasId}", aliasedId);
+                    logger.TimeZoneAliasNotFound(aliasedId);
                 }
             }
 

--- a/src/Quartz/Util/FileUtil.cs
+++ b/src/Quartz/Util/FileUtil.cs
@@ -57,7 +57,7 @@ internal sealed class FileUtil
             catch (SecurityException)
             {
                 var logger = LogProvider.CreateLogger<FileUtil>();
-                logger.LogWarning("Unable to resolve file path '{FileName}' due to security exception, probably running under medium trust", fName);
+                logger.FilePathResolutionDenied(fName);
                 return null;
             }
         }

--- a/src/Quartz/Util/QuartzEnvironment.cs
+++ b/src/Quartz/Util/QuartzEnvironment.cs
@@ -29,7 +29,7 @@ internal static class QuartzEnvironment
         catch (SecurityException)
         {
             var log = LogProvider.CreateLogger(nameof(QuartzEnvironment));
-            log.LogWarning("Unable to read environment variable '{Key}' due to security exception, probably running under medium trust", key);
+            log.EnvironmentVariableReadDenied(key);
         }
         return null;
     }
@@ -51,7 +51,7 @@ internal static class QuartzEnvironment
         catch (SecurityException)
         {
             var log = LogProvider.CreateLogger(nameof(QuartzEnvironment));
-            log.LogWarning("Unable to read environment variables due to security exception, probably running under medium trust");
+            log.EnvironmentVariablesReadDenied();
         }
         return retValue;
     }

--- a/src/Quartz/Util/UtilityLog.cs
+++ b/src/Quartz/Util/UtilityLog.cs
@@ -1,0 +1,82 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Util;
+
+/// <summary>
+/// Every event the parts of Quartz that nothing injects a logger into log — type loading, triggers,
+/// listeners a caller constructs, and the static helpers — as source-generated methods with a pinned
+/// event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 5100-5199 belong to this sub-group of the 5000-5999 range, and are allocated in file
+/// order. These are the sites <see cref="Quartz.Diagnostics.LogProvider" /> exists for: a listener a
+/// caller built, a trigger read back out of a job store, a static helper. Being source-generated
+/// changes nothing about where the logger comes from.
+/// </para>
+/// <para>
+/// An id, once given out, is what an operator filters and alerts on, so it is never reused for a
+/// different event and never renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed
+/// diff.
+/// </para>
+/// </remarks>
+internal static partial class UtilityLog
+{
+    [LoggerMessage(EventId = 5100, Level = LogLevel.Warning, Message = "Misfire instruction '{MisfireInstruction}' is not one of the {Family} trigger names. It resolves to code {Code}, which for this trigger means {Policy}; spell it '{Canonical}'")]
+    public static partial void MisfireInstructionFromAnotherFamily(
+        this ILogger logger,
+        string misfireInstruction,
+        string family,
+        int code,
+        string policy,
+        string canonical);
+
+    [LoggerMessage(EventId = 5101, Level = LogLevel.Error, Message = "Could not find time zone using alias id {AliasId}")]
+    public static partial void TimeZoneAliasNotFound(this ILogger logger, string aliasId);
+
+    [LoggerMessage(EventId = 5102, Level = LogLevel.Warning, Message = "Type '{OldName}' was found as '{NewName}'; the type moved in Quartz 4.0. Update the configuration, as this fallback will not last forever.")]
+    public static partial void TypeFoundUnderNewName(this ILogger logger, string oldName, string newName);
+
+    [LoggerMessage(EventId = 5103, Level = LogLevel.Warning, Message = "Unrecognized misfire policy {MisfireInstruction}. Derived builder will use the default cron trigger behavior (FireOnceNow)")]
+    public static partial void UnrecognizedCronMisfirePolicy(this ILogger logger, int misfireInstruction);
+
+    [LoggerMessage(EventId = 5104, Level = LogLevel.Error, Message = "Listener {ListenerName} - method {MethodName} raised an exception: {ExceptionMessage}")]
+    public static partial void ListenerRaisedException(this ILogger logger, string listenerName, string methodName, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 5105, Level = LogLevel.Error, Message = "Listener method {MethodName} raised an exception: {ExceptionMessage}")]
+    public static partial void SchedulerListenerRaisedException(this ILogger logger, string methodName, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 5106, Level = LogLevel.Information, Message = "Job '{JobKey}' will now chain to Job '{Job}'")]
+    public static partial void ChainingToJob(this ILogger logger, JobKey jobKey, JobKey job);
+
+    [LoggerMessage(EventId = 5107, Level = LogLevel.Error, Message = "Error encountered during chaining to Job '{Job}'")]
+    public static partial void ChainingToJobFailed(this ILogger logger, JobKey job, Exception exception);
+
+    [LoggerMessage(EventId = 5108, Level = LogLevel.Warning, Message = "Unable to resolve file path '{FileName}' due to security exception, probably running under medium trust")]
+    public static partial void FilePathResolutionDenied(this ILogger logger, string fileName);
+
+    [LoggerMessage(EventId = 5109, Level = LogLevel.Warning, Message = "Unable to read environment variable '{Key}' due to security exception, probably running under medium trust")]
+    public static partial void EnvironmentVariableReadDenied(this ILogger logger, string key);
+
+    [LoggerMessage(EventId = 5110, Level = LogLevel.Warning, Message = "Unable to read environment variables due to security exception, probably running under medium trust")]
+    public static partial void EnvironmentVariablesReadDenied(this ILogger logger);
+}

--- a/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
@@ -869,7 +869,7 @@ internal class XmlSchedulingDataProcessor
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.TriggerAlreadyExistedWillRescheduleJob(trigger.Key, trigger.JobKey);
+                        logger.TriggerAlreadyExistedWillReschedule(trigger.Key, trigger.JobKey);
                     }
 
                     // Let's rescheduleJob one more time.

--- a/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
@@ -169,7 +169,7 @@ internal class XmlSchedulingDataProcessor
         // resolve file name first
         fileName = FileUtil.ResolveFile(fileName) ?? fileName;
 
-        logger.LogInformation("Parsing XML file: {FileName} with systemId: {SystemId}", fileName, systemId);
+        logger.ParsingFile(fileName, systemId);
 
         using (var stream = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
         using (StreamReader sr = new StreamReader(stream))
@@ -191,7 +191,7 @@ internal class XmlSchedulingDataProcessor
         string? systemId,
         CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Parsing XML from stream with systemId: {SystemId}", systemId);
+        logger.ParsingStream(systemId);
         using StreamReader sr = new StreamReader(stream);
         ProcessInternal(await sr.ReadToEndAsync(cancellationToken).ConfigureAwait(false));
     }
@@ -276,10 +276,10 @@ internal class XmlSchedulingDataProcessor
 
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug("Found {JobGroupCount} delete job group commands.", jobGroupsToDelete.Count);
-            logger.LogDebug("Found {TriggerGroupDeleteCount}delete trigger group commands.", triggerGroupsToDelete.Count);
-            logger.LogDebug("Found {JobsToDeleteCount} delete job commands.", jobsToDelete.Count);
-            logger.LogDebug("Found {TriggersToDelete} delete trigger commands.", triggersToDelete.Count);
+            logger.FoundDeleteJobGroupCommands(jobGroupsToDelete.Count);
+            logger.FoundDeleteTriggerGroupCommands(triggerGroupsToDelete.Count);
+            logger.FoundDeleteJobCommands(jobsToDelete.Count);
+            logger.FoundDeleteTriggerCommands(triggersToDelete.Count);
         }
 
         //
@@ -287,28 +287,26 @@ internal class XmlSchedulingDataProcessor
         //
         if (data.Directives is not null)
         {
-            logger.LogDebug("Directive 'overwrite-existing-data' specified as: {Overwrite}", data.Directives.OverwriteExistingData);
+            logger.OverwriteExistingDataSpecified(data.Directives.OverwriteExistingData);
             OverwriteExistingData = data.Directives.OverwriteExistingData;
 
-            logger.LogDebug("Directive 'ignore-duplicates' specified as: {IgnoreDuplicates}", data.Directives.IgnoreDuplicates);
+            logger.IgnoreDuplicatesSpecified(data.Directives.IgnoreDuplicates);
             IgnoreDuplicates = data.Directives.IgnoreDuplicates;
 
-            logger.LogDebug("Directive 'schedule-trigger-relative-to-replaced-trigger' specified as: {ScheduleRelative}",
-                data.Directives.ScheduleTriggerRelativeToReplacedTrigger);
+            logger.ScheduleTriggerRelativeSpecified(data.Directives.ScheduleTriggerRelativeToReplacedTrigger);
             ScheduleTriggerRelativeToReplacedTrigger = data.Directives.ScheduleTriggerRelativeToReplacedTrigger;
         }
         else
         {
-            logger.LogDebug("Directive 'overwrite-existing-data' not specified, defaulting to {Overwrite}", OverwriteExistingData);
-            logger.LogDebug("Directive 'ignore-duplicates' not specified, defaulting to {IgnoreDuplicates}", IgnoreDuplicates);
-            logger.LogDebug("Directive 'schedule-trigger-relative-to-replaced-trigger' not specified, defaulting to {ScheduleTriggerRelativeToReplacedTrigger}",
-                ScheduleTriggerRelativeToReplacedTrigger);
+            logger.OverwriteExistingDataDefaulted(OverwriteExistingData);
+            logger.IgnoreDuplicatesDefaulted(IgnoreDuplicates);
+            logger.ScheduleTriggerRelativeDefaulted(ScheduleTriggerRelativeToReplacedTrigger);
         }
 
         //
         // Extract Job definitions...
         //
-        logger.LogDebug("Found {Count} job definitions.", data.Jobs.Count);
+        logger.FoundJobDefinitions(data.Jobs.Count);
 
         foreach (JobDefinition jobDefinition in data.Jobs)
         {
@@ -335,7 +333,7 @@ internal class XmlSchedulingDataProcessor
 
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.LogDebug("Parsed job definition: {JobDetail}", jobDetail);
+                logger.ParsedJobDefinition(jobDetail);
             }
 
             AddJobToSchedule(jobDetail);
@@ -344,7 +342,7 @@ internal class XmlSchedulingDataProcessor
         //
         // Extract Trigger definitions...
         //
-        logger.LogDebug("Found {TriggerCount} trigger definitions.", data.Triggers.Count);
+        logger.FoundTriggerDefinitions(data.Triggers.Count);
 
         foreach (TriggerDefinition triggerNode in data.Triggers)
         {
@@ -447,7 +445,7 @@ internal class XmlSchedulingDataProcessor
 
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.LogDebug("Parsed trigger definition: {Trigger}", trigger);
+                logger.ParsedTriggerDefinition(trigger);
             }
 
             AddTriggerToSchedule(trigger);
@@ -550,7 +548,7 @@ internal class XmlSchedulingDataProcessor
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Unable to validate XML with schema: {Message}", ex.Message);
+            logger.SchemaValidationUnavailable(ex.Message, ex);
         }
     }
 
@@ -562,9 +560,7 @@ internal class XmlSchedulingDataProcessor
         }
         else
         {
-#pragma warning disable CA2254
-            logger.LogWarning(e.Message);
-#pragma warning restore CA2254
+            logger.SchemaValidationWarning(e.Message);
         }
     }
 
@@ -668,7 +664,7 @@ internal class XmlSchedulingDataProcessor
         List<IJobDetail> jobs = new List<IJobDetail>(LoadedJobs);
         List<ITrigger> triggers = new List<ITrigger>(LoadedTriggers);
 
-        logger.LogInformation("Adding {JobCount} jobs, {TriggerCount} triggers", jobs.Count, triggers.Count);
+        logger.AddingJobsAndTriggers(jobs.Count, triggers.Count);
 
         Dictionary<JobKey, List<IMutableTrigger>> triggersByFQJobName = BuildTriggersByFullyQualifiedJobNameMap(triggers);
 
@@ -691,7 +687,7 @@ internal class XmlSchedulingDataProcessor
                 if (e.InnerException is TypeLoadException && OverwriteExistingData)
                 {
                     // We are going to replace jobDetail anyway, so just delete it first.
-                    logger.LogInformation("Removing job: {JobKey}", detail.Key);
+                    logger.RemovingJob(detail.Key);
                     await scheduler.DeleteJob(detail.Key, cancellationToken).ConfigureAwait(false);
                 }
                 else
@@ -704,7 +700,7 @@ internal class XmlSchedulingDataProcessor
             {
                 if (!OverwriteExistingData && IgnoreDuplicates)
                 {
-                    logger.LogInformation("Not overwriting existing job: {JobKey}", dupeJ.Key);
+                    logger.NotOverwritingExistingJob(dupeJ.Key);
                     continue; // just ignore the entry
                 }
 
@@ -716,11 +712,11 @@ internal class XmlSchedulingDataProcessor
 
             if (dupeJ is not null)
             {
-                logger.LogInformation("Replacing job: {JobKey}", detail.Key);
+                logger.ReplacingJob(detail.Key);
             }
             else
             {
-                logger.LogInformation("Adding job: {JobKey}", detail.Key);
+                logger.AddingJob(detail.Key);
             }
 
             triggersByFQJobName.TryGetValue(detail.Key, out var triggersOfJob);
@@ -773,12 +769,12 @@ internal class XmlSchedulingDataProcessor
                         {
                             if (logger.IsEnabled(LogLevel.Debug))
                             {
-                                logger.LogDebug("Rescheduling job: {JobKey} with updated trigger: {TriggerKey}", trigger.JobKey, trigger.Key);
+                                logger.ReschedulingJob(trigger.JobKey, trigger.Key);
                             }
                         }
                         else if (IgnoreDuplicates)
                         {
-                            logger.LogInformation("Not overwriting existing trigger: {Key}", dupeT.Key);
+                            logger.NotOverwritingExistingTriggerByKey(dupeT.Key);
                             continue; // just ignore the trigger (and possibly job)
                         }
                         else
@@ -797,7 +793,7 @@ internal class XmlSchedulingDataProcessor
                     {
                         if (logger.IsEnabled(LogLevel.Debug))
                         {
-                            logger.LogDebug("Scheduling job: {JobKey} with trigger: {TriggerKey}", trigger.JobKey, trigger.Key);
+                            logger.SchedulingJob(trigger.JobKey, trigger.Key);
                         }
 
                         try
@@ -816,9 +812,7 @@ internal class XmlSchedulingDataProcessor
                         {
                             if (logger.IsEnabled(LogLevel.Debug))
                             {
-                                logger.LogDebug("Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed.  "
-                                                + "This is likely due to a race condition between multiple instances "
-                                                + "in the cluster.  Will try to reschedule instead.", trigger.Key, detail.Key);
+                                logger.TriggerAlreadyExistedWillReschedule(trigger.Key, detail.Key);
                             }
 
                             // Let's try one more time as reschedule.
@@ -840,12 +834,12 @@ internal class XmlSchedulingDataProcessor
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.LogDebug("Rescheduling job: {JobKey} with updated trigger: {TriggerKey}", trigger.JobKey, trigger.Key);
+                        logger.ReschedulingJob(trigger.JobKey, trigger.Key);
                     }
                 }
                 else if (IgnoreDuplicates)
                 {
-                    logger.LogInformation("Not overwriting existing trigger: {JobKey}", dupeT.Key);
+                    logger.NotOverwritingExistingTrigger(dupeT.Key);
                     continue; // just ignore the trigger
                 }
                 else
@@ -864,7 +858,7 @@ internal class XmlSchedulingDataProcessor
             {
                 if (logger.IsEnabled(LogLevel.Debug))
                 {
-                    logger.LogDebug("Scheduling job: {JobKey} with trigger: {TriggerKey}", trigger.JobKey, trigger.Key);
+                    logger.SchedulingJob(trigger.JobKey, trigger.Key);
                 }
 
                 try
@@ -875,10 +869,7 @@ internal class XmlSchedulingDataProcessor
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.LogDebug(
-                            "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed. This is likely due to a race condition between multiple instances in the cluster. Will try to reschedule instead.",
-                            trigger.Key,
-                            trigger.JobKey);
+                        logger.TriggerAlreadyExistedWillRescheduleJob(trigger.Key, trigger.JobKey);
                     }
 
                     // Let's rescheduleJob one more time.
@@ -891,8 +882,7 @@ internal class XmlSchedulingDataProcessor
 
     private void ReportDuplicateTrigger(IMutableTrigger trigger)
     {
-        logger.LogWarning("Possibly duplicately named ({TriggerKey}) trigger in configuration, this can be caused by not having a fixed job key for targeted jobs",
-            trigger.Key);
+        logger.DuplicatelyNamedTrigger(trigger.Key);
     }
 
     private ValueTask<DateTimeOffset?> DoRescheduleJob(
@@ -904,7 +894,7 @@ internal class XmlSchedulingDataProcessor
         // if this is a trigger with default start time we can consider relative scheduling
         if (oldTrigger is not null && trigger.StartTimeUtc - timeProvider.GetUtcNow() < TimeSpan.FromSeconds(5) && ScheduleTriggerRelativeToReplacedTrigger)
         {
-            logger.LogDebug("Using relative scheduling for trigger with key {TriggerKey}", trigger.Key);
+            logger.UsingRelativeScheduling(trigger.Key);
 
             var oldTriggerPreviousFireTime = oldTrigger.PreviousFireTimeUtc;
             trigger.StartTimeUtc = oldTrigger.StartTimeUtc;
@@ -954,7 +944,7 @@ internal class XmlSchedulingDataProcessor
         {
             if (group == "*")
             {
-                logger.LogInformation("Deleting all jobs in ALL groups.");
+                logger.DeletingAllJobsInAllGroups();
                 // deliberately unbounded: deleting only the first page would leave survivors behind
                 PagedResult<JobHeader> allJobs = await scheduler.QueryJobs(new JobQuery { Take = int.MaxValue }, cancellationToken).ConfigureAwait(false);
                 foreach (JobHeader job in allJobs.Items)
@@ -969,7 +959,7 @@ internal class XmlSchedulingDataProcessor
             {
                 if (!jobGroupsToNeverDelete.Contains(group))
                 {
-                    logger.LogInformation("Deleting all jobs in group: {Group}", group);
+                    logger.DeletingAllJobsInGroup(group);
                     foreach (JobKey key in await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(group), cancellationToken).ConfigureAwait(false))
                     {
                         await scheduler.DeleteJob(key, cancellationToken).ConfigureAwait(false);
@@ -982,7 +972,7 @@ internal class XmlSchedulingDataProcessor
         {
             if (group == "*")
             {
-                logger.LogInformation("Deleting all triggers in ALL groups.");
+                logger.DeletingAllTriggersInAllGroups();
                 // deliberately unbounded: unscheduling only the first page would leave survivors behind
                 PagedResult<TriggerHeader> allTriggers = await scheduler.QueryTriggers(new TriggerQuery { Take = int.MaxValue }, cancellationToken).ConfigureAwait(false);
                 foreach (TriggerHeader trigger in allTriggers.Items)
@@ -997,7 +987,7 @@ internal class XmlSchedulingDataProcessor
             {
                 if (!triggerGroupsToNeverDelete.Contains(group))
                 {
-                    logger.LogInformation("Deleting all triggers in group: {Group}", group);
+                    logger.DeletingAllTriggersInGroup(group);
                     foreach (TriggerKey key in await scheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals(group), cancellationToken).ConfigureAwait(false))
                     {
                         await scheduler.UnscheduleJob(key, cancellationToken).ConfigureAwait(false);
@@ -1010,7 +1000,7 @@ internal class XmlSchedulingDataProcessor
         {
             if (!jobGroupsToNeverDelete.Contains(key.Group))
             {
-                logger.LogInformation("Deleting job: {Key}", key);
+                logger.DeletingJob(key);
                 await scheduler.DeleteJob(key, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -1019,7 +1009,7 @@ internal class XmlSchedulingDataProcessor
         {
             if (!triggerGroupsToNeverDelete.Contains(key.Group))
             {
-                logger.LogInformation("Deleting trigger: {Key}", key);
+                logger.DeletingTrigger(key);
                 await scheduler.UnscheduleJob(key, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Quartz/Xml/XmlSchedulingLog.cs
+++ b/src/Quartz/Xml/XmlSchedulingLog.cs
@@ -1,0 +1,151 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Xml;
+
+/// <summary>
+/// Every event XML scheduling data processing logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// Event ids 5000-5099 belong to this sub-group of the 5000-5999 range, and are allocated in file
+/// order. An id, once given out, is what an operator filters and alerts on, so it is never reused for
+/// a different event and never renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed
+/// diff.
+/// </remarks>
+internal static partial class XmlSchedulingLog
+{
+    [LoggerMessage(EventId = 5000, Level = LogLevel.Information, Message = "Parsing XML file: {FileName} with systemId: {SystemId}")]
+    public static partial void ParsingFile(this ILogger logger, string fileName, string systemId);
+
+    [LoggerMessage(EventId = 5001, Level = LogLevel.Information, Message = "Parsing XML from stream with systemId: {SystemId}")]
+    public static partial void ParsingStream(this ILogger logger, string? systemId);
+
+    [LoggerMessage(EventId = 5002, Level = LogLevel.Debug, Message = "Found {JobGroupCount} delete job group commands.")]
+    public static partial void FoundDeleteJobGroupCommands(this ILogger logger, int jobGroupCount);
+
+    [LoggerMessage(EventId = 5003, Level = LogLevel.Debug, Message = "Found {TriggerGroupDeleteCount}delete trigger group commands.")]
+    public static partial void FoundDeleteTriggerGroupCommands(this ILogger logger, int triggerGroupDeleteCount);
+
+    [LoggerMessage(EventId = 5004, Level = LogLevel.Debug, Message = "Found {JobsToDeleteCount} delete job commands.")]
+    public static partial void FoundDeleteJobCommands(this ILogger logger, int jobsToDeleteCount);
+
+    [LoggerMessage(EventId = 5005, Level = LogLevel.Debug, Message = "Found {TriggersToDelete} delete trigger commands.")]
+    public static partial void FoundDeleteTriggerCommands(this ILogger logger, int triggersToDelete);
+
+    [LoggerMessage(EventId = 5006, Level = LogLevel.Debug, Message = "Directive 'overwrite-existing-data' specified as: {Overwrite}")]
+    public static partial void OverwriteExistingDataSpecified(this ILogger logger, bool overwrite);
+
+    [LoggerMessage(EventId = 5007, Level = LogLevel.Debug, Message = "Directive 'ignore-duplicates' specified as: {IgnoreDuplicates}")]
+    public static partial void IgnoreDuplicatesSpecified(this ILogger logger, bool ignoreDuplicates);
+
+    [LoggerMessage(EventId = 5008, Level = LogLevel.Debug, Message = "Directive 'schedule-trigger-relative-to-replaced-trigger' specified as: {ScheduleRelative}")]
+    public static partial void ScheduleTriggerRelativeSpecified(this ILogger logger, bool scheduleRelative);
+
+    [LoggerMessage(EventId = 5009, Level = LogLevel.Debug, Message = "Directive 'overwrite-existing-data' not specified, defaulting to {Overwrite}")]
+    public static partial void OverwriteExistingDataDefaulted(this ILogger logger, bool overwrite);
+
+    [LoggerMessage(EventId = 5010, Level = LogLevel.Debug, Message = "Directive 'ignore-duplicates' not specified, defaulting to {IgnoreDuplicates}")]
+    public static partial void IgnoreDuplicatesDefaulted(this ILogger logger, bool ignoreDuplicates);
+
+    [LoggerMessage(EventId = 5011, Level = LogLevel.Debug, Message = "Directive 'schedule-trigger-relative-to-replaced-trigger' not specified, defaulting to {ScheduleTriggerRelativeToReplacedTrigger}")]
+    public static partial void ScheduleTriggerRelativeDefaulted(this ILogger logger, bool scheduleTriggerRelativeToReplacedTrigger);
+
+    [LoggerMessage(EventId = 5012, Level = LogLevel.Debug, Message = "Found {Count} job definitions.")]
+    public static partial void FoundJobDefinitions(this ILogger logger, int count);
+
+    [LoggerMessage(EventId = 5013, Level = LogLevel.Debug, Message = "Parsed job definition: {JobDetail}")]
+    public static partial void ParsedJobDefinition(this ILogger logger, IJobDetail jobDetail);
+
+    [LoggerMessage(EventId = 5014, Level = LogLevel.Debug, Message = "Found {TriggerCount} trigger definitions.")]
+    public static partial void FoundTriggerDefinitions(this ILogger logger, int triggerCount);
+
+    [LoggerMessage(EventId = 5015, Level = LogLevel.Debug, Message = "Parsed trigger definition: {Trigger}")]
+    public static partial void ParsedTriggerDefinition(this ILogger logger, IMutableTrigger trigger);
+
+    [LoggerMessage(EventId = 5016, Level = LogLevel.Warning, Message = "Unable to validate XML with schema: {Message}")]
+    public static partial void SchemaValidationUnavailable(this ILogger logger, string message, Exception exception);
+
+    /// <remarks>
+    /// The whole message is one placeholder because it is the validating reader's own text, which is
+    /// what it always was — this call stood behind a <c>CA2254</c> pragma for exactly that reason.
+    /// </remarks>
+    [LoggerMessage(EventId = 5017, Level = LogLevel.Warning, Message = "{ValidationMessage}")]
+    public static partial void SchemaValidationWarning(this ILogger logger, string validationMessage);
+
+    [LoggerMessage(EventId = 5018, Level = LogLevel.Information, Message = "Adding {JobCount} jobs, {TriggerCount} triggers")]
+    public static partial void AddingJobsAndTriggers(this ILogger logger, int jobCount, int triggerCount);
+
+    [LoggerMessage(EventId = 5019, Level = LogLevel.Information, Message = "Removing job: {JobKey}")]
+    public static partial void RemovingJob(this ILogger logger, JobKey jobKey);
+
+    [LoggerMessage(EventId = 5020, Level = LogLevel.Information, Message = "Not overwriting existing job: {JobKey}")]
+    public static partial void NotOverwritingExistingJob(this ILogger logger, JobKey jobKey);
+
+    [LoggerMessage(EventId = 5021, Level = LogLevel.Information, Message = "Replacing job: {JobKey}")]
+    public static partial void ReplacingJob(this ILogger logger, JobKey jobKey);
+
+    [LoggerMessage(EventId = 5022, Level = LogLevel.Information, Message = "Adding job: {JobKey}")]
+    public static partial void AddingJob(this ILogger logger, JobKey jobKey);
+
+    [LoggerMessage(EventId = 5023, Level = LogLevel.Debug, Message = "Rescheduling job: {JobKey} with updated trigger: {TriggerKey}")]
+    public static partial void ReschedulingJob(this ILogger logger, JobKey jobKey, TriggerKey triggerKey);
+
+    [LoggerMessage(EventId = 5024, Level = LogLevel.Information, Message = "Not overwriting existing trigger: {Key}")]
+    public static partial void NotOverwritingExistingTriggerByKey(this ILogger logger, TriggerKey key);
+
+    [LoggerMessage(EventId = 5025, Level = LogLevel.Debug, Message = "Scheduling job: {JobKey} with trigger: {TriggerKey}")]
+    public static partial void SchedulingJob(this ILogger logger, JobKey jobKey, TriggerKey triggerKey);
+
+    [LoggerMessage(EventId = 5026, Level = LogLevel.Debug, Message = "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed.  This is likely due to a race condition between multiple instances in the cluster.  Will try to reschedule instead.")]
+    public static partial void TriggerAlreadyExistedWillReschedule(this ILogger logger, TriggerKey triggerKey, JobKey jobKey);
+
+    [LoggerMessage(EventId = 5027, Level = LogLevel.Debug, Message = "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed. This is likely due to a race condition between multiple instances in the cluster. Will try to reschedule instead.")]
+    public static partial void TriggerAlreadyExistedWillRescheduleJob(this ILogger logger, TriggerKey triggerKey, JobKey jobKey);
+
+    [LoggerMessage(EventId = 5028, Level = LogLevel.Information, Message = "Not overwriting existing trigger: {JobKey}")]
+    public static partial void NotOverwritingExistingTrigger(this ILogger logger, TriggerKey jobKey);
+
+    [LoggerMessage(EventId = 5029, Level = LogLevel.Warning, Message = "Possibly duplicately named ({TriggerKey}) trigger in configuration, this can be caused by not having a fixed job key for targeted jobs")]
+    public static partial void DuplicatelyNamedTrigger(this ILogger logger, TriggerKey triggerKey);
+
+    [LoggerMessage(EventId = 5030, Level = LogLevel.Debug, Message = "Using relative scheduling for trigger with key {TriggerKey}")]
+    public static partial void UsingRelativeScheduling(this ILogger logger, TriggerKey triggerKey);
+
+    [LoggerMessage(EventId = 5031, Level = LogLevel.Information, Message = "Deleting all jobs in ALL groups.")]
+    public static partial void DeletingAllJobsInAllGroups(this ILogger logger);
+
+    [LoggerMessage(EventId = 5032, Level = LogLevel.Information, Message = "Deleting all jobs in group: {Group}")]
+    public static partial void DeletingAllJobsInGroup(this ILogger logger, string group);
+
+    [LoggerMessage(EventId = 5033, Level = LogLevel.Information, Message = "Deleting all triggers in ALL groups.")]
+    public static partial void DeletingAllTriggersInAllGroups(this ILogger logger);
+
+    [LoggerMessage(EventId = 5034, Level = LogLevel.Information, Message = "Deleting all triggers in group: {Group}")]
+    public static partial void DeletingAllTriggersInGroup(this ILogger logger, string group);
+
+    [LoggerMessage(EventId = 5035, Level = LogLevel.Information, Message = "Deleting job: {Key}")]
+    public static partial void DeletingJob(this ILogger logger, JobKey key);
+
+    [LoggerMessage(EventId = 5036, Level = LogLevel.Information, Message = "Deleting trigger: {Key}")]
+    public static partial void DeletingTrigger(this ILogger logger, TriggerKey key);
+}

--- a/src/Quartz/Xml/XmlSchedulingLog.cs
+++ b/src/Quartz/Xml/XmlSchedulingLog.cs
@@ -43,7 +43,7 @@ internal static partial class XmlSchedulingLog
     [LoggerMessage(EventId = 5002, Level = LogLevel.Debug, Message = "Found {JobGroupCount} delete job group commands.")]
     public static partial void FoundDeleteJobGroupCommands(this ILogger logger, int jobGroupCount);
 
-    [LoggerMessage(EventId = 5003, Level = LogLevel.Debug, Message = "Found {TriggerGroupDeleteCount}delete trigger group commands.")]
+    [LoggerMessage(EventId = 5003, Level = LogLevel.Debug, Message = "Found {TriggerGroupDeleteCount} delete trigger group commands.")]
     public static partial void FoundDeleteTriggerGroupCommands(this ILogger logger, int triggerGroupDeleteCount);
 
     [LoggerMessage(EventId = 5004, Level = LogLevel.Debug, Message = "Found {JobsToDeleteCount} delete job commands.")]
@@ -116,11 +116,13 @@ internal static partial class XmlSchedulingLog
     [LoggerMessage(EventId = 5025, Level = LogLevel.Debug, Message = "Scheduling job: {JobKey} with trigger: {TriggerKey}")]
     public static partial void SchedulingJob(this ILogger logger, JobKey jobKey, TriggerKey triggerKey);
 
-    [LoggerMessage(EventId = 5026, Level = LogLevel.Debug, Message = "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed.  This is likely due to a race condition between multiple instances in the cluster.  Will try to reschedule instead.")]
+    /// <remarks>
+    /// Both places that add a trigger and find one already there raise this. They spelled the same
+    /// sentence with different spacing, which would have made it two events for one thing — 5027 is
+    /// deliberately never allocated.
+    /// </remarks>
+    [LoggerMessage(EventId = 5026, Level = LogLevel.Debug, Message = "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed. This is likely due to a race condition between multiple instances in the cluster. Will try to reschedule instead.")]
     public static partial void TriggerAlreadyExistedWillReschedule(this ILogger logger, TriggerKey triggerKey, JobKey jobKey);
-
-    [LoggerMessage(EventId = 5027, Level = LogLevel.Debug, Message = "Adding trigger: {TriggerKey} for job: {JobKey} failed because the trigger already existed. This is likely due to a race condition between multiple instances in the cluster. Will try to reschedule instead.")]
-    public static partial void TriggerAlreadyExistedWillRescheduleJob(this ILogger logger, TriggerKey triggerKey, JobKey jobKey);
 
     [LoggerMessage(EventId = 5028, Level = LogLevel.Information, Message = "Not overwriting existing trigger: {JobKey}")]
     public static partial void NotOverwritingExistingTrigger(this ILogger logger, TriggerKey jobKey);


### PR DESCRIPTION
Part 1 of 4 for #3414. The `Quartz` package only; `Quartz.Plugins`, `Quartz.Jobs` and
`Quartz.Extensions.Redis` follow in their own pull requests.

## What changed

All 224 `logger.Log{Trace,Debug,Information,Warning,Error,Critical}(…)` calls under `src/Quartz/`
are now calls on source-generated `[LoggerMessage]` methods — 204 events, because a message several
call sites spell identically is one event. Nothing is formatted or boxed when the level is off, and
every message carries a stable event id an operator can filter or alert on.

Nine `internal static partial class <Area>Log` classes, each beside its callers, each drawing from
its area's id range:

| Range | Class | File |
|---|---|---|
| 1000–1999 | `CoreLog` | `src/Quartz/Core/CoreLog.cs` |
| 2000–2999 | `RAMJobStoreLog` | `src/Quartz/Impl/RAMJobStoreLog.cs` |
| 3000–3499 | `AdoJobStoreLog` | `src/Quartz/Impl/AdoJobStore/AdoJobStoreLog.cs` |
| 3500–3599 | `ClusterLog` | `src/Quartz/Impl/AdoJobStore/ClusterLog.cs` |
| 3600–3699 | `MisfireLog` | `src/Quartz/Impl/AdoJobStore/MisfireLog.cs` |
| 3700–3799 | `LockHandlerLog` | `src/Quartz/Impl/AdoJobStore/LockHandlerLog.cs` |
| 4000–4999 | `ConfigurationLog` | `src/Quartz/Configuration/ConfigurationLog.cs` |
| 5000–5099 | `XmlSchedulingLog` | `src/Quartz/Xml/XmlSchedulingLog.cs` |
| 5100–5199 | `UtilityLog` | `src/Quartz/Util/UtilityLog.cs` |

6000–6999, 7000–7999 and 8000–8999 stay reserved for the other three packages, and the catalogue
test fails an id that strays into one.

Two guards, in `Quartz.Tests.Unit`:

* **`LogEventCatalogTest`** reflects over an assembly for every `[LoggerMessage]` method and Verifies
  id, level, name and template as `LogEventCatalogTest_<assembly>.verified.txt`. It also asserts that
  ids are unique and that every one falls in a range allocated to that assembly — which is the same
  thing as saying it stays out of another package's reserved range. The other three packages join
  with one line in `Catalogued` and a snapshot of their own.
* **`LogCallSiteTest`** walks `src/Quartz/` for a plain `.LogInformation(` and its siblings, the way
  `SourceEncodingTest` walks `src/` for a byte-order mark — a conversion is worth nothing if it can
  come back one call at a time. It carries an allow-list, empty, so a justified exception can be
  recorded with its reason rather than silently excluded. Later parts widen the `Converted` list.

`AdoJobStoreBase.LogWarnIfNonZero` is gone; the `CA2254` pragmas are gone; no other structure moved.

## Message templates that changed

Everything else is verbatim — same level, same template, same exception attached. Only these twelve
templates differ: eight where the source built the message rather than declaring it, and four typos
corrected on review, while their ids are new and doing so still costs nobody anything.

| Old | New | Why |
|---|---|---|
| `"ClusterManager: detected " + failedInstances.Count + " failed or restarted instances."` at **Information** (Debug when zero) | `"ClusterManager: detected {Count} failed or restarted instances."` at **Warning**, raised only when non-zero (3503) | `LogWarnIfNonZero` logged at a level its name did not say; the issue asks for the level the name claims. The zero branch said nothing worth a line |
| `"ClusterManager: ......Freed " + acquiredCount + " acquired trigger(s)."` | `"ClusterManager: ......Freed {Count} acquired trigger(s)."` at Warning (3507) | Same |
| `"ClusterManager: ......Deleted " + completeCount + " complete triggers(s)."` | `"ClusterManager: ......Deleted {Count} complete trigger(s)."` at Warning (3508) | Same, plus `triggers(s)` → `trigger(s)`: typo, corrected while the id is new |
| `"ClusterManager: ......Scheduled " + recoveredCount + " recoverable job(s) for recovery."` | `"ClusterManager: ......Scheduled {Count} recoverable job(s) for recovery."` at Warning (3509) | Same |
| `"ClusterManager: ......Cleaned-up " + otherCount + " other failed job(s)."` | `"ClusterManager: ......Cleaned-up {Count} other failed job(s)."` at Warning (3510) | Same |
| `"ClusterManager: ......Deferred recovery of " + deferredCount + " executing [DisallowConcurrentExecution] job(s)."` | `"ClusterManager: ......Deferred recovery of {Count} executing [DisallowConcurrentExecution] job(s)."` at Warning (3511) | Same |
| `PropertySettingJobFactory.HandleError`: `logger.LogWarning(message)` / `logger.LogWarning(e, message)`, the message interpolated at nine call sites, under `#pragma warning disable CA2254` | `"{Problem}"` at Warning (4009) | The message is assembled from the job type, the property and the value that would not go into it, and the same string is what the `Throw` disposition needs. The rendered text is unchanged and the pragma is gone |
| `XmlSchedulingDataProcessor.XmlValidationCallBack`: `logger.LogWarning(e.Message)` under `#pragma warning disable CA2254` | `"{ValidationMessage}"` at Warning (5017) | The text is the validating reader's own, which is what it always was. Rendered text unchanged, pragma gone |
| `"Removed  {Count} 'complete' triggers."` | `"Removed {Count} 'complete' triggers."` (3021) | Two spaces after `Removed`: typo, corrected while the id is new |
| `"Found {TriggerGroupDeleteCount}delete trigger group commands."` | `"Found {TriggerGroupDeleteCount} delete trigger group commands."` (5003) | No space after the placeholder: typo, corrected while the id is new |
| `"Adding trigger: … already existed.␣␣This is likely … cluster.␣␣Will try to reschedule instead."` (5026) and the same sentence single-spaced (5027) | One event, 5026, with the single-space spelling; **5027 is deliberately never allocated** | The two places that add a trigger and find one there spelled one message two ways. Two ids for one message is what the catalogue exists to prevent; typo, corrected while the ids are new |

**Not** in that table, because they are not changes: seven templates that the source spelled as
`"…" + "…"` across several lines were concatenations of *literals*, so they were already compile-time
constants and the attribute carries the identical string — `AdoJobStoreLog.ConnectionCloseFailed`,
`ClusterLog.RecoveredByAnotherInstance`, `ClusterLog.RecoveryDeferred`,
`CoreLog.GaveUpWaitingForRunningJobs`,
`ConfigurationLog.SchedulersShareDatabaseWithDifferentPrefixes`, `UtilityLog.TypeFoundUnderNewName`
and `XmlSchedulingLog.TriggerAlreadyExistedWillReschedule`.

## Benchmark

`dotnet run -c Release -- --filter *JobRunShell*`, same machine, back to back. AMD Ryzen 9 5950X,
.NET 10.0.11, BenchmarkDotNet 0.15.8. This is a developer workstation rather than a quiet box, and
the two runs are one sample each, so read the delta as "no regression, allocation identical" rather
than as a measured 1.5% win.

Base (`6f11175`):

| Method | Mean | Error | StdDev | Gen0 | Allocated |
|--- |---:|---:|---:|---:|---:|
| Success_NoTriggerListenersAndSingleJobListener_MayFireAgain | 520.0 ns | 3.31 ns | 3.10 ns | 0.0458 | 776 B |
| Success_NoTriggerListenersAndSingleJobListener_MayFireAgain_WithScopedLogger | 527.5 ns | 3.23 ns | 3.03 ns | 0.0458 | 776 B |

This branch:

| Method | Mean | Error | StdDev | Gen0 | Allocated |
|--- |---:|---:|---:|---:|---:|
| Success_NoTriggerListenersAndSingleJobListener_MayFireAgain | 512.4 ns | 8.09 ns | 7.57 ns | 0.0458 | 776 B |
| Success_NoTriggerListenersAndSingleJobListener_MayFireAgain_WithScopedLogger | 519.2 ns | 4.88 ns | 4.33 ns | 0.0458 | 776 B |

The shell's own Debug calls already sat behind `IsEnabled` checks and the benchmark's logger is
disabled, so this path was the one with least to gain. What the change buys is everywhere the guard
was missing — the job store, the delegate, the semaphores — which this benchmark does not reach.

## For a reviewer to decide

* **Two classes in the 5000–5999 range, not one.** The area is "serialization, type loading,
  triggers, calendars, utilities and anything else", and its callers span six namespaces, so "one
  class per area, beside its callers" cannot both hold. `XmlSchedulingLog` (5000–5099) sits in
  `Xml/` because it is 36 of the range's 47 events on its own, and `UtilityLog` (5100–5199) takes the
  other 11. Say the word and they collapse into one.
* **`ConfigurationLog` is one class whose callers span two namespaces.** Most of the 4000 range is
  raised from `Quartz.Impl` — the scheduler factory, the thread pools, the job factories — and the
  class lives in `Configuration/` because that is the folder the area is named for. Those callers
  reach it through a `using Quartz.Configuration;`. The alternative was four classes in one range.
* **`"{Problem}"` and `"{ValidationMessage}"` are degenerate templates.** Both messages are built at
  runtime and neither has structure to give named placeholders to. Doing better would mean nine
  events for `HandleError` and rewriting the throw path that shares the string; I did not, because
  the spec said not to restructure for this.
* **Existing `if (logger.IsEnabled(…))` guards are left in place.** They are redundant now — the
  generated method checks for itself — but removing them is a mechanical sweep with its own diff, and
  in `SQLiteSemaphore` the flag is threaded through a parameter. Worth doing; not here.
* **`CA1848` is still in `NoWarn` in `Directory.Build.props`.** It has nothing left to say about
  `Quartz`, but the other three packages still need it. It comes out with part 4.

## Verification

```
dotnet build Quartz.slnx                            0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit                   Passed: 3294, Failed: 0, Skipped: 4
dotnet test src/Quartz.Tests.AspNetCore             Passed:  433, Failed: 0, Skipped: 0
QUARTZ_TEST_DATABASE=basic dotnet test
  src/Quartz.Tests.Integration (non-db categories)  Passed:  158, Failed: 0, Skipped: 0
dotnet fallout VerifyDocsSnippets                   Succeeded (90 markdown files checked)
node docs/.vuepress/check-links.mjs                 no dead links or anchors
grep -rnE "\.Log(Trace|Debug|Information|Warning|Error|Critical)\(|\.Log\(LogLevel" src/Quartz
                                                    no matches
```

Docker was up, so the basic integration leg really ran.

The public API baselines are untouched: every generated class is `internal`. The migration guide
gains the range table, the one level change, and a correction — two entries said
`LogWarnIfNonZero` is private, and it is now gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
