### PR TITLE
Both stores mean the same thing by a misfire

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2940,6 +2940,17 @@ of these is a 3.x behaviour, not a 4.x regression:
   the practical effect is that a trigger due at exactly that instant misfires rather than being fired
   late without its policy. 3.x behaves the old way.
 
+* **An unblocked trigger's misfire policy is applied as it is unblocked, in memory too.** When a
+  `[DisallowConcurrentExecution]` job finishes, the triggers of that job that sat `Blocked` behind it
+  go back to `Waiting` — and a trigger that passed its fire time while it waited has its misfire
+  policy applied there and then, so its state and `NextFireTimeUtc` are settled by the time
+  `TriggeredJobComplete` returns. The ADO store has always done this; `RAMJobStore` returned the
+  trigger to the acquisition set and left the policy to the next acquisition, so a `GetTrigger`
+  in between reported the fire time the trigger had already missed, and a trigger past its end time
+  read as waiting on one store and finished on the other. As on the ADO store, an unblocked trigger
+  whose policy leaves it with nothing to fire is removed rather than kept in `Complete`, so
+  `GetTrigger` answers `null` for it. 3.x behaves the old way.
+
 ## JobKey and TriggerKey Null Validation
 
 `JobKey` and `TriggerKey` now throw `ArgumentNullException` when you specify `null` for `name` or `group`. Triggers can no longer be constructed with a null group name. If your code was relying on null group names, switch to an explicit group name.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2929,6 +2929,17 @@ of these is a 3.x behaviour, not a 4.x regression:
   store and not the other. `ObjectAlreadyExistsException` derives from `JobPersistenceException`, so
   code catching the base type is unaffected.
 
+* **The threshold instant itself is a misfire on the ADO store too.** A trigger is late once its fire
+  time is *at or before* `now - MisfireThreshold`, and that is now one comparison wherever the
+  question is asked. The ADO store's periodic sweep asked for `NEXT_FIRE_TIME < @nextFireTime` while
+  everything else — `RAMJobStore`, and the ADO store's own single-trigger path that a resumed or
+  unblocked trigger goes through — used `<=`, so the ADO store disagreed with the in-memory one and
+  with itself about one tick. The acquisition statement moved with it, from
+  `NEXT_FIRE_TIME >= @noEarlierThan` to `>`, so that a waiting trigger belongs to acquisition or to
+  the misfire handler and never to both. It is a change to the SQL only — no schema migration — and
+  the practical effect is that a trigger due at exactly that instant misfires rather than being fired
+  late without its policy. 3.x behaves the old way.
+
 ## JobKey and TriggerKey Null Validation
 
 `JobKey` and `TriggerKey` now throw `ArgumentNullException` when you specify `null` for `name` or `group`. Triggers can no longer be constructed with a null group name. If your code was relying on null group names, switch to an explicit group name.

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -86,10 +86,17 @@ A **misfire** occurs when a trigger's scheduled fire time passes without the job
 
 ### How It Works
 
-1. On startup (and periodically during operation), Quartz scans for triggers whose `NEXT_FIRE_TIME` is older than `now - misfireThreshold`.
+1. On startup (and periodically during operation), Quartz scans for triggers whose `NEXT_FIRE_TIME` is at or older than `now - misfireThreshold`.
 2. For each misfired trigger, Quartz applies the trigger's configured misfire instruction.
 3. The default misfire threshold is 60 seconds for a persistent store — `JobStore:MisfireThreshold` in 4.x,
    `quartz.jobStore.misfireThreshold` as a flat key on both versions.
+
+A trigger is misfired when its fire time is at or before `now - misfireThreshold` — the threshold
+instant itself counts as late. In 4.x that is one rule wherever the question is asked: the in-memory
+store, the persistent store's periodic sweep, and the single-trigger path a resumed or unblocked
+trigger goes through all draw the line in the same place. On 3.x the persistent store's sweep is
+strictly *before* the threshold instant, so a trigger due at exactly `now - misfireThreshold` is
+misfired in memory and, for one tick, not in the database.
 
 ### Misfire Instructions by Trigger Type
 

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -1876,6 +1876,130 @@ public abstract class JobStoreContractTest
     protected abstract string StoreInstanceId { get; }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
+    // Unblocking the triggers of a job that forbids concurrent execution
+    //
+    // A trigger blocked behind a running execution is out of the acquisition set and out of the
+    // misfire sweep's, so however late it gets while it waits, the completion that unblocks it is the
+    // first thing that can settle the debt - and it is where both stores settle it. A store that
+    // instead left the policy to the next acquisition would hand a caller a past-due fire time in the
+    // window between, which is the divergence #3463 reported.
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task UnblockingAnOverdueTriggerAppliesItsMisfirePolicy()
+    {
+        // FireOnceNow: the missed firing is owed and is fired as soon as the scheduler gets to it, so
+        // the unblocked trigger comes back due now rather than due in the past.
+        BlockedTrigger blocked = await GivenAnOverdueTriggerBlockedBehindAFiring(
+            CronTriggerMisfireInstruction.FireAndProceed, endAt: null);
+
+        DateTimeOffset completionStarted = DateTimeOffset.UtcNow;
+        await Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
+        DateTimeOffset completionFinished = DateTimeOffset.UtcNow;
+
+        (await Store.GetTriggerState(blocked.Key)).Should().Be(TriggerState.Normal,
+            "the trigger has a firing left to do, so completing the execution that blocked it leaves it waiting");
+
+        IOperableTrigger readBack = await Store.GetTrigger(blocked.Key);
+
+        readBack.NextFireTimeUtc.Should().NotBeNull("a trigger that owes a firing has a fire time");
+        readBack.NextFireTimeUtc.Value.Should().BeOnOrAfter(completionStarted).And.BeOnOrBefore(completionFinished,
+            "FireOnceNow reschedules to the moment its policy is applied, and the policy is applied while "
+            + "TriggeredJobComplete is unblocking the trigger - a store that left it to the next acquisition "
+            + "would still be reporting the fire time the trigger missed");
+    }
+
+    [Test]
+    public async Task UnblockingATriggerWithNothingLeftToFireRemovesIt()
+    {
+        // DoNothing past the trigger's end time: the policy writes the missed firing off and looks for
+        // the next scheduled one, and the schedule has ended.
+        BlockedTrigger blocked = await GivenAnOverdueTriggerBlockedBehindAFiring(
+            CronTriggerMisfireInstruction.DoNothing, endAt: DateTimeOffset.UtcNow.AddMinutes(-30));
+
+        await Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
+
+        (await Store.GetTrigger(blocked.Key)).Should().BeNull(
+            "a trigger whose policy left it with nothing to fire is finished, and a store that kept it "
+            + "would go on handing callers a trigger that can never fire again");
+        (await Store.GetTriggerState(blocked.Key)).Should().Be(TriggerState.None,
+            "a trigger that is gone has no state");
+        (await Store.GetJob(blocked.Job.Key)).Should().NotBeNull(
+            "the job still has the trigger that was running, so removing the finished one must not take it");
+    }
+
+    /// <summary>
+    /// Fires one trigger of a job that forbids concurrent execution and leaves a second trigger of the
+    /// same job blocked behind it, long past its own fire time.
+    /// </summary>
+    /// <remarks>
+    /// The blocked trigger is stored after the first one has been acquired, so that it is the fan-out in
+    /// <see cref="IJobStore.TriggersFired" /> that blocks it rather than the store finding the job
+    /// already blocked as the trigger was added. Its fire time is written back by hand, because
+    /// <see cref="IOperableTrigger.ComputeFirstFireTimeUtc" /> advances a past-due schedule to its next
+    /// future slot: a trigger nobody got around to firing is what an hour in the past looks like.
+    /// </remarks>
+    private async Task<BlockedTrigger> GivenAnOverdueTriggerBlockedBehindAFiring(
+        CronTriggerMisfireInstruction instruction,
+        DateTimeOffset? endAt)
+    {
+        IJobDetail job = JobBuilder.Create<NonConcurrentContractTestJob>()
+            .WithIdentity("blocking", JobGroupA)
+            .Build();
+
+        IOperableTrigger running = CreateTrigger("running", TriggerGroupA, job.Key,
+            startAt: DateTimeOffset.UtcNow.AddSeconds(5));
+        await Store.ScheduleJob(job, running);
+
+        List<IOperableTrigger> acquired = await Store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddMinutes(1),
+            MaxCount = 1
+        });
+
+        IOperableTrigger firing = acquired.Should().ContainSingle(x => x.Key.Equals(running.Key),
+            "the trigger that does the blocking has to be handed over before it can fire").Subject;
+
+        TriggerKey blockedKey = new TriggerKey("blocked", TriggerGroupA);
+        DateTimeOffset overdue = DateTimeOffset.UtcNow.AddHours(-1);
+
+        TriggerBuilder<IJob> builder = TriggerBuilder.Create()
+            .WithIdentity(blockedKey)
+            .ForJob(job.Key)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(-2))
+            // Every second, so that "the next slot after now" exists whatever second the test runs in,
+            // and the end time is the only thing that can take it away.
+            .WithCronSchedule("* * * * * ?", x => x
+                .InTimeZone(TimeZoneInfo.Utc)
+                .WithMisfireInstruction(instruction));
+
+        if (endAt is not null)
+        {
+            builder = builder.EndAt(endAt);
+        }
+
+        IOperableTrigger blocked = (IOperableTrigger) builder.Build();
+        blocked.ComputeFirstFireTimeUtc(null);
+        blocked.NextFireTimeUtc = overdue;
+
+        await Store.AddTrigger(blocked, replace: false);
+
+        List<TriggerFiredResult> fired = await Store.TriggersFired([firing]);
+        fired.Should().ContainSingle().Which.TriggerFiredBundle.Should().NotBeNull(
+            "the blocking execution has to actually start, or nothing is blocked");
+
+        (await Store.GetTriggerState(blockedKey)).Should().Be(TriggerState.Blocked,
+            "firing one trigger of a job that forbids concurrent execution blocks the rest of them");
+        (await Store.GetTrigger(blockedKey)).NextFireTimeUtc.Should().Be(overdue,
+            "the missed firing is still owed while the trigger is blocked: nothing sweeps a blocked trigger");
+
+        return new BlockedTrigger(blockedKey, job, firing);
+    }
+
+    /// <summary>The blocked trigger, the job blocking it, and the firing that has to complete to let it go.</summary>
+    private sealed record BlockedTrigger(TriggerKey Key, IJobDetail Job, IOperableTrigger Firing);
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
     // Helpers
     //////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -2004,6 +2128,16 @@ public abstract class JobStoreContractTest
     /// A second job type, so that a test can tell two jobs apart by their type rather than their key.
     /// </summary>
     public sealed class OtherContractTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// A job that forbids concurrent execution, which is what makes a store block the rest of its
+    /// triggers while one of them is firing.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class NonConcurrentContractTestJob : IJob
     {
         public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
     }

--- a/src/Quartz.Tests.Integration/Impl/MisfireMatrixTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireMatrixTest.cs
@@ -206,11 +206,16 @@ public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
 
     /// <summary>
     /// Where a store draws the line, to the tick. The threshold instant itself is the interesting one:
-    /// the in-memory store's <c>ApplyMisfireNoLock</c> declines only a trigger whose fire time is
-    /// strictly <em>after</em> <c>now - MisfireThreshold</c>, so the instant itself is a misfire, while
-    /// the ADO store's recovery SELECT asks for <c>NEXT_FIRE_TIME &lt; @nextFireTime</c>, so the instant
-    /// itself is not.
+    /// both stores' comparison is <c>&lt;=</c> — the in-memory store's <c>ApplyMisfireNoLock</c> declines
+    /// only a trigger whose fire time is strictly <em>after</em> <c>now - MisfireThreshold</c>, and the
+    /// ADO store's recovery SELECT asks for <c>NEXT_FIRE_TIME &lt;= @nextFireTime</c> — so the instant
+    /// itself is a misfire on both.
     /// </summary>
+    /// <remarks>
+    /// The two flags are kept apart rather than collapsed into one so that
+    /// <see cref="BothStoresAgreeOnTheThresholdInstant" /> has two things to compare: a change that moved
+    /// one store's comparison and not the other's would have to say so here first.
+    /// </remarks>
     public sealed record ThresholdEdgeCase(string Position, long TickOffset, bool InMemoryMisfires, bool AdoMisfires)
     {
         public override string ToString() => Position;
@@ -219,7 +224,7 @@ public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
     public static IEnumerable<ThresholdEdgeCase> ThresholdEdgeCases()
     {
         yield return new ThresholdEdgeCase("one tick before the threshold", -1, InMemoryMisfires: true, AdoMisfires: true);
-        yield return new ThresholdEdgeCase("exactly on the threshold", 0, InMemoryMisfires: true, AdoMisfires: false);
+        yield return new ThresholdEdgeCase("exactly on the threshold", 0, InMemoryMisfires: true, AdoMisfires: true);
         yield return new ThresholdEdgeCase("one tick after the threshold", 1, InMemoryMisfires: false, AdoMisfires: false);
     }
 
@@ -232,45 +237,33 @@ public sealed class MisfireMatrixTest : MisfireThroughAStoreTestBase
     }
 
     [TestCaseSource(nameof(ThresholdEdgeCases))]
-    public async Task TheAdoStoreLeavesTheThresholdInstantItselfAlone(ThresholdEdgeCase testCase)
+    public async Task TheAdoStoreCountsTheThresholdInstantItselfAsLate(ThresholdEdgeCase testCase)
     {
         await AssertThresholdEdge(await SqliteStore(Anchor()), testCase, testCase.AdoMisfires,
-            "the recovery SELECT asks for NEXT_FIRE_TIME < now - MisfireThreshold, so the threshold "
-            + "instant itself is strictly excluded");
+            "the recovery SELECT asks for NEXT_FIRE_TIME <= now - MisfireThreshold, so the threshold "
+            + "instant itself is included");
     }
 
     /// <summary>
-    /// The two stores disagree about the threshold instant itself, which is a finding rather than
-    /// something for this test to paper over: the in-memory store's comparison is <c>&lt;=</c> and the
-    /// ADO store's recovery SELECT is <c>&lt;</c>, so a trigger due at exactly
-    /// <c>now - MisfireThreshold</c> misfires on one store and not on the other.
+    /// A trigger due at exactly <c>now - MisfireThreshold</c> means the same thing to both stores: it is
+    /// late. One comparison, <c>&lt;=</c>, wherever the question is asked — the in-memory store's
+    /// <c>ApplyMisfireNoLock</c>, the ADO store's recovery SELECT and its count, and its single-trigger
+    /// <c>UpdateMisfiredTrigger</c> path that a resumed trigger goes through.
     /// </summary>
     /// <remarks>
-    /// Reported rather than asserted, per the rule that a matrix says what 4.0 does and does not change
-    /// it. Note that the ADO store is not even internally consistent about it: its single-trigger path,
-    /// <c>UpdateMisfiredTrigger</c> — which is what a resumed trigger goes through — uses the in-memory
-    /// store's <c>&lt;=</c>.
+    /// The two stores used to disagree here — the ADO sweep's SELECT was <c>&lt;</c> while everything
+    /// else was <c>&lt;=</c>, so the ADO store did not even agree with itself. #3462 closed that.
     /// </remarks>
     [Test]
     public void BothStoresAgreeOnTheThresholdInstant()
     {
         ThresholdEdgeCase edge = ThresholdEdgeCases().Single(x => x.TickOffset == 0);
 
-        if (edge.InMemoryMisfires != edge.AdoMisfires)
-        {
-            Assert.Inconclusive(
-                "A trigger due at exactly now - MisfireThreshold is treated differently by the two stores. "
-                + $"Observed: RAMJobStore misfires it ({edge.InMemoryMisfires}), the ADO store does not "
-                + $"({edge.AdoMisfires}). Expected: the same answer from both. RAMJobStore's "
-                + "ApplyMisfireNoLock declines only when NextFireTimeUtc > now - MisfireThreshold, so its "
-                + "comparison is <=; StdAdoConstants.SqlSelectMisfiredTriggersToRecover asks for "
-                + "NEXT_FIRE_TIME < @nextFireTime, so the ADO sweep's is <. AdoJobStoreBase.UpdateMisfiredTrigger, "
-                + "the ADO store's own single-trigger path, uses <= like the in-memory store, so the ADO "
-                + "store also disagrees with itself.");
-        }
-
         edge.AdoMisfires.Should().Be(edge.InMemoryMisfires,
             "a trigger due at exactly now - MisfireThreshold has to mean the same thing to both stores");
+        edge.InMemoryMisfires.Should().BeTrue(
+            "the one rule is that a trigger is misfired when its fire time is at or before now - MisfireThreshold, "
+            + "so the threshold instant itself is late rather than the last instant that is not");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Integration/Impl/MisfireWhilePausedOrBlockedTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireWhilePausedOrBlockedTest.cs
@@ -113,96 +113,76 @@ public sealed class MisfireWhilePausedOrBlockedTest : MisfireThroughAStoreTestBa
         MisfireMatrixCases.Cell(MisfireTriggerShape.Cron, nameof(CronTriggerMisfireInstruction.DoNothing));
 
     /// <summary>
-    /// The in-memory store's half of the blocked case. A trigger blocked behind a running execution of a
-    /// <see cref="DisallowConcurrentExecutionAttribute" /> job is out of the acquisition set entirely, so
-    /// no pass can reach it however late it gets. Completing the execution puts it back with the missed
-    /// fire time still on it, and the next acquisition is what applies its policy.
+    /// A trigger blocked behind a running execution of a <see cref="DisallowConcurrentExecutionAttribute" />
+    /// job is out of the acquisition set entirely, so no misfire pass can reach it however late it gets.
+    /// Completing the execution is what lets it go, and both stores apply its policy at that moment: by
+    /// the time <c>TriggeredJobComplete</c> returns, the trigger's state and next fire time are the ones
+    /// its own <c>UpdateAfterMisfire</c> asked for.
     /// </summary>
     /// <remarks>
-    /// <c>RAMJobStore.TriggeredJobComplete</c> moves a blocked trigger to <c>Waiting</c> and adds it back
-    /// to <c>timeTriggers</c>, and does nothing else — <c>ApplyMisfireNoLock</c> is reached from
-    /// acquisition and from resume, and the unblocking path is neither. So the debt is settled by the
-    /// very next acquisition, which is also the first thing that could have fired the trigger.
+    /// The ADO store has always done this — <c>TriggeredJobComplete</c> unblocks the job's triggers and
+    /// then calls <c>RecoverUnblockedMisfires</c> in the same transaction. The in-memory store used to
+    /// return the trigger to <c>timeTriggers</c> and nothing more, leaving the policy to the next
+    /// acquisition, so a caller reading the trigger in between saw a past-due fire time on one store and
+    /// a recomputed one on the other. #3463 closed that.
     /// </remarks>
     [Test]
-    public async Task TheInMemoryStoreLeavesAnUnblockedTriggersMisfireToTheNextAcquisition()
+    public async Task BothStoresApplyAnUnblockedTriggersMisfireAsTheyUnblockIt()
     {
         DateTimeOffset anchor = Anchor();
         DateTimeOffset scheduled = anchor - HalfPeriod;
 
-        MisfireStoreUnderTest store = await InMemoryStore(anchor);
-        BlockedTrigger blocked = await GivenATriggerBlockedPastItsThreshold(store, anchor);
+        foreach (MisfireStoreUnderTest store in await BothStores(anchor))
+        {
+            BlockedTrigger blocked = await GivenATriggerBlockedPastItsThreshold(store, anchor);
 
-        await store.Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
+            IOperableTrigger detached = Detached(anchor, store.Clock, blocked.Key, blocked.Job.Key, scheduled);
 
-        (await store.Store.GetTriggerState(blocked.Key)).Should().Be(TriggerState.Normal,
-            "completing the execution is what lets the blocked siblings go");
-        (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc.Should().Be(scheduled,
-            "RAMJobStore's unblocking returns the trigger to the acquisition set and nothing more, so the "
-            + "missed firing is still on the books at this point");
+            MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null, store.Clock);
 
-        IOperableTrigger detached = Detached(anchor, store.Clock, blocked.Key, blocked.Job.Key, scheduled);
+            await store.Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
 
-        MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null, store.Clock);
+            IOperableTrigger readBack = await store.Store.GetTrigger(blocked.Key);
 
-        await store.Sweep(scheduled - TimeSpan.FromTicks(1));
+            readBack.Should().NotBeNull(
+                "{0} must still hold the unblocked trigger: its policy left it a fire time to keep", store.Name);
 
-        expected.AssertAgainst(
-            store.Name,
-            BlockedCase + " unblocked",
-            await store.Store.GetTriggerState(blocked.Key),
-            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc);
+            expected.AssertAgainst(
+                store.Name,
+                BlockedCase + " unblocked",
+                await store.Store.GetTriggerState(blocked.Key),
+                readBack.NextFireTimeUtc);
+        }
     }
 
     /// <summary>
-    /// The ADO store's half, which settles the debt a step earlier: <c>TriggeredJobComplete</c> unblocks
-    /// the job's triggers and then calls <c>RecoverUnblockedMisfires</c>, so the policy has already run
-    /// by the time the caller can look.
+    /// The debt is settled once. A misfire pass run straight after the unblocking finds a trigger that is
+    /// no longer late and leaves it exactly where the unblocking put it — on both stores, since the
+    /// in-memory store's pass is an acquisition and would otherwise apply the policy a second time.
     /// </summary>
     [Test]
-    public async Task TheAdoStoreAppliesAnUnblockedTriggersMisfireAsItUnblocksIt()
+    public async Task AnUnblockedTriggersMisfireIsNotAppliedTwice()
     {
         DateTimeOffset anchor = Anchor();
         DateTimeOffset scheduled = anchor - HalfPeriod;
 
-        MisfireStoreUnderTest store = await SqliteStore(anchor);
-        BlockedTrigger blocked = await GivenATriggerBlockedPastItsThreshold(store, anchor);
+        foreach (MisfireStoreUnderTest store in await BothStores(anchor))
+        {
+            BlockedTrigger blocked = await GivenATriggerBlockedPastItsThreshold(store, anchor);
 
-        IOperableTrigger detached = Detached(anchor, store.Clock, blocked.Key, blocked.Job.Key, scheduled);
+            await store.Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
 
-        MisfireExpectation expected = MisfireExpectation.From(detached, calendar: null, store.Clock);
+            DateTimeOffset? settled = (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc;
+            TriggerState settledState = await store.Store.GetTriggerState(blocked.Key);
 
-        await store.Store.TriggeredJobComplete(blocked.Firing, blocked.Job, SchedulerInstruction.NoInstruction);
+            await store.Sweep(scheduled - TimeSpan.FromTicks(1));
 
-        expected.AssertAgainst(
-            store.Name,
-            BlockedCase + " unblocked",
-            await store.Store.GetTriggerState(blocked.Key),
-            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc);
-    }
-
-    /// <summary>
-    /// The two stores settle an unblocked trigger's misfire at different moments, which is a finding
-    /// rather than something for these tests to smooth over.
-    /// </summary>
-    /// <remarks>
-    /// Reported rather than asserted, per the rule that a matrix says what 4.0 does and does not change
-    /// it. The window between the two is real but narrow — the in-memory store's next acquisition — and
-    /// a caller that reads the trigger inside it sees a fire time in the past on one store and a
-    /// recomputed one on the other.
-    /// </remarks>
-    [Test]
-    public void BothStoresAgreeOnWhenAnUnblockedTriggerMisfires()
-    {
-        Assert.Inconclusive(
-            "The two stores apply an unblocked trigger's misfire policy at different moments. "
-            + "Observed: AdoJobStoreBase.TriggeredJobComplete unblocks the job's triggers and then calls "
-            + "RecoverUnblockedMisfires, so the policy has run by the time TriggeredJobComplete returns; "
-            + "RAMJobStore.TriggeredJobComplete only moves the trigger from Blocked to Waiting and adds it "
-            + "back to timeTriggers, leaving the policy to the next AcquireNextTriggers. Expected: the same "
-            + "moment on both, since a caller reading the trigger between the two gets a different answer "
-            + "depending on which store it is talking to. The two tests above pin each store's actual "
-            + "behaviour, so this reports the gap rather than asserting it away.");
+            (await store.Store.GetTrigger(blocked.Key)).NextFireTimeUtc.Should().Be(settled,
+                "{0} settled the unblocked trigger's misfire as it unblocked it, so the pass after it has "
+                + "nothing left to recompute", store.Name);
+            (await store.Store.GetTriggerState(blocked.Key)).Should().Be(settledState,
+                "{0} must leave the state the unblocking arrived at alone", store.Name);
+        }
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
@@ -14,7 +14,7 @@ public class StdAdoConstantsTest
 
         var sql = StdAdoConstants.SqlCountMisfiredTriggersInStates;
 
-        sql.Should().Be("SELECT COUNT(TRIGGER_NAME) FROM {0}TRIGGERS WHERE SCHED_NAME = @schedulerName AND MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME < @nextFireTime AND TRIGGER_STATE = @state");
+        sql.Should().Be("SELECT COUNT(TRIGGER_NAME) FROM {0}TRIGGERS WHERE SCHED_NAME = @schedulerName AND MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME <= @nextFireTime AND TRIGGER_STATE = @state");
     }
 
     /// <summary>
@@ -54,9 +54,31 @@ public class StdAdoConstantsTest
         var sql = StdAdoConstants.SqlSelectMisfiredTriggersToRecover;
 
         sql.Should().Contain("t.MISFIRE_INSTR <> -1");
-        sql.Should().Contain("t.NEXT_FIRE_TIME < @nextFireTime");
+        sql.Should().Contain("t.NEXT_FIRE_TIME <= @nextFireTime");
         sql.Should().Contain("t.TRIGGER_STATE = @state");
         sql.Should().Contain("ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC");
+    }
+
+    /// <summary>
+    /// A waiting trigger belongs to acquisition or to the misfire handler, never to both and never to
+    /// neither: the acquisition statement's <c>@noEarlierThan</c> predicate has to be the exact
+    /// complement of the misfire statements' <c>@nextFireTime</c> one, since both parameters are bound
+    /// to the same <c>now - MisfireThreshold</c>.
+    /// </summary>
+    /// <remarks>
+    /// The comparison is <c>&lt;=</c> because that is what the whole scheduler means by a misfire —
+    /// <c>RAMJobStore.ApplyMisfireNoLock</c> and <c>AdoJobStoreBase.UpdateMisfiredTrigger</c> decline
+    /// only a trigger whose fire time is strictly later — so the threshold instant itself is late.
+    /// </remarks>
+    [Test]
+    public void TheAcquisitionPredicateShouldBeTheComplementOfTheMisfirePredicate()
+    {
+        StdAdoConstants.SqlCountMisfiredTriggersInStates.Should().Contain("NEXT_FIRE_TIME <= @nextFireTime",
+            "a trigger due at or before now - MisfireThreshold is misfired");
+        StdAdoConstants.SqlSelectMisfiredTriggersToRecover.Should().Contain("t.NEXT_FIRE_TIME <= @nextFireTime",
+            "the sweep and the count it is peeked at with have to select the same rows");
+        StdAdoConstants.SqlSelectNextTriggerToAcquire.Should().Contain("NEXT_FIRE_TIME > @noEarlierThan",
+            "acquisition takes what is not misfired, so a trigger exactly on the threshold instant is left to the misfire handler rather than fired late without its policy");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_FourExclusions.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_FourExclusions.verified.txt
@@ -5,7 +5,7 @@
               JOIN
                 {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
               WHERE
-                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME > @noEarlierThan))
                 AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
                      OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
                 AND jd.JOB_CLASS_NAME NOT IN (@excludedJobType0000, @excludedJobType0001, @excludedJobType0002, @excludedJobType0003)

--- a/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_NoExclusions.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_NoExclusions.verified.txt
@@ -6,7 +6,7 @@ SELECT
               JOIN
                 {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
               WHERE
-                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME > @noEarlierThan))
                 AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
                      OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
               ORDER BY
@@ -20,7 +20,7 @@ SELECT TOP 5
               JOIN
                 {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
               WHERE
-                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME > @noEarlierThan))
                 AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
                      OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
               ORDER BY
@@ -34,7 +34,7 @@ SELECT
               JOIN
                 {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
               WHERE
-                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME > @noEarlierThan))
                 AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
                      OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
               ORDER BY
@@ -48,7 +48,7 @@ SELECT
               JOIN
                 {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
               WHERE
-                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME > @noEarlierThan))
                 AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
                      OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
               ORDER BY
@@ -62,7 +62,7 @@ SELECT
               JOIN
                 {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
               WHERE
-                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME > @noEarlierThan))
                 AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
                      OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
               ORDER BY
@@ -76,7 +76,7 @@ SELECT * FROM (SELECT
               JOIN
                 {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
               WHERE
-                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME > @noEarlierThan))
                 AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
                      OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
               ORDER BY
@@ -90,7 +90,7 @@ SELECT
               JOIN
                 {0}JOB_DETAILS jd ON (jd.SCHED_NAME = t.SCHED_NAME AND  jd.JOB_GROUP = t.JOB_GROUP AND jd.JOB_NAME = t.JOB_NAME)
               WHERE
-                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME >= @noEarlierThan))
+                t.SCHED_NAME = @schedulerName AND TRIGGER_STATE = @state AND NEXT_FIRE_TIME <= @noLaterThan AND (MISFIRE_INSTR = -1 OR (MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME > @noEarlierThan))
                 AND (t.PREFERRED_NODE IS NULL OR t.PREFERRED_NODE = @instanceId OR t.PREFERRED_NODE = @autoPinSentinel
                      OR t.PREFERRED_NODE NOT IN (SELECT ss.INSTANCE_NAME FROM {0}SCHEDULER_STATE ss WHERE ss.SCHED_NAME = t.SCHED_NAME AND ss.LAST_CHECKIN_TIME + ss.CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff))
               ORDER BY

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -989,7 +989,7 @@ public interface IDriverDelegate
     /// </summary>
     /// <param name="conn">The DB connection.</param>
     /// <param name="state">The trigger state to scan.</param>
-    /// <param name="misfireTime">Triggers whose next fire time is before this are misfired.</param>
+    /// <param name="misfireTime">Triggers whose next fire time is at or before this are misfired.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns></returns>
     ValueTask<int> CountMisfiredTriggersInState(
@@ -1058,7 +1058,7 @@ public interface IDriverDelegate
     /// </summary>
     /// <param name="conn">The DB connection.</param>
     /// <param name="state">The trigger state to scan (<see cref="StoredTriggerState.Waiting" />).</param>
-    /// <param name="misfireTime">Triggers whose next fire time is before this are misfired.</param>
+    /// <param name="misfireTime">Triggers whose next fire time is at or before this are misfired.</param>
     /// <param name="count">Maximum number of triggers to return, or -1 for all of them.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     ValueTask<MisfiredTriggerBatch> SelectMisfiredTriggersToRecover(

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -244,8 +244,20 @@ internal static class StdAdoConstants
     public static readonly string SqlSelectJobsInGroup =
         Invariant($"SELECT {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
 
+    /// <summary>
+    /// The cheap count the misfire handler peeks with before it takes the trigger lock. It has to
+    /// select the same rows <see cref="SqlSelectMisfiredTriggersToRecover" /> does, or the sweep
+    /// decides there is nothing to recover and skips work it would have found.
+    /// </summary>
+    /// <remarks>
+    /// <c>NEXT_FIRE_TIME &lt;= @nextFireTime</c> is the one rule about a misfire, spelled here in SQL:
+    /// a trigger is late once its fire time is <em>at or before</em> <c>now - MisfireThreshold</c>.
+    /// <c>RAMJobStore.ApplyMisfireNoLock</c>, <c>AdoJobStoreBase.UpdateMisfiredTrigger</c> and
+    /// <c>AdoJobStoreBase.RecoverUnblockedMisfires</c> all decline a trigger whose fire time is
+    /// strictly greater, and <see cref="SqlSelectNextTriggerToAcquire" /> takes the complement of it.
+    /// </remarks>
     public static readonly string SqlCountMisfiredTriggersInStates =
-        Invariant($"SELECT COUNT({AdoConstants.ColumnTriggerName}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {AdoConstants.ColumnNextFireTime} < @nextFireTime AND {AdoConstants.ColumnTriggerState} = @state");
+        Invariant($"SELECT COUNT({AdoConstants.ColumnTriggerName}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {AdoConstants.ColumnNextFireTime} <= @nextFireTime AND {AdoConstants.ColumnTriggerState} = @state");
 
     /// <summary>
     /// Sentinel stored in PREFERRED_NODE to request auto-pin that has not yet been claimed by
@@ -285,6 +297,12 @@ internal static class StdAdoConstants
     //
     // PREFERRED_NODE is filtered entirely in PreferredNodeWhereClause and is not projected —
     // acquisition never reads it from the result (the trigger is reloaded via GetTrigger).
+    //
+    // NEXT_FIRE_TIME > @noEarlierThan is the exact complement of the misfire predicate in
+    // SqlCountMisfiredTriggersInStates, and has to stay that way: @noEarlierThan is the very
+    // now - MisfireThreshold the sweep asks about, so a waiting trigger belongs either to acquisition
+    // or to the misfire handler and never to both. Acquiring one the store already counts as misfired
+    // would fire it late without ever applying the policy it asked for.
     private static string SelectNextTriggerToAcquire(string exclusionClause) =>
         Invariant($@"SELECT
                 t.{AdoConstants.ColumnTriggerName}, t.{AdoConstants.ColumnTriggerGroup}, jd.{AdoConstants.ColumnJobClass}, t.{AdoConstants.ColumnExecutionGroup}
@@ -293,7 +311,7 @@ internal static class StdAdoConstants
               JOIN
                 {TablePrefixSubst}{AdoConstants.TableJobDetails} jd ON (jd.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND  jd.{AdoConstants.ColumnJobGroup} = t.{AdoConstants.ColumnJobGroup} AND jd.{AdoConstants.ColumnJobName} = t.{AdoConstants.ColumnJobName})
               WHERE
-                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerState} = @state AND {AdoConstants.ColumnNextFireTime} <= @noLaterThan AND ({AdoConstants.ColumnMisfireInstruction} = -1 OR ({AdoConstants.ColumnMisfireInstruction} <> -1 AND {AdoConstants.ColumnNextFireTime} >= @noEarlierThan))
+                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerState} = @state AND {AdoConstants.ColumnNextFireTime} <= @noLaterThan AND ({AdoConstants.ColumnMisfireInstruction} = -1 OR ({AdoConstants.ColumnMisfireInstruction} <> -1 AND {AdoConstants.ColumnNextFireTime} > @noEarlierThan))
                 {PreferredNodeWhereClause}{exclusionClause}
               ORDER BY
                 {AdoConstants.ColumnNextFireTime} ASC, {AdoConstants.ColumnPriority} DESC");
@@ -478,7 +496,7 @@ internal static class StdAdoConstants
                 t.{AdoConstants.ColumnTriggerName},
                 t.{AdoConstants.ColumnTriggerGroup}{TriggerSelectFastPathFrom}
             WHERE
-                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND t.{AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND t.{AdoConstants.ColumnNextFireTime} < @nextFireTime AND t.{AdoConstants.ColumnTriggerState} = @state
+                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND t.{AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND t.{AdoConstants.ColumnNextFireTime} <= @nextFireTime AND t.{AdoConstants.ColumnTriggerState} = @state
             ORDER BY t.{AdoConstants.ColumnNextFireTime} ASC, t.{AdoConstants.ColumnPriority} DESC");
 
     /// <summary>

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -2871,6 +2871,10 @@ public sealed class RAMJobStore : IJobStore
 
                     var triggerWrappersForJob = GetTriggerWrappersForJobNoLock(jd.Key);
 
+                    // Triggers this completion unblocked that have nothing left to fire. Removing one
+                    // mutates the very list being walked, so they are collected and removed afterwards.
+                    List<TriggerKey>? finalized = null;
+
                     for (var i = 0; i < triggerWrappersForJob.Count; i++)
                     {
                         var ttw = triggerWrappersForJob[i];
@@ -2878,12 +2882,40 @@ public sealed class RAMJobStore : IJobStore
                         if (ttw.state == StoredTriggerState.Blocked)
                         {
                             ttw.state = StoredTriggerState.Waiting;
-                            timeTriggers.Add(ttw);
-                        }
 
-                        if (ttw.state == StoredTriggerState.PausedBlocked)
+                            // A trigger that sat blocked while the job ran may well have passed a fire
+                            // time meanwhile, and nothing else would notice it: acquisition is the only
+                            // other place the policy runs, so the trigger would be handed to a caller
+                            // with a past-due fire time still on it until then. The ADO store applies
+                            // the policy as it unblocks (RecoverUnblockedMisfires, in the same
+                            // transaction), and this is the same moment.
+                            await ApplyMisfireNoLock(ttw).ConfigureAwait(false);
+
+                            if (ttw.state == StoredTriggerState.Waiting)
+                            {
+                                timeTriggers.Add(ttw);
+                            }
+                            else
+                            {
+                                // Nothing left to fire. The ADO store deletes such a trigger rather than
+                                // leaving a COMPLETE row that GetTrigger would keep handing back, so a
+                                // one-shot trigger that missed its firing while blocked goes away here too.
+                                (finalized ??= []).Add(ttw.TriggerKey);
+                            }
+                        }
+                        else if (ttw.state == StoredTriggerState.PausedBlocked)
                         {
+                            // A paused trigger accrues no misfire — pausing is a decision not to fire, and
+                            // resuming is what settles the debt — so this one is a state change and nothing more.
                             ttw.state = StoredTriggerState.Paused;
+                        }
+                    }
+
+                    if (finalized is not null)
+                    {
+                        foreach (TriggerKey finalizedKey in finalized)
+                        {
+                            await RemoveTriggerNoLock(finalizedKey, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
                         }
                     }
 


### PR DESCRIPTION
Two store-parity findings about misfires, both of which made the same trigger mean different things
to the two stores. Based on `dec1bca52` (#3468), whose fixtures carry the store's clock into every
trigger — the assertions below are exact instants because of it.

## The threshold instant is late on every store (#3462)

`RAMJobStore.ApplyMisfireNoLock` declines only a trigger whose fire time is strictly *after*
`now - MisfireThreshold`, so the threshold instant itself is a misfire. `AdoJobStoreBase.UpdateMisfiredTrigger`
(the single-trigger path a resumed trigger goes through) and `RecoverUnblockedMisfires` say the same.
The ADO store's periodic sweep asked for `NEXT_FIRE_TIME < @nextFireTime`, so it disagreed with the
in-memory store — and with itself — about one tick.

One rule now: **a trigger is misfired when its fire time is at or before `now - MisfireThreshold`.**

Every misfire-time comparison in the store, and what happened to it:

| Site | Before | After |
|---|---|---|
| `StdAdoConstants.SqlSelectMisfiredTriggersToRecover` | `t.NEXT_FIRE_TIME < @nextFireTime` | `<=` |
| `StdAdoConstants.SqlCountMisfiredTriggersInStates` (the handler's double-check peek) | `NEXT_FIRE_TIME < @nextFireTime` | `<=` |
| `StdAdoConstants.SelectNextTriggerToAcquire` — the template behind `SqlSelectNextTriggerToAcquire` and every exclusion bucket | `NEXT_FIRE_TIME >= @noEarlierThan` | `> @noEarlierThan` |
| `RAMJobStore.ApplyMisfireNoLock` | `tnft > misfireTime` declines | unchanged — it is the rule |
| `AdoJobStoreBase.UpdateMisfiredTrigger` | `NextFireTimeUtc > misfireTime` declines | unchanged |
| `AdoJobStoreBase.RecoverUnblockedMisfires` | `NextFireTimeUtc > misfireTime` skips | unchanged |
| `SqlServerDelegate`, `PostgreSQLDelegate`, `MySQLDelegate`, `SQLiteDelegate`, `OracleDelegate`, `FirebirdDelegate` | each wraps the constant with its own paging/index hint | unchanged — none carries a comparison of its own, so all six moved with the constant |
| `PreferredNodeWhereClause`'s `LAST_CHECKIN_TIME + CHECKIN_INTERVAL * 10000 >= @liveNodeCutoff`, `AdoJobStoreBase.CalcFailedIfAfter` | node-liveness, on `ClusterCheckinMisfireThreshold` | **left alone** — a different threshold about a different question |

**The acquisition statement is the one a reviewer should weigh.** `@noEarlierThan` is bound to the
very `MisfireTime` the sweep asks about, so the two predicates are meant to partition the waiting
triggers: acquisition takes what is not misfired. Leaving it at `>=` while the sweep became `<=`
would have made the threshold instant both acquirable and misfired, which is how a trigger gets
fired late without its policy ever running. `<=` and `>` are exact complements, and that is what
`RAMJobStore` does (acquisition applies `ApplyMisfireNoLock` first and skips what misfired). It moves
the two `AcquisitionSqlTest` Verify baselines — reviewed line by line, the only delta is `>=` → `>`.

No schema change: `<` to `<=` is a statement change, and no migration was generated.

Tests: `MisfireMatrixTest.ThresholdEdgeCases` says `AdoMisfires: true` at the instant,
`TheAdoStoreLeavesTheThresholdInstantItselfAlone` is renamed to
`TheAdoStoreCountsTheThresholdInstantItselfAsLate`, and `BothStoresAgreeOnTheThresholdInstant`
asserts instead of `Assert.Inconclusive`. `StdAdoConstantsTest` gains
`TheAcquisitionPredicateShouldBeTheComplementOfTheMisfirePredicate`, which is what fails if the two
statements ever drift apart again.

## The in-memory store applies the policy of a trigger it unblocks (#3463)

A trigger blocked behind a `[DisallowConcurrentExecution]` job is out of the acquisition set and out
of the sweep's, so the completion that unblocks it is the first thing that can settle its missed
firing. `AdoJobStoreBase.TriggeredJobComplete` settles it there, in `RecoverUnblockedMisfires` and in
the same transaction. `RAMJobStore.TriggeredJobComplete` returned the trigger to `timeTriggers` and
nothing more, so until the next acquisition a caller reading it got the fire time it had already
missed, and a trigger past its end time read as `Normal` on one store and `Complete` on the other.

`RAMJobStore.TriggeredJobComplete` now runs `ApplyMisfireNoLock` over each trigger it unblocks — the
way `ResumeTriggerNoLock` already does — and re-queues what still has a fire time. What has none is
**removed**, rather than left as a `Complete` entry `GetTrigger` would keep handing back: that is
what the ADO path does with such a row, and it is what `MisfiredBlockedTriggerTest` (a fire-and-forget
trigger that misfires while blocked) has always expected of the ADO store. `PausedBlocked → Paused`
stays a state change and nothing more, since a paused trigger accrues no misfire.

Note this differs from the wording of the issue's done-list: the unblocked trigger with nothing left
to fire is **gone**, not `Complete`, because that is the ADO store's answer and parity is the point.

Worth knowing, though not new: `ApplyMisfireNoLock` notifies the trigger listeners (`TriggerMisfired`)
and, for a finalized trigger, the scheduler listeners, while the store's semaphore is held — so a
listener that calls back into the store deadlocks. That is already true of the two paths that reach
it, acquisition and resume; this makes it three. The notification moves from one moment to another
rather than being added: what the next acquisition used to raise, the completion raises now.

Tests: `MisfireWhilePausedOrBlockedTest`'s two per-store tests and the `Assert.Inconclusive` parity
report collapse into `BothStoresApplyAnUnblockedTriggersMisfireAsTheyUnblockIt`, which runs the same
expectation against both stores, plus `AnUnblockedTriggersMisfireIsNotAppliedTwice`.
`JobStoreContractTest` — which runs on `RAMJobStore` and on every dialect — gains
`UnblockingAnOverdueTriggerAppliesItsMisfirePolicy` (`FireOnceNow`: the fire time written is inside
the `TriggeredJobComplete` call) and `UnblockingATriggerWithNothingLeftToFireRemovesIt` (`DoNothing`
past the trigger's end time: `GetTrigger` is `null`, the state is `None`, and the job survives). Both
fail on `RAMJobStore` without this change.

## 3.x

Checked, and **3.x has both divergences**, in the same shape:

* `origin/3.x:src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs` spells `NEXT_FIRE_TIME < @nextFireTime`
  in five statements (`SqlSelectMisfiredTriggers`, `…InGroupInState`, `…InState`,
  `SqlCountMisfiredTriggersInStates`, `SqlSelectHasMisfiredTriggersInState`), while
  `origin/3.x:src/Quartz/Simpl/RAMJobStore.cs`'s `ApplyMisfire` declines on `tnft.Value > misfireTime`.
* `origin/3.x`'s `RAMJobStore.TriggeredJobComplete` moves a blocked trigger to `Waiting`, adds it to
  `timeTriggers` and stops there, while `JobStoreSupport.TriggeredJobComplete` calls
  `UpdateMisfiredTrigger` for each trigger of the job that is now `WAITING` and removes the ones that
  land `COMPLETE` — with a comment saying it does so "so that GetTrigger returns null and the trigger
  doesn't linger in the database", which is the behaviour `RAMJobStore` now matches here.

No 3.x pull request opened, as instructed. Both are documented as 3.x behaviour in the migration
guide's "The two job stores answer the same way" section, and `troubleshooting.md` (which serves both
versions) says which way each behaves.

## Verification

Run locally on Windows, on `75401b22e`:

* `dotnet build Quartz.slnx` — succeeded, 0 warnings, 0 errors
* `dotnet test src/Quartz.Tests.Unit` — `Failed: 0, Passed: 3415, Skipped: 4, Total: 3419`
* integration `basic` leg — `Failed: 0, Passed: 329, Skipped: 0, Total: 329`
* integration `postgres` leg — `Failed: 0, Passed: 148, Skipped: 0, Total: 148`
* integration `sqlserver` leg — `Failed: 0, Passed: 140, Skipped: 0, Total: 140`
* `dotnet fallout VerifyDocsSnippets` — succeeded (90 markdown files checked)

Each new or changed assertion was also run against the unmodified store, to be sure it is a test:
`TheAdoStoreCountsTheThresholdInstantItselfAsLate(exactly on the threshold)`,
`BothStoresApplyAnUnblockedTriggersMisfireAsTheyUnblockIt`, `AnUnblockedTriggersMisfireIsNotAppliedTwice`,
`UnblockingAnOverdueTriggerAppliesItsMisfirePolicy` and `UnblockingATriggerWithNothingLeftToFireRemovesIt`
all fail without the two production changes.

Public API baselines are untouched, as expected: nothing about the signatures moved.

Closes #3462
Closes #3463
