### PR TITLE
Every shipped package logs through source-generated events

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -63,9 +63,6 @@
     <!-- Do not declare static members on generic types -->
     <NoWarn>$(NoWarn);CA1000</NoWarn>
 
-    <!-- For improved performance, use the LoggerMessage delegates -->
-    <NoWarn>$(NoWarn);CA1848</NoWarn>
-
     <!-- Rename type name X so that it does not end in 'Delegate', 'EventHandler', 'Permission' etc -->
     <NoWarn>$(NoWarn);CA1711</NoWarn>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,4 +16,24 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)Analyzers/BannedSymbols.txt" Link="BannedSymbols.txt" />
   </ItemGroup>
 
+  <!--
+    CA1848 - "use the LoggerMessage delegates" - is on for every assembly we ship, and off for the ones
+    we do not. A shipped package's messages are somebody's production log, so they go through a
+    source-generated [LoggerMessage] method with an event id (#3414); LogCallSiteTest guards the same
+    boundary from the source side, and CA1848 is what catches a call the compiler sees and that scan
+    does not.
+
+    The examples and the documentation samples are the reason for the exception rather than a leftover.
+    They are application code shown to a reader, and application code logs with
+    logger.LogInformation(...) - a sample that routed its one message through a generated class would be
+    teaching the wrong lesson about how to use Quartz. Quartz.Server, the benchmarks, the trimming canary
+    and the test projects have no operator to serve at all.
+
+    $(IsPackable) is how this repository marks the projects that ship, and it is not final until the
+    project body has been evaluated, which is why this is here and not in Directory.Build.props.
+  -->
+  <PropertyGroup Condition="'$(IsPackable)' != 'true'">
+    <NoWarn>$(NoWarn);CA1848</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2266,8 +2266,8 @@ Further information on configuring Microsoft.Logging can be found [at Microsoft 
 
 ### Every message carries an event id
 
-The `Quartz` and `Quartz.Plugins` packages log through source-generated `[LoggerMessage]` methods
-rather than `logger.LogInformation(…)` and its siblings. Two things follow. Nothing is formatted or
+Every shipped package logs through source-generated `[LoggerMessage]` methods rather than
+`logger.LogInformation(…)` and its siblings. Two things follow. Nothing is formatted or
 boxed when the level is off, including on the scheduling loop. And every message has a stable event id,
 so an operator can filter or alert on the event rather than on its text.
 
@@ -2288,10 +2288,12 @@ Ids are allocated in ranges by area, and are stable from 4.0 onwards:
 | 6300–6399 | The JSON scheduling data plugin and its processor |
 | 6400–6499 | The job interrupt monitor plugin |
 | 6500–6599 | The management plugins — the shutdown hook |
-| 7000–8999 | Reserved for `Quartz.Jobs` and `Quartz.Extensions.Redis`, which are converting to the same shape |
+| 7000–7399 | `Quartz.Jobs` — the directory scan job (7000–7099), the file scan job (7100–7199), the native job (7200–7299) and the send mail job (7300–7399) |
+| 8000–8099 | `Quartz.Extensions.Redis` — the Redis lock handler |
+| 9000–9099 | `Quartz.AspNetCore` — the HTTP API |
 
 Levels and message templates are otherwise **unchanged from 3.x**, so a log query that matched a
-message before still matches it. Two exceptions:
+message before still matches it. The exceptions:
 
 * `JobStoreSupport.LogWarnIfNonZero` wrote the cluster recovery counts at Information when the count
   was non-zero and at Debug when it was zero, whatever its name said. Those six messages are Warning
@@ -2306,6 +2308,12 @@ message before still matches it. Two exceptions:
 * One message in `Quartz.Plugins` carried a typo, corrected while its id was new: the interrupt
   monitor's `…scheduled to interrupt with the delay :{Delay}` had the space before the colon rather
   than after it.
+* `NativeJob` relayed each line of the spawned process's output through one template, `{Type}>{Line}`,
+  with `Type` holding `stdout` or `stderr`. It is now one event per stream — `stdout>{Line}` at
+  Information (7201) and `stderr>{Line}` at Warning (7202) — so the text a sink renders is unchanged
+  and which stream a line came from is an event id rather than a property. A structured sink that
+  indexed the `Type` property no longer receives one; filter on the id instead. The levels are the ones
+  the two streams already logged at.
 
 `LoggingJobHistoryPlugin` and `LoggingTriggerHistoryPlugin` are a special case, because the message
 they log is a template *you* configure — `JobSuccessMessage` and its siblings, with `{0}`-style

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/ExceptionHandler.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/ExceptionHandler.cs
@@ -40,29 +40,29 @@ internal sealed class ExceptionHandler
     {
         if (exception is BadHttpRequestException badHttpRequestException)
         {
-            logger.LogDebug(exception, "BadHttpRequestException thrown");
+            logger.BadHttpRequest(exception);
             return Problem(exception, GetMessageWithInnerExceptionMessage(exception), badHttpRequestException.StatusCode);
         }
 
         if (exception is JsonSerializationException)
         {
-            logger.LogDebug(exception, "Failed to deserialize request");
+            logger.RequestDeserializationFailed(exception);
             return Problem(exception, GetMessageWithInnerExceptionMessage(exception), StatusCodes.Status400BadRequest);
         }
 
         if (exception is NotFoundException)
         {
-            logger.LogDebug(exception, "NotFoundException thrown");
+            logger.NotFound(exception);
             return Problem(exception, GetMessageWithInnerExceptionMessage(exception), StatusCodes.Status404NotFound);
         }
 
         if (exception is SchedulerException)
         {
-            logger.LogWarning(exception, "SchedulerException thrown when handling api request to url {Url}", context.Request.GetDisplayUrl());
+            logger.SchedulerExceptionHandlingRequest(context.Request.GetDisplayUrl(), exception);
             return Problem(exception, exception.Message, StatusCodes.Status400BadRequest);
         }
 
-        logger.LogError(exception, "Exception thrown when handling api request to url {Url}", context.Request.GetDisplayUrl());
+        logger.ExceptionHandlingRequest(context.Request.GetDisplayUrl(), exception);
         return Problem(exception, exception.Message, StatusCodes.Status500InternalServerError, nameTheExceptionType: false);
     }
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/HttpApiLog.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/HttpApiLog.cs
@@ -1,0 +1,57 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.AspNetCore.HttpApi.Util;
+
+/// <summary>
+/// Every event the HTTP API logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 9000-9099 belong to this area. An id, once given out, is what an operator filters and
+/// alerts on, so it is never reused for a different event and never renumbered; the
+/// <c>LogEventCatalogTest</c> in <c>Quartz.Tests.AspNetCore</c> makes a change to one a reviewed diff.
+/// </para>
+/// <para>
+/// All five are raised while turning an exception into the problem details a request is answered with,
+/// and the level says who has to act: a request the caller got wrong is Debug, a scheduler that
+/// refused is Warning, and anything else is a server fault at Error.
+/// </para>
+/// </remarks>
+internal static partial class HttpApiLog
+{
+    [LoggerMessage(EventId = 9000, Level = LogLevel.Debug, Message = "BadHttpRequestException thrown")]
+    public static partial void BadHttpRequest(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9001, Level = LogLevel.Debug, Message = "Failed to deserialize request")]
+    public static partial void RequestDeserializationFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9002, Level = LogLevel.Debug, Message = "NotFoundException thrown")]
+    public static partial void NotFound(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9003, Level = LogLevel.Warning, Message = "SchedulerException thrown when handling api request to url {Url}")]
+    public static partial void SchedulerExceptionHandlingRequest(this ILogger logger, string url, Exception exception);
+
+    [LoggerMessage(EventId = 9004, Level = LogLevel.Error, Message = "Exception thrown when handling api request to url {Url}")]
+    public static partial void ExceptionHandlingRequest(this ILogger logger, string url, Exception exception);
+}

--- a/src/Quartz.Extensions.Redis/RedisLockHandlerLog.cs
+++ b/src/Quartz.Extensions.Redis/RedisLockHandlerLog.cs
@@ -1,0 +1,79 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Extensions.Redis;
+
+/// <summary>
+/// Every event the Redis lock handler logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 8000-8099 belong to this area. An id, once given out, is what an operator filters and
+/// alerts on, so it is never reused for a different event and never renumbered;
+/// <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// <para>
+/// The class is named for the concept rather than for the type that raises the events: the handler is
+/// still called <c>RedisSemaphore</c> until #3440 renames it, and an event catalogue that renames
+/// itself with its caller is a catalogue that renumbers. The ids and the class name outlive whatever
+/// the implementing type is spelled.
+/// </para>
+/// <para>
+/// The vocabulary is the ADO.NET lock handlers' — a lock is desired, obtained, given, returned — and
+/// several messages are word for word what <c>LockHandlerLog</c> (3700-3799) raises. They are separate
+/// events all the same, because an id names one event raised in one place: an operator filtering 8005
+/// is asking about the Redis handler, not about whichever handler happened to say the same sentence.
+/// </para>
+/// </remarks>
+internal static partial class RedisLockHandlerLog
+{
+    [LoggerMessage(EventId = 8000, Level = LogLevel.Debug, Message = "Lock '{LockName}' is desired by: {RequestorId}")]
+    public static partial void LockDesired(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 8001, Level = LogLevel.Debug, Message = "Lock '{LockName}' already owned by: {RequestorId}")]
+    public static partial void LockAlreadyOwned(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 8002, Level = LogLevel.Debug, Message = "Lock '{LockName}' is being obtained: {RequestorId}")]
+    public static partial void LockBeingObtained(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 8003, Level = LogLevel.Debug, Message = "Lock '{LockName}' was not obtained by: {RequestorId} - cancelled")]
+    public static partial void LockNotObtainedCancelled(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 8004, Level = LogLevel.Debug, Message = "Lock '{LockName}' given to: {RequestorId}")]
+    public static partial void LockGiven(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 8005, Level = LogLevel.Warning, Message = "Lock '{LockName}' attempt to return by: {RequestorId} -- but not owner!")]
+    public static partial void LockReturnedByNonOwner(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 8006, Level = LogLevel.Warning, Message = "stack-trace of wrongful returner: {StackTrace}")]
+    public static partial void WrongfulReturnerStack(this ILogger logger, string stackTrace);
+
+    [LoggerMessage(EventId = 8007, Level = LogLevel.Debug, Message = "Lock '{LockName}' returned by: {RequestorId}")]
+    public static partial void LockReturned(this ILogger logger, string lockName, Guid requestorId);
+
+    [LoggerMessage(EventId = 8008, Level = LogLevel.Warning, Message = "Failed to release Redis lock '{LockName}'")]
+    public static partial void LockReleaseFailed(this ILogger logger, string lockName, Exception exception);
+
+    [LoggerMessage(EventId = 8009, Level = LogLevel.Information, Message = "Connecting to Redis")]
+    public static partial void ConnectingToRedis(this ILogger logger);
+}

--- a/src/Quartz.Extensions.Redis/RedisSemaphore.cs
+++ b/src/Quartz.Extensions.Redis/RedisSemaphore.cs
@@ -158,7 +158,7 @@ public sealed class RedisSemaphore : ISemaphore
 
         if (isDebugEnabled)
         {
-            logger.LogDebug("Lock '{LockName}' is desired by: {RequestorId}", lockName, requestorId);
+            logger.LockDesired(lockName, requestorId);
         }
 
         var lockHandle = GetLock(lockKind);
@@ -167,7 +167,7 @@ public sealed class RedisSemaphore : ISemaphore
         {
             if (isDebugEnabled)
             {
-                logger.LogDebug("Lock '{LockName}' already owned by: {RequestorId}", lockName, requestorId);
+                logger.LockAlreadyOwned(lockName, requestorId);
             }
 
             return false;
@@ -175,7 +175,7 @@ public sealed class RedisSemaphore : ISemaphore
 
         if (isDebugEnabled)
         {
-            logger.LogDebug("Lock '{LockName}' is being obtained: {RequestorId}", lockName, requestorId);
+            logger.LockBeingObtained(lockName, requestorId);
         }
 
         try
@@ -186,7 +186,7 @@ public sealed class RedisSemaphore : ISemaphore
         {
             if (isDebugEnabled)
             {
-                logger.LogDebug("Lock '{LockName}' was not obtained by: {RequestorId} - cancelled", lockName, requestorId);
+                logger.LockNotObtainedCancelled(lockName, requestorId);
             }
 
             return false;
@@ -210,7 +210,7 @@ public sealed class RedisSemaphore : ISemaphore
                 {
                     if (isDebugEnabled)
                     {
-                        logger.LogDebug("Lock '{LockName}' given to: {RequestorId}", lockName, requestorId);
+                        logger.LockGiven(lockName, requestorId);
                     }
 
                     return true;
@@ -225,7 +225,7 @@ public sealed class RedisSemaphore : ISemaphore
 
             if (isDebugEnabled)
             {
-                logger.LogDebug("Lock '{LockName}' was not obtained by: {RequestorId} - cancelled", lockName, requestorId);
+                logger.LockNotObtainedCancelled(lockName, requestorId);
             }
 
             return false;
@@ -250,8 +250,8 @@ public sealed class RedisSemaphore : ISemaphore
         {
             if (logger.IsEnabled(LogLevel.Warning))
             {
-                logger.LogWarning("Lock '{LockName}' attempt to return by: {RequestorId} -- but not owner!", lockName, requestorId);
-                logger.LogWarning("stack-trace of wrongful returner: {StackTrace}", Environment.StackTrace);
+                logger.LockReturnedByNonOwner(lockName, requestorId);
+                logger.WrongfulReturnerStack(Environment.StackTrace);
             }
 
             return;
@@ -270,12 +270,12 @@ public sealed class RedisSemaphore : ISemaphore
 
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.LogDebug("Lock '{LockName}' returned by: {RequestorId}", lockName, requestorId);
+                logger.LockReturned(lockName, requestorId);
             }
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to release Redis lock '{LockName}'", lockName);
+            logger.LockReleaseFailed(lockName, ex);
         }
         finally
         {
@@ -308,7 +308,7 @@ public sealed class RedisSemaphore : ISemaphore
                 return redis;
             }
 
-            logger.LogInformation("Connecting to Redis");
+            logger.ConnectingToRedis();
             redis = await ConnectionMultiplexer.ConnectAsync(RedisConfiguration).ConfigureAwait(false);
             return redis;
         }

--- a/src/Quartz.Jobs/Jobs/DirectoryScanJob.cs
+++ b/src/Quartz.Jobs/Jobs/DirectoryScanJob.cs
@@ -154,7 +154,7 @@ public class DirectoryScanJob : IJob
         {
             foreach (var fileInfo in updatedFiles)
             {
-                logger.LogInformation("Directory {DirectoryName} contents updated, notifying listener.", fileInfo.DirectoryName);
+                logger.DirectoryContentsUpdated(fileInfo.DirectoryName);
             }
 
             // notify call back...
@@ -176,7 +176,7 @@ public class DirectoryScanJob : IJob
         {
             foreach (var dir in model.DirectoriesToScan)
             {
-                logger.LogDebug("Directory '{Directory}' contents unchanged.", dir);
+                logger.DirectoryContentsUnchanged(dir);
             }
         }
     }
@@ -206,7 +206,7 @@ public class DirectoryScanJob : IJob
         DirectoryInfo dir = new DirectoryInfo(directoryName);
         if (!dir.Exists)
         {
-            logger.LogWarning("Directory '{DirectoryName}' does not exist.", directoryName);
+            logger.DirectoryDoesNotExist(directoryName);
             return new DirectoryScanResult([], [], []);
         }
 

--- a/src/Quartz.Jobs/Jobs/DirectoryScanJobLog.cs
+++ b/src/Quartz.Jobs/Jobs/DirectoryScanJobLog.cs
@@ -1,0 +1,53 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// Every event the directory scan job logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 7000-7099 belong to this area and are allocated in file order: the job itself
+/// (7000-7009) and the model that reads its configuration and finds its listener (7010-7019). An id,
+/// once given out, is what an operator filters and alerts on, so it is never reused for a different
+/// event and never renumbered; <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// </remarks>
+internal static partial class DirectoryScanJobLog
+{
+    [LoggerMessage(EventId = 7000, Level = LogLevel.Information, Message = "Directory {DirectoryName} contents updated, notifying listener.")]
+    public static partial void DirectoryContentsUpdated(this ILogger logger, string? directoryName);
+
+    [LoggerMessage(EventId = 7001, Level = LogLevel.Debug, Message = "Directory '{Directory}' contents unchanged.")]
+    public static partial void DirectoryContentsUnchanged(this ILogger logger, string directory);
+
+    [LoggerMessage(EventId = 7002, Level = LogLevel.Warning, Message = "Directory '{DirectoryName}' does not exist.")]
+    public static partial void DirectoryDoesNotExist(this ILogger logger, string directoryName);
+
+    [LoggerMessage(EventId = 7010, Level = LogLevel.Debug, Message = "Could not load some types from assembly {AssemblyName} while scanning for IDirectoryScanListener")]
+    public static partial void SomeTypesNotLoaded(this ILogger logger, string? assemblyName, Exception exception);
+
+    [LoggerMessage(EventId = 7011, Level = LogLevel.Debug, Message = "Could not load assembly {AssemblyName} while scanning for IDirectoryScanListener")]
+    public static partial void AssemblyNotLoaded(this ILogger logger, string? assemblyName, Exception exception);
+}

--- a/src/Quartz.Jobs/Jobs/DirectoryScanJobModel.cs
+++ b/src/Quartz.Jobs/Jobs/DirectoryScanJobModel.cs
@@ -135,13 +135,13 @@ internal sealed class DirectoryScanJobModel
                         catch (ReflectionTypeLoadException ex)
                         {
                             // Some types in the assembly couldn't be loaded, but we can still use the ones that did load
-                            logger.LogDebug(ex, "Could not load some types from assembly {AssemblyName} while scanning for IDirectoryScanListener", assembly.FullName);
+                            logger.SomeTypesNotLoaded(assembly.FullName, ex);
                             return ex.Types.Where(t => t != null)!;
                         }
                         catch (Exception ex) when (ex is FileNotFoundException or BadImageFormatException or NotSupportedException)
                         {
                             // Assembly can't be loaded - skip it
-                            logger.LogDebug(ex, "Could not load assembly {AssemblyName} while scanning for IDirectoryScanListener", assembly.FullName);
+                            logger.AssemblyNotLoaded(assembly.FullName, ex);
                             return Array.Empty<Type>();
                         }
                     })

--- a/src/Quartz.Jobs/Jobs/FileScanJob.cs
+++ b/src/Quartz.Jobs/Jobs/FileScanJob.cs
@@ -138,19 +138,19 @@ public class FileScanJob : IJob
 
         if (newTime is null)
         {
-            logger.LogWarning("File '{FileName}' does not exist.", fileName);
+            logger.FileDoesNotExist(fileName);
             return;
         }
 
         if (lastTime is not null && newTime != lastTime && newTime < maxAgeTime)
         {
             // notify call back...
-            logger.LogInformation("File '{FileName}' updated, notifying listener.", fileName);
+            logger.FileUpdated(fileName);
             await listener.FileUpdated(fileName, cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            logger.LogDebug("File '{FileName}' unchanged.", fileName);
+            logger.FileUnchanged(fileName);
         }
 
         context.JobDetail.JobDataMap[LastModifiedTime] = newTime.Value;

--- a/src/Quartz.Jobs/Jobs/FileScanJobLog.cs
+++ b/src/Quartz.Jobs/Jobs/FileScanJobLog.cs
@@ -1,0 +1,46 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// Every event the file scan job logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 7100-7199 belong to this area. An id, once given out, is what an operator filters and
+/// alerts on, so it is never reused for a different event and never renumbered;
+/// <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// </remarks>
+internal static partial class FileScanJobLog
+{
+    [LoggerMessage(EventId = 7100, Level = LogLevel.Warning, Message = "File '{FileName}' does not exist.")]
+    public static partial void FileDoesNotExist(this ILogger logger, string fileName);
+
+    [LoggerMessage(EventId = 7101, Level = LogLevel.Information, Message = "File '{FileName}' updated, notifying listener.")]
+    public static partial void FileUpdated(this ILogger logger, string fileName);
+
+    [LoggerMessage(EventId = 7102, Level = LogLevel.Debug, Message = "File '{FileName}' unchanged.")]
+    public static partial void FileUnchanged(this ILogger logger, string fileName);
+}

--- a/src/Quartz.Jobs/Jobs/NativeJob.cs
+++ b/src/Quartz.Jobs/Jobs/NativeJob.cs
@@ -183,7 +183,7 @@ public class NativeJob : IJob
 
             temp = temp.Trim();
 
-            logger.LogInformation("About to run {Command} {Temp}...", cmd[0], temp);
+            logger.AboutToRun(cmd[0], temp);
 
             Process proc = new Process();
 
@@ -268,17 +268,17 @@ public class NativeJob : IJob
                 {
                     if (type == StreamTypeError)
                     {
-                        enclosingInstance.logger.LogWarning("{Type}>{Line}", type, line);
+                        enclosingInstance.logger.StandardErrorLine(line);
                     }
                     else
                     {
-                        enclosingInstance.logger.LogInformation("{Type}>{Line}", type, line);
+                        enclosingInstance.logger.StandardOutputLine(line);
                     }
                 }
             }
             catch (IOException ioe)
             {
-                enclosingInstance.logger.LogError(ioe, "Error consuming {Type} stream of spawned process.", type);
+                enclosingInstance.logger.StreamConsumptionFailed(type, ioe);
             }
         }
     }

--- a/src/Quartz.Jobs/Jobs/NativeJobLog.cs
+++ b/src/Quartz.Jobs/Jobs/NativeJobLog.cs
@@ -1,0 +1,57 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// Every event the native job logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 7200-7299 belong to this area. An id, once given out, is what an operator filters and
+/// alerts on, so it is never reused for a different event and never renumbered;
+/// <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// <para>
+/// The spawned process's output is one event per stream rather than one event with the stream's name
+/// as a placeholder. What follows the <c>&gt;</c> is a line of the child process's own text, which has
+/// no structure this package can name, so it is the whole of what the template carries — the same
+/// degenerate shape <c>ConfigurationLog.JobPropertyNotSet</c> and <c>HistoryPluginLog</c> take. Which
+/// stream a line came out of is then an event id an operator filters on rather than a property value
+/// they match, and the two streams already logged at different levels.
+/// </para>
+/// </remarks>
+internal static partial class NativeJobLog
+{
+    [LoggerMessage(EventId = 7200, Level = LogLevel.Information, Message = "About to run {Command} {Temp}...")]
+    public static partial void AboutToRun(this ILogger logger, string command, string temp);
+
+    [LoggerMessage(EventId = 7201, Level = LogLevel.Information, Message = "stdout>{Line}")]
+    public static partial void StandardOutputLine(this ILogger logger, string line);
+
+    [LoggerMessage(EventId = 7202, Level = LogLevel.Warning, Message = "stderr>{Line}")]
+    public static partial void StandardErrorLine(this ILogger logger, string line);
+
+    [LoggerMessage(EventId = 7203, Level = LogLevel.Error, Message = "Error consuming {Type} stream of spawned process.")]
+    public static partial void StreamConsumptionFailed(this ILogger logger, string type, Exception exception);
+}

--- a/src/Quartz.Jobs/Jobs/SendMailJob.cs
+++ b/src/Quartz.Jobs/Jobs/SendMailJob.cs
@@ -193,10 +193,7 @@ public class SendMailJob : IJob
         NetworkCredential? fromJobData = SendMailOptions.ReadJobDataCredentials(data);
         if (fromJobData is not null)
         {
-            logger.LogWarning(
-                "SMTP credentials are being read from job data ('{UserNameKey}' / '{PasswordKey}'), which a persistent job store writes to the database and replicates to every node in the cluster. Register an ICredentialsByHost with the container instead.",
-                PropertyUsername,
-                PropertyPassword);
+            logger.CredentialsReadFromJobData(PropertyUsername, PropertyPassword);
         }
 
         return fromJobData;
@@ -208,7 +205,7 @@ public class SendMailJob : IJob
     /// </summary>
     protected virtual async ValueTask Send(MailInfo mailInfo, CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Sending message {MailMessage}", GetMessageDescription(mailInfo.MailMessage));
+        logger.SendingMessage(GetMessageDescription(mailInfo.MailMessage));
 
         using (var client = new SmtpClient(mailInfo.SmtpHost))
         {

--- a/src/Quartz.Jobs/Jobs/SendMailJobLog.cs
+++ b/src/Quartz.Jobs/Jobs/SendMailJobLog.cs
@@ -1,0 +1,43 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Jobs;
+
+/// <summary>
+/// Every event the send mail job logs, as source-generated methods with a pinned event id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event ids 7300-7399 belong to this area. An id, once given out, is what an operator filters and
+/// alerts on, so it is never reused for a different event and never renumbered;
+/// <c>LogEventCatalogTest</c> makes a change to one a reviewed diff.
+/// </para>
+/// </remarks>
+internal static partial class SendMailJobLog
+{
+    [LoggerMessage(EventId = 7300, Level = LogLevel.Warning, Message = "SMTP credentials are being read from job data ('{UserNameKey}' / '{PasswordKey}'), which a persistent job store writes to the database and replicates to every node in the cluster. Register an ICredentialsByHost with the container instead.")]
+    public static partial void CredentialsReadFromJobData(this ILogger logger, string userNameKey, string passwordKey);
+
+    [LoggerMessage(EventId = 7301, Level = LogLevel.Information, Message = "Sending message {MailMessage}")]
+    public static partial void SendingMessage(this ILogger logger, string mailMessage);
+}

--- a/src/Quartz.Plugins/Plugins/History/StructuredLoggingJobHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/StructuredLoggingJobHistoryPlugin.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 using Microsoft.Extensions.Logging;
@@ -47,6 +48,12 @@ namespace Quartz.Plugins.History;
 /// </para>
 /// </remarks>
 /// <author>Marko Lahma (.NET)</author>
+[SuppressMessage("Performance", "CA1848:Use the LoggerMessage delegates", Justification =
+    "The template is the user's, configured at run time, and its named placeholders are what a structured sink "
+    + "resolves into properties - which is the whole reason this plugin exists. A [LoggerMessage] template is "
+    + "fixed at compile time, and rendering this one first would flatten exactly what is being preserved. Every "
+    + "call is already behind an IsEnabled check, so the allocation CA1848 exists to avoid is already avoided. "
+    + "LogCallSiteTest.Allowed records the same decision from the source side.")]
 public sealed class StructuredLoggingJobHistoryPlugin : ISchedulerPlugin, IJobListener
 {
     private readonly ILogger<StructuredLoggingJobHistoryPlugin> logger;

--- a/src/Quartz.Plugins/Plugins/History/StructuredLoggingTriggerHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/StructuredLoggingTriggerHistoryPlugin.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.Extensions.Logging;
 
 using Quartz.Diagnostics;
@@ -45,6 +47,10 @@ namespace Quartz.Plugins.History;
 /// </para>
 /// </remarks>
 /// <author>Marko Lahma (.NET)</author>
+[SuppressMessage("Performance", "CA1848:Use the LoggerMessage delegates", Justification =
+    "Same as StructuredLoggingJobHistoryPlugin: the configured template's named placeholders are the plugin's "
+    + "reason to exist, and they cannot survive a compile-time template. Every call is already behind an "
+    + "IsEnabled check. LogCallSiteTest.Allowed records the same decision from the source side.")]
 public sealed class StructuredLoggingTriggerHistoryPlugin : ISchedulerPlugin, ITriggerListener
 {
     private readonly ILogger<StructuredLoggingTriggerHistoryPlugin> logger;

--- a/src/Quartz.Tests.AspNetCore/LogEventCatalogTest.cs
+++ b/src/Quartz.Tests.AspNetCore/LogEventCatalogTest.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 
 using Microsoft.Extensions.Logging;
 
-namespace Quartz.Tests.Unit;
+namespace Quartz.Tests.AspNetCore;
 
 /// <summary>
 /// The catalogue of log events a package raises: every <c>[LoggerMessage]</c> method, its event id,
@@ -10,20 +10,14 @@ namespace Quartz.Tests.Unit;
 /// </summary>
 /// <remarks>
 /// <para>
-/// An event id is what an operator filters and alerts on, and a message template is what a
-/// structured-logging consumer matches. Both are contract once shipped, and neither shows up in the
-/// public API baseline, because the generated classes are internal. The snapshot is what makes adding
-/// an event, renumbering one, or rewording a message a reviewed diff instead of an invisible one.
+/// The companion test in <c>Quartz.Tests.Unit</c> covers the packages that do not need ASP.NET Core to
+/// reference, and explains what the catalogue is for. This one covers <c>Quartz.AspNetCore</c>, and
+/// holds the range that package draws from — each test owns the ranges for the assemblies it snapshots,
+/// so no range is written down twice and neither copy can go stale against the other.
 /// </para>
 /// <para>
-/// Ids are allocated in ranges, one set per package, so two packages loaded into the same process
-/// never disagree about what an id means. The ranges live in <see cref="Ranges" />; a package may only
-/// use its own.
-/// </para>
-/// <para>
-/// <c>Quartz.AspNetCore</c> is covered by the test of the same name in <c>Quartz.Tests.AspNetCore</c>,
-/// which is where its dependencies already live, and which holds the 9000-9099 range it draws from.
-/// Between the two, every packable project that logs has a catalogue.
+/// <c>Quartz.Dashboard</c> is not here: it raises no events at all. It is still in
+/// <c>LogCallSiteTest.Converted</c>, which is what says it may not start raising them the plain way.
 /// </para>
 /// </remarks>
 public class LogEventCatalogTest
@@ -31,32 +25,19 @@ public class LogEventCatalogTest
     /// <summary>
     /// Who owns which event ids. Every id an assembly raises must fall inside a range recorded here
     /// against that assembly, which is also what keeps it out of another package's reserved range.
+    /// 1000-8999 belong to the packages the companion test in <c>Quartz.Tests.Unit</c> covers.
     /// </summary>
     private static readonly EventIdRange[] Ranges =
     [
-        new("Quartz", 1000, 1999, "scheduler core"),
-        new("Quartz", 2000, 2999, "in-memory store"),
-        new("Quartz", 3000, 3499, "ADO.NET store"),
-        new("Quartz", 3500, 3599, "clustering"),
-        new("Quartz", 3600, 3699, "misfire handling"),
-        new("Quartz", 3700, 3799, "lock handlers"),
-        new("Quartz", 4000, 4999, "configuration, dependency injection and hosting"),
-        new("Quartz", 5000, 5999, "serialization, type loading, triggers, calendars and utilities"),
-        new("Quartz.Plugins", 6000, 6999, "plugins"),
-        new("Quartz.Jobs", 7000, 7999, "jobs"),
-        new("Quartz.Extensions.Redis", 8000, 8999, "Redis"),
+        new("Quartz.AspNetCore", 9000, 9099, "HTTP API"),
     ];
 
     /// <summary>
-    /// The assemblies whose catalogue is snapshotted. A package joins this list on the day its
-    /// <c>Log*</c> calls become <c>[LoggerMessage]</c> methods — one line, and a snapshot of its own.
+    /// The assemblies whose catalogue is snapshotted.
     /// </summary>
     private static readonly Assembly[] Catalogued =
     [
-        typeof(global::Quartz.IScheduler).Assembly,
-        typeof(global::Quartz.Plugins.Management.ShutdownHookPlugin).Assembly,
-        typeof(global::Quartz.Jobs.DirectoryScanJob).Assembly,
-        typeof(global::Quartz.RedisLockHandlerConfigurationExtensions).Assembly,
+        typeof(global::Quartz.QuartzAspNetCoreConfigurationExtensions).Assembly,
     ];
 
     private static IEnumerable<TestCaseData> Assemblies()
@@ -109,7 +90,7 @@ public class LogEventCatalogTest
         {
             foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly))
             {
-                LoggerMessageAttribute attribute = method.GetCustomAttribute<LoggerMessageAttribute>();
+                LoggerMessageAttribute? attribute = method.GetCustomAttribute<LoggerMessageAttribute>();
                 if (attribute is null)
                 {
                     continue;

--- a/src/Quartz.Tests.AspNetCore/Verify/LogEventCatalogTest_Quartz.AspNetCore.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/LogEventCatalogTest_Quartz.AspNetCore.verified.txt
@@ -1,0 +1,10 @@
+﻿9000  Debug  HttpApiLog.BadHttpRequest
+    "BadHttpRequestException thrown"
+9001  Debug  HttpApiLog.RequestDeserializationFailed
+    "Failed to deserialize request"
+9002  Debug  HttpApiLog.NotFound
+    "NotFoundException thrown"
+9003  Warning  HttpApiLog.SchedulerExceptionHandlingRequest
+    "SchedulerException thrown when handling api request to url {Url}"
+9004  Error  HttpApiLog.ExceptionHandlingRequest
+    "Exception thrown when handling api request to url {Url}"

--- a/src/Quartz.Tests.Unit/Jobs/NativeJobStreamLoggingTest.cs
+++ b/src/Quartz.Tests.Unit/Jobs/NativeJobStreamLoggingTest.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Diagnostics;
+using Quartz.Jobs;
+using Quartz.Tests.Unit.Plugin.History;
+
+namespace Quartz.Tests.Unit.Job;
+
+/// <summary>
+/// What a spawned process writes reaches the log as the event for the stream it came out of.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two streams used to share one message, <c>{Type}&gt;{Line}</c>, with the stream's name as a
+/// placeholder. They are now an event each — <c>stdout&gt;{Line}</c> at Information and
+/// <c>stderr&gt;{Line}</c> at Warning — so which stream a line came from is an id an operator filters
+/// rather than a property value they match. The catalogue snapshot pins the two templates; only a test
+/// that runs a process can say the right one is called for the right stream, which is the way this
+/// could have gone wrong without anything else noticing.
+/// </para>
+/// <para>
+/// Non-parallelizable because <c>NativeJob</c> takes its logger from the ambient factory, so reading
+/// what it logged means replacing the process-wide one for the duration.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class NativeJobStreamLoggingTest
+{
+    private static readonly TimeSpan RelayTimeout = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public void AStandardOutputLineIsTheStandardOutputEvent()
+    {
+        List<LogEntry> entries = RunAndCapture(new NativeJobOptions
+        {
+            Command = "echo",
+            Parameters = "quartz-3414",
+            ConsumeStreams = true,
+        }, eventId: 7201);
+
+        entries.Should().Contain(
+            x => x.EventId.Id == 7201 && x.Level == LogLevel.Information && x.Message.StartsWith("stdout>"),
+            "a line the process wrote to stdout is event 7201 at Information, and the text a sink renders "
+            + "still begins with the stream name the single shared template used to interpolate");
+    }
+
+    [Test]
+    public void AStandardErrorLineIsTheStandardErrorEvent()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            Assert.Ignore(
+                "NativeJob only wraps the command in a shell on Windows and Linux; elsewhere it starts the "
+                + "command itself, so an unknown command fails to start rather than making a shell complain "
+                + "on stderr");
+        }
+
+        List<LogEntry> entries = RunAndCapture(new NativeJobOptions
+        {
+            Command = "quartz-no-such-command-3414",
+            ConsumeStreams = true,
+        }, eventId: 7202);
+
+        entries.Should().Contain(
+            x => x.EventId.Id == 7202 && x.Level == LogLevel.Warning && x.Message.StartsWith("stderr>"),
+            "the shell's complaint about an unknown command comes out of stderr, which is event 7202 at "
+            + "Warning - the level the shared template's stderr branch already logged at");
+    }
+
+    /// <summary>
+    /// Runs the job and waits for the event the caller is after, because the stream consumers relay from
+    /// a thread each and the job does not join them before it returns.
+    /// </summary>
+    private static List<LogEntry> RunAndCapture(NativeJobOptions options, int eventId)
+    {
+        RecordingLoggerProvider recorder = new();
+        using LoggerFactory factory = new();
+        factory.AddProvider(recorder);
+
+        LogProvider.SetLogProvider(factory);
+        try
+        {
+            NativeJob job = new NativeJob();
+            IJobExecutionContext context = TestUtil.NewJobExecutionContextFor(job);
+
+            foreach (KeyValuePair<string, object> pair in options.ToJobData())
+            {
+                context.MergedJobDataMap[pair.Key] = pair.Value;
+            }
+
+            job.Execute(context);
+
+            Stopwatch waited = Stopwatch.StartNew();
+            while (waited.Elapsed < RelayTimeout && !recorder.Entries.Exists(x => x.EventId.Id == eventId))
+            {
+                Thread.Sleep(20);
+            }
+
+            return recorder.Entries;
+        }
+        finally
+        {
+            LogProvider.SetLogProvider(Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/LogCallSiteTest.cs
+++ b/src/Quartz.Tests.Unit/LogCallSiteTest.cs
@@ -14,10 +14,20 @@ namespace Quartz.Tests.Unit;
 /// for — the same job <c>SourceEncodingTest</c> does for byte-order marks.
 /// </para>
 /// <para>
-/// The four packages #3414 names are covered, and so is <c>Quartz.AspNetCore</c>. The rest of what
-/// ships joins <see cref="Converted" /> with the sweep that finishes it; tests, examples and the
-/// documentation samples are deliberately never covered, because a plain call is the right thing to
-/// write in all three.
+/// Every packable project under <c>src/</c> is covered, which
+/// <see cref="EveryPackableProjectIsCovered" /> is what keeps true: a package that ships is a package
+/// whose messages an operator has to be able to filter, so a new one joins <see cref="Converted" /> on
+/// the day it is added rather than on the day somebody notices. <c>CA1848</c> guards the same boundary
+/// from the compiler's side, which is what catches a call in a <c>.razor</c> file that this scan of
+/// <c>.cs</c> files does not see.
+/// </para>
+/// <para>
+/// Nothing that does not ship is covered, and that is deliberate rather than unfinished.
+/// <c>Quartz.Examples*</c> and <c>Quartz.Documentation.Samples</c> are application code shown to a
+/// reader, and application code logs with <c>logger.LogInformation(…)</c> — a sample that routed its
+/// one message through a generated class would be teaching the wrong lesson about how to use Quartz.
+/// <c>Quartz.Server</c>, <c>Quartz.Benchmark</c>, <c>Quartz.Trimming.Canary</c> and the test projects
+/// have no operator to serve at all.
 /// </para>
 /// </remarks>
 public class LogCallSiteTest
@@ -29,9 +39,13 @@ public class LogCallSiteTest
     [
         "src/Quartz",
         "src/Quartz.AspNetCore",
+        "src/Quartz.Dashboard",
         "src/Quartz.Extensions.Redis",
+        "src/Quartz.HttpClient",
         "src/Quartz.Jobs",
         "src/Quartz.Plugins",
+        "src/Quartz.Plugins.TimeZoneConverter",
+        "src/Quartz.Serialization.Newtonsoft",
     ];
 
     /// <summary>
@@ -128,6 +142,36 @@ public class LogCallSiteTest
                 $"{path} is on the allow-list because {reason}. It no longer calls ILogger directly, so the "
                 + "entry excuses nothing and should be deleted before it starts excusing something else");
         }
+    }
+
+    /// <summary>
+    /// A package that ships is a package whose log messages somebody operates on, so the list of covered
+    /// projects is the list of packable ones and nothing less.
+    /// </summary>
+    /// <remarks>
+    /// Without this, a package added after the conversion would ship unguarded — and it would look
+    /// exactly like a package with nothing to convert, because both spend their whole life passing every
+    /// other test in this file. A project that packs nothing is not covered and does not need to be.
+    /// </remarks>
+    [Test]
+    public void EveryPackableProjectIsCovered()
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+
+        List<string> packable = ShippedProjects.Find()
+            .Select(x => Path.GetRelativePath(root.FullName, x.DirectoryName!).Replace('\\', '/'))
+            .ToList();
+
+        packable.Should().BeSubsetOf(Converted,
+            "every package that ships logs to somebody who has to filter it, so its call sites are covered "
+            + "from the day the package exists. A new package joins the Converted list with its own *Log "
+            + "class and an event id range in LogEventCatalogTest; one that logs nothing joins with neither, "
+            + "and stays honest the day it starts logging");
+
+        Converted.Should().BeSubsetOf(packable,
+            "a project that ships nothing has no operator to serve, and covering one would say that the "
+            + "examples and the documentation samples should stop writing the plain call this repository "
+            + "teaches readers to write");
     }
 
     private static IEnumerable<FileInfo> Discover(DirectoryInfo directory)

--- a/src/Quartz.Tests.Unit/LogCallSiteTest.cs
+++ b/src/Quartz.Tests.Unit/LogCallSiteTest.cs
@@ -14,8 +14,8 @@ namespace Quartz.Tests.Unit;
 /// for — the same job <c>SourceEncodingTest</c> does for byte-order marks.
 /// </para>
 /// <para>
-/// <c>src/Quartz/</c> and <c>src/Quartz.Plugins/</c> are covered so far. <c>Quartz.Jobs</c> and
-/// <c>Quartz.Extensions.Redis</c> join <see cref="Converted" /> as their own conversions land (#3414);
+/// <c>src/Quartz/</c>, <c>src/Quartz.Plugins/</c> and <c>src/Quartz.Jobs/</c> are covered so far.
+/// <c>Quartz.Extensions.Redis</c> joins <see cref="Converted" /> as its own conversion lands (#3414);
 /// tests, examples and the documentation samples are deliberately never covered, because a plain call
 /// is the right thing to write in all three.
 /// </para>
@@ -25,7 +25,12 @@ public class LogCallSiteTest
     /// <summary>
     /// The projects whose logging has been converted, relative to the repository root.
     /// </summary>
-    private static readonly string[] Converted = ["src/Quartz", "src/Quartz.Plugins"];
+    private static readonly string[] Converted =
+    [
+        "src/Quartz",
+        "src/Quartz.Jobs",
+        "src/Quartz.Plugins",
+    ];
 
     /// <summary>
     /// Build output and tool caches, which hold the generator's own output among other things.

--- a/src/Quartz.Tests.Unit/LogCallSiteTest.cs
+++ b/src/Quartz.Tests.Unit/LogCallSiteTest.cs
@@ -14,9 +14,10 @@ namespace Quartz.Tests.Unit;
 /// for — the same job <c>SourceEncodingTest</c> does for byte-order marks.
 /// </para>
 /// <para>
-/// The four packages #3414 names are covered. The rest of what ships joins <see cref="Converted" />
-/// with the sweep that finishes it; tests, examples and the documentation samples are deliberately
-/// never covered, because a plain call is the right thing to write in all three.
+/// The four packages #3414 names are covered, and so is <c>Quartz.AspNetCore</c>. The rest of what
+/// ships joins <see cref="Converted" /> with the sweep that finishes it; tests, examples and the
+/// documentation samples are deliberately never covered, because a plain call is the right thing to
+/// write in all three.
 /// </para>
 /// </remarks>
 public class LogCallSiteTest
@@ -27,6 +28,7 @@ public class LogCallSiteTest
     private static readonly string[] Converted =
     [
         "src/Quartz",
+        "src/Quartz.AspNetCore",
         "src/Quartz.Extensions.Redis",
         "src/Quartz.Jobs",
         "src/Quartz.Plugins",

--- a/src/Quartz.Tests.Unit/LogCallSiteTest.cs
+++ b/src/Quartz.Tests.Unit/LogCallSiteTest.cs
@@ -14,10 +14,9 @@ namespace Quartz.Tests.Unit;
 /// for — the same job <c>SourceEncodingTest</c> does for byte-order marks.
 /// </para>
 /// <para>
-/// <c>src/Quartz/</c>, <c>src/Quartz.Plugins/</c> and <c>src/Quartz.Jobs/</c> are covered so far.
-/// <c>Quartz.Extensions.Redis</c> joins <see cref="Converted" /> as its own conversion lands (#3414);
-/// tests, examples and the documentation samples are deliberately never covered, because a plain call
-/// is the right thing to write in all three.
+/// The four packages #3414 names are covered. The rest of what ships joins <see cref="Converted" />
+/// with the sweep that finishes it; tests, examples and the documentation samples are deliberately
+/// never covered, because a plain call is the right thing to write in all three.
 /// </para>
 /// </remarks>
 public class LogCallSiteTest
@@ -28,6 +27,7 @@ public class LogCallSiteTest
     private static readonly string[] Converted =
     [
         "src/Quartz",
+        "src/Quartz.Extensions.Redis",
         "src/Quartz.Jobs",
         "src/Quartz.Plugins",
     ];

--- a/src/Quartz.Tests.Unit/LogEventCatalogTest.cs
+++ b/src/Quartz.Tests.Unit/LogEventCatalogTest.cs
@@ -51,6 +51,7 @@ public class LogEventCatalogTest
         typeof(global::Quartz.IScheduler).Assembly,
         typeof(global::Quartz.Plugins.Management.ShutdownHookPlugin).Assembly,
         typeof(global::Quartz.Jobs.DirectoryScanJob).Assembly,
+        typeof(global::Quartz.RedisLockHandlerConfigurationExtensions).Assembly,
     ];
 
     private static IEnumerable<TestCaseData> Assemblies()

--- a/src/Quartz.Tests.Unit/LogEventCatalogTest.cs
+++ b/src/Quartz.Tests.Unit/LogEventCatalogTest.cs
@@ -50,6 +50,7 @@ public class LogEventCatalogTest
     [
         typeof(global::Quartz.IScheduler).Assembly,
         typeof(global::Quartz.Plugins.Management.ShutdownHookPlugin).Assembly,
+        typeof(global::Quartz.Jobs.DirectoryScanJob).Assembly,
     ];
 
     private static IEnumerable<TestCaseData> Assemblies()

--- a/src/Quartz.Tests.Unit/PackageReadmeTest.cs
+++ b/src/Quartz.Tests.Unit/PackageReadmeTest.cs
@@ -96,39 +96,11 @@ public class PackageReadmeTest
     }
 
     public static IEnumerable<TestCaseData> PackableProjects() =>
-        FindPackableProjects().Select(x => new TestCaseData(x).SetArgDisplayNames(x.Directory!.Name));
+        ShippedProjects.Find().Select(x => new TestCaseData(x).SetArgDisplayNames(x.Directory!.Name));
 
     public static IEnumerable<TestCaseData> PackageReadmes() =>
-        FindPackableProjects()
+        ShippedProjects.Find()
             .Select(x => new FileInfo(Path.Combine(x.DirectoryName!, ReadmeFileName)))
             .Where(x => x.Exists)
             .Select(x => new TestCaseData(x).SetArgDisplayNames(x.Directory!.Name));
-
-    /// <summary>
-    /// Every project under <c>src</c> that produces a package. <c>Directory.Build.props</c> turns packing
-    /// on for the repository, so the packable ones are the ones that have not turned it back off.
-    /// </summary>
-    /// <remarks>
-    /// Only the project file at the top of each project directory. A recursive search would also find the
-    /// projects BenchmarkDotNet generates under <c>bin</c>, which are packable by default and would fail
-    /// every assertion here on a machine that has run the benchmarks.
-    /// </remarks>
-    private static List<FileInfo> FindPackableProjects()
-    {
-        List<FileInfo> projects = RepositoryRoot.Find()
-            .GetDirectories("src")
-            .Single()
-            .GetDirectories()
-            .SelectMany(x => x.GetFiles("*.csproj", SearchOption.TopDirectoryOnly))
-            .Where(x => !IsOptedOut(x))
-            .OrderBy(x => x.Name, StringComparer.Ordinal)
-            .ToList();
-
-        projects.Should().NotBeEmpty("the packable projects are found by walking the repository, and that walk must reach them");
-        return projects;
-    }
-
-    private static bool IsOptedOut(FileInfo project) => XDocument.Load(project.FullName)
-        .Descendants("IsPackable")
-        .Any(x => string.Equals(x.Value.Trim(), "false", StringComparison.OrdinalIgnoreCase));
 }

--- a/src/Quartz.Tests.Unit/Plugins/History/RecordingLoggerProvider.cs
+++ b/src/Quartz.Tests.Unit/Plugins/History/RecordingLoggerProvider.cs
@@ -1,10 +1,26 @@
+using System.Collections.Concurrent;
+
 using Microsoft.Extensions.Logging;
 
 namespace Quartz.Tests.Unit.Plugin.History;
 
+/// <summary>
+/// Records everything logged through it, so a test can assert on the text a sink would render, the
+/// level and the event id.
+/// </summary>
+/// <remarks>
+/// The recording is a concurrent queue rather than a list because not every caller logs from one
+/// thread — <c>NativeJob</c> relays a spawned process's two output streams from a thread each — and a
+/// test helper that corrupts itself under the thing it is watching is worse than no helper.
+/// </remarks>
 internal sealed class RecordingLoggerProvider : ILoggerProvider
 {
-    public List<LogEntry> Entries { get; } = [];
+    private readonly ConcurrentQueue<LogEntry> entries = new();
+
+    /// <summary>
+    /// What has been logged so far, as a snapshot taken when the property is read.
+    /// </summary>
+    public List<LogEntry> Entries => entries.ToList();
 
     public ILogger CreateLogger(string categoryName) => new RecordingLogger(this);
 
@@ -25,7 +41,7 @@ internal sealed class RecordingLoggerProvider : ILoggerProvider
             Exception exception,
             Func<TState, Exception, string> formatter)
         {
-            provider.Entries.Add(new LogEntry(logLevel, eventId, formatter(state, exception), exception));
+            provider.entries.Enqueue(new LogEntry(logLevel, eventId, formatter(state, exception), exception));
         }
     }
 }

--- a/src/Quartz.Tests.Unit/ShippedProjects.cs
+++ b/src/Quartz.Tests.Unit/ShippedProjects.cs
@@ -1,0 +1,38 @@
+using System.Xml.Linq;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The projects under <c>src</c> that produce a package, for the tests that assert something about
+/// what ships rather than about the code in it.
+/// </summary>
+internal static class ShippedProjects
+{
+    /// <summary>
+    /// Every project under <c>src</c> that produces a package. <c>Directory.Build.props</c> turns packing
+    /// on for the repository, so the packable ones are the ones that have not turned it back off.
+    /// </summary>
+    /// <remarks>
+    /// Only the project file at the top of each project directory. A recursive search would also find the
+    /// projects BenchmarkDotNet generates under <c>bin</c>, which are packable by default and belong to
+    /// no package.
+    /// </remarks>
+    public static List<FileInfo> Find()
+    {
+        List<FileInfo> projects = RepositoryRoot.Find()
+            .GetDirectories("src")
+            .Single()
+            .GetDirectories()
+            .SelectMany(x => x.GetFiles("*.csproj", SearchOption.TopDirectoryOnly))
+            .Where(x => !IsOptedOut(x))
+            .OrderBy(x => x.Name, StringComparer.Ordinal)
+            .ToList();
+
+        projects.Should().NotBeEmpty("the packable projects are found by walking the repository, and that walk must reach them");
+        return projects;
+    }
+
+    private static bool IsOptedOut(FileInfo project) => XDocument.Load(project.FullName)
+        .Descendants("IsPackable")
+        .Any(x => string.Equals(x.Value.Trim(), "false", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.Extensions.Redis.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.Extensions.Redis.verified.txt
@@ -1,0 +1,20 @@
+﻿8000  Debug  RedisLockHandlerLog.LockDesired
+    "Lock '{LockName}' is desired by: {RequestorId}"
+8001  Debug  RedisLockHandlerLog.LockAlreadyOwned
+    "Lock '{LockName}' already owned by: {RequestorId}"
+8002  Debug  RedisLockHandlerLog.LockBeingObtained
+    "Lock '{LockName}' is being obtained: {RequestorId}"
+8003  Debug  RedisLockHandlerLog.LockNotObtainedCancelled
+    "Lock '{LockName}' was not obtained by: {RequestorId} - cancelled"
+8004  Debug  RedisLockHandlerLog.LockGiven
+    "Lock '{LockName}' given to: {RequestorId}"
+8005  Warning  RedisLockHandlerLog.LockReturnedByNonOwner
+    "Lock '{LockName}' attempt to return by: {RequestorId} -- but not owner!"
+8006  Warning  RedisLockHandlerLog.WrongfulReturnerStack
+    "stack-trace of wrongful returner: {StackTrace}"
+8007  Debug  RedisLockHandlerLog.LockReturned
+    "Lock '{LockName}' returned by: {RequestorId}"
+8008  Warning  RedisLockHandlerLog.LockReleaseFailed
+    "Failed to release Redis lock '{LockName}'"
+8009  Information  RedisLockHandlerLog.ConnectingToRedis
+    "Connecting to Redis"

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.Jobs.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.Jobs.verified.txt
@@ -1,0 +1,28 @@
+﻿7000  Information  DirectoryScanJobLog.DirectoryContentsUpdated
+    "Directory {DirectoryName} contents updated, notifying listener."
+7001  Debug  DirectoryScanJobLog.DirectoryContentsUnchanged
+    "Directory '{Directory}' contents unchanged."
+7002  Warning  DirectoryScanJobLog.DirectoryDoesNotExist
+    "Directory '{DirectoryName}' does not exist."
+7010  Debug  DirectoryScanJobLog.SomeTypesNotLoaded
+    "Could not load some types from assembly {AssemblyName} while scanning for IDirectoryScanListener"
+7011  Debug  DirectoryScanJobLog.AssemblyNotLoaded
+    "Could not load assembly {AssemblyName} while scanning for IDirectoryScanListener"
+7100  Warning  FileScanJobLog.FileDoesNotExist
+    "File '{FileName}' does not exist."
+7101  Information  FileScanJobLog.FileUpdated
+    "File '{FileName}' updated, notifying listener."
+7102  Debug  FileScanJobLog.FileUnchanged
+    "File '{FileName}' unchanged."
+7200  Information  NativeJobLog.AboutToRun
+    "About to run {Command} {Temp}..."
+7201  Information  NativeJobLog.StandardOutputLine
+    "stdout>{Line}"
+7202  Warning  NativeJobLog.StandardErrorLine
+    "stderr>{Line}"
+7203  Error  NativeJobLog.StreamConsumptionFailed
+    "Error consuming {Type} stream of spawned process."
+7300  Warning  SendMailJobLog.CredentialsReadFromJobData
+    "SMTP credentials are being read from job data ('{UserNameKey}' / '{PasswordKey}'), which a persistent job store writes to the database and replicates to every node in the cluster. Register an ICredentialsByHost with the container instead."
+7301  Information  SendMailJobLog.SendingMessage
+    "Sending message {MailMessage}"


### PR DESCRIPTION
Parts 3 and 4 of 4 for #3414, and the wrap-up that finishes it. #3450 did `Quartz`, #3467 did
`Quartz.Plugins`, and this is the shape they set.

## What changed

| Package | Plain calls | Events | Classes |
|---|---:|---:|---|
| `Quartz.Jobs` | 14 | 14 | `DirectoryScanJobLog` 7000–7099, `FileScanJobLog` 7100–7199, `NativeJobLog` 7200–7299, `SendMailJobLog` 7300–7399 |
| `Quartz.Extensions.Redis` | 11 | 10 | `RedisLockHandlerLog` 8000–8099 |
| `Quartz.AspNetCore` | 5 | 5 | `HttpApiLog` 9000–9099 |

Redis is ten events for eleven calls because the two sites that report a cancelled acquisition spell
one message; the rest are one for one. `DirectoryScanJobLog` splits its range by a gap the way part 2
did — 7000–7009 is the job, 7010–7019 the model that finds its listener.

`Quartz.AspNetCore` is not one of the four packages #3414 names. It is here because the issue's point
is that logging is unguarded, and finishing four packages while a fifth still ships five plain calls
leaves the guard with something outside it. Five calls, one class, no ambiguity about the range.

## The one template that changed

Everything else is verbatim — same level, same template, same exception attached. Only `NativeJob`'s
process output moved:

| Old | New | Why |
|---|---|---|
| `"{Type}>{Line}"` at Information for stdout and at Warning for stderr, `Type` interpolated from the stream name | `"stdout>{Line}"` at Information (7201) and `"stderr>{Line}"` at Warning (7202) | What follows the `>` is a line of the child process's own text, which has no structure this package can name — the degenerate-template case part 1 met as `{Problem}` and part 2 as `{Message}`. One event per stream is the honest shape: the text a sink renders is unchanged, and which stream a line came out of becomes an id an operator filters rather than a property value they match. A structured sink that indexed the `Type` property no longer gets one; that is the trade, and the migration guide says so |

`NativeJobStreamLoggingTest` runs a process and reads back what was logged. The catalogue snapshot
pins the two templates, but only a test that runs something can say the right one is called for the
right stream — a swapped branch is the single way this could have gone wrong with nothing else
noticing, and both tests fail when the branches are swapped. `RecordingLoggerProvider` records into a
`ConcurrentQueue` now, because `NativeJob` relays its two streams from a thread each.

`"Error consuming {Type} stream of spawned process."` stays one event with a placeholder: that one is
a real template with a real named value, not a line of somebody else's text.

## `RedisLockHandlerLog`, not `RedisSemaphoreLog`

The type that raises these events is still called `RedisSemaphore` until #3440 renames it. A catalogue
named after its caller is a catalogue that gets renamed when the caller does, and an event class is
exactly the thing that must not move — so it is named for the concept and #3440 will not touch it.

Half its vocabulary is word for word what `LockHandlerLog` raises at 3700–3799. They are separate
events, on the call part 1 and part 2 both made: an id names one event raised in one place, and an
operator filtering 8005 is asking about the Redis handler, not about whichever handler happened to say
the same sentence.

## The guards now cover everything that ships

* **`LogEventCatalogTest.Catalogued`** gains `Quartz.Jobs` and `Quartz.Extensions.Redis`, with
  `LogEventCatalogTest_Quartz.Jobs.verified.txt` and
  `LogEventCatalogTest_Quartz.Extensions.Redis.verified.txt`.
* **A companion `LogEventCatalogTest` in `Quartz.Tests.AspNetCore`** snapshots `Quartz.AspNetCore`.
  `Quartz.Tests.Unit` cannot reference an assembly that needs ASP.NET Core, which is the same split
  `PublicApiTest` already makes for the same reason. Each of the two owns the ranges for the
  assemblies it snapshots, so no range is written down twice and neither copy can go stale.
* **`LogCallSiteTest.Converted`** is every packable project under `src/`: `Quartz`, `Quartz.AspNetCore`,
  `Quartz.Dashboard`, `Quartz.Extensions.Redis`, `Quartz.HttpClient`, `Quartz.Jobs`, `Quartz.Plugins`,
  `Quartz.Plugins.TimeZoneConverter`, `Quartz.Serialization.Newtonsoft`. The last four had nothing to
  convert — they make no `ILogger` call at all — and are listed so that the day they start logging is
  the day the guard is already there.
* **`LogCallSiteTest.EveryPackableProjectIsCovered`** is new, and asserts the covered list *is* the
  packable list, in both directions. Without it a package added after this conversion would ship
  unguarded and would look exactly like a package with nothing to convert, because both spend their
  whole life passing every other test in the file. Finding the packable projects moved out of
  `PackageReadmeTest` into `ShippedProjects`, which is now two tests' question.

Not covered, deliberately, and the test's remarks say why: `Quartz.Examples*` and
`Quartz.Documentation.Samples` are application code shown to a reader, and application code logs with
`logger.LogInformation(…)` — a sample that routed its one message through a generated class would be
teaching the wrong lesson about how to use Quartz. `Quartz.Server`, `Quartz.Benchmark`,
`Quartz.Trimming.Canary` and the test projects have no operator to serve at all.

## `CA1848` comes out of `NoWarn`

Part 1 said it comes out with part 4, and it is out of `Directory.Build.props`. It is off again for
`$(IsPackable) != 'true'`, in `Directory.Build.targets` beside the banned-API rule that keys on the
same property and for the same reason — that is the boundary above, said to the compiler instead of to
a source scan. The two are complementary rather than redundant: `CA1848` sees a call in a `.razor`
file's `@code` block, which a scan of `.cs` files does not.

`StructuredLoggingJobHistoryPlugin` and `StructuredLoggingTriggerHistoryPlugin` do ship and do keep
their plain calls — part 2's decision, unchanged — so each carries a `[SuppressMessage]` with the
reason, in the file whose behaviour depends on it. `LogCallSiteTest.Allowed` already recorded the same
decision from the source side; now both sides say it, and neither can quietly drift.

## For a reviewer to decide

* **`Quartz.AspNetCore` was not in the issue's scope.** I converted it and gave it 9000–9099 anyway,
  for the reason above. If you would rather it were its own pull request, the third commit is
  self-contained and lifts out cleanly.
* **`"About to run {Command} {Temp}..."` keeps `{Temp}`.** The placeholder is named after a local
  variable rather than after the thing it holds, which is the command's arguments. I left it, because
  the campaign's rule is templates verbatim and a placeholder rename is a structured-property rename —
  the rendered text would not change but a dashboard querying `Temp` would break. Say the word and it
  becomes `{Arguments}` while the id is still new.
* **`NativeJob`'s two streams are two events.** The alternative is one event keeping `{Type}` as a
  placeholder, which preserves the property and costs the separate filterability; I took the reading
  the spec asked for and wrote the trade into the migration guide.
* **`EveryPackableProjectIsCovered` is more than #3414 asked for.** The issue asked for the covered
  list to grow; this makes it grow by itself. It is the piece I would most expect a reviewer to want to
  argue about, because it means a future package must decide about logging on the day it is added.
* **A second `LogEventCatalogTest`, in `Quartz.Tests.AspNetCore`.** ~90 lines of the reflection and
  formatting are the same as the one in `Quartz.Tests.Unit`. The alternative was making
  `Quartz.Tests.Unit` reference `Quartz.AspNetCore` and so the ASP.NET Core shared framework, which is
  a bigger change to a project that is otherwise plain, and which `PublicApiTest` already declined to
  make.

## Verification

```
dotnet build Quartz.slnx                            0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit                   Passed: 3395, Failed: 0, Skipped: 4
dotnet test src/Quartz.Tests.AspNetCore             Passed:  448, Failed: 0, Skipped: 0
QUARTZ_TEST_DATABASE=basic dotnet test
  src/Quartz.Tests.Integration (non-db categories)  Passed:  318, Failed: 0, Skipped: 0
QUARTZ_TEST_DATABASE=redis dotnet test
  src/Quartz.Tests.Integration --filter db-redis    Passed:   12, Failed: 0, Skipped: 0
dotnet fallout VerifyDocsSnippets                   Succeeded (90 markdown files checked)
grep -rnE "\.Log(Trace|Debug|Information|Warning|Error|Critical)\(|\.Log\(LogLevel" \
  src/Quartz src/Quartz.AspNetCore src/Quartz.Dashboard src/Quartz.Extensions.Redis \
  src/Quartz.HttpClient src/Quartz.Jobs src/Quartz.Plugins \
  src/Quartz.Plugins.TimeZoneConverter src/Quartz.Serialization.Newtonsoft
                                                    7 matches, all in the two Structured* plugins
```

Docker was up, so the basic and redis integration legs really ran. The same grep over `*.razor` finds
nothing.

The public API baselines are untouched: every generated class is `internal`, and both `PublicApiTest`s
pass unchanged.

Expect the SonarCloud coverage gate to go red, for the recorded attribution reason rather than for
anything in this diff.

Closes #3414.
