### PR TITLE
The plugins log through source-generated events

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2266,10 +2266,10 @@ Further information on configuring Microsoft.Logging can be found [at Microsoft 
 
 ### Every message carries an event id
 
-The `Quartz` package logs through source-generated `[LoggerMessage]` methods rather than
-`logger.LogInformation(…)` and its siblings. Two things follow. Nothing is formatted or boxed when the
-level is off, including on the scheduling loop. And every message has a stable event id, so an operator
-can filter or alert on the event rather than on its text.
+The `Quartz` and `Quartz.Plugins` packages log through source-generated `[LoggerMessage]` methods
+rather than `logger.LogInformation(…)` and its siblings. Two things follow. Nothing is formatted or
+boxed when the level is off, including on the scheduling loop. And every message has a stable event id,
+so an operator can filter or alert on the event rather than on its text.
 
 Ids are allocated in ranges by area, and are stable from 4.0 onwards:
 
@@ -2283,7 +2283,12 @@ Ids are allocated in ranges by area, and are stable from 4.0 onwards:
 | 3700–3799 | Lock handlers |
 | 4000–4999 | Configuration, dependency injection and hosting, including the thread pools and job factories |
 | 5000–5999 | Serialization, type loading, triggers, calendars, XML scheduling data and the utilities |
-| 6000–8999 | Reserved for `Quartz.Plugins`, `Quartz.Jobs` and `Quartz.Extensions.Redis`, which are converting to the same shape |
+| 6000–6199 | The history plugins — `LoggingJobHistoryPlugin` and `LoggingTriggerHistoryPlugin` |
+| 6200–6299 | The XML scheduling data plugin |
+| 6300–6399 | The JSON scheduling data plugin and its processor |
+| 6400–6499 | The job interrupt monitor plugin |
+| 6500–6599 | The management plugins — the shutdown hook |
+| 7000–8999 | Reserved for `Quartz.Jobs` and `Quartz.Extensions.Redis`, which are converting to the same shape |
 
 Levels and message templates are otherwise **unchanged from 3.x**, so a log query that matched a
 message before still matches it. Two exceptions:
@@ -2298,6 +2303,19 @@ message before still matches it. Two exceptions:
   about a trigger that already existed — spelled with double spaces in one place and single spaces in
   the other — is one event with the single-space spelling. A query matching those on text needs
   updating; one matching on event id does not, which is rather the point.
+* One message in `Quartz.Plugins` carried a typo, corrected while its id was new: the interrupt
+  monitor's `…scheduled to interrupt with the delay :{Delay}` had the space before the colon rather
+  than after it.
+
+`LoggingJobHistoryPlugin` and `LoggingTriggerHistoryPlugin` are a special case, because the message
+they log is a template *you* configure — `JobSuccessMessage` and its siblings, with `{0}`-style
+placeholders — and a template only known at run time cannot be a compile-time one. They format it
+exactly as before and pass the result through an event whose own template is `{Message}`: the text a
+sink renders is unchanged, and each occurrence has an id of its own (6000–6003 for the job plugin,
+6010–6012 for the trigger plugin). `StructuredLoggingJobHistoryPlugin` and
+`StructuredLoggingTriggerHistoryPlugin` keep plain `ILogger` calls and have no event ids, because their
+configured templates carry *named* placeholders that a structured sink resolves into properties for
+itself — which is the whole reason those two plugins exist, and which no fixed template can preserve.
 
 ## The ambient logger factory stays ambient
 

--- a/src/Quartz.Plugins/Plugins/History/HistoryPluginLog.cs
+++ b/src/Quartz.Plugins/Plugins/History/HistoryPluginLog.cs
@@ -1,0 +1,70 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Plugins.History;
+
+/// <summary>
+/// Every event the history plugins log, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 6000-6199 belong to this area and are allocated in file order:
+/// <see cref="LoggingJobHistoryPlugin" /> (6000-6009) and
+/// <see cref="LoggingTriggerHistoryPlugin" /> (6010-6019). An id, once given out, is what an operator
+/// filters and alerts on, so it is never reused for a different event and never renumbered;
+/// <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// <para>
+/// Every template here is <c>"{Message}"</c>, which is degenerate on purpose. What these two plugins
+/// log is a <see cref="string.Format(IFormatProvider, string, object?[])" /> template the user
+/// configures - <c>JobSuccessMessage</c> and its siblings, with <c>{0}</c>-style placeholders - so the
+/// text is only known at run time and cannot be a compile-time template. Formatting it and passing the
+/// result through one event is what the rendered message always was; the id is what is new. The
+/// <c>StructuredLogging*HistoryPlugin</c> pair, whose configured templates carry named placeholders a
+/// structured sink resolves for itself, keeps its direct calls for that reason and is recorded in
+/// <c>LogCallSiteTest</c>'s allow-list.
+/// </para>
+/// </remarks>
+internal static partial class HistoryPluginLog
+{
+    [LoggerMessage(EventId = 6000, Level = LogLevel.Information, Message = "{Message}")]
+    public static partial void JobToBeFired(this ILogger logger, string message);
+
+    [LoggerMessage(EventId = 6001, Level = LogLevel.Information, Message = "{Message}")]
+    public static partial void JobSucceeded(this ILogger logger, string message);
+
+    [LoggerMessage(EventId = 6002, Level = LogLevel.Warning, Message = "{Message}")]
+    public static partial void JobFailed(this ILogger logger, string message, Exception exception);
+
+    [LoggerMessage(EventId = 6003, Level = LogLevel.Information, Message = "{Message}")]
+    public static partial void JobVetoed(this ILogger logger, string message);
+
+    [LoggerMessage(EventId = 6010, Level = LogLevel.Information, Message = "{Message}")]
+    public static partial void TriggerFired(this ILogger logger, string message);
+
+    [LoggerMessage(EventId = 6011, Level = LogLevel.Information, Message = "{Message}")]
+    public static partial void TriggerMisfired(this ILogger logger, string message);
+
+    [LoggerMessage(EventId = 6012, Level = LogLevel.Information, Message = "{Message}")]
+    public static partial void TriggerCompleted(this ILogger logger, string message);
+}

--- a/src/Quartz.Plugins/Plugins/History/LoggingJobHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/LoggingJobHistoryPlugin.cs
@@ -365,7 +365,7 @@ public sealed class LoggingJobHistoryPlugin : ISchedulerPlugin, IJobListener
             context.RefireCount
         ];
 
-        WriteInformation(string.Format(CultureInfo.InvariantCulture, JobToBeFiredMessage, args));
+        logger.JobToBeFired(string.Format(CultureInfo.InvariantCulture, JobToBeFiredMessage, args));
         return default;
     }
 
@@ -403,7 +403,7 @@ public sealed class LoggingJobHistoryPlugin : ISchedulerPlugin, IJobListener
                 errMsg
             ];
 
-            WriteWarning(string.Format(CultureInfo.InvariantCulture, JobFailedMessage, args), jobException);
+            logger.JobFailed(string.Format(CultureInfo.InvariantCulture, JobFailedMessage, args), jobException);
         }
         else
         {
@@ -419,7 +419,7 @@ public sealed class LoggingJobHistoryPlugin : ISchedulerPlugin, IJobListener
                 trigger.PreviousFireTimeUtc, trigger.NextFireTimeUtc, context.RefireCount, result
             ];
 
-            WriteInformation(string.Format(CultureInfo.InvariantCulture, JobSuccessMessage, args));
+            logger.JobSucceeded(string.Format(CultureInfo.InvariantCulture, JobSuccessMessage, args));
         }
         return default;
     }
@@ -454,21 +454,7 @@ public sealed class LoggingJobHistoryPlugin : ISchedulerPlugin, IJobListener
             context.RefireCount
         ];
 
-        WriteInformation(string.Format(CultureInfo.InvariantCulture, JobWasVetoedMessage, args));
+        logger.JobVetoed(string.Format(CultureInfo.InvariantCulture, JobWasVetoedMessage, args));
         return default;
-    }
-
-    private void WriteInformation(string message)
-    {
-#pragma warning disable CA2254
-        logger.LogInformation(message);
-#pragma warning restore CA2254
-    }
-
-    private void WriteWarning(string message, Exception ex)
-    {
-#pragma warning disable CA2254
-        logger.LogWarning(ex, message);
-#pragma warning restore CA2254
     }
 }

--- a/src/Quartz.Plugins/Plugins/History/LoggingTriggerHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/LoggingTriggerHistoryPlugin.cs
@@ -321,7 +321,7 @@ public sealed class LoggingTriggerHistoryPlugin : ISchedulerPlugin, ITriggerList
             context.RefireCount
         ];
 
-        WriteInformation(string.Format(CultureInfo.InvariantCulture, TriggerFiredMessage, args));
+        logger.TriggerFired(string.Format(CultureInfo.InvariantCulture, TriggerFiredMessage, args));
         return default;
     }
 
@@ -359,7 +359,7 @@ public sealed class LoggingTriggerHistoryPlugin : ISchedulerPlugin, ITriggerList
             trigger.JobKey.Group
         ];
 
-        WriteInformation(string.Format(CultureInfo.InvariantCulture, TriggerMisfiredMessage, args));
+        logger.TriggerMisfired(string.Format(CultureInfo.InvariantCulture, TriggerMisfiredMessage, args));
         return default;
     }
 
@@ -421,7 +421,7 @@ public sealed class LoggingTriggerHistoryPlugin : ISchedulerPlugin, ITriggerList
             instrCode
         ];
 
-        WriteInformation(string.Format(CultureInfo.InvariantCulture, TriggerCompleteMessage, args));
+        logger.TriggerCompleted(string.Format(CultureInfo.InvariantCulture, TriggerCompleteMessage, args));
         return default;
     }
 
@@ -444,12 +444,5 @@ public sealed class LoggingTriggerHistoryPlugin : ISchedulerPlugin, ITriggerList
         CancellationToken cancellationToken = default)
     {
         return new ValueTask<bool>(false);
-    }
-
-    private void WriteInformation(string message)
-    {
-#pragma warning disable CA2254
-        logger.LogInformation(message);
-#pragma warning restore CA2254
     }
 }

--- a/src/Quartz.Plugins/Plugins/Interrupt/InterruptPluginLog.cs
+++ b/src/Quartz.Plugins/Plugins/Interrupt/InterruptPluginLog.cs
@@ -1,0 +1,63 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Plugins.Interrupt;
+
+/// <summary>
+/// Every event the job interrupt monitor plugin logs, as source-generated methods with a pinned
+/// event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 6400-6499 belong to this area and are allocated in file order: the plugin itself
+/// (6400-6409) and the monitor that does the interrupting (6410-6419). An id, once given out, is
+/// what an operator filters and alerts on, so it is never reused for a different event and never
+/// renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// </remarks>
+internal static partial class InterruptPluginLog
+{
+    [LoggerMessage(EventId = 6400, Level = LogLevel.Information, Message = "Registering Job Interrupt Monitor Plugin")]
+    public static partial void PluginRegistered(this ILogger logger);
+
+    [LoggerMessage(EventId = 6401, Level = LogLevel.Warning, Message = "Job data map value for {Key} is not a number of milliseconds, using the plugin default of {Delay} instead")]
+    public static partial void MaxRunTimeNotANumber(this ILogger logger, string key, TimeSpan delay);
+
+    [LoggerMessage(EventId = 6402, Level = LogLevel.Debug, Message = "Job's Interrupt Monitor has been scheduled to interrupt with the delay: {Delay}")]
+    public static partial void InterruptMonitorScheduled(this ILogger logger, TimeSpan delay);
+
+    [LoggerMessage(EventId = 6403, Level = LogLevel.Error, Message = "Error scheduling interrupt monitor {ErrorMessage}")]
+    public static partial void InterruptMonitorSchedulingFailed(this ILogger logger, string errorMessage, Exception exception);
+
+    [LoggerMessage(EventId = 6410, Level = LogLevel.Information, Message = "Interrupted Job as it ran more than the configured max time. Job Details [{JobName}:{JobGroup}], fire instance id {FireInstanceId}")]
+    public static partial void JobInterrupted(this ILogger logger, string jobName, string jobGroup, string fireInstanceId);
+
+    [LoggerMessage(EventId = 6411, Level = LogLevel.Debug, Message = "Job execution was no longer running, nothing to interrupt. Job Details [{JobName}:{JobGroup}], fire instance id {FireInstanceId}")]
+    public static partial void JobNoLongerRunning(this ILogger logger, string jobName, string jobGroup, string fireInstanceId);
+
+    [LoggerMessage(EventId = 6412, Level = LogLevel.Error, Message = "Error interrupting Job: {ExceptionMessage}")]
+    public static partial void JobInterruptFailed(this ILogger logger, string exceptionMessage, Exception exception);
+
+    [LoggerMessage(EventId = 6413, Level = LogLevel.Error, Message = "Error cancelling monitor: {ExceptionMessage}")]
+    public static partial void MonitorCancellationFailed(this ILogger logger, string exceptionMessage, Exception exception);
+}

--- a/src/Quartz.Plugins/Plugins/Interrupt/JobInterruptMonitorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Interrupt/JobInterruptMonitorPlugin.cs
@@ -92,16 +92,16 @@ public sealed class JobInterruptMonitorPlugin : ITriggerListener, ISchedulerPlug
                 }
                 else if (context.MergedJobDataMap.ContainsKey(JobDataMapKeyMaxRunTime))
                 {
-                    logger.LogWarning("Job data map value for {Key} is not a number of milliseconds, using the plugin default of {Delay} instead", JobDataMapKeyMaxRunTime, jobDataDelay);
+                    logger.MaxRunTimeNotANumber(JobDataMapKeyMaxRunTime, jobDataDelay);
                 }
 
                 monitorPlugin.ScheduleJobInterruptMonitor(context.FireInstanceId, context.JobDetail.Key, jobDataDelay);
-                logger.LogDebug("Job's Interrupt Monitor has been scheduled to interrupt with the delay :{Delay}", jobDataDelay);
+                logger.InterruptMonitorScheduled(jobDataDelay);
             }
         }
         catch (SchedulerException e)
         {
-            logger.LogError(e, "Error scheduling interrupt monitor {ErrorMessage}", e.Message);
+            logger.InterruptMonitorSchedulingFailed(e.Message, e);
         }
 
         return default;
@@ -124,7 +124,7 @@ public sealed class JobInterruptMonitorPlugin : ITriggerListener, ISchedulerPlug
 
     public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Registering Job Interrupt Monitor Plugin");
+        logger.PluginRegistered();
         this.name = pluginName;
 
         taskScheduler = new QueuedTaskScheduler(1, "JobInterruptMonitorPlugin");
@@ -198,11 +198,11 @@ public sealed class JobInterruptMonitorPlugin : ITriggerListener, ISchedulerPlug
                 bool interrupted = await scheduler.InterruptFireInstance(FireInstanceId, cancellationTokenSource.Token).ConfigureAwait(false);
                 if (interrupted)
                 {
-                    logger.LogInformation("Interrupted Job as it ran more than the configured max time. Job Details [{JobName}:{JobGroup}], fire instance id {FireInstanceId}", jobKey.Name, jobKey.Group, FireInstanceId);
+                    logger.JobInterrupted(jobKey.Name, jobKey.Group, FireInstanceId);
                 }
                 else
                 {
-                    logger.LogDebug("Job execution was no longer running, nothing to interrupt. Job Details [{JobName}:{JobGroup}], fire instance id {FireInstanceId}", jobKey.Name, jobKey.Group, FireInstanceId);
+                    logger.JobNoLongerRunning(jobKey.Name, jobKey.Group, FireInstanceId);
                 }
             }
             catch (TaskCanceledException)
@@ -211,7 +211,7 @@ public sealed class JobInterruptMonitorPlugin : ITriggerListener, ISchedulerPlug
             }
             catch (SchedulerException ex)
             {
-                logger.LogError(ex, "Error interrupting Job: {ExceptionMessage}", ex.Message);
+                logger.JobInterruptFailed(ex.Message, ex);
             }
             finally
             {
@@ -229,7 +229,7 @@ public sealed class JobInterruptMonitorPlugin : ITriggerListener, ISchedulerPlug
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error cancelling monitor: {ExceptionMessage}", ex.Message);
+                logger.MonitorCancellationFailed(ex.Message, ex);
             }
         }
     }

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
@@ -81,7 +81,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
     {
         fileName = FileUtil.ResolveFile(fileName) ?? fileName;
 
-        logger.LogInformation("Parsing JSON file: {FileName}", fileName);
+        logger.ParsingFile(fileName);
 
         var stream = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
         string json;
@@ -179,7 +179,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
         {
             if (group.Equals("*", StringComparison.Ordinal))
             {
-                logger.LogInformation("Deleting all jobs in ALL groups");
+                logger.DeletingAllJobsInAllGroups();
                 // deliberately unbounded: deleting only the first page would leave survivors behind
                 PagedResult<JobHeader> allJobs = await scheduler.QueryJobs(new JobQuery { Take = int.MaxValue }, cancellationToken).ConfigureAwait(false);
                 foreach (JobHeader job in allJobs.Items)
@@ -190,7 +190,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
             }
             else if (!protectedJobGroups.Contains(group))
             {
-                logger.LogInformation("Deleting all jobs in group: {Group}", group);
+                logger.DeletingAllJobsInGroup(group);
                 foreach (var key in await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(group), cancellationToken).ConfigureAwait(false))
                 {
                     await scheduler.DeleteJob(key, cancellationToken).ConfigureAwait(false);
@@ -202,7 +202,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
         {
             if (group.Equals("*", StringComparison.Ordinal))
             {
-                logger.LogInformation("Deleting all triggers in ALL groups");
+                logger.DeletingAllTriggersInAllGroups();
                 // deliberately unbounded: unscheduling only the first page would leave survivors behind
                 PagedResult<TriggerHeader> allTriggers = await scheduler.QueryTriggers(new TriggerQuery { Take = int.MaxValue }, cancellationToken).ConfigureAwait(false);
                 foreach (TriggerHeader trigger in allTriggers.Items)
@@ -213,7 +213,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
             }
             else if (!protectedTriggerGroups.Contains(group))
             {
-                logger.LogInformation("Deleting all triggers in group: {Group}", group);
+                logger.DeletingAllTriggersInGroup(group);
                 foreach (var key in await scheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals(group), cancellationToken).ConfigureAwait(false))
                 {
                     await scheduler.UnscheduleJob(key, cancellationToken).ConfigureAwait(false);
@@ -225,7 +225,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
         {
             if (!protectedJobGroups.Contains(key.Group))
             {
-                logger.LogInformation("Deleting job: {JobKey}", key);
+                logger.DeletingJob(key);
                 await scheduler.DeleteJob(key, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -234,7 +234,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
         {
             if (!protectedTriggerGroups.Contains(key.Group))
             {
-                logger.LogInformation("Deleting trigger: {TriggerKey}", key);
+                logger.DeletingTrigger(key);
                 await scheduler.UnscheduleJob(key, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
@@ -88,7 +88,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         Name = pluginName;
         Scheduler = scheduler;
 
-        logger.LogInformation("Registering Quartz JSON Job Initialization Plug-in");
+        logger.PluginRegistered();
 
         var tokens = FileNames
             .Split([FileNameDelimiter], StringSplitOptions.RemoveEmptyEntries)
@@ -138,7 +138,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
                         job.JobDataMap[FileScanJob.FileScanListenerName] = PluginName + '_' + Name;
 
                         await Scheduler.ScheduleJob(job, trig, cancellationToken).ConfigureAwait(false);
-                        logger.LogDebug("Scheduled file scan job for data file: {FileName}, at interval: {ScanInterval}", jobFile.FileName, ScanInterval);
+                        logger.FileScanJobScheduled(jobFile.FileName, ScanInterval);
                     }
 
                     await ProcessFile(jobFile, cancellationToken).ConfigureAwait(false);
@@ -148,7 +148,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         catch (SchedulerException ex)
         {
             if (FailOnSchedulingError) throw;
-            logger.LogError(ex, "Error starting background-task for watching JSON jobs file");
+            logger.FileWatchStartFailed(ex);
         }
         finally
         {
@@ -210,7 +210,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
             var message = "Could not schedule jobs and triggers from JSON file " + jobFile.FileName + ": " + e.Message;
             var schedulerException = new SchedulerException(message, e);
 
-            logger.LogError(e, "Could not schedule jobs and triggers from JSON file {FileName}", jobFile.FileName);
+            logger.FileProcessingFailed(jobFile.FileName, e);
 
             // No keys: the file names many jobs and triggers, and the failure is the file rather than
             // any one of them.
@@ -229,7 +229,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Error while notifying SchedulerListener of error");
+                    logger.ListenerNotificationOfErrorFailed(ex);
                 }
             }
 
@@ -275,7 +275,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
                 if (f is null)
                 {
                     if (plugin.FailOnFileNotFound) throw new SchedulerException("File named '" + FileName + "' does not exist.");
-                    else plugin.logger.LogWarning("File named '{FileName}' does not exist", FileName);
+                    else plugin.logger.FileNotFound(FileName);
                 }
                 else
                 {
@@ -288,7 +288,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
             finally
             {
                 try { f?.Dispose(); }
-                catch (IOException ioe) { plugin.logger.LogWarning(ioe, "Error closing jobs file {FileName}", FileName); }
+                catch (IOException ioe) { plugin.logger.FileCloseFailed(FileName, ioe); }
             }
 
             return Task.CompletedTask;

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingPluginLog.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingPluginLog.cs
@@ -1,0 +1,83 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Plugins.Json;
+
+/// <summary>
+/// Every event the JSON scheduling data plugin logs, as source-generated methods with a pinned
+/// event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 6300-6399 belong to this area and are allocated in file order: the processor that reads
+/// the file (6300-6319) and the plugin that feeds it files (6320-6339). They are separate from the
+/// XML plugin's 6200-6299 even where the two spell a message identically, because an id names one
+/// event in one place. An id, once given out, is what an operator filters and alerts on, so it is
+/// never reused for a different event and never renumbered; <c>LogEventCatalogTest</c> makes a change
+/// to one a reviewed diff.
+/// </para>
+/// </remarks>
+internal static partial class JsonSchedulingPluginLog
+{
+    [LoggerMessage(EventId = 6300, Level = LogLevel.Information, Message = "Parsing JSON file: {FileName}")]
+    public static partial void ParsingFile(this ILogger logger, string fileName);
+
+    [LoggerMessage(EventId = 6301, Level = LogLevel.Information, Message = "Deleting all jobs in ALL groups")]
+    public static partial void DeletingAllJobsInAllGroups(this ILogger logger);
+
+    [LoggerMessage(EventId = 6302, Level = LogLevel.Information, Message = "Deleting all jobs in group: {Group}")]
+    public static partial void DeletingAllJobsInGroup(this ILogger logger, string group);
+
+    [LoggerMessage(EventId = 6303, Level = LogLevel.Information, Message = "Deleting all triggers in ALL groups")]
+    public static partial void DeletingAllTriggersInAllGroups(this ILogger logger);
+
+    [LoggerMessage(EventId = 6304, Level = LogLevel.Information, Message = "Deleting all triggers in group: {Group}")]
+    public static partial void DeletingAllTriggersInGroup(this ILogger logger, string group);
+
+    [LoggerMessage(EventId = 6305, Level = LogLevel.Information, Message = "Deleting job: {JobKey}")]
+    public static partial void DeletingJob(this ILogger logger, JobKey jobKey);
+
+    [LoggerMessage(EventId = 6306, Level = LogLevel.Information, Message = "Deleting trigger: {TriggerKey}")]
+    public static partial void DeletingTrigger(this ILogger logger, TriggerKey triggerKey);
+
+    [LoggerMessage(EventId = 6320, Level = LogLevel.Information, Message = "Registering Quartz JSON Job Initialization Plug-in")]
+    public static partial void PluginRegistered(this ILogger logger);
+
+    [LoggerMessage(EventId = 6321, Level = LogLevel.Debug, Message = "Scheduled file scan job for data file: {FileName}, at interval: {ScanInterval}")]
+    public static partial void FileScanJobScheduled(this ILogger logger, string fileName, TimeSpan scanInterval);
+
+    [LoggerMessage(EventId = 6322, Level = LogLevel.Error, Message = "Error starting background-task for watching JSON jobs file")]
+    public static partial void FileWatchStartFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 6323, Level = LogLevel.Error, Message = "Could not schedule jobs and triggers from JSON file {FileName}")]
+    public static partial void FileProcessingFailed(this ILogger logger, string fileName, Exception exception);
+
+    [LoggerMessage(EventId = 6324, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of error")]
+    public static partial void ListenerNotificationOfErrorFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 6325, Level = LogLevel.Warning, Message = "File named '{FileName}' does not exist")]
+    public static partial void FileNotFound(this ILogger logger, string fileName);
+
+    [LoggerMessage(EventId = 6326, Level = LogLevel.Warning, Message = "Error closing jobs file {FileName}")]
+    public static partial void FileCloseFailed(this ILogger logger, string fileName, Exception exception);
+}

--- a/src/Quartz.Plugins/Plugins/Management/ManagementPluginLog.cs
+++ b/src/Quartz.Plugins/Plugins/Management/ManagementPluginLog.cs
@@ -1,0 +1,46 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Plugins.Management;
+
+/// <summary>
+/// Every event the management plugins log, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 6500-6599 belong to this area. An id, once given out, is what an operator filters and
+/// alerts on, so it is never reused for a different event and never renumbered;
+/// <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// </remarks>
+internal static partial class ManagementPluginLog
+{
+    [LoggerMessage(EventId = 6500, Level = LogLevel.Information, Message = "Registering Quartz Shutdown hook '{PluginName}'")]
+    public static partial void ShutdownHookRegistered(this ILogger logger, string pluginName);
+
+    [LoggerMessage(EventId = 6501, Level = LogLevel.Information, Message = "Shutting down Quartz...")]
+    public static partial void ShuttingDown(this ILogger logger);
+
+    [LoggerMessage(EventId = 6502, Level = LogLevel.Error, Message = "Error shutting down Quartz: {ErrorMessage}")]
+    public static partial void ShutdownFailed(this ILogger logger, string errorMessage, Exception exception);
+}

--- a/src/Quartz.Plugins/Plugins/Management/ShutdownHookPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Management/ShutdownHookPlugin.cs
@@ -62,17 +62,17 @@ public sealed class ShutdownHookPlugin : ISchedulerPlugin
         IScheduler scheduler,
         CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Registering Quartz Shutdown hook '{PluginName}'", pluginName);
+        logger.ShutdownHookRegistered(pluginName);
         AppDomain.CurrentDomain.ProcessExit += async (sender, ea) =>
         {
-            logger.LogInformation("Shutting down Quartz...");
+            logger.ShuttingDown();
             try
             {
                 await scheduler.Shutdown(CleanShutdown, cancellationToken).ConfigureAwait(false);
             }
             catch (SchedulerException e)
             {
-                logger.LogError(e, "Error shutting down Quartz: {ErrorMessage}", e.Message);
+                logger.ShutdownFailed(e.Message, e);
             }
         };
         return default;

--- a/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
@@ -134,7 +134,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
         Name = pluginName;
         Scheduler = scheduler;
 
-        logger.LogInformation("Registering Quartz Job Initialization Plug-in.");
+        logger.PluginRegistered();
 
         // Create JobFile objects
         var tokens = FileNames.Split(FileNameDelimiter).Select(x => x.TrimStart());
@@ -192,7 +192,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
                         job.JobDataMap[FileScanJob.FileScanListenerName] = JobInitializationPluginName + '_' + Name;
 
                         await Scheduler.ScheduleJob(job, trig, cancellationToken).ConfigureAwait(false);
-                        logger.LogDebug("Scheduled file scan job for data file: {FileName}, at interval: {ScanInterval}", jobFile.FileName, ScanInterval);
+                        logger.FileScanJobScheduled(jobFile.FileName, ScanInterval);
                     }
 
                     await ProcessFile(jobFile, cancellationToken).ConfigureAwait(false);
@@ -205,7 +205,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
             {
                 throw;
             }
-            logger.LogError(se, "Error starting background-task for watching jobs file.");
+            logger.FileWatchStartFailed(se);
         }
         finally
         {
@@ -297,8 +297,8 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error while notifying SchedulerListener of error");
-                logger.LogError(schedulerException, "Original error while notifying scheduler listeners: {Message}", message);
+                logger.ListenerNotificationOfErrorFailed(ex);
+                logger.OriginalErrorForNotification(message, schedulerException);
             }
         }
     }
@@ -335,7 +335,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
             var message = $"Could not schedule jobs and triggers from file {jobFile.FileName}: {e.Message}";
             var schedulerException = new SchedulerException(message, e);
 
-            logger.LogError(e, "Could not schedule jobs and triggers from file {FileName}: {Message}", jobFile.FileName, e.Message);
+            logger.FileProcessingFailed(jobFile.FileName, e.Message, e);
 
             await NotifySchedulerListenersOfError(message, schedulerException, cancellationToken).ConfigureAwait(false);
 
@@ -412,7 +412,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
                     }
                     else
                     {
-                        plugin.logger.LogWarning("File named '{FileName}' does not exist.", FileName);
+                        plugin.logger.FileNotFound(FileName);
                     }
                 }
                 else
@@ -433,7 +433,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
                 }
                 catch (IOException ioe)
                 {
-                    plugin.logger.LogWarning(ioe, "Error closing jobs file {FileName}", FileName);
+                    plugin.logger.FileCloseFailed(FileName, ioe);
                 }
             }
         }

--- a/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingPluginLog.cs
+++ b/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingPluginLog.cs
@@ -1,0 +1,64 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Plugins.Xml;
+
+/// <summary>
+/// Every event the XML scheduling data plugin logs, as source-generated methods with a pinned
+/// event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 6200-6299 belong to this area. The processor these events surround lives in the core
+/// package and draws from 5000-5099 (<c>Quartz.Xml.XmlSchedulingLog</c>); this class covers the
+/// plugin that feeds it files. An id, once given out, is what an operator filters and alerts on, so
+/// it is never reused for a different event and never renumbered; <c>LogEventCatalogTest</c> makes a
+/// change to one a reviewed diff.
+/// </para>
+/// </remarks>
+internal static partial class XmlSchedulingPluginLog
+{
+    [LoggerMessage(EventId = 6200, Level = LogLevel.Information, Message = "Registering Quartz Job Initialization Plug-in.")]
+    public static partial void PluginRegistered(this ILogger logger);
+
+    [LoggerMessage(EventId = 6201, Level = LogLevel.Debug, Message = "Scheduled file scan job for data file: {FileName}, at interval: {ScanInterval}")]
+    public static partial void FileScanJobScheduled(this ILogger logger, string fileName, TimeSpan scanInterval);
+
+    [LoggerMessage(EventId = 6202, Level = LogLevel.Error, Message = "Error starting background-task for watching jobs file.")]
+    public static partial void FileWatchStartFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 6203, Level = LogLevel.Error, Message = "Error while notifying SchedulerListener of error")]
+    public static partial void ListenerNotificationOfErrorFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 6204, Level = LogLevel.Error, Message = "Original error while notifying scheduler listeners: {Message}")]
+    public static partial void OriginalErrorForNotification(this ILogger logger, string message, Exception exception);
+
+    [LoggerMessage(EventId = 6205, Level = LogLevel.Error, Message = "Could not schedule jobs and triggers from file {FileName}: {Message}")]
+    public static partial void FileProcessingFailed(this ILogger logger, string fileName, string message, Exception exception);
+
+    [LoggerMessage(EventId = 6206, Level = LogLevel.Warning, Message = "File named '{FileName}' does not exist.")]
+    public static partial void FileNotFound(this ILogger logger, string fileName);
+
+    [LoggerMessage(EventId = 6207, Level = LogLevel.Warning, Message = "Error closing jobs file {FileName}")]
+    public static partial void FileCloseFailed(this ILogger logger, string fileName, Exception exception);
+}

--- a/src/Quartz.Tests.Unit/LogCallSiteTest.cs
+++ b/src/Quartz.Tests.Unit/LogCallSiteTest.cs
@@ -14,7 +14,7 @@ namespace Quartz.Tests.Unit;
 /// for — the same job <c>SourceEncodingTest</c> does for byte-order marks.
 /// </para>
 /// <para>
-/// Only <c>src/Quartz/</c> is covered so far. <c>Quartz.Plugins</c>, <c>Quartz.Jobs</c> and
+/// <c>src/Quartz/</c> and <c>src/Quartz.Plugins/</c> are covered so far. <c>Quartz.Jobs</c> and
 /// <c>Quartz.Extensions.Redis</c> join <see cref="Converted" /> as their own conversions land (#3414);
 /// tests, examples and the documentation samples are deliberately never covered, because a plain call
 /// is the right thing to write in all three.
@@ -25,7 +25,7 @@ public class LogCallSiteTest
     /// <summary>
     /// The projects whose logging has been converted, relative to the repository root.
     /// </summary>
-    private static readonly string[] Converted = ["src/Quartz"];
+    private static readonly string[] Converted = ["src/Quartz", "src/Quartz.Plugins"];
 
     /// <summary>
     /// Build output and tool caches, which hold the generator's own output among other things.
@@ -33,11 +33,21 @@ public class LogCallSiteTest
     private static readonly string[] NotSearched = ["bin", "obj", "node_modules", "TestResults", ".vs"];
 
     /// <summary>
-    /// Call sites that may keep a plain call, each with the reason it is allowed one. Empty, and
-    /// meant to stay that way — an entry here is a promise that the site has been looked at, not a
-    /// place to put one that has not.
+    /// Call sites that may keep a plain call, each with the reason it is allowed one. An entry here is
+    /// a promise that the site has been looked at, not a place to put one that has not.
     /// </summary>
-    private static readonly (string Path, string Reason)[] Allowed = [];
+    private static readonly (string Path, string Reason)[] Allowed =
+    [
+        ("src/Quartz.Plugins/Plugins/History/StructuredLoggingJobHistoryPlugin.cs",
+            "the message template is the user's, configured at run time, and its placeholders are named "
+            + "- the whole point of this plugin is that a structured sink receives them as properties. A "
+            + "[LoggerMessage] template is fixed at compile time, and rendering the template here first "
+            + "would flatten exactly what the plugin exists to preserve. Every call is already behind an "
+            + "IsEnabled check"),
+        ("src/Quartz.Plugins/Plugins/History/StructuredLoggingTriggerHistoryPlugin.cs",
+            "same as StructuredLoggingJobHistoryPlugin: the configured template's named placeholders are "
+            + "the plugin's reason to exist, and they cannot survive a compile-time template"),
+    ];
 
     /// <summary>
     /// The generated classes themselves, whose whole job is to hold the logging.
@@ -88,6 +98,29 @@ public class LogCallSiteTest
             + "Add the event to the *Log class beside the caller, taking the next id in that area's range, "
             + "and call it. A site that genuinely cannot go through one belongs in this test's allow-list, "
             + "with the reason written down");
+    }
+
+    /// <summary>
+    /// An allow-list entry stops being a considered exception the moment its file stops making a plain
+    /// call: from then on it is a hole nobody decided to leave open, and the next plain call written into
+    /// that file walks straight through it.
+    /// </summary>
+    [Test]
+    public void AllowListCarriesNoEntryThatHasServedItsPurpose()
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+
+        foreach ((string path, string reason) in Allowed)
+        {
+            FileInfo file = new(Path.Combine(root.FullName, path.Replace('/', Path.DirectorySeparatorChar)));
+
+            file.Exists.Should().BeTrue(
+                $"the allow-list excuses {path}, so that has to be a file this repository still has");
+
+            PlainLogCall.IsMatch(File.ReadAllText(file.FullName)).Should().BeTrue(
+                $"{path} is on the allow-list because {reason}. It no longer calls ILogger directly, so the "
+                + "entry excuses nothing and should be deleted before it starts excusing something else");
+        }
     }
 
     private static IEnumerable<FileInfo> Discover(DirectoryInfo directory)

--- a/src/Quartz.Tests.Unit/LogEventCatalogTest.cs
+++ b/src/Quartz.Tests.Unit/LogEventCatalogTest.cs
@@ -49,6 +49,7 @@ public class LogEventCatalogTest
     private static readonly Assembly[] Catalogued =
     [
         typeof(global::Quartz.IScheduler).Assembly,
+        typeof(global::Quartz.Plugins.Management.ShutdownHookPlugin).Assembly,
     ];
 
     private static IEnumerable<TestCaseData> Assemblies()

--- a/src/Quartz.Tests.Unit/Plugins/History/LoggingJobHistoryPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/History/LoggingJobHistoryPluginTest.cs
@@ -84,6 +84,34 @@ public class LoggingJobHistoryPluginTest
         loggerProvider.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Information);
     }
 
+    [Test]
+    public async Task ConfiguredMessagesAreRenderedVerbatimAndCarryAnEventIdOfTheirOwn()
+    {
+        plugin.JobToBeFiredMessage = "fired {1}.{0} by {4}.{3}";
+        plugin.JobSuccessMessage = "done {1}.{0}";
+        plugin.JobFailedMessage = "failed {1}.{0}: {8}";
+        plugin.JobWasVetoedMessage = "vetoed {1}.{0}";
+
+        await plugin.JobToBeExecuted(CreateJobExecutionContext());
+        await plugin.JobWasExecuted(CreateJobExecutionContext(), null);
+        await plugin.JobWasExecuted(CreateJobExecutionContext(), new JobExecutionException("boom"));
+        await plugin.JobExecutionVetoed(CreateJobExecutionContext());
+
+        (int EventId, string Message)[] expected =
+        [
+            (6000, "fired jobGroup.jobName by group.name"),
+            (6001, "done jobGroup.jobName"),
+            (6002, "failed jobGroup.jobName: boom"),
+            (6003, "vetoed jobGroup.jobName"),
+        ];
+
+        loggerProvider.Entries.Select(x => (EventId: x.EventId.Id, x.Message)).Should().Equal(
+            expected,
+            "the template is the user's and is formatted here, so passing the result through a degenerate "
+            + "\"{Message}\" event has to leave the text a sink renders exactly as it was - and the four "
+            + "occurrences have to stay separately filterable, which is what an id per occurrence buys");
+    }
+
     private static IJobExecutionContext CreateJobExecutionContext()
     {
         IOperableTrigger t = new SimpleTriggerImpl { Key = new TriggerKey("name", "group"), StartTimeUtc = TimeProvider.System.GetUtcNow() };

--- a/src/Quartz.Tests.Unit/Plugins/History/LoggingTriggerHistoryPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/History/LoggingTriggerHistoryPluginTest.cs
@@ -99,4 +99,41 @@ public class LoggingTriggerHistoryPluginTest
 
         loggerProvider.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Information);
     }
+
+    [Test]
+    public async Task ConfiguredMessagesAreRenderedVerbatimAndCarryAnEventIdOfTheirOwn()
+    {
+        plugin.TriggerFiredMessage = "fired {1}.{0} for {6}.{5}";
+        plugin.TriggerMisfiredMessage = "misfired {1}.{0} for {6}.{5}";
+        plugin.TriggerCompleteMessage = "completed {1}.{0} with {9}";
+
+        IOperableTrigger t = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("triggerName", "triggerGroup")
+            .WithSchedule(SimpleScheduleBuilder.Create())
+            .Build();
+
+        t.JobKey = new JobKey("jobName", "jobGroup");
+
+        IJobExecutionContext ctx = new JobExecutionContextImpl(
+            null,
+            TestUtil.CreateMinimalFiredBundleWithTypedJobDetail(typeof(NoOpJob), t),
+            null);
+
+        await plugin.TriggerFired(t, ctx);
+        await plugin.TriggerMisfired(A.Fake<IScheduler>(), t);
+        await plugin.TriggerComplete(t, ctx, SchedulerInstruction.ReExecuteJob);
+
+        (int EventId, string Message)[] expected =
+        [
+            (6010, "fired triggerGroup.triggerName for jobGroup.jobName"),
+            (6011, "misfired triggerGroup.triggerName for jobGroup.jobName"),
+            (6012, "completed triggerGroup.triggerName with RE-EXECUTE JOB"),
+        ];
+
+        loggerProvider.Entries.Select(x => (EventId: x.EventId.Id, x.Message)).Should().Equal(
+            expected,
+            "the template is the user's and is formatted here, so passing the result through a degenerate "
+            + "\"{Message}\" event has to leave the text a sink renders exactly as it was - and the three "
+            + "occurrences have to stay separately filterable, which is what an id per occurrence buys");
+    }
 }

--- a/src/Quartz.Tests.Unit/Plugins/History/RecordingLoggerProvider.cs
+++ b/src/Quartz.Tests.Unit/Plugins/History/RecordingLoggerProvider.cs
@@ -25,7 +25,7 @@ internal sealed class RecordingLoggerProvider : ILoggerProvider
             Exception exception,
             Func<TState, Exception, string> formatter)
         {
-            provider.Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+            provider.Entries.Add(new LogEntry(logLevel, eventId, formatter(state, exception), exception));
         }
     }
 }
@@ -33,12 +33,14 @@ internal sealed class RecordingLoggerProvider : ILoggerProvider
 internal sealed class LogEntry
 {
     public LogLevel Level { get; }
+    public EventId EventId { get; }
     public string Message { get; }
     public Exception Exception { get; }
 
-    public LogEntry(LogLevel level, string message, Exception exception)
+    public LogEntry(LogLevel level, EventId eventId, string message, Exception exception)
     {
         Level = level;
+        EventId = eventId;
         Message = message;
         Exception = exception;
     }

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.Plugins.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.Plugins.verified.txt
@@ -1,0 +1,80 @@
+﻿6000  Information  HistoryPluginLog.JobToBeFired
+    "{Message}"
+6001  Information  HistoryPluginLog.JobSucceeded
+    "{Message}"
+6002  Warning  HistoryPluginLog.JobFailed
+    "{Message}"
+6003  Information  HistoryPluginLog.JobVetoed
+    "{Message}"
+6010  Information  HistoryPluginLog.TriggerFired
+    "{Message}"
+6011  Information  HistoryPluginLog.TriggerMisfired
+    "{Message}"
+6012  Information  HistoryPluginLog.TriggerCompleted
+    "{Message}"
+6200  Information  XmlSchedulingPluginLog.PluginRegistered
+    "Registering Quartz Job Initialization Plug-in."
+6201  Debug  XmlSchedulingPluginLog.FileScanJobScheduled
+    "Scheduled file scan job for data file: {FileName}, at interval: {ScanInterval}"
+6202  Error  XmlSchedulingPluginLog.FileWatchStartFailed
+    "Error starting background-task for watching jobs file."
+6203  Error  XmlSchedulingPluginLog.ListenerNotificationOfErrorFailed
+    "Error while notifying SchedulerListener of error"
+6204  Error  XmlSchedulingPluginLog.OriginalErrorForNotification
+    "Original error while notifying scheduler listeners: {Message}"
+6205  Error  XmlSchedulingPluginLog.FileProcessingFailed
+    "Could not schedule jobs and triggers from file {FileName}: {Message}"
+6206  Warning  XmlSchedulingPluginLog.FileNotFound
+    "File named '{FileName}' does not exist."
+6207  Warning  XmlSchedulingPluginLog.FileCloseFailed
+    "Error closing jobs file {FileName}"
+6300  Information  JsonSchedulingPluginLog.ParsingFile
+    "Parsing JSON file: {FileName}"
+6301  Information  JsonSchedulingPluginLog.DeletingAllJobsInAllGroups
+    "Deleting all jobs in ALL groups"
+6302  Information  JsonSchedulingPluginLog.DeletingAllJobsInGroup
+    "Deleting all jobs in group: {Group}"
+6303  Information  JsonSchedulingPluginLog.DeletingAllTriggersInAllGroups
+    "Deleting all triggers in ALL groups"
+6304  Information  JsonSchedulingPluginLog.DeletingAllTriggersInGroup
+    "Deleting all triggers in group: {Group}"
+6305  Information  JsonSchedulingPluginLog.DeletingJob
+    "Deleting job: {JobKey}"
+6306  Information  JsonSchedulingPluginLog.DeletingTrigger
+    "Deleting trigger: {TriggerKey}"
+6320  Information  JsonSchedulingPluginLog.PluginRegistered
+    "Registering Quartz JSON Job Initialization Plug-in"
+6321  Debug  JsonSchedulingPluginLog.FileScanJobScheduled
+    "Scheduled file scan job for data file: {FileName}, at interval: {ScanInterval}"
+6322  Error  JsonSchedulingPluginLog.FileWatchStartFailed
+    "Error starting background-task for watching JSON jobs file"
+6323  Error  JsonSchedulingPluginLog.FileProcessingFailed
+    "Could not schedule jobs and triggers from JSON file {FileName}"
+6324  Error  JsonSchedulingPluginLog.ListenerNotificationOfErrorFailed
+    "Error while notifying SchedulerListener of error"
+6325  Warning  JsonSchedulingPluginLog.FileNotFound
+    "File named '{FileName}' does not exist"
+6326  Warning  JsonSchedulingPluginLog.FileCloseFailed
+    "Error closing jobs file {FileName}"
+6400  Information  InterruptPluginLog.PluginRegistered
+    "Registering Job Interrupt Monitor Plugin"
+6401  Warning  InterruptPluginLog.MaxRunTimeNotANumber
+    "Job data map value for {Key} is not a number of milliseconds, using the plugin default of {Delay} instead"
+6402  Debug  InterruptPluginLog.InterruptMonitorScheduled
+    "Job's Interrupt Monitor has been scheduled to interrupt with the delay: {Delay}"
+6403  Error  InterruptPluginLog.InterruptMonitorSchedulingFailed
+    "Error scheduling interrupt monitor {ErrorMessage}"
+6410  Information  InterruptPluginLog.JobInterrupted
+    "Interrupted Job as it ran more than the configured max time. Job Details [{JobName}:{JobGroup}], fire instance id {FireInstanceId}"
+6411  Debug  InterruptPluginLog.JobNoLongerRunning
+    "Job execution was no longer running, nothing to interrupt. Job Details [{JobName}:{JobGroup}], fire instance id {FireInstanceId}"
+6412  Error  InterruptPluginLog.JobInterruptFailed
+    "Error interrupting Job: {ExceptionMessage}"
+6413  Error  InterruptPluginLog.MonitorCancellationFailed
+    "Error cancelling monitor: {ExceptionMessage}"
+6500  Information  ManagementPluginLog.ShutdownHookRegistered
+    "Registering Quartz Shutdown hook '{PluginName}'"
+6501  Information  ManagementPluginLog.ShuttingDown
+    "Shutting down Quartz..."
+6502  Error  ManagementPluginLog.ShutdownFailed
+    "Error shutting down Quartz: {ErrorMessage}"


### PR DESCRIPTION
Part 2 of 4 for #3414. The `Quartz.Plugins` package only; `Quartz.Jobs` and
`Quartz.Extensions.Redis` follow in their own pull requests. #3450 did `Quartz` and is the shape
this copies.

## What changed

Of the 43 `logger.Log{Trace,Debug,Information,Warning,Error,Critical}(…)` calls under
`src/Quartz.Plugins/`, 36 are now calls on source-generated `[LoggerMessage]` methods and 7 stay
plain, deliberately — see [What keeps a plain call](#what-keeps-a-plain-call). That makes **40
events**, more than the 36 converted calls, because the history plugins funnelled seven distinct
occurrences through three private `WriteInformation`/`WriteWarning` helpers, and each occurrence
now has an id of its own.

Five `internal static partial class <Area>Log` classes, each beside its callers, each drawing from
its slice of the 6000–6999 range `LogEventCatalogTest.Ranges` already reserved for this package:

| Range | Class | File | Events |
|---|---|---|---|
| 6000–6199 | `HistoryPluginLog` | `src/Quartz.Plugins/Plugins/History/HistoryPluginLog.cs` | 7 |
| 6200–6299 | `XmlSchedulingPluginLog` | `src/Quartz.Plugins/Plugins/Xml/XmlSchedulingPluginLog.cs` | 8 |
| 6300–6399 | `JsonSchedulingPluginLog` | `src/Quartz.Plugins/Plugins/Json/JsonSchedulingPluginLog.cs` | 14 |
| 6400–6499 | `InterruptPluginLog` | `src/Quartz.Plugins/Plugins/Interrupt/InterruptPluginLog.cs` | 8 |
| 6500–6599 | `ManagementPluginLog` | `src/Quartz.Plugins/Plugins/Management/ManagementPluginLog.cs` | 3 |

Gaps are left inside each range where a class covers two things: 6000–6009 is
`LoggingJobHistoryPlugin` and 6010–6019 is `LoggingTriggerHistoryPlugin`; 6300–6319 is the JSON
processor and 6320–6339 the plugin that feeds it files; 6400–6409 is the interrupt plugin and
6410–6419 the monitor that does the interrupting.

The two guards join up as part 1 laid out: `LogEventCatalogTest.Catalogued` gains one line and
`LogEventCatalogTest_Quartz.Plugins.verified.txt` is a new snapshot, `LogCallSiteTest.Converted`
gains `"src/Quartz.Plugins"`. The `CA2254` pragmas at the converted sites are gone. No public API
moved — every generated class is `internal`, and the public-API baselines are untouched.

## The history plugins took a degenerate template

`LoggingJobHistoryPlugin` and `LoggingTriggerHistoryPlugin` log a `string.Format` template **the
user configures** — `JobSuccessMessage`, `TriggerMisfiredMessage` and their siblings, with
`{0}`-style placeholders — which is documented, settable through `PluginConfigurationExtensions`,
and covered by tests. A template only known at run time cannot be a compile-time `[LoggerMessage]`
template.

So those seven sites format the configured template exactly as before and pass the result through
an event whose own template is `"{Message}"` — part 1's precedent for `"{Problem}"` and
`"{ValidationMessage}"`. The text a sink renders is unchanged. What is new is the id, and I gave
each occurrence its own rather than sharing one, because "the job failed" and "the job was vetoed"
have to stay separately filterable and that is the entire point of the catalogue:

| Id | Level | Occurrence |
|---|---|---|
| 6000 | Information | `JobToBeFiredMessage` |
| 6001 | Information | `JobSuccessMessage` |
| 6002 | Warning | `JobFailedMessage` (carries the `JobExecutionException`) |
| 6003 | Information | `JobWasVetoedMessage` |
| 6010 | Information | `TriggerFiredMessage` |
| 6011 | Information | `TriggerMisfiredMessage` |
| 6012 | Information | `TriggerCompleteMessage` |

Neither plugin has a configurable *level*, so no site needed the `LogLevel`-parameter form of
`[LoggerMessage]`. The existing `IsEnabled` guards stay: here they are not redundant, because they
guard the argument array and the `string.Format` that precede the call.

`LoggingJobHistoryPluginTest` and `LoggingTriggerHistoryPluginTest` gain a test each that
configures all the templates, drives every occurrence and asserts the rendered text and the id —
the `{Message}` indirection is the one place this change could have altered what an operator sees,
so it is the one place with a test that would catch it. `RecordingLoggerProvider` records the
`EventId` for them.

## What keeps a plain call

`StructuredLoggingJobHistoryPlugin` and `StructuredLoggingTriggerHistoryPlugin` — seven calls —
keep their direct `logger.LogInformation(template, args)`, and are recorded in
`LogCallSiteTest.Allowed` with the reason.

These are the structured-logging counterparts of the pair above: their configured templates carry
**named** placeholders (`{JobGroup}`, `{TriggerName}`, `{FireTime}`) which MEL turns into
properties a Serilog or NLog sink indexes. That is the whole reason the two plugins exist, and it
is what the `{Message}` treatment would destroy — and it cannot be done any other way, because
rendering a named template ahead of time needs MEL's internal `LogValuesFormatter`, and
`LoggerMessage.Define` tops out at six parameters where `JobToBeFiredMessage` takes eight. Every
one of the seven calls already sits behind an `IsEnabled` check, so the allocation the conversion
exists to avoid is already avoided; what they lack is an event id, and only dropping a documented,
tested feature would buy one.

`LogCallSiteTest` gains a second test with the first entries in that allow-list: an entry whose
file no longer makes a plain call is deleted, not kept, because from that moment it is a hole
nobody decided to leave open through which the next plain call walks.

## Message templates that changed

One, and it is a typo corrected while the id is new:

| Old | New | Why |
|---|---|---|
| `"Job's Interrupt Monitor has been scheduled to interrupt with the delay :{Delay}"` | `"…with the delay: {Delay}"` (6402) | The space was before the colon rather than after it |

Everything else is verbatim — same level, same template, same exception attached. Two pairs look
like duplicates in the snapshot and are not: `"Error while notifying SchedulerListener of error"`
and `"Error closing jobs file {FileName}"` are each raised from both the XML plugin and the JSON
plugin, and take an id in each range. That is the same call part 1 made for
`RAMJobStoreLog.TriggerReferencesMissingCalendar` (2002) and
`AdoJobStoreLog.TriggerReferencesMissingCalendar` (3032) — an id names one event in one place; only
call sites *within* one class share one. `"File named '{FileName}' does not exist"` (6325, JSON)
and `"File named '{FileName}' does not exist."` (6206, XML) differ by a full stop, which I left
alone: they are separate events either way, and normalising them would be a text change nobody
asked for.

## For a reviewer to decide

* **Seven ids for the history plugins, not one.** The spec I worked from could be read as "one
  shared `{Message}` event". I gave each occurrence its own id because filtering "the job failed"
  apart from "the job was vetoed" is exactly what an operator wants and the ids cost nothing. Say
  the word and they collapse.
* **The `Structured*` pair stays on plain calls.** This is the one place I did not do what the
  package-wide sweep says, and it is the trade recorded above: their event ids would cost a
  documented, tested feature. The alternative I did not take is dropping template configurability
  from those two plugins and minting fixed templates, which is a 4.x API decision, not a logging
  one.
* **`JsonSchedulingPluginLog` covers two types in two files.** The processor and the plugin are one
  area with one range, split by a gap at 6320 rather than into two classes, because 14 events over
  two adjacent files is not two areas.
* **`CA1848` is still in `NoWarn`.** Same as part 1: `Quartz.Jobs` and `Quartz.Extensions.Redis`
  still need it. It comes out with part 4.

## Verification

```
dotnet build Quartz.slnx                            0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit                   Passed: 3334, Failed: 0, Skipped: 4
dotnet test src/Quartz.Tests.AspNetCore             Passed:  433, Failed: 0, Skipped: 0
QUARTZ_TEST_DATABASE=basic dotnet test
  src/Quartz.Tests.Integration (non-db categories)  Passed:  315, Failed: 0, Skipped: 0
dotnet fallout VerifyDocsSnippets                   Succeeded (90 markdown files checked)
npm run docs:check-links                            212 pages, 769 links, 438 fragments, none dead
grep -rnE "\.Log(Trace|Debug|Information|Warning|Error|Critical)\(|\.Log\(LogLevel" src/Quartz.Plugins
                                                    7 matches, all in the two Structured* plugins
```

Docker was up, so the basic integration leg really ran.

The migration guide's range table gains the five plugin areas, the corrected message, and the
paragraph explaining why two history plugins have event ids and two do not.

**Expect the SonarCloud "coverage on new code" gate to go red**, for the reason recorded on #3450:
the `*Log.cs` files contribute no executable lines, so the "new code" is the converted call-site
lines themselves — counted as new because `logger.LogWarning(…)` became
`logger.SomethingHappened(…)` — sitting where they always sat, on error and rollback paths, with
exactly the coverage they had before. Same attribution artefact as #3318, #3397 and #3450; nothing
here can be tested into coverage without inventing failure injection for every log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
