### PR TITLE
The nodes of a cluster can be listed, on the API and on the dashboard

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/custom-job-store.md
+++ b/docs/documentation/quartz-4.x/how-tos/custom-job-store.md
@@ -176,7 +176,8 @@ are public for exactly this.
 
 ### Queries
 
-The six `Query…` members are abstract, and three rules keep them consistent with the shipped stores:
+The six paged `Query…` members are abstract, and three rules keep them consistent with the shipped
+stores:
 
 - **Order by group, then name, ordinal.** Fire instances add fire instance id as a third key, because
   one trigger can have several firings in flight and group plus name would not order them.
@@ -187,6 +188,23 @@ The six `Query…` members are abstract, and three rules keep them consistent wi
 `QueryFireInstances` answers for the whole cluster if the store keeps firings durably, and for its own
 process otherwise, which is the whole of an in-memory store's world. `FireInstance.JobKey` is `null`
 while a firing is only `Acquired` — the job is not loaded until it starts.
+
+### Cluster nodes
+
+`QueryClusterNodes(ct)` lists the scheduler nodes the store knows about, as `ClusterNode`s. It is not
+paged — a cluster is a handful of nodes, not a data set — and two rules bind it:
+
+- **The current node is always in the list, first, and is the only one with `IsCurrentNode = true`.**
+  It is listed whether or not the store has a record of it yet. The rest follow by instance id, ordinal.
+- **A store that keeps no membership answers with that one node**, `ClusterNodeState.Alive`, with
+  `LastCheckInUtc` and `CheckInInterval` both `null`. That is the honest answer for a store that cannot
+  cluster, and it means a caller never has to branch on `Clustered` before asking.
+
+A store that *does* keep membership reports every node it has a record of, including ones that are dead
+but not yet swept, and decides `State` with **the same predicate its own failover pass uses** — write
+that once and call it from both, so the listing can never disagree with the recovery it predicts.
+`Overdue` is a missed check-in and nothing more; `Failed` is the point at which the store takes the
+node's work over.
 
 ### Bulk members
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3537,6 +3537,7 @@ already have them.
 * **Paged, projected job store queries** — list and count jobs, triggers, groups and calendars a page at a time, with the metadata a listing needs already in the row (see [Job store listings became queries](#job-store-listings-became-queries))
 * **Bulk fetch by key** — `GetJobDetails(keys)` and `GetTriggers(keys)` turn a page of keys into one round trip, over ADO.NET and over HTTP alike (see [Job store listings became queries](#job-store-listings-became-queries))
 * **Fire instances are a listing** — `QueryFireInstances` answers what is running as a paged, projected query that a persistent store answers for the whole cluster, where `GetCurrentlyExecutingJobs` could only speak for this process (see [What is running is a listing, not a list of contexts](#what-is-running-is-a-listing-not-a-list-of-contexts))
+* **The nodes of a cluster can be listed** — `QueryClusterNodes` reports every node the store knows about, with the same `Alive`/`Overdue`/`Failed` verdict the failover sweep decides recovery by. On 3.x nothing in the product read `QRTZ_SCHEDULER_STATE`, so "which of my four nodes is alive" was a question answered by hand-written SQL (see [The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing))
 * **Job data by property name** — bind job data to the job property it is meant for instead of spelling its key (see [Job data can name the property](#job-data-can-name-the-property))
 * **`TriggerState.Executing`** — tell whether a trigger's job is running, across the whole cluster (see [Executing is a trigger state](#executing-is-a-trigger-state))
 * **`JobInstantiationException`** — a job that could not be built names the trigger, the job and the fire instance instead of only interpolating the job key into a message (see [Instantiation failures name the trigger](#instantiation-failures-name-the-trigger))
@@ -3919,8 +3920,10 @@ The scheduler body's `statistics` object gained `localExecutingJobs`, mirroring 
 
 ### If you implement `IJobStore`
 
-Two members. `QueryFireInstances(FireInstanceQuery, CancellationToken)` is the listing, abstract like the
-rest of the query family. And `Initialize` now takes a `SchedulerIdentity`:
+Three members. `QueryFireInstances(FireInstanceQuery, CancellationToken)` is the listing, abstract like
+the rest of the query family; `QueryClusterNodes(CancellationToken)` is the node listing described in
+[The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing). And `Initialize` now
+takes a `SchedulerIdentity`:
 
 ```diff
 - ValueTask Initialize(CancellationToken cancellationToken = default);
@@ -3946,6 +3949,42 @@ rest unrecovered.
 `QRTZ_FIRED_TRIGGERS.EXECUTION_GROUP` is now live: written by the fired-trigger insert and update, read
 back into `FireInstance.ExecutionGroup`. **No schema change** — the column has shipped on every dialect
 since 3.18 — but rows written by an earlier 4.0 preview hold `NULL`.
+
+## The nodes of a cluster are a listing
+
+Nothing in 3.x read `QRTZ_SCHEDULER_STATE`. The table was written on every check-in and swept by the
+failover pass, and that was the whole of it: an operator asking which of four nodes was alive ran SQL by
+hand, because `SchedulerMetadata.JobStoreClustered` — a `bool` saying clustering is *on* — was the only
+cluster fact the API exposed.
+
+```csharp
+List<ClusterNode> nodes = await scheduler.QueryClusterNodes();
+```
+
+`ClusterNode` is `InstanceId`, `LastCheckInUtc`, `CheckInInterval`, a `ClusterNodeState` of `Alive`,
+`Overdue` or `Failed`, and `IsCurrentNode`. The node answering is first, always present — even before
+its first check-in has written a row — and the only one whose `IsCurrentNode` is `true`; the rest follow
+by instance id. The state is decided by the same predicate the recovery sweep applies, so the listing
+and the failover it predicts cannot disagree, and the two times are `null` rather than zero when the
+store keeps no check-in history. **`null` is not the epoch**: a reader that falls back to
+`DateTimeOffset.MinValue` will draw a node that has been dead since year one.
+
+A scheduler that is not clustered answers with the one node it is, `Alive` and with no times, rather
+than with an empty list, so a caller need not branch on whether clustering is on. See
+[Seeing the cluster](tutorial/advanced-enterprise-features.md#seeing-the-cluster).
+
+`SchedulerStateRecord` is unchanged and stays the ADO.NET store's own row shape, the way
+`FiredTriggerRecord` sits beside `FireInstance`; `ClusterNode` is the store-neutral projection.
+
+| Where | What is new |
+|---|---|
+| `IScheduler` | `ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)` — implement it if you have an `IScheduler` of your own; `DelegatingScheduler` forwards it for you |
+| `IJobStore` | `ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)` — a plain member, so a store of your own must implement it. A store with no cluster state answers with one node: itself, `Alive`, both times `null` |
+| HTTP API | `GET {ApiPath}/schedulers/{name}/nodes`, unpaged, and `HttpScheduler.QueryClusterNodes` reads it (see [Cluster nodes](packages/http-api.md#cluster-nodes)) |
+| Dashboard | `IQuartzApiClient.GetClusterNodes(name, CancellationToken)`, and a **Cluster** page at `/quartz/cluster` |
+
+Neither member touches the schema, and neither writes anything: `QueryClusterNodes` is a read of the
+rows the check-in loop already keeps.
 
 ## An unset execution group can be the trigger's group
 
@@ -5900,6 +5939,7 @@ already had `JobKeyDto` and `TriggerKeyDto`. Now it says what Quartz says:
 | `GetHistory(JobHistoryQueryDto)` → `JobHistoryPageDto` (a `JsonElement`) | `GetHistory(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>?` |
 | `GetCurrentlyExecutingJobs(name)` → `List<CurrentlyExecutingJobDto>` | `GetFireInstances(name, DashboardFireInstanceQuery)` → `PagedResult<FireInstanceDto>`, following `IScheduler` — see [What is running is a listing, not a list of contexts](#what-is-running-is-a-listing-not-a-list-of-contexts) |
 | `CurrentlyExecutingJobDto` | `FireInstanceDto`: `FireInstanceId` is non-null and leads, `JobKey` is nullable (an acquired firing has no job loaded yet), and `SchedulerInstanceId`, `FireInstanceState State` and `ScheduledFireTimeUtc` are new |
+| — | `GetClusterNodes(name)` → `List<ClusterNodeDto>` (new), behind the **Cluster** page — see [The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing) |
 | `IsJobGroupPaused(name, group)` → `bool` | `GetJobGroups(name)` → `List<JobGroupDto>`, each carrying `Name` and `Paused`; one call answers for every group instead of one |
 | `ExecutionLimitsDto(IReadOnlyDictionary<string, int?> Limits)` | `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits)` — concrete out, as everywhere else, and each entry carries the limit's [scope](#an-execution-limit-can-be-cluster-wide) as well as its number |
 | `IDashboardHistoryStore.GetPage(name, page, pageSize, jobFilter, triggerFilter)` → `DashboardHistoryPage` | `GetPage(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>` |

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -216,6 +216,10 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
 - Job details and trigger details pages
 - Currently executing jobs view — cluster-wide with a persistent job store, showing which node owns each
   execution, and interrupting the one execution a row names rather than every execution of its job
+- Cluster view at `/quartz/cluster` — one row per node with its state (`Alive`, `Overdue`, `Failed`),
+  its last check-in in the selected time zone and as a relative time, its check-in interval, and how
+  many firings it is holding and running; the node answering is marked, and a scheduler whose store
+  keeps no cluster state says so rather than showing an empty table
 - Live event/log stream for scheduler activity, fed by plugins `AddQuartzDashboard` installs on every
   scheduler in the container — so a named scheduler streams its own events, each plugin instance
   initialized with the name of the scheduler it belongs to

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -70,7 +70,7 @@ validated against.
 
 ## Endpoint groups
 
-- **Schedulers**: list schedulers, read metadata/context, start, stand-by, shutdown, clear, pause-all, resume-all
+- **Schedulers**: list schedulers, read metadata/context, list cluster nodes, start, stand-by, shutdown, clear, pause-all, resume-all
 - **Jobs**: query jobs, fetch details by key, check existence, list fire instances, pause/resume, trigger, interrupt, add, delete
 - **Triggers**: query triggers, fetch by key, read state, pause/resume, reset from error state, schedule/unschedule/reschedule
 - **Calendars**: query names, get details, add/replace, delete
@@ -299,6 +299,46 @@ calendar listings. Both shapes are gone; every listing returns the paged envelop
 `GET {ApiPath}/schedulers/{name}/triggers/groups/paused` was removed — use
 `GET {ApiPath}/schedulers/{name}/triggers/groups?paused=true`.
 :::
+
+## Cluster nodes
+
+`GET {ApiPath}/schedulers/{name}/nodes` answers with the scheduler's nodes — the node that handled the
+request first, then the rest by instance id. It is not paged: a cluster is a handful of nodes, not a
+data set.
+
+```json
+[
+  {
+    "instanceId": "web-01",
+    "lastCheckInUtc": "2026-08-26T09:14:57+00:00",
+    "checkInInterval": "00:00:15",
+    "state": "Alive",
+    "isCurrentNode": true
+  },
+  {
+    "instanceId": "web-02",
+    "lastCheckInUtc": "2026-08-26T09:09:12+00:00",
+    "checkInInterval": "00:00:15",
+    "state": "Failed",
+    "isCurrentNode": false
+  }
+]
+```
+
+`state` is `Alive`, `Overdue` or `Failed`, and is decided by the same predicate the store's recovery
+sweep applies — a node reported `Failed` is a node whose in-flight work the cluster is about to take
+over, after which it stops being listed. `Overdue` means a missed check-in and nothing more.
+
+`checkInInterval` is a `TimeSpan` like every other duration here, and it is the interval *that* node
+was configured with rather than the reader's. Both times are `null` when the store keeps no check-in
+history — an in-memory store, or a persistent one with clustering switched off — which is what a
+single-node answer looks like: one node, `isCurrentNode: true`, `Alive`, and no times. `null` is not
+zero, so a reader must not fall back to `DateTimeOffset.MinValue` here.
+
+The verdicts are what the answering node believes, read off its own clock, so on a cluster with skewed
+clocks two nodes can disagree. Join the listing to
+`GET {ApiPath}/schedulers/{name}/jobs/fire-instances` on `schedulerInstanceId` to see what each node is
+running.
 
 ## Pause and resume report what they did
 

--- a/docs/documentation/quartz-4.x/packages/http-client.md
+++ b/docs/documentation/quartz-4.x/packages/http-client.md
@@ -263,7 +263,11 @@ PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
 that leaves it unset gets the same page size the server would have chosen.
 
 `QueryFireInstances` works the same way and is how a remote console shows what is running — across the
-whole cluster, since the listing is store-backed.
+whole cluster, since the listing is store-backed. `QueryClusterNodes` is its companion and takes no
+query at all: it reads `GET …/schedulers/{name}/nodes` and answers with the nodes themselves, the one
+that served the request first. "Current node" therefore means current on the *server*, not on the
+client — the client has no identity in the cluster — so the order arrives as the server chose it and is
+not re-sorted here.
 
 Bulk fetch posts the keys back:
 

--- a/docs/documentation/quartz-4.x/tutorial/advanced-enterprise-features.md
+++ b/docs/documentation/quartz-4.x/tutorial/advanced-enterprise-features.md
@@ -133,3 +133,65 @@ schedule with second-level precision is a behaviour change, not a tuning knob.
 `MaxBatchSize` may not exceed the thread pool's `MaxConcurrency`, and is rejected at startup if it does:
 triggers acquired beyond the number of threads available to run them are held by this node, unfireable
 by any other, until the pool drains.
+
+## Seeing the cluster
+
+`QRTZ_SCHEDULER_STATE` is where the check-ins land, and `IScheduler.QueryClusterNodes()` is how to read
+it without writing SQL:
+
+<!-- snippet: sample_advanced_cluster_nodes -->
+```csharp
+List<ClusterNode> nodes = await scheduler.QueryClusterNodes();
+
+foreach (ClusterNode node in nodes)
+{
+    string marker = node.IsCurrentNode ? " (this node)" : "";
+    Console.WriteLine($"{node.InstanceId}{marker}: {node.State}, last check-in {node.LastCheckInUtc:u}");
+}
+
+// The verdicts come from the same predicate the failover sweep applies, so a node reported
+// Failed is one whose in-flight work the cluster is about to take over.
+List<ClusterNode> failed = nodes.FindAll(node => node.State == ClusterNodeState.Failed);
+```
+<!-- endSnippet -->
+
+Each `ClusterNode` carries the node's `InstanceId`, its `LastCheckInUtc`, the `CheckInInterval` that
+node was configured with, whether it `IsCurrentNode`, and a `State` of `Alive`, `Overdue` or `Failed`.
+The list is the node answering first, then the rest by instance id, and the node answering is always in
+it — even before its first check-in has written a row.
+
+The verdict is decided by the same predicate the failover sweep uses, so the listing and the recovery
+it predicts cannot disagree: `Failed` means the next check-in pass will take this node's work over and
+delete its row, which is why a corpse is reported for a while and then disappears. `Overdue` is a missed
+check-in and nothing more; nothing is recovered from an overdue node. The verdicts are what *this* node
+believes, read off its own clock — which is another reason the clocks have to agree.
+
+A scheduler that is not clustered answers with the one node it is, `Alive`, and both times `null`:
+there is no check-in history because there is nobody to keep one for. That is the honest answer rather
+than an empty list, so a caller need not branch on whether clustering is on.
+
+To see what each node is doing, join the listing to `QueryFireInstances` on `SchedulerInstanceId`:
+
+<!-- snippet: sample_advanced_cluster_node_firings -->
+```csharp
+List<ClusterNode> nodes = await scheduler.QueryClusterNodes();
+PagedResult<FireInstance> firings = await scheduler.QueryFireInstances(new FireInstanceQuery
+{
+    // both states: what a node is holding is as interesting as what it is running, and a
+    // reservation left behind by a dead node is what recovery is about to clear
+    State = null
+});
+
+foreach (ClusterNode node in nodes)
+{
+    int running = firings.Items.Count(firing =>
+        firing.SchedulerInstanceId == node.InstanceId && firing.State == FireInstanceState.Executing);
+
+    Console.WriteLine($"{node.InstanceId} ({node.State}) is running {running} job(s)");
+}
+```
+<!-- endSnippet -->
+
+The same listing is behind `GET /schedulers/{name}/nodes` in the
+[HTTP API](../packages/http-api.md#cluster-nodes) and the Cluster page of the
+[dashboard](../packages/dashboard.md).

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -42,6 +42,9 @@ internal static class SchedulerEndpoints
         yield return builder.MapPost(patternPrefix + "/{schedulerName}/resume-all", ResumeAll)
             .WithQuartzDefaults(nameof(ResumeAll), "Resume (un-pause) all triggers");
 
+        yield return builder.MapGet(patternPrefix + "/{schedulerName}/nodes", GetClusterNodes)
+            .WithQuartzDefaults(nameof(GetClusterNodes), "Get the scheduler's cluster nodes");
+
         yield return builder.MapGet(patternPrefix + "/{schedulerName}/execution-limits", GetExecutionLimits)
             .WithQuartzDefaults(nameof(GetExecutionLimits), "Get execution group limits");
 
@@ -171,6 +174,31 @@ internal static class SchedulerEndpoints
         CancellationToken cancellationToken = default)
     {
         return EndpointHelper.ExecuteWithOkResponse(schedulerName, schedulerRepository, scheduler => scheduler.ResumeAll(cancellationToken).AsTask());
+    }
+
+    /// <summary>
+    /// The nodes of the cluster, this scheduler's own node first. A scheduler that is not clustered
+    /// answers with the one node it is.
+    /// </summary>
+    [ProducesResponseType(typeof(ClusterNodeDto[]), StatusCodes.Status200OK)]
+    private static Task<IResult> GetClusterNodes(
+        EndpointHelper endpointHelper,
+        ISchedulerRepository schedulerRepository,
+        string schedulerName,
+        CancellationToken cancellationToken = default)
+    {
+        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        {
+            List<ClusterNode> nodes = await scheduler.QueryClusterNodes(cancellationToken).ConfigureAwait(false);
+
+            ClusterNodeDto[] result = new ClusterNodeDto[nodes.Count];
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                result[i] = ClusterNodeDto.Create(nodes[i]);
+            }
+
+            return result;
+        });
     }
 
     [ProducesResponseType(typeof(ExecutionLimitsResponse), StatusCodes.Status200OK)]

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -262,6 +262,11 @@ public class JobRunShellBenchmark
             throw new NotImplementedException();
         }
 
+        public ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public ValueTask<PagedResult<JobGroup>> QueryJobGroups(JobGroupQuery query, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
@@ -79,6 +79,20 @@
         </li>
 
         <li class="qz-nav-item">
+            <a class="qz-nav-link @NavClass("cluster")" href="@Link("cluster")">
+                <svg class="qz-nav-icon" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="9" cy="3" r="2" />
+                    <circle cx="3" cy="14" r="2" />
+                    <circle cx="15" cy="14" r="2" />
+                    <line x1="9" y1="5" x2="4" y2="12" />
+                    <line x1="9" y1="5" x2="14" y2="12" />
+                    <line x1="5" y1="14" x2="13" y2="14" />
+                </svg>
+                <span class="qz-nav-link-text">Cluster</span>
+            </a>
+        </li>
+
+        <li class="qz-nav-item">
             <a class="qz-nav-link @NavClass("history")" href="@Link("history")">
                 <svg class="qz-nav-icon" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <polyline points="1,9 4,6 7,9" />

--- a/src/Quartz.Dashboard/Components/Pages/Cluster.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Cluster.razor
@@ -1,0 +1,262 @@
+@page "/quartz/cluster"
+@using Quartz
+@using Quartz.Dashboard.Components.Shared
+@using Quartz.Dashboard.Services
+@implements IDisposable
+@inject IQuartzApiClient Api
+@inject SchedulerState Scheduler
+
+<div class="qz-page">
+    <div class="qz-page-header">
+        <h1>Cluster</h1>
+        <span class="qz-muted" style="font-size: var(--qz-font-size-xs);">Auto-refreshes every 5s</span>
+        <span class="qz-muted" style="font-size: var(--qz-font-size-xs);">Last updated: @FormatLastUpdated(_lastUpdatedAt)</span>
+    </div>
+
+    @if (_isLoading)
+    {
+        <LoadingSpinner />
+    }
+
+    @if (!string.IsNullOrWhiteSpace(_error))
+    {
+        <ErrorAlert Message="@_error" OnRetry="LoadDataAsync" />
+    }
+
+    @if (IsSingleNodeWithoutClusterState)
+    {
+        <p class="qz-muted">
+            This scheduler is not clustered: its job store keeps no check-in state, so the only node is this one.
+        </p>
+    }
+
+    <table class="qz-table">
+        <thead>
+            <tr>
+                <th>Node</th>
+                <th>State</th>
+                <th>Last check-in</th>
+                <th>Check-in interval</th>
+                <th>Acquired</th>
+                <th>Executing</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if (_nodes.Count == 0)
+            {
+                <tr>
+                    <td colspan="6" class="qz-muted">No nodes to show.</td>
+                </tr>
+            }
+            else
+            {
+                @foreach (ClusterNodeDto node in _nodes)
+                {
+                    <tr>
+                        <td>
+                            @node.InstanceId
+                            @if (node.IsCurrentNode)
+                            {
+                                <span class="qz-muted">&nbsp;(this node)</span>
+                            }
+                        </td>
+                        <td><StateIndicator State="@node.State.ToString()" /></td>
+                        <td>
+                            @if (node.LastCheckInUtc.HasValue)
+                            {
+                                @Scheduler.FormatInSelectedTimeZone(node.LastCheckInUtc, "u")
+                                <span class="qz-muted">&nbsp;(<TimeAgo Timestamp="node.LastCheckInUtc" />)</span>
+                            }
+                            else
+                            {
+                                <span class="qz-muted">&#8212;</span>
+                            }
+                        </td>
+                        <td>@FormatInterval(node.CheckInInterval)</td>
+                        <td>@AcquiredOn(node.InstanceId)</td>
+                        <td>@ExecutingOn(node.InstanceId)</td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+
+    @if (_firingCountsArePartial)
+    {
+        <p class="qz-muted">
+            The per-node counts are taken from the first @_firingsCounted firings; there are more in flight.
+        </p>
+    }
+</div>
+
+@code {
+    private readonly List<ClusterNodeDto> _nodes = [];
+    private readonly Dictionary<string, NodeFirings> _firingsByNode = new(StringComparer.Ordinal);
+    private bool _isLoading = true;
+    private bool _loadingInProgress;
+    private bool _firingCountsArePartial;
+    private int _firingsCounted;
+    private string? _error;
+    private PeriodicTimer? _refreshTimer;
+    private CancellationTokenSource? _refreshLoopCancellation;
+    private DateTimeOffset? _lastUpdatedAt;
+
+    /// <summary>
+    /// A store that keeps no check-in history reports exactly one node — itself — with no times, which
+    /// is what a non-clustered scheduler looks like from here. There is no separate "clustered" flag to
+    /// read: the node list is the answer, and this is the shape it takes.
+    /// </summary>
+    private bool IsSingleNodeWithoutClusterState =>
+        _nodes.Count == 1 && _nodes[0].IsCurrentNode && _nodes[0].LastCheckInUtc is null;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Scheduler.OnSchedulerChanged += OnSchedulerChanged;
+        _refreshLoopCancellation = new CancellationTokenSource();
+        // Every tick is a database read on a persistent store, so this is deliberately slower than the
+        // one-second cadence of the executing-jobs page: a cluster's membership changes on the scale of
+        // its check-in interval, not of a job's duration.
+        _refreshTimer = new PeriodicTimer(TimeSpan.FromSeconds(5));
+        _ = RunRefreshLoopAsync(_refreshLoopCancellation.Token);
+        await LoadDataAsync();
+    }
+
+    private async void OnSchedulerChanged(object? sender, EventArgs e)
+    {
+        await LoadDataAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task RunRefreshLoopAsync(CancellationToken cancellationToken)
+    {
+        if (_refreshTimer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            while (await _refreshTimer.WaitForNextTickAsync(cancellationToken))
+            {
+                try
+                {
+                    await InvokeAsync(async () =>
+                    {
+                        await LoadDataAsync();
+                        StateHasChanged();
+                    });
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    _error = ex.Message;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private async Task LoadDataAsync()
+    {
+        if (_loadingInProgress)
+        {
+            return;
+        }
+
+        _loadingInProgress = true;
+        _error = null;
+
+        try
+        {
+            string? schedulerName = Scheduler.ActiveSchedulerName;
+            _nodes.Clear();
+            _firingsByNode.Clear();
+            _firingCountsArePartial = false;
+            _firingsCounted = 0;
+
+            if (!string.IsNullOrWhiteSpace(schedulerName))
+            {
+                _nodes.AddRange(await Api.GetClusterNodes(schedulerName));
+
+                // Both states, because the two columns are what a node is holding and what it is
+                // running: a reservation left behind by a node that died is exactly the thing an
+                // operator comes to this page to see.
+                PagedResult<FireInstanceDto> firings = await Api.GetFireInstances(
+                    schedulerName,
+                    new DashboardFireInstanceQuery { State = null });
+
+                foreach (FireInstanceDto firing in firings.Items)
+                {
+                    NodeFirings counts = _firingsByNode.TryGetValue(firing.SchedulerInstanceId, out NodeFirings existing)
+                        ? existing
+                        : default;
+
+                    _firingsByNode[firing.SchedulerInstanceId] = firing.State == FireInstanceState.Acquired
+                        ? counts with { Acquired = counts.Acquired + 1 }
+                        : counts with { Executing = counts.Executing + 1 };
+                }
+
+                _firingsCounted = firings.Items.Count;
+                _firingCountsArePartial = firings.HasMore;
+            }
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _lastUpdatedAt = DateTimeOffset.UtcNow;
+            _isLoading = false;
+            _loadingInProgress = false;
+        }
+    }
+
+    private int AcquiredOn(string instanceId)
+    {
+        return _firingsByNode.TryGetValue(instanceId, out NodeFirings counts) ? counts.Acquired : 0;
+    }
+
+    private int ExecutingOn(string instanceId)
+    {
+        return _firingsByNode.TryGetValue(instanceId, out NodeFirings counts) ? counts.Executing : 0;
+    }
+
+    private static string FormatInterval(TimeSpan? interval)
+    {
+        return interval.HasValue ? interval.Value.ToString(@"hh\:mm\:ss") : "—";
+    }
+
+    private string FormatLastUpdated(DateTimeOffset? lastUpdatedAt)
+    {
+        return Scheduler.FormatInSelectedTimeZone(lastUpdatedAt, "HH:mm:ss");
+    }
+
+    public void Dispose()
+    {
+        Scheduler.OnSchedulerChanged -= OnSchedulerChanged;
+        _refreshLoopCancellation?.Cancel();
+        _refreshLoopCancellation?.Dispose();
+        _refreshTimer?.Dispose();
+    }
+
+    /// <summary>
+    /// What one node is holding and what it is running, as the firing listing reports it.
+    /// </summary>
+    private readonly record struct NodeFirings(int Acquired, int Executing);
+}

--- a/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
@@ -44,6 +44,9 @@
             <StatCard Title="Total Triggers" Value="@_totalTriggers.ToString()" Icon="⏱️" Color="info" />
             <StatCard Title="Currently Executing" Value="@_currentlyExecuting.ToString()" Icon="▶" Color="success" />
             <StatCard Title="Error Triggers" Value="@_errorTriggers.ToString()" Icon="⚠" Color="error" />
+            <a class="qz-stat-card-link" href="@DashboardLink.To(Options.Value, "cluster")">
+                <StatCard Title="Nodes" Value="@NodesStatValue" Icon="🖧" Color="@NodesStatColor" />
+            </a>
         </div>
 
         <section class="qz-section">
@@ -96,11 +99,23 @@
     private int _totalTriggers;
     private int _currentlyExecuting;
     private int _errorTriggers;
+    private int _nodes;
+    private int _unhealthyNodes;
     private readonly List<DashboardActionLogEntry> _recentActions = [];
     private bool _showShutdownConfirm;
     private PeriodicTimer? _executingRefreshTimer;
     private CancellationTokenSource? _executingRefreshCancellation;
     private bool IsReadOnly => Options.Value.ReadOnly;
+
+    /// <summary>
+    /// The node count, with the number that are not <see cref="ClusterNodeState.Alive" /> beside it
+    /// when there are any — a cluster of four is only news when one of them has stopped checking in.
+    /// </summary>
+    private string NodesStatValue => _unhealthyNodes == 0
+        ? _nodes.ToString()
+        : $"{_nodes} ({_unhealthyNodes} overdue/failed)";
+
+    private string NodesStatColor => _unhealthyNodes == 0 ? "info" : "error";
 
     protected override async Task OnInitializedAsync()
     {
@@ -132,6 +147,8 @@
                 _totalJobs = 0;
                 _totalTriggers = 0;
                 _currentlyExecuting = 0;
+                _nodes = 0;
+                _unhealthyNodes = 0;
                 _recentActions.Clear();
                 return;
             }
@@ -145,10 +162,14 @@
             PagedResult<TriggerHeaderDto> errorTriggers = await Api.GetTriggers(schedulerName, new DashboardTriggerQuery { Take = 0, State = TriggerState.Error });
             PagedResult<FireInstanceDto> executing = await Api.GetFireInstances(schedulerName, new DashboardFireInstanceQuery { Take = 0 });
 
+            List<ClusterNodeDto> nodes = await Api.GetClusterNodes(schedulerName);
+
             _totalJobs = jobs.TotalCount ?? 0;
             _totalTriggers = triggers.TotalCount ?? 0;
             _currentlyExecuting = executing.TotalCount ?? 0;
             _errorTriggers = errorTriggers.TotalCount ?? 0;
+            _nodes = nodes.Count;
+            _unhealthyNodes = nodes.Count(node => node.State != ClusterNodeState.Alive);
 
             RefreshRecentActions(schedulerName);
         }

--- a/src/Quartz.Dashboard/Components/Shared/StateIndicator.razor
+++ b/src/Quartz.Dashboard/Components/Shared/StateIndicator.razor
@@ -25,7 +25,10 @@
                 return "error";
             }
 
-            if (normalized.Contains("pause") || normalized.Contains("standby") || normalized.Contains("blocked"))
+            // "overdue" is a cluster node that has missed a check-in: not a fault yet, but not healthy
+            // either, which is the same amber the paused states wear.
+            if (normalized.Contains("pause") || normalized.Contains("standby") || normalized.Contains("blocked")
+                || normalized.Contains("overdue"))
             {
                 return "paused";
             }
@@ -36,7 +39,10 @@
                 return "executing";
             }
 
-            if (normalized.Contains("normal") || normalized.Contains("running") || normalized.Contains("complete"))
+            // "alive" is a cluster node that is checking in, which is the healthy green the running
+            // states wear.
+            if (normalized.Contains("normal") || normalized.Contains("running") || normalized.Contains("complete")
+                || normalized.Contains("alive"))
             {
                 return "success";
             }

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -79,6 +79,16 @@ public interface IQuartzApiClient
     ValueTask<PagedResult<FireInstanceDto>> GetFireInstances(string schedulerName, DashboardFireInstanceQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the scheduler's cluster nodes, the node that answered first. A scheduler that is not
+    /// clustered answers with the one node it is, with no check-in times.
+    /// </summary>
+    /// <remarks>
+    /// Joins to <see cref="GetFireInstances" /> on <see cref="FireInstanceDto.SchedulerInstanceId" />,
+    /// which is how the Cluster page counts what each node is running.
+    /// </remarks>
+    ValueTask<List<ClusterNodeDto>> GetClusterNodes(string schedulerName, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Pauses the job. Returns <see langword="true" /> when the job existed and was paused,
     /// <see langword="false" /> when there was nothing to pause.
     /// </summary>
@@ -277,6 +287,21 @@ public sealed record FireInstanceDto(
     DateTimeOffset FireTimeUtc,
     DateTimeOffset? ScheduledFireTimeUtc,
     string? ExecutionGroup);
+
+/// <summary>
+/// One scheduler node, as the dashboard shows it.
+/// </summary>
+/// <remarks>
+/// <see cref="LastCheckInUtc" /> and <see cref="CheckInInterval" /> are null when the store keeps no
+/// check-in history, which is what a non-clustered scheduler looks like: one node, no times, and
+/// nothing to be late for.
+/// </remarks>
+public sealed record ClusterNodeDto(
+    string InstanceId,
+    DateTimeOffset? LastCheckInUtc,
+    TimeSpan? CheckInInterval,
+    ClusterNodeState State,
+    bool IsCurrentNode);
 
 /// <summary>
 /// A trigger to schedule, and the job it fires when that job is not already stored.

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -245,6 +245,25 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return new PagedResult<FireInstanceDto>(items, page.HasMore, page.TotalCount ?? items.Count);
     }
 
+    public async ValueTask<List<ClusterNodeDto>> GetClusterNodes(string schedulerName, CancellationToken cancellationToken = default)
+    {
+        IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
+        List<ClusterNode> nodes = await scheduler.QueryClusterNodes(cancellationToken).ConfigureAwait(false);
+
+        List<ClusterNodeDto> items = new(nodes.Count);
+        foreach (ClusterNode node in nodes)
+        {
+            items.Add(new ClusterNodeDto(
+                InstanceId: node.InstanceId,
+                LastCheckInUtc: node.LastCheckInUtc,
+                CheckInInterval: node.CheckInInterval,
+                State: node.State,
+                IsCurrentNode: node.IsCurrentNode));
+        }
+
+        return items;
+    }
+
     public ValueTask<bool> PauseJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
     {
         EnsureWritable();

--- a/src/Quartz.Dashboard/wwwroot/css/quartz-dashboard.css
+++ b/src/Quartz.Dashboard/wwwroot/css/quartz-dashboard.css
@@ -599,6 +599,14 @@
     color: var(--qz-color-info);
 }
 
+/* A stat card that is also a link to the page it summarises: the anchor carries no styling of its
+   own, so the card inside it looks the same as one that is not a link. */
+.qz-stat-card-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
+
 .qz-stat-card-info {
     --qz-stat-accent: var(--qz-color-info);
     --qz-stat-accent-bg: var(--qz-color-info-bg);

--- a/src/Quartz.Documentation.Samples/Tutorial/AdvancedEnterpriseFeaturesSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/AdvancedEnterpriseFeaturesSamples.cs
@@ -49,6 +49,50 @@ public static class AdvancedEnterpriseFeaturesSamples
         #endregion
     }
 
+    public static async Task SeeingTheCluster(IScheduler scheduler)
+    {
+        #region sample_advanced_cluster_nodes
+
+        List<ClusterNode> nodes = await scheduler.QueryClusterNodes();
+
+        foreach (ClusterNode node in nodes)
+        {
+            string marker = node.IsCurrentNode ? " (this node)" : "";
+            Console.WriteLine($"{node.InstanceId}{marker}: {node.State}, last check-in {node.LastCheckInUtc:u}");
+        }
+
+        // The verdicts come from the same predicate the failover sweep applies, so a node reported
+        // Failed is one whose in-flight work the cluster is about to take over.
+        List<ClusterNode> failed = nodes.FindAll(node => node.State == ClusterNodeState.Failed);
+
+        #endregion
+
+        _ = failed;
+    }
+
+    public static async Task WhatEachNodeIsRunning(IScheduler scheduler)
+    {
+        #region sample_advanced_cluster_node_firings
+
+        List<ClusterNode> nodes = await scheduler.QueryClusterNodes();
+        PagedResult<FireInstance> firings = await scheduler.QueryFireInstances(new FireInstanceQuery
+        {
+            // both states: what a node is holding is as interesting as what it is running, and a
+            // reservation left behind by a dead node is what recovery is about to clear
+            State = null
+        });
+
+        foreach (ClusterNode node in nodes)
+        {
+            int running = firings.Items.Count(firing =>
+                firing.SchedulerInstanceId == node.InstanceId && firing.State == FireInstanceState.Executing);
+
+            Console.WriteLine($"{node.InstanceId} ({node.State}) is running {running} job(s)");
+        }
+
+        #endregion
+    }
+
     public static void BatchAcquisition(IServiceCollection services)
     {
         services.AddQuartz(q =>

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -168,6 +168,23 @@ public sealed class HttpScheduler : IScheduler
         return new PagedResult<FireInstance>(result.Items.Select(x => x.AsFireInstance()).ToList(), result.HasMore, result.TotalCount);
     }
 
+    public async ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+    {
+        ClusterNodeDto[] result = await httpClient
+            .Get<ClusterNodeDto[]>($"{SchedulerEndpointUrl()}/nodes", jsonSerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        // The server has already put the current node first, so the order travels rather than being
+        // recomputed here: "current" means current on the node that answered, not on the one reading.
+        List<ClusterNode> nodes = new(result.Length);
+        foreach (ClusterNodeDto node in result)
+        {
+            nodes.Add(node.AsClusterNode());
+        }
+
+        return nodes;
+    }
+
     public ValueTask Start(CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/start", jsonSerializerOptions, cancellationToken);

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/ClusterPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/ClusterPageTest.cs
@@ -1,0 +1,232 @@
+using AngleSharp.Dom;
+
+using Bunit;
+
+using FakeItEasy;
+
+using Quartz.Dashboard.Components.Pages;
+using Quartz.Dashboard.Services;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard.Components;
+
+/// <summary>
+/// The Cluster page: which nodes it lists, what it says about each one's health, and what it counts
+/// against them.
+/// </summary>
+/// <remarks>
+/// This is the page an operator opens when a job has stopped running, so the two things it must get
+/// right are the verdict — a failed node has to look different from a healthy one at a glance — and the
+/// join to the firings, which is the only place the dashboard says which node is holding what.
+/// </remarks>
+public class ClusterPageTest
+{
+    private DashboardComponentContext context = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        context = new DashboardComponentContext();
+        context.WithScheduler();
+        GivenNodes(CurrentNode());
+        GivenFirings();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    [Test]
+    public void EachNodesStateIsShownWithTheColourItsSeverityEarns()
+    {
+        GivenNodes(
+            CurrentNode(ClusterNodeState.Alive),
+            Node("node-b", ClusterNodeState.Overdue),
+            Node("node-c", ClusterNodeState.Failed));
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        StateModifiers(page).Should().Equal(["qz-state-success", "qz-state-paused", "qz-state-error"],
+            "a node that stopped checking in has to look different from a healthy one without reading "
+            + "the label, which is the whole reason someone opens this page");
+        page.TextOfAll("tbody td").Should().Contain(["Alive", "Overdue", "Failed"]);
+    }
+
+    [Test]
+    public void TheNodeAnsweringIsMarkedAsThisOne()
+    {
+        GivenNodes(CurrentNode(), Node("node-b", ClusterNodeState.Alive));
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        IElement current = page.FindAll("tbody tr")[0];
+        current.TextContent.Should().Contain(TestData.SchedulerInstanceId).And.Contain("(this node)",
+            "the listing is answered by one node about the whole cluster, so which one it is decides "
+            + "what an action taken here will reach");
+        page.FindAll("tbody tr")[1].TextContent.Should().NotContain("(this node)");
+    }
+
+    [Test]
+    public void TheCountsPerNodeComeFromTheFiringsThatNodeOwns()
+    {
+        GivenNodes(CurrentNode(), Node("node-b", ClusterNodeState.Failed));
+        GivenFirings(
+            Firing("node-b", FireInstanceState.Acquired),
+            Firing("node-b", FireInstanceState.Acquired),
+            Firing("node-b", FireInstanceState.Executing),
+            Firing(TestData.SchedulerInstanceId, FireInstanceState.Executing));
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        RowCells(page, rowIndex: 0).Should().EndWith(["0", "1"],
+            "this node holds nothing and is running one firing");
+        RowCells(page, rowIndex: 1).Should().EndWith(["2", "1"],
+            "the dead node's two reservations are exactly the residue recovery is about to clear, so "
+            + "they belong beside its verdict rather than being folded into the running count");
+    }
+
+    [Test]
+    public void ANodeWithNoFiringsCountsZeroRatherThanBlank()
+    {
+        GivenNodes(CurrentNode());
+        GivenFirings(Firing("some-other-node", FireInstanceState.Executing));
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        RowCells(page, rowIndex: 0).Should().EndWith(["0", "0"],
+            "a firing owned by a node that is no longer listed must not be counted against the one that is");
+    }
+
+    [Test]
+    public void ASchedulerWithNoClusterStateSaysSoRatherThanShowingAnEmptyTable()
+    {
+        GivenNodes(new ClusterNodeDto(
+            TestData.SchedulerInstanceId,
+            LastCheckInUtc: null,
+            CheckInInterval: null,
+            ClusterNodeState.Alive,
+            IsCurrentNode: true));
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        page.Markup.Should().Contain("This scheduler is not clustered",
+            "one node with no check-in history is what a non-clustered store looks like from here, and a "
+            + "single-row table with two dashes in it explains nothing");
+        RowCells(page, rowIndex: 0).Should().Contain("—",
+            "an absent check-in time is shown as absent rather than as the epoch");
+    }
+
+    [Test]
+    public void AClusterOfSeveralNodesIsNotDescribedAsUnclustered()
+    {
+        GivenNodes(CurrentNode(), Node("node-b", ClusterNodeState.Alive));
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        page.Markup.Should().NotContain("This scheduler is not clustered");
+    }
+
+    [Test]
+    public void TheCheckInTimeIsShownInTheSelectedZoneWithHowLongAgoItWas()
+    {
+        GivenNodes(CurrentNode());
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        string cell = RowCells(page, rowIndex: 0)[2];
+        cell.Should().Contain("2024-05-06 07:08:09",
+            "the absolute time is what an operator correlates with a log, rendered in the zone they picked");
+        cell.Should().Contain("ago",
+            "and the relative one is what says whether the node is checking in now");
+    }
+
+    [Test]
+    public void AFailedReadIsReportedRatherThanLeavingAnEmptyTable()
+    {
+        A.CallTo(() => context.Api.GetClusterNodes(A<string>._, A<CancellationToken>._))
+            .Throws(new InvalidOperationException("state table unavailable"));
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        page.Markup.Should().Contain("state table unavailable");
+    }
+
+    /// <summary>
+    /// The severity modifier each row's state badge carries, in row order. <c>StateIndicator</c> puts it
+    /// on the indicator and the stylesheet colours the dot through it.
+    /// </summary>
+    private static List<string> StateModifiers(IRenderedComponent<Cluster> page)
+    {
+        List<string> modifiers = [];
+        foreach (IElement indicator in page.FindAll("tbody .qz-state-indicator"))
+        {
+            foreach (string token in indicator.ClassList)
+            {
+                if (token is not "qz-state-indicator")
+                {
+                    modifiers.Add(token);
+                }
+            }
+        }
+
+        return modifiers;
+    }
+
+    private static List<string> RowCells(IRenderedComponent<Cluster> page, int rowIndex)
+    {
+        List<string> cells = [];
+        foreach (IElement cell in page.FindAll("tbody tr")[rowIndex].QuerySelectorAll("td"))
+        {
+            cells.Add(cell.TextContent.Trim());
+        }
+
+        return cells;
+    }
+
+    private static ClusterNodeDto CurrentNode(ClusterNodeState state = ClusterNodeState.Alive)
+    {
+        return new ClusterNodeDto(
+            TestData.SchedulerInstanceId,
+            TestData.Dashboard.FiredAt,
+            TimeSpan.FromSeconds(15),
+            state,
+            IsCurrentNode: true);
+    }
+
+    private static ClusterNodeDto Node(string instanceId, ClusterNodeState state)
+    {
+        return new ClusterNodeDto(
+            instanceId,
+            TestData.Dashboard.FiredAt,
+            TimeSpan.FromSeconds(15),
+            state,
+            IsCurrentNode: false);
+    }
+
+    private static FireInstanceDto Firing(string instanceId, FireInstanceState state)
+    {
+        return new FireInstanceDto(
+            "fire-" + instanceId + "-" + state,
+            new TriggerKeyDto("nightly", "trigger-1"),
+            state == FireInstanceState.Acquired ? null : new JobKeyDto("reports", "job-1"),
+            instanceId,
+            state,
+            TestData.Dashboard.FiredAt,
+            TestData.Dashboard.FiredAt,
+            ExecutionGroup: null);
+    }
+
+    private void GivenNodes(params ClusterNodeDto[] nodes)
+    {
+        A.CallTo(() => context.Api.GetClusterNodes(A<string>._, A<CancellationToken>._))
+            .Returns(nodes.ToList());
+    }
+
+    private void GivenFirings(params FireInstanceDto[] firings)
+    {
+        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+            .Returns(TestData.Dashboard.Page<FireInstanceDto>(firings));
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
@@ -22,6 +22,7 @@ public class DashboardPageTest
         context = new DashboardComponentContext();
         context.WithScheduler();
         GivenCounts(jobs: 0, triggers: 0, errorTriggers: 0, executing: 0);
+        GivenNodes(Node(TestData.SchedulerInstanceId, ClusterNodeState.Alive));
     }
 
     [TearDown]
@@ -62,6 +63,41 @@ public class DashboardPageTest
                 A<DashboardJobQuery>.That.Matches(query => query.Take == 0),
                 A<CancellationToken>._))
             .MustHaveHappened();
+    }
+
+    /// <summary>
+    /// The Nodes tile counts what the cluster has, and says how much of it is not answering.
+    /// </summary>
+    /// <remarks>
+    /// A bare count is no news — a four-node cluster has four nodes on its best day and on its worst.
+    /// What an operator glances for is the second number, so it is in the tile's value rather than a
+    /// click away, and the tile turns red to earn the glance.
+    /// </remarks>
+    [Test]
+    public void TheNodesTileNamesTheNodesThatAreNotAnswering()
+    {
+        GivenNodes(
+            Node("node-a", ClusterNodeState.Alive),
+            Node("node-b", ClusterNodeState.Overdue),
+            Node("node-c", ClusterNodeState.Failed));
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.StatCardValue("Nodes").Should().Be("3 (2 overdue/failed)");
+        page.Find(".qz-stat-card-link .qz-stat-card").ClassList.Should().Contain("qz-stat-card-error",
+            "a cluster with a node that stopped checking in is not an informational fact");
+    }
+
+    [Test]
+    public void TheNodesTileIsACountAloneWhenEveryNodeIsAlive()
+    {
+        GivenNodes(Node("node-a", ClusterNodeState.Alive), Node("node-b", ClusterNodeState.Alive));
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.StatCardValue("Nodes").Should().Be("2", "a healthy cluster has nothing to qualify");
+        page.Find(".qz-stat-card-link").GetAttribute("href").Should().Be("quartz/cluster",
+            "the tile is the way to the page that explains it");
     }
 
     [Test]
@@ -143,5 +179,21 @@ public class DashboardPageTest
                     TotalCount: query.State == TriggerState.Error ? errorTriggers : triggers));
         A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<FireInstanceDto>([], HasMore: false, TotalCount: executing));
+    }
+
+    private void GivenNodes(params ClusterNodeDto[] nodes)
+    {
+        A.CallTo(() => context.Api.GetClusterNodes(A<string>._, A<CancellationToken>._))
+            .Returns(nodes.ToList());
+    }
+
+    private static ClusterNodeDto Node(string instanceId, ClusterNodeState state)
+    {
+        return new ClusterNodeDto(
+            instanceId,
+            TestData.Dashboard.FiredAt,
+            TimeSpan.FromSeconds(15),
+            state,
+            IsCurrentNode: instanceId == TestData.SchedulerInstanceId);
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
@@ -176,7 +176,7 @@ public class RemainingPagesTest
         IRenderedComponent<NavMenu> menu = context.Render<NavMenu>();
 
         menu.FindAll("a").Select(link => link.GetAttribute("href")).Should()
-            .Equal(["quartz", "quartz/jobs", "quartz/triggers", "quartz/calendars", "quartz/executing", "quartz/history", "quartz/live", "quartz/actions"],
+            .Equal(["quartz", "quartz/jobs", "quartz/triggers", "quartz/calendars", "quartz/executing", "quartz/cluster", "quartz/history", "quartz/live", "quartz/actions"],
                 "the links are base-relative, so they survive an application path base as well as a "
                 + "custom dashboard path");
     }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
@@ -17,6 +17,7 @@ public class DashboardRouteTableTest
     [TestCase("triggers", typeof(Pages.Triggers))]
     [TestCase("calendars", typeof(Pages.Calendars))]
     [TestCase("executing", typeof(Pages.CurrentlyExecuting))]
+    [TestCase("cluster", typeof(Pages.Cluster))]
     [TestCase("history", typeof(Pages.History))]
     [TestCase("history?page=2&job=x", typeof(Pages.History))]
     [TestCase("live", typeof(Pages.LiveLogs))]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -562,6 +562,36 @@ public class InProcessQuartzApiClientTest
         }
     }
 
+    /// <summary>
+    /// The node listing reaches the scheduler rather than being answered by the dashboard.
+    /// </summary>
+    /// <remarks>
+    /// In-process the scheduler here is backed by the in-memory store, so the honest answer is one node
+    /// with no check-in history — which is also the answer the Cluster page reads as "not clustered".
+    /// </remarks>
+    [Test]
+    public async Task ClusterNodesComeFromTheScheduler()
+    {
+        IScheduler scheduler = await CreateScheduler("ClusterNodesTest");
+        try
+        {
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            List<ClusterNodeDto> nodes = await client.GetClusterNodes(scheduler.SchedulerName);
+
+            ClusterNodeDto node = nodes.Should().ContainSingle().Subject;
+            node.InstanceId.Should().Be(scheduler.SchedulerInstanceId);
+            node.IsCurrentNode.Should().BeTrue();
+            node.State.Should().Be(ClusterNodeState.Alive);
+            node.LastCheckInUtc.Should().BeNull();
+            node.CheckInInterval.Should().BeNull();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
     private static async Task<IScheduler> CreateScheduler(string testName)
     {
         NameValueCollection properties = new()

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
@@ -73,6 +73,35 @@ public class SchedulerEndpointsTest : WebApiTest
         });
     }
 
+    /// <summary>
+    /// The node listing round-trips whole: the verdict, both times, and the order the server chose.
+    /// </summary>
+    /// <remarks>
+    /// The order is contract rather than presentation — "current node first" is decided by the node that
+    /// answered, and a client that re-sorted would be asserting something about its own identity, which
+    /// it does not have. The node with no check-in history is here because null is not zero: a reader
+    /// that saw <c>0001-01-01</c> would draw a node that has been dead since the epoch.
+    /// </remarks>
+    [Test]
+    public async Task ClusterNodesRoundTripKeepEveryVerdictAndTheServersOrder()
+    {
+        A.CallTo(() => FakeScheduler.QueryClusterNodes(A<CancellationToken>._))
+            .Returns(new List<ClusterNode>
+            {
+                TestData.CurrentClusterNode,
+                TestData.FailedClusterNode,
+                TestData.ClusterNodeWithoutCheckIn
+            });
+
+        List<ClusterNode> nodes = await HttpScheduler.QueryClusterNodes();
+
+        nodes.Should().Equal([
+            TestData.CurrentClusterNode,
+            TestData.FailedClusterNode,
+            TestData.ClusterNodeWithoutCheckIn
+        ]);
+    }
+
     [Test]
     public async Task GetSchedulerDetailsShouldWork()
     {

--- a/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
@@ -106,6 +106,25 @@ public class WireFormatSnapshotTest : WebApiTest
     }
 
     [Test]
+    public async Task ClusterNodesBody()
+    {
+        // Three shapes in one body: the node answering, a peer the cluster has given up on, and one
+        // whose store keeps no check-in history at all. The state goes out as its name, the interval as
+        // a TimeSpan like every other duration the API carries, and the absent times as nulls rather
+        // than as zeros or as missing properties.
+        A.CallTo(() => FakeScheduler.QueryClusterNodes(A<CancellationToken>._))
+            .Returns(new List<ClusterNode>
+            {
+                TestData.CurrentClusterNode,
+                TestData.FailedClusterNode,
+                TestData.ClusterNodeWithoutCheckIn
+            });
+
+        string body = await Get($"{SchedulerUrl}/nodes");
+        await VerifyBody(body);
+    }
+
+    [Test]
     public async Task TriggerStateBody()
     {
         TriggerKey triggerKey = TestData.Wire.CronTrigger.Key;

--- a/src/Quartz.Tests.AspNetCore/Support/TestData.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestData.cs
@@ -53,6 +53,22 @@ public static class TestData
     /// </summary>
     public static readonly FireInstance AcquiredFireInstance;
 
+    /// <summary>
+    /// The node answering the query: checking in on schedule, and marked as the current one.
+    /// </summary>
+    public static readonly ClusterNode CurrentClusterNode;
+
+    /// <summary>
+    /// A peer that stopped checking in: the same members, a different verdict.
+    /// </summary>
+    public static readonly ClusterNode FailedClusterNode;
+
+    /// <summary>
+    /// A node whose store keeps no check-in history: both times absent, which is the shape a round trip
+    /// is most likely to mangle into zeros.
+    /// </summary>
+    public static readonly ClusterNode ClusterNodeWithoutCheckIn;
+
     static TestData()
     {
         Metadata = new SchedulerMetadata
@@ -246,6 +262,27 @@ public static class TestData
             FireTimeUtc: new DateTimeOffset(2024, 5, 6, 7, 8, 10, TimeSpan.Zero),
             ScheduledFireTimeUtc: null,
             ExecutionGroup: null);
+
+        CurrentClusterNode = new ClusterNode(
+            InstanceId: SchedulerInstanceId,
+            LastCheckInUtc: new DateTimeOffset(2024, 5, 6, 7, 8, 5, TimeSpan.Zero),
+            CheckInInterval: TimeSpan.FromSeconds(15),
+            State: ClusterNodeState.Alive,
+            IsCurrentNode: true);
+
+        FailedClusterNode = new ClusterNode(
+            InstanceId: "node-b",
+            LastCheckInUtc: new DateTimeOffset(2024, 5, 6, 7, 0, 0, TimeSpan.Zero),
+            CheckInInterval: TimeSpan.FromSeconds(15),
+            State: ClusterNodeState.Failed,
+            IsCurrentNode: false);
+
+        ClusterNodeWithoutCheckIn = new ClusterNode(
+            InstanceId: "node-c",
+            LastCheckInUtc: null,
+            CheckInInterval: null,
+            State: ClusterNodeState.Alive,
+            IsCurrentNode: false);
 
         ExecutingJobTwo = new JobExecutionContextImpl(
             scheduler: A.Fake<IScheduler>(),

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -123,6 +123,15 @@ namespace Quartz.Dashboard.Services
         public bool Replace { get; init; }
         public bool? StoreNonDurableWhileAwaitingScheduling { get; init; }
     }
+    public sealed class ClusterNodeDto : System.IEquatable<Quartz.Dashboard.Services.ClusterNodeDto>
+    {
+        public ClusterNodeDto(string InstanceId, System.DateTimeOffset? LastCheckInUtc, System.TimeSpan? CheckInInterval, Quartz.ClusterNodeState State, bool IsCurrentNode) { }
+        public System.TimeSpan? CheckInInterval { get; init; }
+        public string InstanceId { get; init; }
+        public bool IsCurrentNode { get; init; }
+        public System.DateTimeOffset? LastCheckInUtc { get; init; }
+        public Quartz.ClusterNodeState State { get; init; }
+    }
     public readonly struct DashboardExecutionLimit : System.IEquatable<Quartz.Dashboard.Services.DashboardExecutionLimit>
     {
         public DashboardExecutionLimit(int? MaxConcurrent, Quartz.ExecutionLimitScope Scope) { }
@@ -196,6 +205,7 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask DeleteJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar> GetCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> GetCalendarNames(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.ClusterNodeDto>> GetClusterNodes(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.ExecutionLimitsDto?> GetExecutionLimits(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.FireInstanceDto>> GetFireInstances(string schedulerName, Quartz.Dashboard.Services.DashboardFireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardHistoryEntry>?> GetHistory(Quartz.Dashboard.Services.DashboardHistoryQuery query, System.Threading.CancellationToken cancellationToken = default);

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ClusterNodesBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ClusterNodesBody.verified.json
@@ -1,0 +1,23 @@
+﻿[
+  {
+    "instanceId": "TEST_NON_CLUSTERED",
+    "lastCheckInUtc": "2024-05-06T07:08:05+00:00",
+    "checkInInterval": "00:00:15",
+    "state": "Alive",
+    "isCurrentNode": true
+  },
+  {
+    "instanceId": "node-b",
+    "lastCheckInUtc": "2024-05-06T07:00:00+00:00",
+    "checkInInterval": "00:00:15",
+    "state": "Failed",
+    "isCurrentNode": false
+  },
+  {
+    "instanceId": "node-c",
+    "lastCheckInUtc": null,
+    "checkInInterval": null,
+    "state": "Alive",
+    "isCurrentNode": false
+  }
+]

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningTestBase.cs
@@ -163,6 +163,68 @@ public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
     }
 
     /// <summary>
+    /// What the node listing says while a corpse is still on the table, and after it is cleared. This is
+    /// the operator's question — "which of my nodes is alive" — asked of the same rows recovery reads,
+    /// so the two can be seen to agree.
+    /// </summary>
+    /// <remarks>
+    /// The survivor is created but not started until the residue is written, because starting it runs
+    /// the first check-in, which is also the pass that sweeps the dead node away. The listing is
+    /// therefore read once before <c>Start()</c> — where the dead node is still there and reported
+    /// <see cref="ClusterNodeState.Failed" /> — and once after recovery, where it is gone.
+    /// </remarks>
+    [Test]
+    public async Task KilledNode_IsListedAsFailedAndThenDisappearsWhenRecovered()
+    {
+        IScheduler survivor = await CreateScheduler("survivor");
+
+        try
+        {
+            await InsertDeadNodeCheckin();
+
+            List<ClusterNode> beforeRecovery = await survivor.QueryClusterNodes();
+
+            beforeRecovery[0].InstanceId.Should().Be("survivor",
+                "the node answering is listed first whether or not it has checked in yet");
+            beforeRecovery[0].IsCurrentNode.Should().BeTrue();
+
+            ClusterNode dead = beforeRecovery.Should().ContainSingle(x => x.InstanceId == DeadNode,
+                    "a node that died leaves its state row behind, and that row is what an operator needs to see")
+                .Subject;
+            dead.State.Should().Be(ClusterNodeState.Failed,
+                "the row was backdated five minutes past a two-second misfire threshold, which is the same "
+                + "arithmetic that decides recovery — the listing must not call it merely overdue");
+            dead.IsCurrentNode.Should().BeFalse();
+            dead.LastCheckInUtc.Should().NotBeNull("the row carries the stamp the dead node last wrote");
+
+            await survivor.Start();
+
+            await WaitForCondition(
+                async () => (await CountDeadNodeRows("QRTZ_SCHEDULER_STATE")) == 0,
+                timeoutMs: 30_000,
+                async () => $"the survivor's check-in to recover the dead node. State:\n{await DumpDatabaseState()}");
+
+            List<ClusterNode> afterRecovery = await survivor.QueryClusterNodes();
+
+            afterRecovery.Should().NotContain(x => x.InstanceId == DeadNode,
+                "recovery deletes the row, so a corpse is reported until it is cleaned up and never after");
+
+            ClusterNode current = afterRecovery.Should().ContainSingle(x => x.IsCurrentNode).Subject;
+            current.InstanceId.Should().Be("survivor");
+            current.State.Should().Be(ClusterNodeState.Alive,
+                "a node whose check-in loop is running reports itself alive");
+            current.LastCheckInUtc.Should().NotBeNull(
+                "once the loop is running, this node has a row of its own like any other");
+            current.CheckInInterval.Should().Be(TimeSpan.FromSeconds(1),
+                "the interval reported is the one this fixture configured the node with");
+        }
+        finally
+        {
+            await survivor.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
     /// The property the clustered job store exists to provide: two nodes, one set of triggers, every
     /// trigger fired exactly once.
     /// </summary>

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -1288,6 +1288,37 @@ public abstract class JobStoreContractTest
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
+    // Cluster nodes
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// <summary>
+    /// Neither store under this fixture is clustered — the in-memory store cannot be and SQLite is
+    /// refused as a clustered store — so both have to answer the same way: with the one node they are.
+    /// </summary>
+    [Test]
+    public async Task AStoreThatKeepsNoClusterStateListsItselfAsTheOnlyNode()
+    {
+        List<ClusterNode> nodes = await Store.QueryClusterNodes();
+
+        using (new AssertionScope())
+        {
+            ClusterNode node = nodes.Should().ContainSingle(
+                "a store with no cluster state has exactly one node to report, and it is the one answering").Subject;
+
+            node.InstanceId.Should().Be(StoreInstanceId,
+                "the node is named by the instance id the store was initialized with, the same value a "
+                + "firing it owns is stamped with");
+            node.IsCurrentNode.Should().BeTrue();
+            node.State.Should().Be(ClusterNodeState.Alive,
+                "the node answering the question is by definition running");
+            node.LastCheckInUtc.Should().BeNull(
+                "a store that keeps no check-in history reports its absence rather than inventing a time");
+            node.CheckInInterval.Should().BeNull(
+                "there is no check-in interval where there are no check-ins");
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
     // Execution limits
     //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -3,6 +3,8 @@ using System.Data.Common;
 using System.Globalization;
 using System.Reflection;
 
+using AwesomeAssertions.Execution;
+
 using FakeItEasy;
 
 using Microsoft.Extensions.Time.Testing;
@@ -1056,6 +1058,16 @@ public class AdoJobStoreBaseTest
         internal DateTimeOffset CallCalcFailedIfAfter(SchedulerStateRecord rec)
         {
             return CalcFailedIfAfter(rec);
+        }
+
+        /// <summary>
+        /// The connection-taking half of the node listing. The public entry point runs through
+        /// <see cref="ExecuteWithoutLock{T}" />, which this store stubs out to return <c>default</c>,
+        /// so a test that wants the rows classified has to hand the connection over itself.
+        /// </summary>
+        internal ValueTask<List<ClusterNode>> CallQueryClusterNodes(ConnectionAndTransactionHolder conn)
+        {
+            return QueryClusterNodes(conn, CancellationToken.None);
         }
 
         internal ValueTask<List<SchedulerStateRecord>> CallClusterCheckIn(ConnectionAndTransactionHolder conn)
@@ -2122,6 +2134,177 @@ public class AdoJobStoreBaseTest
 
         jobStoreSupport.LastCheckin.Should().Be(ClusterNow,
             "a failed scan still stamps the check-in, so the next CalcFailedIfAfter does not treat this node's own silence as elapsed time");
+    }
+
+    #endregion
+
+    #region QueryClusterNodes
+
+    /// <summary>
+    /// The three verdicts, on one stopped clock. This node is healthy, so
+    /// <see cref="AdoJobStoreBase.CalcFailedIfAfter" /> gives each row its own check-in interval plus
+    /// the 7.5s misfire threshold: 17.5s of silence before it is dead, and 10s before it is late.
+    /// </summary>
+    [Test]
+    public async Task QueryClusterNodes_ShouldClassifyEachRowWithTheSamePredicateRecoveryUses()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+        jobStoreSupport.LastCheckin = ClusterNow;
+        jobStoreSupport.SetFirstCheckIn(false);
+
+        GivenSchedulerStates(
+            new SchedulerStateRecord(OwnInstanceId, ClusterNow, CheckinInterval),
+            new SchedulerStateRecord("alive-node", ClusterNow - TimeSpan.FromSeconds(5), CheckinInterval),
+            new SchedulerStateRecord("overdue-node", ClusterNow - TimeSpan.FromSeconds(12), CheckinInterval),
+            new SchedulerStateRecord(DeadInstanceId, ClusterNow - TimeSpan.FromSeconds(60), CheckinInterval));
+
+        List<ClusterNode> nodes = await jobStoreSupport.CallQueryClusterNodes(conn);
+
+        using (new AssertionScope())
+        {
+            StateOf(nodes, "alive-node").Should().Be(ClusterNodeState.Alive,
+                "a node that checked in within its own interval is doing what a running node does");
+            StateOf(nodes, "overdue-node").Should().Be(ClusterNodeState.Overdue,
+                "a missed check-in is late, and only late: nothing of an overdue node's work is taken away");
+            StateOf(nodes, DeadInstanceId).Should().Be(ClusterNodeState.Failed,
+                "past CalcFailedIfAfter the recovery sweep takes this node's work over, so the listing must "
+                + "not report it as merely late");
+
+            // The listing is exactly what the sweep would act on, which is the point of sharing the
+            // predicate rather than writing a second one.
+            List<SchedulerStateRecord> failed = await jobStoreSupport.CallFindFailedInstances(conn);
+            failed.Select(x => x.SchedulerInstanceId).Should().Equal([DeadInstanceId],
+                "the listing and the recovery sweep read the same rows through the same predicate");
+        }
+    }
+
+    [Test]
+    public async Task QueryClusterNodes_ShouldCarryEachRowsCheckInTimeAndInterval()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+        jobStoreSupport.LastCheckin = ClusterNow;
+
+        DateTimeOffset checkedInAt = ClusterNow - TimeSpan.FromSeconds(3);
+        GivenSchedulerStates(new SchedulerStateRecord("other-node", checkedInAt, CheckinInterval));
+
+        List<ClusterNode> nodes = await jobStoreSupport.CallQueryClusterNodes(conn);
+
+        ClusterNode other = nodes.Should().ContainSingle(x => x.InstanceId == "other-node").Subject;
+        other.LastCheckInUtc.Should().Be(checkedInAt, "the row's own stamp is what an operator reads the age off");
+        other.CheckInInterval.Should().Be(CheckinInterval,
+            "the interval reported is the one that node undertook to keep, not the reader's own");
+        other.IsCurrentNode.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task QueryClusterNodes_ShouldListTheCurrentNodeFirstEvenBeforeItHasARow()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+        jobStoreSupport.LastCheckin = ClusterNow;
+
+        // No row for this node: it has not checked in yet, or another node swept it away.
+        GivenSchedulerStates(
+            new SchedulerStateRecord("zzz-node", ClusterNow, CheckinInterval),
+            new SchedulerStateRecord("aaa-node", ClusterNow, CheckinInterval));
+
+        List<ClusterNode> nodes = await jobStoreSupport.CallQueryClusterNodes(conn);
+
+        using (new AssertionScope())
+        {
+            nodes.Select(x => x.InstanceId).Should().Equal([OwnInstanceId, "aaa-node", "zzz-node"],
+                "the node asking is listed first whether or not the table has heard of it, and the rest "
+                + "ordinally, so the same cluster reads the same way on every refresh");
+
+            ClusterNode current = nodes[0];
+            current.IsCurrentNode.Should().BeTrue();
+            current.State.Should().Be(ClusterNodeState.Alive, "a node that is answering queries is running");
+            current.LastCheckInUtc.Should().BeNull("there is no row, so there is no check-in time to report");
+            nodes.Should().ContainSingle(x => x.IsCurrentNode, "exactly one row is the node that answered");
+        }
+    }
+
+    /// <summary>
+    /// This node's own row is judged by the same predicate as anyone else's, which is what stops a
+    /// stalled node reporting itself well.
+    /// </summary>
+    /// <remarks>
+    /// It comes out <see cref="ClusterNodeState.Overdue" /> rather than
+    /// <see cref="ClusterNodeState.Failed" />, and that is <see cref="AdoJobStoreBase.CalcFailedIfAfter" />
+    /// speaking rather than a special case: a node that has been silent for a minute grants every row —
+    /// its own included — that minute of grace, because the silence is evidence about this process
+    /// rather than about the cluster. The same leniency is what stops a stalled node recovering its
+    /// healthy peers out from under them.
+    /// </remarks>
+    [Test]
+    public async Task QueryClusterNodes_ShouldNotExemptTheCurrentNodeFromItsOwnVerdict()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+
+        // This node last checked in a minute ago and has not managed one since.
+        jobStoreSupport.LastCheckin = ClusterNow - TimeSpan.FromSeconds(60);
+        GivenSchedulerStates(new SchedulerStateRecord(OwnInstanceId, ClusterNow - TimeSpan.FromSeconds(60), CheckinInterval));
+
+        List<ClusterNode> nodes = await jobStoreSupport.CallQueryClusterNodes(conn);
+
+        ClusterNode current = nodes.Should().ContainSingle().Subject;
+        current.IsCurrentNode.Should().BeTrue();
+        current.State.Should().Be(ClusterNodeState.Overdue,
+            "a node that has stopped checking in says so about itself rather than reporting Alive because "
+            + "it is the one answering");
+        current.LastCheckInUtc.Should().Be(ClusterNow - TimeSpan.FromSeconds(60),
+            "the row is this node's own, so its stamp is reported rather than replaced with nothing");
+    }
+
+    [Test]
+    public async Task QueryClusterNodes_ShouldWrapDelegateFailures()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+
+        A.CallTo(() => driverDelegate.SelectSchedulerStateRecords(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<string>.Ignored,
+                A<CancellationToken>.Ignored))
+            .Throws(new InvalidOperationException("state table unavailable"));
+
+        Func<Task> act = async () => await jobStoreSupport.CallQueryClusterNodes(conn);
+
+        await act.Should().ThrowAsync<JobPersistenceException>()
+            .WithMessage("*cluster nodes*")
+            .WithInnerException<JobPersistenceException, InvalidOperationException>()
+            .WithMessage("state table unavailable");
+    }
+
+    [Test]
+    public async Task QueryClusterNodes_ShouldNotReadTheStateTableWhenTheStoreIsNotClustered()
+    {
+        // A store that is not clustered never runs the check-in loop, so SCHEDULER_STATE holds nothing
+        // of its own; reading it would answer with another scheduler's rows or with none at all.
+        TestAdoJobStoreBase store = new(clustered: false, timeProvider: new FakeTimeProvider(ClusterNow));
+        store.DirectDelegate = driverDelegate;
+
+        List<ClusterNode> nodes = await store.QueryClusterNodes();
+
+        ClusterNode node = nodes.Should().ContainSingle().Subject;
+        node.IsCurrentNode.Should().BeTrue();
+        node.State.Should().Be(ClusterNodeState.Alive);
+        node.LastCheckInUtc.Should().BeNull();
+        node.CheckInInterval.Should().BeNull();
+
+        A.CallTo(() => driverDelegate.SelectSchedulerStateRecords(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<string>.Ignored,
+                A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+    }
+
+    private static ClusterNodeState StateOf(List<ClusterNode> nodes, string instanceId)
+    {
+        return nodes.Should().ContainSingle(x => x.InstanceId == instanceId).Subject.State;
     }
 
     #endregion

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -117,6 +117,11 @@ public class QuartzHostedServiceTests
             throw new NotImplementedException();
         }
 
+        public ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public ValueTask<IJobDetail> GetJobDetail(JobKey jobKey, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
@@ -49,6 +49,7 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> PauseTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> PauseTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> QueryCalendarNames(Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> QueryJobGroups(Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> QueryJobs(Quartz.JobQuery query, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -81,6 +81,21 @@ namespace Quartz
         public CalendarQuery() { }
         public Quartz.CalendarNameMatcher? Name { get; init; }
     }
+    public sealed class ClusterNode : System.IEquatable<Quartz.ClusterNode>
+    {
+        public ClusterNode(string InstanceId, System.DateTimeOffset? LastCheckInUtc, System.TimeSpan? CheckInInterval, Quartz.ClusterNodeState State, bool IsCurrentNode) { }
+        public System.TimeSpan? CheckInInterval { get; init; }
+        public string InstanceId { get; init; }
+        public bool IsCurrentNode { get; init; }
+        public System.DateTimeOffset? LastCheckInUtc { get; init; }
+        public Quartz.ClusterNodeState State { get; init; }
+    }
+    public enum ClusterNodeState
+    {
+        Alive = 0,
+        Overdue = 1,
+        Failed = 2,
+    }
     public sealed class ClusteringOptions
     {
         public ClusteringOptions() { }
@@ -677,6 +692,7 @@ namespace Quartz
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> PauseTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> PauseTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> QueryCalendarNames(Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> QueryJobGroups(Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> QueryJobs(Quartz.JobQuery query, System.Threading.CancellationToken cancellationToken = default);
@@ -1857,6 +1873,7 @@ namespace Quartz.Extensibility
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> PauseTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> PauseTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> QueryCalendarNames(Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> QueryJobGroups(Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> QueryJobs(Quartz.JobQuery query, System.Threading.CancellationToken cancellationToken = default);
@@ -2196,6 +2213,8 @@ namespace Quartz.Impl.AdoJobStore
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> PauseTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> QueryCalendarNames(Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> QueryCalendarNames(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default) { }
+        protected System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> QueryJobGroups(Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3129,6 +3148,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> PauseTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> PauseTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> QueryCalendarNames(Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> QueryJobGroups(Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> QueryJobs(Quartz.JobQuery query, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3191,6 +3211,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> PauseTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> PauseTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> QueryCalendarNames(Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> QueryJobGroups(Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> QueryJobs(Quartz.JobQuery query, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3314,6 +3335,7 @@ namespace Quartz.Impl
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> PauseTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> PauseTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<string>> QueryCalendarNames(Quartz.CalendarQuery query, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(Quartz.FireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobGroup>> QueryJobGroups(Quartz.JobGroupQuery query, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> QueryJobs(Quartz.JobQuery query, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1624,6 +1624,16 @@ internal sealed class QuartzScheduler
     }
 
     /// <summary>
+    /// Lists the scheduler nodes the job store knows about, this node first.
+    /// </summary>
+    public ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+    {
+        ValidateState();
+
+        return resources.JobStore.QueryClusterNodes(cancellationToken);
+    }
+
+    /// <summary>
     /// Retrieves the given jobs in one round trip.
     /// </summary>
     public ValueTask<List<IJobDetail>> GetJobDetails(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)

--- a/src/Quartz/Extensibility/IJobStore.cs
+++ b/src/Quartz/Extensibility/IJobStore.cs
@@ -412,6 +412,33 @@ public interface IJobStore
     ValueTask<PagedResult<FireInstance>> QueryFireInstances(FireInstanceQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists the scheduler nodes this store knows about, as <see cref="ClusterNode" />s: the current
+    /// node first, then the rest by instance id (ordinal).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The current node is always in the list, whether or not the store has a record of it yet, and it
+    /// is the only one whose <see cref="ClusterNode.IsCurrentNode" /> is <see langword="true" />. A
+    /// store that keeps no check-in history — the in-memory one, and a persistent one that is not
+    /// clustered — answers with that single node, <see cref="ClusterNodeState.Alive" /> and with no
+    /// times, because a lone node has nobody to be late for.
+    /// </para>
+    /// <para>
+    /// A clustered store reports every node it has a check-in record for, including nodes that are
+    /// dead but not yet swept, and decides <see cref="ClusterNode.State" /> with the same predicate its
+    /// recovery pass uses — so a node this listing calls
+    /// <see cref="ClusterNodeState.Failed" /> is a node whose work the cluster is about to take over,
+    /// rather than one that merely looks late to a second opinion.
+    /// </para>
+    /// <para>
+    /// Unpaged, because a cluster is a handful of nodes rather than a data set; the listing that does
+    /// need paging is <see cref="QueryFireInstances" />, which reports what each node is running.
+    /// </para>
+    /// </remarks>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Retrieves the given jobs in one round trip. Keys that do not exist are simply
     /// absent from the result.
     /// </summary>

--- a/src/Quartz/HttpApiContract/HttpApiJson.cs
+++ b/src/Quartz/HttpApiContract/HttpApiJson.cs
@@ -76,6 +76,7 @@ internal static class HttpApiJson
         options.Converters.Add(new JsonStringEnumConverter<SchedulerStatus>());
         options.Converters.Add(new JsonStringEnumConverter<FireInstanceState>());
         options.Converters.Add(new JsonStringEnumConverter<ExecutionLimitScope>());
+        options.Converters.Add(new JsonStringEnumConverter<ClusterNodeState>());
 
         options.UseQuartzContract(HttpApiJsonContext.Default, registry);
 

--- a/src/Quartz/HttpApiContract/HttpApiJsonContext.cs
+++ b/src/Quartz/HttpApiContract/HttpApiJsonContext.cs
@@ -71,6 +71,7 @@ namespace Quartz.HttpApiContract;
 [JsonSerializable(typeof(AffectedGroupsResponse))]
 [JsonSerializable(typeof(AppliedJobKeysResponse))]
 [JsonSerializable(typeof(AppliedTriggerKeysResponse))]
+[JsonSerializable(typeof(ClusterNodeDto[]))]
 [JsonSerializable(typeof(ExecutionLimitsResponse))]
 [JsonSerializable(typeof(ExistsResponse))]
 [JsonSerializable(typeof(GroupPausedResponse))]

--- a/src/Quartz/HttpApiContract/QueryDtos.cs
+++ b/src/Quartz/HttpApiContract/QueryDtos.cs
@@ -180,6 +180,46 @@ internal sealed record FireInstanceDto(
     }
 }
 
+/// <summary>
+/// One scheduler node on the wire.
+/// </summary>
+/// <remarks>
+/// The two times are absent — not zero — when the store keeps no check-in history, so a reader can tell
+/// "this node never checked in" from "this node checked in at the epoch". <see cref="CheckInInterval" />
+/// is a <see cref="TimeSpan" /> like every other duration the API carries.
+/// </remarks>
+internal sealed record ClusterNodeDto(
+    string InstanceId,
+    DateTimeOffset? LastCheckInUtc,
+    TimeSpan? CheckInInterval,
+    ClusterNodeState State,
+    bool IsCurrentNode)
+{
+    public static ClusterNodeDto Create(ClusterNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+
+        return new ClusterNodeDto(
+            InstanceId: node.InstanceId,
+            LastCheckInUtc: node.LastCheckInUtc,
+            CheckInInterval: node.CheckInInterval,
+            State: node.State,
+            IsCurrentNode: node.IsCurrentNode
+        );
+    }
+
+    public ClusterNode AsClusterNode()
+    {
+        return new ClusterNode(
+            InstanceId,
+            LastCheckInUtc,
+            CheckInInterval,
+            State,
+            IsCurrentNode
+        );
+    }
+}
+
 internal sealed record JobGroupDto(string Name, bool Paused)
 {
     public static JobGroupDto Create(JobGroup group)

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -175,6 +175,34 @@ public interface IScheduler : IAsyncDisposable
     ValueTask<PagedResult<FireInstance>> QueryFireInstances(FireInstanceQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists the scheduler nodes the job store knows about, as <see cref="ClusterNode" />s — this node
+    /// first, then the rest by instance id.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This node is always listed, and is the only one whose <see cref="ClusterNode.IsCurrentNode" /> is
+    /// <see langword="true" />; its <see cref="ClusterNode.InstanceId" /> is
+    /// <see cref="SchedulerInstanceId" />. A scheduler that is not clustered — the in-memory store, or a
+    /// persistent one with clustering switched off — answers with that single node and no check-in
+    /// times, which is the truthful answer rather than an empty list.
+    /// </para>
+    /// <para>
+    /// The states are what this node believes, read off its own clock against the check-in stamps the
+    /// other nodes wrote, and they are decided by the same predicate cluster recovery applies. A node
+    /// reported <see cref="ClusterNodeState.Failed" /> has its in-flight work taken over on the next
+    /// check-in pass, after which it stops being listed.
+    /// </para>
+    /// <para>
+    /// The result is an 'instantaneous' snapshot: by the time it is returned a node may have checked in
+    /// or been swept away. Join it with <see cref="QueryFireInstances" /> on
+    /// <see cref="FireInstance.SchedulerInstanceId" /> to see what each node is running.
+    /// </para>
+    /// </remarks>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <seealso cref="ClusterNode" />
+    ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get a reference to the scheduler's <see cref="IListenerManager" />,
     /// through which listeners may be registered.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -2783,6 +2783,94 @@ public abstract class AdoJobStoreBase : IJobStore
     }
 
     /// <inheritdoc />
+    public ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+    {
+        if (!Clustered)
+        {
+            // A store that is not clustered never runs the check-in loop, so SCHEDULER_STATE holds
+            // nothing of this scheduler's — reading it would answer with another cluster's rows or with
+            // none. The one node there is, is this one.
+            return new ValueTask<List<ClusterNode>>(new List<ClusterNode>
+            {
+                new ClusterNode(InstanceId, LastCheckInUtc: null, CheckInInterval: null, ClusterNodeState.Alive, IsCurrentNode: true)
+            });
+        }
+
+        // no locks necessary for read... and the rows of every node are equally visible, which is what
+        // makes this listing cluster-wide
+        return ExecuteWithoutLock(conn => QueryClusterNodes(conn, cancellationToken), cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads SCHEDULER_STATE and classifies every row, current node first.
+    /// </summary>
+    /// <remarks>
+    /// The verdict comes from <see cref="CalcFailedIfAfter" /> — the predicate
+    /// <see cref="FindFailedInstances" /> decides recovery with — rather than from a formula of its own,
+    /// so the listing and the recovery sweep can never disagree about which nodes are dead. The current
+    /// node's own row is judged the same way as any other: a node that has stalled its own check-in
+    /// reports itself honestly rather than flattering itself.
+    /// </remarks>
+    protected async ValueTask<List<ClusterNode>> QueryClusterNodes(
+        ConnectionAndTransactionHolder conn,
+        CancellationToken cancellationToken = default)
+    {
+        List<SchedulerStateRecord> states;
+        try
+        {
+            states = await Delegate.SelectSchedulerStateRecords(conn, instanceId: null, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            Throw.JobPersistenceException("Couldn't query cluster nodes: " + e.Message, e);
+            return default;
+        }
+
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        List<ClusterNode> nodes = new(states.Count);
+        ClusterNode? currentNode = null;
+
+        foreach (SchedulerStateRecord rec in states)
+        {
+            bool isCurrentNode = string.Equals(rec.SchedulerInstanceId, InstanceId, StringComparison.Ordinal);
+            ClusterNode node = new(
+                rec.SchedulerInstanceId,
+                rec.CheckinTimestamp,
+                rec.CheckinInterval,
+                ClassifyClusterNode(rec, now),
+                isCurrentNode);
+
+            if (isCurrentNode)
+            {
+                currentNode = node;
+            }
+            else
+            {
+                nodes.Add(node);
+            }
+        }
+
+        nodes.Sort(static (left, right) => string.CompareOrdinal(left.InstanceId, right.InstanceId));
+
+        // The current node is listed whether or not its row exists yet: it has not written one before its
+        // first check-in, and another node may have swept it away, but it is demonstrably running.
+        currentNode ??= new ClusterNode(InstanceId, LastCheckInUtc: null, CheckInInterval: null, ClusterNodeState.Alive, IsCurrentNode: true);
+        nodes.Insert(0, currentNode);
+
+        return nodes;
+    }
+
+    private ClusterNodeState ClassifyClusterNode(SchedulerStateRecord rec, DateTimeOffset now)
+    {
+        if (CalcFailedIfAfter(rec) < now)
+        {
+            return ClusterNodeState.Failed;
+        }
+
+        return rec.CheckinTimestamp + rec.CheckinInterval < now ? ClusterNodeState.Overdue : ClusterNodeState.Alive;
+    }
+
+    /// <inheritdoc />
     public ValueTask<List<IJobDetail>> GetJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobKeys);

--- a/src/Quartz/Impl/DeferredScheduler.cs
+++ b/src/Quartz/Impl/DeferredScheduler.cs
@@ -119,6 +119,12 @@ internal sealed class DeferredScheduler : IScheduler
         return await target.QueryFireInstances(query, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+    {
+        var target = await Resolve(cancellationToken).ConfigureAwait(false);
+        return await target.QueryClusterNodes(cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask Start(CancellationToken cancellationToken = default)
     {
         var target = await Resolve(cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Impl/DelegatingJobStore.cs
+++ b/src/Quartz/Impl/DelegatingJobStore.cs
@@ -205,6 +205,11 @@ public class DelegatingJobStore : IJobStore
         return jobStore.QueryFireInstances(query, cancellationToken);
     }
 
+    public virtual ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+    {
+        return jobStore.QueryClusterNodes(cancellationToken);
+    }
+
     public virtual ValueTask<List<IJobDetail>> GetJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         return jobStore.GetJobs(jobKeys, cancellationToken);

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -32,6 +32,11 @@ public class DelegatingScheduler : IScheduler
         return scheduler.QueryFireInstances(query, cancellationToken);
     }
 
+    public virtual ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+    {
+        return scheduler.QueryClusterNodes(cancellationToken);
+    }
+
     public virtual IListenerManager ListenerManager => scheduler.ListenerManager;
 
     public virtual ValueTask Start(CancellationToken cancellationToken = default)

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -1562,6 +1562,18 @@ public sealed class RAMJobStore : IJobStore
                && (query.TriggerName is null || query.TriggerName.IsMatch(triggerKey));
     }
 
+    /// <inheritdoc />
+    public ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+    {
+        // This store's world is one process, so the cluster is this node and nothing else. It keeps no
+        // check-in history because it has nobody to keep one for: the times are absent rather than
+        // invented, and the state is Alive because the node answering is by definition running.
+        return new ValueTask<List<ClusterNode>>(new List<ClusterNode>
+        {
+            new ClusterNode(schedulerInstanceId, LastCheckInUtc: null, CheckInInterval: null, ClusterNodeState.Alive, IsCurrentNode: true)
+        });
+    }
+
     /// <summary>
     /// What this store holds in flight per (execution group, trigger group) pair, which is what a
     /// <see cref="ExecutionLimitScope.Cluster" /> execution limit is counted against.

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -107,6 +107,14 @@ internal sealed class StdScheduler : IScheduler
     /// <summary>
     /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
     /// </summary>
+    public ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
+    {
+        return scheduler.QueryClusterNodes(cancellationToken);
+    }
+
+    /// <summary>
+    /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
+    /// </summary>
     public ValueTask Clear(CancellationToken cancellationToken = default)
     {
         return scheduler.Clear(cancellationToken);

--- a/src/Quartz/Queries/ClusterNode.cs
+++ b/src/Quartz/Queries/ClusterNode.cs
@@ -1,0 +1,57 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// One scheduler node as the job store knows it: the listing projection behind
+/// <see cref="IScheduler.QueryClusterNodes" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A node is one running scheduler instance, named by the instance id it was initialized with — the
+/// same value <see cref="IScheduler.SchedulerInstanceId" /> reports on that node and
+/// <see cref="FireInstance.SchedulerInstanceId" /> records against the firings it owns. Joining the two
+/// listings on that id is how an operator sees which node is running what.
+/// </para>
+/// <para>
+/// The store-side sibling is <see cref="Quartz.Impl.AdoJobStore.SchedulerStateRecord" />, which is one
+/// SCHEDULER_STATE row in full, for the ADO.NET store's own check-in and recovery passes. This one is
+/// the store-neutral projection every job store can produce, and it carries the verdict — the
+/// <see cref="State" /> — that a raw row does not.
+/// </para>
+/// </remarks>
+/// <param name="InstanceId">The node's scheduler instance id.</param>
+/// <param name="LastCheckInUtc">When the node last recorded that it was alive, or
+/// <see langword="null" /> when the store keeps no check-in history — an in-memory store, or an
+/// ADO.NET store that is not clustered, neither of which writes SCHEDULER_STATE.</param>
+/// <param name="CheckInInterval">How often the node undertook to check in, or <see langword="null" />
+/// for the same reason <see cref="LastCheckInUtc" /> is. This is the node's own configured interval as
+/// it recorded it, not the reader's.</param>
+/// <param name="State">What the reading node makes of the check-in history above, decided by the same
+/// predicate cluster recovery applies.</param>
+/// <param name="IsCurrentNode">Whether this row is the node that answered the query. Exactly one row
+/// carries <see langword="true" />, and it is always present — even before this node's first check-in
+/// has written a row for it.</param>
+public sealed record ClusterNode(
+    string InstanceId,
+    DateTimeOffset? LastCheckInUtc,
+    TimeSpan? CheckInInterval,
+    ClusterNodeState State,
+    bool IsCurrentNode);

--- a/src/Quartz/Queries/ClusterNodeState.cs
+++ b/src/Quartz/Queries/ClusterNodeState.cs
@@ -1,0 +1,55 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// What the cluster makes of one node's check-in history.
+/// </summary>
+/// <remarks>
+/// The three values are read off one clock — the observing node's — against the check-in stamps every
+/// node writes, so this is what <em>this</em> node believes about the others. The
+/// <see cref="Failed" /> boundary is the same one the recovery sweep applies, so a node this listing
+/// calls failed is a node whose work the cluster is about to take over.
+/// </remarks>
+public enum ClusterNodeState
+{
+    /// <summary>
+    /// The node checked in within its own check-in interval: it is doing what a running node does.
+    /// </summary>
+    Alive,
+
+    /// <summary>
+    /// The node has missed a check-in but has not yet been silent long enough to be declared dead.
+    /// </summary>
+    /// <remarks>
+    /// Normal under load or across a slow link, and the state a node passes through on its way to
+    /// <see cref="Failed" />. Nothing is recovered from an overdue node.
+    /// </remarks>
+    Overdue,
+
+    /// <summary>
+    /// The node has been silent past the point at which the cluster stops waiting for it.
+    /// </summary>
+    /// <remarks>
+    /// The next check-in pass by any node recovers this one's in-flight work and deletes its row, so a
+    /// node reported failed is normally reported once and then disappears from the listing.
+    /// </remarks>
+    Failed
+}


### PR DESCRIPTION
Nothing in the product read `QRTZ_SCHEDULER_STATE`. The table was written on every check-in and swept by
`ClusterRecover`, and that was the whole of it: an operator asking which of four nodes was alive ran SQL by
hand, because `SchedulerMetadata.JobStoreClustered` — a `bool` saying clustering is *on* — was the only
cluster fact the API exposed.

## The design as built

**`ClusterNode` + `ClusterNodeState`, in `Quartz`.** A record of `InstanceId`, `LastCheckInUtc`,
`CheckInInterval`, `State` and `IsCurrentNode`, with a state of `Alive`, `Overdue` or `Failed`.
`SchedulerStateRecord` is untouched and stays the ADO.NET store's own row shape, the way
`FiredTriggerRecord` sits beside `FireInstance`; `ClusterNode` is the store-neutral projection.

**`IJobStore.QueryClusterNodes(CancellationToken)`** — a plain member, not a default interface member, so a
store of its own must answer it and the contract suite can hold every store to the same answers.

* **`AdoJobStoreBase`** reads `SCHEDULER_STATE` through `Delegate.SelectSchedulerStateRecords(conn, null)`
  under `ExecuteWithoutLock` (a read; no `TRIGGER_ACCESS`), and classifies each row with
  **`CalcFailedIfAfter` — the same predicate `FindFailedInstances` decides recovery by** — rather than a
  second formula, so the listing and the recovery it predicts cannot disagree. `Failed` when
  `CalcFailedIfAfter(rec) < now`, otherwise `Overdue` when `rec.CheckinTimestamp + rec.CheckinInterval < now`,
  otherwise `Alive`. Current node first, then the rest by instance id (ordinal). The clock is
  `timeProvider.GetUtcNow()` throughout.
* A **non-clustered ADO store short-circuits without touching the table.** It never creates a
  `ClusterManager` (`AdoJobStoreBase.SchedulerStarted`), so it never writes `SCHEDULER_STATE`, and reading it
  would report another cluster's rows or none. This is the spec's "verify that it never writes; if it does on
  some path, use the rows" — it does not.
* **`RAMJobStore`** answers with one node, itself. **`DelegatingJobStore`** forwards.

**The current node is always in the list and always first**, whether or not the table has a row for it yet,
and it is judged by the same predicate as everyone else — a node that has stalled its own check-in says so
rather than flattering itself. A store with no check-in state answers with that one node, `Alive`, both times
`null`, which is the honest answer rather than an empty list: a caller need not branch on whether clustering
is on, and **`null` is not zero** — an absent check-in is absent, not the epoch.

**`IScheduler.QueryClusterNodes`** sits beside `QueryFireInstances`, implemented by `QuartzScheduler` (forwards
to `resources.JobStore` after `ValidateState()`), `StdScheduler`, `DeferredScheduler`, `DelegatingScheduler`
and `HttpScheduler`.

**`GET {apiPath}/schedulers/{schedulerName}/nodes`**, mapped in `SchedulerEndpoints.cs` beside the
`execution-limits` routes, with `ClusterNodeDto` in `Quartz/HttpApiContract` and registered in
`HttpApiJsonContext`. Unpaged — a cluster is a handful of nodes, not a data set. `state` goes out as a name
through a per-type `JsonStringEnumConverter<ClusterNodeState>`, `checkInInterval` as a `TimeSpan` per #3359.
`HttpScheduler.QueryClusterNodes` reads it and **keeps the order the server chose**: "current node" means
current on the node that answered, and the client has no identity in the cluster to re-sort by.

**Dashboard.** `IQuartzApiClient.GetClusterNodes` with an `InProcessQuartzApiClient` implementation, and a
**Cluster** page at `/quartz/cluster`: instance id with a "this node" marker, a state badge, last check-in in
the selected zone plus a relative time, the check-in interval, and Acquired/Executing counts joined from
`GetFireInstances` on `SchedulerInstanceId`. It refreshes on a five-second `PeriodicTimer` rather than the
one-second cadence of `CurrentlyExecuting.razor` — every tick is a database read, and membership changes on
the scale of a check-in interval, not of a job's duration. A scheduler whose store keeps no check-in state
gets one sentence saying so instead of a table full of dashes. `Dashboard.razor` gains a **Nodes** StatCard
carrying `n (m overdue/failed)` and turning red when `m > 0`, linking to the page.

## Decisions a reviewer may want to overrule

* **The page infers "not clustered" from the node list**, not from a flag: exactly one node,
  `IsCurrentNode`, and no check-in history is what a store that keeps no membership looks like. The one case
  this mislabels is a *clustered* store whose only node has not completed its first check-in yet — at most one
  check-in interval at startup, resolving by itself. Adding `Clustered` to `SchedulerDetailDto` would remove
  the window at the cost of a public dashboard-record change and another call per tick; the spec asked for
  neither, so I did not.
* **`StateIndicator` learned two words** (`alive` → the success green, `overdue` → the paused amber) rather
  than the page carrying a mapping of its own. `failed` already read as an error. This is the shared
  state→colour mapping the rest of the dashboard uses, and keeping one of them was the point.
* **`ClassifyClusterNode` is private on `AdoJobStoreBase`**, not protected: a subclass that wanted a different
  verdict would be disagreeing with its own recovery pass, which is the thing this change exists to prevent.
* **No new log event.** `QueryClusterNodes` is a read that wraps its failure in a `JobPersistenceException`
  like every other query; nothing about it is worth an id in `ClusterLog`'s 3500–3599 range, so
  `LogEventCatalogTest`'s snapshot does not move.

## Deviations from the spec

* **The contract-suite case runs on RAM and SQLite only.** The task brief said "#3453's fixtures" make the
  suite run on every dialect; at base `a084114ff` those fixtures do not exist — `RAMJobStoreContractTest` and
  `SQLiteJobStoreContractTest` are still the only two. The case is written against `JobStoreContractTest`, so
  it will pick up any dialect fixture added later at no cost. The issue itself names exactly these two.
* **`AdoJobStoreBaseTest`: a node cannot report itself `Failed`.** The spec asked for "a node that stalled its
  own check-in reports itself honestly". It reports itself **`Overdue`**, and that is `CalcFailedIfAfter`
  speaking rather than a special case: `passed = now - LastCheckin` widens the deadline for *every* row,
  including this node's own, which is the same leniency that stops a stalled node recovering its healthy
  peers. The test —
  `QueryClusterNodes_ShouldNotExemptTheCurrentNodeFromItsOwnVerdict` — asserts that and explains why. The
  spec's actual requirement, "state computed the same way", holds: there is no branch on `IsCurrentNode` in
  the classification.
* **`ClusteredHardeningTestBase` asserts one thing more than asked.** As well as "the survivor reports the
  killed node `Failed`" and "after recovery the row is gone", it pins that the survivor's own row appears with
  its configured interval once the check-in loop is running. Both engines run it.
* **Two docs pages beyond the list.** `packages/http-client.md` gains a sentence about the client not
  re-sorting, and `how-tos/custom-job-store.md` gains a "Cluster nodes" subsection — a page whose whole subject
  is the members a custom store must implement, which just gained one. Its "the six `Query…` members" now
  reads "the six paged `Query…` members", because `QueryClusterNodes` is a seventh `Query` member and is not
  paged.
* **`DashboardRouteTable` needed no edit.** It builds its table reflectively from `[Route]`, so the `@page`
  directive is the registration; `DashboardRouteTableTest` gains the case that proves it.

## Out of scope, and left alone

History endpoint, execution-group usage panel, fleet page, live-event instance ids, and any change to
`SchedulerStateRecord`'s visibility. No schema change and nothing new written to `SCHEDULER_STATE`:
`QueryClusterNodes` is a read of rows the check-in loop already keeps.

## Public-API baseline additions

`src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt` — 22 lines:

```
    public sealed class ClusterNode : System.IEquatable<Quartz.ClusterNode>
    {
        public ClusterNode(string InstanceId, System.DateTimeOffset? LastCheckInUtc, System.TimeSpan? CheckInInterval, Quartz.ClusterNodeState State, bool IsCurrentNode) { }
        public System.TimeSpan? CheckInInterval { get; init; }
        public string InstanceId { get; init; }
        public bool IsCurrentNode { get; init; }
        public System.DateTimeOffset? LastCheckInUtc { get; init; }
        public Quartz.ClusterNodeState State { get; init; }
    }
    public enum ClusterNodeState
    {
        Alive = 0,
        Overdue = 1,
        Failed = 2,
    }
```

plus one member each on `Quartz.Extensibility.IJobStore` and `Quartz.IScheduler`:

```
        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default);
```

and the implementations:

```
Quartz.Impl.AdoJobStore.AdoJobStoreBase:
        public    …ValueTask<…List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default) { }
        protected …ValueTask<…List<Quartz.ClusterNode>> QueryClusterNodes(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
Quartz.Impl.DelegatingJobStore:  public virtual … QueryClusterNodes(…) { }
Quartz.Impl.DelegatingScheduler: public virtual … QueryClusterNodes(…) { }
Quartz.Impl.RAMJobStore:         public         … QueryClusterNodes(…) { }
```

`QuartzScheduler` and `StdScheduler` are internal, so they do not appear.

`src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt` — 1 line:

```
        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ClusterNode>> QueryClusterNodes(System.Threading.CancellationToken cancellationToken = default) { }
```

`src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt` — 10 lines:

```
    public sealed class ClusterNodeDto : System.IEquatable<Quartz.Dashboard.Services.ClusterNodeDto>
    {
        public ClusterNodeDto(string InstanceId, System.DateTimeOffset? LastCheckInUtc, System.TimeSpan? CheckInInterval, Quartz.ClusterNodeState State, bool IsCurrentNode) { }
        public System.TimeSpan? CheckInInterval { get; init; }
        public string InstanceId { get; init; }
        public bool IsCurrentNode { get; init; }
        public System.DateTimeOffset? LastCheckInUtc { get; init; }
        public Quartz.ClusterNodeState State { get; init; }
    }
        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.ClusterNodeDto>> GetClusterNodes(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
```

`src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.AspNetCore.verified.txt` **does not move** — the
endpoint handler and `ClusterNodeDto` on the wire are both internal.

The same deltas are carried into `docs/documentation/quartz-4.x/migration-guide.md`, under
"The nodes of a cluster are a listing".

New wire snapshot: `src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_ClusterNodesBody.verified.json`,
pinning three shapes in one body — the node answering, a peer given up on, and one with no check-in history
(both members `null`, not zero).

## Verification

```
dotnet build Quartz.slnx
  Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test src/Quartz.Tests.Unit
  Passed! - Failed: 0, Passed: 3301, Skipped: 4, Total: 3305, Duration: 53 s

dotnet test src/Quartz.Tests.AspNetCore
  Passed! - Failed: 0, Passed: 447, Total: 447, Duration: 7 s

integration, basic leg (the seven db-* categories excluded, as build/Build.cs runs it)
  Passed! - Failed: 0, Passed: 160, Total: 160, Duration: 1 m 31 s

integration, TestCategory=db-postgres
  Passed! - Failed: 0, Passed: 70, Total: 70, Duration: 2 m 24 s

integration, TestCategory=db-sqlserver
  Passed! - Failed: 0, Passed: 63, Total: 63, Duration: 2 m 47 s

dotnet fallout VerifyDocsSnippets
  Documentation snippets are up to date (90 markdown files checked) — Succeeded

npm run docs:check-links
  docs: 212 pages, 746 internal links, 432 fragments
  no dead links or anchors
```

Docker was running; both database legs provisioned real containers. `SQLiteJobStoreContractTest` carries no
`db-sqlite` category, so the contract case ran twice in the basic leg — once per store — which is what the
spec asked for. There is no `Quartz.Tests.AOT` project on this branch.

Closes #3418
