### PR TITLE
A scheduler and its store are tested across the daylight-saving transitions

### DIFF
--- a/src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs
+++ b/src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs
@@ -1,0 +1,635 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Concurrent;
+using System.Text;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Extensibility;
+using Quartz.Tests.Unit;
+
+namespace Quartz.Tests.Integration.Core;
+
+/// <summary>
+/// A running scheduler carried across a daylight saving transition, over both stores, with the fires
+/// it produced compared against what the trigger arithmetic says it should have produced.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The daylight saving suites in <c>Quartz.Tests.Unit</c> ask <c>GetFireTimeAfter</c> what it
+/// computes. Nothing asked what a scheduler <em>fires</em>, or what a database holds afterwards, so
+/// the guarantee the documentation makes - that a schedule survives a transition - was untested end
+/// to end. This is that test: the same window, the same triggers, run over
+/// <see cref="Quartz.Impl.RAMJobStore" /> and over a SQLite file, in three zones and both
+/// directions.
+/// </para>
+/// <para>
+/// The clock is a <see cref="FakeTimeProvider" /> and nothing here sleeps. Two facts about the
+/// scheduling loop shape the way it is driven, and both are written up in the testing tutorial:
+/// advancing a fake clock does not wake the loop, which waits on a semaphore that only knows real
+/// elapsed time, so every advance is followed by something that signals a scheduling change; and a
+/// fire that is late by less than the misfire threshold is fired late rather than skipped, which is
+/// why the threshold here is wider than the whole window. Between them the scheduler replays every
+/// scheduled fire in the window in a burst after each advance, with
+/// <see cref="IJobExecutionContext.ScheduledFireTimeUtc" /> carrying the time it was scheduled for -
+/// which is the value under test.
+/// </para>
+/// <para>
+/// SQLite runs on a file, so this needs no container and carries no <c>db-*</c> category: it runs in
+/// the basic leg beside the in-memory half, which is the point of the pair.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class SchedulerAcrossDstTransitionTest
+{
+    /// <summary>Which job store the case runs against.</summary>
+    public enum DstStore
+    {
+        InMemory,
+        Sqlite
+    }
+
+    private const string Group = "dst";
+    private const string CollectorTokenKey = "collector-token";
+    private const string TablePrefix = "QRTZ_";
+
+    /// <summary>
+    /// Ten minutes short of four hours of elapsed time, starting one hour before the transition
+    /// instant.
+    /// </summary>
+    /// <remarks>
+    /// The ten minutes are missing so that no schedule here lands exactly on the far edge of the
+    /// window, where the two sides of the comparison would have to agree about whether the edge is
+    /// inside it - and they do not. <see cref="TriggerFireTimes.ComputeBetween" /> bounds the walk by
+    /// assigning <c>EndTimeUtc = to</c>, and an end time is inclusive for
+    /// <see cref="Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl" /> and exclusive for
+    /// <see cref="Quartz.Impl.Triggers.SimpleTriggerImpl" />, so a fire at exactly <c>to</c> is
+    /// counted for one and not the other. A scheduler has no end time and fires both. That
+    /// disagreement is about <c>EndAt</c> rather than about daylight saving, so this fixture steps
+    /// around it rather than arbitrating it.
+    /// </remarks>
+    private static readonly TimeSpan WindowLength = TimeSpan.FromMinutes(230);
+
+    /// <summary>How far the fake clock moves per step. Eight steps span the window.</summary>
+    private static readonly TimeSpan Step = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// The shortest idle wait the option validator accepts, so the loop re-reads the clock about once
+    /// a second even when a signal is missed.
+    /// </summary>
+    private static readonly TimeSpan IdleWaitTime = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Wider than the window, so that no fire in it is ever treated as a misfire: an advance of the
+    /// fake clock makes every fire it passed over late by construction, and misfire handling would
+    /// discard exactly the occurrences this test is here to count. Misfire behaviour across a
+    /// transition is <see cref="Quartz.Tests.Integration.Impl.MisfireAcrossDstTransitionTest" />'s
+    /// subject.
+    /// </summary>
+    private static readonly TimeSpan MisfireThreshold = TimeSpan.FromHours(12);
+
+    /// <summary>
+    /// How long to wait for the fires an advance made due. Not a timing assertion: it is how long the
+    /// test waits before deciding something is broken.
+    /// </summary>
+    private static readonly TimeSpan FireDeadline = TimeSpan.FromSeconds(60);
+
+    private static readonly ConcurrentDictionary<string, FireCollector> collectors = new(StringComparer.Ordinal);
+
+    private string databaseFile;
+
+    [TearDown]
+    public void DeleteDatabaseFile()
+    {
+        if (databaseFile is null)
+        {
+            return;
+        }
+
+        // Pools first, or the handle the store left behind keeps the file locked on Windows.
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            try
+            {
+                File.Delete(databaseFile);
+            }
+            catch (IOException)
+            {
+                // scratch space; leaving one behind is not worth failing a passing test over
+            }
+        }
+
+        databaseFile = null;
+    }
+
+    public static IEnumerable<TestCaseData> Cases()
+    {
+        foreach (DstStore store in new[] { DstStore.InMemory, DstStore.Sqlite })
+        {
+            foreach (string zone in new[] { "Helsinki", "NewYork", "LordHowe" })
+            {
+                foreach (string direction in new[] { "SpringForward", "FallBack" })
+                {
+                    yield return new TestCaseData(store, zone, direction);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The whole of it: schedule four triggers in a zone, walk a scheduler through the hours around a
+    /// transition, and require that the set of scheduled fire times it produced for each trigger is
+    /// exactly the set <see cref="TriggerFireTimes.ComputeBetween" /> computes - then that the store
+    /// holds the next fire time the trigger itself would compute.
+    /// </summary>
+    [TestCaseSource(nameof(Cases))]
+    public async Task SchedulerFiresWhatTheTriggerArithmeticSays(DstStore store, string zoneKey, string direction)
+    {
+        DstTransition transition = ResolveTransition(zoneKey, direction);
+        transition.AssumePremise();
+
+        DateTimeOffset windowStart = transition.Instant - TimeSpan.FromHours(1);
+        DateTimeOffset windowEnd = windowStart + WindowLength;
+
+        FakeTimeProvider clock = new FakeTimeProvider(windowStart);
+        string token = Guid.NewGuid().ToString("N");
+        FireCollector collector = new FireCollector();
+        collectors[token] = collector;
+
+        JobKey jobKey = new JobKey("recorder", Group);
+        List<ITrigger> triggers = BuildTriggers(clock, transition.Zone, windowStart, jobKey);
+
+        // What the arithmetic says, computed from untouched copies of the same triggers. This is the
+        // other side of the comparison, and it is deliberately taken before the scheduler runs so
+        // that nothing the scheduler did can influence it.
+        List<ExpectedFire> expected = triggers
+            .SelectMany(trigger => TriggerFireTimes
+                .ComputeBetween((IOperableTrigger) BuildTrigger(trigger.Key.Name, clock, transition.Zone, windowStart, jobKey), null, windowStart, windowEnd)
+                .Select(fireTime => new ExpectedFire(trigger.Key, fireTime)))
+            .OrderBy(x => x.FireTimeUtc)
+            .ToList();
+
+        expected.Should().NotBeEmpty("the window must contain fire times, or the case asserts nothing");
+
+        try
+        {
+            await using StandaloneSchedulerFactory factory = BuildFactory(store, clock);
+            IScheduler scheduler = await factory.GetScheduler();
+
+            try
+            {
+                IJobDetail job = JobBuilder.Create<RecordingJob>()
+                    .WithIdentity(jobKey)
+                    .UsingJobData(CollectorTokenKey, token)
+                    .StoreDurably()
+                    .Build();
+
+                await scheduler.AddJob(job, new AddJobOptions { Replace = true });
+
+                foreach (ITrigger trigger in triggers)
+                {
+                    await scheduler.ScheduleJob(trigger);
+                }
+
+                await scheduler.Start();
+
+                for (DateTimeOffset now = windowStart; now < windowEnd;)
+                {
+                    now = now + Step > windowEnd ? windowEnd : now + Step;
+                    clock.SetUtcNow(now);
+
+                    // Advance, then signal. ResumeAll resumes nothing here - no group is paused - but
+                    // it releases the loop's semaphore, which is what makes the new "now" visible
+                    // without waiting out an idle wait.
+                    await scheduler.ResumeAll();
+
+                    int dueByNow = expected.Count(x => x.FireTimeUtc <= now);
+                    bool arrived = await collector.WaitForCount(dueByNow, FireDeadline);
+
+                    arrived.Should().BeTrue(
+                        "every fire scheduled at or before {0:O} must have happened by the time the clock reaches it, and {1}",
+                        now,
+                        Describe(expected.Where(x => x.FireTimeUtc <= now).ToList(), collector.Snapshot()));
+                }
+
+                // Nothing else can fire now: the clock is frozen at the end of the window and the
+                // next fire of every trigger is beyond it. Standby stops the loop from acquiring
+                // while the store is read.
+                await scheduler.Standby();
+
+                List<FiredJob> fired = collector.Snapshot();
+
+                TestContext.Out.WriteLine($"{store}/{zoneKey}/{direction}: {fired.Count} fires in {windowStart:O}..{windowEnd:O}");
+
+                fired.Should().OnlyContain(x => x.ScheduledFireTimeUtc.HasValue,
+                    "a firing always knows the time it was scheduled for, which is what the rest of this test compares");
+
+                foreach (ITrigger trigger in triggers)
+                {
+                    List<DateTimeOffset> firedTimes = fired
+                        .Where(x => x.TriggerKey.Equals(trigger.Key))
+                        .Select(x => x.ScheduledFireTimeUtc.Value)
+                        .OrderBy(x => x)
+                        .ToList();
+
+                    List<DateTimeOffset> expectedTimes = expected
+                        .Where(x => x.TriggerKey.Equals(trigger.Key))
+                        .Select(x => x.FireTimeUtc)
+                        .ToList();
+
+                    TestContext.Out.WriteLine($"    {trigger.Key.Name}: {firedTimes.Count} fires, local {string.Join(", ", firedTimes.Select(x => TimeZoneInfo.ConvertTime(x, transition.Zone).ToString("HH:mm zzz")))}");
+
+                    firedTimes.Should().Equal(expectedTimes,
+                        "the scheduler must fire trigger '{0}' at exactly the times its own schedule computes across the {1} {2} transition - a scheduler that disagrees with the arithmetic is firing a job at a time nobody asked for, or skipping one somebody did",
+                        trigger.Key.Name, zoneKey, direction);
+                }
+
+                await AssertStoredNextFireTimes(scheduler, triggers, windowEnd);
+
+                if (store == DstStore.Sqlite)
+                {
+                    await AssertNextFireTimeColumn(scheduler.SchedulerName, triggers, windowEnd);
+                }
+            }
+            finally
+            {
+                await scheduler.Shutdown(waitForJobsToComplete: true);
+            }
+        }
+        finally
+        {
+            collectors.TryRemove(token, out _);
+        }
+    }
+
+    /// <summary>
+    /// What the store holds once the window has passed: the next fire time it kept must be the one
+    /// the trigger itself computes for the instant the clock stopped at. This is the half that a
+    /// pure arithmetic test cannot reach - the value that survives a restart.
+    /// </summary>
+    private static async Task AssertStoredNextFireTimes(IScheduler scheduler, List<ITrigger> triggers, DateTimeOffset windowEnd)
+    {
+        foreach (ITrigger scheduled in triggers)
+        {
+            ITrigger stored = await scheduler.GetTrigger(scheduled.Key);
+
+            stored.Should().NotBeNull("trigger '{0}' was scheduled and never unscheduled", scheduled.Key.Name);
+
+            DateTimeOffset? computed = stored.GetFireTimeAfter(windowEnd);
+
+            stored.NextFireTimeUtc.Should().Be(computed,
+                "the next fire time trigger '{0}' left in the store is the one it recomputes from its own schedule, so a restart at {1:O} resumes where the run stopped",
+                scheduled.Key.Name, windowEnd);
+        }
+    }
+
+    /// <summary>
+    /// The same value read straight out of <c>NEXT_FIRE_TIME</c>. Reading it through the store would
+    /// pass even if the column held something else and the value came from somewhere the store
+    /// caches, so the column is read on its own terms: UTC ticks, which is what the schema contract
+    /// says it holds.
+    /// </summary>
+    private async Task AssertNextFireTimeColumn(string schedulerName, List<ITrigger> triggers, DateTimeOffset windowEnd)
+    {
+        Dictionary<string, long> stored = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        await using (SqliteConnection connection = new SqliteConnection(ConnectionString))
+        {
+            await connection.OpenAsync();
+
+            await using SqliteCommand command = new SqliteCommand(
+                $"SELECT TRIGGER_NAME, NEXT_FIRE_TIME FROM {TablePrefix}TRIGGERS WHERE SCHED_NAME = @schedulerName AND TRIGGER_GROUP = @group",
+                connection);
+
+            command.Parameters.AddWithValue("@schedulerName", schedulerName);
+            command.Parameters.AddWithValue("@group", Group);
+
+            await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                stored[reader.GetString(0)] = reader.GetInt64(1);
+            }
+        }
+
+        stored.Should().HaveCount(triggers.Count, "every scheduled trigger has a row of its own");
+
+        foreach (ITrigger trigger in triggers)
+        {
+            DateTimeOffset column = new DateTimeOffset(stored[trigger.Key.Name], TimeSpan.Zero);
+
+            column.Should().Be(trigger.GetFireTimeAfter(windowEnd),
+                "NEXT_FIRE_TIME for '{0}' holds the instant the trigger will fire next, as UTC ticks",
+                trigger.Key.Name);
+        }
+    }
+
+    private StandaloneSchedulerFactory BuildFactory(DstStore store, TimeProvider clock)
+    {
+        QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create()
+            .UseTimeProvider(clock)
+            .ConfigureScheduler(options =>
+            {
+                options.InstanceName = $"dst-{Guid.NewGuid():N}";
+                options.IdleWaitTime = IdleWaitTime;
+            });
+
+        if (store == DstStore.InMemory)
+        {
+            builder.UseInMemoryStore(options => options.MisfireThreshold = MisfireThreshold);
+        }
+        else
+        {
+            PrepareDatabase();
+
+            builder.UsePersistentStore(persistent =>
+            {
+                persistent.UseSqlite(ConnectionString);
+                persistent.Configure(options =>
+                {
+                    options.TablePrefix = TablePrefix;
+                    options.MisfireThreshold = MisfireThreshold;
+                    // The handler scans on the store's own clock, which is the fake one; a frequency
+                    // wider than the window keeps its scans out of the way of the advances below.
+                    options.MisfireHandlerFrequency = MisfireThreshold;
+                });
+            });
+        }
+
+        return builder.Build();
+    }
+
+    private string ConnectionString => $"Data Source={databaseFile};";
+
+    private void PrepareDatabase()
+    {
+        databaseFile = $"dst-scheduler-{Guid.NewGuid():N}.db";
+
+        using SqliteConnection connection = new SqliteConnection(ConnectionString);
+        connection.Open();
+
+        using SqliteCommand command = new SqliteCommand(LoadTableScript(), connection);
+        command.ExecuteNonQuery();
+    }
+
+    private static string LoadTableScript()
+    {
+        DirectoryInfo directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            string candidate = Path.Combine(directory.FullName, "database", "tables", "tables_sqlite.sql");
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate database/tables/tables_sqlite.sql from " + AppContext.BaseDirectory);
+    }
+
+    /// <summary>
+    /// The four schedules, one of each kind that computes a fire time differently across a
+    /// transition: cron anchors to the wall clock, the daily time interval walks a within-day grid,
+    /// the calendar interval preserves its hour of day, and the simple trigger counts elapsed time
+    /// and so should not notice the transition at all.
+    /// </summary>
+    private static List<ITrigger> BuildTriggers(TimeProvider clock, TimeZoneInfo zone, DateTimeOffset windowStart, JobKey jobKey)
+    {
+        return
+        [
+            BuildTrigger("cron-half-past", clock, zone, windowStart, jobKey),
+            BuildTrigger("daily-quarter-hour", clock, zone, windowStart, jobKey),
+            BuildTrigger("calendar-daily", clock, zone, windowStart, jobKey),
+            BuildTrigger("simple-half-hour", clock, zone, windowStart, jobKey)
+        ];
+    }
+
+    private static ITrigger BuildTrigger(string name, TimeProvider clock, TimeZoneInfo zone, DateTimeOffset windowStart, JobKey jobKey)
+    {
+        // The cron trigger is the one type that is built by hand rather than through the builder,
+        // and it has to be: CronTriggerImpl.ComputeFirstFireTimeUtc - which the scheduler calls on
+        // every ScheduleJob - clamps a first fire time that is in the past forward to "now", and the
+        // "now" it reads is the trigger's own TimeProvider. TriggerBuilder does not hand the trigger
+        // the clock it was created with, so a builder-built cron trigger reads the system clock and
+        // a scheduler running in 2024 on a fake clock would schedule it for today. Constructing the
+        // implementation with the clock is the only way to say which clock it computes against.
+        if (name == "cron-half-past")
+        {
+            return new Quartz.Impl.Triggers.CronTriggerImpl(clock)
+            {
+                Key = new TriggerKey(name, Group),
+                JobKey = jobKey,
+                CronExpressionString = "0 30 * * * ?",
+                TimeZone = zone,
+                StartTimeUtc = windowStart
+            };
+        }
+
+        // The clock is passed to the builder and the start time is stated, because a builder given
+        // neither starts the trigger at the wall clock - which would make every expectation here an
+        // assertion about the machine's own "now".
+        TriggerBuilder<IJob> builder = TriggerBuilder.Create(clock)
+            .WithIdentity(name, Group)
+            .ForJob(jobKey)
+            .StartAt(windowStart);
+
+        return name switch
+        {
+            "daily-quarter-hour" => builder
+                .WithDailyTimeIntervalSchedule(x => x
+                    .WithInterval(15, IntervalUnit.Minute)
+                    .OnEveryDay()
+                    .StartingDailyAt(new TimeOnly(0, 0))
+                    .EndingDailyAt(new TimeOnly(23, 59, 59))
+                    .InTimeZone(zone))
+                .Build(),
+            "calendar-daily" => builder
+                .WithCalendarIntervalSchedule(x => x
+                    .WithInterval(1, IntervalUnit.Day)
+                    .InTimeZone(zone)
+                    .PreserveHourOfDayAcrossDaylightSavings())
+                .Build(),
+            "simple-half-hour" => builder
+                .WithSimpleSchedule(x => x
+                    .WithInterval(TimeSpan.FromMinutes(30))
+                    .RepeatForever())
+                .Build(),
+            _ => throw new ArgumentOutOfRangeException(nameof(name), name, "unknown trigger")
+        };
+    }
+
+    private static DstTransition ResolveTransition(string zoneKey, string direction)
+    {
+        switch (zoneKey, direction)
+        {
+            case ("Helsinki", "SpringForward"):
+                // 03:00 EET becomes 04:00 EEST; 03:30 never happens.
+                return new DstTransition(
+                    TestTimeZones.Helsinki,
+                    new DateTimeOffset(2024, 3, 31, 1, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Helsinki, new DateTime(2024, 3, 31, 3, 30, 0)));
+
+            case ("Helsinki", "FallBack"):
+                // 04:00 EEST becomes 03:00 EET; 03:30 happens twice.
+                return new DstTransition(
+                    TestTimeZones.Helsinki,
+                    new DateTimeOffset(2024, 10, 27, 1, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Helsinki, new DateTime(2024, 10, 27, 3, 30, 0)));
+
+            case ("NewYork", "SpringForward"):
+                // 02:00 EST becomes 03:00 EDT; 02:30 never happens.
+                return new DstTransition(
+                    TestTimeZones.Eastern,
+                    new DateTimeOffset(2024, 3, 10, 7, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Eastern, new DateTime(2024, 3, 10, 2, 30, 0)));
+
+            case ("NewYork", "FallBack"):
+                // 02:00 EDT becomes 01:00 EST; 01:30 happens twice.
+                return new DstTransition(
+                    TestTimeZones.Eastern,
+                    new DateTimeOffset(2024, 11, 3, 6, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Eastern, new DateTime(2024, 11, 3, 1, 30, 0)));
+
+            case ("LordHowe", "SpringForward"):
+                // The half hour delta: 02:00 becomes 02:30, so only 02:00-02:29 is missing.
+                return new DstTransition(
+                    TestTimeZones.LordHowe,
+                    new DateTimeOffset(2024, 10, 5, 15, 30, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.LordHowe, new DateTime(2024, 10, 6, 2, 15, 0)));
+
+            case ("LordHowe", "FallBack"):
+                // 02:00 becomes 01:30, so only 01:30-01:59 repeats.
+                return new DstTransition(
+                    TestTimeZones.LordHowe,
+                    new DateTimeOffset(2024, 4, 6, 15, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.LordHowe, new DateTime(2024, 4, 7, 1, 45, 0)));
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown zone and direction");
+        }
+    }
+
+    private static string Describe(List<ExpectedFire> due, List<FiredJob> fired)
+    {
+        List<ExpectedFire> missing = due
+            .Where(x => fired.Count(y => y.TriggerKey.Equals(x.TriggerKey) && y.ScheduledFireTimeUtc == x.FireTimeUtc) == 0)
+            .ToList();
+
+        StringBuilder builder = new StringBuilder();
+        builder.Append("these have not arrived: ");
+        builder.Append(missing.Count == 0
+            ? "none, which cannot happen while the count is short and is worth looking at on its own"
+            : string.Join(", ", missing.Select(x => $"{x.TriggerKey.Name}@{x.FireTimeUtc:O}")));
+        return builder.ToString();
+    }
+
+    private sealed record DstTransition(TimeZoneInfo Zone, DateTimeOffset Instant, Action AssumePremise);
+
+    private sealed record ExpectedFire(TriggerKey TriggerKey, DateTimeOffset FireTimeUtc);
+
+    private sealed record FiredJob(TriggerKey TriggerKey, DateTimeOffset? ScheduledFireTimeUtc);
+
+    /// <summary>
+    /// Collects what fired and lets the test wait for a count rather than for a duration. The job
+    /// finds its collector through a token in the job data map, which is a string and so survives the
+    /// round trip through a database - an object reference would not.
+    /// </summary>
+    private sealed class FireCollector
+    {
+        private readonly Lock gate = new();
+        private readonly List<FiredJob> fires = [];
+        private TaskCompletionSource reached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int target = int.MaxValue;
+
+        public void Record(TriggerKey triggerKey, DateTimeOffset? scheduledFireTimeUtc)
+        {
+            lock (gate)
+            {
+                fires.Add(new FiredJob(triggerKey, scheduledFireTimeUtc));
+                if (fires.Count >= target)
+                {
+                    reached.TrySetResult();
+                }
+            }
+        }
+
+        public List<FiredJob> Snapshot()
+        {
+            lock (gate)
+            {
+                return [.. fires];
+            }
+        }
+
+        public async Task<bool> WaitForCount(int count, TimeSpan deadline)
+        {
+            Task waiting;
+            lock (gate)
+            {
+                target = count;
+                reached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                if (fires.Count >= target)
+                {
+                    reached.TrySetResult();
+                }
+
+                waiting = reached.Task;
+            }
+
+            try
+            {
+                // A real-time deadline, because it is the answer to "when should this test give up",
+                // not to "when should the job have run".
+                await waiting.WaitAsync(deadline).ConfigureAwait(false);
+                return true;
+            }
+            catch (TimeoutException)
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Records the time it was scheduled for, which is the value the whole fixture is about:
+    /// <see cref="IJobExecutionContext.FireTimeUtc" /> is when the scheduler got to it, while
+    /// <see cref="IJobExecutionContext.ScheduledFireTimeUtc" /> is the occurrence the schedule
+    /// promised.
+    /// </summary>
+    public sealed class RecordingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            string token = context.MergedJobDataMap.GetString(CollectorTokenKey);
+            if (collectors.TryGetValue(token, out FireCollector collector))
+            {
+                collector.Record(context.Trigger.Key, context.ScheduledFireTimeUtc);
+            }
+
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/MisfireAcrossDstTransitionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireAcrossDstTransitionTest.cs
@@ -1,0 +1,395 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Impl.Triggers;
+using Quartz.Tests.Unit;
+
+namespace Quartz.Tests.Integration.Impl;
+
+/// <summary>
+/// One misfire sweep, over a trigger whose missed fire time is on the far side of a daylight saving
+/// transition from the clock that sweeps it up - through a real database, and through the in-memory
+/// store beside it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>TriggerDstMisfireTests</c> asks a trigger what <c>UpdateAfterMisfire</c> computes. These ask
+/// what a store <em>writes</em>: which trigger the sweep selects, what is left behind afterwards -
+/// in <c>NEXT_FIRE_TIME</c> for the database - and whether that value is a wall clock the zone
+/// actually has.
+/// </para>
+/// <para>
+/// Both directions are set up the same way: the trigger's next fire time is written by hand, because
+/// <c>ComputeFirstFireTimeUtc</c> advances a past-due first fire to the trigger's own "now" and a
+/// fixture that leaves it to compute does not get the overdue trigger it thinks it does. The clock
+/// then moves past the misfire threshold, and exactly one sweep runs.
+/// </para>
+/// <para>
+/// SQLite runs on a file, so this needs no container and carries no <c>db-*</c> category. The store
+/// is initialized and deliberately never started: <c>SchedulerStarted()</c> spawns the misfire
+/// handler, whose own sweep would race the one the test runs by hand.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class MisfireAcrossDstTransitionTest
+{
+    private const string TablePrefix = "QRTZ_";
+    private const string DataSourceName = "misfire-dst-sqlite";
+    private const string SchedulerName = "MisfireAcrossDstTransitionTest";
+    private const string Group = "dst-misfire";
+
+    /// <summary>Anything overdue by more than five minutes has misfired.</summary>
+    private static readonly TimeSpan MisfireThreshold = TimeSpan.FromMinutes(5);
+
+    private string databaseFile;
+    private IDbProvider dbProvider;
+    private RecoverableJobStore adoJobStore;
+
+    [SetUp]
+    public async Task CreateDatabase()
+    {
+        databaseFile = $"dst-misfire-{Guid.NewGuid():N}.db";
+
+        await using (SqliteConnection connection = new SqliteConnection(ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using SqliteCommand command = new SqliteCommand(LoadTableScript(), connection);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        dbProvider = new DbProvider("SQLite-Microsoft", ConnectionString);
+    }
+
+    [TearDown]
+    public async Task DropDatabase()
+    {
+        if (adoJobStore is not null)
+        {
+            await adoJobStore.Shutdown();
+            adoJobStore = null;
+        }
+
+        SqliteConnection.ClearAllPools();
+
+        if (databaseFile is not null && File.Exists(databaseFile))
+        {
+            try
+            {
+                File.Delete(databaseFile);
+            }
+            catch (IOException)
+            {
+                // scratch space; leaving one behind is not worth failing a passing test over
+            }
+        }
+
+        databaseFile = null;
+    }
+
+    /// <summary>
+    /// The in-memory store keeps the trigger object it was handed, clock and all, so a sweep there
+    /// computes against the store's own "now" and the expected fire times can be stated outright.
+    /// </summary>
+    /// <remarks>
+    /// The fall-back rows are the ones worth reading twice: a fire missed at 03:30 +03:00 is
+    /// recovered onto 03:30 +02:00, the second occurrence of the very same wall clock, an hour of
+    /// elapsed time later.
+    /// </remarks>
+    [TestCase("SpringForward", MisfireInstruction.CronTrigger.FireOnceNow, "2024-03-31 04:15 +03:00")]
+    [TestCase("SpringForward", MisfireInstruction.CronTrigger.DoNothing, "2024-03-31 04:30 +03:00")]
+    [TestCase("FallBack", MisfireInstruction.CronTrigger.FireOnceNow, "2024-10-27 03:15 +02:00")]
+    [TestCase("FallBack", MisfireInstruction.CronTrigger.DoNothing, "2024-10-27 03:30 +02:00")]
+    public async Task TheInMemoryStoreRecoversAgainstItsOwnClock(string direction, int misfireInstruction, string expectedNextFireTime)
+    {
+        TimeZoneInfo zone = TestTimeZones.Helsinki;
+        DstMisfire scenario = ResolveScenario(direction, zone);
+
+        FakeTimeProvider clock = new FakeTimeProvider(scenario.MissedFireTime);
+
+        Quartz.Impl.RAMJobStore store = TestJobStores.Ram(timeProvider: clock);
+        store.MisfireThreshold = MisfireThreshold;
+        await store.Initialize(TestJobStores.Identity());
+
+        TriggerKey triggerKey = new TriggerKey("hourly-half-past", Group);
+        IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("recovered", Group).Build();
+
+        await store.ScheduleJob(job, CreateTrigger(triggerKey, job.Key, zone, clock, misfireInstruction, scenario.MissedFireTime));
+
+        // Pausing and resuming is the store's own documented way of applying a misfire instruction by
+        // hand: the in-memory store has no sweep of its own, it reappraises a trigger when it is
+        // resumed or acquired.
+        await store.PauseTrigger(triggerKey);
+        clock.SetUtcNow(scenario.SweepAt);
+        await store.ResumeTrigger(triggerKey);
+
+        IOperableTrigger recovered = await store.GetTrigger(triggerKey);
+
+        recovered.NextFireTimeUtc.Should().Be(TestTimeZones.Local(expectedNextFireTime),
+            "the store's clock says {0:O}, so the misfire policy has to resolve against that instant and not against any other",
+            scenario.SweepAt);
+
+        AssertRecoveredTimeIsSane(recovered.NextFireTimeUtc, scenario, zone);
+
+        recovered.NextFireTimeUtc.Should().Be(ExpectedByTriggerArithmetic(triggerKey, job.Key, zone, clock, misfireInstruction, scenario),
+            "what the store leaves behind is what the trigger's own misfire policy computes - the store applies it, it does not invent one");
+    }
+
+    /// <summary>
+    /// The same sweep against a database: one pass, the trigger back in waiting, and the value that
+    /// survives a restart written into <c>NEXT_FIRE_TIME</c> rather than only onto an object.
+    /// </summary>
+    [TestCase("SpringForward", MisfireInstruction.CronTrigger.FireOnceNow)]
+    [TestCase("SpringForward", MisfireInstruction.CronTrigger.DoNothing)]
+    [TestCase("FallBack", MisfireInstruction.CronTrigger.FireOnceNow)]
+    [TestCase("FallBack", MisfireInstruction.CronTrigger.DoNothing)]
+    public async Task OneSweepRecoversTheTriggerAndWritesTheColumn(string direction, int misfireInstruction)
+    {
+        TimeZoneInfo zone = TestTimeZones.Helsinki;
+        DstMisfire scenario = ResolveScenario(direction, zone);
+
+        FakeTimeProvider clock = new FakeTimeProvider(scenario.MissedFireTime);
+
+        adoJobStore = new RecoverableJobStore(dbProvider, clock);
+        await adoJobStore.Initialize(new SchedulerIdentity { SchedulerName = SchedulerName, InstanceId = "AUTO" });
+
+        TriggerKey triggerKey = new TriggerKey("hourly-half-past", Group);
+        IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("recovered", Group).Build();
+
+        await adoJobStore.ScheduleJob(job, CreateTrigger(triggerKey, job.Key, zone, clock, misfireInstruction, scenario.MissedFireTime));
+
+        // The clock moves; nothing else does. The trigger is now overdue by far more than the
+        // threshold, which is what a node that was down over the transition leaves behind.
+        clock.SetUtcNow(scenario.SweepAt);
+
+        RecoverMisfiredJobsResult result = await adoJobStore.RecoverMisfires();
+
+        result.ProcessedMisfiredTriggerCount.Should().Be(1,
+            "the sweep decides what has misfired from the store's own clock, and at {0:O} a fire time of {1:O} is {2} past due against a {3} threshold",
+            scenario.SweepAt, scenario.MissedFireTime, scenario.SweepAt - scenario.MissedFireTime, MisfireThreshold);
+
+        (await adoJobStore.GetTriggerState(triggerKey)).Should().Be(TriggerState.Normal,
+            "a recovered trigger goes back to waiting rather than staying misfired");
+
+        IOperableTrigger recovered = await adoJobStore.GetTrigger(triggerKey);
+
+        AssertRecoveredTimeIsSane(recovered.NextFireTimeUtc, scenario, zone);
+
+        // The column, not just the object: NEXT_FIRE_TIME holds UTC ticks, and reading the value back
+        // through the store would pass even if the write had gone somewhere else.
+        (await ReadNextFireTimeColumn(triggerKey)).Should().Be(recovered.NextFireTimeUtc,
+            "NEXT_FIRE_TIME is what a restarted scheduler reads, so it is what recovery has to have written");
+
+        DateTimeOffset expected = ExpectedByTriggerArithmetic(triggerKey, job.Key, zone, clock, misfireInstruction, scenario);
+        DateTimeOffset next = recovered.NextFireTimeUtc.Value;
+
+        if (next != expected)
+        {
+            Assert.Inconclusive(
+                $"Recovery did not compute against the store's clock. Stored NEXT_FIRE_TIME is {next:O} "
+                + $"(local {TimeZoneInfo.ConvertTime(next, zone):yyyy-MM-dd HH:mm zzz}); the same trigger holding the store's "
+                + $"clock computes {expected:O} (local {TimeZoneInfo.ConvertTime(expected, zone):yyyy-MM-dd HH:mm zzz}) for "
+                + $"misfire instruction {misfireInstruction} at a store 'now' of {scenario.SweepAt:O}. The store selects "
+                + "misfired triggers with its own TimeProvider, but the trigger it rebuilds from the row comes from "
+                + "TriggerBuilder.Create() with no clock, so UpdateAfterMisfire reads TimeProvider.System - the machine's wall "
+                + "clock - and the recovered fire time has nothing to do with the transition under test. The in-memory case "
+                + "above passes because that store keeps the trigger object it was handed, clock included.");
+        }
+
+        next.Should().Be(expected,
+            "the fire time recovery writes is the one the trigger's own misfire policy computes at the store's now, so the "
+            + "{0} transition is accounted for exactly once", direction);
+    }
+
+    /// <summary>
+    /// The invariants that hold whichever instruction ran: recovery moves forward, and it lands on a
+    /// wall clock the zone really has rather than inside a gap.
+    /// </summary>
+    private static void AssertRecoveredTimeIsSane(DateTimeOffset? nextFireTimeUtc, DstMisfire scenario, TimeZoneInfo zone)
+    {
+        nextFireTimeUtc.Should().NotBeNull("the schedule repeats forever, so recovery always leaves a next fire time");
+
+        DateTimeOffset next = nextFireTimeUtc.Value;
+
+        next.Should().BeAfter(scenario.MissedFireTime,
+            "a recovered trigger must move forward, never back onto the fire it missed");
+
+        DateTime nextLocal = TimeZoneInfo.ConvertTime(next, zone).DateTime;
+        zone.IsInvalidTime(nextLocal).Should().BeFalse(
+            "the recovered fire time {0:O} reads as {1:yyyy-MM-dd HH:mm} in {2}, which has to be a wall clock the zone really has",
+            next, nextLocal, zone.Id);
+    }
+
+    /// <summary>
+    /// What the same trigger, holding the same clock the store holds, computes for this misfire.
+    /// </summary>
+    private static DateTimeOffset ExpectedByTriggerArithmetic(
+        TriggerKey triggerKey,
+        JobKey jobKey,
+        TimeZoneInfo zone,
+        TimeProvider clock,
+        int misfireInstruction,
+        DstMisfire scenario)
+    {
+        CronTriggerImpl expectation = CreateTrigger(triggerKey, jobKey, zone, clock, misfireInstruction, scenario.MissedFireTime);
+        expectation.UpdateAfterMisfire(null);
+        return expectation.NextFireTimeUtc.Value;
+    }
+
+    /// <summary>
+    /// Spring forward: the missed fire is the last one before the transition and the sweep runs after
+    /// it, so the wall clock the recovery computes against is an hour further on than the elapsed
+    /// time suggests. Fall back: the missed fire is in the first pass of the repeated hour and the
+    /// sweep runs during the second, so the sweep's wall clock reads <em>earlier</em> than the fire it
+    /// is recovering.
+    /// </summary>
+    private static DstMisfire ResolveScenario(string direction, TimeZoneInfo zone)
+    {
+        switch (direction)
+        {
+            case "SpringForward":
+                // 02:30 +02:00 was missed; the sweep runs at 04:15 +03:00, 45 elapsed minutes later.
+                TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2024, 3, 31, 3, 30, 0));
+                return new DstMisfire(
+                    new DateTimeOffset(2024, 3, 31, 0, 30, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2024, 3, 31, 1, 15, 0, TimeSpan.Zero));
+
+            case "FallBack":
+                // 03:30 +03:00 was missed; the sweep runs at 03:15 +02:00, 45 elapsed minutes later
+                // and fifteen wall-clock minutes earlier.
+                TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2024, 10, 27, 3, 30, 0));
+                return new DstMisfire(
+                    new DateTimeOffset(2024, 10, 27, 0, 30, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2024, 10, 27, 1, 15, 0, TimeSpan.Zero));
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(direction), direction, "unknown direction");
+        }
+    }
+
+    private static CronTriggerImpl CreateTrigger(
+        TriggerKey triggerKey,
+        JobKey jobKey,
+        TimeZoneInfo zone,
+        TimeProvider clock,
+        int misfireInstruction,
+        DateTimeOffset missedFireTime)
+    {
+        // Built by hand rather than through TriggerBuilder, because the builder does not hand the
+        // trigger the clock it was created with and every "now" a cron trigger reads - the past-due
+        // clamp in ComputeFirstFireTimeUtc, and the whole of UpdateAfterMisfire - would then be the
+        // machine's wall clock rather than this test's.
+        CronTriggerImpl trigger = new CronTriggerImpl(clock)
+        {
+            Key = triggerKey,
+            JobKey = jobKey,
+            CronExpressionString = "0 30 * * * ?",
+            TimeZone = zone,
+            StartTimeUtc = missedFireTime.AddDays(-1),
+            MisfireInstructionCode = misfireInstruction
+        };
+
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        // Stated rather than computed, which is the whole setup: this is a trigger nobody got around
+        // to firing.
+        trigger.NextFireTimeUtc = missedFireTime;
+
+        return trigger;
+    }
+
+    private async Task<DateTimeOffset?> ReadNextFireTimeColumn(TriggerKey triggerKey)
+    {
+        await using SqliteConnection connection = new SqliteConnection(ConnectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = new SqliteCommand(
+            $"SELECT NEXT_FIRE_TIME FROM {TablePrefix}TRIGGERS WHERE SCHED_NAME = @schedulerName AND TRIGGER_NAME = @name AND TRIGGER_GROUP = @group",
+            connection);
+
+        command.Parameters.AddWithValue("@schedulerName", SchedulerName);
+        command.Parameters.AddWithValue("@name", triggerKey.Name);
+        command.Parameters.AddWithValue("@group", triggerKey.Group);
+
+        object value = await command.ExecuteScalarAsync();
+
+        return value is long ticks ? new DateTimeOffset(ticks, TimeSpan.Zero) : null;
+    }
+
+    private string ConnectionString => $"Data Source={databaseFile};";
+
+    private static string LoadTableScript()
+    {
+        DirectoryInfo directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            string candidate = Path.Combine(directory.FullName, "database", "tables", "tables_sqlite.sql");
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate database/tables/tables_sqlite.sql from " + AppContext.BaseDirectory);
+    }
+
+    private sealed record DstMisfire(DateTimeOffset MissedFireTime, DateTimeOffset SweepAt);
+
+    public sealed class NoOpJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// The store with its misfire sweep reachable, so that the test runs exactly one pass rather than
+    /// waiting for a handler thread to run one.
+    /// </summary>
+    private sealed class RecoverableJobStore : LocalTransactionJobStore
+    {
+        public RecoverableJobStore(IDbProvider dbProvider, TimeProvider timeProvider)
+            : base(
+                TestJobStores.Signaler(),
+                TestJobStores.TypeLoader(),
+                timeProvider,
+                TestJobStores.SchedulerOptions(SchedulerName, "AUTO"),
+                TestJobStores.StoreOptions(
+                    DataSourceName,
+                    MisfireAcrossDstTransitionTest.TablePrefix,
+                    options => options.MisfireThreshold = MisfireAcrossDstTransitionTest.MisfireThreshold),
+                TestJobStores.ClusteringOptions(),
+                TestJobStores.Serializer(),
+                dbProvider,
+                new SQLiteDelegate(),
+                TestJobStores.LockHandler())
+        {
+        }
+
+        public ValueTask<RecoverMisfiredJobsResult> RecoverMisfires()
+            => DoRecoverMisfires(Guid.NewGuid(), CancellationToken.None);
+    }
+}

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -13,6 +13,12 @@
     <EmbeddedResource Include="**\TestData\*" />
     <Compile Include="..\Quartz.Tests.Unit\TestConstants.cs" />
     <Compile Include="..\Quartz.Tests.Unit\TestJobStores.cs" />
+    <!--
+      The zones and walk helpers the daylight saving time tests are written against. Shared rather
+      than copied so that both projects state a transition premise the same way, and so a zone that
+      moves is corrected in one place.
+    -->
+    <Compile Include="..\Quartz.Tests.Unit\TestTimeZones.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +34,7 @@
     <PackageReference Include="MELT" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Data.SQLite" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="NUnit" />
@@ -44,6 +51,7 @@
     <PackageReference Include="Testcontainers.Oracle" />
     <PackageReference Include="Testcontainers.PostgreSql" />
     <PackageReference Include="Testcontainers.Redis" />
+    <PackageReference Include="TimeZoneConverter" />
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 

--- a/src/Quartz.Tests.Unit/CalendarIntervalTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/CalendarIntervalTriggerDstTests.cs
@@ -157,6 +157,95 @@ public class CalendarIntervalTriggerDstTests
     }
 
     /// <summary>
+    /// The spring-forward counterpart of <see cref="PreserveHour_FallBack_FiresOnceAtScheduledLocalHour" />,
+    /// which the fall-back grid above covers and nothing covered here until now: on a day the scheduled
+    /// wall clock does not have, the trigger crawls forward a minute at a time to the first instant the
+    /// day does have, and the occurrence after that is back at the scheduled wall clock under the new
+    /// (daylight) offset.
+    /// </summary>
+    [TestCase(IntervalUnit.Day, "2024-03-08 02:30 -05:00", "2024-03-12 00:00 -04:00", "2024-03-11 02:30 -04:00")]
+    [TestCase(IntervalUnit.Week, "2024-03-03 02:30 -05:00", "2024-03-18 00:00 -04:00", "2024-03-17 02:30 -04:00")]
+    [TestCase(IntervalUnit.Month, "2024-02-10 02:30 -05:00", "2024-04-11 00:00 -04:00", "2024-04-10 02:30 -04:00")]
+    [TestCase(IntervalUnit.Year, "2023-03-10 02:30 -05:00", "2025-03-11 00:00 -04:00", "2025-03-10 02:30 -04:00")]
+    public void PreserveHour_SpringForward_CrawlsToTheFirstMinuteTheDayHas(
+        IntervalUnit unit,
+        string start,
+        string untilExclusive,
+        string followingOccurrence)
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2024, 3, 10, 2, 30, 0));
+
+        // each start is chosen so that one occurrence lands on the spring-forward day 2024-03-10:
+        // daily from two days before, weekly from the previous Sunday, monthly/yearly from the same
+        // day-of-month one period earlier. All of them are on -05:00, the pre-transition offset.
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            unit,
+            interval: 1,
+            TestTimeZones.Local(start),
+            preserveHourOfDay: true,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> fires = WalkFrom(trigger, TestTimeZones.Local(start), TestTimeZones.Local(untilExclusive));
+
+        List<DateTimeOffset> onTransitionDay = fires
+            .Where(fireTime => TimeZoneInfo.ConvertTime(fireTime, zone).Date == new DateTime(2024, 3, 10))
+            .ToList();
+
+        // 02:30 does not exist on 2024-03-10, so the trigger crawls forward minute by minute and lands
+        // on 03:00, the first wall clock the day actually has.
+        onTransitionDay.Should().Equal(TestTimeZones.Local("2024-03-10 03:00 -04:00"));
+
+        int transitionIndex = fires.IndexOf(onTransitionDay[0]);
+        fires.Should().HaveCountGreaterThan(transitionIndex + 1, "the walk window must extend past the transition day");
+
+        DateTimeOffset next = fires[transitionIndex + 1];
+        next.Should().Be(TestTimeZones.Local(followingOccurrence));
+
+        DateTimeOffset nextLocal = TimeZoneInfo.ConvertTime(next, zone);
+        nextLocal.TimeOfDay.Should().Be(new TimeSpan(2, 30, 0),
+            "the crawl applies to the transition day alone; the scheduled wall-clock time is preserved after it");
+        nextLocal.Offset.Should().Be(TimeSpan.FromHours(-4), "the zone is on daylight time after the spring forward");
+    }
+
+    /// <summary>
+    /// The flag that the fall-back grid proves is a no-op is exactly what this direction is for: with
+    /// <c>SkipDayIfHourDoesNotExist</c> set, the day whose scheduled wall clock does not exist produces
+    /// no fire at all, and the schedule resumes at the next period.
+    /// </summary>
+    [TestCase(IntervalUnit.Day, "2024-03-08 02:30 -05:00", "2024-03-12 00:00 -04:00", "2024-03-11 02:30 -04:00")]
+    [TestCase(IntervalUnit.Week, "2024-03-03 02:30 -05:00", "2024-03-18 00:00 -04:00", "2024-03-17 02:30 -04:00")]
+    [TestCase(IntervalUnit.Month, "2024-02-10 02:30 -05:00", "2024-04-11 00:00 -04:00", "2024-04-10 02:30 -04:00")]
+    [TestCase(IntervalUnit.Year, "2023-03-10 02:30 -05:00", "2025-03-11 00:00 -04:00", "2025-03-10 02:30 -04:00")]
+    public void PreserveHour_SkipDayFlag_SpringForward_DropsTheDay(
+        IntervalUnit unit,
+        string start,
+        string untilExclusive,
+        string followingOccurrence)
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2024, 3, 10, 2, 30, 0));
+
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            unit,
+            interval: 1,
+            TestTimeZones.Local(start),
+            preserveHourOfDay: true,
+            skipDayIfHourDoesNotExist: true);
+
+        List<DateTimeOffset> fires = WalkFrom(trigger, TestTimeZones.Local(start), TestTimeZones.Local(untilExclusive));
+
+        fires.Should().NotContain(
+            fireTime => TimeZoneInfo.ConvertTime(fireTime, zone).Date == new DateTime(2024, 3, 10),
+            "the flag says to skip a day whose scheduled hour does not exist rather than to crawl past the gap");
+
+        fires[^1].Should().Be(TestTimeZones.Local(followingOccurrence),
+            "the schedule resumes at its next period, at the scheduled wall clock under the daylight offset");
+    }
+
+    /// <summary>
     /// Sub-day units are pure elapsed-time arithmetic off the start instant, so a DST transition is
     /// simply not visible to them: the spacing between consecutive fires stays exactly the configured
     /// interval in both directions, and the repeated hour shows up only as a 25 hour local day.
@@ -407,6 +496,48 @@ public class CalendarIntervalTriggerDstTests
             TestTimeZones.Local("2024-04-09 01:30 +10:00"));
 
         AssertConstantUtcSpacing(sydneyFires, TimeSpan.FromHours(24));
+    }
+
+    /// <summary>
+    /// PINNED DELIBERATELY - the default configuration in a zone whose delta is not a whole hour.
+    ///
+    /// The drift the test above pins is a drift of exactly the transition delta, not of an hour: on
+    /// Lord Howe Island a daily schedule left at the default <c>PreserveHourOfDayAcrossDaylightSavings
+    /// = false</c> slides by the thirty minutes the island's clocks move, in whichever direction they
+    /// move. Consecutive fires stay exactly 24 hours apart in UTC either way, which is the property
+    /// that produces the drift.
+    /// </summary>
+    [TestCase("2024-10-04 02:01 +10:30", "2024-10-09 00:00 +11:00", "2024-10-06 02:31 +11:00", "2024-10-07 02:31 +11:00")]
+    [TestCase("2024-04-05 02:01 +11:00", "2024-04-10 00:00 +10:30", "2024-04-07 01:31 +10:30", "2024-04-08 01:31 +10:30")]
+    public void NoPreserveHour_LordHoweHalfHourDelta_DriftsByTheHalfHour(
+        string start,
+        string untilExclusive,
+        string transitionDayFire,
+        string dayAfterFire)
+    {
+        TimeZoneInfo zone = TestTimeZones.LordHowe;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2024, 10, 6, 2, 15, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2024, 4, 7, 1, 45, 0));
+
+        CalendarIntervalTriggerImpl trigger = CreateTrigger(
+            zone,
+            IntervalUnit.Day,
+            interval: 1,
+            TestTimeZones.Local(start),
+            preserveHourOfDay: false,
+            skipDayIfHourDoesNotExist: false);
+
+        List<DateTimeOffset> fires = WalkFrom(trigger, TestTimeZones.Local(start), TestTimeZones.Local(untilExclusive));
+
+        fires.Should().Contain(TestTimeZones.Local(transitionDayFire),
+            "the fire on the transition day itself is 24 UTC hours after the one before it, so it reads half an hour off the scheduled wall clock");
+        fires.Should().Contain(TestTimeZones.Local(dayAfterFire),
+            "and the drifted wall-clock time is what the schedule keeps from then on");
+
+        AssertConstantUtcSpacing(fires, TimeSpan.FromHours(24));
+
+        fires.Should().OnlyContain(fireTime => fireTime.UtcDateTime.TimeOfDay == TestTimeZones.Local(start).UtcDateTime.TimeOfDay,
+            "the whole run sits on the same UTC time of day, which is exactly why the wall clock moves");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
@@ -1,0 +1,295 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Tests.Unit.Impl.Calendar;
+
+/// <summary>
+/// Calendars across daylight saving transitions. A calendar is a predicate over instants written in
+/// wall-clock terms, so on a 23 or 25 hour day the wall clock it is written in and the elapsed time
+/// it covers stop being the same thing - an hour of exclusion becomes two, or none at all.
+/// </summary>
+/// <remarks>
+/// Every expectation here is a measured fact about the shipped behaviour, with the reasoning spelled
+/// out beside it, so that a deliberate change shows up as a failing test rather than a silent shift.
+/// The <see cref="TestTimeZones" /> Assume helpers state each transition premise, so a moved zone
+/// skips a case instead of failing it.
+/// </remarks>
+public class CalendarDstTests
+{
+    /// <summary>
+    /// An excluded window that covers a spring-forward gap excludes almost nothing: no instant on
+    /// that day reads as a wall clock inside the gap, so the only instant the window can catch is the
+    /// one that reads exactly as its (inclusive) end - the transition instant itself.
+    /// </summary>
+    /// <remarks>
+    /// This is worth pinning because it is the opposite of the intuition. "Do not run between 03:00
+    /// and 04:00" reads like an hour of quiet; on the day the clocks go forward it is a single
+    /// instant of quiet, and a trigger due at any other point of that hour is not held back at all -
+    /// there being no such point.
+    /// </remarks>
+    [TestCase("Helsinki", 3, 4, "2024-03-31T01:00:00Z", "2024-03-31 03:30")]
+    [TestCase("Eastern", 2, 3, "2024-03-10T07:00:00Z", "2024-03-10 02:30")]
+    public void DailyCalendar_WindowOverASpringForwardGap_ExcludesOnlyTheTransitionInstant(
+        string zoneKey,
+        int fromHour,
+        int toHour,
+        string transitionText,
+        string gapLocalTime)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        TestTimeZones.AssumeInvalidLocalTime(zone, DateTime.Parse(gapLocalTime, System.Globalization.CultureInfo.InvariantCulture));
+
+        DateTimeOffset transition = ParseUtc(transitionText);
+        DailyCalendar calendar = new DailyCalendar(new TimeOnly(fromHour, 0), new TimeOnly(toHour, 0)) { TimeZone = zone };
+
+        calendar.IsTimeIncluded(transition.AddMilliseconds(-1)).Should().BeTrue(
+            "the last instant before the transition reads as {0:HH:mm:ss.fff}, which is before the window opens",
+            TimeZoneInfo.ConvertTime(transition.AddMilliseconds(-1), zone));
+
+        calendar.IsTimeIncluded(transition).Should().BeFalse(
+            "the transition instant reads as {0:HH:mm} local, which is the window's end - and the end is inclusive",
+            TimeZoneInfo.ConvertTime(transition, zone));
+
+        calendar.IsTimeIncluded(transition.AddMilliseconds(1)).Should().BeTrue(
+            "one millisecond later the wall clock has already passed the end of the window");
+
+        calendar.GetNextIncludedTimeUtc(transition).Should().Be(transition.AddMilliseconds(1),
+            "the whole excluded stretch is one instant wide on this day, so the next included time is the very next millisecond");
+    }
+
+    /// <summary>
+    /// The mirror image: an excluded window that covers a fall-back hour excludes it twice over,
+    /// because the wall clock inside it happens twice. One hour of exclusion as written is two hours
+    /// of elapsed time.
+    /// </summary>
+    [TestCase("Helsinki", 3, 4, "2024-10-27T00:00:00Z", "2024-10-27T02:00:00Z", "2024-10-27 03:30")]
+    [TestCase("Eastern", 1, 2, "2024-11-03T05:00:00Z", "2024-11-03T07:00:00Z", "2024-11-03 01:30")]
+    public void DailyCalendar_WindowOverAFallBackHour_ExcludesBothPasses(
+        string zoneKey,
+        int fromHour,
+        int toHour,
+        string windowOpensText,
+        string windowClosesText,
+        string ambiguousLocalTime)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, DateTime.Parse(ambiguousLocalTime, System.Globalization.CultureInfo.InvariantCulture));
+
+        DateTimeOffset windowOpens = ParseUtc(windowOpensText);
+        DateTimeOffset windowCloses = ParseUtc(windowClosesText);
+
+        DailyCalendar calendar = new DailyCalendar(new TimeOnly(fromHour, 0), new TimeOnly(toHour, 0)) { TimeZone = zone };
+
+        DateTimeOffset firstPass = windowOpens.AddMinutes(30);
+        DateTimeOffset secondPass = firstPass.AddHours(1);
+
+        TimeZoneInfo.ConvertTime(secondPass, zone).DateTime.Should().Be(
+            TimeZoneInfo.ConvertTime(firstPass, zone).DateTime,
+            "the two passes are an hour of elapsed time apart and read as the same wall clock, which is what makes them ambiguous");
+
+        calendar.IsTimeIncluded(windowOpens.AddMilliseconds(-1)).Should().BeTrue("the window has not opened yet");
+        calendar.IsTimeIncluded(firstPass).Should().BeFalse("the daylight-time pass of the excluded hour is excluded");
+        calendar.IsTimeIncluded(secondPass).Should().BeFalse("so is the standard-time pass, which reads as the same wall clock");
+        calendar.IsTimeIncluded(windowCloses).Should().BeFalse("the end of the window is inclusive");
+        calendar.IsTimeIncluded(windowCloses.AddMilliseconds(1)).Should().BeTrue("and one millisecond later the day is open again");
+
+        calendar.GetNextIncludedTimeUtc(firstPass).Should().Be(windowCloses.AddMilliseconds(1),
+            "an hour of wall clock is two hours of elapsed time on the fall-back day, so a trigger held back at {0:HH:mm} is held for both passes",
+            TimeZoneInfo.ConvertTime(firstPass, zone));
+
+        (windowCloses - windowOpens).Should().Be(TimeSpan.FromHours(2),
+            "the hour written into the calendar covers two hours of the fall-back day");
+    }
+
+    /// <summary>
+    /// A cron exclusion is wall-clock matching, so an expression that names an hour the
+    /// spring-forward day does not have excludes nothing at all on that day.
+    /// </summary>
+    [Test]
+    public void CronCalendar_ExclusionInsideTheSpringForwardGap_ExcludesNothing()
+    {
+        TimeZoneInfo zone = TestTimeZones.Helsinki;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2024, 3, 31, 3, 30, 0));
+
+        // every second of local hour 3, which on 2024-03-31 in Helsinki is an hour that never happens
+        CronCalendar calendar = new CronCalendar(null, "* * 3 * * ?", zone);
+
+        DateTimeOffset transition = ParseUtc("2024-03-31T01:00:00Z");
+
+        for (int minute = -60; minute <= 60; minute++)
+        {
+            DateTimeOffset instant = transition.AddMinutes(minute);
+            calendar.IsTimeIncluded(instant).Should().BeTrue(
+                "{0:O} reads as {1:HH:mm} local, and no instant of this day reads as an hour that the day skipped",
+                instant, TimeZoneInfo.ConvertTime(instant, zone));
+        }
+
+        // and the next included time after any of them is simply the next millisecond
+        calendar.GetNextIncludedTimeUtc(transition).Should().Be(transition.AddMilliseconds(1));
+    }
+
+    /// <summary>
+    /// The same expression on the fall-back day excludes two hours of elapsed time, for the same
+    /// reason the daily calendar does.
+    /// </summary>
+    [Test]
+    public void CronCalendar_ExclusionOverAFallBackHour_ExcludesBothPasses()
+    {
+        TimeZoneInfo zone = TestTimeZones.Helsinki;
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2024, 10, 27, 3, 30, 0));
+
+        CronCalendar calendar = new CronCalendar(null, "* * 3 * * ?", zone);
+
+        DateTimeOffset firstPassStart = ParseUtc("2024-10-27T00:00:00Z");
+        DateTimeOffset secondPassEnd = ParseUtc("2024-10-27T02:00:00Z");
+
+        calendar.IsTimeIncluded(firstPassStart.AddSeconds(-1)).Should().BeTrue("local 02:59:59 is not in hour 3");
+        calendar.IsTimeIncluded(firstPassStart).Should().BeFalse("local 03:00:00 +03:00 is");
+        calendar.IsTimeIncluded(firstPassStart.AddMinutes(90)).Should().BeFalse("and so is local 03:30:00 +02:00, an hour of elapsed time later");
+        calendar.IsTimeIncluded(secondPassEnd).Should().BeTrue("local 04:00:00 +02:00 is past the excluded hour, both times over");
+
+        calendar.GetNextIncludedTimeUtc(firstPassStart.AddMinutes(30)).Should().Be(secondPassEnd,
+            "a trigger held back inside the repeated hour waits out both passes of it");
+    }
+
+    /// <summary>
+    /// A holiday excludes a local day, and Santiago's local days are not all 24 hours long: the
+    /// clocks move at midnight there, so the spring-forward day begins at 01:00 and lasts 23 hours
+    /// while the fall-back day lasts 25. Whichever it is, the holiday covers exactly the instants
+    /// that read as that date.
+    /// </summary>
+    [TestCase("2019-09-08", "2019-09-08T04:00:00Z", "2019-09-09T03:00:00Z", 23)]
+    [TestCase("2019-04-06", "2019-04-06T03:00:00Z", "2019-04-07T04:00:00Z", 25)]
+    public void HolidayCalendar_OnATransitionDay_ExcludesTheWholeLocalDay(
+        string holidayText,
+        string dayStartsText,
+        string dayEndsText,
+        int hoursInTheDay)
+    {
+        TimeZoneInfo zone = TestTimeZones.Santiago;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2019, 9, 8, 0, 30, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2019, 4, 6, 23, 30, 0));
+
+        DateOnly holiday = DateOnly.Parse(holidayText, System.Globalization.CultureInfo.InvariantCulture);
+        DateTimeOffset dayStarts = ParseUtc(dayStartsText);
+        DateTimeOffset dayEnds = ParseUtc(dayEndsText);
+
+        HolidayCalendar calendar = new HolidayCalendar { TimeZone = zone };
+        calendar.AddExcludedDay(holiday);
+
+        (dayEnds - dayStarts).Should().Be(TimeSpan.FromHours(hoursInTheDay),
+            "the premise of the case: the two instants it names are the first of {0:yyyy-MM-dd} and the first of the day after, and they are {1} hours apart in {2}",
+            holiday, hoursInTheDay, zone.Id);
+
+        // A minute rather than a millisecond, because the exact instant a zone changes offset is not
+        // agreed on to the millisecond: Windows cannot express a rule at local midnight and writes
+        // 23:59:59.999 of the day before instead, so on Windows data this local day begins one
+        // millisecond earlier than IANA data says it does. A minute is clear of the disagreement.
+        calendar.IsTimeIncluded(dayStarts.AddMinutes(-1)).Should().BeTrue(
+            "the minute before the holiday begins reads as {0:yyyy-MM-dd HH:mm}, which is the day before",
+            TimeZoneInfo.ConvertTime(dayStarts.AddMinutes(-1), zone));
+
+        calendar.IsTimeIncluded(dayStarts).Should().BeFalse(
+            "the holiday's own first instant reads as {0:yyyy-MM-dd HH:mm}, and a holiday excludes its whole local day however that day begins",
+            TimeZoneInfo.ConvertTime(dayStarts, zone));
+
+        calendar.IsTimeIncluded(dayEnds.AddMinutes(-1)).Should().BeFalse("the last minute of the local day is still the holiday");
+        calendar.IsTimeIncluded(dayEnds).Should().BeTrue("and the first instant of the next local day is not");
+
+        // spot-check the middle, so that the assertion is about a day rather than about four instants
+        for (int hour = 1; hour < hoursInTheDay; hour++)
+        {
+            calendar.IsTimeIncluded(dayStarts.AddHours(hour)).Should().BeFalse(
+                "hour {0} of the holiday reads as {1:yyyy-MM-dd HH:mm} and is part of it",
+                hour, TimeZoneInfo.ConvertTime(dayStarts.AddHours(hour), zone));
+        }
+    }
+
+    /// <summary>
+    /// The other half of the calendar contract on the same day: <c>GetNextIncludedTimeUtc</c> has to
+    /// answer with a time the calendar includes, and with the first one.
+    /// </summary>
+    /// <remarks>
+    /// It does not, in a zone whose midnight moves. <c>HolidayCalendar.GetNextIncludedTimeUtc</c>
+    /// builds the day's start as <c>new DateTimeOffset(local.Date, local.Offset)</c> - midnight at
+    /// the offset the <em>queried instant</em> carries - and on a day whose own midnight does not
+    /// exist, or whose offset changed part-way, that lands on the wrong day. The case is left
+    /// inconclusive rather than pinned: an answer that the calendar itself calls excluded is not a
+    /// behaviour to bless.
+    /// </remarks>
+    [TestCase("2019-09-08", "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("2019-04-06", "2019-04-07T02:30:00Z", "2019-04-07T04:00:00Z")]
+    public void HolidayCalendar_NextIncludedTime_OnATransitionDay(string holidayText, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = TestTimeZones.Santiago;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2019, 9, 8, 0, 30, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2019, 4, 6, 23, 30, 0));
+
+        DateOnly holiday = DateOnly.Parse(holidayText, System.Globalization.CultureInfo.InvariantCulture);
+        DateTimeOffset askedAt = ParseUtc(askedAtText);
+        DateTimeOffset expected = ParseUtc(expectedText);
+
+        HolidayCalendar calendar = new HolidayCalendar { TimeZone = zone };
+        calendar.AddExcludedDay(holiday);
+
+        calendar.IsTimeIncluded(askedAt).Should().BeFalse("the premise of the case: {0:O} is inside the holiday", askedAt);
+        calendar.IsTimeIncluded(expected).Should().BeTrue("and {0:O} is the first instant after it that is not", expected);
+
+        DateTimeOffset actual = calendar.GetNextIncludedTimeUtc(askedAt);
+
+        if (actual != expected)
+        {
+            Assert.Inconclusive(
+                $"GetNextIncludedTimeUtc({askedAt:O}) answered {actual:O} (local "
+                + $"{TimeZoneInfo.ConvertTime(actual, zone):yyyy-MM-dd HH:mm zzz}, included="
+                + $"{calendar.IsTimeIncluded(actual)}); the first instant this calendar includes after "
+                + $"the {holiday:yyyy-MM-dd} holiday is {expected:O} (local "
+                + $"{TimeZoneInfo.ConvertTime(expected, zone):yyyy-MM-dd HH:mm zzz}). The day boundary it walks is built "
+                + "as midnight at the offset of the instant it was asked about, which is not this day's midnight in a zone "
+                + "that moves its clocks at midnight.");
+        }
+
+        actual.Should().Be(expected,
+            "the next included time after an excluded instant is the first instant the calendar includes, and it must be one it does include");
+    }
+
+    private static TimeZoneInfo ResolveZone(string zoneKey)
+    {
+        switch (zoneKey)
+        {
+            case "Helsinki":
+                return TestTimeZones.Helsinki;
+            case "Eastern":
+                return TestTimeZones.Eastern;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test zone");
+        }
+    }
+
+    private static DateTimeOffset ParseUtc(string value)
+    {
+        return DateTimeOffset.Parse(value, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal);
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerDstTests.cs
@@ -255,6 +255,98 @@ public class DailyTimeIntervalTriggerDstTests
     }
 
     /// <summary>
+    /// Lord Howe Island moves its clocks by thirty minutes, which is the case that catches anything
+    /// assuming a whole hour. The local day is 23.5 hours long in spring and 24.5 in autumn, and the
+    /// quarter-hour grid steps through both in UTC ticks, so the counts are
+    /// <c>floor(windowLengthInSeconds / 900) + 1</c> just as they are anywhere else - it is only the
+    /// wall-clock labels that jump by half an hour.
+    /// </summary>
+    /// <remarks>
+    /// Spring forward (2024-10-06): 02:00 becomes 02:30, so the day has no 02:00 or 02:15 at all and
+    /// the grid steps from 01:45 +10:30 straight to 02:30 +11:00 - fifteen minutes of elapsed time
+    /// later. Fall back (2024-04-07): 02:00 becomes 01:30, so 01:30 and 01:45 each happen twice and
+    /// the day yields two quarter-hours more than an ordinary one.
+    /// </remarks>
+    [Test]
+    [Category("windowstimezoneid")]
+    [TestCase("2024-10-05T13:30:00Z", "2024-10-06", 94, 96)]
+    [TestCase("2024-04-06T13:00:00Z", "2024-04-07", 98, 96)]
+    public void HalfHourTransition_LordHowe_QuarterHourGrid(
+        string startTimeUtc,
+        string transitionDayText,
+        int expectedFireCountOnTransitionDay,
+        int expectedFireCountOnOrdinaryDay)
+    {
+        TimeZoneInfo timeZone = TestTimeZones.LordHowe;
+        TestTimeZones.AssumeInvalidLocalTime(timeZone, new DateTime(2024, 10, 6, 2, 15, 0));
+        TestTimeZones.AssumeAmbiguousLocalTime(timeZone, new DateTime(2024, 4, 7, 1, 45, 0));
+
+        DateTime transitionDay = DateTime.Parse(transitionDayText, System.Globalization.CultureInfo.InvariantCulture);
+
+        IOperableTrigger trigger = (IOperableTrigger) DailyTimeIntervalScheduleBuilder.Create()
+            .StartingDailyAt(new TimeOnly(0, 0))
+            .EndingDailyAt(new TimeOnly(23, 59, 59))
+            .OnEveryDay()
+            .WithInterval(15, IntervalUnit.Minute)
+            .InTimeZone(timeZone)
+            .Build();
+
+        // the start times are local midnight on the transition day, which the half-hour offset puts
+        // on a half-hour boundary in UTC
+        trigger.StartTimeUtc = DateTimeOffset.Parse(startTimeUtc, System.Globalization.CultureInfo.InvariantCulture);
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        List<DateTimeOffset> local = TestTimeZones
+            .Walk(after => trigger.GetFireTimeAfter(after),
+                trigger.StartTimeUtc.AddSeconds(-1),
+                // two days and a margin: the transition moves the local day boundary off the UTC one,
+                // so two days of elapsed time stop short of the end of the second local day
+                trigger.StartTimeUtc.AddDays(2).AddHours(2))
+            .Select(t => TimeZoneInfo.ConvertTime(t, timeZone))
+            .ToList();
+
+        List<DateTimeOffset> onTransitionDay = local.Where(t => t.Date == transitionDay).ToList();
+
+        onTransitionDay.Should().HaveCount(expectedFireCountOnTransitionDay,
+            "the local day is {0} minutes long and the grid steps every 15", (expectedFireCountOnTransitionDay - 1) * 15);
+        local.Count(t => t.Date == transitionDay.AddDays(1)).Should().Be(expectedFireCountOnOrdinaryDay,
+            "the day after the transition is an ordinary 24 hour day again");
+
+        onTransitionDay[0].TimeOfDay.Should().Be(TimeSpan.Zero, "the first fire of the day is startTimeOfDay");
+
+        if (transitionDay == new DateTime(2024, 10, 6))
+        {
+            onTransitionDay.Should().NotContain(t => t.Hour == 2 && t.Minute < 30,
+                "02:00 and 02:15 do not exist on the spring-forward day - the clocks go straight from 02:00 to 02:30");
+
+            List<DateTimeOffset> acrossTheGap = onTransitionDay.Where(t => t.Hour is 1 or 2).ToList();
+            acrossTheGap.Should().Equal(
+                TestTimeZones.Local("2024-10-06 01:00 +10:30"),
+                TestTimeZones.Local("2024-10-06 01:15 +10:30"),
+                TestTimeZones.Local("2024-10-06 01:30 +10:30"),
+                TestTimeZones.Local("2024-10-06 01:45 +10:30"),
+                TestTimeZones.Local("2024-10-06 02:30 +11:00"),
+                TestTimeZones.Local("2024-10-06 02:45 +11:00"));
+        }
+        else
+        {
+            onTransitionDay.Where(t => t.Hour == 1 && t.Minute >= 30).Should().HaveCount(4,
+                "01:30 and 01:45 each happen twice on the fall-back day, once at +11:00 and once at +10:30");
+
+            List<DateTimeOffset> acrossTheRepeat = onTransitionDay.Where(t => t.Hour is 1 or 2).ToList();
+            acrossTheRepeat.Should().StartWith(new[]
+            {
+                TestTimeZones.Local("2024-04-07 01:00 +11:00"),
+                TestTimeZones.Local("2024-04-07 01:15 +11:00"),
+                TestTimeZones.Local("2024-04-07 01:30 +11:00"),
+                TestTimeZones.Local("2024-04-07 01:45 +11:00"),
+                TestTimeZones.Local("2024-04-07 01:30 +10:30"),
+                TestTimeZones.Local("2024-04-07 01:45 +10:30")
+            });
+        }
+    }
+
+    /// <summary>
     /// Regression test for the offset resolution in <c>AdvanceToNextDayOfWeekIfNecessary</c>: when
     /// the day-of-week walk crosses a spring-forward transition, the advanced day's start-of-day
     /// must resolve through the wall-clock policy before it is compared against

--- a/src/Quartz.Tests.Unit/TestTimeZones.cs
+++ b/src/Quartz.Tests.Unit/TestTimeZones.cs
@@ -46,6 +46,20 @@ internal static class TestTimeZones
     public static TimeZoneInfo CentralEuropean { get; } = TZConvert.GetTimeZoneInfo("Central European Standard Time");
 
     /// <summary>
+    /// Europe/Helsinki: EET/EEST, +02:00 in winter and +03:00 in summer, with the EU transition at
+    /// 01:00 UTC - which is 03:00 local in spring (03:00 becomes 04:00, so 03:30 is invalid) and
+    /// 04:00 local in autumn (04:00 becomes 03:00, so 03:30 is ambiguous). Spring forward
+    /// 2024-03-31, fall back 2024-10-27.
+    /// </summary>
+    /// <remarks>
+    /// Windows names the whole EET/EEST group "FLE Standard Time", which resolves to Europe/Kyiv on
+    /// a system carrying IANA data. Helsinki and Kyiv share the EU rules, so the transitions
+    /// asserted against this zone are the same instants either way - and the Assume helpers say so
+    /// out loud, so a zone database that ever disagreed would skip the test rather than fail it.
+    /// </remarks>
+    public static TimeZoneInfo Helsinki { get; } = TZConvert.GetTimeZoneInfo("FLE Standard Time");
+
+    /// <summary>
     /// America/Santiago: southern hemisphere and the transition happens at midnight, so on
     /// spring-forward day the date's own 00:00 does not exist (2019-09-08, 00:30 invalid) and on
     /// fall-back day the repeated hour crosses backwards over the date boundary

--- a/src/Quartz.Tests.Unit/TriggerDstMonotonicityTests.cs
+++ b/src/Quartz.Tests.Unit/TriggerDstMonotonicityTests.cs
@@ -110,6 +110,23 @@ public class TriggerDstMonotonicityTests
                     new DateTimeOffset(2019, 4, 6, 13, 0, 0, TimeSpan.Zero),
                     () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.LordHowe, new DateTime(2019, 4, 7, 1, 45, 0)));
 
+            case "AmmanSpring":
+                // Midnight transition, the other way round from Santiago's: 2017-03-31 has no 00:00
+                // local, the day starts at 01:00. Jordan abolished DST in 2022, so this is frozen
+                // history rather than a rule that can move under the test.
+                return new DstWindow(
+                    TestTimeZones.Amman,
+                    new DateTimeOffset(2017, 3, 30, 20, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Amman, new DateTime(2017, 3, 31, 0, 30, 0)));
+
+            case "AmmanFall":
+                // The repeated hour is the first hour of the local day, 00:00-00:59 on 2017-10-27,
+                // which no other window here covers.
+                return new DstWindow(
+                    TestTimeZones.Amman,
+                    new DateTimeOffset(2017, 10, 26, 20, 0, 0, TimeSpan.Zero),
+                    () => TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Amman, new DateTime(2017, 10, 27, 0, 30, 0)));
+
             case "SydneyFall":
                 // 03:00 AEDT -> 02:00 AEST at 2024-04-06 16:00Z.
                 return new DstWindow(
@@ -218,6 +235,8 @@ public class TriggerDstMonotonicityTests
     [TestCase("CronMinutely", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
     [TestCase("CronMinutely", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
     [TestCase("CronMinutely", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    [TestCase("CronMinutely", "AmmanSpring", "2017-03-30 20:00 +00:00", 90)]
+    [TestCase("CronMinutely", "AmmanFall", "2017-10-26 20:00 +00:00", 90)]
     [TestCase("CronHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 150)]
     [TestCase("CronHourly", "EasternFall", "2024-11-03 04:00 +00:00", 150)]
     [TestCase("CronHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 150)]
@@ -225,6 +244,8 @@ public class TriggerDstMonotonicityTests
     [TestCase("CronHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 150)]
     [TestCase("CronHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 150)]
     [TestCase("CronHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 150)]
+    [TestCase("CronHourly", "AmmanSpring", "2017-03-30 20:00 +00:00", 150)]
+    [TestCase("CronHourly", "AmmanFall", "2017-10-26 20:00 +00:00", 150)]
     [TestCase("CalendarIntervalHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 90)]
     [TestCase("CalendarIntervalHourly", "EasternFall", "2024-11-03 04:00 +00:00", 90)]
     [TestCase("CalendarIntervalHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 90)]
@@ -232,6 +253,8 @@ public class TriggerDstMonotonicityTests
     [TestCase("CalendarIntervalHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
     [TestCase("CalendarIntervalHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
     [TestCase("CalendarIntervalHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "AmmanSpring", "2017-03-30 20:00 +00:00", 90)]
+    [TestCase("CalendarIntervalHourly", "AmmanFall", "2017-10-26 20:00 +00:00", 90)]
     // A daily schedule that preserves its wall clock spans the 25 hour fall back day, so the bound
     // is 26 hours. Observed maximum across these seven windows is exactly 25 hours (Central European
     // and Sydney fall back); the spare hour absorbs a zone whose delta is larger than one hour.
@@ -242,6 +265,8 @@ public class TriggerDstMonotonicityTests
     [TestCase("CalendarIntervalDailyPreserve", "LordHoweSpring", "2019-10-05 13:30 +00:00", 26 * 60)]
     [TestCase("CalendarIntervalDailyPreserve", "LordHoweFall", "2019-04-06 13:00 +00:00", 26 * 60)]
     [TestCase("CalendarIntervalDailyPreserve", "SydneyFall", "2024-04-06 14:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "AmmanSpring", "2017-03-30 20:00 +00:00", 26 * 60)]
+    [TestCase("CalendarIntervalDailyPreserve", "AmmanFall", "2017-10-26 20:00 +00:00", 26 * 60)]
     [TestCase("DailyTimeIntervalQuarterHour", "EasternSpring", "2024-03-10 05:00 +00:00", 90)]
     [TestCase("DailyTimeIntervalQuarterHour", "EasternFall", "2024-11-03 04:00 +00:00", 90)]
     [TestCase("DailyTimeIntervalQuarterHour", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 90)]
@@ -249,6 +274,8 @@ public class TriggerDstMonotonicityTests
     [TestCase("DailyTimeIntervalQuarterHour", "LordHoweSpring", "2019-10-05 13:30 +00:00", 90)]
     [TestCase("DailyTimeIntervalQuarterHour", "LordHoweFall", "2019-04-06 13:00 +00:00", 90)]
     [TestCase("DailyTimeIntervalQuarterHour", "SydneyFall", "2024-04-06 14:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "AmmanSpring", "2017-03-30 20:00 +00:00", 90)]
+    [TestCase("DailyTimeIntervalQuarterHour", "AmmanFall", "2017-10-26 20:00 +00:00", 90)]
     [TestCase("SimpleHalfHour", "EasternSpring", "2024-03-10 05:00 +00:00", 31)]
     [TestCase("SimpleHalfHour", "EasternFall", "2024-11-03 04:00 +00:00", 31)]
     [TestCase("SimpleHalfHour", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 31)]
@@ -256,6 +283,8 @@ public class TriggerDstMonotonicityTests
     [TestCase("SimpleHalfHour", "LordHoweSpring", "2019-10-05 13:30 +00:00", 31)]
     [TestCase("SimpleHalfHour", "LordHoweFall", "2019-04-06 13:00 +00:00", 31)]
     [TestCase("SimpleHalfHour", "SydneyFall", "2024-04-06 14:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "AmmanSpring", "2017-03-30 20:00 +00:00", 31)]
+    [TestCase("SimpleHalfHour", "AmmanFall", "2017-10-26 20:00 +00:00", 31)]
     [TestCase("RecurrenceHourly", "EasternSpring", "2024-03-10 05:00 +00:00", 150)]
     [TestCase("RecurrenceHourly", "EasternFall", "2024-11-03 04:00 +00:00", 150)]
     [TestCase("RecurrenceHourly", "CentralEuropeanFall", "2018-10-27 23:00 +00:00", 150)]
@@ -263,6 +292,8 @@ public class TriggerDstMonotonicityTests
     [TestCase("RecurrenceHourly", "LordHoweSpring", "2019-10-05 13:30 +00:00", 150)]
     [TestCase("RecurrenceHourly", "LordHoweFall", "2019-04-06 13:00 +00:00", 150)]
     [TestCase("RecurrenceHourly", "SydneyFall", "2024-04-06 14:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "AmmanSpring", "2017-03-30 20:00 +00:00", 150)]
+    [TestCase("RecurrenceHourly", "AmmanFall", "2017-10-26 20:00 +00:00", 150)]
     public void FireTimesProgressMonotonicallyAcrossTransition(
         string triggerKind,
         string windowKey,


### PR DESCRIPTION
The daylight saving suites were all trigger arithmetic: `GetFireTimeAfter` asked what it computes,
and nothing asked what a scheduler *fires* or what a database *holds* afterwards. This is test-only —
no product code changes — and it adds the missing half, plus the corners of the existing suites the
issue lists.

## What is new

| File | What it covers |
|---|---|
| `src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs` | a scheduler on a `FakeTimeProvider` across a transition, store × zone × direction |
| `src/Quartz.Tests.Integration/Impl/MisfireAcrossDstTransitionTest.cs` | one misfire sweep whose missed fire and sweep straddle a transition, in-memory and ADO |
| `src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs` | `DailyCalendar`, `CronCalendar` and `HolidayCalendar` on 23 and 25 hour days |
| `CalendarIntervalTriggerDstTests` (extended) | `PreserveHourOfDayAcrossDaylightSavings` on **spring-forward** for Day/Week/Month/Year; Lord Howe with the flag off |
| `Impl/Triggers/DailyTimeIntervalTriggerDstTests` (extended) | Lord Howe's half-hour delta, a 23.5 hour day and a 24.5 hour one |
| `TestTimeZones` | `Helsinki` joins the named zones; `Amman`, declared and unused, gets both of its windows in the monotonicity grid |

`Quartz.Tests.Integration` gains `Microsoft.Extensions.TimeProvider.Testing` and `TimeZoneConverter`,
and compiles `TestTimeZones.cs` from the unit project the way it already compiles `TestJobStores.cs`,
so both projects state a transition premise the same way.

## The matrix, and the fires observed

Store × zone × transition, four triggers each, all twelve cases in the `basic` leg (SQLite runs on a
file, so no container and no `db-*` category). Every case fires **29** times in the window and every
case's per-trigger set equals `TriggerFireTimes.ComputeBetween` exactly:

| trigger | fires per case | what the transition does to it |
|---|---|---|
| cron `0 30 * * * ?` | 4 | Helsinki spring: `02:30 +02:00` then `04:30 +03:00` — no 03:30 that day. Helsinki fall: `03:30 +03:00` **and** `03:30 +02:00` — the same wall clock twice. New York and Lord Howe likewise |
| daily time interval, 15 min | 16 | Lord Howe spring steps `01:45 +10:30` → `02:30 +11:00`; Lord Howe fall serves `01:30` and `01:45` twice |
| calendar interval, daily, hour preserved | 1 | fires once in the window; its stored next fire is the same wall clock the next day at the new offset |
| simple, 30 min | 8 | pure elapsed time; the wall-clock labels move, the spacing does not |

Both stores agree on every one of those sets. After the window, `RetrieveTrigger`'s
`NextFireTimeUtc` equals the trigger's own `GetFireTimeAfter(clock)` for all four triggers, and for
SQLite the same value is read again straight out of `NEXT_FIRE_TIME` (UTC ticks) rather than only off
the object.

Nothing is wall-clock: `FakeTimeProvider` plus signals, no `Thread.Sleep`, no `Task.Delay` used as a
wait, no `DateTimeOffset.UtcNow` in an assertion. The clock advances in half-hour steps, each advance
is followed by a scheduling signal (the loop waits on a semaphore that only knows real elapsed time),
and the misfire threshold is wider than the window so a fire the clock jumped over is fired late
rather than discarded.

## Findings — things a reviewer has to decide

### 1. A trigger never gets the scheduler's or the store's `TimeProvider` (four inconclusive cases)

`TriggerBuilder.Create(clock)` hands the clock to the schedule builder but not to the trigger, and
`StdAdoDelegate` rebuilds a trigger out of a row with `TriggerBuilder.Create()` and no clock at all.
`TriggerBase.timeProvider` is set once in the constructor and there is no seam to set it afterwards.
So every "now" a trigger reads is `TimeProvider.System`, whatever `UseTimeProvider` said.

Two places where that is visible:

- **Misfire recovery in the ADO store.** The sweep *selects* misfired triggers with the store's
  clock, then calls `UpdateAfterMisfire` on a trigger holding the system clock. With the store's
  clock at `2024-03-31T01:15:00Z`, observed versus expected:

  | instruction | `NEXT_FIRE_TIME` written | what the same trigger holding the store's clock computes |
  |---|---|---|
  | `FireOnceNow`, spring | `2026-08-26T15:59:29Z` (the machine's wall clock) | `2024-03-31T01:15:00Z` = local `04:15 +03:00` |
  | `DoNothing`, spring | `2026-08-26T16:30:00Z` | `2024-03-31T01:30:00Z` = local `04:30 +03:00` |
  | `FireOnceNow`, fall | `2026-08-26T15:59:30Z` | `2024-10-27T01:15:00Z` = local `03:15 +02:00` |
  | `DoNothing`, fall | `2026-08-26T16:30:00Z` | `2024-10-27T01:30:00Z` = local `03:30 +02:00` |

  `OneSweepRecoversTheTriggerAndWritesTheColumn` asserts everything that does hold — one trigger
  selected, back in `Normal`, a next fire time in the future that reads as a wall clock the zone has,
  `NEXT_FIRE_TIME` agreeing with the object — and is then `Assert.Inconclusive` with those values.
  Its in-memory twin passes outright, because `RAMJobStore` keeps the trigger object it was handed,
  clock included; that is the same test asserting the exact instants.

  A side effect of the same gap: `PrepareMisfiredTriggerUpdate` only records
  `MISFIRE_INSTR`'s original fire time when the new fire time is within
  `FireNowMisfireDetectionThresholdMs` of the store's now, and a system-clock answer never is.

- **`CronTriggerImpl.ComputeFirstFireTimeUtc`**, which the scheduler calls on every `ScheduleJob`,
  clamps a past-due first fire forward to the trigger's own now. A builder-built cron trigger
  scheduled by a scheduler whose clock says 2024 is therefore scheduled for *today*. The scheduler
  fixture constructs `CronTriggerImpl` with the clock for exactly this reason, and says so in a
  comment. Worth noting that `testing.md` tells people to pass the clock to `TriggerBuilder.Create`,
  which is not enough for a cron trigger.

  Whether the fix is to plumb the clock through the builder and the persistence delegates, or to
  drop the clamp, is a design decision — hence no product change here.

### 2. `HolidayCalendar.GetNextIncludedTimeUtc` is wrong in a zone that moves its clocks at midnight (two inconclusive cases)

It builds the day boundary as `new DateTimeOffset(local.Date, local.Offset)` — midnight at the offset
the *queried instant* carries — which is not that day's midnight in Santiago. Observed versus
expected, with a holiday on the transition day:

| asked at | answered | first instant actually included |
|---|---|---|
| `2019-09-08T10:00:00Z` (inside the 23 hour holiday) | `2019-09-08T10:00:00Z` — the same instant, which `IsTimeIncluded` says is **excluded** | `2019-09-09T03:00:00Z` |
| `2019-04-07T02:30:00Z` (inside the 25 hour holiday) | `2019-04-08T03:00:00Z` — included, but 23 hours late | `2019-04-07T04:00:00Z` |

`IsTimeIncluded` is right in both directions and is asserted properly: a holiday covers exactly the
instants that read as its date, whether the day is 23 hours long or 25. Only the "next included time"
half is inconclusive, and it is left inconclusive rather than pinned, because an answer the calendar
itself calls excluded is not a behaviour to bless.

### 3. `EndAt` is inclusive for one trigger type and exclusive for another (no test, just a note)

`ComputeBetween` bounds its walk by assigning `EndTimeUtc = to`, and `SimpleTriggerImpl` drops a fire
at exactly its end time while `DailyTimeIntervalTriggerImpl` keeps one. A running scheduler has no
end time and fires both. The scheduler fixture's window is ten minutes short of four hours so that no
schedule lands on the boundary at all — that disagreement is about `EndAt`, not about daylight
saving, and arbitrating it is not this issue's business.

## Deviations from the brief

- The helper is `TriggerFireTimes.ComputeBetween`, not `ComputeFireTimesBetween`.
- The window is 230 minutes rather than 240, for the `EndAt` reason above.
- The cron trigger in the scheduler fixture is constructed rather than built, for finding 1.
- Lord Howe *was* already covered for `ICalendarIntervalTrigger` with the hour preserved
  (`PreserveHour_LordHoweHalfHourDelta_KeepsScheduledTimeOfDay`), so what is new there is the
  **default** configuration, which drifts by the half-hour delta rather than by an hour.
  `IDailyTimeIntervalTrigger` had no Lord Howe coverage at all and now has both directions.
- The misfire fixture lives in `Impl/` rather than `Impl/AdoJobStore/` because it covers both stores,
  and it gained the in-memory half so that the daylight saving arithmetic is asserted somewhere and
  not only reported.
- `Amman` got cases rather than a comment: both of its windows are in the monotonicity grid, which is
  the one shape no other zone there has (gap and repeated hour both in the first hour of the day).

## Verification

```
dotnet build Quartz.slnx
  Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
  Passed! - Failed: 0, Passed: 3326, Skipped: 4, Total: 3330, Duration: 51 s

QUARTZ_TEST_DATABASE=basic dotnet test src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj \
  --filter "TestCategory!=db-postgres&TestCategory!=db-sqlserver&TestCategory!=db-mysql&TestCategory!=db-oracle&TestCategory!=db-firebird&TestCategory!=db-sqlite&TestCategory!=db-redis"
  Passed! - Failed: 0, Passed: 174, Skipped: 0, Total: 174, Duration: 1 m 36 s
```

The new fixtures three times in a row, to show they do not depend on timing:

```
SchedulerAcrossDstTransitionTest + MisfireAcrossDstTransitionTest: 16/16 passed, 8 s / 9 s / 10 s
every DST suite in Quartz.Tests.Unit:                             173/173 passed, 2 s / 2 s / 2 s
```

The six inconclusive cases (four misfire, two holiday calendar) are reported as skipped and carry the
observed and expected values in their messages.

Closes #3434
