### PR TITLE
A holiday is the whole local day, in a zone where midnight moves too

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
@@ -232,20 +232,30 @@ public class CalendarDstTests
     /// answer with a time the calendar includes, and with the first one.
     /// </summary>
     /// <remarks>
-    /// It does not, in a zone whose midnight moves. <c>HolidayCalendar.GetNextIncludedTimeUtc</c>
-    /// builds the day's start as <c>new DateTimeOffset(local.Date, local.Offset)</c> - midnight at
-    /// the offset the <em>queried instant</em> carries - and on a day whose own midnight does not
-    /// exist, or whose offset changed part-way, that lands on the wrong day. The case is left
-    /// inconclusive rather than pinned: an answer that the calendar itself calls excluded is not a
-    /// behaviour to bless.
+    /// <para>
+    /// It did not, on any day whose clocks move (#3457). The day boundary was built as
+    /// <c>new DateTimeOffset(local.Date, local.Offset)</c> - midnight at the offset the
+    /// <em>queried instant</em> carries - which is a different instant from the day's own first one
+    /// whenever the offset changed between the two: an hour out in a zone that moves its clocks at
+    /// midnight, and on the neighbouring local day in a zone that moves them later.
+    /// </para>
+    /// <para>
+    /// The two Santiago cases are the ones #3455 found and left inconclusive, because an answer the
+    /// calendar itself calls excluded was not a behaviour to bless. The rest say the same thing for
+    /// the transition shapes the other zones carry.
+    /// </para>
     /// </remarks>
-    [TestCase("2019-09-08", "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
-    [TestCase("2019-04-06", "2019-04-07T02:30:00Z", "2019-04-07T04:00:00Z")]
-    public void HolidayCalendar_NextIncludedTime_OnATransitionDay(string holidayText, string askedAtText, string expectedText)
+    [TestCase("SantiagoSpring", "2019-09-08", "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", "2019-04-06", "2019-04-07T02:30:00Z", "2019-04-07T04:00:00Z")]
+    [TestCase("AmmanSpring", "2017-03-31", "2017-03-31T10:00:00Z", "2017-03-31T21:00:00Z")]
+    [TestCase("AmmanFall", "2017-10-26", "2017-10-26T10:00:00Z", "2017-10-26T21:00:00Z")]
+    [TestCase("HelsinkiSpring", "2024-03-31", "2024-03-31T10:00:00Z", "2024-03-31T21:00:00Z")]
+    [TestCase("HelsinkiFall", "2024-10-27", "2024-10-27T10:00:00Z", "2024-10-27T22:00:00Z")]
+    [TestCase("EasternSpring", "2024-03-10", "2024-03-10T16:00:00Z", "2024-03-11T04:00:00Z")]
+    [TestCase("EasternFall", "2024-11-03", "2024-11-03T16:00:00Z", "2024-11-04T05:00:00Z")]
+    public void HolidayCalendar_NextIncludedTime_OnATransitionDay(string dayKey, string holidayText, string askedAtText, string expectedText)
     {
-        TimeZoneInfo zone = TestTimeZones.Santiago;
-        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2019, 9, 8, 0, 30, 0));
-        TestTimeZones.AssumeAmbiguousLocalTime(zone, new DateTime(2019, 4, 6, 23, 30, 0));
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
 
         DateOnly holiday = DateOnly.Parse(holidayText, System.Globalization.CultureInfo.InvariantCulture);
         DateTimeOffset askedAt = ParseUtc(askedAtText);
@@ -254,25 +264,180 @@ public class CalendarDstTests
         HolidayCalendar calendar = new HolidayCalendar { TimeZone = zone };
         calendar.AddExcludedDay(holiday);
 
-        calendar.IsTimeIncluded(askedAt).Should().BeFalse("the premise of the case: {0:O} is inside the holiday", askedAt);
-        calendar.IsTimeIncluded(expected).Should().BeTrue("and {0:O} is the first instant after it that is not", expected);
+        AssertNextIncludedTime(calendar, zone, askedAt, expected);
+    }
+
+    /// <summary>
+    /// The control for the case above: on a day with no transition in it the answer is plain local
+    /// midnight, in each of the zones the transition cases use.
+    /// </summary>
+    [TestCase("Helsinki", "2024-06-15", "2024-06-15T10:00:00Z", "2024-06-15T21:00:00Z")]
+    [TestCase("Eastern", "2024-01-15", "2024-01-15T16:00:00Z", "2024-01-16T05:00:00Z")]
+    [TestCase("Santiago", "2019-06-15", "2019-06-15T15:00:00Z", "2019-06-16T04:00:00Z")]
+    public void HolidayCalendar_NextIncludedTime_OnAnOrdinaryDay(string zoneKey, string holidayText, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+
+        DateOnly holiday = DateOnly.Parse(holidayText, System.Globalization.CultureInfo.InvariantCulture);
+        DateTimeOffset askedAt = ParseUtc(askedAtText);
+        DateTimeOffset expected = ParseUtc(expectedText);
+
+        Assume.That(
+            zone.GetUtcOffset(TimeZoneInfo.ConvertTime(askedAt, zone).Date) == zone.GetUtcOffset(expected),
+            $"test premise: the clocks do not move on {holiday:yyyy-MM-dd} in zone {zone.Id}");
+
+        HolidayCalendar calendar = new HolidayCalendar { TimeZone = zone };
+        calendar.AddExcludedDay(holiday);
+
+        AssertNextIncludedTime(calendar, zone, askedAt, expected);
+    }
+
+    /// <summary>
+    /// A run of holidays is walked a day at a time, and the walk crosses the transition rather than
+    /// starting on it. Adding a day to a <see cref="DateTimeOffset" /> keeps the offset it already
+    /// had, so a walk that begins before the clocks move carries the old offset over them and lands
+    /// an hour out on the far side: a holiday that ends on a Sunday releases the scheduler at 01:00
+    /// on the Monday when the clocks went forward, and an hour before the holiday is over when they
+    /// went back.
+    /// </summary>
+    [TestCase("HelsinkiSpring", "2024-03-29,2024-03-30,2024-03-31", "2024-03-29T10:00:00Z", "2024-03-31T21:00:00Z")]
+    [TestCase("HelsinkiFall", "2024-10-25,2024-10-26,2024-10-27", "2024-10-25T10:00:00Z", "2024-10-27T22:00:00Z")]
+    [TestCase("SantiagoSpring", "2019-09-06,2019-09-07,2019-09-08", "2019-09-06T15:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", "2019-04-04,2019-04-05,2019-04-06", "2019-04-04T15:00:00Z", "2019-04-07T04:00:00Z")]
+    public void HolidayCalendar_NextIncludedTime_WalkingAcrossATransition(string dayKey, string holidaysText, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        DateTimeOffset askedAt = ParseUtc(askedAtText);
+        DateTimeOffset expected = ParseUtc(expectedText);
+
+        HolidayCalendar calendar = new HolidayCalendar { TimeZone = zone };
+        foreach (string holidayText in holidaysText.Split(','))
+        {
+            calendar.AddExcludedDay(DateOnly.Parse(holidayText, System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        AssertNextIncludedTime(calendar, zone, askedAt, expected);
+    }
+
+    /// <summary>
+    /// An annual calendar excludes a date of every year, and walks days the same way a holiday
+    /// calendar does, so it had the same boundary.
+    /// </summary>
+    [TestCase("SantiagoSpring", 9, 8, "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", 4, 6, "2019-04-06T12:00:00Z", "2019-04-07T04:00:00Z")]
+    public void AnnualCalendar_NextIncludedTime_OnATransitionDay(string dayKey, int month, int day, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        AnnualCalendar calendar = new AnnualCalendar { TimeZone = zone };
+        calendar.AddExcludedDay(new MonthDay(month, day));
+
+        AssertNextIncludedTime(calendar, zone, ParseUtc(askedAtText), ParseUtc(expectedText));
+    }
+
+    /// <summary>
+    /// So did a monthly calendar, which excludes a day of the month.
+    /// </summary>
+    [TestCase("SantiagoSpring", 8, "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", 6, "2019-04-06T12:00:00Z", "2019-04-07T04:00:00Z")]
+    public void MonthlyCalendar_NextIncludedTime_OnATransitionDay(string dayKey, int day, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        MonthlyCalendar calendar = new MonthlyCalendar { TimeZone = zone };
+        calendar.AddExcludedDay(day);
+
+        AssertNextIncludedTime(calendar, zone, ParseUtc(askedAtText), ParseUtc(expectedText));
+    }
+
+    /// <summary>
+    /// And so did a weekly calendar, which excludes a day of the week.
+    /// </summary>
+    [TestCase("SantiagoSpring", DayOfWeek.Sunday, "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", DayOfWeek.Saturday, "2019-04-06T12:00:00Z", "2019-04-07T04:00:00Z")]
+    public void WeeklyCalendar_NextIncludedTime_OnATransitionDay(string dayKey, DayOfWeek excluded, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        WeeklyCalendar calendar = new WeeklyCalendar { TimeZone = zone };
+        calendar.RemoveExcludedDay(DayOfWeek.Saturday);
+        calendar.RemoveExcludedDay(DayOfWeek.Sunday);
+        calendar.AddExcludedDay(excluded);
+
+        AssertNextIncludedTime(calendar, zone, ParseUtc(askedAtText), ParseUtc(expectedText));
+    }
+
+    /// <summary>
+    /// A daily calendar was already right on these days, and this says why. It builds its day
+    /// boundaries at the queried instant's offset too, but compares them only with values carrying
+    /// that same offset, so every comparison it makes is a wall-clock one and stays correct whatever
+    /// the offset is. The window therefore lands where the wall clock says even on the day whose
+    /// midnight never happens, and on the day whose last hour happens twice it catches both passes.
+    /// </summary>
+    /// <remarks>
+    /// These are <see cref="ICalendar.IsTimeIncluded" /> cases only.
+    /// <see cref="DailyCalendar.GetNextIncludedTimeUtc" /> computes its window and day boundaries in
+    /// the offset the <em>argument</em> carries rather than in the calendar's zone, so asking it in
+    /// UTC about a calendar in another zone walks a millisecond at a time and can step over an
+    /// included window entirely. That is a separate defect from the day boundary this fixture is
+    /// about, it predates it, and it is not fixed here.
+    /// </remarks>
+    [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T03:30:00Z", true)]
+    [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T04:30:00Z", false)]
+    [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T05:30:00Z", true)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T02:15:00Z", false)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T02:45:00Z", true)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T03:15:00Z", false)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T03:45:00Z", true)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T04:00:00Z", true)]
+    public void DailyCalendar_OnADayThatIsNot24HoursLong_ExcludesTheWallClockWindow(
+        string dayKey,
+        string fromText,
+        string toText,
+        string instantText,
+        bool expectedIncluded)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        TimeOnly from = TimeOnly.Parse(fromText, System.Globalization.CultureInfo.InvariantCulture);
+        TimeOnly to = TimeOnly.Parse(toText, System.Globalization.CultureInfo.InvariantCulture);
+        DateTimeOffset instant = ParseUtc(instantText);
+
+        DailyCalendar calendar = new DailyCalendar(from, to) { TimeZone = zone };
+
+        calendar.IsTimeIncluded(instant).Should().Be(expectedIncluded,
+            "{0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local and the excluded window is {2:HH:mm}-{3:HH:mm} of every local day",
+            instant, TimeZoneInfo.ConvertTime(instant, zone), from, to);
+    }
+
+    /// <summary>
+    /// Asserts the whole of the <c>GetNextIncludedTimeUtc</c> contract for one case: the instant it
+    /// is asked about is excluded, the expected answer is included, nothing between the two is, and
+    /// the answer is that instant.
+    /// </summary>
+    private static void AssertNextIncludedTime(ICalendar calendar, TimeZoneInfo zone, DateTimeOffset askedAt, DateTimeOffset expected)
+    {
+        calendar.IsTimeIncluded(askedAt).Should().BeFalse(
+            "the premise of the case: {0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local, which this calendar excludes",
+            askedAt, TimeZoneInfo.ConvertTime(askedAt, zone));
+
+        calendar.IsTimeIncluded(expected).Should().BeTrue(
+            "and {0:O}, which reads as {1:yyyy-MM-dd HH:mm zzz} local, is not excluded",
+            expected, TimeZoneInfo.ConvertTime(expected, zone));
+
+        // A minute rather than a millisecond, because the exact instant a zone changes offset is not
+        // agreed on to the millisecond: Windows cannot express a rule at local midnight and writes
+        // 23:59:59.999 of the day before instead. A minute is clear of the disagreement.
+        calendar.IsTimeIncluded(expected.AddMinutes(-1)).Should().BeFalse(
+            "and it is the first such instant - a minute earlier reads as {0:yyyy-MM-dd HH:mm zzz} local, which is still excluded",
+            TimeZoneInfo.ConvertTime(expected.AddMinutes(-1), zone));
 
         DateTimeOffset actual = calendar.GetNextIncludedTimeUtc(askedAt);
 
-        if (actual != expected)
-        {
-            Assert.Inconclusive(
-                $"GetNextIncludedTimeUtc({askedAt:O}) answered {actual:O} (local "
-                + $"{TimeZoneInfo.ConvertTime(actual, zone):yyyy-MM-dd HH:mm zzz}, included="
-                + $"{calendar.IsTimeIncluded(actual)}); the first instant this calendar includes after "
-                + $"the {holiday:yyyy-MM-dd} holiday is {expected:O} (local "
-                + $"{TimeZoneInfo.ConvertTime(expected, zone):yyyy-MM-dd HH:mm zzz}). The day boundary it walks is built "
-                + "as midnight at the offset of the instant it was asked about, which is not this day's midnight in a zone "
-                + "that moves its clocks at midnight.");
-        }
-
         actual.Should().Be(expected,
-            "the next included time after an excluded instant is the first instant the calendar includes, and it must be one it does include");
+            "the next included time after an excluded instant is the first instant the calendar includes, and {0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local (included={2})",
+            actual, TimeZoneInfo.ConvertTime(actual, zone), calendar.IsTimeIncluded(actual));
     }
 
     private static TimeZoneInfo ResolveZone(string zoneKey)
@@ -283,8 +448,70 @@ public class CalendarDstTests
                 return TestTimeZones.Helsinki;
             case "Eastern":
                 return TestTimeZones.Eastern;
+            case "Santiago":
+                return TestTimeZones.Santiago;
             default:
                 throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test zone");
+        }
+    }
+
+    /// <summary>
+    /// The zone a transition-day case runs in, with that day's premise stated. Resolved per case
+    /// rather than from a shared table, because <see cref="TestTimeZones.Amman" /> ignores the test
+    /// when the zone is missing from the system.
+    /// </summary>
+    private static TimeZoneInfo ZoneForTransitionDay(string dayKey)
+    {
+        switch (dayKey)
+        {
+            case "SantiagoSpring":
+                // The clocks move at midnight: 2019-09-08 has no 00:00 local, it starts at 01:00 and
+                // is 23 hours long.
+                TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Santiago, new DateTime(2019, 9, 8, 0, 30, 0));
+                return TestTimeZones.Santiago;
+
+            case "SantiagoFall":
+                // The same transition the other way: the hour before midnight happens twice, so
+                // 2019-04-06 is 25 hours long and 2019-04-07 begins an hour later than the arithmetic
+                // of the day before it says.
+                TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Santiago, new DateTime(2019, 4, 6, 23, 30, 0));
+                return TestTimeZones.Santiago;
+
+            case "AmmanSpring":
+                // Midnight moves here too: 2017-03-31 has no 00:00 local. Jordan abolished DST in
+                // 2022, so this is frozen history rather than a rule that can move under the test.
+                TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Amman, new DateTime(2017, 3, 31, 0, 30, 0));
+                return TestTimeZones.Amman;
+
+            case "AmmanFall":
+                // The one zone here whose own midnight happens twice: 00:00-00:59 on 2017-10-27 is
+                // the repeated hour, so that day starts at the first of two midnights.
+                TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Amman, new DateTime(2017, 10, 27, 0, 30, 0));
+                return TestTimeZones.Amman;
+
+            case "HelsinkiSpring":
+                // Not at midnight: 03:00 EET becomes 04:00 EEST on 2024-03-31, so the day begins at
+                // +02:00 and every instant after the transition carries +03:00.
+                TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Helsinki, new DateTime(2024, 3, 31, 3, 30, 0));
+                return TestTimeZones.Helsinki;
+
+            case "HelsinkiFall":
+                // 04:00 EEST becomes 03:00 EET on 2024-10-27.
+                TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Helsinki, new DateTime(2024, 10, 27, 3, 30, 0));
+                return TestTimeZones.Helsinki;
+
+            case "EasternSpring":
+                // 02:00 EST becomes 03:00 EDT on 2024-03-10.
+                TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Eastern, new DateTime(2024, 3, 10, 2, 30, 0));
+                return TestTimeZones.Eastern;
+
+            case "EasternFall":
+                // 02:00 EDT becomes 01:00 EST on 2024-11-03.
+                TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Eastern, new DateTime(2024, 11, 3, 1, 30, 0));
+                return TestTimeZones.Eastern;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(dayKey), dayKey, "unknown transition day");
         }
     }
 

--- a/src/Quartz/Impl/Calendar/AnnualCalendar.cs
+++ b/src/Quartz/Impl/Calendar/AnnualCalendar.cs
@@ -211,8 +211,13 @@ public sealed class AnnualCalendar : BaseCalendar, IEquatable<AnnualCalendar>
         //apply the timezone
         timeStampUtc = TimeZones.ConvertTime(timeStampUtc, TimeZone);
 
-        // Get timestamp for 00:00:00, in the correct timezone offset
-        DateTimeOffset day = new DateTimeOffset(timeStampUtc.Date, timeStampUtc.Offset);
+        // The first instant of the local day, resolved in the zone: a day does not always begin at
+        // midnight, and the offset it begins at is not always the offset the queried instant
+        // carries. Each further day is reached by naming the next local date and resolving that,
+        // because adding a day to a DateTimeOffset keeps the old offset and so drifts by the
+        // transition delta the moment the walk crosses one.
+        DateOnly date = DateOnly.FromDateTime(timeStampUtc.Date);
+        DateTimeOffset day = TimeZones.StartOfLocalDay(date, TimeZone);
 
         if (!IsDateTimeExcluded(day, checkBaseCalendar: true))
         {
@@ -222,7 +227,8 @@ public sealed class AnnualCalendar : BaseCalendar, IEquatable<AnnualCalendar>
 
         while (IsDateTimeExcluded(day, checkBaseCalendar: true))
         {
-            day = day.AddDays(1);
+            date = date.AddDays(1);
+            day = TimeZones.StartOfLocalDay(date, TimeZone);
         }
 
         return day;

--- a/src/Quartz/Impl/Calendar/HolidayCalendar.cs
+++ b/src/Quartz/Impl/Calendar/HolidayCalendar.cs
@@ -177,17 +177,19 @@ public sealed class HolidayCalendar : BaseCalendar, IEquatable<HolidayCalendar>
         //apply the timezone
         timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone);
 
-        // Get timestamp for 00:00:00, with the correct timezone offset
-        DateTimeOffset day = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);
+        // The first instant of the local day the query lands in, resolved in the zone: a day does
+        // not always begin at midnight, and the offset it begins at is not always the offset the
+        // queried instant carries. Each further day is reached by naming the next local date and
+        // resolving that, because adding a day to a DateTimeOffset keeps the old offset and so
+        // drifts by the transition delta the moment the walk crosses one.
+        DateOnly date = DateOnly.FromDateTime(timeUtc.Date);
+        DateTimeOffset day = TimeZones.StartOfLocalDay(date, TimeZone);
+
         while (!IsTimeIncludedThisCalendar(day) || !base.IsTimeIncluded(timeUtc))
         {
-            day = day.AddDays(1);
-            timeUtc = timeUtc.AddDays(1);
-            //ensure earliest value is assigned to return value
-            if (day < timeUtc)
-            {
-                timeUtc = day;
-            }
+            date = date.AddDays(1);
+            day = TimeZones.StartOfLocalDay(date, TimeZone);
+            timeUtc = day;
         }
 
         return timeUtc;

--- a/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
@@ -215,12 +215,18 @@ public sealed class MonthlyCalendar : BaseCalendar, IEquatable<MonthlyCalendar>
         //apply the timezone
         timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone);
 
-        // Get timestamp for 00:00:00, in the correct timezone offset
-        DateTimeOffset newTimeStamp = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);
+        // The first instant of the local day, resolved in the zone: a day does not always begin at
+        // midnight, and the offset it begins at is not always the offset the queried instant
+        // carries. Each further day is reached by naming the next local date and resolving that,
+        // because adding a day to a DateTimeOffset keeps the old offset and so drifts by the
+        // transition delta the moment the walk crosses one.
+        DateOnly date = DateOnly.FromDateTime(timeUtc.Date);
+        DateTimeOffset newTimeStamp = TimeZones.StartOfLocalDay(date, TimeZone);
 
         while (excludeDays.Contains(newTimeStamp.Day))
         {
-            newTimeStamp = newTimeStamp.AddDays(1);
+            date = date.AddDays(1);
+            newTimeStamp = TimeZones.StartOfLocalDay(date, TimeZone);
         }
 
         return newTimeStamp;

--- a/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
@@ -203,12 +203,18 @@ public sealed class WeeklyCalendar : BaseCalendar, IEquatable<WeeklyCalendar>
         //apply the timezone
         timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone);
 
-        // Get timestamp for 00:00:00, in the correct timezone offset
-        DateTimeOffset d = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);
+        // The first instant of the local day, resolved in the zone: a day does not always begin at
+        // midnight, and the offset it begins at is not always the offset the queried instant
+        // carries. Each further day is reached by naming the next local date and resolving that,
+        // because adding a day to a DateTimeOffset keeps the old offset and so drifts by the
+        // transition delta the moment the walk crosses one.
+        DateOnly date = DateOnly.FromDateTime(timeUtc.Date);
+        DateTimeOffset d = TimeZones.StartOfLocalDay(date, TimeZone);
 
         while (excludeDays.Contains(d.DayOfWeek))
         {
-            d = d.AddDays(1);
+            date = date.AddDays(1);
+            d = TimeZones.StartOfLocalDay(date, TimeZone);
         }
 
         return d;

--- a/src/Quartz/TimeZones.cs
+++ b/src/Quartz/TimeZones.cs
@@ -232,6 +232,24 @@ public static class TimeZones
     }
 
     /// <summary>
+    /// The first instant of the given local date in the given zone, carrying that zone's offset.
+    /// Local midnight is resolved with <see cref="ResolveLocal" />, so a date whose own midnight
+    /// falls in a spring-forward gap begins at the end of that gap, and a date whose midnight
+    /// happens twice begins at the first of the two.
+    /// </summary>
+    /// <remarks>
+    /// Building a day boundary as <c>new DateTimeOffset(local.Date, local.Offset)</c> - midnight at
+    /// the offset that some other instant of the day happens to carry - lands on the wrong instant
+    /// whenever the offset the date starts at is not the offset of the instant that named it, which
+    /// is every transition day: an hour out in a zone that moves its clocks at midnight, and on the
+    /// day before or the day after in a zone that moves them later.
+    /// </remarks>
+    internal static DateTimeOffset StartOfLocalDay(DateOnly date, TimeZoneInfo timeZoneInfo)
+    {
+        return ConvertTime(ResolveLocal(date.ToDateTime(TimeOnly.MinValue), timeZoneInfo), timeZoneInfo);
+    }
+
+    /// <summary>
     /// Determines the wall-clock window that occurs twice around a fall-back transition. Returns
     /// false when the given time is not ambiguous. On success <paramref name="windowStart"/> is the
     /// first ambiguous wall-clock minute (pairing it with the standard offset yields the transition


### PR DESCRIPTION
`HolidayCalendar.GetNextIncludedTimeUtc` built the day boundary it walks as
`new DateTimeOffset(local.Date, local.Offset)` — midnight at the offset the *queried instant*
happened to carry — and then advanced it with `AddDays`, which keeps that offset. Both steps assume
a local day begins at midnight at the same offset the rest of the day carries, and a transition day
is exactly the day where that is not true.

## The mechanism

Two independent failures came out of the one assumption.

**The boundary.** `local.Offset` is the offset at the instant asked about, not the offset the day
begins at. In America/Santiago, where the clocks move at midnight, they differ for the whole day:

- 2019-09-08 (23 hours, midnight is in the gap). Asked at `2019-09-08T10:00Z` the boundary came out
  as `2019-09-08T00:00-03:00` = `03:00Z`, which reads as *2019-09-07 23:00* local. The holiday
  looked already over, so the method returned the instant it was asked about — one that
  `IsTimeIncluded` reports as excluded.
- 2019-04-06 (25 hours). Asked at `2019-04-07T02:30Z` it overshot to `2019-04-08T00:00-03:00`,
  23 hours past the `2019-04-07T04:00Z` it should have answered.

The same thing happens in a zone that moves its clocks later in the day, one date over instead of
one hour: in Europe/Helsinki on 2024-03-31 the day begins at `+02:00` while every instant after
03:00 local carries `+03:00`, so a query from the afternoon built midnight at `+03:00` and landed on
2024-03-30. That case failed before this change too — this is not a midnight-zones-only defect, and
the Helsinki and America/New_York cases the issue expected to be passing controls are only controls
in the fall-back direction (see below).

**The walk.** `day.AddDays(1)` carries the old offset over the transition, so a run of excluded days
that crosses one drifts by the transition delta: three Helsinki holidays ending on 2024-03-31
released the scheduler at 01:00 on 2024-04-01 rather than midnight.

## The fix

`TimeZones.StartOfLocalDay(DateOnly, TimeZoneInfo)` (internal, new) resolves local midnight through
the existing `TimeZones.ResolveLocal`, which already carries the scheduler-wide policy: a midnight
that does not exist is paired with the pre-gap offset, which puts the instant at the end of the gap;
a midnight that happens twice takes the first of the two. Each further day is reached by naming the
next local *date* and resolving that, never by adding 24 hours. The method's contract and its
base-calendar composition (`base.GetNextIncludedTimeUtc` first, `base.IsTimeIncluded` in the loop)
are unchanged.

One behavioural consequence worth naming: the loop no longer keeps `min(timeUtc + 1 day, dayStart)`.
That `//ensure earliest value is assigned to return value` step is what returned an instant inside a
25 hour excluded day, because `timeUtc + 24h` does not leave a day that is 25 hours long. On every
ordinary day the two are the same value.

## The sibling calendars

`grep -n "\.Date, .*\.Offset\|AddDays(1)" src/Quartz/Impl/Calendar/*.cs` finds the shape in five
files:

| Calendar | Verdict |
|---|---|
| `HolidayCalendar` | Fixed. Both Santiago directions were wrong, plus every spring-forward zone. |
| `AnnualCalendar` | Fixed — same shape, same failure. Wrong on Santiago's 25 hour day (answered `2019-04-07T03:00Z`, which is still 2019-04-06 locally). |
| `MonthlyCalendar` | Fixed — same. |
| `WeeklyCalendar` | Fixed — same. |
| `DailyCalendar` | **Already correct, left alone.** It builds `GetStartOfDay`/`GetEndOfDay` at the queried offset too, but only ever compares them with values carrying that same offset, which makes every comparison a wall-clock one and correct at any offset. Its one day-boundary jump (the inverted range's "move past the end of this day") is re-tested rather than trusted, so an undershoot costs a loop turn rather than an answer. Pinned by new `IsTimeIncluded` cases on both Santiago days. |
| `CronCalendar` | Does not have the shape; already covered by #3455. |

## Tests

`src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs`. The two Santiago `Assert.Inconclusive`
cells left by #3455 are now assertions, and every case goes through one helper that asserts the
whole contract: the instant asked about is excluded, the expected answer is included, the minute
before it is not, and the answer is that instant. 12 of the 37 cases in the fixture fail on the
parent commit and pass here:

- `HolidayCalendar_NextIncludedTime_OnATransitionDay` — Santiago (both), Asia/Amman (both, the one
  zone available whose *own* midnight happens twice), Helsinki (both), Eastern (both). Failing
  before: both Santiago, Amman spring, Helsinki spring, Eastern spring. The three fall-back cases in
  the non-midnight zones passed before and are the controls the issue asked for.
- `HolidayCalendar_NextIncludedTime_OnAnOrdinaryDay` — Helsinki, Eastern and Santiago on days with
  no transition; passed before and after, so the fix is neutral on the ordinary case.
- `HolidayCalendar_NextIncludedTime_WalkingAcrossATransition` — four cases, all four failing before.
- `AnnualCalendar_`/`MonthlyCalendar_`/`WeeklyCalendar_NextIncludedTime_OnATransitionDay` — the
  fall-back case of each failed before.
- `DailyCalendar_OnADayThatIsNot24HoursLong_ExcludesTheWallClockWindow` — the control described
  above; passes either way.

Every case states its transition premise with the `TestTimeZones` `Assume` helpers, so a moved time
zone database skips the case rather than failing it.

## Reviewer decisions

1. **`3.x` has the identical shape and is not fixed here**, per the task's scope. On `origin/3.x`:
   `src/Quartz/Impl/Calendar/HolidayCalendar.cs:161` (`new DateTimeOffset(timeUtc.Date, timeUtc.Offset)`)
   and `:164-165` (`AddDays(1)`); `AnnualCalendar.cs:248` and `:258`; `MonthlyCalendar.cs:231` and
   `:242`; `WeeklyCalendar.cs:251` and `:260`. `TimeZoneUtil` there already has `ResolveLocal`
   (`src/Quartz/Util/TimeZoneUtil.cs:123`), so the port is the same edit plus a `StartOfLocalDay`
   beside it; the only difference is that 3.x's `HolidayCalendar` keeps `SortedSet<DateTime>` rather
   than `DateOnly`.
2. **A separate `DailyCalendar` defect found on the way, deliberately not fixed.**
   `DailyCalendar.GetNextIncludedTimeUtc` computes its window and day boundaries from the offset the
   *argument* carries rather than from the calendar's `TimeZone` (`rangeStart.OnDate(timeUtc)`,
   `GetStartOfDay(timeUtc)`), while `IsTimeIncluded` converts properly. Asked in UTC about a
   calendar in another zone it therefore walks a millisecond at a time and can step straight over an
   included window: an inverted 21:00-22:00 Santiago calendar asked at `2019-04-07T01:30Z` spins for
   two and a half minutes and answers `2019-09-09T00:00Z`, five months late. It predates this change
   and is untouched by it; it wants its own issue. The `<remarks>` on the new daily-calendar test
   records it.
3. `AnnualCalendarTest.TestExclusionAndNextIncludedTime` uses `DateTimeOffset.UtcNow.Date` and
   asserts `test.AddDays(1)`. It is unchanged and passes, but on a machine whose local zone has a
   transition that night the expected value it computes is now the wrong one — the true next
   midnight is what the calendar answers. Left alone (CI runs in UTC), noted in case it ever flakes.

No public API change: `StartOfLocalDay` is `internal`, and the `PublicApiTest_*` baselines are
untouched.

## Verification

```
dotnet build Quartz.slnx                                → Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit                       → Passed! Failed: 0, Passed: 3357, Skipped: 4, Total: 3361
dotnet test src/Quartz.Tests.AspNetCore                 → Passed! Failed: 0, Passed: 433, Total: 433
QUARTZ_TEST_DATABASE=basic dotnet test
  src/Quartz.Tests.Integration (the basic leg's filter) → Passed! Failed: 0, Passed: 261, Total: 261
```

The basic integration leg's four `MisfireAcrossDstTransitionTest.OneSweepRecoversTheTriggerAndWritesTheColumn`
cases report inconclusive on the parent commit too — that fixture's own `Assert.Inconclusive` about
`UpdateAfterMisfire` reading `TimeProvider.System`, unrelated to this change.

Closes #3457
