### PR TITLE
A daily calendar's window is a local window, however the question is asked

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 
 using Quartz.Impl.Calendar;
 
@@ -369,19 +370,18 @@ public class CalendarDstTests
     }
 
     /// <summary>
-    /// A daily calendar was already right on these days, and this says why. It builds its day
-    /// boundaries at the queried instant's offset too, but compares them only with values carrying
-    /// that same offset, so every comparison it makes is a wall-clock one and stays correct whatever
-    /// the offset is. The window therefore lands where the wall clock says even on the day whose
-    /// midnight never happens, and on the day whose last hour happens twice it catches both passes.
+    /// A daily calendar's day boundary was already right on these days, and this says why. It builds
+    /// its day boundaries at the queried instant's offset too, but compares them only with values
+    /// carrying that same offset, so every comparison it makes is a wall-clock one and stays correct
+    /// whatever the offset is. The window therefore lands where the wall clock says even on the day
+    /// whose midnight never happens, and on the day whose last hour happens twice it catches both
+    /// passes.
     /// </summary>
     /// <remarks>
     /// These are <see cref="ICalendar.IsTimeIncluded" /> cases only.
-    /// <see cref="DailyCalendar.GetNextIncludedTimeUtc" /> computes its window and day boundaries in
-    /// the offset the <em>argument</em> carries rather than in the calendar's zone, so asking it in
-    /// UTC about a calendar in another zone walks a millisecond at a time and can step over an
-    /// included window entirely. That is a separate defect from the day boundary this fixture is
-    /// about, it predates it, and it is not fixed here.
+    /// <see cref="DailyCalendar.GetNextIncludedTimeUtc" /> had a defect of its own, which the cases
+    /// below this one are about: it computed the window and the day boundaries in the offset the
+    /// <em>argument</em> carried rather than in the calendar's zone (#3466).
     /// </remarks>
     [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T03:30:00Z", true)]
     [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T04:30:00Z", false)]
@@ -409,6 +409,239 @@ public class CalendarDstTests
         calendar.IsTimeIncluded(instant).Should().Be(expectedIncluded,
             "{0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local and the excluded window is {2:HH:mm}-{3:HH:mm} of every local day",
             instant, TimeZoneInfo.ConvertTime(instant, zone), from, to);
+    }
+
+    /// <summary>
+    /// The other half of the daily calendar's contract, on the days where the wall clock and elapsed
+    /// time part company: the next included time is the first instant the window lets go of, and it
+    /// is the same instant however the question is phrased.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It was not (#3466). The window's edges were named on the date the <em>argument</em> fell on
+    /// and paired with the offset it carried, while <see cref="ICalendar.IsTimeIncluded" /> converted
+    /// into the calendar's zone first, so a question asked in UTC about a calendar keeping another
+    /// zone's hours was answered against a window an offset away from the one being tested. The walk
+    /// then fell through to its last resort, a millisecond at a time, and could step clean over an
+    /// included stretch on the way.
+    /// </para>
+    /// <para>
+    /// Each case states the answer it expects, and
+    /// <see cref="AssertDailyCalendarNextIncludedTime" /> holds it to the rest of the contract:
+    /// the answer is included, nothing between the question and the answer is, and asking in the
+    /// calendar's own zone rather than in UTC gives the same instant back.
+    /// </para>
+    /// </remarks>
+    // The reproduction from #3466: this one spun for some two and a half minutes and answered five
+    // months late, because 21:00-22:00 read as UTC is never 21:00-22:00 read in Santiago.
+    [TestCase("SantiagoFall", "21:00", "22:00", true, "2019-04-07T01:30:00Z", "2019-04-08T01:00:00Z")]
+    // The window's edges are inside the hour that happens twice, so the day opens twice as well: once
+    // on each pass, and a question standing in the second pass is answered from the second.
+    [TestCase("SantiagoFall", "23:00", "23:30", false, "2019-04-07T02:15:00Z", "2019-04-07T02:30:00.001Z")]
+    [TestCase("SantiagoFall", "23:00", "23:30", false, "2019-04-07T03:15:00Z", "2019-04-07T03:30:00.001Z")]
+    // A window that runs to the end of the local day opens again at the next local midnight, which on
+    // the 25 hour day is two hours further off than the wall clock makes it look...
+    [TestCase("SantiagoFall", "22:00", "23:59:59.999", false, "2019-04-07T01:30:00Z", "2019-04-07T04:00:00Z")]
+    // ...and on the 23 hour day is a midnight that never happens, so the day opens at the end of the
+    // gap instead.
+    [TestCase("SantiagoSpring", "22:00", "23:59:59.999", false, "2019-09-08T02:00:00Z", "2019-09-08T04:00:00Z")]
+    // An inverted window that begins at that same missing midnight is one instant wide: only its
+    // inclusive end survives the gap.
+    [TestCase("SantiagoSpring", "00:00", "01:00", true, "2019-09-07T20:00:00Z", "2019-09-08T04:00:00Z")]
+    // The clock going back does not only repeat an hour, it takes the day back to before the window
+    // opened, so the calendar lets go at the transition itself rather than at the window's end.
+    [TestCase("HelsinkiFall", "03:30", "04:30", false, "2024-10-27T00:40:00Z", "2024-10-27T01:00:00Z")]
+    [TestCase("HelsinkiFall", "03:00", "03:15", true, "2024-10-27T00:20:00Z", "2024-10-27T01:00:00Z")]
+    // An edge inside the spring-forward gap is no instant at all; the day turns over at the end of
+    // the gap, not an hour past it.
+    [TestCase("HelsinkiSpring", "02:30", "03:30", false, "2024-03-31T00:45:00Z", "2024-03-31T01:00:00Z")]
+    [TestCase("HelsinkiSpring", "03:30", "04:30", true, "2024-03-31T00:30:00Z", "2024-03-31T01:00:00Z")]
+    // The controls: the same calendars on a day whose clocks do not move.
+    [TestCase("Santiago", "21:00", "22:00", true, "2019-06-15T22:00:00Z", "2019-06-16T01:00:00Z")]
+    [TestCase("Helsinki", "03:30", "04:30", false, "2024-06-15T01:00:00Z", "2024-06-15T01:30:00.001Z")]
+    public void DailyCalendar_NextIncludedTime_IsTheFirstInstantTheWindowLetsGoOf(
+        string zoneKey,
+        string fromText,
+        string toText,
+        bool inverted,
+        string askedAtText,
+        string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForCase(zoneKey);
+
+        DailyCalendar calendar = new DailyCalendar(
+            TimeOnly.Parse(fromText, System.Globalization.CultureInfo.InvariantCulture),
+            TimeOnly.Parse(toText, System.Globalization.CultureInfo.InvariantCulture))
+        {
+            InvertTimeRange = inverted,
+            TimeZone = zone
+        };
+
+        AssertDailyCalendarNextIncludedTime(calendar, zone, ParseUtc(askedAtText), ParseUtc(expectedText));
+    }
+
+    /// <summary>
+    /// Asked about an instant it already includes, a calendar answers with the very next millisecond
+    /// - there being nothing to wait for. The days these are asked on are the awkward ones, because
+    /// the shape of the answer must not depend on where in a transition the question lands.
+    /// </summary>
+    [TestCase("SantiagoFall", "21:00", "22:00", true, "2019-04-08T01:30:00Z")]
+    [TestCase("HelsinkiFall", "03:30", "04:30", false, "2024-10-27T03:00:00Z")]
+    [TestCase("SantiagoSpring", "22:00", "23:59:59.999", false, "2019-09-08T04:00:00Z")]
+    public void DailyCalendar_NextIncludedTime_WhenTheDayIsAlreadyOpen_IsTheNextMillisecond(
+        string zoneKey,
+        string fromText,
+        string toText,
+        bool inverted,
+        string askedAtText)
+    {
+        TimeZoneInfo zone = ZoneForCase(zoneKey);
+        DateTimeOffset askedAt = ParseUtc(askedAtText);
+
+        DailyCalendar calendar = new DailyCalendar(
+            TimeOnly.Parse(fromText, System.Globalization.CultureInfo.InvariantCulture),
+            TimeOnly.Parse(toText, System.Globalization.CultureInfo.InvariantCulture))
+        {
+            InvertTimeRange = inverted,
+            TimeZone = zone
+        };
+
+        calendar.IsTimeIncluded(askedAt).Should().BeTrue(
+            "the premise of the case: {0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local, which this calendar includes",
+            askedAt, TimeZoneInfo.ConvertTime(askedAt, zone));
+
+        calendar.GetNextIncludedTimeUtc(askedAt).Should().Be(askedAt.AddMilliseconds(1),
+            "the next included time after an included instant is the one right after it");
+    }
+
+    /// <summary>
+    /// The measured symptom of #3466, which is what made it a bug worth a number rather than an
+    /// inaccuracy: the answer was not merely wrong, it was arrived at a millisecond at a time.
+    /// </summary>
+    /// <remarks>
+    /// Two bounds, because each says something the other does not. The call count is exact and does
+    /// not care how fast the machine is: a base calendar that includes everything is asked once per
+    /// pass of the loop, so counting its calls counts the passes. The elapsed time is what a user
+    /// noticed, and its bound is loose enough that only a walk could break it - the run this replaced
+    /// took about 150 seconds.
+    /// </remarks>
+    [Test]
+    public void DailyCalendar_NextIncludedTime_IsJumpedToRatherThanWalkedUpTo()
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay("SantiagoFall");
+
+        CountingCalendar passes = new CountingCalendar();
+        DailyCalendar calendar = new DailyCalendar(new TimeOnly(21, 0), new TimeOnly(22, 0), passes)
+        {
+            InvertTimeRange = true,
+            TimeZone = zone
+        };
+
+        DateTimeOffset askedAt = ParseUtc("2019-04-07T01:30:00Z");
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        DateTimeOffset actual = calendar.GetNextIncludedTimeUtc(askedAt);
+        stopwatch.Stop();
+
+        actual.Should().Be(ParseUtc("2019-04-08T01:00:00Z"),
+            "the window is 21:00-22:00 in Santiago, and the first of those hours after {0:O} begins at {1:O}",
+            askedAt, ParseUtc("2019-04-08T01:00:00Z"));
+
+        passes.Calls.Should().BeLessThan(10,
+            "the answer is named from the window's own edges, where the walk it replaced tested every one of the 84.6 million milliseconds in between");
+
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5),
+            "a bound no jump can miss and no millisecond walk can meet");
+    }
+
+    /// <summary>
+    /// A base calendar that includes every instant and counts the times it was asked. Attaching one
+    /// counts the passes <see cref="DailyCalendar.GetNextIncludedTimeUtc" /> makes without the
+    /// calendar having to carry a counter of its own, since the loop asks its base calendar once per
+    /// pass and this one never changes the answer.
+    /// </summary>
+    private sealed class CountingCalendar : BaseCalendar
+    {
+        public int Calls { get; private set; }
+
+        public override bool IsTimeIncluded(DateTimeOffset timeStampUtc)
+        {
+            Calls++;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Asserts the whole of the daily calendar's <c>GetNextIncludedTimeUtc</c> contract for one case:
+    /// the instant asked about is excluded, the answer is the expected one, the answer is included,
+    /// nothing between the two is, and the same question asked in the calendar's own zone rather than
+    /// in UTC is answered with the same instant.
+    /// </summary>
+    private static void AssertDailyCalendarNextIncludedTime(
+        DailyCalendar calendar,
+        TimeZoneInfo zone,
+        DateTimeOffset askedAt,
+        DateTimeOffset expected)
+    {
+        calendar.IsTimeIncluded(askedAt).Should().BeFalse(
+            "the premise of the case: {0:O} reads as {1:yyyy-MM-dd HH:mm:ss.fff zzz} local, which this calendar excludes",
+            askedAt, TimeZoneInfo.ConvertTime(askedAt, zone));
+
+        calendar.IsTimeIncluded(expected).Should().BeTrue(
+            "and {0:O}, which reads as {1:yyyy-MM-dd HH:mm:ss.fff zzz} local, is not excluded",
+            expected, TimeZoneInfo.ConvertTime(expected, zone));
+
+        // How close to the answer the walk may come. Usually the millisecond before it, but where the
+        // answer is the instant the clocks moved, only to the minute: the exact instant a zone
+        // changes offset is not agreed on to the millisecond, because Windows cannot express a rule
+        // at local midnight and writes 23:59:59.999 of the day before instead, which puts the end of
+        // Santiago's spring-forward gap a millisecond earlier there than on IANA data.
+        TimeSpan slack = zone.GetUtcOffset(expected) == zone.GetUtcOffset(expected.AddMinutes(-1))
+            ? TimeSpan.FromMilliseconds(1)
+            : TimeSpan.FromMinutes(1);
+
+        calendar.IsTimeIncluded(expected - slack).Should().BeFalse(
+            "and it is the first such instant - {0} earlier reads as {1:yyyy-MM-dd HH:mm:ss.fff zzz} local, which is still excluded",
+            slack, TimeZoneInfo.ConvertTime(expected - slack, zone));
+
+        AssertNothingIncludedBetween(calendar, zone, askedAt, expected - slack);
+
+        DateTimeOffset askedInUtc = calendar.GetNextIncludedTimeUtc(askedAt);
+        askedInUtc.Should().Be(expected,
+            "the next included time after an excluded instant is the first instant the calendar includes, and {0:O} reads as {1:yyyy-MM-dd HH:mm:ss.fff zzz} local (included={2})",
+            askedInUtc, TimeZoneInfo.ConvertTime(askedInUtc, zone), calendar.IsTimeIncluded(askedInUtc));
+
+        DateTimeOffset askedInZone = calendar.GetNextIncludedTimeUtc(TimeZoneInfo.ConvertTime(askedAt, zone));
+        askedInZone.Should().Be(expected,
+            "the same instant asked about in the calendar's own zone rather than in UTC is the same question, so it has the same answer");
+    }
+
+    /// <summary>
+    /// Walks the span between a question and its answer a second at a time, so that an answer which
+    /// stepped over an included stretch fails rather than passes. A second rather than a millisecond
+    /// because every window in this fixture opens and closes on a whole minute; how close to the
+    /// answer the walk comes is the caller's business.
+    /// </summary>
+    private static void AssertNothingIncludedBetween(ICalendar calendar, TimeZoneInfo zone, DateTimeOffset after, DateTimeOffset until)
+    {
+        (until - after).Should().BeLessThan(TimeSpan.FromDays(2),
+            "the scan below walks the whole span, so a case has to keep it short enough to walk");
+
+        DateTimeOffset? included = null;
+        for (DateTimeOffset instant = after.AddSeconds(1); instant <= until; instant = instant.AddSeconds(1))
+        {
+            if (calendar.IsTimeIncluded(instant))
+            {
+                included = instant;
+                break;
+            }
+        }
+
+        included.Should().BeNull(
+            "nothing between {0:O} and the answer {1:O} may be included, or the answer is not the first one; this instant reads as {2} local",
+            after,
+            until,
+            included is null ? "-" : TimeZoneInfo.ConvertTime(included.Value, zone).ToString("yyyy-MM-dd HH:mm:ss zzz", System.Globalization.CultureInfo.InvariantCulture));
     }
 
     /// <summary>
@@ -453,6 +686,18 @@ public class CalendarDstTests
             default:
                 throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test zone");
         }
+    }
+
+    /// <summary>
+    /// The zone a case runs in, whether it names a transition day or a plain zone. A case grid that
+    /// mixes the two - a transition day and the ordinary day that controls it - names them the same
+    /// way and lets this tell them apart.
+    /// </summary>
+    private static TimeZoneInfo ZoneForCase(string key)
+    {
+        return key.EndsWith("Spring", StringComparison.Ordinal) || key.EndsWith("Fall", StringComparison.Ordinal)
+            ? ZoneForTransitionDay(key)
+            : ResolveZone(key);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/TimeZonesTest.cs
+++ b/src/Quartz.Tests.Unit/TimeZonesTest.cs
@@ -188,6 +188,63 @@ public class TimeZonesTest
         TimeZones.WalkToGapEnd(alreadyValid, zone).Should().Be(alreadyValid, "a valid time is returned unchanged");
     }
 
+    // A boundary inside a spring-forward gap is crossed the moment the clocks move, which is earlier
+    // than the instant ResolveLocal hands a trigger for the same wall clock. The second case is why
+    // the gap is walked from the whole minute: a boundary a millisecond into the gap is still crossed
+    // at the transition, not a millisecond after it.
+    [TestCase("Eastern", "2024-03-10 02:30", "2024-03-10 03:00")]
+    [TestCase("Eastern", "2024-03-10 02:30:00.001", "2024-03-10 03:00")]
+    [TestCase("LordHowe", "2019-10-06 02:15", "2019-10-06 02:30")]
+    [TestCase("Santiago", "2019-09-08 00:30", "2019-09-08 01:00")]
+    public void FirstInstantAtOrAfterLocal_InvalidLocalTime_IsTheInstantTheClocksMoved(string zoneKey, string invalidLocal, string expectedRenderedLocal)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(invalidLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, local);
+
+        DateTimeOffset first = TimeZones.FirstInstantAtOrAfterLocal(local, zone);
+
+        TimeZoneInfo.ConvertTime(first, zone).DateTime
+            .Should().Be(DateTime.Parse(expectedRenderedLocal, CultureInfo.InvariantCulture),
+                "the clock reads the end of the gap the moment it passes a boundary inside it");
+
+        first.Should().BeBefore(TimeZones.ResolveLocal(local, zone),
+            "ResolveLocal answers a trigger's question - when does this wall clock happen - by shifting past the gap, which is later than the moment the clock passed the boundary");
+    }
+
+    [Test]
+    public void FirstInstantAtOrAfterLocal_LocalTimeThatExists_IsWhereResolveLocalPutsIt()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+
+        DateTime ambiguous = new DateTime(2024, 11, 3, 1, 30, 0);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, ambiguous);
+        TimeZones.FirstInstantAtOrAfterLocal(ambiguous, zone).Should().Be(TimeZones.ResolveLocal(ambiguous, zone),
+            "a wall clock that happens twice is first read at the first of the two");
+
+        DateTime plain = new DateTime(2024, 6, 15, 12, 0, 0);
+        TimeZones.FirstInstantAtOrAfterLocal(plain, zone).Should().Be(TimeZones.ResolveLocal(plain, zone),
+            "and one that happens once is read then");
+    }
+
+    [TestCase("Eastern", "2024-11-03 01:30", "2024-11-03T06:30:00Z")]
+    [TestCase("Santiago", "2019-04-06 23:30", "2019-04-07T03:30:00Z")]
+    [TestCase("LordHowe", "2019-04-07 01:45", "2019-04-06T15:15:00Z")]
+    public void TryResolveSecondPass_AmbiguousLocalTime_IsTheOccurrenceAfterTheTransition(string zoneKey, string ambiguousLocal, string expectedUtc)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(ambiguousLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        TimeZones.TryResolveSecondPass(local, zone, out DateTimeOffset second).Should().BeTrue();
+
+        second.Should().Be(DateTimeOffset.Parse(expectedUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+        second.Should().BeAfter(TimeZones.ResolveLocal(local, zone), "the second pass of a repeated wall clock comes after the first");
+        TimeZoneInfo.ConvertTime(second, zone).DateTime.Should().Be(local, "and it reads as the same wall clock");
+
+        TimeZones.TryResolveSecondPass(local.Date.AddHours(12), zone, out _).Should().BeFalse("noon is not ambiguous");
+    }
+
     [Test]
     public void ResolveLocal_NegativeDaylightDeltaZone_DoesNotMoveBackwards()
     {

--- a/src/Quartz/Impl/Calendar/DailyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/DailyCalendar.cs
@@ -164,29 +164,36 @@ public sealed class DailyCalendar : BaseCalendar, IEquatable<DailyCalendar>
         }
 
         //Before we start, apply the correct timezone offsets.
-        timeUtc = TimeZones.ConvertTime(timeUtc, TimeZone);
+        return IsInsideTheOpenPartOfTheDay(TimeZones.ConvertTime(timeUtc, TimeZone));
+    }
 
-        DateTimeOffset startOfDayInMillis = GetStartOfDay(timeUtc);
-        DateTimeOffset endOfDayInMillis = GetEndOfDay(timeUtc);
-        DateTimeOffset timeRangeStartingTimeInMillis = GetTimeRangeStartingTimeUtc(timeUtc);
-        DateTimeOffset timeRangeEndingTimeInMillis = GetTimeRangeEndingTimeUtc(timeUtc);
+    /// <summary>
+    /// The calendar's own rule with no base calendar in it: whether the given instant, already
+    /// expressed in <see cref="BaseCalendar.TimeZone" />, reads as a wall clock this calendar
+    /// includes.
+    /// </summary>
+    /// <remarks>
+    /// Every value it compares against carries the same offset as <paramref name="timeInZone" />, so
+    /// every comparison it makes is a wall-clock one. That is what makes the window mean the same
+    /// thing on a day that is 23 or 25 hours long as it does on any other day: an hour of exclusion
+    /// as written can be no elapsed time at all, or two hours of it.
+    /// </remarks>
+    private bool IsInsideTheOpenPartOfTheDay(DateTimeOffset timeInZone)
+    {
+        DateTimeOffset startOfDayInMillis = GetStartOfDay(timeInZone);
+        DateTimeOffset endOfDayInMillis = GetEndOfDay(timeInZone);
+        DateTimeOffset timeRangeStartingTimeInMillis = GetTimeRangeStartingTimeUtc(timeInZone);
+        DateTimeOffset timeRangeEndingTimeInMillis = GetTimeRangeEndingTimeUtc(timeInZone);
         if (!InvertTimeRange)
         {
-            if (timeUtc >= startOfDayInMillis &&
-                timeUtc < timeRangeStartingTimeInMillis ||
-                timeUtc > timeRangeEndingTimeInMillis &&
-                timeUtc <= endOfDayInMillis)
-            {
-                return true;
-            }
-            return false;
+            return timeInZone >= startOfDayInMillis &&
+                   timeInZone < timeRangeStartingTimeInMillis ||
+                   timeInZone > timeRangeEndingTimeInMillis &&
+                   timeInZone <= endOfDayInMillis;
         }
-        if (timeUtc >= timeRangeStartingTimeInMillis &&
-            timeUtc <= timeRangeEndingTimeInMillis)
-        {
-            return true;
-        }
-        return false;
+
+        return timeInZone >= timeRangeStartingTimeInMillis &&
+               timeInZone <= timeRangeEndingTimeInMillis;
     }
 
     /// <summary>
@@ -194,6 +201,16 @@ public sealed class DailyCalendar : BaseCalendar, IEquatable<DailyCalendar>
     /// Calendar after the given time. Return the original value if timeStamp is
     /// included. Return 0 if all days are excluded.
     /// </summary>
+    /// <remarks>
+    /// The question is answered in <see cref="BaseCalendar.TimeZone" /> whatever offset it is asked
+    /// in, because the window is a wall-clock window of the calendar's own zone: the argument is
+    /// converted first, exactly as <see cref="IsTimeIncluded" /> converts it, and the day's edges are
+    /// named as wall-clock times on the local date and resolved back to instants there. Computing
+    /// them at the offset the argument happened to carry made the two methods disagree whenever those
+    /// offsets differed, and the walk then crept forward a millisecond at a time through a stretch it
+    /// had already been told was excluded - minutes of spinning for an answer months out of place
+    /// (#3466).
+    /// </remarks>
     /// <param name="timeUtc"></param>
     /// <returns></returns>
     /// <seealso cref="ICalendar.GetNextIncludedTimeUtc"/>
@@ -203,68 +220,124 @@ public sealed class DailyCalendar : BaseCalendar, IEquatable<DailyCalendar>
 
         while (!IsTimeIncluded(nextIncludedTime))
         {
-            if (!InvertTimeRange)
+            DateTimeOffset candidate;
+            if (!IsInsideTheOpenPartOfTheDay(TimeZones.ConvertTime(nextIncludedTime, TimeZone)))
             {
-                //If the time is in a range excluded by this calendar, we can
-                // move to the end of the excluded time range and continue
-                // testing from there. Otherwise, if nextIncludedTime is
-                // excluded by the baseCalendar, ask it the next time it
-                // includes and begin testing from there. Failing this, add one
-                // millisecond and continue testing.
-                if (nextIncludedTime >=
-                    GetTimeRangeStartingTimeUtc(nextIncludedTime) &&
-                    nextIncludedTime <=
-                    GetTimeRangeEndingTimeUtc(nextIncludedTime))
-                {
-                    nextIncludedTime =
-                        GetTimeRangeEndingTimeUtc(nextIncludedTime).AddMilliseconds(OneMillis);
-                }
-                else if (CalendarBase is not null &&
-                         !CalendarBase.IsTimeIncluded(nextIncludedTime))
-                {
-                    nextIncludedTime =
-                        CalendarBase.GetNextIncludedTimeUtc(nextIncludedTime);
-                }
-                else
-                {
-                    nextIncludedTime = nextIncludedTime.AddMilliseconds(1);
-                }
+                // The calendar's own window is what holds this time back, and the window's own edges
+                // say when it lets go, so jump there rather than testing what lies between.
+                candidate = NextTimeThisCalendarIncludes(nextIncludedTime);
+            }
+            else if (CalendarBase is not null &&
+                     !CalendarBase.IsTimeIncluded(nextIncludedTime))
+            {
+                // The window is open and the base calendar is what holds the time back; it knows when
+                // it lets go, so ask it and carry on testing from there.
+                candidate = CalendarBase.GetNextIncludedTimeUtc(nextIncludedTime);
             }
             else
             {
-                //If the time is in a range excluded by this calendar, we can
-                // move to the end of the excluded time range and continue
-                // testing from there. Otherwise, if nextIncludedTime is
-                // excluded by the baseCalendar, ask it the next time it
-                // includes and begin testing from there. Failing this, add one
-                // millisecond and continue testing.
-                if (nextIncludedTime <
-                    GetTimeRangeStartingTimeUtc(nextIncludedTime))
-                {
-                    nextIncludedTime =
-                        GetTimeRangeStartingTimeUtc(nextIncludedTime);
-                }
-                else if (nextIncludedTime >
-                         GetTimeRangeEndingTimeUtc(nextIncludedTime))
-                {
-                    //(move to start of next day)
-                    nextIncludedTime = GetEndOfDay(nextIncludedTime);
-                    nextIncludedTime = nextIncludedTime.AddMilliseconds(1);
-                }
-                else if (CalendarBase is not null &&
-                         !CalendarBase.IsTimeIncluded(nextIncludedTime))
-                {
-                    nextIncludedTime =
-                        CalendarBase.GetNextIncludedTimeUtc(nextIncludedTime);
-                }
-                else
-                {
-                    nextIncludedTime = nextIncludedTime.AddMilliseconds(1);
-                }
+                candidate = nextIncludedTime.AddMilliseconds(OneMillis);
             }
+
+            // Both jumps move forward by construction; the millisecond step is what keeps a base
+            // calendar that answers with a time of its own choosing from spinning the loop.
+            nextIncludedTime = candidate > nextIncludedTime
+                ? candidate
+                : nextIncludedTime.AddMilliseconds(OneMillis);
         }
 
         return nextIncludedTime;
+    }
+
+    /// <summary>
+    /// The first instant after <paramref name="time" /> that this calendar's own window rule
+    /// includes, with no base calendar in it.
+    /// </summary>
+    /// <remarks>
+    /// The answer is named rather than walked up to. While the zone's offset holds still the wall
+    /// clock only enters the open part of a day at an edge of it, so the edges of the local date the
+    /// query lands in - and of the date after it, once that one has no open time left - are the only
+    /// instants worth asking about. Each is checked against the rule before it is taken, so an edge
+    /// the zone makes meaningless drops out on its own, and the earliest survivor is the answer.
+    /// </remarks>
+    private DateTimeOffset NextTimeThisCalendarIncludes(DateTimeOffset time)
+    {
+        DateOnly date = DateOnly.FromDateTime(TimeZones.ConvertTime(time, TimeZone).DateTime);
+
+        while (true)
+        {
+            DateTimeOffset? included = FirstIncludedInstantOnLocalDate(date, time);
+            if (included is not null)
+            {
+                return included.Value;
+            }
+
+            // A calendar whose window leaves no open time on any day never has an answer to give;
+            // the walk then runs out of dates, which is the end the millisecond walk came to as well.
+            date = date.AddDays(1);
+        }
+    }
+
+    /// <summary>
+    /// The first instant of the given local date that is both past <paramref name="after" /> and
+    /// inside the open part of the day, or <see langword="null" /> when that date has none.
+    /// </summary>
+    private DateTimeOffset? FirstIncludedInstantOnLocalDate(DateOnly date, DateTimeOffset after)
+    {
+        TimeZoneInfo timeZone = TimeZone;
+
+        // The wall clock at which the day opens, and the one at which it closes again. An ordinary
+        // calendar opens a millisecond past the window's end; an inverted one opens at its start.
+        DateTime opens = InvertTimeRange
+            ? date.ToDateTime(rangeStart)
+            : date.ToDateTime(rangeEnd).AddMilliseconds(OneMillis);
+
+        DateTime closes = InvertTimeRange
+            ? date.ToDateTime(rangeEnd).AddMilliseconds(OneMillis)
+            : date.ToDateTime(rangeStart);
+
+        // The day's own first instant, which is neither always midnight nor always at the offset the
+        // rest of the day carries.
+        DateTimeOffset? earliest = EarliestIncluded(soFar: null, TimeZones.StartOfLocalDay(date, timeZone), after);
+
+        // The instant the day opens at: the first instant the clock reads that edge or later. One
+        // that happens twice resolves to the first of the two, that being the first instant the day
+        // is open at, and one that never happens at all - the edge fell in a spring-forward gap - to
+        // the instant the clocks moved.
+        earliest = EarliestIncluded(earliest, TimeZones.FirstInstantAtOrAfterLocal(opens, timeZone), after);
+
+        // ...and, when that wall clock happens twice, the second of the two, for a query that already
+        // stands past the first.
+        if (TimeZones.TryResolveSecondPass(opens, timeZone, out DateTimeOffset opensAgain))
+        {
+            earliest = EarliestIncluded(earliest, opensAgain, after);
+        }
+
+        // A fall-back does not merely repeat a wall clock, it takes the clock back into a part of the
+        // day that was already over. That happens exactly when the edge the day closes at is inside
+        // the repeated hour: the transition lands on the wall clock that hour began with, which is
+        // before the closing edge and so back inside the open part of the day.
+        if (TimeZones.TryGetAmbiguousWindow(closes, timeZone, out DateTime repeatedFrom, out _)
+            && TimeZones.TryResolveSecondPass(repeatedFrom, timeZone, out DateTimeOffset clockGoesBack))
+        {
+            earliest = EarliestIncluded(earliest, clockGoesBack, after);
+        }
+
+        return earliest;
+    }
+
+    /// <summary>
+    /// The earlier of <paramref name="soFar" /> and <paramref name="candidate" />, keeping only a
+    /// candidate that lies past <paramref name="after" /> and that the calendar's own rule includes.
+    /// </summary>
+    private DateTimeOffset? EarliestIncluded(DateTimeOffset? soFar, DateTimeOffset candidate, DateTimeOffset after)
+    {
+        if (candidate <= after || !IsInsideTheOpenPartOfTheDay(TimeZones.ConvertTime(candidate, TimeZone)))
+        {
+            return soFar;
+        }
+
+        return soFar is null || candidate < soFar.Value ? candidate : soFar;
     }
 
     public override ICalendar Clone()
@@ -281,26 +354,40 @@ public sealed class DailyCalendar : BaseCalendar, IEquatable<DailyCalendar>
     /// Returns the start time of the time range of the day
     /// specified in <paramref name="timeUtc" />.
     /// </summary>
+    /// <remarks>
+    /// The day is the local day of <see cref="BaseCalendar.TimeZone" />, so the argument is converted
+    /// into the zone before its date is read: asked in UTC about a calendar that keeps another zone's
+    /// hours, the answer is about the local date the instant falls in rather than the UTC one. The
+    /// value is a wall clock paired with the offset that instant carries, which is what makes it
+    /// comparable with the instant it was derived from; around a transition that offset need not be
+    /// the one the edge itself would be resolved at, and
+    /// <see cref="GetNextIncludedTimeUtc" />, which needs instants rather than comparands, resolves
+    /// the edges through the zone instead.
+    /// </remarks>
     /// <returns>
     ///     a DateTime representing the start time of the
     ///     time range for the specified date.
     /// </returns>
     public DateTimeOffset GetTimeRangeStartingTimeUtc(DateTimeOffset timeUtc)
     {
-        return rangeStart.OnDate(timeUtc);
+        return rangeStart.OnDate(TimeZones.ConvertTime(timeUtc, TimeZone));
     }
 
     /// <summary>
     /// Returns the end time of the time range of the day
     /// specified in <paramref name="timeUtc" />
     /// </summary>
+    /// <remarks>
+    /// The day is the local day of <see cref="BaseCalendar.TimeZone" />; see
+    /// <see cref="GetTimeRangeStartingTimeUtc" />.
+    /// </remarks>
     /// <returns>
     /// A DateTime representing the end time of the
     /// time range for the specified date.
     /// </returns>
     public DateTimeOffset GetTimeRangeEndingTimeUtc(DateTimeOffset timeUtc)
     {
-        return rangeEnd.OnDate(timeUtc);
+        return rangeEnd.OnDate(TimeZones.ConvertTime(timeUtc, TimeZone));
     }
 
     /// <summary>
@@ -363,7 +450,14 @@ public sealed class DailyCalendar : BaseCalendar, IEquatable<DailyCalendar>
     /// <summary>
     /// Gets the start of day, practically zeroes time part.
     /// </summary>
-    /// <param name="time">The time.</param>
+    /// <remarks>
+    /// A wall-clock comparand, not an instant: it is midnight at whatever offset
+    /// <paramref name="time" /> carries, which is the day's first instant only on a day whose offset
+    /// never changes. That is all <see cref="IsInsideTheOpenPartOfTheDay" /> asks of it, since it
+    /// compares it with a value carrying that same offset. Code that needs the instant a local day
+    /// begins at uses <see cref="TimeZones.StartOfLocalDay" />.
+    /// </remarks>
+    /// <param name="time">The time, already expressed in the calendar's zone.</param>
     /// <returns></returns>
     private static DateTimeOffset GetStartOfDay(DateTimeOffset time)
     {
@@ -373,7 +467,10 @@ public sealed class DailyCalendar : BaseCalendar, IEquatable<DailyCalendar>
     /// <summary>
     /// Gets the end of day, practically sets time parts to maximum allowed values.
     /// </summary>
-    /// <param name="time">The time.</param>
+    /// <remarks>
+    /// A wall-clock comparand; see <see cref="GetStartOfDay" />.
+    /// </remarks>
+    /// <param name="time">The time, already expressed in the calendar's zone.</param>
     /// <returns></returns>
     private static DateTimeOffset GetEndOfDay(DateTimeOffset time)
     {

--- a/src/Quartz/TimeZones.cs
+++ b/src/Quartz/TimeZones.cs
@@ -288,6 +288,58 @@ public static class TimeZones
     }
 
     /// <summary>
+    /// The first instant at which the zone's clock reads <paramref name="dateTime" /> or later.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A wall clock that exists resolves through <see cref="ResolveLocal" />, so one that happens
+    /// twice answers with the first of the two. One that does not exist - it fell in a spring-forward
+    /// gap - is answered with the instant the clocks moved, that being the first instant the clock
+    /// reads past it. This is deliberately not what <see cref="ResolveLocal" /> alone says of an
+    /// in-gap time: a trigger asking when a wall clock happens is answered with the gap's end shifted
+    /// forward by the transition delta, whereas a boundary is crossed the moment the clock passes it.
+    /// </para>
+    /// <para>
+    /// The gap's end is walked to from the whole minute the given time falls in, because a zone
+    /// changes offset on a minute and walking from the time's own second would carry that second past
+    /// the transition.
+    /// </para>
+    /// </remarks>
+    internal static DateTimeOffset FirstInstantAtOrAfterLocal(DateTime dateTime, TimeZoneInfo timeZoneInfo)
+    {
+        if (!timeZoneInfo.IsInvalidTime(dateTime))
+        {
+            return ResolveLocal(dateTime, timeZoneInfo);
+        }
+
+        DateTime minute = new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, 0, dateTime.Kind);
+        return ResolveLocal(WalkToGapEnd(minute, timeZoneInfo), timeZoneInfo);
+    }
+
+    /// <summary>
+    /// The second of the two instants an ambiguous wall-clock time names - the one after the
+    /// fall-back transition. Returns false when the time is not ambiguous, so it also answers
+    /// "does this wall clock happen twice, and when is the second time".
+    /// </summary>
+    /// <remarks>
+    /// The second pass always carries the smaller of the two offsets: a clock that goes back is a
+    /// clock whose offset shrinks, whichever of the two periods the zone labels as its daylight one.
+    /// <see cref="ResolveLocal" /> resolves the same wall clock to the first of the two, which is
+    /// what a trigger wants; a caller that has already gone past the first pass wants this one.
+    /// </remarks>
+    internal static bool TryResolveSecondPass(DateTime dateTime, TimeZoneInfo timeZoneInfo, out DateTimeOffset instant)
+    {
+        if (!timeZoneInfo.IsAmbiguousTime(dateTime))
+        {
+            instant = default;
+            return false;
+        }
+
+        instant = new DateTimeOffset(dateTime, timeZoneInfo.GetAmbiguousTimeOffsets(dateTime).Min());
+        return true;
+    }
+
+    /// <summary>
     /// Walks forward from a wall-clock time inside a spring-forward gap to the first wall-clock
     /// time that exists in the given zone (the end of the gap). Returns the input unchanged when it
     /// is already valid.


### PR DESCRIPTION
`DailyCalendar.GetNextIncludedTimeUtc` named the window's edges — `rangeStart.OnDate(timeUtc)`,
`rangeEnd.OnDate(timeUtc)` — on the date the *argument* fell on and paired them with the offset the
argument carried, and took its day boundaries (`GetStartOfDay`, `GetEndOfDay`) the same way, while
`IsTimeIncluded` converts into the calendar's zone first. Asked in UTC about a calendar keeping
another zone's hours the two disagreed, and the disagreement was not benign in either direction:

- the jump landed on a window an offset away from the one being tested, so the loop arrived somewhere
  `IsTimeIncluded` still called excluded and fell through to its last resort, a millisecond at a time;
- the millisecond walk was bounded only by where the wrong window happened to end, so it could step
  clean over an included stretch, and a day whose whole UTC-shaped window never coincides with the
  local one made the walk repeat itself day after day.

## The measurement

The reproduction from #3466, an inverted 21:00–22:00 `America/Santiago` calendar asked at
`2019-04-07T01:30Z`:

| | before | after |
|---|---|---|
| answer | `2019-09-09T00:00Z` | `2019-04-08T01:00Z` |
| time to answer | 2 m 17 s | under a millisecond |
| passes of the loop | ~558 million | 2 |

Both numbers are measured on this branch: the 2 m 17 s figure is a run of the new
`DailyCalendar_NextIncludedTime_IsJumpedToRatherThanWalkedUpTo` against the unfixed
`DailyCalendar.cs`, which failed with `<2019-09-09 +0h> does not` after `2 m 17 s`. The answer is
five months late because `21:00–22:00` read in UTC is only ever `21:00–22:00` read in Santiago at an
offset Santiago does not have; the walk crawled an hour of milliseconds a day until the zone's
September transition made the two coincide.

## The mechanism of the fix

The argument is converted into `TimeZone` first, as `IsTimeIncluded` does, and the answer is *named*
rather than walked up to. Within a stretch of unchanging offset the wall clock only enters the open
part of a day at an edge of it, so the edges of the local date the query lands in — and of the date
after it, once that one has no open time left — are the only instants worth asking about:

- **the instant the day opens at**, through the new `TimeZones.FirstInstantAtOrAfterLocal`;
- **the second reading of that edge**, where the clock repeats it, through the new
  `TimeZones.TryResolveSecondPass` — this is where a query already standing in the second pass of a
  repeated hour has to continue from;
- **the instant the clocks moved**, where a fall-back takes the clock back to *before* the window
  opened. This is not an edge crossing at all and is the case a naive fix misses: a non-inverted
  03:30–04:30 Helsinki calendar asked at `2024-10-27T00:40Z` is answered `01:00Z`, the transition
  itself, because at that instant the clock reads 03:00 +02:00 again — half an hour before the window
  opens — and the window's own end is not reached until `02:30:00.001Z`;
- **the day's own first instant**, from `TimeZones.StartOfLocalDay` (#3465), for a day that does not
  begin at midnight.

Each candidate is checked against the calendar's own rule before it is taken, so an edge the zone
makes meaningless — a window lying inside a spring-forward gap, an edge already gone past on the
first pass of a repeated hour — drops out on its own, and the earliest survivor is the answer. A date
with no open time left hands the walk on to the next local date, named as a `DateOnly` and re-resolved
rather than reached by adding twenty-four hours to an offset that has since changed. The base
calendar composition (`CalendarBase.IsTimeIncluded` / `CalendarBase.GetNextIncludedTimeUtc`) is
untouched; a millisecond step remains as the guard that keeps a base calendar answering with a time
of its own choosing from spinning the loop.

`IsTimeIncluded` keeps its wall-clock semantics exactly — its comparands all carry the same offset as
the value being tested, which is what makes an hour of exclusion mean an hour of wall clock on a 23-
or 25-hour day. Its body moved into a private `IsInsideTheOpenPartOfTheDay` so that the jump and the
test are the same rule, asked once.

## Points a reviewer has to decide

**1. `GetTimeRangeStartingTimeUtc` / `GetTimeRangeEndingTimeUtc` now convert their argument into the
zone.** These are public and carried the same offset assumption in public: asked in UTC about a
Santiago calendar they answered about the UTC date at `+00:00`, which no caller can use. They now read
the date of the *local* day the instant falls in. The value stays a wall-clock comparand — the edge
paired with the offset the given instant carries, not the offset the edge itself would resolve at —
because that is what makes it comparable with the instant it came from, and it is what `IsTimeIncluded`
needs. For the call `IsTimeIncluded` makes the conversion is a no-op, that value already being in the
zone. No signature changed and no public API baseline moved. This is behaviour visible to a caller
that holds a `DailyCalendar` in a zone other than the one it asks in, so it is worth a deliberate nod.

**2. A boundary in a spring-forward gap resolves to the end of the gap, not the way `ResolveLocal`
resolves one.** The issue's "done means" says the resolution helpers, and the task I was given said
"an edge inside a spring-forward gap resolves the way the trigger code resolves one". Following that
literally is wrong here and I did not: `ResolveLocal` answers a trigger's question — *when does this
wall clock happen* — with the gap's end shifted forward by the transition delta, so a non-inverted
02:30–03:30 Helsinki calendar would be answered `2024-03-31T01:30:00.001Z` when the clock in fact
passes 03:30 at `01:00Z`, stepping over half an hour of included time. `FirstInstantAtOrAfterLocal`
asks the boundary's question instead — *when is this boundary crossed* — and its doc comment says
which and why. An edge in the repeated hour resolves to the first occurrence, since that is the first
instant the day is open at, with the second occurrence offered as its own candidate.

**3. One millisecond of imprecision survives, deliberately.** `WalkToGapEnd` and
`TryGetAmbiguousWindow` locate a transition by scanning a minute at a time, which is what lets them
handle deltas that are not whole hours. Windows zone data cannot express a rule at local midnight and
writes 23:59:59.999 of the day before instead, so Santiago's spring-forward gap ends a millisecond
earlier there than IANA data says; the answer for a boundary inside that gap is therefore a
millisecond late on Windows and exact on Linux. This is the same precision the trigger code has
carried since the helpers were written, and the two existing `<remarks>` in `CalendarDstTests` already
say the instant is not agreed on to the millisecond. `AssertDailyCalendarNextIncludedTime` states this
in a `slack` variable: the walk comes to the millisecond before the answer, except where the answer
*is* a transition instant, where it comes to the minute. Making `DailyCalendar` alone exact here would
need a transition bisection the rest of the library does not have.

## Tests

`CalendarDstTests` gains twelve `GetNextIncludedTimeUtc` cases across Santiago and Helsinki, inverted
and not — inside the window and outside it, a window edge in the gap, a window edge in the repeated
hour on both of its passes, a window running to the end of a 23- and of a 25-hour local day, and two
ordinary-day controls — plus three cases where the instant asked about is already included and the
answer is the very next millisecond. Every case goes through one helper that holds the answer to the
whole contract: the instant asked about is excluded, the answer is included, **nothing between the two
is** (walked a second at a time), and the same instant asked about in the calendar's own zone rather
than in UTC gives the same answer back.

The no-crawl assertion is made twice, because each bound says something the other does not. The
`Stopwatch` bound is loose (5 s) and is what a user noticed. The exact one needs no counter inside
`DailyCalendar`: a base calendar that includes every instant is asked once per pass of the loop, so a
counting one attached as the base counts the passes — 2, against the ~558 million the walk took.

`TimeZonesTest` covers the two new helpers directly, including the case that says why the gap is
walked from the whole minute.

## `3.x`

`git show origin/3.x:src/Quartz/Impl/Calendar/DailyCalendar.cs` has the **same defect in the same
shape**, so this needs a companion PR there as #3457's did:

| member | `3.x` lines | same defect? |
|---|---|---|
| `IsTimeIncluded` | 435–466 | correct, converts with `TimeZoneUtil.ConvertTime` first |
| `GetNextIncludedTimeUtc` | 477–543 | **yes** — identical algorithm, `precisionStepMillis` where `main` has `OneMillis` |
| `GetTimeRangeStartingTimeUtc` | 565–571 | **yes** — built from the argument's `Year`/`Month`/`Day`/`Offset` |
| `GetTimeRangeEndingTimeUtc` | 581–587 | **yes** |
| `GetStartOfDay` / `GetEndOfDay` | 818–821 / 828–831 | same shape, same "only compared with same-offset values" defence |

Two differences matter for that port. `precisionStepMillis` is 1000 by default there (line 77),
dropping to 1 only when the range carries sub-second precision (lines 771–775), so the 3.x walk steps
a *second* at a time: a thousand times faster to go wrong, and able to skip an included stretch
shorter than a second outright. And `TimeZoneUtil` on 3.x has `ResolveLocal` and `WalkToGapEnd` but
neither `StartOfLocalDay` (which #3465 added here) nor `TryGetAmbiguousWindow`, so the port carries
those over too. No 3.x PR in this one.

## Verification

```
dotnet build Quartz.slnx                     Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit            Passed! Failed: 0, Passed: 3438, Skipped: 4, Total: 3442
dotnet test src/Quartz.Tests.AspNetCore      Passed! Failed: 0, Passed:  447, Skipped: 0, Total:  447
Quartz.Tests.Integration, 'basic' leg        Passed! Failed: 0, Passed:  322, Skipped: 0, Total:  322
```

The integration leg is the container-free negation `Build.cs` runs, with `QUARTZ_TEST_DATABASE=basic`;
the DST fixtures in it (`SchedulerAcrossDstTransitionTest`, `MisfireAcrossDstTransitionTest`, 20 cases
including the `calendar-daily` trigger that is held by a `DailyCalendar` across each transition) were
confirmed to execute rather than skip. No public API baseline moved.

Closes #3466

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
