### PR TITLE
The dashboard shows the fleet, built or not, and what each scheduler is made of

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1692,6 +1692,34 @@ public enum SchedulerOrigin { Container, Runtime }
 Nothing is removed: `GetAllSchedulers()` still means what it always meant, and it is still the call to
 make when you want the live schedulers themselves rather than an inventory.
 
+### `GET /schedulers` answers from the registry
+
+The HTTP API's scheduler listing reads `ISchedulerRegistry` too, so it carries the registrations rather
+than only what has been built, and each entry says which it is:
+
+```json
+{ "name": "acme", "schedulerInstanceId": null, "status": null, "origin": "Container" }
+```
+
+| | 3.x and the 4.0 previews | 4.0.0-alpha.3 |
+|---|---|---|
+| Source | `ISchedulerRepository.LookupAll()` | `ISchedulerRegistry.QuerySchedulers()` |
+| `status` | always a name | `null` when nothing has built the scheduler |
+| `schedulerInstanceId` | always present | `null` when nothing has built the scheduler |
+| `origin` | — | `Container` or `Runtime` |
+
+A reader that assumed `status` and `schedulerInstanceId` are always present has to handle `null`, and
+one that took the listing to mean "the schedulers that are running" should filter on `status`. Nothing
+else moved: a scheduler's own routes still resolve through the repository, so `GET /schedulers/{name}`
+answers `404` for a registration nothing has built.
+
+`Quartz.Dashboard`'s own projection changed with it — `SchedulerHeaderDto.Status` and
+`SchedulerInstanceId` are nullable, it gained `Origin` and `IsCreated`, and `SchedulerDetailDto` grew the
+`SchedulerMetadata` the dashboard used to drop: `Clustered`, `Persistent`, `JobStoreTypeName`,
+`ThreadPoolTypeName`, `ThreadPoolSize`, `RunningSince`, `JobsExecuted` and `Version`. Both types are
+public because `IQuartzApiClient` is replaceable; an application that implements that interface itself
+has to fill the new members.
+
 `ISchedulerRegistry` is deliberately the *narrow* half of the API [#3338](https://github.com/quartznet/quartznet/issues/3338)
 sketches for runtime tenant lifecycle. Adding and removing schedulers at runtime is a 4.1 concern; when it
 lands, its manager interface extends this one rather than replacing it.

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -159,13 +159,19 @@ up the distinction matters less than it looks. It matters while the host is stil
 resolve schedulers yourself, when a start failed, and whenever you want an inventory rather than a list
 of live objects.
 
-::: warning The dashboard and the HTTP API list the repository, not the registry
-Both resolve a scheduler by looking it up in `ISchedulerRepository`, which holds the schedulers something
-has already built. A tenant that is registered but has never been created is therefore absent from the
-dashboard's scheduler list, and its API routes answer `404` — not because the name is unknown, but
-because nothing has built it yet. Under `AddQuartzHostedService()` that window closes as the host starts;
-outside it — a scheduler resolved lazily, or one whose start failed — the two views disagree, and
-`ISchedulerRegistry` is the one that knows the tenant exists.
+The dashboard and the HTTP API read the same registry, so a tenant nothing has built is listed by both.
+`GET {ApiPath}/schedulers` reports it with a `null` status and no instance id, and the dashboard's
+**Schedulers** page at `/quartz/schedulers` gives it a row saying **not created** — beside, for every
+tenant that does exist, what its job store and thread pool are, when it started, how many jobs it has
+executed and how many nodes it has. The header's scheduler picker offers it too, greyed out.
+
+::: warning A tenant's own routes still resolve through the repository
+The listing is the one read that goes through the registry. Everything addressed *at* a scheduler —
+`GET {ApiPath}/schedulers/acme`, its jobs, its triggers — resolves through `ISchedulerRepository`, which
+holds the schedulers something has already built, so those routes answer `404` for a tenant nothing has
+created. Not because the name is unknown: the listing is where you see that it is not. Under
+`AddQuartzHostedService()` that window closes as the host starts; outside it — a scheduler resolved
+lazily, or one whose start failed — it stays open.
 :::
 
 ### What is per scheduler

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -110,7 +110,10 @@ in-memory store is never asked, because the answer would always be "one".
 Following a row makes that scheduler the active one and opens its Dashboard page, which is the same
 switch the header's scheduler picker makes. A registration nothing has built is not a link: there is no
 scheduler behind it for any page to show. The picker offers it too, greyed out, so that a tenant that
-failed to start is visible rather than looking as though it had never been registered.
+failed to start is visible rather than looking as though it had never been registered. Should such a
+registration end up being the active scheduler anyway — it is the only one there is, or the one that was
+running has just been shut down — the Dashboard page says it has not been created rather than reporting
+a scheduler it could not find.
 
 ## Hosting under a custom path
 

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -93,6 +93,25 @@ scheduler selector and its jobs and triggers rendered, but its Live Logs view an
 silently always empty. There was nothing to configure to get them; this is a fix rather than a new option.
 :::
 
+### Schedulers
+
+The **Schedulers** page at `/quartz/schedulers` is the fleet: one row per scheduler the container knows
+about, whether or not anything has built it. It reads `ISchedulerRegistry`, so a scheduler registered
+with `AddQuartz("acme", …)` that nothing has resolved yet is listed with its origin and a **not created**
+status rather than being absent — and listing it does not build it.
+
+Each row that has a scheduler behind it shows what that scheduler is made of, read from its
+`SchedulerMetadata`: its instance id, whether its job store is persistent and whether it is clustered,
+the store and thread pool it uses, the pool size, when it started (in the time zone the header picker
+selects), how many jobs it has executed, and the version of Quartz running it. The node count beside it
+comes from the cluster-node query, and only for a store that has nodes — a persistent, clustered one. An
+in-memory store is never asked, because the answer would always be "one".
+
+Following a row makes that scheduler the active one and opens its Dashboard page, which is the same
+switch the header's scheduler picker makes. A registration nothing has built is not a link: there is no
+scheduler behind it for any page to show. The picker offers it too, greyed out, so that a tenant that
+failed to start is visible rather than looking as though it had never been registered.
+
 ## Hosting under a custom path
 
 When the dashboard hosts its own Blazor root, it can be served from a custom base path. Name it where the endpoints are mapped, the way the rest of ASP.NET Core reads (`MapHealthChecks("/health")`):
@@ -216,18 +235,23 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
 - Job details and trigger details pages
 - Currently executing jobs view — cluster-wide with a persistent job store, showing which node owns each
   execution, and interrupting the one execution a row names rather than every execution of its job
+- Schedulers view at `/quartz/schedulers` — one row per scheduler the container knows about, built or
+  merely registered, with its origin and status and, for one that exists, its job store and thread pool,
+  when it started, how many jobs it has executed, its node count when it is clustered, and its version;
+  a row is the link that makes that scheduler the active one
 - Cluster view at `/quartz/cluster` — one row per node with its state (`Alive`, `Overdue`, `Failed`),
   its last check-in in the selected time zone and as a relative time, its check-in interval, and how
-  many firings it is holding and running; the node answering is marked, and a scheduler whose store
-  keeps no cluster state says so rather than showing an empty table
+  many firings it is holding and running; the node answering is marked, and a scheduler whose job store
+  is not clustered says so rather than showing an empty table
 - Live event/log stream for scheduler activity, fed by plugins `AddQuartzDashboard` installs on every
   scheduler in the container — so a named scheduler streams its own events, each plugin instance
   initialized with the name of the scheduler it belongs to
 - Pause, resume, trigger-now, and unschedule/delete actions (when not in read-only mode)
 - Trigger detail cron reschedule and job detail trigger-with-overrides actions
 - Calendar create/replace (cron calendar), details, and delete actions
-- Multi-scheduler selection, over the schedulers the container has *built* — the dashboard lists
-  `ISchedulerRepository`, so a registered scheduler nothing has created yet does not appear
+- Multi-scheduler selection, over every scheduler the container knows about — the dashboard lists
+  `ISchedulerRegistry`, so a registered scheduler nothing has created yet is offered greyed out rather
+  than omitted
 - Read-only mode support via dashboard options
 
 ::: warning Fixed in 4.0.0-alpha.2

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -75,6 +75,45 @@ validated against.
 - **Triggers**: query triggers, fetch by key, read state, pause/resume, reset from error state, schedule/unschedule/reschedule
 - **Calendars**: query names, get details, add/replace, delete
 
+## The scheduler listing carries registrations
+
+`GET {ApiPath}/schedulers` answers with every scheduler the container knows about, ordered by name — the
+ones something has *registered* as well as the ones something has *built*. It is not paged: a process
+runs a handful of schedulers, not a data set.
+
+```json
+[
+  {
+    "name": "acme",
+    "schedulerInstanceId": null,
+    "status": null,
+    "origin": "Container"
+  },
+  {
+    "name": "core",
+    "schedulerInstanceId": "web-01",
+    "status": "Running",
+    "origin": "Container"
+  }
+]
+```
+
+`status` and `schedulerInstanceId` are `null` together, for a registration nothing has built: there is
+no scheduler to be in a state or to have an instance id, and listing it did not create one. That is the
+only way to tell "this tenant has not started" from "there is no such tenant" — the scheduler's own
+routes answer `404` for both.
+
+`origin` says where the scheduler came from: `Container` for one `AddQuartz()` or `AddQuartz(name, …)`
+registered, `Runtime` for one that is in the repository without a registration behind it — a scheduler
+bound by hand, or a remote one from `AddQuartzHttpClient`.
+
+::: warning Changed in 4.0.0-alpha.3
+This listing used to read `ISchedulerRepository`, so it carried only schedulers something had already
+created, and every entry had a status and an instance id. A reader that assumed both are present needs
+to handle `null`, and one that treated the listing as "the schedulers that are running" should now filter
+on `status`.
+:::
+
 ## Enums travel as names
 
 Every enum the API puts on the wire — a scheduler's `status`, a trigger's `state`, a trigger's

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -55,15 +55,33 @@ internal static class SchedulerEndpoints
             .WithQuartzDefaults(nameof(ClearExecutionLimits), "Clear execution group limits");
     }
 
+    /// <summary>
+    /// Lists every scheduler the container knows about, ordered by name.
+    /// </summary>
+    /// <remarks>
+    /// The registrations rather than the repository: a repository holds the schedulers something has
+    /// already built, so a tenant nobody has asked for was invisible here — and the caller could not tell
+    /// that from "no such tenant". Such an entry is listed with a null status, and asking for it does not
+    /// build it. The repository is still read, for the instance id of the schedulers that do exist.
+    /// </remarks>
     [ProducesResponseType(typeof(SchedulerHeaderDto[]), StatusCodes.Status200OK)]
-    private static Task<IResult> GetAllSchedulers(
+    private static async Task<IResult> GetAllSchedulers(
         EndpointHelper endpointHelper,
+        ISchedulerRegistry schedulerRegistry,
         ISchedulerRepository schedulerRepository,
         CancellationToken cancellationToken = default)
     {
-        var schedulers = schedulerRepository.LookupAll();
-        var result = schedulers.Select(SchedulerHeaderDto.Create).ToArray();
-        return Task.FromResult(EndpointHelper.JsonResponse(result));
+        List<SchedulerRegistration> registrations = await schedulerRegistry.QuerySchedulers(cancellationToken).ConfigureAwait(false);
+
+        SchedulerHeaderDto[] result = new SchedulerHeaderDto[registrations.Count];
+        for (int i = 0; i < registrations.Count; i++)
+        {
+            SchedulerRegistration registration = registrations[i];
+            IScheduler? scheduler = registration.IsCreated ? schedulerRepository.Lookup(registration.Name) : null;
+            result[i] = SchedulerHeaderDto.Create(registration, scheduler);
+        }
+
+        return EndpointHelper.JsonResponse(result);
     }
 
     [ProducesResponseType(typeof(SchedulerDto), StatusCodes.Status200OK)]

--- a/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Quartz.Dashboard/Components/Layout/NavMenu.razor
@@ -79,6 +79,20 @@
         </li>
 
         <li class="qz-nav-item">
+            <a class="qz-nav-link @NavClass("schedulers")" href="@Link("schedulers")">
+                <svg class="qz-nav-icon" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="2" y="2" width="14" height="4" rx="1" />
+                    <rect x="2" y="7" width="14" height="4" rx="1" />
+                    <rect x="2" y="12" width="14" height="4" rx="1" />
+                    <line x1="5" y1="4" x2="5" y2="4" />
+                    <line x1="5" y1="9" x2="5" y2="9" />
+                    <line x1="5" y1="14" x2="5" y2="14" />
+                </svg>
+                <span class="qz-nav-link-text">Schedulers</span>
+            </a>
+        </li>
+
+        <li class="qz-nav-item">
             <a class="qz-nav-link @NavClass("cluster")" href="@Link("cluster")">
                 <svg class="qz-nav-icon" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <circle cx="9" cy="3" r="2" />

--- a/src/Quartz.Dashboard/Components/Layout/SchedulerSelector.razor
+++ b/src/Quartz.Dashboard/Components/Layout/SchedulerSelector.razor
@@ -64,22 +64,9 @@
 
             SchedulerState.AvailableSchedulers = schedulers.AsReadOnly();
 
-            if (SchedulerState.ActiveSchedulerName is null && schedulers.Count > 0)
+            if (SchedulerState.ActiveSchedulerName is null)
             {
-                // The first scheduler that exists, falling back to the first registration. A dashboard
-                // that opened on a tenant nothing has built would show its not-created state on every
-                // page while a running scheduler sat further down the list.
-                Quartz.Dashboard.Services.SchedulerHeaderDto? created = null;
-                foreach (Quartz.Dashboard.Services.SchedulerHeaderDto scheduler in schedulers)
-                {
-                    if (scheduler.IsCreated)
-                    {
-                        created = scheduler;
-                        break;
-                    }
-                }
-
-                SchedulerState.ActiveSchedulerName = (created ?? schedulers[0]).SchedulerName;
+                SchedulerState.ActiveSchedulerName = SchedulerState.DefaultSchedulerName;
             }
 
             await UpdateStatusAsync();
@@ -110,7 +97,7 @@
 
         // A registration nothing has built has no scheduler to ask, and asking would answer "no such
         // scheduler" — which reads as a fault rather than as the thing the listing already told us.
-        if (!SchedulerState.IsCreated(SchedulerState.ActiveSchedulerName))
+        if (SchedulerState.Find(SchedulerState.ActiveSchedulerName) is { IsCreated: false })
         {
             _statusLabel = "Not created";
             _schedulerStatus = null;

--- a/src/Quartz.Dashboard/Components/Layout/SchedulerSelector.razor
+++ b/src/Quartz.Dashboard/Components/Layout/SchedulerSelector.razor
@@ -14,9 +14,14 @@
         }
         else
         {
-            @foreach (string scheduler in SchedulerState.AvailableSchedulers)
+            @foreach (Quartz.Dashboard.Services.SchedulerHeaderDto scheduler in SchedulerState.AvailableSchedulers)
             {
-                <option value="@scheduler">@scheduler</option>
+                @* A registration nothing has built is offered and greyed out rather than omitted: it is a
+                   tenant the container knows about, and leaving it out of the picker is what made it look
+                   as though it had never been registered. There is nothing behind it to select. *@
+                <option value="@scheduler.SchedulerName" disabled="@(!scheduler.IsCreated)">
+                    @(scheduler.IsCreated ? scheduler.SchedulerName : scheduler.SchedulerName + " (not created)")
+                </option>
             }
         }
     </select>
@@ -54,20 +59,27 @@
     {
         try
         {
-            System.Collections.Generic.IReadOnlyList<Quartz.Dashboard.Services.SchedulerHeaderDto> schedulers =
+            System.Collections.Generic.List<Quartz.Dashboard.Services.SchedulerHeaderDto> schedulers =
                 await ApiClient.GetSchedulers();
 
-            System.Collections.Generic.List<string> names = new();
-            foreach (Quartz.Dashboard.Services.SchedulerHeaderDto s in schedulers)
-            {
-                names.Add(s.SchedulerName);
-            }
+            SchedulerState.AvailableSchedulers = schedulers.AsReadOnly();
 
-            SchedulerState.AvailableSchedulers = names.AsReadOnly();
-
-            if (SchedulerState.ActiveSchedulerName is null && names.Count > 0)
+            if (SchedulerState.ActiveSchedulerName is null && schedulers.Count > 0)
             {
-                SchedulerState.ActiveSchedulerName = names[0];
+                // The first scheduler that exists, falling back to the first registration. A dashboard
+                // that opened on a tenant nothing has built would show its not-created state on every
+                // page while a running scheduler sat further down the list.
+                Quartz.Dashboard.Services.SchedulerHeaderDto? created = null;
+                foreach (Quartz.Dashboard.Services.SchedulerHeaderDto scheduler in schedulers)
+                {
+                    if (scheduler.IsCreated)
+                    {
+                        created = scheduler;
+                        break;
+                    }
+                }
+
+                SchedulerState.ActiveSchedulerName = (created ?? schedulers[0]).SchedulerName;
             }
 
             await UpdateStatusAsync();
@@ -93,6 +105,15 @@
     {
         if (SchedulerState.ActiveSchedulerName is null)
         {
+            return;
+        }
+
+        // A registration nothing has built has no scheduler to ask, and asking would answer "no such
+        // scheduler" — which reads as a fault rather than as the thing the listing already told us.
+        if (!SchedulerState.IsCreated(SchedulerState.ActiveSchedulerName))
+        {
+            _statusLabel = "Not created";
+            _schedulerStatus = null;
             return;
         }
 

--- a/src/Quartz.Dashboard/Components/Pages/Cluster.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Cluster.razor
@@ -23,7 +23,7 @@
         <ErrorAlert Message="@_error" OnRetry="LoadDataAsync" />
     }
 
-    @if (IsSingleNodeWithoutClusterState)
+    @if (_isClustered == false)
     {
         <p class="qz-muted">
             This scheduler is not clustered: its job store keeps no check-in state, so the only node is this one.
@@ -102,12 +102,16 @@
     private DateTimeOffset? _lastUpdatedAt;
 
     /// <summary>
-    /// A store that keeps no check-in history reports exactly one node — itself — with no times, which
-    /// is what a non-clustered scheduler looks like from here. There is no separate "clustered" flag to
-    /// read: the node list is the answer, and this is the shape it takes.
+    /// Whether the scheduler's job store is clustered, as the scheduler itself reports it, or null while
+    /// nothing has been read.
     /// </summary>
-    private bool IsSingleNodeWithoutClusterState =>
-        _nodes.Count == 1 && _nodes[0].IsCurrentNode && _nodes[0].LastCheckInUtc is null;
+    /// <remarks>
+    /// This used to be inferred from the node list — one node, current, with no check-in history — which
+    /// is the shape a store that keeps no cluster state takes. It is also the shape a clustered store
+    /// takes for the first check-in interval after a node starts, so the page told an operator their
+    /// brand new cluster was not one. The scheduler's metadata is the answer, and it is never ambiguous.
+    /// </remarks>
+    private bool? _isClustered;
 
     protected override async Task OnInitializedAsync()
     {
@@ -188,9 +192,13 @@
             _firingsByNode.Clear();
             _firingCountsArePartial = false;
             _firingsCounted = 0;
+            _isClustered = null;
 
             if (!string.IsNullOrWhiteSpace(schedulerName))
             {
+                SchedulerDetailDto scheduler = await Api.GetScheduler(schedulerName);
+                _isClustered = scheduler.Clustered;
+
                 _nodes.AddRange(await Api.GetClusterNodes(schedulerName));
 
                 // Both states, because the two columns are what a node is holding and what it is

--- a/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
@@ -347,14 +347,14 @@
 
     private async Task RefreshSchedulersAsync(string? preferredSchedulerName)
     {
-        IReadOnlyList<SchedulerHeaderDto> schedulers = await Api.GetSchedulers();
+        List<SchedulerHeaderDto> schedulers = await Api.GetSchedulers();
+        Scheduler.AvailableSchedulers = schedulers.AsReadOnly();
+
         List<string> names = [];
         foreach (SchedulerHeaderDto scheduler in schedulers)
         {
             names.Add(scheduler.SchedulerName);
         }
-
-        Scheduler.AvailableSchedulers = names.AsReadOnly();
 
         string? nextActive = preferredSchedulerName;
         if (string.IsNullOrWhiteSpace(nextActive) ||

--- a/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
@@ -21,6 +21,13 @@
     {
         <ErrorAlert Message="@_error" OnRetry="LoadDataAsync" />
     }
+    else if (_schedulerIsNotCreated)
+    {
+        <p class="qz-muted">
+            This scheduler is registered but has not been created, so there is nothing to show for it yet.
+            <a href="@DashboardLink.To(Options.Value, "schedulers")">See every scheduler this process knows about</a>.
+        </p>
+    }
     else
     {
         <div class="qz-row">
@@ -101,6 +108,12 @@
     private int _errorTriggers;
     private int _nodes;
     private int _unhealthyNodes;
+
+    /// <summary>
+    /// Whether the active scheduler is a registration nothing has built, which the listing already said
+    /// and which every read on this page would otherwise report as a scheduler it could not find.
+    /// </summary>
+    private bool _schedulerIsNotCreated;
     private readonly List<DashboardActionLogEntry> _recentActions = [];
     private bool _showShutdownConfirm;
     private PeriodicTimer? _executingRefreshTimer;
@@ -137,12 +150,14 @@
         _isLoading = true;
         _error = null;
         _errorTriggers = 0;
+        _schedulerIsNotCreated = false;
 
         try
         {
             string? schedulerName = Scheduler.ActiveSchedulerName;
-            if (string.IsNullOrWhiteSpace(schedulerName))
+            if (string.IsNullOrWhiteSpace(schedulerName) || Scheduler.Find(schedulerName) is { IsCreated: false })
             {
+                _schedulerIsNotCreated = !string.IsNullOrWhiteSpace(schedulerName);
                 _schedulerStatus = SchedulerStatus.Unknown;
                 _totalJobs = 0;
                 _totalTriggers = 0;
@@ -350,17 +365,13 @@
         List<SchedulerHeaderDto> schedulers = await Api.GetSchedulers();
         Scheduler.AvailableSchedulers = schedulers.AsReadOnly();
 
-        List<string> names = [];
-        foreach (SchedulerHeaderDto scheduler in schedulers)
-        {
-            names.Add(scheduler.SchedulerName);
-        }
-
+        // The preferred scheduler has to still exist, not merely still be registered: shutting one down
+        // leaves its registration in the listing, and staying on it would leave the page reporting a
+        // scheduler nothing can read.
         string? nextActive = preferredSchedulerName;
-        if (string.IsNullOrWhiteSpace(nextActive) ||
-            !names.Contains(nextActive, StringComparer.OrdinalIgnoreCase))
+        if (Scheduler.Find(nextActive) is not { IsCreated: true })
         {
-            nextActive = names.Count > 0 ? names[0] : null;
+            nextActive = Scheduler.DefaultSchedulerName;
         }
 
         Scheduler.ActiveSchedulerName = nextActive;

--- a/src/Quartz.Dashboard/Components/Pages/Schedulers.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Schedulers.razor
@@ -1,0 +1,284 @@
+@page "/quartz/schedulers"
+@using Microsoft.Extensions.Options
+@using Quartz
+@using Quartz.Dashboard.Components.Shared
+@using Quartz.Dashboard.Services
+@inject IQuartzApiClient Api
+@inject SchedulerState Scheduler
+@inject IOptions<QuartzDashboardOptions> Options
+@inject NavigationManager Navigation
+
+<div class="qz-page">
+    <div class="qz-page-header">
+        <h1>Schedulers</h1>
+        <span class="qz-muted" style="font-size: var(--qz-font-size-xs);">
+            Every scheduler this process has registered, whether or not one has been built
+        </span>
+    </div>
+
+    @if (_isLoading)
+    {
+        <LoadingSpinner />
+    }
+
+    @if (!string.IsNullOrWhiteSpace(_error))
+    {
+        <ErrorAlert Message="@_error" OnRetry="LoadDataAsync" />
+    }
+
+    <table class="qz-table">
+        <thead>
+            <tr>
+                <th>Scheduler</th>
+                <th>Origin</th>
+                <th>Status</th>
+                <th>Job store</th>
+                <th>Threads</th>
+                <th>Running since</th>
+                <th>Jobs executed</th>
+                <th>Nodes</th>
+                <th>Version</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if (_rows.Count == 0)
+            {
+                <tr>
+                    <td colspan="9" class="qz-muted">No schedulers registered.</td>
+                </tr>
+            }
+            else
+            {
+                @foreach (SchedulerRow row in _rows)
+                {
+                    <tr>
+                        <td>
+                            @if (row.Header.IsCreated)
+                            {
+                                <a href="@DashboardHref" @onclick="() => SelectAsync(row.Header.SchedulerName)" @onclick:preventDefault>@row.Header.SchedulerName</a>
+                            }
+                            else
+                            {
+                                @row.Header.SchedulerName
+                            }
+
+                            @if (row.Header.SchedulerInstanceId is { Length: > 0 } instanceId)
+                            {
+                                <div class="qz-muted" style="font-size: var(--qz-font-size-xs);">@instanceId</div>
+                            }
+                        </td>
+                        <td>@row.Header.Origin.ToString()</td>
+                        <td>
+                            @if (row.Header.Status is { } status)
+                            {
+                                <SchedulerStatusIndicator Status="status" />
+                            }
+                            else
+                            {
+                                <StateIndicator State="Not created" />
+                            }
+
+                            @if (!string.IsNullOrWhiteSpace(row.Error))
+                            {
+                                <div class="qz-muted" style="font-size: var(--qz-font-size-xs);">@row.Error</div>
+                            }
+                        </td>
+                        <td>
+                            @if (row.Detail is { } jobStore)
+                            {
+                                <span title="@jobStore.JobStoreTypeName">@ShortTypeName(jobStore.JobStoreTypeName)</span>
+                                <span class="qz-tag">@(jobStore.Persistent ? "persistent" : "in-memory")</span>
+                                @if (jobStore.Clustered)
+                                {
+                                    <span class="qz-tag">clustered</span>
+                                }
+                            }
+                            else
+                            {
+                                @Dash
+                            }
+                        </td>
+                        <td>
+                            @if (row.Detail is { } threadPool)
+                            {
+                                <span title="@threadPool.ThreadPoolTypeName">@threadPool.ThreadPoolSize</span>
+                            }
+                            else
+                            {
+                                @Dash
+                            }
+                        </td>
+                        <td>
+                            @if (row.Detail?.RunningSince is { } runningSince)
+                            {
+                                @Scheduler.FormatInSelectedTimeZone(runningSince)
+                            }
+                            else
+                            {
+                                @Dash
+                            }
+                        </td>
+                        <td>
+                            @if (row.Detail is { } statistics)
+                            {
+                                @statistics.JobsExecuted
+                            }
+                            else
+                            {
+                                @Dash
+                            }
+                        </td>
+                        <td>
+                            @if (row.NodeCount is { } nodeCount)
+                            {
+                                @nodeCount
+                            }
+                            else
+                            {
+                                @Dash
+                            }
+                        </td>
+                        <td>
+                            @if (row.Detail is { } version)
+                            {
+                                @version.Version
+                            }
+                            else
+                            {
+                                @Dash
+                            }
+                        </td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+</div>
+
+@code {
+    /// <summary>
+    /// What an absent value reads as. A scheduler nothing has built has no metadata to show, and a blank
+    /// cell reads as a rendering fault.
+    /// </summary>
+    private const string Dash = "—";
+
+    private readonly List<SchedulerRow> _rows = [];
+    private bool _isLoading = true;
+    private string? _error;
+
+    private string DashboardHref => DashboardLink.To(Options.Value, "");
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDataAsync();
+    }
+
+    private async Task LoadDataAsync()
+    {
+        _isLoading = true;
+        _error = null;
+
+        try
+        {
+            _rows.Clear();
+
+            List<SchedulerHeaderDto> schedulers = await Api.GetSchedulers();
+            Scheduler.AvailableSchedulers = schedulers.AsReadOnly();
+
+            foreach (SchedulerHeaderDto header in schedulers)
+            {
+                _rows.Add(await LoadRowAsync(header));
+            }
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    /// <summary>
+    /// One registration's row: its metadata when a scheduler exists behind it, and its node count when
+    /// that scheduler's store is one that has nodes.
+    /// </summary>
+    /// <remarks>
+    /// A scheduler that cannot answer is reported in its own row rather than allowed to escape. This is
+    /// the fleet view, and one unreachable tenant must not be the reason an operator cannot see the
+    /// others.
+    /// </remarks>
+    private async Task<SchedulerRow> LoadRowAsync(SchedulerHeaderDto header)
+    {
+        if (!header.IsCreated)
+        {
+            return new SchedulerRow(header);
+        }
+
+        try
+        {
+            SchedulerDetailDto detail = await Api.GetScheduler(header.SchedulerName);
+
+            // Only a persistent, clustered store has a node table to read. A RAM store answers with the
+            // one node it is, which is a query per scheduler for an answer that is always "1".
+            int? nodeCount = null;
+            if (detail.Persistent && detail.Clustered)
+            {
+                List<ClusterNodeDto> nodes = await Api.GetClusterNodes(header.SchedulerName);
+                nodeCount = nodes.Count;
+            }
+
+            return new SchedulerRow(header) { Detail = detail, NodeCount = nodeCount };
+        }
+        catch (Exception ex)
+        {
+            return new SchedulerRow(header) { Error = ex.Message };
+        }
+    }
+
+    /// <summary>
+    /// Makes <paramref name="schedulerName" /> the scheduler the rest of the dashboard is about, and
+    /// opens its Dashboard page.
+    /// </summary>
+    private Task SelectAsync(string schedulerName)
+    {
+        Scheduler.ActiveSchedulerName = schedulerName;
+        Navigation.NavigateTo(DashboardHref);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The type's own name, with the full name kept as the cell's tooltip. A column of
+    /// assembly-qualified names is a column nobody can read.
+    /// </summary>
+    private static string ShortTypeName(string typeName)
+    {
+        int comma = typeName.IndexOf(',', StringComparison.Ordinal);
+        string withoutAssembly = comma < 0 ? typeName : typeName.Substring(0, comma);
+
+        int lastDot = withoutAssembly.LastIndexOf('.');
+        return lastDot < 0 ? withoutAssembly : withoutAssembly.Substring(lastDot + 1);
+    }
+
+    /// <summary>
+    /// One registration as the page shows it.
+    /// </summary>
+    private sealed record SchedulerRow(SchedulerHeaderDto Header)
+    {
+        /// <summary>
+        /// What the scheduler is made of, or null when nothing has built it or it could not answer.
+        /// </summary>
+        public SchedulerDetailDto? Detail { get; init; }
+
+        /// <summary>
+        /// How many nodes the cluster has, or null when the store keeps no node table.
+        /// </summary>
+        public int? NodeCount { get; init; }
+
+        /// <summary>
+        /// Why the scheduler could not be read, when it could not.
+        /// </summary>
+        public string? Error { get; init; }
+    }
+}

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -68,6 +68,7 @@ public static class QuartzDashboardServiceCollectionExtensions
         // application that registers its own IQuartzApiClient first is the one that answers.
         services.TryAddScoped<IQuartzApiClient>(static provider => new InProcessQuartzApiClient(
             provider.GetRequiredService<ISchedulerRepository>(),
+            provider.GetRequiredService<ISchedulerRegistry>(),
             provider.GetRequiredService<IOptions<QuartzDashboardOptions>>(),
             provider.GetRequiredService<IDashboardHistoryStore>()));
         services.TryAddScoped<SchedulerState>();

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -43,8 +43,22 @@ namespace Quartz.Dashboard.Services;
 /// </remarks>
 public interface IQuartzApiClient
 {
+    /// <summary>
+    /// Returns every scheduler the container knows about, ordered by name — the registrations included,
+    /// so a scheduler nothing has built yet is listed with a null <see cref="SchedulerHeaderDto.Status" />
+    /// rather than being invisible.
+    /// </summary>
+    /// <remarks>
+    /// Nothing is created by asking. That is why the listing is the registrations rather than the
+    /// repository: an operator enumerating tenants must not start every one of them.
+    /// </remarks>
     ValueTask<List<SchedulerHeaderDto>> GetSchedulers(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns one scheduler with the metadata it was built with. Only a scheduler that exists can
+    /// answer; a registration nothing has built is reported by <see cref="GetSchedulers" /> and has no
+    /// detail to read.
+    /// </summary>
     ValueTask<SchedulerDetailDto> GetScheduler(string schedulerName, CancellationToken cancellationToken = default);
 
     ValueTask StartScheduler(string schedulerName, CancellationToken cancellationToken = default);
@@ -230,9 +244,74 @@ public sealed record DashboardHistoryQuery : PagedQuery
     public string? TriggerFilter { get; init; }
 }
 
-public sealed record SchedulerHeaderDto(string SchedulerName, string SchedulerInstanceId, SchedulerStatus Status);
+/// <summary>
+/// One scheduler the container knows about, whether or not anything has built it.
+/// </summary>
+/// <remarks>
+/// <see cref="Status" /> and <see cref="SchedulerInstanceId" /> are null for a registration nothing has
+/// created: there is no scheduler to ask, and listing the registrations must not build one. The rest of
+/// what a built scheduler is made of arrives with <see cref="SchedulerDetailDto" />, which is a read per
+/// scheduler rather than part of the listing.
+/// </remarks>
+/// <param name="SchedulerName">The scheduler's name, spelled as it was registered.</param>
+/// <param name="SchedulerInstanceId">
+/// The instance id of the scheduler behind this registration, or <see langword="null" /> when nothing
+/// has built one.
+/// </param>
+/// <param name="Status">
+/// What state the scheduler is in, or <see langword="null" /> when no scheduler exists under this name.
+/// </param>
+/// <param name="Origin">Where the scheduler came from.</param>
+public sealed record SchedulerHeaderDto(
+    string SchedulerName,
+    string? SchedulerInstanceId,
+    SchedulerStatus? Status,
+    SchedulerOrigin Origin)
+{
+    /// <summary>
+    /// Whether a scheduler exists under this name, which is what decides whether the rest of the
+    /// dashboard has anything to show for it.
+    /// </summary>
+    public bool IsCreated => Status is not null;
+}
 
-public sealed record SchedulerDetailDto(string SchedulerInstanceId, string SchedulerName, SchedulerStatus Status);
+/// <summary>
+/// One scheduler and what it is made of: its identity, its state, and the settings and capabilities
+/// <see cref="SchedulerMetadata" /> reports.
+/// </summary>
+/// <remarks>
+/// The metadata is on the detail rather than on <see cref="SchedulerHeaderDto" /> because reading it is
+/// a call per scheduler — over HTTP for a remote one — while the listing must stay one call.
+/// </remarks>
+/// <param name="SchedulerInstanceId">The scheduler's instance id.</param>
+/// <param name="SchedulerName">The scheduler's name.</param>
+/// <param name="Status">Where the scheduler is in its lifecycle.</param>
+/// <param name="Clustered">
+/// Whether the job store is clustered. This is the answer to "is this scheduler part of a cluster";
+/// the node listing cannot be, because a clustered store whose only node has not finished its first
+/// check-in looks exactly like a store that keeps no check-in state at all.
+/// </param>
+/// <param name="Persistent">Whether the job store survives a restart.</param>
+/// <param name="JobStoreTypeName">The job store's type name, without its assembly version.</param>
+/// <param name="ThreadPoolTypeName">The thread pool's type name, without its assembly version.</param>
+/// <param name="ThreadPoolSize">How many threads the pool has.</param>
+/// <param name="RunningSince">
+/// When the scheduler started, or <see langword="null" /> when it has not been started.
+/// </param>
+/// <param name="JobsExecuted">How many jobs this node has executed since it started.</param>
+/// <param name="Version">The version of Quartz that is running.</param>
+public sealed record SchedulerDetailDto(
+    string SchedulerInstanceId,
+    string SchedulerName,
+    SchedulerStatus Status,
+    bool Clustered,
+    bool Persistent,
+    string JobStoreTypeName,
+    string ThreadPoolTypeName,
+    int ThreadPoolSize,
+    DateTimeOffset? RunningSince,
+    int JobsExecuted,
+    string Version);
 
 public sealed record JobKeyDto(string Group, string Name);
 

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -33,36 +33,62 @@ namespace Quartz.Dashboard.Services;
 internal sealed class InProcessQuartzApiClient : IQuartzApiClient
 {
     private readonly ISchedulerRepository schedulerRepository;
+    private readonly ISchedulerRegistry schedulerRegistry;
     private readonly IOptions<QuartzDashboardOptions> options;
     private readonly IDashboardHistoryStore historyStore;
 
     public InProcessQuartzApiClient(
         ISchedulerRepository schedulerRepository,
+        ISchedulerRegistry schedulerRegistry,
         IOptions<QuartzDashboardOptions> options,
         IDashboardHistoryStore historyStore)
     {
         this.schedulerRepository = schedulerRepository;
+        this.schedulerRegistry = schedulerRegistry;
         this.options = options;
         this.historyStore = historyStore;
     }
 
-    public ValueTask<List<SchedulerHeaderDto>> GetSchedulers(CancellationToken cancellationToken = default)
+    /// <remarks>
+    /// The registrations, not the repository: a tenant nothing has built yet is still a tenant, and the
+    /// dashboard is where an operator goes to find out that it has not started. The repository is asked
+    /// only for the instance id of the schedulers that do exist, which a registration does not carry.
+    /// </remarks>
+    public async ValueTask<List<SchedulerHeaderDto>> GetSchedulers(CancellationToken cancellationToken = default)
     {
-        List<IScheduler> schedulers = schedulerRepository.LookupAll();
-        List<SchedulerHeaderDto> result = [];
-        foreach (IScheduler scheduler in schedulers)
+        List<SchedulerRegistration> registrations = await schedulerRegistry.QuerySchedulers(cancellationToken).ConfigureAwait(false);
+
+        List<SchedulerHeaderDto> result = new(registrations.Count);
+        foreach (SchedulerRegistration registration in registrations)
         {
-            result.Add(new SchedulerHeaderDto(scheduler.SchedulerName, scheduler.SchedulerInstanceId, scheduler.Status));
+            IScheduler? scheduler = registration.IsCreated ? schedulerRepository.Lookup(registration.Name) : null;
+            result.Add(new SchedulerHeaderDto(
+                registration.Name,
+                scheduler?.SchedulerInstanceId,
+                registration.Status,
+                registration.Origin));
         }
 
-        return ValueTask.FromResult(result);
+        return result;
     }
 
-    public ValueTask<SchedulerDetailDto> GetScheduler(string schedulerName, CancellationToken cancellationToken = default)
+    public async ValueTask<SchedulerDetailDto> GetScheduler(string schedulerName, CancellationToken cancellationToken = default)
     {
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        SchedulerDetailDto result = new(scheduler.SchedulerInstanceId, scheduler.SchedulerName, scheduler.Status);
-        return ValueTask.FromResult(result);
+        SchedulerMetadata metadata = await scheduler.GetMetadata(cancellationToken).ConfigureAwait(false);
+
+        return new SchedulerDetailDto(
+            scheduler.SchedulerInstanceId,
+            scheduler.SchedulerName,
+            metadata.Status,
+            metadata.JobStoreClustered,
+            metadata.JobStorePersistent,
+            metadata.JobStoreTypeName,
+            metadata.ThreadPoolTypeName,
+            metadata.ThreadPoolSize,
+            metadata.RunningSince,
+            metadata.JobsExecuted,
+            metadata.Version);
     }
 
     public ValueTask StartScheduler(string schedulerName, CancellationToken cancellationToken = default)

--- a/src/Quartz.Dashboard/Services/SchedulerState.cs
+++ b/src/Quartz.Dashboard/Services/SchedulerState.cs
@@ -79,26 +79,56 @@ internal sealed class SchedulerState
     public IReadOnlyList<SchedulerHeaderDto> AvailableSchedulers { get; set; } = [];
 
     /// <summary>
-    /// Whether a scheduler exists under <paramref name="schedulerName" />, as the last listing reported
-    /// it. A name the listing does not carry reads as created, so a page that was pointed at a scheduler
-    /// by hand is not told it does not exist.
+    /// The scheduler the dashboard should be about when nothing has chosen one: the first that exists,
+    /// falling back to the first registration, and <see langword="null" /> when there are none.
     /// </summary>
-    public bool IsCreated(string? schedulerName)
+    /// <remarks>
+    /// A registration nothing has built has no pages to render, so opening on one would show its
+    /// not-created state everywhere while a running scheduler sat further down the list. It is still the
+    /// fallback, because a process whose only scheduler has not started is better described by that
+    /// scheduler than by nothing at all.
+    /// </remarks>
+    public string? DefaultSchedulerName
+    {
+        get
+        {
+            foreach (SchedulerHeaderDto scheduler in AvailableSchedulers)
+            {
+                if (scheduler.IsCreated)
+                {
+                    return scheduler.SchedulerName;
+                }
+            }
+
+            return AvailableSchedulers.Count > 0 ? AvailableSchedulers[0].SchedulerName : null;
+        }
+    }
+
+    /// <summary>
+    /// What the last listing said about <paramref name="schedulerName" />, or <see langword="null" />
+    /// when it said nothing about it.
+    /// </summary>
+    /// <remarks>
+    /// Null and <c>IsCreated: false</c> are different answers, which is why this returns the header
+    /// rather than a flag: a page pointed at a scheduler the listing does not carry must not be told the
+    /// scheduler does not exist, while one pointed at a registration nothing has built must.
+    /// </remarks>
+    public SchedulerHeaderDto? Find(string? schedulerName)
     {
         if (string.IsNullOrWhiteSpace(schedulerName))
         {
-            return false;
+            return null;
         }
 
         foreach (SchedulerHeaderDto scheduler in AvailableSchedulers)
         {
             if (string.Equals(scheduler.SchedulerName, schedulerName, StringComparison.OrdinalIgnoreCase))
             {
-                return scheduler.IsCreated;
+                return scheduler;
             }
         }
 
-        return true;
+        return null;
     }
 
     public string SelectedTimeZoneId

--- a/src/Quartz.Dashboard/Services/SchedulerState.cs
+++ b/src/Quartz.Dashboard/Services/SchedulerState.cs
@@ -68,7 +68,38 @@ internal sealed class SchedulerState
         }
     }
 
-    public IReadOnlyList<string> AvailableSchedulers { get; set; } = [];
+    /// <summary>
+    /// Every scheduler the container knows about, registrations that nothing has built included.
+    /// </summary>
+    /// <remarks>
+    /// The headers rather than the names, because whether a scheduler exists is the one thing a picker
+    /// has to know about a name it is offering: a registration nobody has built has nothing to show, and
+    /// omitting it would make the tenant look as if it had never been registered.
+    /// </remarks>
+    public IReadOnlyList<SchedulerHeaderDto> AvailableSchedulers { get; set; } = [];
+
+    /// <summary>
+    /// Whether a scheduler exists under <paramref name="schedulerName" />, as the last listing reported
+    /// it. A name the listing does not carry reads as created, so a page that was pointed at a scheduler
+    /// by hand is not told it does not exist.
+    /// </summary>
+    public bool IsCreated(string? schedulerName)
+    {
+        if (string.IsNullOrWhiteSpace(schedulerName))
+        {
+            return false;
+        }
+
+        foreach (SchedulerHeaderDto scheduler in AvailableSchedulers)
+        {
+            if (string.Equals(scheduler.SchedulerName, schedulerName, StringComparison.OrdinalIgnoreCase))
+            {
+                return scheduler.IsCreated;
+            }
+        }
+
+        return true;
+    }
 
     public string SelectedTimeZoneId
     {

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/ClusterPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/ClusterPageTest.cs
@@ -112,8 +112,8 @@ public class ClusterPageTest
         IRenderedComponent<Cluster> page = context.Render<Cluster>();
 
         page.Markup.Should().Contain("This scheduler is not clustered",
-            "one node with no check-in history is what a non-clustered store looks like from here, and a "
-            + "single-row table with two dashes in it explains nothing");
+            "the scheduler says its store is not clustered, and a single-row table with two dashes in it "
+            + "explains nothing");
         RowCells(page, rowIndex: 0).Should().Contain("—",
             "an absent check-in time is shown as absent rather than as the epoch");
     }
@@ -121,11 +121,40 @@ public class ClusterPageTest
     [Test]
     public void AClusterOfSeveralNodesIsNotDescribedAsUnclustered()
     {
+        context.WithScheduler(clustered: true, persistent: true);
         GivenNodes(CurrentNode(), Node("node-b", ClusterNodeState.Alive));
 
         IRenderedComponent<Cluster> page = context.Render<Cluster>();
 
         page.Markup.Should().NotContain("This scheduler is not clustered");
+    }
+
+    /// <summary>
+    /// The one case the node list cannot decide: a clustered store whose only node has not finished its
+    /// first check-in looks exactly like a store that keeps no cluster state.
+    /// </summary>
+    /// <remarks>
+    /// The page used to infer the verdict from that shape and so told an operator, for up to one
+    /// check-in interval after every fresh start, that the cluster they had just configured was not one.
+    /// <c>SchedulerDetailDto.Clustered</c> is what the scheduler itself reports, and it is never
+    /// ambiguous.
+    /// </remarks>
+    [Test]
+    public void AClusteredSchedulerWhoseOnlyNodeHasNotCheckedInYetIsNotCalledUnclustered()
+    {
+        context.WithScheduler(clustered: true, persistent: true);
+        GivenNodes(new ClusterNodeDto(
+            TestData.SchedulerInstanceId,
+            LastCheckInUtc: null,
+            CheckInInterval: null,
+            ClusterNodeState.Alive,
+            IsCurrentNode: true));
+
+        IRenderedComponent<Cluster> page = context.Render<Cluster>();
+
+        page.Markup.Should().NotContain("This scheduler is not clustered",
+            "the store is clustered whatever its check-in table has had time to say, and a cluster of one "
+            + "that has just started is the commonest way to see this page");
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
@@ -85,12 +85,14 @@ internal sealed class DashboardComponentContext : BunitContext
     /// </summary>
     public DashboardComponentContext WithScheduler(
         string schedulerName = TestData.SchedulerName,
-        SchedulerStatus status = SchedulerStatus.Running)
+        SchedulerStatus status = SchedulerStatus.Running,
+        bool clustered = false,
+        bool persistent = false)
     {
         A.CallTo(() => Api.GetSchedulers(A<CancellationToken>._))
             .Returns(new List<SchedulerHeaderDto> { TestData.Dashboard.SchedulerHeader(schedulerName, status) });
         A.CallTo(() => Api.GetScheduler(schedulerName, A<CancellationToken>._))
-            .Returns(TestData.Dashboard.SchedulerDetail(status, schedulerName));
+            .Returns(TestData.Dashboard.SchedulerDetail(status, schedulerName, clustered, persistent));
 
         SchedulerState.ActiveSchedulerName = schedulerName;
         return this;

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
@@ -167,6 +167,31 @@ public class DashboardPageTest
             "no scheduler selected is not a scheduler in some state, which is what Unknown means");
     }
 
+    /// <summary>
+    /// The page an operator lands on when the scheduler they picked is a registration nothing has built.
+    /// </summary>
+    /// <remarks>
+    /// The listing carries such a registration now, so it can be the active scheduler — after shutting
+    /// the only one down, or by following it from the Schedulers page. Every read this page makes would
+    /// answer "no such scheduler", which reads as a fault rather than as the state the listing already
+    /// reported.
+    /// </remarks>
+    [Test]
+    public void ASchedulerNothingHasBuiltSaysSoRatherThanReportingAFault()
+    {
+        context.SchedulerState.AvailableSchedulers = new List<SchedulerHeaderDto>
+        {
+            TestData.Dashboard.RegisteredSchedulerHeader("acme")
+        };
+        context.SchedulerState.ActiveSchedulerName = "acme";
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.Markup.Should().Contain("registered but has not been created");
+        page.FindAll(".qz-stat-card").Should().BeEmpty("there is nothing to count");
+        A.CallTo(() => context.Api.GetScheduler("acme", A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
     private void GivenCounts(int jobs, int triggers, int errorTriggers, int executing)
     {
         A.CallTo(() => context.Api.GetJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
@@ -176,7 +176,7 @@ public class RemainingPagesTest
         IRenderedComponent<NavMenu> menu = context.Render<NavMenu>();
 
         menu.FindAll("a").Select(link => link.GetAttribute("href")).Should()
-            .Equal(["quartz", "quartz/jobs", "quartz/triggers", "quartz/calendars", "quartz/executing", "quartz/cluster", "quartz/history", "quartz/live", "quartz/actions"],
+            .Equal(["quartz", "quartz/jobs", "quartz/triggers", "quartz/calendars", "quartz/executing", "quartz/schedulers", "quartz/cluster", "quartz/history", "quartz/live", "quartz/actions"],
                 "the links are base-relative, so they survive an application path base as well as a "
                 + "custom dashboard path");
     }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulerSelectorTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulerSelectorTest.cs
@@ -83,6 +83,43 @@ public class SchedulerSelectorTest
             "there is no status to show, and Unknown would claim there is a scheduler in some state");
     }
 
+    /// <summary>
+    /// A registration nothing has built is a tenant the container knows about, so the picker offers it —
+    /// greyed out, because there is nothing behind it to show.
+    /// </summary>
+    /// <remarks>
+    /// It used to be omitted, the listing being the repository's. An operator looking for a tenant that
+    /// had failed to start found no trace of it and no way to tell that from "never registered".
+    /// </remarks>
+    [Test]
+    public void ARegistrationNothingHasBuiltIsOfferedGreyedOutRatherThanOmitted()
+    {
+        GivenSchedulers(TestData.Dashboard.SchedulerHeader("core"), TestData.Dashboard.RegisteredSchedulerHeader("acme"));
+
+        IRenderedComponent<SchedulerSelector> selector = context.Render<SchedulerSelector>();
+
+        selector.TextOfAll("option").Should().Equal(["core", "acme (not created)"]);
+        selector.FindAll("option")[1].HasAttribute("disabled").Should().BeTrue(
+            "there is no scheduler behind the name, so selecting it would only produce an error");
+        context.SchedulerState.ActiveSchedulerName.Should().Be("core",
+            "the dashboard opens on a scheduler that exists when there is one");
+    }
+
+    [Test]
+    public void ASchedulerThatHasNotBeenBuiltShowsTheNotCreatedStateRatherThanAnError()
+    {
+        GivenSchedulers(TestData.Dashboard.RegisteredSchedulerHeader("acme"));
+
+        IRenderedComponent<SchedulerSelector> selector = context.Render<SchedulerSelector>();
+
+        context.SchedulerState.ActiveSchedulerName.Should().Be("acme",
+            "it is the only registration there is, so it is what the dashboard is about");
+        selector.Markup.Should().Contain("Not created",
+            "the listing already said no scheduler exists under this name, so asking for one and "
+            + "reporting the refusal would dress a known state up as a fault");
+        A.CallTo(() => context.Api.GetScheduler("acme", A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
     [Test]
     public void WhileTheSchedulersAreBeingFetchedThePickerSaysSo()
     {
@@ -100,10 +137,22 @@ public class SchedulerSelectorTest
         foreach ((string name, SchedulerStatus status) in schedulers)
         {
             headers.Add(TestData.Dashboard.SchedulerHeader(name, status));
-            A.CallTo(() => context.Api.GetScheduler(name, A<CancellationToken>._))
-                .Returns(TestData.Dashboard.SchedulerDetail(status, name));
         }
 
-        A.CallTo(() => context.Api.GetSchedulers(A<CancellationToken>._)).Returns(headers);
+        GivenSchedulers(headers.ToArray());
+    }
+
+    private void GivenSchedulers(params SchedulerHeaderDto[] schedulers)
+    {
+        foreach (SchedulerHeaderDto scheduler in schedulers)
+        {
+            if (scheduler.Status is { } status)
+            {
+                A.CallTo(() => context.Api.GetScheduler(scheduler.SchedulerName, A<CancellationToken>._))
+                    .Returns(TestData.Dashboard.SchedulerDetail(status, scheduler.SchedulerName));
+            }
+        }
+
+        A.CallTo(() => context.Api.GetSchedulers(A<CancellationToken>._)).Returns(schedulers.ToList());
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulersPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulersPageTest.cs
@@ -1,0 +1,185 @@
+using AngleSharp.Dom;
+
+using Bunit;
+
+using FakeItEasy;
+
+using Quartz.Dashboard.Components.Pages;
+using Quartz.Dashboard.Services;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard.Components;
+
+/// <summary>
+/// The Schedulers page: the fleet, built or not, and what each one that exists is made of.
+/// </summary>
+/// <remarks>
+/// This is the page that answers "what does this process run" without starting anything, so the two
+/// things it must get right are that a registration nothing has built is <em>listed</em> rather than
+/// silently missing, and that the reads it makes per scheduler are the ones that have an answer — a
+/// node query against an in-memory store costs a round trip to be told there is one node.
+/// </remarks>
+public class SchedulersPageTest
+{
+    private DashboardComponentContext context = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        context = new DashboardComponentContext();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    [Test]
+    public void ARegistrationNothingHasBuiltIsListedWithNoMetadataRatherThanOmitted()
+    {
+        GivenSchedulers(TestData.Dashboard.RegisteredSchedulerHeader("acme"));
+
+        IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
+
+        List<string> cells = RowCells(page, rowIndex: 0);
+        cells[0].Should().Be("acme",
+            "a tenant the container knows about is a tenant an operator came here to see, whether or not "
+            + "anything has built it");
+        cells[2].Should().Contain("Not created");
+        cells.Skip(3).Should().AllBe("—",
+            "there is no scheduler to read metadata from, and a blank cell reads as a rendering fault");
+
+        A.CallTo(() => context.Api.GetScheduler("acme", A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public void ABuiltSchedulerShowsWhatItIsMadeOf()
+    {
+        GivenSchedulers(TestData.Dashboard.SchedulerHeader("core"));
+        GivenDetail("core", TestData.Dashboard.SchedulerDetail(SchedulerStatus.Running, "core"));
+
+        IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
+
+        List<string> cells = RowCells(page, rowIndex: 0);
+        cells[0].Should().Contain("core").And.Contain(TestData.SchedulerInstanceId);
+        cells[1].Should().Be("Container");
+        cells[2].Should().Contain("Running");
+        cells[3].Should().Contain("RAMJobStore").And.Contain("in-memory");
+        cells[4].Should().Be("10", "the pool size is the number an operator sizes a scheduler by");
+        cells[5].Should().Be("2024-05-06 07:08:09 +00:00", "times are rendered in the zone the user picked");
+        cells[6].Should().Be("42");
+        cells[8].Should().Be("4.0.0.0");
+    }
+
+    [Test]
+    public void OnlyAPersistentClusteredSchedulerIsAskedForItsNodes()
+    {
+        GivenSchedulers(
+            TestData.Dashboard.SchedulerHeader("core"),
+            TestData.Dashboard.SchedulerHeader("reporting"));
+        GivenDetail("core", TestData.Dashboard.SchedulerDetail(SchedulerStatus.Running, "core", clustered: true, persistent: true));
+        GivenDetail("reporting", TestData.Dashboard.SchedulerDetail(SchedulerStatus.Running, "reporting"));
+        A.CallTo(() => context.Api.GetClusterNodes("core", A<CancellationToken>._))
+            .Returns(new List<ClusterNodeDto> { Node("node-a", isCurrent: true), Node("node-b", isCurrent: false) });
+
+        IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
+
+        RowCells(page, rowIndex: 0)[7].Should().Be("2");
+        RowCells(page, rowIndex: 1)[7].Should().Be("—",
+            "a store with no node table answers with the one node it is, so asking is a round trip per "
+            + "scheduler for a number that is always one");
+
+        A.CallTo(() => context.Api.GetClusterNodes("reporting", A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public void FollowingASchedulersLinkMakesItTheActiveOne()
+    {
+        GivenSchedulers(
+            TestData.Dashboard.SchedulerHeader("core"),
+            TestData.Dashboard.SchedulerHeader("reporting"));
+        GivenDetail("core", TestData.Dashboard.SchedulerDetail(SchedulerStatus.Running, "core"));
+        GivenDetail("reporting", TestData.Dashboard.SchedulerDetail(SchedulerStatus.Standby, "reporting"));
+
+        IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
+        page.FindAll("tbody tr")[1].QuerySelector("a")!.Click();
+
+        context.SchedulerState.ActiveSchedulerName.Should().Be("reporting",
+            "the row is how an operator switches the dashboard to a scheduler, which is the only reason "
+            + "to list them all in one place");
+    }
+
+    [Test]
+    public void ARegistrationNothingHasBuiltIsNotALink()
+    {
+        GivenSchedulers(TestData.Dashboard.RegisteredSchedulerHeader("acme"));
+
+        IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
+
+        page.FindAll("tbody tr")[0].QuerySelectorAll("a").Should().BeEmpty(
+            "there is no scheduler behind the name, so every page the link leads to would report a "
+            + "scheduler it could not find");
+    }
+
+    /// <summary>
+    /// One scheduler that cannot answer must not blank the fleet.
+    /// </summary>
+    [Test]
+    public void ASchedulerThatCannotBeReadIsReportedInItsOwnRow()
+    {
+        GivenSchedulers(
+            TestData.Dashboard.SchedulerHeader("core"),
+            TestData.Dashboard.SchedulerHeader("remote"));
+        GivenDetail("core", TestData.Dashboard.SchedulerDetail(SchedulerStatus.Running, "core"));
+        A.CallTo(() => context.Api.GetScheduler("remote", A<CancellationToken>._))
+            .Throws(new InvalidOperationException("the other process is not answering"));
+
+        IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
+
+        RowCells(page, rowIndex: 1)[2].Should().Contain("the other process is not answering");
+        RowCells(page, rowIndex: 0)[6].Should().Be("42",
+            "the scheduler that did answer is still shown, which is the whole point of a fleet view");
+    }
+
+    [Test]
+    public void AProcessWithNoSchedulersSaysSoRatherThanShowingAnEmptyTable()
+    {
+        GivenSchedulers();
+
+        IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
+
+        page.Markup.Should().Contain("No schedulers registered.");
+    }
+
+    private static ClusterNodeDto Node(string instanceId, bool isCurrent)
+    {
+        return new ClusterNodeDto(
+            instanceId,
+            TestData.Dashboard.FiredAt,
+            TimeSpan.FromSeconds(15),
+            ClusterNodeState.Alive,
+            isCurrent);
+    }
+
+    private static List<string> RowCells(IRenderedComponent<Schedulers> page, int rowIndex)
+    {
+        List<string> cells = [];
+        foreach (IElement cell in page.FindAll("tbody tr")[rowIndex].QuerySelectorAll("td"))
+        {
+            cells.Add(cell.TextContent.Trim());
+        }
+
+        return cells;
+    }
+
+    private void GivenSchedulers(params SchedulerHeaderDto[] schedulers)
+    {
+        A.CallTo(() => context.Api.GetSchedulers(A<CancellationToken>._)).Returns(schedulers.ToList());
+    }
+
+    private void GivenDetail(string schedulerName, SchedulerDetailDto detail)
+    {
+        A.CallTo(() => context.Api.GetScheduler(schedulerName, A<CancellationToken>._)).Returns(detail);
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardRouteTableTest.cs
@@ -17,6 +17,7 @@ public class DashboardRouteTableTest
     [TestCase("triggers", typeof(Pages.Triggers))]
     [TestCase("calendars", typeof(Pages.Calendars))]
     [TestCase("executing", typeof(Pages.CurrentlyExecuting))]
+    [TestCase("schedulers", typeof(Pages.Schedulers))]
     [TestCase("cluster", typeof(Pages.Cluster))]
     [TestCase("history", typeof(Pages.History))]
     [TestCase("history?page=2&job=x", typeof(Pages.History))]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 
 using Quartz.Dashboard.Components.Shared;
 using Quartz.Dashboard.Services;
+using Quartz.Extensibility;
 using Quartz.Impl;
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
@@ -567,7 +568,7 @@ public class InProcessQuartzApiClientTest
     /// </summary>
     /// <remarks>
     /// In-process the scheduler here is backed by the in-memory store, so the honest answer is one node
-    /// with no check-in history — which is also the answer the Cluster page reads as "not clustered".
+    /// with no check-in history.
     /// </remarks>
     [Test]
     public async Task ClusterNodesComeFromTheScheduler()
@@ -592,6 +593,77 @@ public class InProcessQuartzApiClientTest
         }
     }
 
+    /// <summary>
+    /// The scheduler detail carries what the scheduler is made of, not only its name and its state.
+    /// </summary>
+    /// <remarks>
+    /// Everything <see cref="SchedulerMetadata" /> knows used to be dropped on the way to the UI, so the
+    /// dashboard could not say whether a scheduler was clustered, what store it used, or how many
+    /// threads it had. The values are read from the scheduler rather than assembled here, which is why
+    /// this asserts against its own metadata rather than against literals.
+    /// </remarks>
+    [Test]
+    public async Task TheSchedulerDetailCarriesTheMetadataTheSchedulerReports()
+    {
+        IScheduler scheduler = await CreateScheduler("SchedulerDetailTest");
+        try
+        {
+            await scheduler.Start();
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            SchedulerMetadata metadata = await scheduler.GetMetadata();
+            SchedulerDetailDto detail = await client.GetScheduler(scheduler.SchedulerName);
+
+            detail.SchedulerName.Should().Be(scheduler.SchedulerName);
+            detail.SchedulerInstanceId.Should().Be(scheduler.SchedulerInstanceId);
+            detail.Status.Should().Be(SchedulerStatus.Running);
+            detail.Clustered.Should().BeFalse("an in-memory store has no cluster to be part of");
+            detail.Persistent.Should().BeFalse();
+            detail.JobStoreTypeName.Should().Be(metadata.JobStoreTypeName);
+            detail.ThreadPoolTypeName.Should().Be(metadata.ThreadPoolTypeName);
+            detail.ThreadPoolSize.Should().Be(1, "the scheduler was built with one thread");
+            detail.RunningSince.Should().NotBeNull("the scheduler has been started");
+            detail.JobsExecuted.Should().Be(metadata.JobsExecuted);
+            detail.Version.Should().Be(metadata.Version);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// The listing is the registrations, so a tenant nothing has built is in it — with no status and no
+    /// instance id, because there is no scheduler to have either.
+    /// </summary>
+    [Test]
+    public async Task TheListingCarriesRegistrationsNothingHasBuilt()
+    {
+        IScheduler scheduler = await CreateScheduler("SchedulerListingTest");
+        try
+        {
+            InProcessQuartzApiClient client = CreateClient(scheduler, "acme");
+
+            List<SchedulerHeaderDto> schedulers = await client.GetSchedulers();
+
+            SchedulerHeaderDto built = schedulers.Should().ContainSingle(x => x.SchedulerName == scheduler.SchedulerName).Subject;
+            built.IsCreated.Should().BeTrue();
+            built.SchedulerInstanceId.Should().Be(scheduler.SchedulerInstanceId,
+                "the registration does not carry an instance id, so the repository is asked for the one "
+                + "scheduler that has one");
+
+            SchedulerHeaderDto registered = schedulers.Should().ContainSingle(x => x.SchedulerName == "acme").Subject;
+            registered.IsCreated.Should().BeFalse();
+            registered.Status.Should().BeNull("null is what says the registration is there and nothing has built it");
+            registered.SchedulerInstanceId.Should().BeNull("there is no scheduler to have one");
+            registered.Origin.Should().Be(SchedulerOrigin.Container);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
     private static async Task<IScheduler> CreateScheduler(string testName)
     {
         NameValueCollection properties = new()
@@ -603,14 +675,49 @@ public class InProcessQuartzApiClientTest
         return await QuartzSchedulerBuilder.Create().UseProperties(properties).BuildScheduler();
     }
 
-    private static InProcessQuartzApiClient CreateClient(IScheduler scheduler)
+    private static InProcessQuartzApiClient CreateClient(IScheduler scheduler, params string[] registeredButNotCreated)
     {
         SchedulerRepository repository = new();
         repository.Bind(scheduler);
         return new InProcessQuartzApiClient(
             repository,
+            new StubSchedulerRegistry(repository, registeredButNotCreated),
             Options.Create(new QuartzDashboardOptions()),
             new DashboardHistoryStore());
+    }
+
+    /// <summary>
+    /// A registry over a repository plus the names nothing has built, which is the shape
+    /// <c>ContainerSchedulerRegistry</c> answers with. The real one needs a container to be told what was
+    /// registered; what this client does with the answer is what these tests are about.
+    /// </summary>
+    private sealed class StubSchedulerRegistry : ISchedulerRegistry
+    {
+        private readonly ISchedulerRepository repository;
+        private readonly IReadOnlyList<string> registeredButNotCreated;
+
+        public StubSchedulerRegistry(ISchedulerRepository repository, IReadOnlyList<string> registeredButNotCreated)
+        {
+            this.repository = repository;
+            this.registeredButNotCreated = registeredButNotCreated;
+        }
+
+        public ValueTask<List<SchedulerRegistration>> QuerySchedulers(CancellationToken cancellationToken = default)
+        {
+            List<SchedulerRegistration> registrations = [];
+            foreach (IScheduler scheduler in repository.LookupAll())
+            {
+                registrations.Add(new SchedulerRegistration(scheduler.SchedulerName, SchedulerOrigin.Container, scheduler.Status));
+            }
+
+            foreach (string name in registeredButNotCreated)
+            {
+                registrations.Add(new SchedulerRegistration(name, SchedulerOrigin.Container, Status: null));
+            }
+
+            registrations.Sort(static (left, right) => string.CompareOrdinal(left.Name, right.Name));
+            return new ValueTask<List<SchedulerRegistration>>(registrations);
+        }
     }
 
     private sealed class NoOpJob : IJob

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
@@ -17,11 +17,22 @@ namespace Quartz.Tests.AspNetCore.HttpApi;
 
 public class SchedulerEndpointsTest : WebApiTest
 {
+    /// <summary>
+    /// The listing is the registry's, so it carries both what has been built and what has only been
+    /// registered — and says which is which.
+    /// </summary>
+    /// <remarks>
+    /// The test application registers a default scheduler with <c>AddQuartz()</c> and never builds it,
+    /// which is exactly the case the old listing could not report: it read the repository, so a
+    /// registration nothing had resolved was indistinguishable from a name that did not exist.
+    /// </remarks>
     [Test]
-    public async Task GetAllSchedulersShouldWork()
+    public async Task GetAllSchedulersListsRegistrationsAndTheSchedulersBuiltFromThem()
     {
-        var secondFake = A.Fake<IScheduler>();
+        IScheduler secondFake = A.Fake<IScheduler>();
+        A.CallTo(() => secondFake.SchedulerName).Returns("SecondScheduler");
         A.CallTo(() => secondFake.SchedulerInstanceId).Returns("TEST_2_NON_CLUSTERED");
+        A.CallTo(() => secondFake.Status).Returns(SchedulerStatus.Standby);
         WebApplicationFactory.Services.GetRequiredService<ISchedulerRepository>().Bind(secondFake);
 
         // This endpoint is not used by HttpScheduler, so the reader is built here - off the same wire
@@ -33,9 +44,18 @@ public class SchedulerEndpointsTest : WebApiTest
         var result = await httpClient.Get<SchedulerHeaderDto[]>("schedulers", serializerOptions, CancellationToken.None);
         using (new AssertionScope())
         {
-            result.Length.Should().Be(2);
-            result.Should().ContainSingle(x => x.SchedulerInstanceId == TestData.SchedulerInstanceId);
-            result.Should().ContainSingle(x => x.SchedulerInstanceId == "TEST_2_NON_CLUSTERED");
+            SchedulerHeaderDto bound = result.Should().ContainSingle(x => x.Name == TestData.SchedulerName).Subject;
+            bound.SchedulerInstanceId.Should().Be(TestData.SchedulerInstanceId);
+            bound.Origin.Should().Be(SchedulerOrigin.Runtime, "a scheduler bound into the repository has no registration behind it");
+
+            SchedulerHeaderDto second = result.Should().ContainSingle(x => x.Name == "SecondScheduler").Subject;
+            second.SchedulerInstanceId.Should().Be("TEST_2_NON_CLUSTERED");
+            second.Status.Should().Be(SchedulerStatus.Standby);
+
+            SchedulerHeaderDto registered = result.Should().ContainSingle(x => x.Name == QuartzSchedulerOptions.DefaultInstanceName).Subject;
+            registered.Status.Should().BeNull("nothing has built the default scheduler, and listing it did not");
+            registered.SchedulerInstanceId.Should().BeNull("there is no scheduler to have an instance id");
+            registered.Origin.Should().Be(SchedulerOrigin.Container);
         }
     }
 

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
@@ -18,10 +18,11 @@ namespace Quartz.Tests.AspNetCore.HttpApi;
 /// </summary>
 /// <remarks>
 /// Both routes resolve through <see cref="ISchedulerRepository" />, which holds the schedulers something
-/// has already created and indexes them ignoring case. That is two separate statements in
-/// <c>multi-tenancy.md</c> — the "the dashboard and the HTTP API list the repository, not the registry"
-/// box, and the scheduler name being compared case-insensitively there while the container compares
-/// service keys ordinally — and neither had gone through the wire.
+/// has already created and indexes them ignoring case: a tenant nothing has built answers <c>404</c>,
+/// and one asked for under another casing resolves. The <em>listing</em> is the one read that does not
+/// go through the repository — it answers from <see cref="ISchedulerRegistry" />, so the tenant that is
+/// missing from the routes is present there, which is how a caller tells "not built yet" from "no such
+/// tenant".
 /// </remarks>
 [NonParallelizable]
 public sealed class TenantSchedulerRoutingTest
@@ -41,12 +42,12 @@ public sealed class TenantSchedulerRoutingTest
 
     /// <summary>
     /// The window <c>AddQuartzHostedService()</c> closes and everything else leaves open: the container
-    /// knows the tenant, nothing has built it, and the two views of "what schedulers are there" disagree
-    /// on purpose. The API answering <c>404</c> here is not "unknown name" — it is "nothing has built it
-    /// yet", and <see cref="ISchedulerRegistry" /> is the read that can tell the two apart.
+    /// knows the tenant and nothing has built it. Its routes answer <c>404</c> — not "unknown name" but
+    /// "nothing has built it yet" — while the listing carries it with a null status, which is the
+    /// difference <see cref="ISchedulerRegistry" /> exists to report and the API now passes on.
     /// </summary>
     [Test]
-    public async Task ATenantNothingHasBuiltIsMissingFromTheApiAndPresentInTheRegistry()
+    public async Task ATenantNothingHasBuiltIsListedWithoutAStatusAndItsRoutesAnswerNotFound()
     {
         WebApplicationFactory<Program> application = CreateApplication("acme");
 
@@ -58,8 +59,12 @@ public sealed class TenantSchedulerRoutingTest
             + "answering it by building one would make an operator's dashboard start every tenant it lists");
 
         SchedulerHeaderDto[] listed = await ReadSchedulers(client);
-        listed.Should().NotContain(x => x.Name == "acme",
-            "the listing reads the same repository the lookup does, so a tenant absent from one is absent from both");
+        SchedulerHeaderDto tenant = listed.Should().ContainSingle(x => x.Name == "acme",
+            "the listing reads the registry, so a tenant nothing has built is listed rather than being "
+            + "indistinguishable from a name that does not exist").Subject;
+        tenant.Status.Should().BeNull("null is what says the registration is there and nothing has built it");
+        tenant.SchedulerInstanceId.Should().BeNull("there is no scheduler to have an instance id");
+        tenant.Origin.Should().Be(SchedulerOrigin.Container);
 
         List<SchedulerRegistration> registrations =
             await application.Services.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();

--- a/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
@@ -134,6 +134,25 @@ public class WireFormatSnapshotTest : WebApiTest
         await VerifyBody(body);
     }
 
+    /// <summary>
+    /// The scheduler listing, whose two shapes are the point of it: a scheduler that exists, and a
+    /// registration nothing has built.
+    /// </summary>
+    /// <remarks>
+    /// The test application registers a default scheduler and never builds it, so the second shape is
+    /// there without arranging anything — <c>status</c> and <c>schedulerInstanceId</c> both <c>null</c>,
+    /// rather than the entry being missing as it was before the listing read the registry. <c>origin</c>
+    /// goes out as its name, like every other enum on this wire.
+    /// </remarks>
+    [Test]
+    public async Task SchedulerListingBody()
+    {
+        A.CallTo(() => FakeScheduler.Status).Returns(SchedulerStatus.Running);
+
+        string body = await Get("schedulers");
+        await VerifyBody(body);
+    }
+
     [Test]
     public async Task SchedulerBody()
     {

--- a/src/Quartz.Tests.AspNetCore/Support/TestData.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestData.cs
@@ -315,16 +315,40 @@ public static class TestData
 
         public static SchedulerHeaderDto SchedulerHeader(
             string schedulerName = SchedulerName,
-            SchedulerStatus status = SchedulerStatus.Running)
+            SchedulerStatus status = SchedulerStatus.Running,
+            SchedulerOrigin origin = SchedulerOrigin.Container)
         {
-            return new SchedulerHeaderDto(schedulerName, SchedulerInstanceId, status);
+            return new SchedulerHeaderDto(schedulerName, SchedulerInstanceId, status, origin);
+        }
+
+        /// <summary>
+        /// A registration nothing has built: no status, and so no instance id either.
+        /// </summary>
+        public static SchedulerHeaderDto RegisteredSchedulerHeader(
+            string schedulerName,
+            SchedulerOrigin origin = SchedulerOrigin.Container)
+        {
+            return new SchedulerHeaderDto(schedulerName, SchedulerInstanceId: null, Status: null, origin);
         }
 
         public static SchedulerDetailDto SchedulerDetail(
             SchedulerStatus status = SchedulerStatus.Running,
-            string schedulerName = SchedulerName)
+            string schedulerName = SchedulerName,
+            bool clustered = false,
+            bool persistent = false)
         {
-            return new SchedulerDetailDto(SchedulerInstanceId, schedulerName, status);
+            return new SchedulerDetailDto(
+                SchedulerInstanceId,
+                schedulerName,
+                status,
+                Clustered: clustered,
+                Persistent: persistent,
+                JobStoreTypeName: persistent ? "Quartz.Impl.AdoJobStore.LocalTransactionJobStore" : "Quartz.Simpl.RAMJobStore",
+                ThreadPoolTypeName: "Quartz.Simpl.DefaultThreadPool",
+                ThreadPoolSize: 10,
+                RunningSince: status == SchedulerStatus.Running ? FiredAt : null,
+                JobsExecuted: 42,
+                Version: "4.0.0.0");
         }
 
         /// <summary>

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -274,17 +274,27 @@ namespace Quartz.Dashboard.Services
     }
     public sealed class SchedulerDetailDto : System.IEquatable<Quartz.Dashboard.Services.SchedulerDetailDto>
     {
-        public SchedulerDetailDto(string SchedulerInstanceId, string SchedulerName, Quartz.SchedulerStatus Status) { }
+        public SchedulerDetailDto(string SchedulerInstanceId, string SchedulerName, Quartz.SchedulerStatus Status, bool Clustered, bool Persistent, string JobStoreTypeName, string ThreadPoolTypeName, int ThreadPoolSize, System.DateTimeOffset? RunningSince, int JobsExecuted, string Version) { }
+        public bool Clustered { get; init; }
+        public string JobStoreTypeName { get; init; }
+        public int JobsExecuted { get; init; }
+        public bool Persistent { get; init; }
+        public System.DateTimeOffset? RunningSince { get; init; }
         public string SchedulerInstanceId { get; init; }
         public string SchedulerName { get; init; }
         public Quartz.SchedulerStatus Status { get; init; }
+        public int ThreadPoolSize { get; init; }
+        public string ThreadPoolTypeName { get; init; }
+        public string Version { get; init; }
     }
     public sealed class SchedulerHeaderDto : System.IEquatable<Quartz.Dashboard.Services.SchedulerHeaderDto>
     {
-        public SchedulerHeaderDto(string SchedulerName, string SchedulerInstanceId, Quartz.SchedulerStatus Status) { }
-        public string SchedulerInstanceId { get; init; }
+        public SchedulerHeaderDto(string SchedulerName, string? SchedulerInstanceId, Quartz.SchedulerStatus? Status, Quartz.SchedulerOrigin Origin) { }
+        public bool IsCreated { get; }
+        public Quartz.SchedulerOrigin Origin { get; init; }
+        public string? SchedulerInstanceId { get; init; }
         public string SchedulerName { get; init; }
-        public Quartz.SchedulerStatus Status { get; init; }
+        public Quartz.SchedulerStatus? Status { get; init; }
     }
     public sealed class TriggerHeaderDto : System.IEquatable<Quartz.Dashboard.Services.TriggerHeaderDto>
     {

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SchedulerListingBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_SchedulerListingBody.verified.json
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "name": "QuartzScheduler",
+    "schedulerInstanceId": null,
+    "status": null,
+    "origin": "Container"
+  },
+  {
+    "name": "TestScheduler",
+    "schedulerInstanceId": "TEST_NON_CLUSTERED",
+    "status": "Running",
+    "origin": "Runtime"
+  }
+]

--- a/src/Quartz/HttpApiContract/HttpApiJson.cs
+++ b/src/Quartz/HttpApiContract/HttpApiJson.cs
@@ -77,6 +77,7 @@ internal static class HttpApiJson
         options.Converters.Add(new JsonStringEnumConverter<FireInstanceState>());
         options.Converters.Add(new JsonStringEnumConverter<ExecutionLimitScope>());
         options.Converters.Add(new JsonStringEnumConverter<ClusterNodeState>());
+        options.Converters.Add(new JsonStringEnumConverter<SchedulerOrigin>());
 
         options.UseQuartzContract(HttpApiJsonContext.Default, registry);
 

--- a/src/Quartz/HttpApiContract/SchedulerHeaderDto.cs
+++ b/src/Quartz/HttpApiContract/SchedulerHeaderDto.cs
@@ -21,12 +21,29 @@
 
 namespace Quartz.HttpApiContract;
 
-internal record SchedulerHeaderDto(string Name, string SchedulerInstanceId, SchedulerStatus Status)
+/// <summary>
+/// One scheduler in the listing: a registration, and the scheduler behind it when there is one.
+/// </summary>
+/// <remarks>
+/// <see cref="Status" /> and <see cref="SchedulerInstanceId" /> are <see langword="null" /> together,
+/// for a registration nothing has built. Listing the registrations is what lets an operator see a
+/// tenant that has not started; building one to fill the listing in would start every tenant an
+/// inventory touched.
+/// </remarks>
+internal record SchedulerHeaderDto(
+    string Name,
+    string? SchedulerInstanceId,
+    SchedulerStatus? Status,
+    SchedulerOrigin Origin)
 {
-    public static SchedulerHeaderDto Create(IScheduler scheduler)
+    public static SchedulerHeaderDto Create(SchedulerRegistration registration, IScheduler? scheduler)
     {
-        ArgumentNullException.ThrowIfNull(scheduler);
+        ArgumentNullException.ThrowIfNull(registration);
 
-        return new SchedulerHeaderDto(scheduler.SchedulerName, scheduler.SchedulerInstanceId, scheduler.Status);
+        return new SchedulerHeaderDto(
+            registration.Name,
+            scheduler?.SchedulerInstanceId,
+            registration.Status,
+            registration.Origin);
     }
 }


### PR DESCRIPTION
The dashboard could not show a fleet. `SchedulerDetailDto` was `(SchedulerInstanceId, SchedulerName,
Status)`, so everything `SchedulerMetadata` knows was dropped on the way to the UI, and both scheduler
listings — the dashboard's and `GET /schedulers` — read `ISchedulerRepository`, which holds only what
something has already built. A tenant registered with `AddQuartz("acme", …)` that nothing had resolved
was invisible in both, and a caller could not tell that from "no such tenant".

## As built

**`GET /schedulers` answers from `ISchedulerRegistry`.** `SchedulerHeaderDto` gains `Origin` and makes
`Status` and `SchedulerInstanceId` nullable — they are null together, for a registration nothing has
built. The repository is still read, for the instance id of the schedulers that do exist. `SchedulerOrigin`
goes out as its name, like every other enum on this wire. Nothing else moved: a scheduler's own routes
still resolve through the repository, so they answer `404` for a name nothing has built, and the tenancy
test now pins both halves of that difference.

**`SchedulerDetailDto` carries the metadata**: `Clustered`, `Persistent`, `JobStoreTypeName`,
`ThreadPoolTypeName`, `ThreadPoolSize`, `RunningSince`, `JobsExecuted`, `Version`, filled by
`InProcessQuartzApiClient` from `scheduler.GetMetadata()`.

**The Cluster page reads `Clustered`** rather than inferring it from the node list. One node, current,
with no check-in history is what a store that keeps no cluster state looks like — and also what a
clustered store looks like for the first check-in interval after a node starts, so the page told an
operator their new cluster was not one (the scope note on #3420, from #3460). The metadata is never
ambiguous. Costs one `GetScheduler` per five-second refresh, which in process is a field read.

**A Schedulers page at `/quartz/schedulers`**: one row per registration with its name, origin and status,
and for a scheduler that exists its instance id, job store (with persistent/clustered tags), pool size,
start time in the selected zone, jobs executed, version, and node count. `GetClusterNodes` is called only
for a persistent, clustered store — a RAM store's answer is always "one node", and it would be a round
trip per scheduler to be told so. A row is the link that makes that scheduler the active one and opens
its Dashboard page. One scheduler that cannot answer is reported in its own row rather than blanking the
fleet. Nav entry beside Cluster.

**The picker greys out registrations that are not built** rather than omitting them, and shows their
not-created state rather than asking for a scheduler the listing already said does not exist.

## For a reviewer to decide

- **A registration that is not built is not a link on the Schedulers page.** Every page behind the link
  would report a scheduler it could not find. The spec said "a row is a link"; this is the one row where
  it is not.
- **The overview page gained a not-created state** (the last commit), which the spec scoped to the picker
  alone. Without it this change *regresses* the single-scheduler shutdown: the registration now survives
  the shutdown in the listing, so the page would stay on it and show an error alert where it used to show
  the empty state. The choice of default scheduler moved to `SchedulerState` so the picker and the
  overview's post-action refresh cannot drift.
- **The other pages (Jobs, Triggers, Cluster, …) still show an error alert** when the active scheduler is
  a registration nothing has built. Left alone deliberately: it is the same shape they show for any
  scheduler they cannot resolve, and the overview is the page the fleet view and the picker land on.
- **The Schedulers page makes one `GetScheduler` per built scheduler and one `GetClusterNodes` per
  clustered one.** Sequential, as the spec asked. In process that is cheap; over a remote client it is a
  request per scheduler.

## Baselines

`PublicApiTest_Quartz.Dashboard`, accepted through Verify:

```diff
 public sealed class SchedulerDetailDto
-    public SchedulerDetailDto(string SchedulerInstanceId, string SchedulerName, SchedulerStatus Status)
+    public SchedulerDetailDto(string SchedulerInstanceId, string SchedulerName, SchedulerStatus Status, bool Clustered, bool Persistent, string JobStoreTypeName, string ThreadPoolTypeName, int ThreadPoolSize, DateTimeOffset? RunningSince, int JobsExecuted, string Version)
+    public bool Clustered { get; init; }
+    public string JobStoreTypeName { get; init; }
+    public int JobsExecuted { get; init; }
+    public bool Persistent { get; init; }
+    public DateTimeOffset? RunningSince { get; init; }
+    public int ThreadPoolSize { get; init; }
+    public string ThreadPoolTypeName { get; init; }
+    public string Version { get; init; }

 public sealed class SchedulerHeaderDto
-    public SchedulerHeaderDto(string SchedulerName, string SchedulerInstanceId, SchedulerStatus Status)
-    public string SchedulerInstanceId { get; init; }
-    public SchedulerStatus Status { get; init; }
+    public SchedulerHeaderDto(string SchedulerName, string? SchedulerInstanceId, SchedulerStatus? Status, SchedulerOrigin Origin)
+    public bool IsCreated { get; }
+    public SchedulerOrigin Origin { get; init; }
+    public string? SchedulerInstanceId { get; init; }
+    public SchedulerStatus? Status { get; init; }
```

`PublicApiTest_Quartz.AspNetCore` and `PublicApiTest_Quartz.HttpClient` are unchanged — the wire
`SchedulerHeaderDto` is internal, and nothing in `Quartz.HttpClient` reads the header list.

New wire snapshot `WireFormatSnapshotTest_SchedulerListingBody`, whose two shapes are the point of it:

```json
[
  { "name": "QuartzScheduler", "schedulerInstanceId": null, "status": null, "origin": "Container" },
  { "name": "TestScheduler", "schedulerInstanceId": "TEST_NON_CLUSTERED", "status": "Running", "origin": "Runtime" }
]
```

## Verification

```
dotnet build Quartz.slnx                          Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit                 Passed! Failed: 0, Passed: 3357, Skipped: 4, Total: 3361
dotnet test src/Quartz.Tests.AspNetCore           Passed! Failed: 0, Passed: 462, Skipped: 0, Total: 462
integration, basic leg (Docker)                   Passed! Failed: 0, Passed: 318, Skipped: 0, Total: 318
integration, postgres leg (Docker)                Passed! Failed: 0, Passed: 146, Skipped: 0, Total: 146
dotnet fallout VerifyDocsSnippets                 Succeeded
npm run docs:check-links                          212 pages, 778 internal links, 446 fragments, no dead links or anchors
```

The first commit was verified on its own — `dotnet build Quartz.slnx` clean and 448 AspNetCore tests
passing at `c9a616140` — so the wire change stands without the dashboard one.

## Documentation

- `packages/http-api.md` — a section for the listing's shape, with the `null`/`null` registration entry
  and a *Changed in 4.0.0-alpha.3* note for a reader that assumed both were present.
- `packages/dashboard.md` — a **Schedulers** section, the Features entry, and the multi-scheduler bullet
  that used to say the dashboard lists what has been built.
- `multi-tenancy.md` — the "the dashboard and the HTTP API list the repository, not the registry" box is
  the statement this change falsifies; it now says the listing is the registry's and only a scheduler's
  own routes go through the repository.
- `migration-guide.md` — the wire change as a before/after table, and the two dashboard DTOs.

Closes #3420
