### PR TITLE
A trigger keeps the clock it was built with, wherever it came from

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -7046,7 +7046,36 @@ is built:
   not by the `EndingDailyAfterCount` call. A count that is not positive is still rejected immediately.
 
 `DailyTimeIntervalScheduleBuilder.Create()` takes no `TimeProvider` — none of the schedule builders
-do; the clock belongs to `TriggerBuilder.Create(TimeProvider?)`.
+do; the clock belongs to `TriggerBuilder.Create(TimeProvider?)`, and it reaches the trigger itself as
+well as the schedule — see [A trigger holds the clock that built it](#a-trigger-holds-the-clock-that-built-it).
+
+## A trigger holds the clock that built it
+
+3.x had one clock. `SystemTime.UtcNow` was a process-wide hook, so a trigger, the store that swept it
+up and the scheduler that fired it could not disagree about what time it was. 4.x replaced it with
+`TimeProvider`, which is an object rather than a hook — which means each trigger *has* a clock, and it
+matters where it got one.
+
+It gets one from whoever produced it:
+
+* `TriggerBuilder.Create(clock)...Build()` gives the built trigger that clock. Previously it used the
+  clock only for the default start time and for the schedule builder's own arithmetic, and the trigger
+  itself was left on `TimeProvider.System` — so the past-due clamp in `ComputeFirstFireTimeUtc` and the
+  whole of `UpdateAfterMisfire` read the machine's wall clock. `TriggerBuilder.Create()` with no
+  argument still means `TimeProvider.System`.
+* `trigger.GetTriggerBuilder()` carries the trigger's clock into the rebuilt trigger.
+* A job store hands its scheduler's clock to every trigger it materializes. `RAMJobStore` hands back
+  the object it was given, clock and all; the ADO.NET store builds triggers from rows and stamps each
+  one — the blob path included, since the clock does not serialize.
+
+In production every one of these is `TimeProvider.System` and nothing looks different. It shows up in a
+scheduler configured with a `FakeTimeProvider`: a misfire that the store *selected* on the test's clock
+used to be *recovered* onto the machine's, which is the ADO.NET half of what
+[#3456](https://github.com/quartznet/quartznet/issues/3456) reported.
+
+The clock is not part of a trigger's public surface. It is a construction-or-store decision, because
+the decision that a trigger has misfired and the arithmetic that recovers it have to be made against
+one reading of "now".
 
 ## `InTimeZone` is nullable everywhere
 

--- a/docs/documentation/quartz-4.x/tutorial/testing.md
+++ b/docs/documentation/quartz-4.x/tutorial/testing.md
@@ -68,6 +68,10 @@ scheduled.
 `TriggerBuilder.Create()` with no argument defaults its start time to the **wall clock**, even inside a
 test holding a `FakeTimeProvider`. Pass the clock — `TriggerBuilder.Create(clock)` — and set `StartAt`
 explicitly. See [Time and TimeProvider](time-and-timeprovider.md#the-trap-triggers-built-outside-the-container).
+
+Passing the clock is enough: the built trigger keeps it, so every "now" it reads afterwards — a cron
+trigger's past-due clamp in `ComputeFirstFireTimeUtc`, and the whole of `UpdateAfterMisfire` — is the
+clock you passed rather than the machine's.
 :::
 
 Calendars are testable the same way: `ICalendar.IsTimeIncluded(when)` needs nothing but the calendar.

--- a/docs/documentation/quartz-4.x/tutorial/time-and-timeprovider.md
+++ b/docs/documentation/quartz-4.x/tutorial/time-and-timeprovider.md
@@ -93,10 +93,11 @@ TriggerBuilder.Create(TimeProvider? timeProvider = null);
 TriggerBuilder.Create<TJob>(TimeProvider? timeProvider = null);
 ```
 
-Inside the builder it does three things: it is the default `StartTimeUtc` when you do not call
-`StartAt`, it is what `StartNow()` reads, and it is handed to the schedule builder at `Build()` time so
+Inside the builder it does four things: it is the default `StartTimeUtc` when you do not call
+`StartAt`, it is what `StartNow()` reads, it is handed to the schedule builder at `Build()` time so
 that a schedule computed there — `DailyTimeIntervalScheduleBuilder.EndingDailyAfterCount(n)` is the one
-that does this — is computed against the same clock.
+that does this — is computed against the same clock, and it is handed to the trigger itself, which
+keeps it. See [Which clock a trigger holds](#which-clock-a-trigger-holds).
 
 The five schedule builders take **no** clock:
 
@@ -178,12 +179,34 @@ ITrigger trigger = TriggerBuilder.Create(fakeClock)
 An explicit `StartAt` sidesteps the question entirely, which is why it is worth being explicit in tests
 even when you would not bother in production code.
 
+## Which clock a trigger holds
+
+A trigger does not go looking for a clock; it is given one, and it keeps it. Everything it later reads
+as "now" — the past-due clamp in `ComputeFirstFireTimeUtc`, and the whole of `UpdateAfterMisfire` — is
+that clock.
+
+| A trigger produced by | holds |
+|---|---|
+| `TriggerBuilder.Create(clock)` | `clock` |
+| `TriggerBuilder.Create()` | `TimeProvider.System` |
+| `AddTrigger<TJob>` / `ScheduleJob<T>` in DI configuration | the scheduler's `TimeProvider` |
+| `trigger.GetTriggerBuilder().Build()` | whatever `trigger` held |
+| `new CronTriggerImpl(clock)` and its siblings | `clock`, or `TimeProvider.System` when omitted |
+| a job store reading it back | the clock that store's scheduler runs on |
+
+The last row is the one that is easy to miss. `RAMJobStore` hands back the very object it was given, so
+a trigger stored there keeps whatever built it. The ADO.NET store has only rows, so it builds a trigger
+afresh on every read and gives it the store's clock — including a trigger deserialized from
+`BLOB_TRIGGERS`, whose clock cannot have survived the round trip because the field does not serialize.
+
+That is what keeps a misfire honest. The store decides a trigger has misfired by its own clock; the
+trigger computes the recovery. Both readings have to come from the same place, or a scheduler on a
+`FakeTimeProvider` recovers a 2024 misfire onto today.
+
 ::: warning
-Constructing a trigger implementation directly —
-`new SimpleTriggerImpl(timeProvider)`, `new CronTriggerImpl(name, group, expression, timeProvider)` and
-their siblings — takes a `TimeProvider?` that defaults to `TimeProvider.System`. The parameter is also
-not serialized: a trigger read back out of a job store reads the system clock until the store hands it
-one.
+The clock is not part of a trigger's public surface — there is no `ITrigger.TimeProvider` to read or
+assign. It is decided when the trigger is constructed, or by the store that materialized it, and
+nothing else changes it.
 :::
 
 ## Time zones are a separate axis

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
@@ -315,7 +315,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
             var triggerGroup = NormalizeEmpty(triggerDef.Group);
             var triggerJobGroup = NormalizeEmpty(triggerDef.JobGroup);
 
-            var tb = TriggerBuilder.Create();
+            var tb = TriggerBuilder.Create(timeProvider);
             if (triggerGroup is not null) tb.WithIdentity(triggerName, triggerGroup);
             else tb.WithIdentity(triggerName);
             if (triggerJobGroup is not null) tb.ForJob(triggerJobName, triggerJobGroup);

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
@@ -123,7 +123,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
 
                         await Scheduler.UnscheduleJob(tKey, cancellationToken).ConfigureAwait(false);
 
-                        var trig = new SimpleTriggerImpl();
+                        var trig = new SimpleTriggerImpl(timeProvider);
                         trig.Key = tKey;
                         trig.StartTimeUtc = timeProvider.GetUtcNow();
                         trig.EndTimeUtc = null;

--- a/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
@@ -177,7 +177,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
                         await Scheduler.UnscheduleJob(tKey, cancellationToken).ConfigureAwait(false);
 
                         // TODO: convert to use builder
-                        var trig = new SimpleTriggerImpl();
+                        var trig = new SimpleTriggerImpl(timeProvider);
                         trig.Key = tKey;
                         trig.StartTimeUtc = timeProvider.GetUtcNow();
                         trig.EndTimeUtc = null;

--- a/src/Quartz.Tests.Integration/Impl/MisfireAcrossDstTransitionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireAcrossDstTransitionTest.cs
@@ -162,11 +162,17 @@ public sealed class MisfireAcrossDstTransitionTest
     /// The same sweep against a database: one pass, the trigger back in waiting, and the value that
     /// survives a restart written into <c>NEXT_FIRE_TIME</c> rather than only onto an object.
     /// </summary>
-    [TestCase("SpringForward", MisfireInstruction.CronTrigger.FireOnceNow)]
-    [TestCase("SpringForward", MisfireInstruction.CronTrigger.DoNothing)]
-    [TestCase("FallBack", MisfireInstruction.CronTrigger.FireOnceNow)]
-    [TestCase("FallBack", MisfireInstruction.CronTrigger.DoNothing)]
-    public async Task OneSweepRecoversTheTriggerAndWritesTheColumn(string direction, int misfireInstruction)
+    /// <remarks>
+    /// The expected instants are the in-memory twin's, cell for cell. They can be: the trigger the
+    /// store rebuilds out of the row is handed the store's clock, so the two stores' misfire
+    /// arithmetic is the same arithmetic. Before that they were not — the rebuilt trigger read
+    /// <c>TimeProvider.System</c> and recovery landed on whenever the test happened to run.
+    /// </remarks>
+    [TestCase("SpringForward", MisfireInstruction.CronTrigger.FireOnceNow, "2024-03-31 04:15 +03:00")]
+    [TestCase("SpringForward", MisfireInstruction.CronTrigger.DoNothing, "2024-03-31 04:30 +03:00")]
+    [TestCase("FallBack", MisfireInstruction.CronTrigger.FireOnceNow, "2024-10-27 03:15 +02:00")]
+    [TestCase("FallBack", MisfireInstruction.CronTrigger.DoNothing, "2024-10-27 03:30 +02:00")]
+    public async Task OneSweepRecoversTheTriggerAndWritesTheColumn(string direction, int misfireInstruction, string expectedNextFireTime)
     {
         TimeZoneInfo zone = TestTimeZones.Helsinki;
         DstMisfire scenario = ResolveScenario(direction, zone);
@@ -203,25 +209,15 @@ public sealed class MisfireAcrossDstTransitionTest
         (await ReadNextFireTimeColumn(triggerKey)).Should().Be(recovered.NextFireTimeUtc,
             "NEXT_FIRE_TIME is what a restarted scheduler reads, so it is what recovery has to have written");
 
-        DateTimeOffset expected = ExpectedByTriggerArithmetic(triggerKey, job.Key, zone, clock, misfireInstruction, scenario);
         DateTimeOffset next = recovered.NextFireTimeUtc.Value;
 
-        if (next != expected)
-        {
-            Assert.Inconclusive(
-                $"Recovery did not compute against the store's clock. Stored NEXT_FIRE_TIME is {next:O} "
-                + $"(local {TimeZoneInfo.ConvertTime(next, zone):yyyy-MM-dd HH:mm zzz}); the same trigger holding the store's "
-                + $"clock computes {expected:O} (local {TimeZoneInfo.ConvertTime(expected, zone):yyyy-MM-dd HH:mm zzz}) for "
-                + $"misfire instruction {misfireInstruction} at a store 'now' of {scenario.SweepAt:O}. The store selects "
-                + "misfired triggers with its own TimeProvider, but the trigger it rebuilds from the row comes from "
-                + "TriggerBuilder.Create() with no clock, so UpdateAfterMisfire reads TimeProvider.System - the machine's wall "
-                + "clock - and the recovered fire time has nothing to do with the transition under test. The in-memory case "
-                + "above passes because that store keeps the trigger object it was handed, clock included.");
-        }
+        next.Should().Be(TestTimeZones.Local(expectedNextFireTime),
+            "the store's clock says {0:O}, and the trigger it rebuilt out of the row holds that same clock, so the "
+            + "{1} transition is accounted for exactly once - and to the same instant the in-memory twin lands on",
+            scenario.SweepAt, direction);
 
-        next.Should().Be(expected,
-            "the fire time recovery writes is the one the trigger's own misfire policy computes at the store's now, so the "
-            + "{0} transition is accounted for exactly once", direction);
+        next.Should().Be(ExpectedByTriggerArithmetic(triggerKey, job.Key, zone, clock, misfireInstruction, scenario),
+            "what recovery writes is what the trigger's own misfire policy computes - the store applies it, it does not invent one");
     }
 
     /// <summary>
@@ -298,10 +294,10 @@ public sealed class MisfireAcrossDstTransitionTest
         int misfireInstruction,
         DateTimeOffset missedFireTime)
     {
-        // Built by hand rather than through TriggerBuilder, because the builder does not hand the
-        // trigger the clock it was created with and every "now" a cron trigger reads - the past-due
-        // clamp in ComputeFirstFireTimeUtc, and the whole of UpdateAfterMisfire - would then be the
-        // machine's wall clock rather than this test's.
+        // Built by hand rather than through TriggerBuilder: the last step states NextFireTimeUtc,
+        // which only the implementation exposes. TriggerBuilder.Create(clock) would hand over the
+        // clock just as well, but this doubles as the oracle for what the store rebuilds, and an
+        // oracle that goes through the same builder the store does would move with it.
         CronTriggerImpl trigger = new CronTriggerImpl(clock)
         {
             Key = triggerKey,

--- a/src/Quartz.Tests.Integration/Impl/MisfireCalendarExclusionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireCalendarExclusionTest.cs
@@ -17,6 +17,8 @@
  */
 #endregion
 
+using Microsoft.Extensions.Time.Testing;
+
 using Quartz.Extensibility;
 using Quartz.Impl.Calendar;
 
@@ -47,9 +49,12 @@ public sealed class MisfireCalendarExclusionTest : MisfireThroughAStoreTestBase
         DateTimeOffset anchor = Anchor();
         DateTimeOffset scheduled = anchor - HalfPeriod;
 
+        // Where both stores' clocks stand when their pass runs, so one expectation answers for both.
+        FakeTimeProvider clock = ClockAt(anchor);
+
         // What the policy picks with nothing in its way. The calendar is then built to exclude exactly
         // that day, so the store has to move past it or the assertion below is not about a calendar.
-        MisfireExpectation withoutCalendar = MisfireExpectation.From(Detached(testCase, anchor, scheduled), calendar: null);
+        MisfireExpectation withoutCalendar = MisfireExpectation.From(Detached(testCase, anchor, clock, scheduled), calendar: null, clock);
 
         withoutCalendar.NextFireTimeUtc.Should().NotBeNull(
             "'{0}' has to have a slot to skip before there is anything for a calendar to exclude", testCase);
@@ -57,7 +62,7 @@ public sealed class MisfireCalendarExclusionTest : MisfireThroughAStoreTestBase
         HolidayCalendar calendar = new() { TimeZone = TimeZoneInfo.Utc };
         calendar.AddExcludedDay(DateOnly.FromDateTime(withoutCalendar.NextFireTimeUtc.Value.UtcDateTime));
 
-        MisfireExpectation expected = MisfireExpectation.From(Detached(testCase, anchor, scheduled), calendar);
+        MisfireExpectation expected = MisfireExpectation.From(Detached(testCase, anchor, clock, scheduled), calendar, clock);
 
         expected.NextFireTimeUtc.Should().NotBe(withoutCalendar.NextFireTimeUtc,
             "the calendar excludes the day '{0}' would otherwise land on, so a stored fire time equal to "
@@ -70,7 +75,7 @@ public sealed class MisfireCalendarExclusionTest : MisfireThroughAStoreTestBase
 
             await store.Store.AddCalendar(CalendarName, calendar);
 
-            IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor)
+            IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor, store.Clock)
                 .WithIdentity(triggerKey)
                 .ForJob(jobKey)
                 .WithCalendarName(CalendarName)
@@ -79,25 +84,27 @@ public sealed class MisfireCalendarExclusionTest : MisfireThroughAStoreTestBase
             await Store(store, Job(jobKey), trigger, scheduled, calendar);
             store.Clock.Advance(HalfPeriod);
 
-            DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
+            store.Clock.GetUtcNow().Should().Be(clock.GetUtcNow(),
+                "the expectation was computed on a clock frozen where this store's now stands, so the two "
+                + "have to be the same instant for it to answer for this store");
+
             await store.Sweep(scheduled - TimeSpan.FromTicks(1));
-            DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
 
             TriggerState state = await store.Store.GetTriggerState(triggerKey);
             IOperableTrigger readBack = await store.Store.GetTrigger(triggerKey);
 
             readBack.Should().NotBeNull("{0} must still hold '{1}' after a misfire pass", store.Name, testCase);
 
-            expected.AssertAgainst(store.Name, testCase + " with an excluded day", state, readBack.NextFireTimeUtc, passStarted, passFinished);
+            expected.AssertAgainst(store.Name, testCase + " with an excluded day", state, readBack.NextFireTimeUtc);
         }
     }
 
-    private static IOperableTrigger Detached(MisfireMatrixCase testCase, DateTimeOffset anchor, DateTimeOffset scheduled)
+    private static IOperableTrigger Detached(MisfireMatrixCase testCase, DateTimeOffset anchor, TimeProvider clock, DateTimeOffset scheduled)
     {
         TriggerKey triggerKey = new("calendar-detached", Group);
         JobKey jobKey = new("calendar-detached", Group);
 
-        IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor)
+        IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor, clock)
             .WithIdentity(triggerKey)
             .ForJob(jobKey)
             .Build();

--- a/src/Quartz.Tests.Integration/Impl/MisfireExpectation.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireExpectation.cs
@@ -37,12 +37,12 @@ namespace Quartz.Tests.Integration.Impl;
 /// what makes it a parity assertion rather than two independent ones that happen to agree.
 /// </para>
 /// <para>
-/// The one outcome that cannot be an exact instant is "fire now": the policies that reschedule to now
-/// read the clock at the moment the store applies them, so the detached copy's value and the store's
-/// differ by however long the pass took. Those are asserted to fall inside the pass instead, which is
-/// tighter than a tolerance and says the same thing. The rule that sorts a "now" from a scheduled
-/// instant is <see cref="TriggerBase.FireNowMisfireDetectionThresholdMs" /> — the same one both stores
-/// use to decide whether a misfire earned a recorded original fire time.
+/// Every outcome is an exact instant, "fire now" included. The policies that reschedule to now read
+/// the trigger's own clock, and a trigger keeps the clock it was built with — so a detached copy built
+/// on the store's clock, which does not move on its own, computes the very instant the store's own copy
+/// does. The rule that sorts a "now" from a scheduled instant is
+/// <see cref="TriggerBase.FireNowMisfireDetectionThresholdMs" /> — the same one both stores use to
+/// decide whether a misfire earned a recorded original fire time.
 /// </para>
 /// </remarks>
 public sealed class MisfireExpectation
@@ -72,9 +72,16 @@ public sealed class MisfireExpectation
     /// Applies the misfire policy to <paramref name="detached" /> — a copy no store has ever seen —
     /// and captures what came out.
     /// </summary>
-    public static MisfireExpectation From(IOperableTrigger detached, ICalendar calendar)
+    /// <param name="detached">The copy to run the policy on. It must hold <paramref name="clock" />.</param>
+    /// <param name="calendar">The calendar the policy consults, or <see langword="null" />.</param>
+    /// <param name="clock">
+    /// The clock the copy reads, which is the store's. Taken rather than read off the trigger so that a
+    /// copy accidentally left on some other clock produces a wrong expectation here rather than a
+    /// self-consistent one.
+    /// </param>
+    public static MisfireExpectation From(IOperableTrigger detached, ICalendar calendar, TimeProvider clock)
     {
-        DateTimeOffset now = TimeProvider.System.GetUtcNow();
+        DateTimeOffset now = clock.GetUtcNow();
 
         detached.UpdateAfterMisfire(calendar);
 
@@ -92,15 +99,11 @@ public sealed class MisfireExpectation
     /// <param name="cell">What the case under test is, as it reads in a failure message.</param>
     /// <param name="state">The state the store reports.</param>
     /// <param name="actual">The next fire time read back out of the store.</param>
-    /// <param name="passStarted">Real time immediately before the store's misfire pass.</param>
-    /// <param name="passFinished">Real time immediately after it.</param>
     public void AssertAgainst(
         string storeName,
         string cell,
         TriggerState state,
-        DateTimeOffset? actual,
-        DateTimeOffset passStarted,
-        DateTimeOffset passFinished)
+        DateTimeOffset? actual)
     {
         state.Should().Be(State,
             "{0} must park '{1}' in the state its remaining fire times call for, and UpdateAfterMisfire left it {2}",
@@ -117,11 +120,10 @@ public sealed class MisfireExpectation
         if (firesNow)
         {
             actual.Should().NotBeNull("'{0}' reschedules to now, so {1} must have given it a fire time", cell, storeName);
-            actual.Value.Should().BeOnOrAfter(passStarted).And.BeOnOrBefore(passFinished,
-                "'{0}' reschedules to the moment the policy is applied, so {1} must have written an instant "
-                + "inside its own pass ({2} .. {3}) rather than {4}",
-                cell, storeName,
-                Format(passStarted), Format(passFinished), Format(actual.Value));
+            actual.Should().Be(nextFireTimeUtc,
+                "'{0}' reschedules to the store's own reading of now, which is {1} and does not move on its "
+                + "own — so {2} must have written that instant and not the machine's",
+                cell, Format(nextFireTimeUtc.Value), storeName);
             return;
         }
 

--- a/src/Quartz.Tests.Integration/Impl/MisfireMatrixCases.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireMatrixCases.cs
@@ -54,11 +54,16 @@ public sealed class MisfireMatrixCase
     public string Instruction { get; init; }
 
     /// <summary>
-    /// Builds the trigger this cell is about, anchored on the instant the test froze. Called more than
-    /// once per test: once for the copy that is stored, and once for the detached copy that computes
-    /// what the store must arrive at.
+    /// Builds the trigger this cell is about, anchored on the instant the test froze and holding the
+    /// clock the store under test reads. Called more than once per test: once for the copy that is
+    /// stored, and once for the detached copy that computes what the store must arrive at.
     /// </summary>
-    public Func<DateTimeOffset, TriggerBuilder<IJob>> Trigger { get; init; }
+    /// <remarks>
+    /// The clock is the trigger's, not only the builder's: a trigger keeps the clock it was built with,
+    /// so a policy that reschedules to "now" resolves against the test's clock rather than the
+    /// machine's, on either store.
+    /// </remarks>
+    public Func<DateTimeOffset, TimeProvider, TriggerBuilder<IJob>> Trigger { get; init; }
 
     /// <summary>
     /// Whether this cell's instruction is the one that says a missed firing is not a misfire at all.
@@ -91,8 +96,7 @@ public sealed class MisfireMatrixCase
 /// <para>
 /// Every schedule has a period of one day and is anchored so that its missed firing sits half a day
 /// before the test's <c>anchor</c> and its next slot half a day after. Nothing here is within hours of
-/// a schedule boundary, which is what lets the expected instants be exact even though the triggers
-/// themselves compute on real time.
+/// a schedule boundary, so a cell reads as a schedule rather than as arithmetic on a boundary.
 /// </para>
 /// </remarks>
 public static class MisfireMatrixCases
@@ -116,7 +120,7 @@ public static class MisfireMatrixCases
                     is SimpleTriggerMisfireInstruction.NextWithExistingCount
                     or SimpleTriggerMisfireInstruction.NextWithRemainingCount
                     or SimpleTriggerMisfireInstruction.SmartPolicy,
-                Trigger = anchor => TriggerBuilder.Create()
+                Trigger = (anchor, clock) => TriggerBuilder.Create(clock)
                     .StartAt(anchor - HalfPeriod)
                     .WithSimpleSchedule(x => x
                         .WithInterval(Period)
@@ -134,7 +138,7 @@ public static class MisfireMatrixCases
                 // A one-shot trigger has no next slot to skip to, so the calendar loop is unreachable
                 // whatever the instruction: it runs out of fire times first.
                 ConsultsCalendar = false,
-                Trigger = anchor => TriggerBuilder.Create()
+                Trigger = (anchor, clock) => TriggerBuilder.Create(clock)
                     .StartAt(anchor - HalfPeriod)
                     .WithSimpleSchedule(x => x
                         .WithInterval(Period)
@@ -153,7 +157,7 @@ public static class MisfireMatrixCases
                 Instruction = instruction.ToString(),
                 IgnoresMisfires = instruction == CronTriggerMisfireInstruction.IgnoreMisfires,
                 ConsultsCalendar = instruction == CronTriggerMisfireInstruction.DoNothing,
-                Trigger = anchor => TriggerBuilder.Create()
+                Trigger = (anchor, clock) => TriggerBuilder.Create(clock)
                     .StartAt(anchor - HalfPeriod - Period)
                     .WithCronSchedule(DailyCronAt(anchor + HalfPeriod), x => x
                         .InTimeZone(TimeZoneInfo.Utc)
@@ -171,7 +175,7 @@ public static class MisfireMatrixCases
                 Instruction = instruction.ToString(),
                 IgnoresMisfires = instruction == CalendarIntervalTriggerMisfireInstruction.IgnoreMisfires,
                 ConsultsCalendar = instruction == CalendarIntervalTriggerMisfireInstruction.DoNothing,
-                Trigger = anchor => TriggerBuilder.Create()
+                Trigger = (anchor, clock) => TriggerBuilder.Create(clock)
                     .StartAt(anchor - HalfPeriod)
                     .WithCalendarIntervalSchedule(x => x
                         .WithInterval(1, IntervalUnit.Day)
@@ -190,7 +194,7 @@ public static class MisfireMatrixCases
                 Instruction = instruction.ToString(),
                 IgnoresMisfires = instruction == DailyTimeIntervalTriggerMisfireInstruction.IgnoreMisfires,
                 ConsultsCalendar = instruction == DailyTimeIntervalTriggerMisfireInstruction.DoNothing,
-                Trigger = anchor => TriggerBuilder.Create()
+                Trigger = (anchor, clock) => TriggerBuilder.Create(clock)
                     .StartAt(anchor - HalfPeriod - Period)
                     .WithDailyTimeIntervalSchedule(x => x
                         .StartingDailyAt(TimeOfDay(anchor + HalfPeriod))
@@ -211,7 +215,7 @@ public static class MisfireMatrixCases
                 Instruction = instruction.ToString(),
                 IgnoresMisfires = instruction == RecurrenceTriggerMisfireInstruction.IgnoreMisfires,
                 ConsultsCalendar = instruction == RecurrenceTriggerMisfireInstruction.DoNothing,
-                Trigger = anchor => TriggerBuilder.Create()
+                Trigger = (anchor, clock) => TriggerBuilder.Create(clock)
                     .StartAt(anchor - HalfPeriod)
                     .WithRecurrenceSchedule("FREQ=DAILY", x => x
                         .InTimeZone(TimeZoneInfo.Utc)

--- a/src/Quartz.Tests.Integration/Impl/MisfireMatrixTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireMatrixTest.cs
@@ -19,6 +19,8 @@
 
 using System.Globalization;
 
+using Microsoft.Extensions.Time.Testing;
+
 using Quartz.Extensibility;
 
 namespace Quartz.Tests.Integration.Impl;
@@ -88,6 +90,10 @@ public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
         DateTimeOffset anchor = Anchor();
         DateTimeOffset scheduled = anchor - HalfPeriod;
 
+        // Where a store's clock stands when its pass runs. No store is built here; this walk is about
+        // what the cells resolve to, not about what a store does with them.
+        FakeTimeProvider clock = ClockAt(anchor);
+
         List<(MisfireMatrixCase Case, MisfireExpectation Expected)> outcomes = [];
 
         foreach (MisfireMatrixCase testCase in Cases())
@@ -95,13 +101,13 @@ public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
             TriggerKey triggerKey = new("outcome", Group);
             JobKey jobKey = new("outcome", Group);
 
-            IOperableTrigger detached = Build(testCase, anchor, triggerKey, jobKey);
+            IOperableTrigger detached = Build(testCase, anchor, clock, triggerKey, jobKey);
             detached.ComputeFirstFireTimeUtc(null);
             detached.NextFireTimeUtc = scheduled;
 
             MisfireExpectation expected = testCase.IgnoresMisfires
                 ? MisfireExpectation.Untouched(scheduled)
-                : MisfireExpectation.From(detached, calendar: null);
+                : MisfireExpectation.From(detached, calendar: null, clock);
 
             outcomes.Add((testCase, expected));
             TestContext.Out.WriteLine($"{testCase} -> {expected}");
@@ -132,32 +138,31 @@ public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
             TriggerKey triggerKey = new("matrix-" + Guid.NewGuid().ToString("N"), Group);
             JobKey jobKey = new(triggerKey.Name, Group);
 
-            await Store(store, Job(jobKey), Build(testCase, anchor, triggerKey, jobKey), scheduled);
+            await Store(store, Job(jobKey), Build(testCase, anchor, store.Clock, triggerKey, jobKey), scheduled);
 
             // The trigger's own scheduled time is where the clock started, so nothing was late until
             // here. Half a day is far past the one-minute threshold, and no wall clock moved for it.
             store.Clock.Advance(HalfPeriod);
 
-            // The copy the expectation comes from goes through the same two steps the stored one did,
-            // so the only difference between them is that this one never met a store.
-            IOperableTrigger detached = Build(testCase, anchor, triggerKey, jobKey);
+            // The copy the expectation comes from goes through the same two steps the stored one did
+            // and holds the same clock, so the only difference between them is that this one never met
+            // a store.
+            IOperableTrigger detached = Build(testCase, anchor, store.Clock, triggerKey, jobKey);
             detached.ComputeFirstFireTimeUtc(null);
             detached.NextFireTimeUtc = scheduled;
 
-            DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
             MisfireExpectation expected = testCase.IgnoresMisfires
                 ? MisfireExpectation.Untouched(scheduled)
-                : MisfireExpectation.From(detached, calendar: null);
+                : MisfireExpectation.From(detached, calendar: null, store.Clock);
 
             await store.Sweep(scheduled - TimeSpan.FromTicks(1));
-            DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
 
             TriggerState state = await store.Store.GetTriggerState(triggerKey);
             IOperableTrigger readBack = await store.Store.GetTrigger(triggerKey);
 
             readBack.Should().NotBeNull("{0} must still hold '{1}' after a misfire pass", store.Name, testCase);
 
-            expected.AssertAgainst(store.Name, testCase.ToString(), state, readBack.NextFireTimeUtc, passStarted, passFinished);
+            expected.AssertAgainst(store.Name, testCase.ToString(), state, readBack.NextFireTimeUtc);
         }
     }
 
@@ -179,7 +184,7 @@ public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
             TriggerKey triggerKey = new("ignoring-" + Guid.NewGuid().ToString("N"), Group);
             JobKey jobKey = new(triggerKey.Name, Group);
 
-            await Store(store, Job(jobKey), Build(testCase, anchor, triggerKey, jobKey), scheduled);
+            await Store(store, Job(jobKey), Build(testCase, anchor, store.Clock, triggerKey, jobKey), scheduled);
             store.Clock.Advance(HalfPeriod);
 
             await store.Sweep(scheduled - TimeSpan.FromTicks(1));
@@ -329,9 +334,9 @@ public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
 
     #endregion
 
-    private static IOperableTrigger Build(MisfireMatrixCase testCase, DateTimeOffset anchor, TriggerKey triggerKey, JobKey jobKey)
+    private static IOperableTrigger Build(MisfireMatrixCase testCase, DateTimeOffset anchor, TimeProvider clock, TriggerKey triggerKey, JobKey jobKey)
     {
-        return (IOperableTrigger) testCase.Trigger(anchor)
+        return (IOperableTrigger) testCase.Trigger(anchor, clock)
             .WithIdentity(triggerKey)
             .ForJob(jobKey)
             .Build();

--- a/src/Quartz.Tests.Integration/Impl/MisfireThroughAStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireThroughAStoreTestBase.cs
@@ -40,15 +40,14 @@ namespace Quartz.Tests.Integration.Impl;
 /// threshold" is an assignment rather than a wait.
 /// </para>
 /// <para>
-/// <b>Triggers keep the system clock, whichever store holds them.</b> Every schedule builder news up
-/// its trigger with <see cref="TimeProvider.System" /> — <c>TriggerBuilder.Create(clock)</c> hands its
-/// clock to the schedule builder, not to the trigger — and the ADO store rebuilds a trigger it reads
-/// through <c>TriggerBuilder.Create()</c>, which has no clock to hand it in the first place. So a fake
-/// clock decides only <em>whether</em> a store treats a trigger as misfired; <em>what</em>
-/// <c>UpdateAfterMisfire</c> then computes is on real time in both stores. That is why every schedule
-/// here is anchored half a period out (twelve hours either side of <c>anchor</c>): a "reschedule to the
-/// next slot" instant is then the same value however many milliseconds pass between the detached
-/// computation and the store's own, and a "fire now" instant is asserted to fall inside the pass.
+/// <b>A trigger reads the clock of whoever produced it, and these are all produced on the store's.</b>
+/// <c>TriggerBuilder.Create(clock)</c> hands its clock to the trigger it builds, and the ADO store
+/// hands its own to every trigger it materializes out of its rows, so <em>what</em>
+/// <c>UpdateAfterMisfire</c> computes is on the fake clock in both stores, not only <em>whether</em> a
+/// store treats a trigger as late. Nothing here reads real time, so every expected instant is exact —
+/// a "fire now" one included, since a <see cref="FakeTimeProvider" /> does not move unless the test
+/// moves it. Schedules are still anchored half a period out (twelve hours either side of
+/// <c>anchor</c>) so that no cell sits on a schedule boundary.
 /// </para>
 /// </remarks>
 [NonParallelizable]
@@ -121,10 +120,20 @@ public abstract class MisfireThroughAStoreTestBase
     }
 
     /// <summary>
-    /// The instant every schedule in a test is anchored on, and the value the store clocks reach once
-    /// the test has moved them. Real time, because that is the clock the triggers themselves read.
+    /// The instant every schedule in a test is anchored on, and the value both store clocks reach once
+    /// the test has advanced them.
     /// </summary>
+    /// <remarks>
+    /// Real time only as a seed: nothing reads the machine clock again after this, so a test is
+    /// deterministic relative to whatever instant it started from.
+    /// </remarks>
     protected static DateTimeOffset Anchor() => TimeProvider.System.GetUtcNow();
+
+    /// <summary>
+    /// A clock frozen where both stores' clocks stand once a test has advanced them, for a detached
+    /// copy that has to compute what a store computed but is built before either store exists.
+    /// </summary>
+    protected static FakeTimeProvider ClockAt(DateTimeOffset instant) => new FakeTimeProvider(instant);
 
     /// <summary>
     /// Both stores, in the order they are reported in: the in-memory one first, because a failure

--- a/src/Quartz.Tests.Integration/Impl/MisfireWhilePausedOrBlockedTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireWhilePausedOrBlockedTest.cs
@@ -59,7 +59,7 @@ public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBa
             TriggerKey triggerKey = new("paused-" + Guid.NewGuid().ToString("N"), Group);
             JobKey jobKey = new(triggerKey.Name, Group);
 
-            IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor)
+            IOperableTrigger trigger = (IOperableTrigger) testCase.Trigger(anchor, store.Clock)
                 .WithIdentity(triggerKey)
                 .ForJob(jobKey)
                 .Build();
@@ -87,25 +87,22 @@ public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBa
                 await ado.MarkSchedulerRunning();
             }
 
-            IOperableTrigger detached = (IOperableTrigger) testCase.Trigger(anchor)
+            IOperableTrigger detached = (IOperableTrigger) testCase.Trigger(anchor, store.Clock)
                 .WithIdentity(triggerKey)
                 .ForJob(jobKey)
                 .Build();
             detached.ComputeFirstFireTimeUtc(null);
             detached.NextFireTimeUtc = scheduled;
 
-            DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
-            MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null);
+            MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null, store.Clock);
 
             (await store.Store.ResumeTrigger(triggerKey)).Should().BeTrue(
                 "{0} has to report that it resumed '{1}'", store.Name, testCase);
 
-            DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
-
             TriggerState state = await store.Store.GetTriggerState(triggerKey);
             IOperableTrigger readBack = await store.Store.GetTrigger(triggerKey);
 
-            expected.AssertAgainst(store.Name, testCase + " on resume", state, readBack.NextFireTimeUtc, passStarted, passFinished);
+            expected.AssertAgainst(store.Name, testCase + " on resume", state, readBack.NextFireTimeUtc);
         }
     }
 
@@ -144,21 +141,17 @@ public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBa
             "RAMJobStore's unblocking returns the trigger to the acquisition set and nothing more, so the "
             + "missed firing is still on the books at this point");
 
-        IOperableTrigger detached = Detached(anchor, blocked.Key, blocked.Job.Key, scheduled);
+        IOperableTrigger detached = Detached(anchor, store.Clock, blocked.Key, blocked.Job.Key, scheduled);
 
-        DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
-        MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null);
+        MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null, store.Clock);
 
         await store.Sweep(scheduled - TimeSpan.FromTicks(1));
-        DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
 
         expected.AssertAgainst(
             store.Name,
             BlockedCase + " unblocked",
             await store.Store.GetTriggerState(blocked.Key),
-            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc,
-            passStarted,
-            passFinished);
+            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc);
     }
 
     /// <summary>
@@ -175,21 +168,17 @@ public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBa
         MisfireStoreUnderTest store = await SqliteStore(anchor);
         BlockedTrigger blocked = await GivenATriggerBlockedPastItsThreshold(store, anchor);
 
-        IOperableTrigger detached = Detached(anchor, blocked.Key, blocked.Job.Key, scheduled);
+        IOperableTrigger detached = Detached(anchor, store.Clock, blocked.Key, blocked.Job.Key, scheduled);
 
-        DateTimeOffset passStarted = TimeProvider.System.GetUtcNow();
-        MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null);
+        MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null, store.Clock);
 
         await store.Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
-        DateTimeOffset passFinished = TimeProvider.System.GetUtcNow();
 
         expected.AssertAgainst(
             store.Name,
             BlockedCase + " unblocked",
             await store.Store.GetTriggerState(blocked.Key),
-            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc,
-            passStarted,
-            passFinished);
+            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc);
     }
 
     /// <summary>
@@ -230,7 +219,7 @@ public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBa
         IJobDetail job = JobBuilder.Create<NonConcurrentMisfireTestJob>().WithIdentity(jobKey).Build();
 
         // Due exactly on the store's clock, so the trigger that does the blocking is not itself late.
-        IOperableTrigger running = (IOperableTrigger) TriggerBuilder.Create()
+        IOperableTrigger running = (IOperableTrigger) TriggerBuilder.Create(store.Clock)
             .WithIdentity("running-" + jobKey.Name, Group)
             .ForJob(jobKey)
             .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromDays(1)).RepeatForever())
@@ -247,7 +236,7 @@ public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBa
         // Stored after the acquisition, so it is the fan-out in TriggersFired that blocks it rather than
         // the store having found the job already blocked when the trigger was added.
         TriggerKey blockedKey = new("blocked-" + jobKey.Name, Group);
-        IOperableTrigger blocked = (IOperableTrigger) BlockedCase.Trigger(anchor)
+        IOperableTrigger blocked = (IOperableTrigger) BlockedCase.Trigger(anchor, store.Clock)
             .WithIdentity(blockedKey)
             .ForJob(jobKey)
             .Build();
@@ -274,9 +263,9 @@ public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBa
         return new BlockedTrigger(blockedKey, job, acquired[0]);
     }
 
-    private static IOperableTrigger Detached(DateTimeOffset anchor, TriggerKey triggerKey, JobKey jobKey, DateTimeOffset scheduled)
+    private static IOperableTrigger Detached(DateTimeOffset anchor, TimeProvider clock, TriggerKey triggerKey, JobKey jobKey, DateTimeOffset scheduled)
     {
-        IOperableTrigger detached = (IOperableTrigger) BlockedCase.Trigger(anchor)
+        IOperableTrigger detached = (IOperableTrigger) BlockedCase.Trigger(anchor, clock)
             .WithIdentity(triggerKey)
             .ForJob(jobKey)
             .Build();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -26,6 +26,7 @@ using System.Runtime.Serialization;
 using FakeItEasy;
 
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Time.Testing;
 
 using Quartz.Impl.AdoJobStore;
 using Quartz.Impl.AdoJobStore.Common;
@@ -755,6 +756,146 @@ public class StdAdoDelegateTest
         var act = () => adoDelegate.Initialize(driverDelegateContext);
 
         act.Should().NotThrow("the registered set arrives typed, the same delegate twice included");
+    }
+
+    /// <summary>
+    /// A trigger materialized from its rows computes its misfires against the clock the store runs on,
+    /// whatever type of trigger it turns out to be. The store selects a misfired trigger by its own
+    /// <see cref="TimeProvider" />; if the trigger it hands back reads a different one, the recovery is
+    /// arithmetic on two clocks.
+    /// </summary>
+    [TestCaseSource(nameof(EveryTriggerTypeAStoreReadsBack))]
+    public async Task ATriggerReadBackCarriesTheStoresClock(string discriminator, IScheduleBuilder schedule)
+    {
+        FakeTimeProvider clock = new FakeTimeProvider(new DateTimeOffset(2024, 3, 31, 1, 15, 0, TimeSpan.Zero));
+
+        ITriggerPersistenceDelegate persistenceDelegate = A.Fake<ITriggerPersistenceDelegate>();
+        A.CallTo(() => persistenceDelegate.ReadTriggerPropertyBundle(A<DbDataReader>._))
+            .Returns(new TriggerPropertyBundle(schedule));
+        A.CallTo(() => persistenceDelegate.LoadExtendedTriggerProperties(A<ConnectionAndTransactionHolder>._, A<TriggerKey>._, A<CancellationToken>._))
+            .Returns(new ValueTask<TriggerPropertyBundle>(new TriggerPropertyBundle(schedule)));
+
+        StdAdoDelegate adoDelegate = new TestStdAdoDelegate(persistenceDelegate);
+        DbDataReader dataReader = InitializeForTriggerRead(adoDelegate, clock, out ConnectionAndTransactionHolder conn);
+        DescribeTriggerRow(dataReader, discriminator);
+
+        IOperableTrigger trigger = await adoDelegate.SelectTrigger(conn, new TriggerKey("read-back", "DEFAULT"));
+
+        trigger.Should().BeAssignableTo<TriggerBase>()
+            .Which.TimeProvider.Should().BeSameAs(clock,
+                "the store built this {0} trigger out of rows, so the only clock it can have is the store's",
+                discriminator);
+    }
+
+    /// <summary>
+    /// And a trigger that came out of BLOB_TRIGGERS, which is the one case where the store cannot have
+    /// built it: the clock does not serialize, so a deserialized trigger arrives on the system clock
+    /// and the store has to say otherwise.
+    /// </summary>
+    [Test]
+    public async Task ABlobTriggerReadBackCarriesTheStoresClock()
+    {
+        FakeTimeProvider clock = new FakeTimeProvider(new DateTimeOffset(2024, 3, 31, 1, 15, 0, TimeSpan.Zero));
+
+        // No clock, exactly as deserialization leaves one.
+        SimpleTriggerImpl deserialized = new SimpleTriggerImpl
+        {
+            Key = new TriggerKey("read-back", "DEFAULT"),
+            JobKey = new JobKey("testJob", "DEFAULT")
+        };
+
+        deserialized.TimeProvider.Should().BeSameAs(TimeProvider.System,
+            "the premise: a trigger nobody handed a clock reads the machine's");
+
+        StdAdoDelegate adoDelegate = new BlobTriggerOverrideDelegate(deserialized);
+        DbDataReader dataReader = InitializeForTriggerRead(adoDelegate, clock, out ConnectionAndTransactionHolder conn);
+        DescribeTriggerRow(dataReader, AdoConstants.TriggerTypeBlob);
+
+        IOperableTrigger trigger = await adoDelegate.SelectTrigger(conn, new TriggerKey("read-back", "DEFAULT"));
+
+        trigger.Should().BeSameAs(deserialized, "the blob path hands back the object it deserialized");
+        ((TriggerBase) trigger).TimeProvider.Should().BeSameAs(clock,
+            "the store is the only thing that can give a deserialized trigger a clock, and it has to");
+    }
+
+    /// <summary>
+    /// One row per trigger type a shipped persistence delegate handles, each with the schedule builder
+    /// that delegate returns for it — which is what decides the trigger implementation
+    /// <c>BuildTrigger</c> ends up with.
+    /// </summary>
+    private static IEnumerable<TestCaseData> EveryTriggerTypeAStoreReadsBack()
+    {
+        yield return new TestCaseData(AdoConstants.TriggerTypeCron, CronScheduleBuilder.Create("0 30 * * * ?"));
+        yield return new TestCaseData(AdoConstants.TriggerTypeSimple, SimpleScheduleBuilder.Create().WithInterval(TimeSpan.FromHours(1)).RepeatForever());
+        yield return new TestCaseData(AdoConstants.TriggerTypeCalendarInterval, CalendarIntervalScheduleBuilder.Create().WithInterval(1, IntervalUnit.Day));
+        yield return new TestCaseData(AdoConstants.TriggerTypeDailyTimeInterval, DailyTimeIntervalScheduleBuilder.Create().WithInterval(15, IntervalUnit.Minute));
+        yield return new TestCaseData(AdoConstants.TriggerTypeRecurrence, RecurrenceScheduleBuilder.Create("FREQ=DAILY"));
+    }
+
+    /// <summary>
+    /// Puts a delegate on a faked provider and initializes it with the given clock, handing back the
+    /// reader its statements will read from.
+    /// </summary>
+    private DbDataReader InitializeForTriggerRead(StdAdoDelegate adoDelegate, TimeProvider timeProvider, out ConnectionAndTransactionHolder conn)
+    {
+        IDbProvider dbProvider = A.Fake<IDbProvider>();
+        DbCommand command = (DbCommand) A.Fake<StubCommand>();
+        A.CallTo(() => dbProvider.Metadata).Returns(new DbMetadata());
+        A.CallTo(() => dbProvider.CreateCommand()).Returns(command);
+
+        DbDataReader dataReader = FakeReader();
+        A.CallTo(command).Where(x => x.Method.Name == "ExecuteDbDataReaderAsync")
+            .WithReturnType<Task<DbDataReader>>()
+            .Returns(Task.FromResult(dataReader));
+        A.CallTo(command).Where(x => x.Method.Name == "get_DbParameterCollection")
+            .WithReturnType<DbParameterCollection>()
+            .Returns(new StubParameterCollection());
+        A.CallTo(command).Where(x => x.Method.Name == "CreateDbParameter")
+            .WithReturnType<DbParameter>()
+            .Returns(new SqlParameter());
+        A.CallTo(() => command.CommandText).Returns("");
+
+        adoDelegate.Initialize(new DriverDelegateContext
+        {
+            TablePrefix = "QRTZ_",
+            InstanceId = "TESTSCHED",
+            SchedulerName = "INSTANCE",
+            TypeLoader = new SimpleTypeLoader(),
+            UseProperties = false,
+            DbProvider = dbProvider,
+            ObjectSerializer = serializer,
+            TimeProvider = timeProvider
+        });
+
+        conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), A.Fake<DbTransaction>());
+        return dataReader;
+    }
+
+    /// <summary>
+    /// One TRIGGERS row of the given type, with nothing on it that the clock question depends on.
+    /// </summary>
+    private static void DescribeTriggerRow(DbDataReader dataReader, string discriminator)
+    {
+        A.CallTo(() => dataReader.ReadAsync(CancellationToken.None)).Returns(true);
+
+        A.CallTo(() => dataReader[AdoConstants.ColumnTriggerType]).Returns(discriminator);
+        A.CallTo(() => dataReader[AdoConstants.ColumnJobName]).Returns("testJob");
+        A.CallTo(() => dataReader[AdoConstants.ColumnJobGroup]).Returns("DEFAULT");
+        A.CallTo(() => dataReader[AdoConstants.ColumnDescription]).Returns(DBNull.Value);
+        A.CallTo(() => dataReader[AdoConstants.ColumnCalendarName]).Returns(DBNull.Value);
+        A.CallTo(() => dataReader[AdoConstants.ColumnMisfireInstruction]).Returns(MisfireInstruction.SmartPolicy);
+        A.CallTo(() => dataReader[AdoConstants.ColumnPriority]).Returns(5);
+        A.CallTo(() => dataReader[AdoConstants.ColumnNextFireTime]).Returns(new DateTimeOffset(2024, 3, 31, 0, 30, 0, TimeSpan.Zero).UtcTicks);
+        A.CallTo(() => dataReader[AdoConstants.ColumnPreviousFireTime]).Returns(DBNull.Value);
+        A.CallTo(() => dataReader[AdoConstants.ColumnStartTime]).Returns(new DateTimeOffset(2024, 3, 30, 0, 30, 0, TimeSpan.Zero).UtcTicks);
+        A.CallTo(() => dataReader[AdoConstants.ColumnEndTime]).Returns(DBNull.Value);
+        A.CallTo(() => dataReader[AdoConstants.ColumnMisfireOriginalFireTime]).Returns(DBNull.Value);
+
+        // The job data map column reads as absent, and so does the preferred-node auto-claim flag;
+        // both are read by literal ordinal, well below the ones FakeReader hands out.
+        A.CallTo(() => dataReader.IsDBNull(11)).Returns(true);
+        A.CallTo(() => dataReader.GetOrdinal(AdoConstants.ColumnPreferredNodeAuto)).Returns(20);
+        A.CallTo(() => dataReader.IsDBNull(20)).Returns(true);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.Time.Testing;
+
 using Quartz.Extensibility;
+using Quartz.Impl.Triggers;
 
 namespace Quartz.Tests.Unit;
 
@@ -237,5 +240,98 @@ public class TriggerBuilderTest
             .Build();
 
         trigger.Should().BeAssignableTo<ICronTrigger>();
+    }
+
+    /// <summary>
+    /// Every schedule builder Quartz ships constructs its trigger with no clock at all - it has no
+    /// reason to know about one - so the trigger builder is what puts its own clock on the trigger
+    /// it hands back.
+    /// </summary>
+    [TestCaseSource(nameof(EveryShippedSchedule))]
+    public void TheBuiltTriggerHoldsTheBuildersClock(string _, IScheduleBuilder schedule)
+    {
+        FakeTimeProvider clock = new FakeTimeProvider(new DateTimeOffset(2024, 6, 15, 8, 0, 0, TimeSpan.Zero));
+
+        ITrigger trigger = TriggerBuilder.Create(clock)
+            .WithIdentity("clocked")
+            .WithSchedule(schedule)
+            .Build();
+
+        trigger.Should().BeAssignableTo<TriggerBase>()
+            .Which.TimeProvider.Should().BeSameAs(clock,
+                "every 'now' the trigger reads afterwards - the past-due clamp and the whole of UpdateAfterMisfire - "
+                + "has to be the clock the builder was created with, not the machine's");
+    }
+
+    /// <summary>
+    /// And a builder created without one leaves the trigger on the system clock, which is what
+    /// <c>TriggerBuilder.Create()</c> has always meant.
+    /// </summary>
+    [TestCaseSource(nameof(EveryShippedSchedule))]
+    public void ABuilderWithNoClockLeavesTheTriggerOnTheSystemClock(string _, IScheduleBuilder schedule)
+    {
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("unclocked")
+            .WithSchedule(schedule)
+            .Build();
+
+        trigger.Should().BeAssignableTo<TriggerBase>()
+            .Which.TimeProvider.Should().BeSameAs(TimeProvider.System,
+                "passing no clock is how a caller asks for the machine's");
+    }
+
+    /// <summary>
+    /// The clock survives a rebuild, so rescheduling a trigger read out of a store does not quietly
+    /// put it back on the machine's clock.
+    /// </summary>
+    [Test]
+    public void GetTriggerBuilder_CarriesTheTriggersClockIntoTheRebuiltTrigger()
+    {
+        FakeTimeProvider clock = new FakeTimeProvider(new DateTimeOffset(2024, 6, 15, 8, 0, 0, TimeSpan.Zero));
+
+        ITrigger original = TriggerBuilder.Create(clock)
+            .WithIdentity("rebuilt")
+            .WithCronSchedule("0 0 12 * * ?")
+            .Build();
+
+        ITrigger rebuilt = original.GetTriggerBuilder().Build();
+
+        rebuilt.Should().BeAssignableTo<TriggerBase>()
+            .Which.TimeProvider.Should().BeSameAs(clock,
+                "GetTriggerBuilder() rebuilds this trigger, and a rebuild of it is still it");
+    }
+
+    /// <summary>
+    /// The arithmetic, not just the field: a cron trigger whose first fire time is already past has it
+    /// clamped forward to "now", and on a 2024 clock that lands in 2024.
+    /// </summary>
+    [Test]
+    public void ACronTriggerScheduledOnAFakeClockComputesItsFirstFireTimeOnThatClock()
+    {
+        FakeTimeProvider clock = new FakeTimeProvider(new DateTimeOffset(2024, 6, 15, 8, 0, 0, TimeSpan.Zero));
+
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("noon-daily")
+            .StartAt(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero))
+            .WithCronSchedule("0 0 12 * * ?", x => x.InTimeZone(TimeZoneInfo.Utc))
+            .Build();
+
+        DateTimeOffset? first = trigger.ComputeFirstFireTimeUtc(null);
+
+        first.Should().Be(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero),
+            "the start time is months past, so the first fire is clamped forward to the first noon after the "
+            + "builder's now - and the builder's now is 2024-06-15T08:00Z, not whenever this test happens to run");
+    }
+
+    /// <summary>
+    /// The five shipped schedules, each of which builds a different trigger implementation.
+    /// </summary>
+    private static IEnumerable<TestCaseData> EveryShippedSchedule()
+    {
+        yield return new TestCaseData("cron", CronScheduleBuilder.Create("0 0 12 * * ?"));
+        yield return new TestCaseData("simple", SimpleScheduleBuilder.Create().WithInterval(TimeSpan.FromHours(1)).RepeatForever());
+        yield return new TestCaseData("daily time interval", DailyTimeIntervalScheduleBuilder.Create().WithInterval(15, IntervalUnit.Minute));
+        yield return new TestCaseData("calendar interval", CalendarIntervalScheduleBuilder.Create().WithInterval(1, IntervalUnit.Day));
+        yield return new TestCaseData("recurrence", RecurrenceScheduleBuilder.Create("FREQ=DAILY"));
     }
 }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1152,7 +1152,8 @@ internal sealed class QuartzScheduler
             this.resources.TimeProvider.GetUtcNow(),
             null,
             0,
-            TimeSpan.Zero);
+            TimeSpan.Zero,
+            this.resources.TimeProvider);
 
         trig.ComputeFirstFireTimeUtc(null);
         if (data is not null)

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -4938,7 +4938,7 @@ public abstract class AdoJobStoreBase : IJobStore
                             // executed..
                             if (await JobExists(conn, jKey!, cancellationToken).ConfigureAwait(false))
                             {
-                                SimpleTriggerImpl rcvryTrig = new SimpleTriggerImpl
+                                SimpleTriggerImpl rcvryTrig = new SimpleTriggerImpl(timeProvider)
                                 {
                                     Key = new TriggerKey($"recover_{rec.SchedulerInstanceId}_{recoverIds++}", SchedulerConstants.DefaultRecoveryGroup),
                                     StartTimeUtc = ftRec.FireTimestamp,

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -134,7 +134,7 @@ public partial class StdAdoDelegate
                     int priority = Convert.ToInt32(rs[AdoConstants.ColumnPriority], CultureInfo.InvariantCulture);
                     DateTimeOffset firedTime = GetDateTimeFromDbValue(rs[AdoConstants.ColumnFiredTime]) ?? DateTimeOffset.MinValue;
                     DateTimeOffset scheduledTime = GetDateTimeFromDbValue(rs[AdoConstants.ColumnScheduledTime]) ?? DateTimeOffset.MinValue;
-                    SimpleTriggerImpl rcvryTrig = new SimpleTriggerImpl
+                    SimpleTriggerImpl rcvryTrig = new SimpleTriggerImpl(timeProvider)
                     {
                         Key = new TriggerKey("recover_" + instanceId + "_" + Convert.ToString(dumId++, CultureInfo.InvariantCulture), SchedulerConstants.DefaultRecoveryGroup),
                         StartTimeUtc = scheduledTime,
@@ -1001,18 +1001,39 @@ public partial class StdAdoDelegate
     /// Applies the TRIGGERS row state onto a trigger deserialized from BLOB_TRIGGERS. The schedule
     /// itself came out of the blob, so there are no extended properties to apply in between.
     /// </summary>
-    private static void ApplyBlobTriggerRowState(IOperableTrigger trigger, TriggerRow row)
+    private void ApplyBlobTriggerRowState(IOperableTrigger trigger, TriggerRow row)
     {
+        ApplyStoreClock(trigger);
         ApplyTriggerFireState(trigger, row);
         ApplyTriggerRoutingState(trigger, row);
     }
 
     /// <summary>
+    /// Hands a materialized trigger the clock this store runs on, so that the misfire arithmetic the
+    /// store is about to ask it for is done against the same reading of "now" the store decided it
+    /// had misfired by.
+    /// </summary>
+    /// <remarks>
+    /// A trigger out of a blob carries no clock at all — the field does not serialize — and one out of
+    /// a schedule builder only carries whatever built it, which is this store only because
+    /// <see cref="BuildTrigger" /> creates the builder with the store's clock.
+    /// </remarks>
+    private void ApplyStoreClock(IOperableTrigger trigger)
+    {
+        if (trigger is TriggerBase triggerBase)
+        {
+            triggerBase.TimeProvider = timeProvider;
+        }
+    }
+
+    /// <summary>
     /// Builds a non-blob trigger from its TRIGGERS row and its type-specific extended properties.
     /// </summary>
-    private static IOperableTrigger BuildTrigger(TriggerKey triggerKey, TriggerRow row, TriggerPropertyBundle triggerProps)
+    private IOperableTrigger BuildTrigger(TriggerKey triggerKey, TriggerRow row, TriggerPropertyBundle triggerProps)
     {
-        var tb = TriggerBuilder.Create()
+        // The store's clock, not the machine's: TriggerBuilder gives it to the trigger it builds, so
+        // everything the trigger reads as "now" from here on is the scheduler's reading.
+        var tb = TriggerBuilder.Create(timeProvider)
             .WithDescription(row.Description)
             .WithPriority(row.Priority)
             .StartAt(row.StartTimeUtc)

--- a/src/Quartz/Impl/Triggers/TriggerBase.cs
+++ b/src/Quartz/Impl/Triggers/TriggerBase.cs
@@ -87,9 +87,32 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
     private bool preferredNodeDirty;
 
     [NonSerialized]
-    private TimeProvider timeProvider;
+    private TimeProvider? timeProvider;
 
-    internal TimeProvider TimeProvider => timeProvider ?? TimeProvider.System;
+    /// <summary>
+    /// The clock every "now" this trigger reads comes from: the past-due clamp in
+    /// <see cref="ComputeFirstFireTimeUtc" />, and the whole of <see cref="UpdateAfterMisfire" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It arrives from whoever produced the trigger, and only from there:
+    /// <see cref="TriggerBuilder{TJob}.Build" /> hands over the clock its <c>Create</c> was given, and a
+    /// job store hands over the scheduler's clock to every trigger it materializes from its rows. A
+    /// trigger nobody handed a clock reads <see cref="System.TimeProvider.System" />, which is also what
+    /// a deserialized one starts out with — the field is <see cref="NonSerializedAttribute" />, so a
+    /// trigger out of a blob has no clock until the store that read it says otherwise.
+    /// </para>
+    /// <para>
+    /// Settable, but internal: a trigger's clock is a construction-or-store decision. Nothing outside
+    /// Quartz swaps the clock under a scheduled trigger, because the misfire decision and the misfire
+    /// arithmetic have to be made against the same reading.
+    /// </para>
+    /// </remarks>
+    internal TimeProvider TimeProvider
+    {
+        get => timeProvider ?? TimeProvider.System;
+        set => timeProvider = value;
+    }
 
     /// <summary>
     /// Stores the original NextFireTimeUtc before misfire handling changes it.
@@ -160,7 +183,10 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
 
     public TriggerBuilder<IJob> GetTriggerBuilder()
     {
-        return TriggerBuilder.Create()
+        // This trigger's own clock, so that rebuilding a trigger keeps the reading of "now" it was
+        // computing against - the past-due clamp in ComputeFirstFireTimeUtc runs on whatever the
+        // rebuilt trigger ends up holding.
+        return TriggerBuilder.Create(TimeProvider)
             .ForJob(JobKey)
             .WithCalendarName(CalendarName)
             .UsingJobData(JobDataMap)
@@ -430,7 +456,9 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
     protected TriggerBase(TimeProvider? timeProvider = null)
 #pragma warning restore S5766
     {
-        this.timeProvider = timeProvider ?? TimeProvider.System;
+        // Left null when none was given, so the getter answers TimeProvider.System: a trigger that
+        // came back through deserialization is in exactly that state, and the two read alike.
+        this.timeProvider = timeProvider;
     }
 
     /// <summary>

--- a/src/Quartz/TriggerBuilder.cs
+++ b/src/Quartz/TriggerBuilder.cs
@@ -22,6 +22,7 @@ using System.Linq.Expressions;
 
 using Quartz.Extensibility;
 using Quartz.Impl;
+using Quartz.Impl.Triggers;
 using Quartz.Util;
 
 namespace Quartz;
@@ -162,6 +163,16 @@ public sealed class TriggerBuilder<[DynamicallyAccessedMembers(JobTypeMembers.Re
         }
 
         IMutableTrigger trig = scheduleBuilder.Build();
+
+        // And hand the trigger itself the same clock. The schedule builder constructs it with no
+        // clock at all - it has no reason to know about one - so without this every "now" the built
+        // trigger reads (the past-due clamp in ComputeFirstFireTimeUtc, the whole of
+        // UpdateAfterMisfire) would be the machine's, whatever clock this builder was created with.
+        // A trigger from outside the shipped hierarchy is left alone; there is nothing to set on it.
+        if (trig is TriggerBase triggerBase)
+        {
+            triggerBase.TimeProvider = timeProvider;
+        }
 
         trig.CalendarName = calendarName;
         trig.Description = description;

--- a/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XmlSchedulingDataProcessor.cs
@@ -436,7 +436,7 @@ internal class XmlSchedulingDataProcessor
                 return;
             }
 
-            IMutableTrigger trigger = (IMutableTrigger) TriggerBuilder.Create()
+            IMutableTrigger trigger = (IMutableTrigger) TriggerBuilder.Create(timeProvider)
                 .WithIdentity(triggerName, triggerGroup)
                 .WithDescription(triggerDescription)
                 .ForJob(triggerJobName, triggerJobGroup)


### PR DESCRIPTION
A trigger's misfire arithmetic ran on `TimeProvider.System` whenever the trigger did not come out of a constructor that was handed a clock — which was every trigger a `TriggerBuilder` built and every trigger the ADO.NET store read back. The store selected a misfired trigger with its own clock and then asked a machine-clock trigger to compute the recovery, so the decision and the arithmetic were made on two different readings of "now".

In production both are the system clock and nothing looks wrong. It shows up the moment an application gives the scheduler a non-system `TimeProvider` — which 4.0 invites, and which the testing tutorial actively recommended.

## The shape

`TriggerBase.TimeProvider` gains an **internal setter**, and `TriggerBuilder.Build()` assigns it to the trigger the schedule builder just constructed.

An internal setter rather than a `TimeProvider` parameter on every shipped `IScheduleBuilder`, because a construction-time mechanism cannot cover the case that matters most: a trigger read out of `BLOB_TRIGGERS` is *deserialized*, and the clock field is `[NonSerialized]`, so there is no constructor to pass it to. One mechanism covers both, and it also covers a custom `IScheduleBuilder` that returns a `TriggerBase` subclass without knowing about clocks at all. It stays internal because a trigger's clock is a construction-or-store decision — nothing outside Quartz should swap the clock under a scheduled trigger, since the misfire *decision* and the misfire *arithmetic* have to be made against one reading.

`ITimeProviderAwareScheduleBuilder` is untouched and still does its own job: handing the clock to a *schedule builder* whose computation is deferred to `Build()` (`EndingDailyAfterCount`). The new assignment is the same idea applied one layer down, not a second mechanism for the same thing.

## Every construction site changed

Grepped for `TriggerBuilder.Create()` and `new *TriggerImpl(` across every shipped project.

| Site | Change |
|---|---|
| `TriggerBuilder<TJob>.Build()` | assigns the builder's clock to the built trigger |
| `TriggerBase.GetTriggerBuilder()` | `TriggerBuilder.Create(TimeProvider)` — a rebuild of a trigger is still that trigger |
| `StdAdoDelegate.BuildTrigger` (`StdAdoDelegate.Triggers.cs:1015`) | `TriggerBuilder.Create(timeProvider)`; no longer `static` |
| `StdAdoDelegate.ApplyBlobTriggerRowState` | new `ApplyStoreClock` stamps the store's clock on a deserialized blob trigger; no longer `static` |
| `StdAdoDelegate.SelectTriggersForRecoveringJobs` (`:137`) | `new SimpleTriggerImpl(timeProvider)` |
| `AdoJobStoreBase.ClusterRecover` (`:4853`) | `new SimpleTriggerImpl(timeProvider)` |
| `QuartzScheduler.TriggerJob` | passes `resources.TimeProvider` to the `SimpleTriggerImpl` it already read the start time from |
| `XmlSchedulingDataProcessor` | `TriggerBuilder.Create(timeProvider)` |
| `Quartz.Plugins` `JsonSchedulingDataProcessor` | `TriggerBuilder.Create(timeProvider)` |
| `XmlSchedulingDataProcessorPlugin` / `JsonSchedulingDataProcessorPlugin` | `new SimpleTriggerImpl(timeProvider)` for their file-scan triggers |

**No trigger persistence delegate constructs a trigger.** Each returns a schedule builder in a `TriggerPropertyBundle`, and `BuildTrigger` builds the trigger — so all five shipped delegates are covered by the `BuildTrigger` change alone, with no edit of their own.

Deliberately left alone, and why:

- **`JsonSchedulingHelper.ReadTriggers`** reads triggers into `QuartzOptions` while the `IServiceCollection` is still being configured, so there is no resolved `TimeProvider` to hand it. Threading one there is a separate change to how scheduling options are bound.
- **The two `TriggerConverter`s** (System.Text.Json and Newtonsoft) build with no clock because a serializer has none. The store stamps the clock on what they produce, which is the only path they are reached from in a job store.
- **The five schedule builders** still `new` their trigger with no clock. That is the point of the fix: `TriggerBuilder` supplies it.
- **`RecurrenceTriggerImpl()`** is the one trigger constructor that does not take an optional `TimeProvider?` (it hard-codes `base(TimeProvider.System)`, which is what `base(null)` now means anyway). Adding the parameter would move the public API baseline for no behavioural gain, so it stays as it is.

## Public API

**None.** `PublicApiTest_Quartz.verified.txt` is byte-identical with `main`; the baselines did not move.

An earlier revision added `TriggerPersistenceDelegateContext.TimeProvider` for symmetry with `DriverDelegateContext`. It came back out on review: no shipped delegate reads it, because all five return a schedule builder that the driver delegate then builds the trigger from with the store's clock. Public surface with no consumer is what this repo avoids, and a custom persistence delegate that genuinely needs a clock can ask for one then.

`docs/documentation/quartz-4.x/migration-guide.md` therefore gains a behaviour section and no API row.

## Tests

- `TriggerBuilderTest` — a cron, simple, daily-time-interval, calendar-interval and recurrence trigger built with `TriggerBuilder.Create(fakeClock)` each report `fakeClock`; the no-argument overload still reports `TimeProvider.System`; `GetTriggerBuilder()` round-trips the clock; and a cron trigger scheduled on a fake 2024 clock with a start time months past clamps to **2024-06-15T12:00Z** rather than to whenever the test ran.
- `StdAdoDelegateTest` — a trigger read back through `SelectTrigger` carries the context's clock, once per trigger type the persistence delegates handle (`CRON`, `SIMPLE`, `CAL_INT`, `DAILY_I`, `RECUR`) plus the `BLOB` path, which asserts its premise first: a trigger nobody handed a clock reads the machine's.
- `MisfireAcrossDstTransitionTest` — the four ADO cells that were `Assert.Inconclusive` are assertions, on the exact instants the in-memory twin already asserted, and pass.

Every one of these fails without the production change; verified by reverting `TriggerBuilder.cs` and `StdAdoDelegate.Triggers.cs` and watching all nineteen go red.

## The misfire matrix had to move with it

`MisfireMatrixTest` and friends landed on `main` while this was in flight (`373d17038`), and `MisfireThroughAStoreTestBase` documented the bug as a premise:

> **Triggers keep the system clock, whichever store holds them.** […] So a fake clock decides only *whether* a store treats a trigger as misfired; *what* `UpdateAfterMisfire` then computes is on real time in both stores.

Seventeen "fire now" cells therefore asserted that the recovered instant falls inside the *real* wall-clock window of the store's pass. With the fix the store writes its fake clock's instant instead, and they failed by the milliseconds between the two.

The fixture now builds every trigger on the store's clock (`MisfireMatrixCase.Trigger` takes a `TimeProvider`) and asserts **exact equality for "fire now" as well** — a `FakeTimeProvider` does not move on its own, so the detached expectation copy and the store's own copy resolve to the same instant. `passStarted`/`passFinished` are gone; nothing in those fixtures reads the machine clock after the anchor they seed from. The assertions got stricter, not looser.

I rebased onto `origin/main` rather than merging, per the branch's instructions — most recently onto `132083a38`.

## Docs

- `tutorial/time-and-timeprovider.md` — a new "Which clock a trigger holds" table, the store row included, and the old warning that a stored trigger "reads the system clock until the store hands it one" replaced with what the store now does.
- `tutorial/testing.md` — "Controlling time"'s caveat now says that passing the clock is enough, because it reaches a cron trigger's past-due clamp and `UpdateAfterMisfire`.
- `migration-guide.md` — "A trigger holds the clock that built it", linked from the `EndingDailyAfterCount` section beside it.

`docs/documentation/quartz-3.x/` is untouched.

## Verification

At this head:

```
dotnet build Quartz.slnx                                    0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit                           Passed: 3414, Failed: 0, Skipped: 4
integration, basic leg (Build.cs filter)                    Passed:  322, Failed: 0
dotnet fallout VerifyDocsSnippets                           Succeeded (90 markdown files)
npm run docs:check-links                                    780 links, 448 fragments, none dead
```

At the previous rebase point, before the context member came out and before `#3465`/`#3467` landed under this branch:

```
integration, postgres leg (db-postgres)                     Passed:  146, Failed: 0
dotnet test src/Quartz.Tests.AspNetCore                     Passed:  447, Failed: 0
```

Docker was running; both integration legs are real container/SQLite runs. Each of the first three commits was also built and unit-tested on its own.

Closes #3456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
