### PR TITLE
Every misfire instruction is pinned against both stores

### DIFF
--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
@@ -18,7 +18,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// <c>[NonParallelizable]</c> because they also share static execution records.
 /// </para>
 /// <para>
-/// <b>There is deliberately no <c>FakeTimeProvider</c> anywhere in this project.</b> A clustered node
+/// <b>There is deliberately no <c>FakeTimeProvider</c> under this base class.</b> A clustered node
 /// decides that a peer has died by comparing the peer's <c>LAST_CHECKIN_TIME</c> — an absolute instant
 /// sitting in <c>QRTZ_SCHEDULER_STATE</c> — against its own clock, and the same is true of every other
 /// node reading the same row. The database is the clock the cluster agrees on. Handing one node
@@ -26,6 +26,8 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// and the server's own timing stayed on real time, so the test would exercise a cluster that does not
 /// exist. Where a test needs the past, it moves the database instead: see
 /// <see cref="BackdateCheckin"/>, which ages a check-in row rather than sleeping past a threshold.
+/// A single-node fixture that drives a store's own misfire pass by hand has no such peers to agree
+/// with, and does use a fake clock — see <c>MisfireThroughAStoreTestBase</c>.
 /// </para>
 /// </summary>
 [NonParallelizable]

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredTestDatabase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredTestDatabase.cs
@@ -4,6 +4,8 @@ using Microsoft.Data.SqlClient;
 
 using Npgsql;
 
+using Quartz.Impl.AdoJobStore;
+
 namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 
 /// <summary>
@@ -52,6 +54,13 @@ public abstract class ClusteredTestDatabase
     public abstract string DriverDelegateType { get; }
 
     /// <summary>
+    /// This engine's driver delegate, for a fixture that constructs a job store directly instead of
+    /// through configuration. <see cref="DriverDelegateType"/> is a name for the property bridge to
+    /// resolve, which is no use to a caller holding a constructor.
+    /// </summary>
+    public abstract IDriverDelegate CreateDriverDelegate();
+
+    /// <summary>
     /// Opens a connection of this engine's own type, for the fixtures' direct SQL. Test SQL is written
     /// in unquoted upper case, which SQL Server matches case-insensitively and PostgreSQL folds to the
     /// lower-case identifiers its scripts create, so the statements themselves stay dialect-neutral.
@@ -68,6 +77,8 @@ public abstract class ClusteredTestDatabase
 
         public override string DriverDelegateType => "Quartz.Impl.AdoJobStore.PostgreSQLDelegate, Quartz";
 
+        public override IDriverDelegate CreateDriverDelegate() => new PostgreSQLDelegate();
+
         public override DbConnection CreateConnection() => new NpgsqlConnection(ConnectionString);
     }
 
@@ -78,6 +89,8 @@ public abstract class ClusteredTestDatabase
         public override string ConnectionString => TestConstants.SqlServerConnectionString;
 
         public override string DriverDelegateType => "Quartz.Impl.AdoJobStore.SqlServerDelegate, Quartz";
+
+        public override IDriverDelegate CreateDriverDelegate() => new SqlServerDelegate();
 
         public override DbConnection CreateConnection() => new SqlConnection(ConnectionString);
     }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ConcurrentMisfireRecoveryPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ConcurrentMisfireRecoveryPostgresTest.cs
@@ -1,0 +1,15 @@
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Concurrent misfire recovery against PostgreSQL, whose nodes serialize on
+/// <c>PostgreSqlSelectForUpdateSemaphore</c> — a <c>SELECT ... FOR UPDATE</c> against
+/// <c>QRTZ_LOCKS</c>, held for the length of the sweep's own transaction.
+/// </summary>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class ConcurrentMisfireRecoveryPostgresTest : ConcurrentMisfireRecoveryTestBase
+{
+    public ConcurrentMisfireRecoveryPostgresTest() : base(TestConstants.PostgresProvider)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ConcurrentMisfireRecoveryTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ConcurrentMisfireRecoveryTestBase.cs
@@ -1,0 +1,215 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Globalization;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Two nodes sweeping for misfires at the same moment, over one database. Every misfired trigger has
+/// to be recovered exactly once: recovering it twice would apply its misfire policy twice, and
+/// recovering it not at all would leave it stuck behind its own fire time forever.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The nodes here are job stores rather than schedulers, and they are initialized but never started —
+/// <c>SchedulerStarted()</c> is what spawns the <c>MisfireHandler</c> loop, and a loop sweeping on its
+/// own schedule is precisely the thing that would make "exactly once" unobservable. The stores are
+/// built with no lock handler so that each picks the one its own dialect calls for, which is the whole
+/// mechanism under test: on PostgreSQL that is <c>PostgreSqlSelectForUpdateSemaphore</c>, and the
+/// second node's sweep has to wait behind the first node's row lock and then find nothing left to do.
+/// </para>
+/// <para>
+/// Real time, per <see cref="ClusteredJobStoreTestBase" />: the nodes share a database rather than a
+/// clock. Nothing waits, because the triggers are stored twelve hours overdue rather than becoming
+/// overdue while the test watches.
+/// </para>
+/// </remarks>
+public abstract class ConcurrentMisfireRecoveryTestBase : ClusteredJobStoreTestBase
+{
+    private const string Group = "concurrentMisfireRecovery";
+    private const int TriggerCount = 50;
+
+    /// <summary>Half of the triggers' one-day period; see <c>MisfireMatrixCases</c> for why.</summary>
+    private static readonly TimeSpan HalfPeriod = TimeSpan.FromHours(12);
+
+    private readonly List<LocalTransactionJobStore> nodes = [];
+
+    protected ConcurrentMisfireRecoveryTestBase(string provider) : base(provider)
+    {
+    }
+
+    protected override string SchedulerName => "ConcurrentMisfireRecoveryTest";
+
+    [TearDown]
+    public async Task ShutDownNodes()
+    {
+        foreach (LocalTransactionJobStore node in nodes)
+        {
+            await node.Shutdown();
+        }
+
+        nodes.Clear();
+    }
+
+    [Test]
+    public async Task TwoNodesSweepingAtOnceRecoverEachMisfiredTriggerExactlyOnce()
+    {
+        DateTimeOffset anchor = TimeProvider.System.GetUtcNow();
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        LocalTransactionJobStore nodeA = await CreateNode("nodeA");
+        LocalTransactionJobStore nodeB = await CreateNode("nodeB");
+
+        IJobDetail job = JobBuilder.Create<ConcurrentSweepJob>()
+            .WithIdentity("concurrentSweepJob", Group)
+            .StoreDurably()
+            .Build();
+
+        await nodeA.AddJob(job, replace: true);
+
+        for (int i = 0; i < TriggerCount; i++)
+        {
+            IOperableTrigger trigger = BuildTrigger(anchor, "misfired-" + i.ToString(CultureInfo.InvariantCulture), job.Key);
+            trigger.ComputeFirstFireTimeUtc(null);
+            trigger.NextFireTimeUtc = scheduled;
+
+            await nodeA.AddTrigger(trigger, replace: true);
+        }
+
+        (await CountTriggersDueAt(scheduled)).Should().Be(TriggerCount,
+            "all {0} triggers have to be stored overdue before anything sweeps, or the race is not the one under test", TriggerCount);
+
+        // What the policy arrives at. Every trigger carries the same schedule and DoNothing recomputes
+        // from now rather than from the missed time, so all of them land on this one instant.
+        IOperableTrigger detached = BuildTrigger(anchor, "expected", job.Key);
+        detached.ComputeFirstFireTimeUtc(null);
+        detached.NextFireTimeUtc = scheduled;
+        detached.UpdateAfterMisfire(null);
+
+        detached.NextFireTimeUtc.Should().NotBeNull("a DoNothing cron trigger always has a next slot to skip to");
+        DateTimeOffset expected = detached.NextFireTimeUtc.Value;
+
+        // Both sweeps are on threads of their own and both are waiting on the gate before either starts,
+        // so the second one reaches the lock while the first still holds it. Starting them inline would
+        // let the first run to completion before the second was ever scheduled, and the test would pass
+        // without the two having contended at all.
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<RecoverMisfiredJobsResult> sweepA = Task.Run(() => Sweep(nodeA));
+        Task<RecoverMisfiredJobsResult> sweepB = Task.Run(() => Sweep(nodeB));
+
+        gate.SetResult();
+
+        RecoverMisfiredJobsResult[] results = await Task.WhenAll(sweepA, sweepB);
+
+        async Task<RecoverMisfiredJobsResult> Sweep(LocalTransactionJobStore node)
+        {
+            await gate.Task;
+            return await node.DoRecoverMisfires(Guid.NewGuid());
+        }
+
+        TestContext.Out.WriteLine(
+            $"Recovered per node: nodeA={results[0].ProcessedMisfiredTriggerCount}, nodeB={results[1].ProcessedMisfiredTriggerCount}");
+
+        results.Sum(x => x.ProcessedMisfiredTriggerCount).Should().Be(TriggerCount,
+            "the two sweeps have to partition the misfired triggers between them — a total above {0} means "
+            + "both nodes handled the same rows and applied their misfire policies twice, and one below it "
+            + "means rows were claimed and dropped", TriggerCount);
+
+        results.Should().AllSatisfy(x => x.HasMoreMisfiredTriggers.Should().BeFalse(
+            "the batch limit is above the number of misfired triggers, so neither sweep should report a remainder"));
+
+        (await CountTriggersDueAt(expected)).Should().Be(TriggerCount,
+            "every trigger has to end up on the instant its own misfire policy computed");
+        (await CountTriggersDueAt(scheduled)).Should().Be(0,
+            "a trigger still sitting on its missed fire time was never recovered by either node");
+        (await CountRows(
+            "SELECT COUNT(*) FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName AND TRIGGER_STATE <> 'WAITING'",
+            ("schedulerName", SchedulerName))).Should().Be(0,
+            "recovery leaves a trigger that still has fire times waiting, whichever node did the recovering");
+    }
+
+    /// <summary>
+    /// A cron trigger firing once a day, half a period out from <paramref name="anchor" />, whose misfire
+    /// instruction skips the missed firing rather than replaying it — so the instant it recomputes is a
+    /// scheduled one and can be asserted exactly.
+    /// </summary>
+    private static IOperableTrigger BuildTrigger(DateTimeOffset anchor, string name, JobKey jobKey)
+    {
+        DateTime slot = (anchor + HalfPeriod).UtcDateTime;
+
+        return (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity(name, Group)
+            .ForJob(jobKey)
+            .StartAt(anchor - HalfPeriod - TimeSpan.FromDays(1))
+            .WithCronSchedule(
+                string.Create(CultureInfo.InvariantCulture, $"{slot.Second} {slot.Minute} {slot.Hour} * * ?"),
+                x => x.InTimeZone(TimeZoneInfo.Utc).WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing))
+            .Build();
+    }
+
+    private Task<int> CountTriggersDueAt(DateTimeOffset dueAt)
+    {
+        return CountRows(
+            "SELECT COUNT(*) FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName AND NEXT_FIRE_TIME = @nextFireTime",
+            ("schedulerName", SchedulerName),
+            ("nextFireTime", dueAt.UtcTicks));
+    }
+
+    /// <summary>
+    /// One clustered node, with no lock handler of its own so that the store installs the one its
+    /// dialect calls for.
+    /// </summary>
+    private async Task<LocalTransactionJobStore> CreateNode(string instanceId)
+    {
+        LocalTransactionJobStore node = new(
+            TestJobStores.Signaler(),
+            TestJobStores.TypeLoader(),
+            TimeProvider.System,
+            TestJobStores.SchedulerOptions(SchedulerName, instanceId),
+            TestJobStores.StoreOptions("default", "QRTZ_", options =>
+            {
+                // Comfortably above the trigger count, so a short sweep means contention rather than a
+                // truncated batch.
+                options.MaxMisfiresToHandleAtATime = TriggerCount * 2;
+            }),
+            TestJobStores.ClusteringOptions(options => options.Enabled = true),
+            TestJobStores.Serializer(),
+            new DbProvider(Database.Provider, Database.ConnectionString),
+            Database.CreateDriverDelegate());
+
+        // Initialized but never started, so that no MisfireHandler loop exists to sweep behind the
+        // test's back — the two sweeps below are the only ones there are.
+        await node.Initialize(TestJobStores.Identity(SchedulerName, instanceId));
+
+        nodes.Add(node);
+        return node;
+    }
+
+    /// <summary>A job that never runs: this fixture drives stores, not schedulers.</summary>
+    public sealed class ConcurrentSweepJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/MisfireCalendarExclusionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireCalendarExclusionTest.cs
@@ -1,0 +1,110 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Quartz.Extensibility;
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Tests.Integration.Impl;
+
+/// <summary>
+/// A trigger that misfires onto a day its calendar excludes has to keep going past it. Every trigger
+/// family carries that loop in its "reschedule to the next slot" branch; this asserts that the loop is
+/// actually reached through a store, which means the store found the calendar, handed it to
+/// <c>UpdateAfterMisfire</c>, and stored what came back.
+/// </summary>
+/// <remarks>
+/// The calendar the store hands over is not the one the test holds — the ADO store serializes it into
+/// <c>QRTZ_CALENDARS</c> and reads it back — so a calendar whose time zone did not survive the round
+/// trip would fail here rather than silently exclude a different day.
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public sealed class MisfireCalendarExclusionTest : MisfireThroughAStoreTestBase
+{
+    private const string CalendarName = "excludes-the-slot-the-misfire-would-pick";
+
+    public static IEnumerable<MisfireMatrixCase> Cases() => MisfireMatrixCases.OnePerShapeThatConsultsACalendar();
+
+    [TestCaseSource(nameof(Cases))]
+    public async Task AMisfireSkipsPastTheDayItsCalendarExcludes(MisfireMatrixCase testCase)
+    {
+        DateTimeOffset anchor = Anchor();
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        // What the policy picks with nothing in its way. The calendar is then built to exclude exactly
+        // that day, so the store has to move past it or the assertion below is not about a calendar.
+        MisfireExpectation withoutCalendar = MisfireExpectation.From(Detached(testCase, anchor, scheduled), calendar: null);
+
+        withoutCalendar.NextFireTimeUtc.Should().NotBeNull(
+            "'{0}' has to have a slot to skip before there is anything for a calendar to exclude", testCase);
+
+        HolidayCalendar calendar = new() { TimeZone = TimeZoneInfo.Utc };
+        calendar.AddExcludedDay(DateOnly.FromDateTime(withoutCalendar.NextFireTimeUtc.Value.UtcDateTime));
+
+        MisfireExpectation expected = MisfireExpectation.From(Detached(testCase, anchor, scheduled), calendar);
+
+        expected.NextFireTimeUtc.Should().NotBe(withoutCalendar.NextFireTimeUtc,
+            "the calendar excludes the day '{0}' would otherwise land on, so a stored fire time equal to "
+            + "the uncalendared one would mean the calendar was never consulted", testCase);
+
+        foreach (MisfireStoreUnderTest store in await BothStores(anchor))
+        {
+            TriggerKey triggerKey = new("calendar-" + Guid.NewGuid().ToString("N"), Group);
+            JobKey jobKey = new(triggerKey.Name, Group);
+
+            await store.Store.AddCalendar(CalendarName, calendar);
+
+            IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor)
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .WithCalendarName(CalendarName)
+                .Build();
+
+            await Store(store, Job(jobKey), trigger, scheduled, calendar);
+            store.Clock.Advance(HalfPeriod);
+
+            DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
+            await store.Sweep(scheduled - TimeSpan.FromTicks(1));
+            DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
+
+            TriggerState state = await store.Store.GetTriggerState(triggerKey);
+            IOperableTrigger readBack = await store.Store.GetTrigger(triggerKey);
+
+            readBack.Should().NotBeNull("{0} must still hold '{1}' after a misfire pass", store.Name, testCase);
+
+            expected.AssertAgainst(store.Name, testCase + " with an excluded day", state, readBack.NextFireTimeUtc, passStarted, passFinished);
+        }
+    }
+
+    private static IOperableTrigger Detached(MisfireMatrixCase testCase, DateTimeOffset anchor, DateTimeOffset scheduled)
+    {
+        TriggerKey triggerKey = new("calendar-detached", Group);
+        JobKey jobKey = new("calendar-detached", Group);
+
+        IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor)
+            .WithIdentity(triggerKey)
+            .ForJob(jobKey)
+            .Build();
+
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.NextFireTimeUtc = scheduled;
+
+        return trigger;
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/MisfireExpectation.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireExpectation.cs
@@ -1,0 +1,151 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Globalization;
+
+using Quartz.Extensibility;
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Integration.Impl;
+
+/// <summary>
+/// What a store must leave behind once it has applied a trigger's misfire policy, worked out by
+/// running <see cref="IOperableTrigger.UpdateAfterMisfire" /> on a detached copy of the very trigger
+/// that was stored.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The trigger's own arithmetic is the specification; a store's only job on top of it is the state
+/// rule — a trigger left with no fire time is <see cref="TriggerState.Complete" />, anything else is
+/// <see cref="TriggerState.Normal" />. Both stores are asserted against one instance of this, which is
+/// what makes it a parity assertion rather than two independent ones that happen to agree.
+/// </para>
+/// <para>
+/// The one outcome that cannot be an exact instant is "fire now": the policies that reschedule to now
+/// read the clock at the moment the store applies them, so the detached copy's value and the store's
+/// differ by however long the pass took. Those are asserted to fall inside the pass instead, which is
+/// tighter than a tolerance and says the same thing. The rule that sorts a "now" from a scheduled
+/// instant is <see cref="TriggerBase.FireNowMisfireDetectionThresholdMs" /> — the same one both stores
+/// use to decide whether a misfire earned a recorded original fire time.
+/// </para>
+/// </remarks>
+public sealed class MisfireExpectation
+{
+    private readonly DateTimeOffset? nextFireTimeUtc;
+    private readonly bool firesNow;
+
+    private MisfireExpectation(DateTimeOffset? nextFireTimeUtc, bool firesNow)
+    {
+        this.nextFireTimeUtc = nextFireTimeUtc;
+        this.firesNow = firesNow;
+    }
+
+    /// <summary>The state a store must report for the trigger afterwards.</summary>
+    public TriggerState State => nextFireTimeUtc.HasValue ? TriggerState.Normal : TriggerState.Complete;
+
+    /// <summary>
+    /// The expectation for a trigger a store must not have touched at all: it is still waiting, on the
+    /// very fire time it was stored with.
+    /// </summary>
+    public static MisfireExpectation Untouched(DateTimeOffset scheduledFireTimeUtc)
+    {
+        return new MisfireExpectation(scheduledFireTimeUtc, firesNow: false);
+    }
+
+    /// <summary>
+    /// Applies the misfire policy to <paramref name="detached" /> — a copy no store has ever seen —
+    /// and captures what came out.
+    /// </summary>
+    public static MisfireExpectation From(IOperableTrigger detached, ICalendar calendar)
+    {
+        DateTimeOffset now = TimeProvider.System.GetUtcNow();
+
+        detached.UpdateAfterMisfire(calendar);
+
+        DateTimeOffset? after = detached.NextFireTimeUtc;
+        bool firesNow = after.HasValue
+            && Math.Abs((after.Value - now).TotalMilliseconds) < TriggerBase.FireNowMisfireDetectionThresholdMs;
+
+        return new MisfireExpectation(after, firesNow);
+    }
+
+    /// <summary>
+    /// Asserts that a store's stored state and next fire time are the ones this expectation names.
+    /// </summary>
+    /// <param name="storeName">The store, as it reads in a failure message.</param>
+    /// <param name="cell">What the case under test is, as it reads in a failure message.</param>
+    /// <param name="state">The state the store reports.</param>
+    /// <param name="actual">The next fire time read back out of the store.</param>
+    /// <param name="passStarted">Real time immediately before the store's misfire pass.</param>
+    /// <param name="passFinished">Real time immediately after it.</param>
+    public void AssertAgainst(
+        string storeName,
+        string cell,
+        TriggerState state,
+        DateTimeOffset? actual,
+        DateTimeOffset passStarted,
+        DateTimeOffset passFinished)
+    {
+        state.Should().Be(State,
+            "{0} must park '{1}' in the state its remaining fire times call for, and UpdateAfterMisfire left it {2}",
+            storeName, cell, nextFireTimeUtc.HasValue ? "with one" : "with none");
+
+        if (!nextFireTimeUtc.HasValue)
+        {
+            actual.Should().BeNull(
+                "'{0}' has nothing left to fire after its misfire policy ran, so {1} must not have invented a fire time",
+                cell, storeName);
+            return;
+        }
+
+        if (firesNow)
+        {
+            actual.Should().NotBeNull("'{0}' reschedules to now, so {1} must have given it a fire time", cell, storeName);
+            actual.Value.Should().BeOnOrAfter(passStarted).And.BeOnOrBefore(passFinished,
+                "'{0}' reschedules to the moment the policy is applied, so {1} must have written an instant "
+                + "inside its own pass ({2} .. {3}) rather than {4}",
+                cell, storeName,
+                Format(passStarted), Format(passFinished), Format(actual.Value));
+            return;
+        }
+
+        actual.Should().Be(nextFireTimeUtc,
+            "'{0}' reschedules to a scheduled instant, and a detached copy of the same trigger computed {1} — "
+            + "{2} must arrive at the same one",
+            cell, Format(nextFireTimeUtc.Value), storeName);
+    }
+
+    /// <summary>The instant this expectation names, for a test that wants to reason about it.</summary>
+    public DateTimeOffset? NextFireTimeUtc => nextFireTimeUtc;
+
+    /// <summary>Whether the policy rescheduled to "now" rather than to a scheduled instant.</summary>
+    public bool FiresNow => firesNow;
+
+    public override string ToString()
+    {
+        if (!nextFireTimeUtc.HasValue)
+        {
+            return "complete";
+        }
+
+        return firesNow ? "fires now" : "fires at " + Format(nextFireTimeUtc.Value);
+    }
+
+    private static string Format(DateTimeOffset value) => value.UtcDateTime.ToString("O", CultureInfo.InvariantCulture);
+}

--- a/src/Quartz.Tests.Integration/Impl/MisfireMatrixCases.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireMatrixCases.cs
@@ -1,0 +1,271 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Globalization;
+
+namespace Quartz.Tests.Integration.Impl;
+
+/// <summary>
+/// The trigger shapes the matrix runs. Five families, six shapes: a repeating simple trigger and a
+/// one-shot one take different branches of the same instruction.
+/// </summary>
+public enum MisfireTriggerShape
+{
+    SimpleRepeating,
+    SimpleOneShot,
+    Cron,
+    CalendarInterval,
+    DailyTimeInterval,
+    Recurrence
+}
+
+/// <summary>
+/// One cell of the misfire matrix: a trigger shape and one of the misfire instructions its family
+/// offers.
+/// </summary>
+public sealed class MisfireMatrixCase
+{
+    /// <summary>The trigger shape this cell is one instruction of.</summary>
+    public MisfireTriggerShape Shape { get; init; }
+
+    /// <summary>The trigger shape, as a failure message names it.</summary>
+    public string ShapeName { get; init; }
+
+    /// <summary>The enum the instruction is spelled in, which is what the coverage guard walks.</summary>
+    public Type InstructionEnum { get; init; }
+
+    /// <summary>The instruction, as its own family spells it.</summary>
+    public string Instruction { get; init; }
+
+    /// <summary>
+    /// Builds the trigger this cell is about, anchored on the instant the test froze. Called more than
+    /// once per test: once for the copy that is stored, and once for the detached copy that computes
+    /// what the store must arrive at.
+    /// </summary>
+    public Func<DateTimeOffset, TriggerBuilder<IJob>> Trigger { get; init; }
+
+    /// <summary>
+    /// Whether this cell's instruction is the one that says a missed firing is not a misfire at all.
+    /// Both stores skip such a trigger outright rather than running its policy, and the matrix asserts
+    /// that they do — but a test that wants a trigger to actually misfire has to leave it out.
+    /// </summary>
+    public bool IgnoresMisfires { get; init; }
+
+    /// <summary>
+    /// Whether this cell's instruction consults the trigger's calendar while it recomputes. Only the
+    /// "reschedule to the next slot" branches do; the "fire now" ones set the clock's reading and never
+    /// look at a calendar.
+    /// </summary>
+    public bool ConsultsCalendar { get; init; }
+
+    public override string ToString() => $"{ShapeName} / {Instruction}";
+}
+
+/// <summary>
+/// The trigger-shape by misfire-instruction matrix that every job store has to answer the same way.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Six shapes cover the five trigger families; <see cref="ISimpleTrigger" /> gets two, because a
+/// repeating simple trigger and a one-shot one take different branches of
+/// <c>SimpleTriggerImpl.UpdateAfterMisfire</c> for the same instruction — <c>FireNow</c> on a repeating
+/// trigger is rewritten to <c>RescheduleNowWithRemainingRepeatCount</c>, and the "reschedule to the
+/// next slot" instructions run a one-shot trigger out of fire times altogether.
+/// </para>
+/// <para>
+/// Every schedule has a period of one day and is anchored so that its missed firing sits half a day
+/// before the test's <c>anchor</c> and its next slot half a day after. Nothing here is within hours of
+/// a schedule boundary, which is what lets the expected instants be exact even though the triggers
+/// themselves compute on real time.
+/// </para>
+/// </remarks>
+public static class MisfireMatrixCases
+{
+    private static readonly TimeSpan HalfPeriod = MisfireThroughAStoreTestBase.HalfPeriod;
+    private static readonly TimeSpan Period = TimeSpan.FromDays(1);
+
+    /// <summary>Every cell of the matrix.</summary>
+    public static IEnumerable<MisfireMatrixCase> All()
+    {
+        foreach (SimpleTriggerMisfireInstruction instruction in Enum.GetValues<SimpleTriggerMisfireInstruction>())
+        {
+            yield return new MisfireMatrixCase
+            {
+                Shape = MisfireTriggerShape.SimpleRepeating,
+                ShapeName = "SimpleTrigger repeating daily",
+                InstructionEnum = typeof(SimpleTriggerMisfireInstruction),
+                Instruction = instruction.ToString(),
+                IgnoresMisfires = instruction == SimpleTriggerMisfireInstruction.IgnoreMisfires,
+                ConsultsCalendar = instruction
+                    is SimpleTriggerMisfireInstruction.NextWithExistingCount
+                    or SimpleTriggerMisfireInstruction.NextWithRemainingCount
+                    or SimpleTriggerMisfireInstruction.SmartPolicy,
+                Trigger = anchor => TriggerBuilder.Create()
+                    .StartAt(anchor - HalfPeriod)
+                    .WithSimpleSchedule(x => x
+                        .WithInterval(Period)
+                        .RepeatForever()
+                        .WithMisfireInstruction(instruction))
+            };
+
+            yield return new MisfireMatrixCase
+            {
+                Shape = MisfireTriggerShape.SimpleOneShot,
+                ShapeName = "SimpleTrigger one-shot",
+                InstructionEnum = typeof(SimpleTriggerMisfireInstruction),
+                Instruction = instruction.ToString(),
+                IgnoresMisfires = instruction == SimpleTriggerMisfireInstruction.IgnoreMisfires,
+                // A one-shot trigger has no next slot to skip to, so the calendar loop is unreachable
+                // whatever the instruction: it runs out of fire times first.
+                ConsultsCalendar = false,
+                Trigger = anchor => TriggerBuilder.Create()
+                    .StartAt(anchor - HalfPeriod)
+                    .WithSimpleSchedule(x => x
+                        .WithInterval(Period)
+                        .WithRepeatCount(0)
+                        .WithMisfireInstruction(instruction))
+            };
+        }
+
+        foreach (CronTriggerMisfireInstruction instruction in Enum.GetValues<CronTriggerMisfireInstruction>())
+        {
+            yield return new MisfireMatrixCase
+            {
+                Shape = MisfireTriggerShape.Cron,
+                ShapeName = "CronTrigger firing once a day",
+                InstructionEnum = typeof(CronTriggerMisfireInstruction),
+                Instruction = instruction.ToString(),
+                IgnoresMisfires = instruction == CronTriggerMisfireInstruction.IgnoreMisfires,
+                ConsultsCalendar = instruction == CronTriggerMisfireInstruction.DoNothing,
+                Trigger = anchor => TriggerBuilder.Create()
+                    .StartAt(anchor - HalfPeriod - Period)
+                    .WithCronSchedule(DailyCronAt(anchor + HalfPeriod), x => x
+                        .InTimeZone(TimeZoneInfo.Utc)
+                        .WithMisfireInstruction(instruction))
+            };
+        }
+
+        foreach (CalendarIntervalTriggerMisfireInstruction instruction in Enum.GetValues<CalendarIntervalTriggerMisfireInstruction>())
+        {
+            yield return new MisfireMatrixCase
+            {
+                Shape = MisfireTriggerShape.CalendarInterval,
+                ShapeName = "CalendarIntervalTrigger every day",
+                InstructionEnum = typeof(CalendarIntervalTriggerMisfireInstruction),
+                Instruction = instruction.ToString(),
+                IgnoresMisfires = instruction == CalendarIntervalTriggerMisfireInstruction.IgnoreMisfires,
+                ConsultsCalendar = instruction == CalendarIntervalTriggerMisfireInstruction.DoNothing,
+                Trigger = anchor => TriggerBuilder.Create()
+                    .StartAt(anchor - HalfPeriod)
+                    .WithCalendarIntervalSchedule(x => x
+                        .WithInterval(1, IntervalUnit.Day)
+                        .InTimeZone(TimeZoneInfo.Utc)
+                        .WithMisfireInstruction(instruction))
+            };
+        }
+
+        foreach (DailyTimeIntervalTriggerMisfireInstruction instruction in Enum.GetValues<DailyTimeIntervalTriggerMisfireInstruction>())
+        {
+            yield return new MisfireMatrixCase
+            {
+                Shape = MisfireTriggerShape.DailyTimeInterval,
+                ShapeName = "DailyTimeIntervalTrigger with a one-instant window",
+                InstructionEnum = typeof(DailyTimeIntervalTriggerMisfireInstruction),
+                Instruction = instruction.ToString(),
+                IgnoresMisfires = instruction == DailyTimeIntervalTriggerMisfireInstruction.IgnoreMisfires,
+                ConsultsCalendar = instruction == DailyTimeIntervalTriggerMisfireInstruction.DoNothing,
+                Trigger = anchor => TriggerBuilder.Create()
+                    .StartAt(anchor - HalfPeriod - Period)
+                    .WithDailyTimeIntervalSchedule(x => x
+                        .StartingDailyAt(TimeOfDay(anchor + HalfPeriod))
+                        .EndingDailyAt(TimeOfDay(anchor + HalfPeriod))
+                        .WithInterval(1, IntervalUnit.Hour)
+                        .InTimeZone(TimeZoneInfo.Utc)
+                        .WithMisfireInstruction(instruction))
+            };
+        }
+
+        foreach (RecurrenceTriggerMisfireInstruction instruction in Enum.GetValues<RecurrenceTriggerMisfireInstruction>())
+        {
+            yield return new MisfireMatrixCase
+            {
+                Shape = MisfireTriggerShape.Recurrence,
+                ShapeName = "RecurrenceTrigger on FREQ=DAILY",
+                InstructionEnum = typeof(RecurrenceTriggerMisfireInstruction),
+                Instruction = instruction.ToString(),
+                IgnoresMisfires = instruction == RecurrenceTriggerMisfireInstruction.IgnoreMisfires,
+                ConsultsCalendar = instruction == RecurrenceTriggerMisfireInstruction.DoNothing,
+                Trigger = anchor => TriggerBuilder.Create()
+                    .StartAt(anchor - HalfPeriod)
+                    .WithRecurrenceSchedule("FREQ=DAILY", x => x
+                        .InTimeZone(TimeZoneInfo.Utc)
+                        .WithMisfireInstruction(instruction))
+            };
+        }
+    }
+
+    /// <summary>
+    /// One cell per trigger shape, for the tests whose subject is the recomputation rather than the
+    /// instruction — the shape's calendar-consulting instruction, which is the only branch that has a
+    /// calendar to consult.
+    /// </summary>
+    public static IEnumerable<MisfireMatrixCase> OnePerShapeThatConsultsACalendar()
+    {
+        // SmartPolicy resolves to the same branch, so it would do — but a failure message that names
+        // the branch outright is worth more than one that makes the reader resolve it.
+        return All()
+            .Where(x => x.ConsultsCalendar && !string.Equals(x.Instruction, nameof(CronTriggerMisfireInstruction.SmartPolicy), StringComparison.Ordinal))
+            .GroupBy(x => x.Shape)
+            .Select(x => x.First());
+    }
+
+    /// <summary>
+    /// One named cell, for a test whose subject is something other than the matrix but which wants a
+    /// trigger the matrix has already pinned.
+    /// </summary>
+    public static MisfireMatrixCase Cell(MisfireTriggerShape shape, string instruction)
+    {
+        return All().Single(x => x.Shape == shape && string.Equals(x.Instruction, instruction, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Every misfire-instruction enum the library exports, found rather than listed so that a new
+    /// trigger family cannot arrive without the matrix noticing.
+    /// </summary>
+    public static IEnumerable<Type> InstructionEnums()
+    {
+        return typeof(ITrigger).Assembly.GetExportedTypes()
+            .Where(x => x.IsEnum && x.Name.EndsWith("TriggerMisfireInstruction", StringComparison.Ordinal))
+            .OrderBy(x => x.Name, StringComparer.Ordinal);
+    }
+
+    /// <summary>A cron expression that fires once a day, at the UTC time of <paramref name="when" />.</summary>
+    private static string DailyCronAt(DateTimeOffset when)
+    {
+        DateTime utc = when.UtcDateTime;
+        return string.Create(CultureInfo.InvariantCulture, $"{utc.Second} {utc.Minute} {utc.Hour} * * ?");
+    }
+
+    /// <summary>The UTC time of day of <paramref name="when" />, to the second.</summary>
+    private static TimeOnly TimeOfDay(DateTimeOffset when)
+    {
+        DateTime utc = when.UtcDateTime;
+        return new TimeOnly(utc.Hour, utc.Minute, utc.Second);
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/MisfireMatrixTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireMatrixTest.cs
@@ -1,0 +1,339 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Globalization;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Integration.Impl;
+
+/// <summary>
+/// What a store does when a trigger misfires: every trigger shape against every misfire instruction of
+/// its own family, on the in-memory store and on a real SQLite one, both asserted against the same
+/// expectation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The behaviour each instruction names — fire now, reschedule now with the existing count, reschedule
+/// to the next slot with the remaining count, do nothing — belongs to the trigger, and
+/// <c>UpdateAfterMisfire</c> is where it lives. A store's contribution is to notice the trigger is late,
+/// run that method, and record what came out. So each cell here computes what a detached copy of the
+/// stored trigger produces, and then asserts that both stores arrived at exactly that; the stores are
+/// compared with each other by being compared with one expectation rather than two.
+/// </para>
+/// <para>
+/// <see cref="MisfireInstructionFamilyCases" /> in the unit tests is the other half of this: it is a
+/// (stored family × requested family) matrix over the rejection of an instruction phrased in the wrong
+/// family's vocabulary. That one is about the name; this one is about what the name does.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
+{
+    public static IEnumerable<MisfireMatrixCase> Cases() => MisfireMatrixCases.All();
+
+    /// <summary>
+    /// Guards the table itself. The enums are discovered from the assembly rather than listed, so a new
+    /// trigger family, or a new instruction inside an existing one, fails here rather than quietly
+    /// going untested against either store.
+    /// </summary>
+    [Test]
+    public void EveryInstructionHasACase()
+    {
+        List<Type> families = MisfireMatrixCases.InstructionEnums().ToList();
+
+        families.Should().NotBeEmpty("the guard is only a guard while it finds the enums it walks");
+
+        foreach (Type family in families)
+        {
+            Cases()
+                .Where(x => x.InstructionEnum == family)
+                .Select(x => x.Instruction)
+                .Distinct(StringComparer.Ordinal)
+                .Should().BeEquivalentTo(Enum.GetNames(family),
+                    "the matrix is only a matrix while every {0} value has a cell", family.Name);
+        }
+    }
+
+    /// <summary>
+    /// Guards the matrix against going vacuous, and writes out what each cell resolves to — which is
+    /// the table a reader wants when one of the cells below fails.
+    /// </summary>
+    /// <remarks>
+    /// A misfire has exactly three outcomes: the trigger fires as soon as the scheduler gets to it, it
+    /// skips to a scheduled slot, or it has nothing left to fire. If a change ever collapsed the matrix
+    /// onto one of them, every cell would still pass — each is asserted against the trigger's own
+    /// arithmetic — and the matrix would be asserting nothing.
+    /// </remarks>
+    [Test]
+    public void TheMatrixExercisesEveryOutcomeAMisfireCanHave()
+    {
+        DateTimeOffset anchor = Anchor();
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        List<(MisfireMatrixCase Case, MisfireExpectation Expected)> outcomes = [];
+
+        foreach (MisfireMatrixCase testCase in Cases())
+        {
+            TriggerKey triggerKey = new("outcome", Group);
+            JobKey jobKey = new("outcome", Group);
+
+            IOperableTrigger detached = Build(testCase, anchor, triggerKey, jobKey);
+            detached.ComputeFirstFireTimeUtc(null);
+            detached.NextFireTimeUtc = scheduled;
+
+            MisfireExpectation expected = testCase.IgnoresMisfires
+                ? MisfireExpectation.Untouched(scheduled)
+                : MisfireExpectation.From(detached, calendar: null);
+
+            outcomes.Add((testCase, expected));
+            TestContext.Out.WriteLine($"{testCase} -> {expected}");
+        }
+
+        outcomes.Should().Contain(x => x.Expected.FiresNow,
+            "the 'fire now' half of the misfire vocabulary has to be exercised by some cell");
+        outcomes.Should().Contain(x => !x.Expected.FiresNow && x.Expected.State == TriggerState.Normal,
+            "the 'reschedule to a scheduled slot' half has to be exercised by some cell");
+        outcomes.Should().Contain(x => x.Expected.State == TriggerState.Complete,
+            "a trigger that runs out of fire times while catching up has to be exercised by some cell");
+    }
+
+    /// <summary>
+    /// The matrix. One trigger, stored with its next fire time pinned half a day in the past; the clock
+    /// then moved past the threshold; then exactly one misfire pass; then the trigger's stored state and
+    /// next fire time, on both stores, against what its own <c>UpdateAfterMisfire</c> said they should
+    /// be.
+    /// </summary>
+    [TestCaseSource(nameof(Cases))]
+    public async Task AMisfirePassLeavesATriggerWhereItsOwnPolicySays(MisfireMatrixCase testCase)
+    {
+        DateTimeOffset anchor = Anchor();
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        foreach (MisfireStoreUnderTest store in await BothStores(anchor))
+        {
+            TriggerKey triggerKey = new("matrix-" + Guid.NewGuid().ToString("N"), Group);
+            JobKey jobKey = new(triggerKey.Name, Group);
+
+            await Store(store, Job(jobKey), Build(testCase, anchor, triggerKey, jobKey), scheduled);
+
+            // The trigger's own scheduled time is where the clock started, so nothing was late until
+            // here. Half a day is far past the one-minute threshold, and no wall clock moved for it.
+            store.Clock.Advance(HalfPeriod);
+
+            // The copy the expectation comes from goes through the same two steps the stored one did,
+            // so the only difference between them is that this one never met a store.
+            IOperableTrigger detached = Build(testCase, anchor, triggerKey, jobKey);
+            detached.ComputeFirstFireTimeUtc(null);
+            detached.NextFireTimeUtc = scheduled;
+
+            DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
+            MisfireExpectation expected = testCase.IgnoresMisfires
+                ? MisfireExpectation.Untouched(scheduled)
+                : MisfireExpectation.From(detached, calendar: null);
+
+            await store.Sweep(scheduled - TimeSpan.FromTicks(1));
+            DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
+
+            TriggerState state = await store.Store.GetTriggerState(triggerKey);
+            IOperableTrigger readBack = await store.Store.GetTrigger(triggerKey);
+
+            readBack.Should().NotBeNull("{0} must still hold '{1}' after a misfire pass", store.Name, testCase);
+
+            expected.AssertAgainst(store.Name, testCase.ToString(), state, readBack.NextFireTimeUtc, passStarted, passFinished);
+        }
+    }
+
+    /// <summary>
+    /// A trigger whose instruction is <c>IgnoreMisfirePolicy</c> is not late, however late it is. Both
+    /// stores implement that by never running the policy at all — the in-memory one returns from
+    /// <c>ApplyMisfireNoLock</c> before it looks at the clock, and the ADO one excludes the row in SQL
+    /// with <c>MISFIRE_INSTR &lt;&gt; -1</c> — so this is the one row of the matrix where a store's
+    /// answer does not come from <c>UpdateAfterMisfire</c>.
+    /// </summary>
+    [TestCaseSource(nameof(IgnoringCases))]
+    public async Task AnIgnoringTriggerIsLeftExactlyAsItWasStored(MisfireMatrixCase testCase)
+    {
+        DateTimeOffset anchor = Anchor();
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        foreach (MisfireStoreUnderTest store in await BothStores(anchor))
+        {
+            TriggerKey triggerKey = new("ignoring-" + Guid.NewGuid().ToString("N"), Group);
+            JobKey jobKey = new(triggerKey.Name, Group);
+
+            await Store(store, Job(jobKey), Build(testCase, anchor, triggerKey, jobKey), scheduled);
+            store.Clock.Advance(HalfPeriod);
+
+            await store.Sweep(scheduled - TimeSpan.FromTicks(1));
+
+            IOperableTrigger readBack = await store.Store.GetTrigger(triggerKey);
+
+            readBack.NextFireTimeUtc.Should().Be(scheduled,
+                "{0} must leave '{1}' on the fire time it was stored with; an ignoring trigger catches up "
+                + "when it is next acquired, and moving its fire time here would lose the firing it owes",
+                store.Name, testCase);
+            (await store.Store.GetTriggerState(triggerKey)).Should().Be(TriggerState.Normal,
+                "{0} must leave '{1}' waiting", store.Name, testCase);
+        }
+    }
+
+    public static IEnumerable<MisfireMatrixCase> IgnoringCases() => MisfireMatrixCases.All().Where(x => x.IgnoresMisfires);
+
+    #region The threshold edge
+
+    /// <summary>
+    /// Where a store draws the line, to the tick. The threshold instant itself is the interesting one:
+    /// the in-memory store's <c>ApplyMisfireNoLock</c> declines only a trigger whose fire time is
+    /// strictly <em>after</em> <c>now - MisfireThreshold</c>, so the instant itself is a misfire, while
+    /// the ADO store's recovery SELECT asks for <c>NEXT_FIRE_TIME &lt; @nextFireTime</c>, so the instant
+    /// itself is not.
+    /// </summary>
+    public sealed record ThresholdEdgeCase(string Position, long TickOffset, bool InMemoryMisfires, bool AdoMisfires)
+    {
+        public override string ToString() => Position;
+    }
+
+    public static IEnumerable<ThresholdEdgeCase> ThresholdEdgeCases()
+    {
+        yield return new ThresholdEdgeCase("one tick before the threshold", -1, InMemoryMisfires: true, AdoMisfires: true);
+        yield return new ThresholdEdgeCase("exactly on the threshold", 0, InMemoryMisfires: true, AdoMisfires: false);
+        yield return new ThresholdEdgeCase("one tick after the threshold", 1, InMemoryMisfires: false, AdoMisfires: false);
+    }
+
+    [TestCaseSource(nameof(ThresholdEdgeCases))]
+    public async Task TheInMemoryStoreCountsTheThresholdInstantItselfAsLate(ThresholdEdgeCase testCase)
+    {
+        await AssertThresholdEdge(await InMemoryStore(Anchor()), testCase, testCase.InMemoryMisfires,
+            "RAMJobStore misfires a trigger whose fire time is at or before now - MisfireThreshold: "
+            + "ApplyMisfireNoLock returns early only when the fire time is strictly greater");
+    }
+
+    [TestCaseSource(nameof(ThresholdEdgeCases))]
+    public async Task TheAdoStoreLeavesTheThresholdInstantItselfAlone(ThresholdEdgeCase testCase)
+    {
+        await AssertThresholdEdge(await SqliteStore(Anchor()), testCase, testCase.AdoMisfires,
+            "the recovery SELECT asks for NEXT_FIRE_TIME < now - MisfireThreshold, so the threshold "
+            + "instant itself is strictly excluded");
+    }
+
+    /// <summary>
+    /// The two stores disagree about the threshold instant itself, which is a finding rather than
+    /// something for this test to paper over: the in-memory store's comparison is <c>&lt;=</c> and the
+    /// ADO store's recovery SELECT is <c>&lt;</c>, so a trigger due at exactly
+    /// <c>now - MisfireThreshold</c> misfires on one store and not on the other.
+    /// </summary>
+    /// <remarks>
+    /// Reported rather than asserted, per the rule that a matrix says what 4.0 does and does not change
+    /// it. Note that the ADO store is not even internally consistent about it: its single-trigger path,
+    /// <c>UpdateMisfiredTrigger</c> — which is what a resumed trigger goes through — uses the in-memory
+    /// store's <c>&lt;=</c>.
+    /// </remarks>
+    [Test]
+    public void BothStoresAgreeOnTheThresholdInstant()
+    {
+        ThresholdEdgeCase edge = ThresholdEdgeCases().Single(x => x.TickOffset == 0);
+
+        if (edge.InMemoryMisfires != edge.AdoMisfires)
+        {
+            Assert.Inconclusive(
+                "A trigger due at exactly now - MisfireThreshold is treated differently by the two stores. "
+                + $"Observed: RAMJobStore misfires it ({edge.InMemoryMisfires}), the ADO store does not "
+                + $"({edge.AdoMisfires}). Expected: the same answer from both. RAMJobStore's "
+                + "ApplyMisfireNoLock declines only when NextFireTimeUtc > now - MisfireThreshold, so its "
+                + "comparison is <=; StdAdoConstants.SqlSelectMisfiredTriggersToRecover asks for "
+                + "NEXT_FIRE_TIME < @nextFireTime, so the ADO sweep's is <. AdoJobStoreBase.UpdateMisfiredTrigger, "
+                + "the ADO store's own single-trigger path, uses <= like the in-memory store, so the ADO "
+                + "store also disagrees with itself.");
+        }
+
+        edge.AdoMisfires.Should().Be(edge.InMemoryMisfires,
+            "a trigger due at exactly now - MisfireThreshold has to mean the same thing to both stores");
+    }
+
+    /// <summary>
+    /// Stores a cron trigger due at <c>now - MisfireThreshold + offset</c> on the store's own clock, runs
+    /// one pass, and asserts whether the pass moved it.
+    /// </summary>
+    /// <remarks>
+    /// Both stores arrive at the same <c>now - MisfireThreshold</c> to the tick — the in-memory store
+    /// subtracts <c>MisfireThreshold.Ticks</c> and the ADO store subtracts
+    /// <c>MisfireThreshold.TotalMilliseconds</c>, which are the same instant for a whole number of
+    /// milliseconds — so the only thing left to differ is the comparison.
+    /// </remarks>
+    private async Task AssertThresholdEdge(
+        MisfireStoreUnderTest store,
+        ThresholdEdgeCase testCase,
+        bool shouldMisfire,
+        string because)
+    {
+        DateTimeOffset clockNow = store.Clock.GetUtcNow() + HalfPeriod;
+        DateTimeOffset scheduled = clockNow - Threshold + TimeSpan.FromTicks(testCase.TickOffset);
+
+        TriggerKey triggerKey = new("edge-" + Guid.NewGuid().ToString("N"), Group);
+        JobKey jobKey = new(triggerKey.Name, Group);
+
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity(triggerKey)
+            .ForJob(jobKey)
+            .StartAt(clockNow - TimeSpan.FromDays(2))
+            .WithCronSchedule(DailyCronAt(clockNow + HalfPeriod), x => x
+                .InTimeZone(TimeZoneInfo.Utc)
+                .WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing))
+            .Build();
+
+        await Store(store, Job(jobKey), trigger, scheduled);
+        store.Clock.Advance(HalfPeriod);
+
+        store.Clock.GetUtcNow().Should().Be(clockNow,
+            "the whole case is a tick either side of now - MisfireThreshold, so 'now' has to be the instant the case was built from");
+
+        await store.Sweep(scheduled - TimeSpan.FromTicks(1));
+
+        IOperableTrigger readBack = await store.Store.GetTrigger(triggerKey);
+
+        if (shouldMisfire)
+        {
+            readBack.NextFireTimeUtc.Should().NotBe(scheduled,
+                "{0} treats a trigger due {1} as misfired, because {2}", store.Name, testCase.Position, because);
+        }
+        else
+        {
+            readBack.NextFireTimeUtc.Should().Be(scheduled,
+                "{0} treats a trigger due {1} as still on time, because {2}", store.Name, testCase.Position, because);
+        }
+    }
+
+    private static string DailyCronAt(DateTimeOffset when)
+    {
+        DateTime utc = when.UtcDateTime;
+        return string.Create(CultureInfo.InvariantCulture, $"{utc.Second} {utc.Minute} {utc.Hour} * * ?");
+    }
+
+    #endregion
+
+    private static IOperableTrigger Build(MisfireMatrixCase testCase, DateTimeOffset anchor, TriggerKey triggerKey, JobKey jobKey)
+    {
+        return (IOperableTrigger) testCase.Trigger(anchor)
+            .WithIdentity(triggerKey)
+            .ForJob(jobKey)
+            .Build();
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/MisfireThroughAStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireThroughAStoreTestBase.cs
@@ -1,0 +1,369 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Data.Sqlite;
+
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Tests.Integration.Impl;
+
+/// <summary>
+/// The scaffolding behind the misfire matrix: an in-memory store and a real SQLite one, each on a
+/// clock the test moves, each driven through exactly one misfire pass by hand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pattern is #3303's: initialize the store and never call <c>SchedulerStarted()</c>, so the ADO
+/// store's <c>MisfireHandler</c> loop is never spawned and cannot recover a trigger out from under
+/// the assertions. The clock is a <see cref="FakeTimeProvider" /> so that "past the misfire
+/// threshold" is an assignment rather than a wait.
+/// </para>
+/// <para>
+/// <b>Triggers keep the system clock, whichever store holds them.</b> Every schedule builder news up
+/// its trigger with <see cref="TimeProvider.System" /> — <c>TriggerBuilder.Create(clock)</c> hands its
+/// clock to the schedule builder, not to the trigger — and the ADO store rebuilds a trigger it reads
+/// through <c>TriggerBuilder.Create()</c>, which has no clock to hand it in the first place. So a fake
+/// clock decides only <em>whether</em> a store treats a trigger as misfired; <em>what</em>
+/// <c>UpdateAfterMisfire</c> then computes is on real time in both stores. That is why every schedule
+/// here is anchored half a period out (twelve hours either side of <c>anchor</c>): a "reschedule to the
+/// next slot" instant is then the same value however many milliseconds pass between the detached
+/// computation and the store's own, and a "fire now" instant is asserted to fall inside the pass.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public abstract class MisfireThroughAStoreTestBase
+{
+    /// <summary>The group every job and trigger in these fixtures lives in.</summary>
+    protected const string Group = "misfire-through-a-store";
+
+    /// <summary>
+    /// The threshold both stores are configured with. Generous next to the twelve hours a matrix
+    /// trigger is late by, and small enough that the threshold-edge cases are legible.
+    /// </summary>
+    public static readonly TimeSpan Threshold = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Half of every schedule's period. A matrix trigger's missed firing sits this far before
+    /// <c>anchor</c> and its next slot this far after, so neither is near a schedule boundary.
+    /// </summary>
+    public static readonly TimeSpan HalfPeriod = TimeSpan.FromHours(12);
+
+    private const string TablePrefix = "QRTZ_";
+    private const string DataSourceName = "misfire-through-a-store-sqlite";
+
+    private string databaseFileName;
+    private IDbProvider dbProvider;
+    private readonly List<MisfireStoreUnderTest> stores = [];
+    private int storeCounter;
+
+    [OneTimeSetUp]
+    public async Task CreateDatabase()
+    {
+        databaseFileName = $"test-misfire-store-{Guid.NewGuid():N}.db";
+
+        await using (SqliteConnection connection = new($"Data Source={databaseFileName};"))
+        {
+            await connection.OpenAsync();
+            await using SqliteCommand command = new(LoadSqliteTableScript(), connection);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        dbProvider = new DbProvider("SQLite-Microsoft", $"Data Source={databaseFileName};");
+    }
+
+    [OneTimeTearDown]
+    public void DropDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(databaseFileName))
+        {
+            try
+            {
+                File.Delete(databaseFileName);
+            }
+            catch (IOException)
+            {
+                // the file is only test scratch space, leaving it behind is not worth failing over
+            }
+        }
+    }
+
+    [TearDown]
+    public async Task ShutDownStores()
+    {
+        foreach (MisfireStoreUnderTest store in stores)
+        {
+            await store.Store.Shutdown();
+        }
+
+        stores.Clear();
+    }
+
+    /// <summary>
+    /// The instant every schedule in a test is anchored on, and the value the store clocks reach once
+    /// the test has moved them. Real time, because that is the clock the triggers themselves read.
+    /// </summary>
+    protected static DateTimeOffset Anchor() => TimeProvider.System.GetUtcNow();
+
+    /// <summary>
+    /// Both stores, in the order they are reported in: the in-memory one first, because a failure
+    /// there is a failure of the simpler of the two.
+    /// </summary>
+    protected async ValueTask<MisfireStoreUnderTest[]> BothStores(DateTimeOffset anchor)
+    {
+        return [await InMemoryStore(anchor), await SqliteStore(anchor)];
+    }
+
+    /// <summary>
+    /// An in-memory store whose clock starts at <paramref name="anchor" /> less half a period — which
+    /// is where a matrix trigger's missed firing sits, so nothing is late until the test says so.
+    /// </summary>
+    protected async ValueTask<MisfireStoreUnderTest> InMemoryStore(DateTimeOffset anchor)
+    {
+        FakeTimeProvider clock = new(anchor - HalfPeriod);
+        RAMJobStore store = TestJobStores.Ram(timeProvider: clock);
+        store.MisfireThreshold = Threshold;
+
+        await store.Initialize(TestJobStores.Identity(instanceId: NextInstanceId()));
+
+        return Track(new InMemoryMisfireStore(store, clock));
+    }
+
+    /// <summary>
+    /// A SQLite-backed ADO store over the fixture's own database file, cleared so that each test sees
+    /// only its own rows.
+    /// </summary>
+    protected async ValueTask<MisfireStoreUnderTest> SqliteStore(DateTimeOffset anchor)
+    {
+        FakeTimeProvider clock = new(anchor - HalfPeriod);
+        string instanceId = NextInstanceId();
+
+        LocalTransactionJobStore store = new(
+            TestJobStores.Signaler(),
+            TestJobStores.TypeLoader(),
+            clock,
+            TestJobStores.SchedulerOptions(instanceName: "MisfireThroughAStoreTest", instanceId: instanceId),
+            TestJobStores.StoreOptions(DataSourceName, TablePrefix, options =>
+            {
+                options.MisfireThreshold = Threshold;
+            }),
+            TestJobStores.ClusteringOptions(),
+            TestJobStores.Serializer(),
+            dbProvider,
+            new SQLiteDelegate(),
+            TestJobStores.LockHandler());
+
+        // Initialized but deliberately not started: SchedulerStarted() spawns the MisfireHandler loop,
+        // which would sweep on its own thread and race every assertion below.
+        await store.Initialize(TestJobStores.Identity(instanceName: "MisfireThroughAStoreTest", instanceId: instanceId));
+        await store.Clear();
+
+        return Track(new SqliteMisfireStore(store, clock));
+    }
+
+    private MisfireStoreUnderTest Track(MisfireStoreUnderTest store)
+    {
+        stores.Add(store);
+        return store;
+    }
+
+    /// <summary>
+    /// A fresh instance id per store, so two stores in one test are two nodes rather than one node
+    /// talking to itself.
+    /// </summary>
+    private string NextInstanceId() => "node-" + (++storeCounter);
+
+    /// <summary>
+    /// Stores a job and its trigger with the trigger's next fire time pinned half a period in the past.
+    /// </summary>
+    /// <remarks>
+    /// Writing the fire time back by hand is the whole trick: <c>ComputeFirstFireTimeUtc</c> advances a
+    /// past-due schedule to its next future slot, so a trigger built with a past start time is not
+    /// overdue by the time it reaches a store. A trigger nobody got around to firing looks like this.
+    /// </remarks>
+    protected static async ValueTask<IOperableTrigger> Store(
+        MisfireStoreUnderTest store,
+        IJobDetail job,
+        IOperableTrigger trigger,
+        DateTimeOffset scheduledFireTimeUtc,
+        ICalendar calendar = null)
+    {
+        trigger.ComputeFirstFireTimeUtc(calendar);
+        trigger.NextFireTimeUtc = scheduledFireTimeUtc;
+
+        await store.Store.ScheduleJob(job, trigger);
+        return trigger;
+    }
+
+    /// <summary>
+    /// Stores a second trigger for a job that is already there, with its next fire time pinned the same
+    /// way <see cref="Store" /> pins the first one's.
+    /// </summary>
+    protected static async ValueTask<IOperableTrigger> StoreTrigger(
+        MisfireStoreUnderTest store,
+        IOperableTrigger trigger,
+        DateTimeOffset scheduledFireTimeUtc,
+        ICalendar calendar = null)
+    {
+        trigger.ComputeFirstFireTimeUtc(calendar);
+        trigger.NextFireTimeUtc = scheduledFireTimeUtc;
+
+        await store.Store.AddTrigger(trigger, replace: false);
+        return trigger;
+    }
+
+    /// <summary>
+    /// The job the matrix's triggers point at. It never runs: these tests drive the store, not the
+    /// scheduler.
+    /// </summary>
+    protected static IJobDetail Job(JobKey jobKey) => JobBuilder.Create<MisfireTestJob>().WithIdentity(jobKey).Build();
+
+    private static string LoadSqliteTableScript()
+    {
+        string path = File.Exists("../../../../database/tables/tables_sqlite.sql")
+            ? "../../../../database/tables/tables_sqlite.sql"
+            : "../../../../../database/tables/tables_sqlite.sql";
+
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>A job that does nothing, because nothing here ever fires one.</summary>
+    public sealed class MisfireTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// A job that forbids concurrent execution, for the blocked-trigger cases.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class NonConcurrentMisfireTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+}
+
+/// <summary>
+/// One store under test, its clock, and the single operation that makes it apply a trigger's misfire
+/// policy.
+/// </summary>
+public abstract class MisfireStoreUnderTest
+{
+    protected MisfireStoreUnderTest(FakeTimeProvider clock)
+    {
+        Clock = clock;
+    }
+
+    /// <summary>The store's name, as it reads in a failure message.</summary>
+    public abstract string Name { get; }
+
+    /// <summary>The store itself.</summary>
+    public abstract IJobStore Store { get; }
+
+    /// <summary>The clock the store reads. The test moves it; nothing waits on it.</summary>
+    public FakeTimeProvider Clock { get; }
+
+    /// <summary>
+    /// Runs exactly one misfire pass.
+    /// </summary>
+    /// <param name="noLaterThan">
+    /// Only the in-memory store reads this; see <see cref="InMemoryMisfireStore.Sweep" />.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    public abstract ValueTask Sweep(DateTimeOffset noLaterThan, CancellationToken cancellationToken = default);
+
+    public override string ToString() => Name;
+}
+
+/// <summary>
+/// The in-memory store. It has no misfire sweep of its own — <c>RAMJobStore.ApplyMisfireNoLock</c> is
+/// reached from exactly two places, <c>AcquireNextTriggers</c> and <c>ResumeTrigger</c> — so
+/// acquisition <em>is</em> the pass.
+/// </summary>
+public sealed class InMemoryMisfireStore : MisfireStoreUnderTest
+{
+    private readonly RAMJobStore store;
+
+    internal InMemoryMisfireStore(RAMJobStore store, FakeTimeProvider clock) : base(clock)
+    {
+        this.store = store;
+    }
+
+    public override string Name => "RAMJobStore";
+
+    public override IJobStore Store => store;
+
+    /// <summary>
+    /// Asks for triggers due no later than <paramref name="noLaterThan" />, which the caller sets
+    /// <em>before</em> the misfired trigger's own fire time. Acquisition applies the misfire policy
+    /// before it decides whether the trigger is in the batch, so a window that excludes the trigger
+    /// still runs the policy and then leaves the trigger alone — the state that comes out is the
+    /// misfire's doing and nothing else's.
+    /// </summary>
+    public override async ValueTask Sweep(DateTimeOffset noLaterThan, CancellationToken cancellationToken = default)
+    {
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(
+            new TriggerAcquisitionRequest { NoLaterThan = noLaterThan, MaxCount = 1 },
+            cancellationToken);
+
+        acquired.Should().BeEmpty(
+            "the acquisition window is set before the misfired trigger's own fire time, so the pass must "
+            + "apply the misfire policy without also acquiring the trigger and clouding its state");
+    }
+}
+
+/// <summary>
+/// The ADO store over SQLite. Its pass is the misfire handler's own, called by hand.
+/// </summary>
+public sealed class SqliteMisfireStore : MisfireStoreUnderTest
+{
+    private readonly LocalTransactionJobStore store;
+
+    internal SqliteMisfireStore(LocalTransactionJobStore store, FakeTimeProvider clock) : base(clock)
+    {
+        this.store = store;
+    }
+
+    public override string Name => "SQLite ADO store";
+
+    public override IJobStore Store => store;
+
+    public override async ValueTask Sweep(DateTimeOffset noLaterThan, CancellationToken cancellationToken = default)
+    {
+        await store.DoRecoverMisfires(Guid.NewGuid(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Tells the store the scheduler is running, without starting it.
+    /// </summary>
+    /// <remarks>
+    /// <c>AdoJobStoreBase.ResumeTrigger</c> applies a resumed trigger's misfire policy only when
+    /// <c>schedulerRunning</c> is set, and the only two things that set it are <c>SchedulerStarted</c>
+    /// — which also spawns the misfire handler loop these tests exist to keep out — and
+    /// <c>SchedulerResumed</c>, which sets the flag and nothing else. The in-memory store has no such
+    /// condition, so without this the two stores would differ for a reason that belongs to the test
+    /// rather than to either store.
+    /// </remarks>
+    public ValueTask MarkSchedulerRunning() => store.SchedulerResumed();
+}

--- a/src/Quartz.Tests.Integration/Impl/MisfireWhilePausedOrBlockedTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireWhilePausedOrBlockedTest.cs
@@ -1,0 +1,294 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Integration.Impl;
+
+/// <summary>
+/// A trigger that is not eligible to fire cannot misfire either. Pausing one, and blocking one behind a
+/// job that forbids concurrent execution, are the two ways that happens — and both end with the debt
+/// being settled later rather than forgiven.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBase
+{
+    /// <summary>
+    /// One "fire now" instruction and one "reschedule to the next slot" instruction, since resuming a
+    /// paused trigger is where the difference between them is most visible: one owes an immediate
+    /// firing and the other has written the missed one off.
+    /// </summary>
+    public static IEnumerable<MisfireMatrixCase> Cases()
+    {
+        yield return MisfireMatrixCases.Cell(MisfireTriggerShape.Cron, nameof(CronTriggerMisfireInstruction.FireAndProceed));
+        yield return MisfireMatrixCases.Cell(MisfireTriggerShape.Cron, nameof(CronTriggerMisfireInstruction.DoNothing));
+        yield return MisfireMatrixCases.Cell(MisfireTriggerShape.SimpleOneShot, nameof(SimpleTriggerMisfireInstruction.FireNow));
+    }
+
+    /// <summary>
+    /// A paused trigger accrues no misfire, however far past its fire time the clock goes: a pause is a
+    /// decision not to fire, so there is nothing to be late for. Resuming it is what settles the debt,
+    /// and it settles it through the trigger's own misfire policy rather than by firing whatever was
+    /// missed.
+    /// </summary>
+    [TestCaseSource(nameof(Cases))]
+    public async Task APausedTriggerMisfiresOnResumeAndNotBefore(MisfireMatrixCase testCase)
+    {
+        DateTimeOffset anchor = Anchor();
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        foreach (MisfireStoreUnderTest store in await BothStores(anchor))
+        {
+            TriggerKey triggerKey = new("paused-" + Guid.NewGuid().ToString("N"), Group);
+            JobKey jobKey = new(triggerKey.Name, Group);
+
+            IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor)
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .Build();
+
+            await Store(store, Job(jobKey), trigger, scheduled);
+
+            (await store.Store.PauseTrigger(triggerKey)).Should().BeTrue(
+                "{0} has to actually pause '{1}', or the rest of this test is about a waiting trigger", store.Name, testCase);
+
+            store.Clock.Advance(HalfPeriod);
+
+            await store.Sweep(scheduled - TimeSpan.FromTicks(1));
+
+            (await store.Store.GetTriggerState(triggerKey)).Should().Be(TriggerState.Paused,
+                "{0} must leave '{1}' paused: a misfire pass that resumed a trigger would start it firing "
+                + "behind the operator's back", store.Name, testCase);
+            (await store.Store.GetTrigger(triggerKey)).NextFireTimeUtc.Should().Be(scheduled,
+                "{0} must leave a paused '{1}' on the fire time it was paused with, so that resuming it has "
+                + "the missed firing to apply a policy to", store.Name, testCase);
+
+            // The ADO store applies a resumed trigger's misfire policy only while it believes the
+            // scheduler is running; the in-memory store has no such condition. See MarkSchedulerRunning.
+            if (store is SqliteMisfireStore ado)
+            {
+                await ado.MarkSchedulerRunning();
+            }
+
+            IOperableTrigger detached = (IOperableTrigger) testCase.Trigger(anchor)
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .Build();
+            detached.ComputeFirstFireTimeUtc(null);
+            detached.NextFireTimeUtc = scheduled;
+
+            DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
+            MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null);
+
+            (await store.Store.ResumeTrigger(triggerKey)).Should().BeTrue(
+                "{0} has to report that it resumed '{1}'", store.Name, testCase);
+
+            DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
+
+            TriggerState state = await store.Store.GetTriggerState(triggerKey);
+            IOperableTrigger readBack = await store.Store.GetTrigger(triggerKey);
+
+            expected.AssertAgainst(store.Name, testCase + " on resume", state, readBack.NextFireTimeUtc, passStarted, passFinished);
+        }
+    }
+
+    #region Blocked behind a job that forbids concurrent execution
+
+    /// <summary>The trigger shape and instruction the blocked cases use.</summary>
+    private static MisfireMatrixCase BlockedCase =>
+        MisfireMatrixCases.Cell(MisfireTriggerShape.Cron, nameof(CronTriggerMisfireInstruction.DoNothing));
+
+    /// <summary>
+    /// The in-memory store's half of the blocked case. A trigger blocked behind a running execution of a
+    /// <see cref="DisallowConcurrentExecutionAttribute" /> job is out of the acquisition set entirely, so
+    /// no pass can reach it however late it gets. Completing the execution puts it back with the missed
+    /// fire time still on it, and the next acquisition is what applies its policy.
+    /// </summary>
+    /// <remarks>
+    /// <c>RAMJobStore.TriggeredJobComplete</c> moves a blocked trigger to <c>Waiting</c> and adds it back
+    /// to <c>timeTriggers</c>, and does nothing else — <c>ApplyMisfireNoLock</c> is reached from
+    /// acquisition and from resume, and the unblocking path is neither. So the debt is settled by the
+    /// very next acquisition, which is also the first thing that could have fired the trigger.
+    /// </remarks>
+    [Test]
+    public async Task TheInMemoryStoreLeavesAnUnblockedTriggersMisfireToTheNextAcquisition()
+    {
+        DateTimeOffset anchor = Anchor();
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        MisfireStoreUnderTest store = await InMemoryStore(anchor);
+        BlockedTrigger blocked = await GivenATriggerBlockedPastItsThreshold(store, anchor);
+
+        await store.Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
+
+        (await store.Store.GetTriggerState(blocked.Key)).Should().Be(TriggerState.Normal,
+            "completing the execution is what lets the blocked siblings go");
+        (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc.Should().Be(scheduled,
+            "RAMJobStore's unblocking returns the trigger to the acquisition set and nothing more, so the "
+            + "missed firing is still on the books at this point");
+
+        IOperableTrigger detached = Detached(anchor, blocked.Key, blocked.Job.Key, scheduled);
+
+        DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
+        MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null);
+
+        await store.Sweep(scheduled - TimeSpan.FromTicks(1));
+        DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
+
+        expected.AssertAgainst(
+            store.Name,
+            BlockedCase + " unblocked",
+            await store.Store.GetTriggerState(blocked.Key),
+            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc,
+            passStarted,
+            passFinished);
+    }
+
+    /// <summary>
+    /// The ADO store's half, which settles the debt a step earlier: <c>TriggeredJobComplete</c> unblocks
+    /// the job's triggers and then calls <c>RecoverUnblockedMisfires</c>, so the policy has already run
+    /// by the time the caller can look.
+    /// </summary>
+    [Test]
+    public async Task TheAdoStoreAppliesAnUnblockedTriggersMisfireAsItUnblocksIt()
+    {
+        DateTimeOffset anchor = Anchor();
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        MisfireStoreUnderTest store = await SqliteStore(anchor);
+        BlockedTrigger blocked = await GivenATriggerBlockedPastItsThreshold(store, anchor);
+
+        IOperableTrigger detached = Detached(anchor, blocked.Key, blocked.Job.Key, scheduled);
+
+        DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
+        MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null);
+
+        await store.Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
+        DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
+
+        expected.AssertAgainst(
+            store.Name,
+            BlockedCase + " unblocked",
+            await store.Store.GetTriggerState(blocked.Key),
+            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc,
+            passStarted,
+            passFinished);
+    }
+
+    /// <summary>
+    /// The two stores settle an unblocked trigger's misfire at different moments, which is a finding
+    /// rather than something for these tests to smooth over.
+    /// </summary>
+    /// <remarks>
+    /// Reported rather than asserted, per the rule that a matrix says what 4.0 does and does not change
+    /// it. The window between the two is real but narrow — the in-memory store's next acquisition — and
+    /// a caller that reads the trigger inside it sees a fire time in the past on one store and a
+    /// recomputed one on the other.
+    /// </remarks>
+    [Test]
+    public void BothStoresAgreeOnWhenAnUnblockedTriggerMisfires()
+    {
+        Assert.Inconclusive(
+            "The two stores apply an unblocked trigger's misfire policy at different moments. "
+            + "Observed: AdoJobStoreBase.TriggeredJobComplete unblocks the job's triggers and then calls "
+            + "RecoverUnblockedMisfires, so the policy has run by the time TriggeredJobComplete returns; "
+            + "RAMJobStore.TriggeredJobComplete only moves the trigger from Blocked to Waiting and adds it "
+            + "back to timeTriggers, leaving the policy to the next AcquireNextTriggers. Expected: the same "
+            + "moment on both, since a caller reading the trigger between the two gets a different answer "
+            + "depending on which store it is talking to. The two tests above pin each store's actual "
+            + "behaviour, so this reports the gap rather than asserting it away.");
+    }
+
+    /// <summary>
+    /// Gets a store into the state the blocked cases are about: one trigger of a
+    /// <see cref="DisallowConcurrentExecutionAttribute" /> job firing, a second trigger of the same job
+    /// blocked behind it, the clock moved past the threshold, and one misfire pass already run to show
+    /// that it could not reach the blocked trigger.
+    /// </summary>
+    private async Task<BlockedTrigger> GivenATriggerBlockedPastItsThreshold(MisfireStoreUnderTest store, DateTimeOffset anchor)
+    {
+        DateTimeOffset scheduled = anchor - HalfPeriod;
+
+        JobKey jobKey = new("blocking-" + Guid.NewGuid().ToString("N"), Group);
+        IJobDetail job = JobBuilder.Create<NonConcurrentMisfireTestJob>().WithIdentity(jobKey).Build();
+
+        // Due exactly on the store's clock, so the trigger that does the blocking is not itself late.
+        IOperableTrigger running = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("running-" + jobKey.Name, Group)
+            .ForJob(jobKey)
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromDays(1)).RepeatForever())
+            .Build();
+
+        await Store(store, job, running, scheduled);
+
+        List<IOperableTrigger> acquired = await store.Store.AcquireNextTriggers(
+            new TriggerAcquisitionRequest { NoLaterThan = scheduled, MaxCount = 1 });
+
+        acquired.Should().ContainSingle(
+            "{0} has to hand over the trigger that does the blocking before it can fire", store.Name);
+
+        // Stored after the acquisition, so it is the fan-out in TriggersFired that blocks it rather than
+        // the store having found the job already blocked when the trigger was added.
+        TriggerKey blockedKey = new("blocked-" + jobKey.Name, Group);
+        IOperableTrigger blocked = (IOperableTrigger) BlockedCase.Trigger(anchor)
+            .WithIdentity(blockedKey)
+            .ForJob(jobKey)
+            .Build();
+
+        await StoreTrigger(store, blocked, scheduled);
+
+        List<TriggerFiredResult> fired = await store.Store.TriggersFired(acquired);
+
+        fired.Should().ContainSingle().Which.TriggerFiredBundle.Should().NotBeNull(
+            "the blocking execution has to actually start on {0}, or nothing is blocked", store.Name);
+
+        (await store.Store.GetTriggerState(blockedKey)).Should().Be(TriggerState.Blocked,
+            "firing one trigger of a job that forbids concurrent execution blocks the rest of them");
+
+        store.Clock.Advance(HalfPeriod);
+
+        await store.Sweep(scheduled - TimeSpan.FromTicks(1));
+
+        (await store.Store.GetTriggerState(blockedKey)).Should().Be(TriggerState.Blocked,
+            "{0} does not sweep a blocked trigger: a misfire pass looks at what is waiting", store.Name);
+        (await store.Store.GetTrigger(blockedKey)).NextFireTimeUtc.Should().Be(scheduled,
+            "the missed firing is still owed while the trigger is blocked");
+
+        return new BlockedTrigger(blockedKey, job, acquired[0]);
+    }
+
+    private static IOperableTrigger Detached(DateTimeOffset anchor, TriggerKey triggerKey, JobKey jobKey, DateTimeOffset scheduled)
+    {
+        IOperableTrigger detached = (IOperableTrigger) BlockedCase.Trigger(anchor)
+            .WithIdentity(triggerKey)
+            .ForJob(jobKey)
+            .Build();
+
+        detached.ComputeFirstFireTimeUtc(null);
+        detached.NextFireTimeUtc = scheduled;
+
+        return detached;
+    }
+
+    /// <summary>The blocked trigger, the job blocking it, and the firing that has to complete to let go.</summary>
+    private sealed record BlockedTrigger(TriggerKey Key, IJobDetail Job, IOperableTrigger Firing);
+
+    #endregion
+}

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="MELT" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Data.SQLite" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="NUnit" />

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MisfireHandlerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MisfireHandlerTest.cs
@@ -145,6 +145,53 @@ public class MisfireHandlerTest
         timeToSleep.Should().Be(TimeSpan.FromSeconds(15));
     }
 
+    /// <summary>
+    /// The cadence the loop sleeps at is the configured one, and an unconfigured one falls back to the
+    /// misfire threshold — a store that scans less often than it counts a trigger late would leave a
+    /// misfire sitting for the difference.
+    /// </summary>
+    /// <remarks>
+    /// Asserted through <see cref="MisfireHandler.ComputeTimeToSleep" /> rather than by starting the
+    /// loop and watching it: the loop's only use of the frequency is the value it passes here, so this
+    /// is the whole of the cadence, and it costs no thread and no wall time to say so.
+    /// </remarks>
+    [Test]
+    public void MisfireHandlerFrequency_IsWhatTheLoopSleepsFor_WhenConfigured()
+    {
+        TimeSpan configured = TimeSpan.FromSeconds(20);
+        TestAdoJobStoreBase jobStore = new(misfireHandlerFrequency: configured, misfireThreshold: TimeSpan.FromMinutes(5));
+
+        jobStore.MisfireHandlerFrequency.Should().Be(configured,
+            "a configured cadence is the one the store reports, whatever its misfire threshold says");
+
+        MisfireHandler.ComputeTimeToSleep(
+            hasMoreMisfiredTriggers: false,
+            misfireHandlerFrequency: jobStore.MisfireHandlerFrequency,
+            elapsed: TimeSpan.Zero,
+            dbRetryInterval: jobStore.DbRetryInterval,
+            numFails: 0).Should().Be(configured,
+            "a scan that took no time is followed by a full cycle of sleep");
+    }
+
+    [Test]
+    public void MisfireHandlerFrequency_FallsBackToTheMisfireThreshold_WhenNotConfigured()
+    {
+        TimeSpan threshold = TimeSpan.FromSeconds(45);
+        TestAdoJobStoreBase jobStore = new(misfireHandlerFrequency: null, misfireThreshold: threshold);
+
+        jobStore.MisfireHandlerFrequency.Should().Be(threshold,
+            "with no cadence configured the store scans as often as it declares a trigger late, so that a "
+            + "misfire is never left waiting longer than it took to become one");
+
+        MisfireHandler.ComputeTimeToSleep(
+            hasMoreMisfiredTriggers: false,
+            misfireHandlerFrequency: jobStore.MisfireHandlerFrequency,
+            elapsed: TimeSpan.Zero,
+            dbRetryInterval: jobStore.DbRetryInterval,
+            numFails: 0).Should().Be(threshold,
+            "the fallback is the cadence, so it is also what the loop sleeps for");
+    }
+
     [Test]
     public async Task QueuedTaskScheduler_ShouldNotDeadlock_WhenDisposedBeforeTaskStarts()
     {
@@ -169,10 +216,25 @@ public class MisfireHandlerTest
 
     private sealed class TestAdoJobStoreBase : AdoJobStoreBase
     {
-        public TestAdoJobStoreBase()
-        // A short misfire handler frequency so that if the Run loop starts, it quickly checks the
-        // cancellation token and exits, letting shutdown tests complete faster.
-        : base(TestJobStores.Signaler(), TestJobStores.TypeLoader(), TimeProvider.System, TestJobStores.SchedulerOptions("TestInstance", "TestInstanceId"), TestJobStores.StoreOptions(configure: options => options.MisfireHandlerFrequency = TimeSpan.FromMilliseconds(100)), TestJobStores.ClusteringOptions(), TestJobStores.Serializer(), TestJobStores.DbProvider(), TestJobStores.DriverDelegate(), TestJobStores.LockHandler())
+        /// <summary>
+        /// A store with a short misfire handler frequency, so that if the Run loop starts it quickly
+        /// checks the cancellation token and exits, letting the shutdown tests complete faster.
+        /// </summary>
+        public TestAdoJobStoreBase() : this(TimeSpan.FromMilliseconds(100), TimeSpan.FromMinutes(1))
+        {
+        }
+
+        /// <param name="misfireHandlerFrequency">
+        /// The configured cadence, or <see langword="null" /> to leave it unset so that the fallback is
+        /// what answers for it.
+        /// </param>
+        /// <param name="misfireThreshold">The configured misfire threshold.</param>
+        public TestAdoJobStoreBase(TimeSpan? misfireHandlerFrequency, TimeSpan misfireThreshold)
+        : base(TestJobStores.Signaler(), TestJobStores.TypeLoader(), TimeProvider.System, TestJobStores.SchedulerOptions("TestInstance", "TestInstanceId"), TestJobStores.StoreOptions(configure: options =>
+        {
+            options.MisfireHandlerFrequency = misfireHandlerFrequency;
+            options.MisfireThreshold = misfireThreshold;
+        }), TestJobStores.ClusteringOptions(), TestJobStores.Serializer(), TestJobStores.DbProvider(), TestJobStores.DriverDelegate(), TestJobStores.LockHandler())
         {
         }
 


### PR DESCRIPTION
`MisfireInstructionFamilyCases` is a matrix over the *rejection message* an instruction phrased in the
wrong family's vocabulary earns. Nothing walked a trigger past its threshold, ran a sweep, and asserted
where it ended up — so what "fire now", "reschedule now with the existing count", "reschedule to the
next slot with the remaining count" and "do nothing" actually *do* was pinned nowhere, on either store.

Test-only. No product code changed.

## How a cell works

Six trigger shapes across the five families × every misfire instruction of each family × two stores
(`RAMJobStore`, and a real SQLite ADO store over `database/tables/tables_sqlite.sql`).

A cell stores its trigger with `NextFireTimeUtc` written back half a day into the past (because
`ComputeFirstFireTimeUtc` advances a past-due schedule to its next future slot, so a past start time is
not enough), moves the store's `FakeTimeProvider` past the threshold, runs **exactly one** misfire pass,
and asserts the stored state and the next fire time read back through `GetTrigger` against what a
**detached copy of the same trigger** produced from `UpdateAfterMisfire(calendar)` plus the store's state
rule (no fire time left → `Complete`, otherwise `Normal`). Both stores are asserted against **one**
expectation object — that is the parity assertion.

The pass is per store, and the tests say which:

- **ADO** — `RecoverMisfiredJobs`, driven by hand through `DoRecoverMisfires`.
- **RAM** — `AcquireNextTriggers`. `RAMJobStore` has no sweep: `ApplyMisfireNoLock` is reached from
  exactly two places, acquisition and `ResumeTrigger`. The acquisition window is set *before* the
  misfired trigger's own fire time, so the pass applies the policy and then declines to acquire, leaving
  the resulting state to the misfire alone.

Neither store is started, per #3303, so no `MisfireHandler` loop exists to race the assertions. Nothing
is wall-clock: no `Thread.Sleep`, no `Task.Delay`, no polling.

One thing worth knowing for anyone extending this: **a trigger keeps `TimeProvider.System` whichever
store holds it.** `TriggerBuilder.Create(clock)` hands its clock to the *schedule builder*, not to the
trigger, and the ADO store rebuilds a trigger it reads through `TriggerBuilder.Create()` with no clock at
all. So a fake clock decides only *whether* a store treats a trigger as late; what `UpdateAfterMisfire`
then computes is on real time in both stores. Every schedule here therefore has a one-day period anchored
half a period out, which makes a "next slot" instant exact regardless of the milliseconds between the
detached computation and the store's own; a "fire now" instant is asserted to fall inside the pass, which
is tighter than a tolerance.

## The matrix

`anchor` is the instant the test froze; the missed firing sits at `anchor − 12h` and the next slot at
`anchor + 12h`. Both stores agree with the expectation in every cell below.

| Trigger shape | Instruction | Outcome |
|---|---|---|
| SimpleTrigger repeating daily | SmartPolicy | fires at `anchor + 12h` (resolves to `RescheduleNextWithRemainingCount`) |
| SimpleTrigger repeating daily | IgnoreMisfires | untouched — still `anchor − 12h`, still `Normal` |
| SimpleTrigger repeating daily | FireNow | fires now (rewritten to `RescheduleNowWithRemainingRepeatCount`) |
| SimpleTrigger repeating daily | NowWithExistingCount | fires now |
| SimpleTrigger repeating daily | NowWithRemainingCount | fires now |
| SimpleTrigger repeating daily | NextWithRemainingCount | fires at `anchor + 12h` |
| SimpleTrigger repeating daily | NextWithExistingCount | fires at `anchor + 12h` |
| SimpleTrigger one-shot | SmartPolicy | fires now (resolves to `FireNow`) |
| SimpleTrigger one-shot | IgnoreMisfires | untouched |
| SimpleTrigger one-shot | FireNow | fires now |
| SimpleTrigger one-shot | NowWithExistingCount | fires now |
| SimpleTrigger one-shot | NowWithRemainingCount | fires now |
| SimpleTrigger one-shot | NextWithRemainingCount | **complete** — no slot left to skip to |
| SimpleTrigger one-shot | NextWithExistingCount | **complete** |
| CronTrigger firing once a day | SmartPolicy | fires now |
| CronTrigger firing once a day | IgnoreMisfires | untouched |
| CronTrigger firing once a day | FireAndProceed | fires now |
| CronTrigger firing once a day | DoNothing | fires at `anchor + 12h` |
| CalendarIntervalTrigger every day | SmartPolicy | fires now |
| CalendarIntervalTrigger every day | IgnoreMisfires | untouched |
| CalendarIntervalTrigger every day | FireAndProceed | fires now |
| CalendarIntervalTrigger every day | DoNothing | fires at `anchor + 12h` |
| DailyTimeIntervalTrigger, one-instant window | SmartPolicy | fires now |
| DailyTimeIntervalTrigger, one-instant window | IgnoreMisfires | untouched |
| DailyTimeIntervalTrigger, one-instant window | FireAndProceed | fires now |
| DailyTimeIntervalTrigger, one-instant window | DoNothing | fires at `anchor + 12h` |
| RecurrenceTrigger on `FREQ=DAILY` | SmartPolicy | fires now |
| RecurrenceTrigger on `FREQ=DAILY` | IgnoreMisfires | untouched |
| RecurrenceTrigger on `FREQ=DAILY` | FireAndProceed | fires now |
| RecurrenceTrigger on `FREQ=DAILY` | DoNothing | fires at `anchor + 12h` |

`ISimpleTrigger` gets two shapes because a repeating trigger and a one-shot one take different branches
of `SimpleTriggerImpl.UpdateAfterMisfire` for the same instruction.

`EveryInstructionHasACase` finds the `*TriggerMisfireInstruction` enums by reflecting over the shipped
assembly rather than listing them, so a new family — or a new instruction inside an existing one — fails
the guard instead of quietly going untested. `TheMatrixExercisesEveryOutcomeAMisfireCanHave` keeps the
matrix from going vacuous (every cell would still pass if all of them collapsed onto one outcome, since
each is asserted against the trigger's own arithmetic) and writes the table above into the test output.

## Beside the matrix

- **The threshold edge**, to the tick: one tick before, exactly on, one tick after. Both stores compute
  `now − MisfireThreshold` to the same tick (`AddTicks(-Threshold.Ticks)` on one, `AddMilliseconds` on
  the other, identical for a whole number of milliseconds), so only the comparison differs.
- **`MisfireHandlerFrequency`** — the configured cadence is what the loop sleeps for, and an
  unconfigured one falls back to `MisfireThreshold`. Asserted through `MisfireHandler.ComputeTimeToSleep`,
  the loop's only use of the value, rather than by starting a thread.
- **Misfire while paused** — a paused trigger accrues no misfire on a pass on either store (state stays
  `Paused`, fire time unchanged), and `ResumeTrigger` is what settles the debt through the trigger's own
  policy. Covered for `FireAndProceed`, `DoNothing` and a one-shot `FireNow`.
- **Calendar-excluded recomputation**, for every shape whose instruction has a calendar loop to reach: a
  `HolidayCalendar` excluding exactly the day the policy would otherwise land on, with the test first
  asserting that the calendar changes the answer before asserting that both stores arrive at it. The ADO
  store's calendar goes through `QRTZ_CALENDARS` and back, so a lost time zone would fail here.
- **Blocked behind a `[DisallowConcurrentExecution]` job** — a blocked trigger is out of the acquisition
  set entirely, so no pass can reach it however late it gets; both stores are then pinned for what
  completing the execution does.
- **Two nodes sweeping at once** (PostgreSQL, `[Category("db-postgres")]`) — 50 misfired triggers, two
  clustered stores over one database, both running `RecoverMisfiredJobs` from threads of their own behind
  a gate so the second reaches the lock while the first still holds it. The two counts have to sum to
  exactly 50, every trigger has to end up on the instant its own policy computed, and none may still sit
  on its missed fire time.

## Findings

Both are reported through `Assert.Inconclusive` with observed vs expected, not asserted away and not
"fixed" here — the matrix's job is to say what 4.0 does. Each store's actual behaviour *is* asserted, so
the tests are green and the divergence is what is inconclusive. **These are the two things a reviewer has
to decide about**, and both would be their own issue.

### 1. `<` vs `<=` at the threshold instant

A trigger due at exactly `now − MisfireThreshold`:

- **`RAMJobStore` misfires it.** `ApplyMisfireNoLock` returns early only when
  `NextFireTimeUtc > now − MisfireThreshold`, so its comparison is `<=`.
- **The ADO sweep does not.** `StdAdoConstants.SqlSelectMisfiredTriggersToRecover` asks for
  `NEXT_FIRE_TIME < @nextFireTime`, so its comparison is `<`.
- Expected: the same answer from both.
- Worse, the ADO store disagrees with itself: `AdoJobStoreBase.UpdateMisfiredTrigger` — its
  single-trigger path, which is what a resumed trigger goes through — uses `<=`, like the in-memory
  store. So the same store draws the line in two places.

One tick either side, both stores agree, and all six of those cells are asserted.

### 2. An unblocked trigger's policy runs at different moments

- **The ADO store applies it as it unblocks.** `AdoJobStoreBase.TriggeredJobComplete` moves the job's
  triggers out of `BLOCKED` and then calls `RecoverUnblockedMisfires`, so the policy has run by the time
  `TriggeredJobComplete` returns.
- **`RAMJobStore` does not.** Its `TriggeredJobComplete` moves the trigger from `Blocked` to `Waiting`
  and adds it back to `timeTriggers`, and nothing else — `ApplyMisfireNoLock` is reached from acquisition
  and from resume, and unblocking is neither. The policy runs on the next acquisition.
- Expected: the same moment on both. A caller that reads the trigger in the window between sees a fire
  time in the past on one store and a recomputed one on the other.

(The issue's "done means" list phrases this one as "RAM applies the blocked trigger's misfire policy on
unblock". It does not; the ADO store is the one that does. Both halves are now pinned as they actually
behave, and the gap is reported here.)

## Verification

```
dotnet build Quartz.slnx                                            0 warnings, 0 errors
dotnet test src/Quartz.Tests.Unit                                   3294 passed, 4 skipped, 0 failed
integration `basic` leg (Build.cs's own filter)                     212 passed, 0 failed
integration `postgres` leg (whole leg, Docker up)                   70 passed, 0 failed
src/Quartz.Tests.AspNetCore                                         433 passed, 0 failed
```

The new fixtures were run three times each: 54/54 on the `basic` leg every time, and the two-node
PostgreSQL case three times, reporting `nodeA=50, nodeB=0` on each run.

The two-node assertion was checked for teeth: giving each node a per-process `SimpleSemaphore` instead of
letting the store install `PostgreSqlSelectForUpdateSemaphore` makes both nodes recover all fifty and the
test fails with a total of 100.

Two skipped tests in the counts above are the `Assert.Inconclusive` findings; the other three are
pre-existing skips.

## Notes for the reviewer

- `Microsoft.Extensions.TimeProvider.Testing` is now referenced by `Quartz.Tests.Integration`, and
  `ClusteredJobStoreTestBase`'s "there is deliberately no `FakeTimeProvider` anywhere in this project"
  paragraph is narrowed to "under this base class". Its reasoning is about *clustered* nodes agreeing on
  the database's clock, which a single-node fixture driving one store's pass by hand has no part in; the
  paragraph now says so and points at the new base class.
- `ClusteredTestDatabase` gains `CreateDriverDelegate()`, since `DriverDelegateType` is a name for the
  property bridge to resolve and no use to a fixture holding a constructor.
- `ConcurrentMisfireRecoveryTestBase` is a base with one subclass today. It is shaped that way because the
  recovery SQL is dialect-specific — SQL Server splices `TOP n` into the same statement everyone else ends
  with `LIMIT n` — so a SQL Server subclass is a five-line file when someone wants it.
- Left alone deliberately: every trigger a builder produces carries `TimeProvider.System`, whatever clock
  the scheduler was configured with, because no schedule builder passes one to the trigger it news up.
  That is why the "fire now" cells assert a window rather than an instant. It is a pre-existing property
  of the trigger builders, out of scope here, and worth its own look.

Closes #3435
