### PR TITLE
A trigger declared twice in one scheduling-data file is an error, not a silent overwrite

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/json.md
+++ b/docs/documentation/quartz-4.x/configuration/json.md
@@ -358,3 +358,16 @@ Commands executed before scheduling. All fields are optional:
 | `OverwriteExistingData` | `true` | Replace existing jobs/triggers with the same identity. |
 | `IgnoreDuplicates` | `false` | When `OverwriteExistingData` is `false`, silently skip duplicates instead of erroring. |
 | `ScheduleTriggerRelativeToReplacedTrigger` | `false` | Adjust new trigger timing based on old trigger's last fire time. |
+
+::: warning Declaring one key twice in a file is an error
+Every directive above describes how the file relates to the scheduler. None of them describes how the
+file relates to itself, so none of them suppresses the error a file gets for declaring one job or
+trigger key — name **and** group — twice:
+
+```text
+Trigger 'DEFAULT.myTrigger' is defined more than once in the scheduling data.
+```
+
+The same holds for the XML format's `<overwrite-existing-data>` and `<ignore-duplicates>`. Before
+Quartz.NET 4, the last definition of a repeated key won and said so only at `Debug`.
+:::

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -470,6 +470,10 @@ registered in code, or declared in a file, already exist in the store under the 
 | `IgnoreDuplicates` | bool | `false` | With `OverwriteExistingData` off, a name that already exists is skipped instead of throwing. |
 | `ScheduleTriggerRelativeToReplacedTrigger` | bool | `false` | A replaced trigger's next fire time is computed from the old trigger's last fire time rather than from now. |
 
+All three are about a *file or registration versus the store*. None of them can say anything about one
+scheduling data file that declares the same job or trigger key twice, so none of them suppresses the
+error that file gets — see [ProcessingDirectives](json.md#processingdirectives).
+
 <!-- snippet: sample_reference_scheduling_options -->
 ```csharp
 services.Configure<QuartzOptions>(options => options.Scheduling.IgnoreDuplicates = true);

--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -174,6 +174,12 @@ services.AddQuartz(q =>
 The periodically scanning of files for changes is not currently supported in a clustered environment.
 :::
 
+A file that declares the same job or trigger key — name **and** group — twice is rejected, whatever
+`<processing-directives>` it carries. `<overwrite-existing-data>` and `<ignore-duplicates>` say how
+the file relates to the scheduler, and neither can say anything about how the file relates to itself.
+The [ProcessingDirectives](../configuration/json.md#processingdirectives) section has the details; they
+apply to both formats.
+
 ### JsonSchedulingDataProcessorPlugin
 
 This plugin loads JSON file(s) to add jobs and schedule them with triggers as the scheduler is initialized, and can optionally periodically scan the file for changes. It is the JSON analog of `XmlSchedulingDataProcessorPlugin`.

--- a/src/Quartz.Tests.Integration/Xml/TestData/MinimalConfiguration_20.xml
+++ b/src/Quartz.Tests.Integration/Xml/TestData/MinimalConfiguration_20.xml
@@ -52,18 +52,6 @@
         <cron-expression>0/10 * * * * ?</cron-expression>
       </cron>
     </trigger>
-    <trigger>
-      <cron>
-        <name>cronName</name>
-        <group>cronGroup</group>
-        <job-name>jobName1</job-name>
-        <job-group>jobGroup1</job-group>
-        <start-time>
-          1982-06-28T18:15:00+02:00
-        </start-time>
-        <cron-expression>0/10 * * * * ?</cron-expression>
-      </cron>
-    </trigger>
 
 
   </schedule>

--- a/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorTest.cs
@@ -268,6 +268,33 @@ public class JsonSchedulingDataProcessorTest
         act.Should().Throw<SchedulerConfigException>().WithMessage("*mutually exclusive*");
     }
 
+    /// <summary>
+    /// The guard lives in <c>XmlSchedulingDataProcessor.AddTriggerToSchedule</c>, the funnel this
+    /// processor's own parsing calls, so it is inherited rather than written twice.
+    /// </summary>
+    [Test]
+    public void TwoTriggersWithOneNameAndGroup_Throws()
+    {
+        string json = """
+        {
+            "Schedule": {
+                "Jobs": [{ "Name": "dupJob", "JobType": "Quartz.Jobs.NativeJob, Quartz.Jobs", "Durable": true }],
+                "Triggers": [
+                    { "Name": "dupTrigger", "JobName": "dupJob", "Cron": { "Expression": "0/10 * * * * ?" } },
+                    { "Name": "dupTrigger", "JobName": "dupJob", "Cron": { "Expression": "0 0 12 * * ?" } }
+                ]
+            }
+        }
+        """;
+
+        JsonSchedulingDataProcessor processor = CreateProcessor();
+        Action act = () => processor.ProcessJsonContent(json);
+
+        act.Should().Throw<SchedulingDataValidationException>(
+                "the JSON loader inherits the XML processor's duplicate-key guard, so the flaw cannot be fixed on one side only")
+            .WithMessage("*Trigger 'DEFAULT.dupTrigger' is defined more than once in the scheduling data.*");
+    }
+
     [Test]
     public void NullJsonContent_Throws()
     {

--- a/src/Quartz.Tests.Unit/Xml/XmlSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Unit/Xml/XmlSchedulingDataProcessorTest.cs
@@ -824,6 +824,181 @@ public class XmlSchedulingDataProcessorTest
     }
 
     // ---------------------------------------------------------------------------------------------
+    // Keys declared twice in one document
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task TwoTriggersWithOneNameAndGroupAreRejected()
+    {
+        TestProcessor processor = CreateProcessor();
+
+        Func<Task> act = async () => await processor.ProcessStream(ToStream(Document($"""
+            <schedule>
+              {Job}
+              <trigger>
+                <simple>
+                  <name>myTrigger</name>
+                  <job-name>job1</job-name>
+                  <job-group>group1</job-group>
+                  <repeat-count>0</repeat-count>
+                  <repeat-interval>1000</repeat-interval>
+                </simple>
+              </trigger>
+              <trigger>
+                <simple>
+                  <name>myTrigger</name>
+                  <job-name>job1</job-name>
+                  <job-group>group1</job-group>
+                  <repeat-count>5</repeat-count>
+                  <repeat-interval>2000</repeat-interval>
+                </simple>
+              </trigger>
+            </schedule>
+            """)), null);
+
+        (await act.Should().ThrowAsync<SchedulingDataValidationException>(
+                "the second definition otherwise overwrites the first and says so only at Debug"))
+            .WithMessage("*Trigger 'DEFAULT.myTrigger' is defined more than once in the scheduling data.*",
+                "the message has to name the key, or a large file gives the author nowhere to look");
+    }
+
+    [Test]
+    public async Task TwoTriggersWithOneNameInDifferentGroupsAreBothScheduled()
+    {
+        TestProcessor processor = await Process(Document($"""
+            <schedule>
+              {Job}
+              <trigger>
+                <simple>
+                  <name>myTrigger</name>
+                  <group>groupA</group>
+                  <job-name>job1</job-name>
+                  <job-group>group1</job-group>
+                  <repeat-count>0</repeat-count>
+                  <repeat-interval>1000</repeat-interval>
+                </simple>
+              </trigger>
+              <trigger>
+                <simple>
+                  <name>myTrigger</name>
+                  <group>groupB</group>
+                  <job-name>job1</job-name>
+                  <job-group>group1</job-group>
+                  <repeat-count>0</repeat-count>
+                  <repeat-interval>1000</repeat-interval>
+                </simple>
+              </trigger>
+            </schedule>
+            """));
+
+        processor.Triggers.Select(x => x.Key).Should().BeEquivalentTo(
+            new[] { new TriggerKey("myTrigger", "groupA"), new TriggerKey("myTrigger", "groupB") },
+            "a trigger's identity is its name and its group, so these two are different triggers");
+    }
+
+    [Test]
+    public async Task TwoJobsWithOneNameAndGroupAreRejected()
+    {
+        TestProcessor processor = CreateProcessor();
+
+        Func<Task> act = async () => await processor.ProcessStream(ToStream(Document($"""
+            <schedule>
+              <job>
+                <name>myJob</name>
+                <job-type>{JobType}</job-type>
+              </job>
+              <job>
+                <name>myJob</name>
+                <job-type>{JobType}</job-type>
+              </job>
+            </schedule>
+            """)), null);
+
+        (await act.Should().ThrowAsync<SchedulingDataValidationException>(
+                "the second definition otherwise replaces the first without a word"))
+            .WithMessage("*Job 'DEFAULT.myJob' is defined more than once in the scheduling data.*",
+                "the message has to name the key, or a large file gives the author nowhere to look");
+    }
+
+    [Test]
+    public async Task TwoJobsWithOneNameInDifferentGroupsAreBothScheduled()
+    {
+        TestProcessor processor = await Process(Document($"""
+            <schedule>
+              <job>
+                <name>myJob</name>
+                <group>groupA</group>
+                <job-type>{JobType}</job-type>
+              </job>
+              <job>
+                <name>myJob</name>
+                <group>groupB</group>
+                <job-type>{JobType}</job-type>
+              </job>
+            </schedule>
+            """));
+
+        processor.Jobs.Select(x => x.Key).Should().BeEquivalentTo(
+            new[] { new JobKey("myJob", "groupA"), new JobKey("myJob", "groupB") },
+            "a job's identity is its name and its group, so these two are different jobs");
+    }
+
+    /// <summary>
+    /// <c>ignore-duplicates</c> and <c>overwrite-existing-data</c> say how the file relates to the
+    /// scheduler. Neither can express "declared twice in one document", so neither turns this off.
+    /// </summary>
+    [Test]
+    public async Task IgnoreDuplicatesDoesNotSuppressAKeyDeclaredTwice()
+    {
+        TestProcessor processor = CreateProcessor();
+
+        Func<Task> act = async () => await processor.ProcessStream(ToStream(Document($"""
+            <processing-directives>
+              <overwrite-existing-data>false</overwrite-existing-data>
+              <ignore-duplicates>true</ignore-duplicates>
+            </processing-directives>
+            <schedule>
+              <job>
+                <name>myJob</name>
+                <job-type>{JobType}</job-type>
+              </job>
+              <job>
+                <name>myJob</name>
+                <job-type>{JobType}</job-type>
+              </job>
+            </schedule>
+            """)), null);
+
+        (await act.Should().ThrowAsync<SchedulingDataValidationException>(
+                "the directives are about the file versus the scheduler, not the file versus itself"))
+            .WithMessage("*neither of them suppresses this*",
+                "the message has to say why the directive the author reached for did not help");
+    }
+
+    [Test]
+    public async Task KeysDeclaredInOneDocumentAreForgottenByTheNext()
+    {
+        TestProcessor processor = CreateProcessor();
+
+        string document = Document($"""
+            <schedule>
+              <job>
+                <name>myJob</name>
+                <job-type>{JobType}</job-type>
+              </job>
+            </schedule>
+            """);
+
+        await processor.ProcessStream(ToStream(document), null);
+
+        Func<Task> act = async () => await processor.ProcessStream(ToStream(document), null);
+
+        await act.Should().NotThrowAsync(
+            "the accepted keys are per document, and one instance processes every file the plugin is given");
+        processor.Jobs.Should().ContainSingle().Which.Key.Should().Be(new JobKey("myJob"));
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // Pre-processing commands
     // ---------------------------------------------------------------------------------------------
 

--- a/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
@@ -59,6 +59,10 @@ internal class XmlSchedulingDataProcessor
     public const string QuartzXmlFileName = "quartz_jobs.xml";
     public const string QuartzXsdResourceName = "Quartz.Xml.job_scheduling_data_2_0.xsd";
 
+    private const string DirectivesDoNotApply =
+        "The ignore-duplicates and overwrite-existing-data directives describe how the file relates to "
+        + "the scheduler, so neither of them suppresses this.";
+
     // pre-processing commands
     private readonly List<string> jobGroupsToDelete = new List<string>();
     private readonly List<string> triggerGroupsToDelete = new List<string>();
@@ -68,6 +72,11 @@ internal class XmlSchedulingDataProcessor
     // scheduling commands
     private readonly List<IJobDetail> loadedJobs = new List<IJobDetail>();
     private readonly List<ITrigger> loadedTriggers = new List<ITrigger>();
+
+    // the keys accepted so far from the document being processed, so that a key declared twice in
+    // one document is caught before the second definition silently overwrites the first
+    private readonly HashSet<JobKey> loadedJobKeys = new HashSet<JobKey>();
+    private readonly HashSet<TriggerKey> loadedTriggerKeys = new HashSet<TriggerKey>();
 
     // directives
     private readonly List<Exception> validationExceptions = new List<Exception>();
@@ -211,6 +220,8 @@ internal class XmlSchedulingDataProcessor
 
         loadedJobs.Clear();
         loadedTriggers.Clear();
+        loadedJobKeys.Clear();
+        loadedTriggerKeys.Clear();
     }
 
     [RequiresUnreferencedCode("Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in job_scheduling_data XML is not guaranteed to survive trimming.")]
@@ -452,13 +463,45 @@ internal class XmlSchedulingDataProcessor
         }
     }
 
+    /// <summary>
+    /// Accepts a parsed job definition into the set that will be scheduled.
+    /// </summary>
+    /// <remarks>
+    /// Every loader funnels its jobs through here, so this is where a job key declared twice in one
+    /// document is caught; an override that does not call <c>base</c> gives that check up.
+    /// </remarks>
+    /// <exception cref="SchedulingDataValidationException">
+    /// The document being processed has already declared a job with this name and group.
+    /// </exception>
     protected virtual void AddJobToSchedule(IJobDetail job)
     {
+        if (!loadedJobKeys.Add(job.Key))
+        {
+            throw new SchedulingDataValidationException(
+                $"Job '{job.Key}' is defined more than once in the scheduling data. {DirectivesDoNotApply}");
+        }
+
         loadedJobs.Add(job);
     }
 
+    /// <summary>
+    /// Accepts a parsed trigger definition into the set that will be scheduled.
+    /// </summary>
+    /// <remarks>
+    /// Every loader funnels its triggers through here, so this is where a trigger key declared twice
+    /// in one document is caught; an override that does not call <c>base</c> gives that check up.
+    /// </remarks>
+    /// <exception cref="SchedulingDataValidationException">
+    /// The document being processed has already declared a trigger with this name and group.
+    /// </exception>
     protected virtual void AddTriggerToSchedule(IMutableTrigger trigger)
     {
+        if (!loadedTriggerKeys.Add(trigger.Key))
+        {
+            throw new SchedulingDataValidationException(
+                $"Trigger '{trigger.Key}' is defined more than once in the scheduling data. {DirectivesDoNotApply}");
+        }
+
         loadedTriggers.Add(trigger);
     }
 


### PR DESCRIPTION
A scheduling-data file that declared the same trigger key twice scheduled the last definition and
discarded the earlier ones without a word above `Debug`.

`AddTriggerToSchedule` and `AddJobToSchedule` are the funnels every parsed definition passes through,
and both appended to a list with no key check. `ScheduleJobs` then walked that list: reaching the
second definition of a key, `scheduler.GetTrigger` returned the trigger the same loop had just
written, `OverwriteExistingData` defaults to `true`, and the branch rescheduled over it logging
"Rescheduling job … with updated trigger" at `Debug`. `ReportDuplicateTrigger` warns only when the
duplicate names a *different* job, so the common case — one key, one job, two definitions — was
silent. The XSD has no `xs:unique` to catch it either.

## What changed

Both funnels keep a `HashSet` of the keys they have accepted and throw
`SchedulingDataValidationException` naming the key on a repeat:

```text
Trigger 'DEFAULT.myTrigger' is defined more than once in the scheduling data. The ignore-duplicates
and overwrite-existing-data directives describe how the file relates to the scheduler, so neither of
them suppresses this.
```

- The throw is direct, not through `AddValidationException` — that overload takes an `XmlException`,
  which the JSON path never has.
- The sets are cleared in `PrepareForProcessing` beside `loadedJobs.Clear()`, so one instance can go
  on processing file after file. `KeysDeclaredInOneDocumentAreForgottenByTheNext` is the guard.
- `JsonSchedulingDataProcessor` derives from `XmlSchedulingDataProcessor` and calls the same two
  funnels, so it inherits the check rather than repeating it. `TwoTriggersWithOneNameAndGroup_Throws`
  in `JsonSchedulingDataProcessorTest` proves that, so the guard cannot be lost on one side alone.
- The doc comments on both `protected virtual` members say that an override which skips `base` gives
  the check up.
- No public surface moves: `XmlSchedulingDataProcessor` is `internal`, and the API baselines are
  untouched.

`ignore-duplicates` and `overwrite-existing-data` describe how the file relates to the *scheduler*.
Neither can express "declared twice in one document", so neither suppresses this. That is the second
sentence of the exception message, and it is now in the directive docs
(`configuration/json.md`, `configuration/reference.md`, `packages/quartz-plugins.md`) —
`IgnoreDuplicatesDoesNotSuppressAKeyDeclaredTwice` holds the code to it.

## Adopted from #745

This adopts @siyamandayubi's [#745](https://github.com/quartznet/quartznet/pull/745), closed in favour
of the reworked change, and the commit carries their `Co-authored-by` trailer. Three differences from
that patch:

- the check keys on **name and group**, since that pair is a trigger's or job's identity — two
  triggers named `myTrigger` in `groupA` and `groupB` are different triggers and both still schedule;
- it lives in `Add*ToSchedule`, the one funnel both the XML and the JSON loader pass through, rather
  than in the XML-specific parsing;
- it throws `SchedulingDataValidationException`, so a caller that already catches `SchedulerException`
  around loading scheduling data needs no second catch block.

## For a reviewer

`src/Quartz.Tests.Integration/Xml/TestData/MinimalConfiguration_20.xml` declared its `cronGroup.cronName`
trigger twice, verbatim, and the new check reports it. I read that as a copy-paste rather than a
statement — the test using it asserts only that `OverwriteExistingData` is false and that
`ScheduleJobs` runs, and the second copy says nothing the first does not — so I deleted one copy. Say
so if you would rather the fixture kept it and the test asserted the throw.

## Verification

```
dotnet build Quartz.slnx                      Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit             Passed! Failed: 0, Passed: 3335, Skipped: 4, Total: 3339
dotnet test src/Quartz.Tests.AspNetCore       Passed! Failed: 0, Passed: 433, Total: 433
dotnet test src/Quartz.Tests.Integration      Passed! Failed: 0, Passed: 24, Total: 24
  --filter ...Xml.XmlSchedulingDataProcessorTest
dotnet fallout VerifyDocsSnippets             Documentation snippets are up to date (90 files checked)
npm run docs:check-links                      212 pages, 771 internal links, 440 fragments; no dead links or anchors
```

The four new assertions were confirmed to fail against the unfixed processor: with only the tests
applied, `TwoTriggersWithOneNameAndGroupAreRejected`, `TwoJobsWithOneNameAndGroupAreRejected`,
`IgnoreDuplicatesDoesNotSuppressAKeyDeclaredTwice` and the JSON
`TwoTriggersWithOneNameAndGroup_Throws` all fail.

Closes #3416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
