### PR TITLE
History and live events say which node they came from, and history forgets by age

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -6005,9 +6005,11 @@ dashboard's contract needed a name for it, and it is what
 `Running`: the in-process client used to call it `"Started"` while the HTTP-backed client called the same
 state `"Running"`, and code that matched on either string now matches on the enum.
 
-The dashboard hub's `SchedulerStateDto` follows: it is `(string SchedulerName, SchedulerStatus Status)`
-rather than `(string SchedulerName, string State)`, and it is pushed once per state the scheduler
-arrives in. `SchedulerStarting` pushes nothing, being an event rather than a state.
+The dashboard hub's `SchedulerStateDto` follows: it is
+`(string SchedulerName, string SchedulerInstanceId, SchedulerStatus Status)` rather than
+`(string SchedulerName, string State)`, and it is pushed once per state the scheduler arrives in.
+`SchedulerStarting` pushes nothing, being an event rather than a state. The instance id is new in
+alpha.3 — see [History and live events say which node they came from](#history-and-live-events-say-which-node-they-came-from).
 
 ### A trigger is an `ITrigger`, a calendar is an `ICalendar`
 
@@ -6067,6 +6069,42 @@ endpoint no Quartz HTTP API serves — and it is designed in
 
 `QuartzHttpApiOptions.ApiPath`, which is where the HTTP API itself is served, is unaffected: it is a
 different option on a different type, and `AddQuartzHttpApi` still reads it.
+
+## History and live events say which node they came from
+
+A cluster is one scheduler running in several processes. Each node keeps its own history of its own
+executions and pushes its own live events, and neither said which node it was — so the History page
+could not attribute a row to a machine and the Live Logs view could not tell a local event from a
+peer's. Both feeds carry the node now, and the history is bounded by age as well as by count.
+
+| 4.0 preview | 4.0 |
+|---|---|
+| `DashboardHistoryEntry(SchedulerName, JobGroup, …)` | `DashboardHistoryEntry(SchedulerName, SchedulerInstanceId, JobGroup, …)` |
+| — | `DashboardMisfireEntry(SchedulerName, SchedulerInstanceId, TriggerGroup, TriggerName, JobKeyDto? JobKey, MisfiredAtUtc, DateTimeOffset? ScheduledFireTimeUtc)` (new) |
+| — | `DashboardMisfireQuery : PagedQuery`, with `SchedulerName`, `SchedulerInstanceId` and `TriggerFilter` (new) |
+| `DashboardHistoryQuery` | gained `string? SchedulerInstanceId` — null lists every node's |
+| `IDashboardHistoryStore` | gained `AddMisfire`, `GetMisfires(DashboardMisfireQuery)` and `CountMisfires(name, since)` |
+| `IQuartzApiClient` | gained `GetMisfires(DashboardMisfireQuery)` → `PagedResult<DashboardMisfireEntry>?` |
+| `QuartzDashboardOptions` | gained `TimeSpan HistoryRetention` (24 hours) and `int HistoryMaxEntriesPerScheduler` (2000) |
+| `DashboardHistoryPlugin(IServiceProvider)` | `DashboardHistoryPlugin(IServiceProvider, TimeProvider)`, and it implements `ITriggerListener` as well as `IJobListener` |
+| `SchedulerStateDto(SchedulerName, Status)` | `SchedulerStateDto(SchedulerName, SchedulerInstanceId, Status)` |
+| `SchedulerErrorDto(SchedulerName, Message, …)` | `SchedulerErrorDto(SchedulerName, SchedulerInstanceId, Message, …)` |
+| `JobEventDto(JobKey, …)`, `JobExecutionResultDto(JobKey, …)`, `TriggerEventDto(TriggerKey, …)` | each leads with `string SchedulerInstanceId` |
+| `IQuartzDashboardHubClient.TriggerPaused(TriggerKeyDto)` / `TriggerResumed` | take `TriggerLifecycleDto(SchedulerInstanceId, TriggerKey)` |
+| `IQuartzDashboardHubClient.JobPaused(JobKeyDto)` / `JobResumed` | take `JobLifecycleDto(SchedulerInstanceId, JobKey)` |
+
+**`IDashboardHistoryStore` is public and is the documented persistence seam, so the three new members
+are a breaking change for anyone who implemented it.** A store that only records executions can throw
+`NotSupportedException` from the misfire members; the History page reports a data source that answers
+`null` for misfires by omitting the section rather than by failing.
+
+A pause and a resume get a payload of their own rather than growing `JobKeyDto` / `TriggerKeyDto`:
+those are keys, `IQuartzApiClient` uses them everywhere, and a key does not belong to a node.
+
+The two new options are what bounds the shipped in-memory store. It was bounded by count alone, which
+says nothing about a scheduler that has gone quiet — it keeps whatever it last recorded, so its page
+shows executions from an arbitrary distance in the past. The window is measured on the scheduler's
+`TimeProvider` and applied when history is read as well as when it is written.
 
 ## `CheckExists` is `Exists`
 
@@ -7764,6 +7802,7 @@ Parameters and behavior are unchanged:
 | `StdAdoConstants` group and fired-trigger statements were split | `SqlDeletePausedTriggerGroup`, `SqlSelectTriggerGroupsFiltered`, `SqlUpdateTriggerGroupStateFromState` and `SqlUpdateTriggerGroupStateFromStates` are `…Equals` / `…Like` pairs, and the FIRED_TRIGGERS statements are one `SqlSelectFiredTriggers` / `SqlDeleteFiredTriggers` base plus `SqlFiredTrigger*Predicate` fragments. The type is internal |
 | `IDashboardAuthorizationFilter` and `QuartzDashboardOptions.AuthorizationFilter` removed | Nothing ever invoked the filter, so setting it bought a false sense of security. Use `AuthorizationPolicy`, which is enforced |
 | `IDashboardHistoryStore` is asynchronous | `ValueTask Add`, `ValueTask<PagedResult<DashboardHistoryEntry>> GetPage(DashboardHistoryQuery)`, so a store can talk to a database. `SearchFilter.DebounceMilliseconds` is a `TimeSpan Debounce`, and `InProcessQuartzApiClient` is internal — resolve `IQuartzApiClient` |
+| `IDashboardHistoryStore` carries the misfire feed | `AddMisfire`, `GetMisfires(DashboardMisfireQuery)` and `CountMisfires(name, since)` are new members on the interface, so **an application with its own store has to implement three more** — see [History and live events say which node they came from](#history-and-live-events-say-which-node-they-came-from) |
 | `IQuartzApiClient` speaks Quartz's vocabulary | See [The dashboard's client speaks one currency](#the-dashboard-s-client-speaks-one-currency) |
 | The dashboard's HTTP-backed API client is gone | `QuartzApiClient` was never registered; the dashboard renders the schedulers in its own process, and `QuartzDashboardOptions.BaseUrl` and `.ApiPath` went with it — see [The dashboard reads the schedulers in its own process](#the-dashboard-reads-the-schedulers-in-its-own-process) |
 | Serializers outside a scheduler read a container-wide registry | Because the serializer maps are per-serializer, the HTTP API and `Quartz.HttpClient` read a `SystemTextJsonSerializerRegistry` registered in the container. Register it as a singleton to make a custom serializer visible to them. The dashboard no longer registers one of its own: it passes triggers and calendars through as themselves |

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -59,7 +59,7 @@ the dashboard needs it: the pages read the schedulers in this process directly.
 
 ## Options
 
-`AddQuartzDashboard(options => …)` takes three settings, and none of them points the dashboard at a
+`AddQuartzDashboard(options => …)` takes five settings, and none of them points the dashboard at a
 scheduler — **the dashboard renders the schedulers registered in its own application**, reading them
 through the `IQuartzApiClient` in the container rather than over a network.
 
@@ -68,6 +68,11 @@ through the `IQuartzApiClient` in the container rather than over a network.
 | `DashboardPath` | `/quartz` | The base path the UI is served from — see [Hosting under a custom path](#hosting-under-a-custom-path) |
 | `AuthorizationPolicy` | none | The policy applied to the dashboard pages, hub, circuit and assets — see [Policy and role-based authorization](#policy-and-role-based-authorization) |
 | `ReadOnly` | `false` | Hides every mutating action: no pause, resume, trigger-now, reschedule, unschedule or delete |
+| `HistoryRetention` | 24 hours | How far back the dashboard's own history store keeps executions and misfires — see [Execution history and misfires](#execution-history-and-misfires) |
+| `HistoryMaxEntriesPerScheduler` | `2000` | How many executions and how many misfires it keeps per scheduler, oldest dropped first |
+
+Both history bounds are rejected at startup if they are not positive: a window of zero forgets every
+execution the moment it is recorded, which looks exactly like a history plugin that was never installed.
 
 ::: tip Pointing a dashboard at another process
 There is no option for it. `AddQuartzDashboard` registers its client with `TryAdd`, so an application
@@ -159,10 +164,46 @@ In earlier releases the Blazor circuit stayed at the site root; with a custom `D
 A custom dashboard path is **not** supported when integrating into an existing Blazor application with `MapQuartzDashboard(blazor)`; the dashboard page routes are fixed at `/quartz` in that mode and startup fails with a descriptive exception if a custom path is configured. There is no `MapQuartzDashboard(blazor, pattern)` overload for the same reason.
 :::
 
-## Enabling history plugin
+## Execution history and misfires
 
-To populate execution history and make related views useful, add the Quartz history plugins to the
-scheduler:
+`AddQuartzDashboard()` installs the history plugin itself, so the **History** page at `/quartz/history`
+is populated without anything further being written. Each row carries the node that ran it, so a
+clustered scheduler's history is readable rather than an undifferentiated stream, and the page's node
+filter narrows the listing — and the figures on its stat cards, whose titles then say which node they
+cover — to one machine.
+
+Beneath the executions the page lists **misfires**: firings the scheduler missed. Nothing ran, so they
+never appear in the execution history however long a reader stares at it; each row names the trigger,
+the job it points at, the node that noticed, the firing that was missed and when it was noticed.
+
+The store `AddQuartzDashboard` registers is per-process and in-memory, bounded both by age
+(`HistoryRetention`, 24 hours) and by count (`HistoryMaxEntriesPerScheduler`, 2000 of each feed per
+scheduler):
+
+<!-- snippet: sample_dashboard_history_bounds -->
+```csharp
+services.AddQuartzDashboard(options =>
+{
+    options.HistoryRetention = TimeSpan.FromHours(6);
+    options.HistoryMaxEntriesPerScheduler = 500;
+});
+```
+<!-- endSnippet -->
+
+The age bound is what a count alone cannot supply: a scheduler that has gone quiet keeps whatever it
+last recorded, so its page shows executions from an arbitrary distance in the past with nothing to say
+how old they are. The window is measured on the scheduler's `TimeProvider`, and it applies when history
+is read as well as when it is written — otherwise a scheduler that never writes again never forgets.
+
+To keep history somewhere that survives a restart, register your own `IDashboardHistoryStore` before
+calling `AddQuartzDashboard` (its registration is a `TryAdd`). Both feeds carry `SchedulerInstanceId`,
+which is what makes one store shared by a whole cluster readable. It carries the `CountMisfires(name,
+since)` count-over-a-window a summary needs, so an implementation backed by a database can answer that
+with one `COUNT(*)` rather than by loading rows it would throw away.
+
+### Enabling the history plugins
+
+For history written to your application's log as well, add the Quartz history plugins to the scheduler:
 
 <!-- snippet: sample_dashboard_history_plugins -->
 ```csharp
@@ -229,7 +270,7 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
 - **Many local schedulers in one host:** dashboard scheduler selector supports multiple registered schedulers; use clear scheduler names and environment-specific grouping.
 - **Reverse proxy and Blazor Server:** enable WebSocket/SignalR forwarding and sticky sessions where required by your hosting stack. The Blazor circuit connects to `/_blazor` (or `{DashboardPath}/_blazor` when a custom `DashboardPath` is configured).
 - **Split operator experiences:** expose a read-only dashboard instance (`ReadOnly = true`) for observers, and a separate write-enabled dashboard for operators.
-- **Operational retention:** dashboard history is plugin-fed operational history; configure plugin + external retention/reporting if you need long-term analytics.
+- **Operational retention:** the built-in history store is per-process and in-memory, bounded by `HistoryRetention` and `HistoryMaxEntriesPerScheduler`. Every node of a cluster therefore keeps its own; the rows name the node they came from, so registering a shared `IDashboardHistoryStore` gives one page over the whole fleet. Configure external retention/reporting if you need long-term analytics.
 
 ## Features
 
@@ -246,9 +287,14 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
   its last check-in in the selected time zone and as a relative time, its check-in interval, and how
   many firings it is holding and running; the node answering is marked, and a scheduler whose job store
   is not clustered says so rather than showing an empty table
+- Execution history at `/quartz/history` — one row per execution with the node that ran it, filterable
+  by job, by trigger and by node, with the page's stat cards saying which scope their figures cover; and
+  a misfires section listing the firings the scheduler missed. Bounded by age as well as by count — see
+  [Execution history and misfires](#execution-history-and-misfires)
 - Live event/log stream for scheduler activity, fed by plugins `AddQuartzDashboard` installs on every
   scheduler in the container — so a named scheduler streams its own events, each plugin instance
-  initialized with the name of the scheduler it belongs to
+  initialized with the name of the scheduler it belongs to. Every event names the node that raised it,
+  and the page says which node its own process is
 - Pause, resume, trigger-now, and unschedule/delete actions (when not in read-only mode)
 - Trigger detail cron reschedule and job detail trigger-with-overrides actions
 - Calendar create/replace (cron calendar), details, and delete actions
@@ -318,6 +364,6 @@ This property tells the .NET SDK to include the Blazor framework scripts (`_fram
 ## Current limitations
 
 - Live views are near-real-time polling/streaming and are not guaranteed to be lossless event storage
-- No built-in persistence UI for historical analytics; plugin-backed history is operational/log oriented
+- No built-in persistence UI for historical analytics; the shipped history store is in-memory and per-process, so history does not survive a restart and one node cannot show another's unless you register a shared `IDashboardHistoryStore`. A database-backed one ships with 4.1 ([#3387](https://github.com/quartznet/quartznet/issues/3387))
 - Advanced management remains intentionally scoped; rich typed editors are currently focused on cron calendars/triggers and operational overrides
 - UX is optimized for Quartz APIs and scheduler operations, not full workflow/business process visualization

--- a/src/Quartz.Dashboard/Components/Pages/History.razor
+++ b/src/Quartz.Dashboard/Components/Pages/History.razor
@@ -28,6 +28,21 @@
                        placeholder="group.name or fragment"
                        @bind="_triggerFilter" />
             </div>
+            <div class="qz-form-group">
+                <label class="qz-form-label" for="history-node-filter">Node</label>
+                @* Applies on its own rather than waiting for the button beside the text filters: a
+                   dropdown that does nothing when it is changed reads as a broken control. *@
+                <select id="history-node-filter"
+                        class="qz-select"
+                        value="@_appliedNodeFilter"
+                        @onchange="OnNodeFilterChangedAsync">
+                    <option value="">All nodes</option>
+                    @foreach (string node in NodeOptions())
+                    {
+                        <option value="@node">@node</option>
+                    }
+                </select>
+            </div>
         </div>
         <div class="qz-actions qz-group-actions">
             <button type="button" class="qz-button qz-button-primary" @onclick="ApplyFiltersAsync">Apply filters</button>
@@ -38,10 +53,7 @@
     @if (!_isLoading && !_historyUnavailable && string.IsNullOrWhiteSpace(_error))
     {
         <p class="qz-muted">Page @_page / @_totalPages · Showing @_entries.Count row(s) · Total @_totalCount row(s)</p>
-        @if (HasFilters)
-        {
-            <p class="qz-muted">@BuildFilterSummary()</p>
-        }
+        <p class="qz-muted">@BuildFilterSummary()</p>
     }
 
     @if (_isLoading)
@@ -63,10 +75,10 @@
     else
     {
         <div class="qz-grid qz-grid-4">
-            <StatCard Title="Success rate (page)" Value="@GetSuccessRateText()" Icon="✔" Color="success" />
-            <StatCard Title="Failures (page)" Value="@_pageFailureCount.ToString()" Icon="⚠" Color="error" />
-            <StatCard Title="Avg duration (page)" Value="@FormatDurationValue(_pageAverageDuration)" Icon="⏱️" Color="info" />
-            <StatCard Title="P95 duration (page)" Value="@FormatDurationValue(_pageP95Duration)" Icon="📈" Color="info" />
+            <StatCard Title="@ScopedStatTitle("Success rate")" Value="@GetSuccessRateText()" Icon="✔" Color="success" />
+            <StatCard Title="@ScopedStatTitle("Failures")" Value="@_pageFailureCount.ToString()" Icon="⚠" Color="error" />
+            <StatCard Title="@ScopedStatTitle("Avg duration")" Value="@FormatDurationValue(_pageAverageDuration)" Icon="⏱️" Color="info" />
+            <StatCard Title="@ScopedStatTitle("P95 duration")" Value="@FormatDurationValue(_pageP95Duration)" Icon="📈" Color="info" />
         </div>
 
         <table class="qz-table">
@@ -74,6 +86,7 @@
                 <tr>
                     <th>Job</th>
                     <th>Trigger</th>
+                    <th>Node</th>
                     <th>Fired</th>
                     <th>Duration</th>
                     <th>Status</th>
@@ -86,6 +99,7 @@
                     <tr>
                         <td><KeyBadge GroupName="@entry.JobGroup" ItemName="@entry.JobName" /></td>
                         <td><KeyBadge GroupName="@entry.TriggerGroup" ItemName="@entry.TriggerName" /></td>
+                        <td class="qz-table-cell-mono qz-history-node">@NodeLabel(entry.SchedulerInstanceId)</td>
                         <td>@FormatFiredAt(entry.FiredAtUtc)</td>
                         <td>@FormatDurationValue(entry.Duration)</td>
                         <td><StateIndicator State="@(entry.Succeeded ? "Complete" : "Error")" /></td>
@@ -99,6 +113,57 @@
                     PageSize="@_currentPageSize"
                     CurrentPage="@_page"
                     OnPageChanged="OnPageChangedAsync" />
+    }
+
+    @if (!_isLoading && !_historyUnavailable && string.IsNullOrWhiteSpace(_error) && !_misfiresUnavailable)
+    {
+        <section class="qz-section qz-misfires">
+            <h2>Misfires</h2>
+            <p class="qz-muted">
+                Firings the scheduler missed. Nothing ran, so these never appear above — they are the
+                triggers whose misfire instruction decided what happened instead.
+            </p>
+
+            @if (_misfires.Count == 0)
+            {
+                <p class="qz-muted">No misfires recorded@(HasNodeFilter ? " for this node." : ".")</p>
+            }
+            else
+            {
+                <table class="qz-table">
+                    <thead>
+                        <tr>
+                            <th>Trigger</th>
+                            <th>Job</th>
+                            <th>Node</th>
+                            <th>Missed firing</th>
+                            <th>Noticed</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (DashboardMisfireEntry misfire in _misfires)
+                        {
+                            <tr>
+                                <td><KeyBadge GroupName="@misfire.TriggerGroup" ItemName="@misfire.TriggerName" /></td>
+                                <td>
+                                    @if (misfire.JobKey is { } jobKey)
+                                    {
+                                        <KeyBadge GroupName="@jobKey.Group" ItemName="@jobKey.Name" />
+                                    }
+                                    else
+                                    {
+                                        <span class="qz-muted">&#8212;</span>
+                                    }
+                                </td>
+                                <td class="qz-table-cell-mono qz-misfire-node">@NodeLabel(misfire.SchedulerInstanceId)</td>
+                                <td>@FormatFiredAt(misfire.ScheduledFireTimeUtc)</td>
+                                <td>@FormatFiredAt(misfire.MisfiredAtUtc)</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+        </section>
     }
 </div>
 
@@ -120,6 +185,20 @@
     private string _triggerFilter = string.Empty;
     private string _appliedJobFilter = string.Empty;
     private string _appliedTriggerFilter = string.Empty;
+    private string _appliedNodeFilter = string.Empty;
+    private readonly List<DashboardMisfireEntry> _misfires = [];
+    private bool _misfiresUnavailable;
+
+    /// <summary>
+    /// The nodes the filter offers: the scheduler's cluster nodes, so a node that has stopped producing
+    /// history is still selectable.
+    /// </summary>
+    /// <remarks>
+    /// Read once per scheduler rather than on every refresh tick — on a persistent store it is a database
+    /// read, and the page refreshes once a second.
+    /// </remarks>
+    private readonly List<string> _clusterNodes = [];
+    private string? _clusterNodesLoadedFor;
     private PeriodicTimer? _refreshTimer;
     private CancellationTokenSource? _refreshLoopCancellation;
     private bool _loadingInProgress;
@@ -133,12 +212,19 @@
     public string? TriggerFilterQuery { get; set; }
 
     [Parameter]
+    [SupplyParameterFromQuery(Name = "node")]
+    public string? NodeFilterQuery { get; set; }
+
+    [Parameter]
     [SupplyParameterFromQuery(Name = "page")]
     public int? PageQuery { get; set; }
 
     private bool HasFilters =>
         !string.IsNullOrWhiteSpace(_appliedJobFilter) ||
-        !string.IsNullOrWhiteSpace(_appliedTriggerFilter);
+        !string.IsNullOrWhiteSpace(_appliedTriggerFilter) ||
+        HasNodeFilter;
+
+    private bool HasNodeFilter => !string.IsNullOrWhiteSpace(_appliedNodeFilter);
 
     protected override Task OnInitializedAsync()
     {
@@ -153,12 +239,14 @@
     {
         string requestedJobFilter = (JobFilterQuery ?? string.Empty).Trim();
         string requestedTriggerFilter = (TriggerFilterQuery ?? string.Empty).Trim();
+        string requestedNodeFilter = (NodeFilterQuery ?? string.Empty).Trim();
         int requestedPage = Math.Max(1, PageQuery ?? 1);
 
         _jobFilter = requestedJobFilter;
         _triggerFilter = requestedTriggerFilter;
         _appliedJobFilter = requestedJobFilter;
         _appliedTriggerFilter = requestedTriggerFilter;
+        _appliedNodeFilter = requestedNodeFilter;
         _page = requestedPage;
 
         await LoadDataAsync();
@@ -221,8 +309,13 @@
         _loadingInProgress = true;
         _isLoading = true;
         _historyUnavailable = false;
+        // Nothing has answered yet, so there is no misfire feed to show. Anything short of a page coming
+        // back — no scheduler selected, a data source that keeps no history, a read that threw — leaves
+        // the section out rather than rendering "no misfires" over an answer nobody gave.
+        _misfiresUnavailable = true;
         _error = null;
         _entries.Clear();
+        _misfires.Clear();
         _totalCount = 0;
         _totalPages = 1;
         _pageSuccessCount = 0;
@@ -237,6 +330,8 @@
             {
                 return;
             }
+
+            await LoadClusterNodesAsync(schedulerName);
 
             PagedResult<DashboardHistoryEntry>? page = await Api.GetHistory(HistoryQuery(schedulerName, _page));
             if (page is null)
@@ -259,6 +354,13 @@
 
             _entries.AddRange(page.Items);
 
+            PagedResult<DashboardMisfireEntry>? misfires = await Api.GetMisfires(MisfireQuery(schedulerName));
+            _misfiresUnavailable = misfires is null;
+            if (misfires is not null)
+            {
+                _misfires.AddRange(misfires.Items);
+            }
+
             ComputeAnalytics();
         }
         catch (Exception ex)
@@ -273,11 +375,39 @@
     }
 
     /// <summary>
+    /// Reads the scheduler's nodes so the filter can offer them. A data source that cannot answer leaves
+    /// the dropdown with whatever the loaded rows name, which is a narrower list rather than an error.
+    /// </summary>
+    private async Task LoadClusterNodesAsync(string schedulerName)
+    {
+        if (string.Equals(_clusterNodesLoadedFor, schedulerName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _clusterNodesLoadedFor = schedulerName;
+        _clusterNodes.Clear();
+
+        try
+        {
+            foreach (ClusterNodeDto node in await Api.GetClusterNodes(schedulerName))
+            {
+                _clusterNodes.Add(node.InstanceId);
+            }
+        }
+        catch (Exception)
+        {
+            // a node listing is a convenience here, not the page
+        }
+    }
+
+    /// <summary>
     /// The 1-based page the pager speaks, as the <c>Skip</c>/<c>Take</c> the API speaks.
     /// </summary>
     private DashboardHistoryQuery HistoryQuery(string schedulerName, int page) => new()
     {
         SchedulerName = schedulerName,
+        SchedulerInstanceId = NormalizedNodeFilter(),
         JobFilter = _appliedJobFilter,
         TriggerFilter = _appliedTriggerFilter,
         Skip = Math.Max(0, page - 1) * _pageSize,
@@ -285,30 +415,50 @@
         IncludeTotalCount = true
     };
 
+    /// <remarks>
+    /// The newest page only: the misfire feed is a "what has been going wrong" list beside the history,
+    /// not a listing of its own with a pager.
+    /// </remarks>
+    private DashboardMisfireQuery MisfireQuery(string schedulerName) => new()
+    {
+        SchedulerName = schedulerName,
+        SchedulerInstanceId = NormalizedNodeFilter(),
+        TriggerFilter = _appliedTriggerFilter,
+        Take = _pageSize
+    };
+
+    private string? NormalizedNodeFilter() => string.IsNullOrWhiteSpace(_appliedNodeFilter) ? null : _appliedNodeFilter;
+
     private async Task OnPageChangedAsync(int page)
     {
-        await UpdateQueryStateAsync(page, _appliedJobFilter, _appliedTriggerFilter);
+        await UpdateQueryStateAsync(page, _appliedJobFilter, _appliedTriggerFilter, _appliedNodeFilter);
     }
 
     private Task ApplyFiltersAsync()
     {
-        return UpdateQueryStateAsync(1, _jobFilter, _triggerFilter);
+        return UpdateQueryStateAsync(1, _jobFilter, _triggerFilter, _appliedNodeFilter);
+    }
+
+    private Task OnNodeFilterChangedAsync(ChangeEventArgs args)
+    {
+        return UpdateQueryStateAsync(1, _appliedJobFilter, _appliedTriggerFilter, args.Value?.ToString() ?? string.Empty);
     }
 
     private Task ClearFiltersAsync()
     {
         _jobFilter = string.Empty;
         _triggerFilter = string.Empty;
-        return UpdateQueryStateAsync(1, string.Empty, string.Empty);
+        return UpdateQueryStateAsync(1, string.Empty, string.Empty, string.Empty);
     }
 
-    private Task UpdateQueryStateAsync(int page, string jobFilter, string triggerFilter)
+    private Task UpdateQueryStateAsync(int page, string jobFilter, string triggerFilter, string nodeFilter)
     {
         int normalizedPage = Math.Max(1, page);
         string normalizedJobFilter = jobFilter.Trim();
         string normalizedTriggerFilter = triggerFilter.Trim();
+        string normalizedNodeFilter = nodeFilter.Trim();
 
-        string updatedPath = BuildHistoryRelativeUri(normalizedPage, normalizedJobFilter, normalizedTriggerFilter);
+        string updatedPath = BuildHistoryRelativeUri(normalizedPage, normalizedJobFilter, normalizedTriggerFilter, normalizedNodeFilter);
 
         // Not Navigation.ToBaseRelativePath: it compares ordinally and throws when the browser URL
         // casing differs from the base URI casing (server-side route matching is case-insensitive,
@@ -319,6 +469,7 @@
             _page = normalizedPage;
             _appliedJobFilter = normalizedJobFilter;
             _appliedTriggerFilter = normalizedTriggerFilter;
+            _appliedNodeFilter = normalizedNodeFilter;
             return LoadDataAsync();
         }
 
@@ -342,7 +493,7 @@
             && leftQuery.SequenceEqual(rightQuery);
     }
 
-    private string BuildHistoryRelativeUri(int page, string jobFilter, string triggerFilter)
+    private string BuildHistoryRelativeUri(int page, string jobFilter, string triggerFilter, string nodeFilter)
     {
         List<string> queryParts = [];
         if (page > 1)
@@ -360,6 +511,11 @@
             queryParts.Add("trigger=" + Uri.EscapeDataString(triggerFilter));
         }
 
+        if (!string.IsNullOrWhiteSpace(nodeFilter))
+        {
+            queryParts.Add("node=" + Uri.EscapeDataString(nodeFilter));
+        }
+
         if (queryParts.Count == 0)
         {
             return DashboardLink.To(Options.Value, "history");
@@ -372,7 +528,68 @@
     {
         string jobPart = string.IsNullOrWhiteSpace(_appliedJobFilter) ? "Any job" : "Job: " + _appliedJobFilter;
         string triggerPart = string.IsNullOrWhiteSpace(_appliedTriggerFilter) ? "Any trigger" : "Trigger: " + _appliedTriggerFilter;
-        return jobPart + " · " + triggerPart;
+        return jobPart + " · " + triggerPart + " · Node: " + NodeScopeLabel();
+    }
+
+    /// <summary>
+    /// What the listing is narrowed to by node, in the words the stat cards and the summary both use.
+    /// </summary>
+    private string NodeScopeLabel() => HasNodeFilter ? _appliedNodeFilter : "all nodes";
+
+    /// <summary>
+    /// A stat card's title, carrying the scope the figure covers.
+    /// </summary>
+    /// <remarks>
+    /// The figures are over the rows on the page — never over the whole history — and now over one node
+    /// as well when the filter names one, so the title has to say which.
+    /// </remarks>
+    private string ScopedStatTitle(string measure)
+    {
+        return HasNodeFilter
+            ? measure + " (page, " + _appliedNodeFilter + ")"
+            : measure + " (page)";
+    }
+
+    /// <summary>
+    /// The nodes the filter offers: the cluster's, plus any the loaded rows name that it did not list —
+    /// a node that has stopped checking in still has history worth reading.
+    /// </summary>
+    private List<string> NodeOptions()
+    {
+        List<string> options = [];
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string node in _clusterNodes)
+        {
+            if (!string.IsNullOrWhiteSpace(node) && seen.Add(node))
+            {
+                options.Add(node);
+            }
+        }
+
+        foreach (DashboardHistoryEntry entry in _entries)
+        {
+            if (!string.IsNullOrWhiteSpace(entry.SchedulerInstanceId) && seen.Add(entry.SchedulerInstanceId))
+            {
+                options.Add(entry.SchedulerInstanceId);
+            }
+        }
+
+        if (HasNodeFilter && seen.Add(_appliedNodeFilter))
+        {
+            options.Add(_appliedNodeFilter);
+        }
+
+        options.Sort(StringComparer.OrdinalIgnoreCase);
+        return options;
+    }
+
+    /// <summary>
+    /// The node a row came from, or a dash where a store recorded none.
+    /// </summary>
+    private static string NodeLabel(string? schedulerInstanceId)
+    {
+        return string.IsNullOrWhiteSpace(schedulerInstanceId) ? "—" : schedulerInstanceId;
     }
 
     /// <summary>

--- a/src/Quartz.Dashboard/Components/Pages/LiveLogs.razor
+++ b/src/Quartz.Dashboard/Components/Pages/LiveLogs.razor
@@ -7,6 +7,7 @@
 @implements IAsyncDisposable
 @inject NavigationManager Navigation
 @inject SchedulerState Scheduler
+@inject IQuartzApiClient Api
 @inject IOptions<QuartzDashboardOptions> Options
 @inject Microsoft.AspNetCore.Http.IHttpContextAccessor HttpContextAccessor
 @inject IDashboardLiveConnectionFactory LiveConnections
@@ -30,7 +31,10 @@
 
         @if (!string.IsNullOrWhiteSpace(_joinedScheduler))
         {
-            <span class="qz-muted">Listening to: @_joinedScheduler</span>
+            @* The scheduler names the group; the node names the process this page is rendered by. In a
+               cluster that group is fed by every node running that scheduler, so a reader has to be able
+               to tell an event from here apart from an event from a peer. *@
+            <span class="qz-muted">Listening to: @_joinedScheduler@(string.IsNullOrWhiteSpace(_thisNode) ? "" : " · this node is " + _thisNode)</span>
         }
     </div>
 
@@ -76,6 +80,7 @@
                 <li class="qz-live-event qz-live-@liveEvent.Category">
                     <span class="qz-live-time"><TimeAgo Timestamp="@liveEvent.Timestamp" /></span>
                     <span class="qz-live-type">@liveEvent.EventType</span>
+                    <span class="qz-live-node" title="Node">@(liveEvent.SchedulerInstanceId ?? "—")</span>
                     <span class="qz-live-description">@liveEvent.Description</span>
                 </li>
             }
@@ -105,6 +110,12 @@
     private IDashboardLiveConnection? _connection;
     private string? _error;
     private string? _joinedScheduler;
+
+    /// <summary>
+    /// The instance id of the scheduler this page's own process is running, or null when it could not be
+    /// read. The toolbar names it so that an event from a peer is distinguishable from a local one.
+    /// </summary>
+    private string? _thisNode;
     private bool _isConnecting;
     private PeriodicTimer? _connectionMonitorTimer;
     private CancellationTokenSource? _connectionMonitorCancellation;
@@ -268,13 +279,32 @@
         {
             await _connection.Invoke("JoinScheduler", schedulerName);
             _joinedScheduler = schedulerName;
+            _thisNode = await ReadThisNodeAsync(schedulerName);
+        }
+    }
+
+    /// <summary>
+    /// The instance id of the scheduler in this process, read the way every other page reads a
+    /// scheduler's facts. A data source that cannot answer leaves the toolbar saying nothing about the
+    /// node rather than failing the page.
+    /// </summary>
+    private async Task<string?> ReadThisNodeAsync(string schedulerName)
+    {
+        try
+        {
+            SchedulerDetailDto detail = await Api.GetScheduler(schedulerName);
+            return detail.SchedulerInstanceId;
+        }
+        catch (Exception)
+        {
+            return null;
         }
     }
 
     private Task AddEventAsync(string eventType, string category, object? payload)
     {
         string description = BuildDescription(eventType, payload);
-        LiveEventItem item = new(DateTimeOffset.UtcNow, eventType, category, description);
+        LiveEventItem item = new(DateTimeOffset.UtcNow, eventType, category, ReadSchedulerInstanceId(payload), description);
 
         _events.Insert(0, item);
         if (_events.Count > 100)
@@ -335,6 +365,32 @@
         }
     }
 
+    /// <summary>
+    /// The node an event came from, read out of the payload the hub serialized.
+    /// </summary>
+    /// <remarks>
+    /// Every payload carries it, but the page receives them as JSON rather than as the records they were
+    /// sent as — deserializing eleven shapes to read one member of each would be the same answer at
+    /// eleven times the cost. Both spellings are tried because the member name is subject to whatever
+    /// naming policy the host's SignalR JSON protocol is configured with.
+    /// </remarks>
+    private static string? ReadSchedulerInstanceId(object? payload)
+    {
+        if (payload is not System.Text.Json.JsonElement element
+            || element.ValueKind != System.Text.Json.JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (!element.TryGetProperty("schedulerInstanceId", out System.Text.Json.JsonElement node)
+            && !element.TryGetProperty("SchedulerInstanceId", out node))
+        {
+            return null;
+        }
+
+        return node.ValueKind == System.Text.Json.JsonValueKind.String ? node.GetString() : null;
+    }
+
     private static string BuildDescription(string eventType, object? payload)
     {
         if (payload is null)
@@ -369,5 +425,10 @@
         }
     }
 
-    private sealed record LiveEventItem(DateTimeOffset Timestamp, string EventType, string Category, string Description);
+    private sealed record LiveEventItem(
+        DateTimeOffset Timestamp,
+        string EventType,
+        string Category,
+        string? SchedulerInstanceId,
+        string Description);
 }

--- a/src/Quartz.Dashboard/Hubs/IQuartzDashboardHubClient.cs
+++ b/src/Quartz.Dashboard/Hubs/IQuartzDashboardHubClient.cs
@@ -35,6 +35,14 @@ namespace Quartz.Dashboard.Hubs;
 /// The <see cref="Task" /> return types are dictated by SignalR for the same reason: the typed-client
 /// proxy only implements members returning <see cref="Task" /> or <see cref="Task{TResult}" />.
 /// </para>
+/// <para>
+/// Every payload leads with the <c>SchedulerInstanceId</c> of the node that raised the event. A browser
+/// joins a group named after a scheduler, and in a cluster that group is fed by every node running that
+/// scheduler — so without the id a live view cannot say which machine an event came from, which is what
+/// <see href="https://github.com/quartznet/quartznet/issues/3422" /> reported. A pause and a resume get
+/// a payload of their own for it rather than a <c>JobKeyDto</c> / <c>TriggerKeyDto</c>: those are keys,
+/// used by <see cref="Services.IQuartzApiClient" /> everywhere, and a key does not belong to a node.
+/// </para>
 /// </remarks>
 public interface IQuartzDashboardHubClient
 {
@@ -48,13 +56,13 @@ public interface IQuartzDashboardHubClient
 
     Task TriggerMisfired(TriggerEventDto triggerEvent);
 
-    Task TriggerPaused(TriggerKeyDto triggerKey);
+    Task TriggerPaused(TriggerLifecycleDto triggerEvent);
 
-    Task TriggerResumed(TriggerKeyDto triggerKey);
+    Task TriggerResumed(TriggerLifecycleDto triggerEvent);
 
-    Task JobPaused(JobKeyDto jobKey);
+    Task JobPaused(JobLifecycleDto jobEvent);
 
-    Task JobResumed(JobKeyDto jobKey);
+    Task JobResumed(JobLifecycleDto jobEvent);
 
     Task SchedulerStateChanged(SchedulerStateDto state);
 
@@ -62,6 +70,7 @@ public interface IQuartzDashboardHubClient
 }
 
 public sealed record JobEventDto(
+    string SchedulerInstanceId,
     JobKeyDto JobKey,
     TriggerKeyDto TriggerKey,
     DateTimeOffset FireTimeUtc,
@@ -73,6 +82,7 @@ public sealed record JobEventDto(
 /// be threw away everything below one.
 /// </remarks>
 public sealed record JobExecutionResultDto(
+    string SchedulerInstanceId,
     JobKeyDto JobKey,
     TriggerKeyDto TriggerKey,
     DateTimeOffset FireTimeUtc,
@@ -81,9 +91,20 @@ public sealed record JobExecutionResultDto(
     string? ExceptionMessage);
 
 public sealed record TriggerEventDto(
+    string SchedulerInstanceId,
     TriggerKeyDto TriggerKey,
     JobKeyDto? JobKey,
     DateTimeOffset? FireTimeUtc);
+
+/// <summary>
+/// A trigger that was paused or resumed, and the node that did it.
+/// </summary>
+public sealed record TriggerLifecycleDto(string SchedulerInstanceId, TriggerKeyDto TriggerKey);
+
+/// <summary>
+/// A job that was paused or resumed, and the node that did it.
+/// </summary>
+public sealed record JobLifecycleDto(string SchedulerInstanceId, JobKeyDto JobKey);
 
 /// <summary>
 /// The state a scheduler is now in, pushed whenever it changes.
@@ -93,8 +114,12 @@ public sealed record TriggerEventDto(
 /// call site, which is how a running scheduler came to be announced as <c>"Started"</c> here while the
 /// same state was called <c>"Running"</c> everywhere else. It carries the state the scheduler is in,
 /// so an event that is not a state — a scheduler that is starting — is not one of these at all.
+/// <para>
+/// The state is one node's. A cluster is a scheduler running in several processes at once, each with a
+/// lifecycle of its own, so a node going into standby says nothing about its peers.
+/// </para>
 /// </remarks>
-public sealed record SchedulerStateDto(string SchedulerName, SchedulerStatus Status);
+public sealed record SchedulerStateDto(string SchedulerName, string SchedulerInstanceId, SchedulerStatus Status);
 
 /// <remarks>
 /// <see cref="TriggerKey" /> and <see cref="JobKey" /> are null when the scheduler could not say what
@@ -102,6 +127,7 @@ public sealed record SchedulerStateDto(string SchedulerName, SchedulerStatus Sta
 /// </remarks>
 public sealed record SchedulerErrorDto(
     string SchedulerName,
+    string SchedulerInstanceId,
     string Message,
     string? Cause,
     TriggerKeyDto? TriggerKey,

--- a/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
@@ -24,12 +24,13 @@ using Quartz.Extensibility;
 
 namespace Quartz.Dashboard.Plugins;
 
-public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
+public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener, ITriggerListener
 {
     private readonly IServiceProvider serviceProvider;
+    private readonly TimeProvider timeProvider;
 
     /// <summary>
-    /// Takes the container the history store is resolved from.
+    /// Takes the container the history store is resolved from, and the clock a misfire is stamped with.
     /// </summary>
     /// <remarks>
     /// A plugin is constructed by the container — this one is registered for every scheduler by
@@ -37,10 +38,16 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
     /// to read the container back out of <c>scheduler.Context["Quartz.ServiceProvider"]</c>, which put
     /// Quartz's plumbing into the application's own map, and left the scheduler-context endpoint of the
     /// HTTP API answering <c>500</c> for every scheduler a container had built.
+    /// <para>
+    /// The clock is this scheduler's: a named scheduler is built through a provider that resolves its own
+    /// parts, so a scheduler given a <see cref="TimeProvider" /> of its own stamps its misfires with it.
+    /// An execution needs no clock — it carries the fire time the scheduler already recorded.
+    /// </para>
     /// </remarks>
-    public DashboardHistoryPlugin(IServiceProvider serviceProvider)
+    public DashboardHistoryPlugin(IServiceProvider serviceProvider, TimeProvider timeProvider)
     {
         this.serviceProvider = serviceProvider;
+        this.timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public string Name { get; private set; } = "QuartzDashboardHistory";
@@ -49,6 +56,7 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
     {
         Name = pluginName;
         scheduler.ListenerManager.AddJobListener(this, Matchers.AllJobs());
+        scheduler.ListenerManager.AddTriggerListener(this, Matchers.AllTriggers());
         return default;
     }
 
@@ -64,11 +72,7 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
     {
         try
         {
-            // Resolved per execution and allowed to be absent, as when this went through the scheduler
-            // context: a dashboard that was never registered is a reason to record nothing, not a reason
-            // to fail the execution that just finished. Nor is a container the host has begun disposing,
-            // which is what the catch below is for.
-            IDashboardHistoryStore? store = serviceProvider.GetService<IDashboardHistoryStore>();
+            IDashboardHistoryStore? store = Store();
             if (store is null)
             {
                 return default;
@@ -76,6 +80,7 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
 
             DashboardHistoryEntry entry = new(
                 SchedulerName: context.Scheduler.SchedulerName,
+                SchedulerInstanceId: context.Scheduler.SchedulerInstanceId,
                 JobGroup: context.JobDetail.Key.Group,
                 JobName: context.JobDetail.Key.Name,
                 TriggerGroup: context.Trigger.Key.Group,
@@ -92,4 +97,64 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener
             return default;
         }
     }
+
+    public ValueTask TriggerFired(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+
+    public ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(false);
+    }
+
+    /// <summary>
+    /// Records a firing the scheduler missed.
+    /// </summary>
+    /// <remarks>
+    /// A misfire never becomes an execution, so it is invisible in the execution history however long a
+    /// reader stares at it. The scheduler notifies before it applies the trigger's misfire instruction,
+    /// so <see cref="ITrigger.NextFireTimeUtc" /> is still the firing that was missed rather than the one
+    /// it was rescheduled to.
+    /// </remarks>
+    public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            IDashboardHistoryStore? store = Store();
+            if (store is null)
+            {
+                return default;
+            }
+
+            DashboardMisfireEntry entry = new(
+                SchedulerName: scheduler.SchedulerName,
+                SchedulerInstanceId: scheduler.SchedulerInstanceId,
+                TriggerGroup: trigger.Key.Group,
+                TriggerName: trigger.Key.Name,
+                JobKey: trigger.JobKey is null ? null : new JobKeyDto(trigger.JobKey.Group, trigger.JobKey.Name),
+                MisfiredAtUtc: timeProvider.GetUtcNow(),
+                ScheduledFireTimeUtc: trigger.NextFireTimeUtc);
+
+            return store.AddMisfire(entry, cancellationToken);
+        }
+        catch (ObjectDisposedException)
+        {
+            return default;
+        }
+    }
+
+    public ValueTask TriggerComplete(
+        ITrigger trigger,
+        IJobExecutionContext context,
+        SchedulerInstruction triggerInstructionCode,
+        CancellationToken cancellationToken = default) => default;
+
+    /// <summary>
+    /// The store to record into, or <see langword="null" /> when there is none.
+    /// </summary>
+    /// <remarks>
+    /// Resolved per event and allowed to be absent, as when this went through the scheduler context: a
+    /// dashboard that was never registered is a reason to record nothing, not a reason to fail the
+    /// execution that just finished. Nor is a container the host has begun disposing, which is what the
+    /// callers' <see cref="ObjectDisposedException" /> handlers are for.
+    /// </remarks>
+    private IDashboardHistoryStore? Store() => serviceProvider.GetService<IDashboardHistoryStore>();
 }

--- a/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
@@ -35,7 +35,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     /// Takes the container the dashboard's SignalR hub is resolved from.
     /// </summary>
     /// <remarks>
-    /// <inheritdoc cref="DashboardHistoryPlugin(IServiceProvider)" path="/remarks" />
+    /// <inheritdoc cref="DashboardHistoryPlugin(IServiceProvider, TimeProvider)" path="/remarks" />
     /// </remarks>
     public DashboardLiveEventsPlugin(IServiceProvider serviceProvider)
     {
@@ -62,6 +62,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         JobEventDto payload = new(
+            SchedulerInstanceId: context.Scheduler.SchedulerInstanceId,
             JobKey: new JobKeyDto(context.JobDetail.Key.Group, context.JobDetail.Key.Name),
             TriggerKey: new TriggerKeyDto(context.Trigger.Key.Group, context.Trigger.Key.Name),
             FireTimeUtc: context.FireTimeUtc,
@@ -73,6 +74,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         JobExecutionResultDto payload = new(
+            SchedulerInstanceId: context.Scheduler.SchedulerInstanceId,
             JobKey: new JobKeyDto(context.JobDetail.Key.Group, context.JobDetail.Key.Name),
             TriggerKey: new TriggerKeyDto(context.Trigger.Key.Group, context.Trigger.Key.Name),
             FireTimeUtc: context.FireTimeUtc,
@@ -86,6 +88,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
     {
         JobExecutionResultDto payload = new(
+            SchedulerInstanceId: context.Scheduler.SchedulerInstanceId,
             JobKey: new JobKeyDto(context.JobDetail.Key.Group, context.JobDetail.Key.Name),
             TriggerKey: new TriggerKeyDto(context.Trigger.Key.Group, context.Trigger.Key.Name),
             FireTimeUtc: context.FireTimeUtc,
@@ -99,6 +102,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     public ValueTask TriggerFired(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         TriggerEventDto payload = new(
+            SchedulerInstanceId: context.Scheduler.SchedulerInstanceId,
             TriggerKey: new TriggerKeyDto(trigger.Key.Group, trigger.Key.Name),
             JobKey: new JobKeyDto(context.JobDetail.Key.Group, context.JobDetail.Key.Name),
             FireTimeUtc: context.FireTimeUtc);
@@ -114,6 +118,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     public ValueTask TriggerMisfired(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
     {
         TriggerEventDto payload = new(
+            SchedulerInstanceId: scheduler.SchedulerInstanceId,
             TriggerKey: new TriggerKeyDto(trigger.Key.Group, trigger.Key.Name),
             JobKey: trigger.JobKey is null ? null : new JobKeyDto(trigger.JobKey.Group, trigger.JobKey.Name),
             FireTimeUtc: null);
@@ -128,6 +133,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         CancellationToken cancellationToken = default)
     {
         TriggerEventDto payload = new(
+            SchedulerInstanceId: context.Scheduler.SchedulerInstanceId,
             TriggerKey: new TriggerKeyDto(trigger.Key.Group, trigger.Key.Name),
             JobKey: new JobKeyDto(context.JobDetail.Key.Group, context.JobDetail.Key.Name),
             FireTimeUtc: context.FireTimeUtc);
@@ -143,7 +149,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
 
     public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        TriggerKeyDto payload = new(triggerKey.Group, triggerKey.Name);
+        TriggerLifecycleDto payload = new(scheduler.SchedulerInstanceId, new TriggerKeyDto(triggerKey.Group, triggerKey.Name));
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.TriggerPaused(payload));
     }
 
@@ -151,7 +157,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
 
     public ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        TriggerKeyDto payload = new(triggerKey.Group, triggerKey.Name);
+        TriggerLifecycleDto payload = new(scheduler.SchedulerInstanceId, new TriggerKeyDto(triggerKey.Group, triggerKey.Name));
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.TriggerResumed(payload));
     }
 
@@ -163,7 +169,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
 
     public ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        JobKeyDto payload = new(jobKey.Group, jobKey.Name);
+        JobLifecycleDto payload = new(scheduler.SchedulerInstanceId, new JobKeyDto(jobKey.Group, jobKey.Name));
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.JobPaused(payload));
     }
 
@@ -173,7 +179,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
 
     public ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        JobKeyDto payload = new(jobKey.Group, jobKey.Name);
+        JobLifecycleDto payload = new(scheduler.SchedulerInstanceId, new JobKeyDto(jobKey.Group, jobKey.Name));
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.JobResumed(payload));
     }
 
@@ -183,6 +189,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     {
         SchedulerErrorDto payload = new(
             SchedulerName: scheduler.SchedulerName,
+            SchedulerInstanceId: scheduler.SchedulerInstanceId,
             Message: errorContext.Message,
             Cause: errorContext.Exception.Message,
             TriggerKey: errorContext.TriggerKey is null ? null : new TriggerKeyDto(errorContext.TriggerKey.Group, errorContext.TriggerKey.Name),
@@ -226,7 +233,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     /// </summary>
     private ValueTask BroadcastState(IScheduler scheduler, SchedulerStatus status)
     {
-        SchedulerStateDto payload = new(scheduler.SchedulerName, status);
+        SchedulerStateDto payload = new(scheduler.SchedulerName, scheduler.SchedulerInstanceId, status);
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.SchedulerStateChanged(payload));
     }
 

--- a/src/Quartz.Dashboard/QuartzDashboardOptions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardOptions.cs
@@ -47,6 +47,22 @@ public sealed class QuartzDashboardOptions
     public bool ReadOnly { get; set; }
 
     /// <summary>
+    /// How far back the dashboard's own history store keeps executions and misfires. Defaults to 24 hours.
+    /// </summary>
+    /// <remarks>
+    /// The count bound below cannot answer for a scheduler that has gone quiet: it keeps whatever it last
+    /// recorded, so a page shows executions from an arbitrary distance in the past with nothing to say how
+    /// old they are. Both bounds apply, and whichever bites first wins.
+    /// </remarks>
+    public TimeSpan HistoryRetention { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// How many executions and how many misfires the dashboard's own history store keeps per scheduler,
+    /// oldest dropped first. Defaults to 2000 of each.
+    /// </summary>
+    public int HistoryMaxEntriesPerScheduler { get; set; } = 2000;
+
+    /// <summary>
     /// <see cref="DashboardPath"/> normalized to a rooted path without a trailing slash,
     /// falling back to <see cref="DefaultDashboardPath"/> when unset or empty.
     /// </summary>

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -44,7 +44,13 @@ public static class QuartzDashboardServiceCollectionExtensions
                 "DashboardPath must start with '/'")
             .Validate(
                 options => IsRoutableDashboardPath(options.DashboardPath),
-                "DashboardPath must be a simple URL path: it cannot contain '{', '}', '?', '#', '.' or '..' segments, or empty segments ('//')");
+                "DashboardPath must be a simple URL path: it cannot contain '{', '}', '?', '#', '.' or '..' segments, or empty segments ('//')")
+            .Validate(
+                options => options.HistoryRetention > TimeSpan.Zero,
+                "HistoryRetention must be positive: a zero or negative window would forget every execution the moment it was recorded")
+            .Validate(
+                options => options.HistoryMaxEntriesPerScheduler > 0,
+                "HistoryMaxEntriesPerScheduler must be at least 1");
 
         if (configure is not null)
         {
@@ -74,7 +80,12 @@ public static class QuartzDashboardServiceCollectionExtensions
         services.TryAddScoped<SchedulerState>();
         services.TryAddScoped<ToastService>();
         services.TryAddSingleton<IDashboardLiveConnectionFactory, SignalRDashboardLiveConnectionFactory>();
-        services.TryAddSingleton<IDashboardHistoryStore, DashboardHistoryStore>();
+        // The store measures its retention window on the scheduler's clock, and falls back to the system
+        // one only when the dashboard is registered without Quartz — which AddQuartz would otherwise have
+        // put in the container.
+        services.TryAddSingleton<IDashboardHistoryStore>(static provider => new DashboardHistoryStore(
+            provider.GetRequiredService<IOptions<QuartzDashboardOptions>>(),
+            provider.GetService<TimeProvider>() ?? TimeProvider.System));
         services.TryAddSingleton<DashboardActionLogService>();
 
         // The dashboard's own plugins, registered rather than named by a quartz.plugin.*.type key. A type

--- a/src/Quartz.Dashboard/Services/DashboardHistoryStore.cs
+++ b/src/Quartz.Dashboard/Services/DashboardHistoryStore.cs
@@ -19,14 +19,31 @@
 
 using System.Collections.Concurrent;
 
+using Microsoft.Extensions.Options;
+
 namespace Quartz.Dashboard.Services;
 
 /// <remarks>
 /// <see cref="Duration" /> is a <see cref="TimeSpan" />, as every other duration the dashboard shows
 /// is; it used to be a count of whole milliseconds, which lost every execution shorter than one.
 /// </remarks>
+/// <param name="SchedulerName">The scheduler the execution belongs to.</param>
+/// <param name="SchedulerInstanceId">
+/// The node that ran it. Every node of a cluster keeps its own history of its own executions, so
+/// without this a row cannot say which machine it came from — and a store shared across the cluster
+/// cannot say it either.
+/// </param>
+/// <param name="JobGroup">The group of the job that ran.</param>
+/// <param name="JobName">The name of the job that ran.</param>
+/// <param name="TriggerGroup">The group of the trigger that fired it.</param>
+/// <param name="TriggerName">The name of the trigger that fired it.</param>
+/// <param name="FiredAtUtc">When the execution fired.</param>
+/// <param name="Duration">How long the job took.</param>
+/// <param name="Succeeded">Whether the job completed without throwing.</param>
+/// <param name="ExceptionMessage">What it threw, or <see langword="null" /> when it succeeded.</param>
 public sealed record DashboardHistoryEntry(
     string SchedulerName,
+    string SchedulerInstanceId,
     string JobGroup,
     string JobName,
     string TriggerGroup,
@@ -36,6 +53,43 @@ public sealed record DashboardHistoryEntry(
     bool Succeeded,
     string? ExceptionMessage);
 
+/// <summary>
+/// One trigger that missed its scheduled firing, as the scheduler reported it.
+/// </summary>
+/// <remarks>
+/// A misfire is not an execution — nothing ran — so it is recorded beside the executions rather than
+/// among them, under the same bounds.
+/// </remarks>
+/// <param name="SchedulerName">The scheduler the trigger belongs to.</param>
+/// <param name="SchedulerInstanceId">The node that noticed the misfire.</param>
+/// <param name="TriggerGroup">The group of the trigger that missed its firing.</param>
+/// <param name="TriggerName">The name of the trigger that missed its firing.</param>
+/// <param name="JobKey">
+/// The job the trigger points at, or <see langword="null" /> when the trigger names none.
+/// </param>
+/// <param name="MisfiredAtUtc">When the misfire was noticed, on the scheduler's clock.</param>
+/// <param name="ScheduledFireTimeUtc">
+/// The firing that was missed, or <see langword="null" /> when the trigger had no next firing left to
+/// name. The scheduler reports a misfire before it applies the trigger's misfire instruction, so this
+/// is the time the trigger was still due at.
+/// </param>
+public sealed record DashboardMisfireEntry(
+    string SchedulerName,
+    string SchedulerInstanceId,
+    string TriggerGroup,
+    string TriggerName,
+    JobKeyDto? JobKey,
+    DateTimeOffset MisfiredAtUtc,
+    DateTimeOffset? ScheduledFireTimeUtc);
+
+/// <summary>
+/// Where the dashboard's execution history and misfire feed live.
+/// </summary>
+/// <remarks>
+/// The seam an application replaces to keep history somewhere that survives a restart — the shipped
+/// implementation is per-process and in-memory, so every node of a cluster holds its own. Both feeds
+/// carry the node that produced each row, which is what makes a shared implementation readable.
+/// </remarks>
 public interface IDashboardHistoryStore
 {
     ValueTask Add(DashboardHistoryEntry entry, CancellationToken cancellationToken = default);
@@ -44,25 +98,71 @@ public interface IDashboardHistoryStore
     /// Returns one page of the recorded executions, newest first.
     /// </summary>
     ValueTask<PagedResult<DashboardHistoryEntry>> GetPage(DashboardHistoryQuery query, CancellationToken cancellationToken = default);
+
+    ValueTask AddMisfire(DashboardMisfireEntry entry, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns one page of the recorded misfires, newest first.
+    /// </summary>
+    ValueTask<PagedResult<DashboardMisfireEntry>> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// How many misfires the scheduler has recorded since <paramref name="since" />.
+    /// </summary>
+    /// <remarks>
+    /// A count rather than a page, because a summary asks "how bad is it right now" and a store that
+    /// keeps history in a database can answer that with one <c>COUNT(*)</c> instead of loading rows it
+    /// would throw away.
+    /// </remarks>
+    ValueTask<int> CountMisfires(string schedulerName, DateTimeOffset since, CancellationToken cancellationToken = default);
 }
 
+/// <summary>
+/// The per-process history the dashboard keeps when nothing else is registered.
+/// </summary>
+/// <remarks>
+/// Bounded twice: by <see cref="QuartzDashboardOptions.HistoryMaxEntriesPerScheduler" />, so a busy
+/// scheduler cannot grow it without limit, and by <see cref="QuartzDashboardOptions.HistoryRetention" />,
+/// so a quiet one stops showing executions from an arbitrary distance in the past. The count bound alone
+/// left the second case unanswered, which is what <see href="https://github.com/quartznet/quartznet/issues/3422" />
+/// reported.
+/// </remarks>
 internal sealed class DashboardHistoryStore : IDashboardHistoryStore
 {
-    private readonly ConcurrentDictionary<string, List<DashboardHistoryEntry>> entriesByScheduler = new(StringComparer.OrdinalIgnoreCase);
-    private readonly int maxEntriesPerScheduler = 2000;
+    private readonly ConcurrentDictionary<string, List<DashboardHistoryEntry>> executionsByScheduler = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, List<DashboardMisfireEntry>> misfiresByScheduler = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TimeProvider timeProvider;
+    private readonly int maxEntriesPerScheduler;
+    private readonly TimeSpan retention;
+
+    /// <param name="options">The bounds the history is kept under.</param>
+    /// <param name="timeProvider">
+    /// The clock the retention window is measured on — the scheduler's, so a test that moves it forward
+    /// sees the store forget.
+    /// </param>
+    public DashboardHistoryStore(IOptions<QuartzDashboardOptions> options, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.timeProvider = timeProvider;
+        maxEntriesPerScheduler = options.Value.HistoryMaxEntriesPerScheduler;
+        retention = options.Value.HistoryRetention;
+    }
 
     public ValueTask Add(DashboardHistoryEntry entry, CancellationToken cancellationToken = default)
     {
-        List<DashboardHistoryEntry> list = entriesByScheduler.GetOrAdd(entry.SchedulerName, _ => []);
-        lock (list)
-        {
-            list.Add(entry);
-            if (list.Count > maxEntriesPerScheduler)
-            {
-                list.RemoveRange(0, list.Count - maxEntriesPerScheduler);
-            }
-        }
+        ArgumentNullException.ThrowIfNull(entry);
 
+        Record(executionsByScheduler, entry.SchedulerName, entry, FiredAt);
+        return default;
+    }
+
+    public ValueTask AddMisfire(DashboardMisfireEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        Record(misfiresByScheduler, entry.SchedulerName, entry, MisfiredAt);
         return default;
     }
 
@@ -70,17 +170,11 @@ internal sealed class DashboardHistoryStore : IDashboardHistoryStore
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        List<DashboardHistoryEntry> snapshot = [];
+        IEnumerable<DashboardHistoryEntry> filtered = OnNode(
+            Snapshot(executionsByScheduler, query.SchedulerName, FiredAt),
+            query.SchedulerInstanceId,
+            static entry => entry.SchedulerInstanceId);
 
-        if (entriesByScheduler.TryGetValue(query.SchedulerName, out List<DashboardHistoryEntry>? list))
-        {
-            lock (list)
-            {
-                snapshot.AddRange(list);
-            }
-        }
-
-        IEnumerable<DashboardHistoryEntry> filtered = snapshot;
         if (!string.IsNullOrWhiteSpace(query.JobFilter))
         {
             string normalizedJobFilter = query.JobFilter.Trim();
@@ -95,15 +189,122 @@ internal sealed class DashboardHistoryStore : IDashboardHistoryStore
                 MatchesFilter(x.TriggerGroup, x.TriggerName, normalizedTriggerFilter));
         }
 
-        List<DashboardHistoryEntry> ordered = filtered
-            .OrderByDescending(x => x.FiredAtUtc)
-            .ToList();
+        return ValueTask.FromResult(Page(filtered.OrderByDescending(static entry => entry.FiredAtUtc).ToList(), query));
+    }
 
+    public ValueTask<PagedResult<DashboardMisfireEntry>> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        IEnumerable<DashboardMisfireEntry> filtered = OnNode(
+            Snapshot(misfiresByScheduler, query.SchedulerName, MisfiredAt),
+            query.SchedulerInstanceId,
+            static entry => entry.SchedulerInstanceId);
+
+        if (!string.IsNullOrWhiteSpace(query.TriggerFilter))
+        {
+            string normalizedTriggerFilter = query.TriggerFilter.Trim();
+            filtered = filtered.Where(x =>
+                MatchesFilter(x.TriggerGroup, x.TriggerName, normalizedTriggerFilter));
+        }
+
+        return ValueTask.FromResult(Page(filtered.OrderByDescending(static entry => entry.MisfiredAtUtc).ToList(), query));
+    }
+
+    public ValueTask<int> CountMisfires(string schedulerName, DateTimeOffset since, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(schedulerName);
+
+        int count = 0;
+        foreach (DashboardMisfireEntry entry in Snapshot(misfiresByScheduler, schedulerName, MisfiredAt))
+        {
+            if (entry.MisfiredAtUtc >= since)
+            {
+                count++;
+            }
+        }
+
+        return ValueTask.FromResult(count);
+    }
+
+    private static DateTimeOffset FiredAt(DashboardHistoryEntry entry) => entry.FiredAtUtc;
+
+    private static DateTimeOffset MisfiredAt(DashboardMisfireEntry entry) => entry.MisfiredAtUtc;
+
+    private static IEnumerable<T> OnNode<T>(List<T> entries, string? schedulerInstanceId, Func<T, string> nodeOf)
+    {
+        if (string.IsNullOrWhiteSpace(schedulerInstanceId))
+        {
+            return entries;
+        }
+
+        string normalized = schedulerInstanceId.Trim();
+        return entries.Where(entry => string.Equals(nodeOf(entry), normalized, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static PagedResult<T> Page<T>(List<T> ordered, PagedQuery query)
+    {
         // Skip past the end is an empty page rather than an error, the same answer a job store gives.
         int skip = Math.Min(query.Skip, ordered.Count);
-        List<DashboardHistoryEntry> pageItems = ordered.Skip(skip).Take(query.Take).ToList();
+        List<T> pageItems = ordered.Skip(skip).Take(query.Take).ToList();
         bool hasMore = skip + pageItems.Count < ordered.Count;
-        return ValueTask.FromResult(new PagedResult<DashboardHistoryEntry>(pageItems, hasMore, ordered.Count));
+        return new PagedResult<T>(pageItems, hasMore, ordered.Count);
+    }
+
+    private void Record<T>(ConcurrentDictionary<string, List<T>> byScheduler, string schedulerName, T entry, Func<T, DateTimeOffset> timeOf)
+    {
+        List<T> list = byScheduler.GetOrAdd(schedulerName, static _ => []);
+        lock (list)
+        {
+            list.Add(entry);
+            Trim(list, timeOf);
+        }
+    }
+
+    /// <summary>
+    /// Takes a copy of what a scheduler holds, forgetting whatever has fallen out of bounds first.
+    /// </summary>
+    /// <remarks>
+    /// Reading trims as writing does, because a scheduler that has stopped running jobs never writes
+    /// again — and it is exactly that scheduler whose page would otherwise keep showing executions from
+    /// an arbitrary distance in the past.
+    /// </remarks>
+    private List<T> Snapshot<T>(ConcurrentDictionary<string, List<T>> byScheduler, string schedulerName, Func<T, DateTimeOffset> timeOf)
+    {
+        List<T> snapshot = [];
+
+        if (byScheduler.TryGetValue(schedulerName, out List<T>? list))
+        {
+            lock (list)
+            {
+                Trim(list, timeOf);
+                snapshot.AddRange(list);
+            }
+        }
+
+        return snapshot;
+    }
+
+    /// <summary>
+    /// Applies both bounds, age before count.
+    /// </summary>
+    /// <remarks>
+    /// The age pass is a full scan rather than a walk in from the oldest end: entries are appended in
+    /// arrival order, which is only the same as timestamp order while one node is writing, and a store
+    /// fed by a whole cluster would leave a late arrival stranded behind a fresher one forever.
+    /// </remarks>
+    private void Trim<T>(List<T> list, Func<T, DateTimeOffset> timeOf)
+    {
+        if (retention > TimeSpan.Zero)
+        {
+            DateTimeOffset cutoff = timeProvider.GetUtcNow() - retention;
+            list.RemoveAll(entry => timeOf(entry) < cutoff);
+        }
+
+        if (list.Count > maxEntriesPerScheduler)
+        {
+            list.RemoveRange(0, list.Count - maxEntriesPerScheduler);
+        }
     }
 
     private static bool MatchesFilter(string group, string name, string filter)

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -193,6 +193,12 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<PagedResult<DashboardHistoryEntry>?> GetHistory(DashboardHistoryQuery query, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns one page of the triggers that missed a firing, newest first, or <see langword="null" />
+    /// when the data source keeps no history.
+    /// </summary>
+    ValueTask<PagedResult<DashboardMisfireEntry>?> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default);
+
     ValueTask<ExecutionLimitsDto?> GetExecutionLimits(string schedulerName, CancellationToken cancellationToken = default);
 }
 
@@ -230,7 +236,7 @@ public sealed record DashboardFireInstanceQuery : PagedQuery
 }
 
 /// <summary>
-/// One page of the execution history of a scheduler, optionally narrowed by job and trigger.
+/// One page of the execution history of a scheduler, optionally narrowed by node, job and trigger.
 /// </summary>
 /// <remarks>
 /// A filter matches a key's group, its name, or the two joined as <c>group.name</c>, case-insensitively.
@@ -239,7 +245,30 @@ public sealed record DashboardHistoryQuery : PagedQuery
 {
     public required string SchedulerName { get; init; }
 
+    /// <summary>
+    /// The node whose executions to list, or <see langword="null" /> for every node's.
+    /// </summary>
+    public string? SchedulerInstanceId { get; init; }
+
     public string? JobFilter { get; init; }
+
+    public string? TriggerFilter { get; init; }
+}
+
+/// <summary>
+/// One page of the misfires of a scheduler, optionally narrowed by node and trigger.
+/// </summary>
+/// <remarks>
+/// <inheritdoc cref="DashboardHistoryQuery" path="/remarks" />
+/// </remarks>
+public sealed record DashboardMisfireQuery : PagedQuery
+{
+    public required string SchedulerName { get; init; }
+
+    /// <summary>
+    /// The node whose misfires to list, or <see langword="null" /> for every node's.
+    /// </summary>
+    public string? SchedulerInstanceId { get; init; }
 
     public string? TriggerFilter { get; init; }
 }

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -518,6 +518,13 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return await historyStore.GetPage(query, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<PagedResult<DashboardMisfireEntry>?> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        return await historyStore.GetMisfires(query, cancellationToken).ConfigureAwait(false);
+    }
+
     private static GroupMatcher<TKey>? BuildGroupMatcher<TKey>(string? groupFilter) where TKey : Key<TKey>
     {
         return string.IsNullOrWhiteSpace(groupFilter) ? null : GroupMatcher<TKey>.GroupContains(groupFilter);

--- a/src/Quartz.Dashboard/wwwroot/css/quartz-dashboard.css
+++ b/src/Quartz.Dashboard/wwwroot/css/quartz-dashboard.css
@@ -1633,7 +1633,7 @@
 
 .qz-live-event {
     display: grid;
-    grid-template-columns: 90px max-content minmax(0, 1fr);
+    grid-template-columns: 90px max-content max-content minmax(0, 1fr);
     align-items: center;
     gap: var(--qz-space-sm);
     padding: var(--qz-space-sm) var(--qz-space-md);
@@ -1656,6 +1656,17 @@
 
 .qz-live-type {
     font-weight: var(--qz-font-weight-semibold);
+    white-space: nowrap;
+}
+
+/* Which node raised the event. In a cluster one browser sees every node's events at once. */
+.qz-live-node {
+    color: var(--qz-color-text-muted);
+    font-family: var(--qz-font-mono);
+    font-size: var(--qz-font-size-xs);
+    max-width: 16ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
 }
 

--- a/src/Quartz.Documentation.Samples/Packages/DashboardSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/DashboardSamples.cs
@@ -87,6 +87,19 @@ public static class DashboardSamples
         #endregion
     }
 
+    public static void HistoryBounds(IServiceCollection services)
+    {
+        #region sample_dashboard_history_bounds
+
+        services.AddQuartzDashboard(options =>
+        {
+            options.HistoryRetention = TimeSpan.FromHours(6);
+            options.HistoryMaxEntriesPerScheduler = 500;
+        });
+
+        #endregion
+    }
+
     public static void AuthorizationPolicy(WebApplicationBuilder builder)
     {
         #region sample_dashboard_authorization_policy

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
@@ -80,6 +80,11 @@ internal sealed class DashboardComponentContext : BunitContext
     }
 
     /// <summary>
+    /// Where the browser is now, which is what a page writing its filters into the query string moves.
+    /// </summary>
+    public string CurrentUri => Services.GetRequiredService<NavigationManager>().Uri;
+
+    /// <summary>
     /// Points the pages at a scheduler that exists and is running, which is what all but the
     /// no-scheduler-selected tests want.
     /// </summary>

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/HistoryPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/HistoryPageTest.cs
@@ -184,12 +184,121 @@ public class HistoryPageTest
             .MustHaveHappened();
     }
 
-    private static DashboardHistoryEntry Entry(int durationMilliseconds, bool succeeded = true, string? exceptionMessage = null)
+    [Test]
+    public void EachRowSaysWhichNodeRanIt()
+    {
+        GivenHistory(
+            Entry(100, node: "node-a"),
+            Entry(200, node: "node-b"));
+
+        IRenderedComponent<History> page = context.Render<History>();
+
+        page.TextOfAll(".qz-history-node").Should().Equal(["node-a", "node-b"],
+            "every node of a cluster keeps its own history, and a row that does not name one cannot be "
+            + "attributed to a machine");
+    }
+
+    [Test]
+    public void TheNodeFilterNarrowsTheListingAndTheStatCardsSaySo()
+    {
+        GivenHistory(Entry(100, node: "node-b"));
+
+        context.Navigate("/quartz/history?node=node-b");
+
+        IRenderedComponent<History> page = context.Render<History>();
+
+        A.CallTo(() => context.Api.GetHistory(
+                A<DashboardHistoryQuery>.That.Matches(query => query.SchedulerInstanceId == "node-b"),
+                A<CancellationToken>._))
+            .MustHaveHappened();
+
+        page.StatCardValue("Success rate (page, node-b)").Should().Be("100.0 %",
+            "the figures are over one node's rows now, so the card has to say which node they cover");
+        page.Markup.Should().Contain("Node: node-b",
+            "the summary above the table says what the listing is narrowed to");
+    }
+
+    [Test]
+    public void AnUnfilteredListingSaysItCoversEveryNode()
+    {
+        GivenHistory(Entry(100));
+
+        IRenderedComponent<History> page = context.Render<History>();
+
+        page.Markup.Should().Contain("Node: all nodes",
+            "a reader has to be able to tell 'every node' from 'the one node this page happens to show'");
+        page.StatCardValue("Success rate (page)").Should().Be("100.0 %");
+    }
+
+    [Test]
+    public void TheNodeFilterOffersTheClusterNodesEvenWhereNoRowNamesThem()
+    {
+        GivenHistory(Entry(100, node: "node-a"));
+        A.CallTo(() => context.Api.GetClusterNodes(TestData.SchedulerName, A<CancellationToken>._))
+            .Returns(new List<ClusterNodeDto>
+            {
+                new("node-a", null, null, ClusterNodeState.Alive, IsCurrentNode: true),
+                new("node-b", null, null, ClusterNodeState.Failed, IsCurrentNode: false)
+            });
+
+        IRenderedComponent<History> page = context.Render<History>();
+
+        page.TextOfAll("#history-node-filter option").Should().Equal(["All nodes", "node-a", "node-b"],
+            "a node that has produced nothing on this page is still a node worth asking about — most "
+            + "of all the one that stopped");
+    }
+
+    [Test]
+    public void ChoosingANodePutsItInTheUrlSoTheViewCanBeShared()
+    {
+        GivenHistory(Entry(100, node: "node-a"), Entry(200, node: "node-b"));
+
+        IRenderedComponent<History> page = context.Render<History>();
+        page.Find("#history-node-filter").Change("node-b");
+
+        context.CurrentUri.Should().EndWith("/quartz/history?node=node-b",
+            "the filters are query parameters so a narrowed listing is a link someone can send");
+    }
+
+    [Test]
+    public void MisfiresAreListedBesideTheExecutions()
+    {
+        GivenHistory(Entry(100));
+        GivenMisfires(
+            TestData.Dashboard.MisfireEntry("nightly", jobKey: new JobKeyDto("reports", "rollup")),
+            TestData.Dashboard.MisfireEntry("hourly", schedulerInstanceId: "node-b"));
+
+        IRenderedComponent<History> page = context.Render<History>();
+
+        page.TextOfAll(".qz-misfire-node").Should().Equal([TestData.SchedulerInstanceId, "node-b"]);
+        page.Markup.Should().Contain("nightly").And.Contain("hourly");
+        page.Markup.Should().Contain("reports.rollup",
+            "the job a missed trigger points at is what a reader is looking for");
+    }
+
+    [Test]
+    public void ASchedulerWithNoMisfiresSaysSoRatherThanShowingNothing()
+    {
+        GivenHistory(Entry(100));
+        GivenMisfires();
+
+        IRenderedComponent<History> page = context.Render<History>();
+
+        page.Markup.Should().Contain("No misfires recorded",
+            "an empty section says the scheduler is healthy; a missing one says nothing at all");
+    }
+
+    private static DashboardHistoryEntry Entry(
+        int durationMilliseconds,
+        bool succeeded = true,
+        string? exceptionMessage = null,
+        string node = TestData.SchedulerInstanceId)
     {
         return TestData.Dashboard.HistoryEntry(
             TimeSpan.FromMilliseconds(durationMilliseconds),
             succeeded,
-            exceptionMessage: exceptionMessage);
+            exceptionMessage: exceptionMessage,
+            schedulerInstanceId: node);
     }
 
     private void GivenHistory(params DashboardHistoryEntry[] entries)
@@ -201,5 +310,16 @@ public class HistoryPageTest
     {
         A.CallTo(() => context.Api.GetHistory(A<DashboardHistoryQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<DashboardHistoryEntry>(entries, totalCount));
+    }
+
+    /// <remarks>
+    /// Left unstubbed the fake answers null, which is the "this data source keeps no history" answer —
+    /// so a test that says nothing about misfires renders no misfire section, and the tests above are
+    /// unaffected by one.
+    /// </remarks>
+    private void GivenMisfires(params DashboardMisfireEntry[] entries)
+    {
+        A.CallTo(() => context.Api.GetMisfires(A<DashboardMisfireQuery>._, A<CancellationToken>._))
+            .Returns(TestData.Dashboard.Page<DashboardMisfireEntry>(entries));
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/LiveLogsPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/LiveLogsPageTest.cs
@@ -42,6 +42,43 @@ public class LiveLogsPageTest
             "a connection that joined nothing receives nothing");
         page.Markup.Should().Contain("● Connected");
         page.Markup.Should().Contain("Listening to: " + TestData.SchedulerName);
+        page.Markup.Should().Contain("this node is " + TestData.SchedulerInstanceId,
+            "the group is fed by every node running that scheduler, so the page has to say which of "
+            + "them its own process is");
+    }
+
+    [Test]
+    public void AnEventSaysWhichNodeRaisedIt()
+    {
+        IRenderedComponent<LiveLogs> page = context.Render<LiveLogs>();
+
+        page.InvokeAsync(() => context.LiveConnections.Current.Push("JobExecuted", Payload("node-b"))).Wait();
+
+        page.TextOfAll(".qz-live-node").Should().Equal(["node-b"],
+            "one browser watching a clustered scheduler sees every node's events at once");
+    }
+
+    [Test]
+    public void AnEventFromAHubThatNamesNoNodeIsStillListed()
+    {
+        IRenderedComponent<LiveLogs> page = context.Render<LiveLogs>();
+
+        page.InvokeAsync(() => context.LiveConnections.Current.Push("JobExecuted", "reports.nightly")).Wait();
+
+        page.TextOfAll(".qz-live-node").Should().Equal(["—"],
+            "an event whose payload says nothing about a node is a gap in the row, not a dropped event");
+    }
+
+    /// <summary>
+    /// A payload as the hub puts it on the wire: JSON, which is what the page reads the node out of.
+    /// </summary>
+    private static System.Text.Json.JsonElement Payload(string schedulerInstanceId)
+    {
+        return System.Text.Json.JsonSerializer.SerializeToElement(new
+        {
+            schedulerInstanceId,
+            jobKey = new { group = "reports", name = "nightly" }
+        });
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardDurationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardDurationTest.cs
@@ -1,6 +1,7 @@
 using FakeItEasy;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 
 using Quartz.Dashboard.Hubs;
 using Quartz.Dashboard.Plugins;
@@ -21,13 +22,23 @@ public class DashboardDurationTest
 {
     private static readonly TimeSpan SubMillisecond = TimeSpan.FromTicks(4_567);
 
+    /// <summary>
+    /// The instant everything here is recorded at. The store forgets by age as well as by count, so a
+    /// test whose fire times are constants — as they must be, to be asserted on — needs a clock standing
+    /// beside them rather than the wall's.
+    /// </summary>
+    private static readonly DateTimeOffset TestTime = new(2025, 1, 1, 0, 0, 30, TimeSpan.Zero);
+
+    private static DashboardHistoryStore StoreAtTestTime() =>
+        TestData.Dashboard.HistoryStore(new FakeTimeProvider(TestTime));
+
     [Test]
     public async Task HistoryPluginRecordsTheRunTimeItWasGiven()
     {
-        DashboardHistoryStore store = new();
+        DashboardHistoryStore store = StoreAtTestTime();
         IScheduler scheduler = FakeScheduler();
 
-        DashboardHistoryPlugin plugin = new(ProviderWith(store));
+        DashboardHistoryPlugin plugin = new(ProviderWith(store), TimeProvider.System);
         await plugin.Initialize("history", scheduler);
         await plugin.JobWasExecuted(ExecutionContext(scheduler, SubMillisecond), jobException: null);
 
@@ -44,10 +55,10 @@ public class DashboardDurationTest
     [Test]
     public async Task HistoryPluginRecordsTheFailureAndItsMessage()
     {
-        DashboardHistoryStore store = new();
+        DashboardHistoryStore store = StoreAtTestTime();
         IScheduler scheduler = FakeScheduler();
 
-        DashboardHistoryPlugin plugin = new(ProviderWith(store));
+        DashboardHistoryPlugin plugin = new(ProviderWith(store), TimeProvider.System);
         await plugin.Initialize("history", scheduler);
         await plugin.JobWasExecuted(
             ExecutionContext(scheduler, TimeSpan.FromSeconds(2)),
@@ -70,7 +81,7 @@ public class DashboardDurationTest
     {
         IScheduler scheduler = FakeScheduler();
 
-        DashboardLiveEventsPlugin plugin = new(ProviderWith(new DashboardHistoryStore()));
+        DashboardLiveEventsPlugin plugin = new(ProviderWith(StoreAtTestTime()));
         await plugin.Initialize("live", scheduler);
 
         Func<Task> executed = async () =>
@@ -86,6 +97,7 @@ public class DashboardDurationTest
     public void JobExecutionResultCarriesTheRunTimeAsATimeSpan()
     {
         JobExecutionResultDto result = new(
+            SchedulerInstanceId: TestData.SchedulerInstanceId,
             JobKey: new JobKeyDto("group", "job"),
             TriggerKey: new TriggerKeyDto("group", "trigger"),
             FireTimeUtc: new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
@@ -99,7 +111,7 @@ public class DashboardDurationTest
     [Test]
     public async Task HistoryPageIsNewestFirstAndCountsTheWholeMatch()
     {
-        DashboardHistoryStore store = new();
+        DashboardHistoryStore store = StoreAtTestTime();
         for (int i = 0; i < 5; i++)
         {
             await store.Add(EntryAt(new DateTimeOffset(2025, 1, 1, 0, 0, i, TimeSpan.Zero), "job" + i));
@@ -120,6 +132,7 @@ public class DashboardDurationTest
 
     private static DashboardHistoryEntry EntryAt(DateTimeOffset firedAt, string jobName) => new(
         SchedulerName: "TestScheduler",
+        SchedulerInstanceId: TestData.SchedulerInstanceId,
         JobGroup: "DummyGroup",
         JobName: jobName,
         TriggerGroup: "DummyTriggerGroup",
@@ -144,6 +157,7 @@ public class DashboardDurationTest
     {
         IScheduler scheduler = A.Fake<IScheduler>();
         A.CallTo(() => scheduler.SchedulerName).Returns("TestScheduler");
+        A.CallTo(() => scheduler.SchedulerInstanceId).Returns(TestData.SchedulerInstanceId);
         A.CallTo(() => scheduler.ListenerManager).Returns(A.Fake<IListenerManager>());
         return scheduler;
     }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardHistoryPluginTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardHistoryPluginTest.cs
@@ -1,0 +1,159 @@
+using FakeItEasy;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Dashboard.Plugins;
+using Quartz.Dashboard.Services;
+using Quartz.Extensibility;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// What the history plugin records, and which node it says recorded it.
+/// </summary>
+/// <remarks>
+/// A cluster runs one scheduler in several processes. Each keeps its own history of its own work, so
+/// until a row names the node it came from a reader cannot tell one machine's executions from another's
+/// — and a store an application shares across the cluster cannot tell them apart at all.
+/// </remarks>
+public class DashboardHistoryPluginTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 26, 12, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public async Task AnExecutionIsRecordedAgainstTheNodeThatRanIt()
+    {
+        DashboardHistoryStore store = TestData.Dashboard.HistoryStore(new FakeTimeProvider(Now));
+        IScheduler scheduler = FakeScheduler();
+
+        DashboardHistoryPlugin plugin = new(ProviderWith(store), new FakeTimeProvider(Now));
+        await plugin.Initialize("history", scheduler);
+        await plugin.JobWasExecuted(ExecutionContext(scheduler), jobException: null);
+
+        PagedResult<DashboardHistoryEntry> page = await store.GetPage(
+            new DashboardHistoryQuery { SchedulerName = "TestScheduler" });
+
+        page.Items.Should().ContainSingle().Which.SchedulerInstanceId.Should().Be("node-a",
+            "every node keeps its own history, so a row that does not name one cannot be attributed");
+    }
+
+    [Test]
+    public async Task AMisfireIsRecorded()
+    {
+        DashboardHistoryStore store = TestData.Dashboard.HistoryStore(new FakeTimeProvider(Now));
+        IScheduler scheduler = FakeScheduler();
+
+        DashboardHistoryPlugin plugin = new(ProviderWith(store), new FakeTimeProvider(Now));
+        await plugin.Initialize("history", scheduler);
+        await plugin.TriggerMisfired(scheduler, MisfiringTrigger());
+
+        PagedResult<DashboardMisfireEntry> misfires = await store.GetMisfires(
+            new DashboardMisfireQuery { SchedulerName = "TestScheduler" });
+
+        DashboardMisfireEntry entry = misfires.Items.Should().ContainSingle().Subject;
+        entry.SchedulerInstanceId.Should().Be("node-a");
+        entry.TriggerGroup.Should().Be("DummyTriggerGroup");
+        entry.TriggerName.Should().Be("DummyTrigger");
+        entry.JobKey.Should().Be(new JobKeyDto("DummyGroup", "DummyJob"));
+        entry.MisfiredAtUtc.Should().Be(Now,
+            "the scheduler's clock says when the misfire was noticed; nothing here reads the wall");
+        entry.ScheduledFireTimeUtc.Should().Be(Now.AddMinutes(-10),
+            "the scheduler notifies before it applies the misfire instruction, so the trigger still "
+            + "names the firing that was missed rather than the one it was moved to");
+    }
+
+    [Test]
+    public async Task AMisfireIsNotAnExecution()
+    {
+        DashboardHistoryStore store = TestData.Dashboard.HistoryStore(new FakeTimeProvider(Now));
+        IScheduler scheduler = FakeScheduler();
+
+        DashboardHistoryPlugin plugin = new(ProviderWith(store), new FakeTimeProvider(Now));
+        await plugin.Initialize("history", scheduler);
+        await plugin.TriggerMisfired(scheduler, MisfiringTrigger());
+
+        PagedResult<DashboardHistoryEntry> page = await store.GetPage(
+            new DashboardHistoryQuery { SchedulerName = "TestScheduler" });
+
+        page.Items.Should().BeEmpty("nothing ran, so there is no execution to show");
+    }
+
+    [Test]
+    public async Task AMisfireWithoutADashboardRegisteredIsNotWorthFailingTheSchedulerOver()
+    {
+        IScheduler scheduler = FakeScheduler();
+        DashboardHistoryPlugin plugin = new(new ServiceCollection().BuildServiceProvider(), new FakeTimeProvider(Now));
+        await plugin.Initialize("history", scheduler);
+
+        Func<Task> misfired = async () => await plugin.TriggerMisfired(scheduler, MisfiringTrigger());
+
+        await misfired.Should().NotThrowAsync(
+            "an application with no history store has nothing to record to, which is not an error");
+    }
+
+    [Test]
+    public async Task ThePluginListensToTriggersAsWellAsJobs()
+    {
+        IScheduler scheduler = FakeScheduler();
+        IListenerManager listeners = scheduler.ListenerManager;
+
+        DashboardHistoryPlugin plugin = new(new ServiceCollection().BuildServiceProvider(), new FakeTimeProvider(Now));
+        await plugin.Initialize("history", scheduler);
+
+        A.CallTo(() => listeners.AddTriggerListener(plugin, A<IReadOnlyCollection<IMatcher<TriggerKey>>>._))
+            .MustHaveHappened();
+        A.CallTo(() => listeners.AddJobListener(plugin, A<IReadOnlyCollection<IMatcher<JobKey>>>._))
+            .MustHaveHappened();
+    }
+
+    private static ServiceProvider ProviderWith(IDashboardHistoryStore store)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton(store);
+        return services.BuildServiceProvider();
+    }
+
+    private static IScheduler FakeScheduler()
+    {
+        IScheduler scheduler = A.Fake<IScheduler>();
+        A.CallTo(() => scheduler.SchedulerName).Returns("TestScheduler");
+        A.CallTo(() => scheduler.SchedulerInstanceId).Returns("node-a");
+        A.CallTo(() => scheduler.ListenerManager).Returns(A.Fake<IListenerManager>());
+        return scheduler;
+    }
+
+    /// <summary>
+    /// A trigger as the scheduler hands it to a listener at the moment it misfires: still due at the
+    /// firing it missed, because the misfire instruction has not been applied yet.
+    /// </summary>
+    private static ITrigger MisfiringTrigger()
+    {
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("DummyTrigger", "DummyTriggerGroup")
+            .ForJob("DummyJob", "DummyGroup")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)))
+            .Build();
+
+        ((IMutableTrigger) trigger).NextFireTimeUtc = Now.AddMinutes(-10);
+        return trigger;
+    }
+
+    private static IJobExecutionContext ExecutionContext(IScheduler scheduler)
+    {
+        IJobExecutionContext context = A.Fake<IJobExecutionContext>();
+        A.CallTo(() => context.Scheduler).Returns(scheduler);
+        A.CallTo(() => context.JobDetail).Returns(
+            JobBuilder.Create<DummyJob>().WithIdentity("DummyJob", "DummyGroup").Build());
+        A.CallTo(() => context.Trigger).Returns(
+            TriggerBuilder.Create()
+                .WithIdentity("DummyTrigger", "DummyTriggerGroup")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)))
+                .Build());
+        A.CallTo(() => context.FireTimeUtc).Returns(Now);
+        A.CallTo(() => context.JobRunTime).Returns(TimeSpan.FromMilliseconds(12));
+        A.CallTo(() => context.FireInstanceId).Returns("fire-1");
+        return context;
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardHistoryStoreTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardHistoryStoreTest.cs
@@ -1,0 +1,212 @@
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Dashboard.Services;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// What the dashboard's own history store keeps, and what it forgets.
+/// </summary>
+/// <remarks>
+/// It used to be bounded by count alone, which says nothing about a scheduler that has gone quiet: it
+/// keeps whatever it last recorded, so the page shows executions from an arbitrary distance in the past
+/// with nothing to say how old they are. Both bounds are exercised here, on a clock the test moves —
+/// a retention window measured against the wall clock is a test that passes for the wrong reason.
+/// </remarks>
+public class DashboardHistoryStoreTest
+{
+    private const string SchedulerName = "TestScheduler";
+    private static readonly DateTimeOffset Start = new(2026, 8, 26, 12, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public async Task AnExecutionOlderThanTheRetentionWindowIsForgotten()
+    {
+        FakeTimeProvider clock = new(Start);
+        DashboardHistoryStore store = Store(clock, retention: TimeSpan.FromHours(1));
+
+        await store.Add(Entry(Start, "nightly"));
+
+        clock.Advance(TimeSpan.FromMinutes(59));
+        (await Page(store)).Items.Should().ContainSingle(
+            "the window has not closed yet, and an execution inside it is what the page is for");
+
+        clock.Advance(TimeSpan.FromMinutes(2));
+        (await Page(store)).Items.Should().BeEmpty(
+            "an hour was the whole window, and a row nothing can date is worse than no row");
+    }
+
+    [Test]
+    public async Task ASchedulerThatHasStoppedRunningJobsStillForgets()
+    {
+        FakeTimeProvider clock = new(Start);
+        DashboardHistoryStore store = Store(clock, retention: TimeSpan.FromHours(1));
+
+        await store.Add(Entry(Start, "nightly"));
+        clock.Advance(TimeSpan.FromHours(2));
+
+        // nothing is added in between: this scheduler has gone quiet, which is exactly the case a
+        // trim-on-write-only store cannot answer
+        (await Page(store)).TotalCount.Should().Be(0,
+            "reading has to apply the window too, or a scheduler that never writes again keeps its "
+            + "history forever");
+    }
+
+    [Test]
+    public async Task OnlyTheNewestExecutionsSurviveTheCountBound()
+    {
+        FakeTimeProvider clock = new(Start);
+        DashboardHistoryStore store = Store(clock, maxEntriesPerScheduler: 3);
+
+        for (int index = 0; index < 5; index++)
+        {
+            await store.Add(Entry(Start.AddSeconds(index), "job" + index));
+        }
+
+        PagedResult<DashboardHistoryEntry> page = await Page(store);
+
+        page.Items.Select(entry => entry.JobName).Should().Equal(["job4", "job3", "job2"],
+            "the cap drops the oldest and the page reads newest first");
+    }
+
+    [Test]
+    public async Task TheTwoBoundsApplyTogether()
+    {
+        FakeTimeProvider clock = new(Start);
+        DashboardHistoryStore store = Store(clock, retention: TimeSpan.FromMinutes(10), maxEntriesPerScheduler: 100);
+
+        await store.Add(Entry(Start.AddMinutes(-30), "old"));
+        await store.Add(Entry(Start, "fresh"));
+
+        PagedResult<DashboardHistoryEntry> page = await Page(store);
+
+        page.Items.Select(entry => entry.JobName).Should().Equal(["fresh"],
+            "the count bound had room for both, so it is the age bound that dropped the old one");
+    }
+
+    [Test]
+    public async Task ExecutionsCanBeReadForOneNode()
+    {
+        DashboardHistoryStore store = Store(new FakeTimeProvider(Start));
+
+        await store.Add(Entry(Start, "on-a", node: "node-a"));
+        await store.Add(Entry(Start, "on-b", node: "node-b"));
+
+        PagedResult<DashboardHistoryEntry> everywhere = await Page(store);
+        everywhere.Items.Should().HaveCount(2, "an unfiltered query is every node's");
+
+        PagedResult<DashboardHistoryEntry> onB = await Page(store, node: "node-b");
+        onB.Items.Should().ContainSingle().Which.JobName.Should().Be("on-b",
+            "a cluster's history is unreadable until it can be narrowed to one machine");
+    }
+
+    [Test]
+    public async Task AMisfireIsRecordedBesideTheExecutionsAndReadBack()
+    {
+        DashboardHistoryStore store = Store(new FakeTimeProvider(Start));
+
+        await store.Add(Entry(Start, "ran"));
+        await store.AddMisfire(Misfire(Start, "nightly"));
+
+        (await Page(store)).Items.Should().ContainSingle(
+            "a misfire is not an execution — nothing ran — so it must not appear in the history");
+
+        PagedResult<DashboardMisfireEntry> misfires = await store.GetMisfires(
+            new DashboardMisfireQuery { SchedulerName = SchedulerName, IncludeTotalCount = true });
+
+        DashboardMisfireEntry misfire = misfires.Items.Should().ContainSingle().Subject;
+        misfire.TriggerName.Should().Be("nightly");
+        misfire.SchedulerInstanceId.Should().Be("node-a");
+        misfire.ScheduledFireTimeUtc.Should().Be(Start.AddMinutes(-5),
+            "the missed firing is the point of the row: it says what did not happen and when");
+    }
+
+    [Test]
+    public async Task MisfiresAreBoundedTheWayExecutionsAre()
+    {
+        FakeTimeProvider clock = new(Start);
+        DashboardHistoryStore store = Store(clock, retention: TimeSpan.FromHours(1), maxEntriesPerScheduler: 2);
+
+        await store.AddMisfire(Misfire(Start, "one"));
+        await store.AddMisfire(Misfire(Start.AddSeconds(1), "two"));
+        await store.AddMisfire(Misfire(Start.AddSeconds(2), "three"));
+
+        PagedResult<DashboardMisfireEntry> capped = await store.GetMisfires(
+            new DashboardMisfireQuery { SchedulerName = SchedulerName });
+        capped.Items.Select(entry => entry.TriggerName).Should().Equal(["three", "two"],
+            "the cap is per feed, and the misfire feed is not exempt from it");
+
+        clock.Advance(TimeSpan.FromHours(2));
+        PagedResult<DashboardMisfireEntry> aged = await store.GetMisfires(
+            new DashboardMisfireQuery { SchedulerName = SchedulerName });
+        aged.Items.Should().BeEmpty("the retention window covers misfires too");
+    }
+
+    [Test]
+    public async Task MisfiresAreCountedOverAWindow()
+    {
+        DashboardHistoryStore store = Store(new FakeTimeProvider(Start));
+
+        await store.AddMisfire(Misfire(Start.AddMinutes(-30), "old"));
+        await store.AddMisfire(Misfire(Start.AddMinutes(-5), "recent"));
+        await store.AddMisfire(Misfire(Start.AddMinutes(-1), "newest"));
+
+        int lastTenMinutes = await store.CountMisfires(SchedulerName, Start.AddMinutes(-10));
+
+        lastTenMinutes.Should().Be(2,
+            "a summary asks how bad it is right now, which is a count over a window rather than a page");
+    }
+
+    [Test]
+    public async Task MisfiresCanBeReadForOneNode()
+    {
+        DashboardHistoryStore store = Store(new FakeTimeProvider(Start));
+
+        await store.AddMisfire(Misfire(Start, "on-a", node: "node-a"));
+        await store.AddMisfire(Misfire(Start, "on-b", node: "node-b"));
+
+        PagedResult<DashboardMisfireEntry> onA = await store.GetMisfires(
+            new DashboardMisfireQuery { SchedulerName = SchedulerName, SchedulerInstanceId = "node-a" });
+
+        onA.Items.Should().ContainSingle().Which.TriggerName.Should().Be("on-a");
+    }
+
+    private static DashboardHistoryStore Store(
+        FakeTimeProvider clock,
+        TimeSpan? retention = null,
+        int? maxEntriesPerScheduler = null)
+    {
+        return TestData.Dashboard.HistoryStore(clock, retention, maxEntriesPerScheduler);
+    }
+
+    private static ValueTask<PagedResult<DashboardHistoryEntry>> Page(DashboardHistoryStore store, string? node = null)
+    {
+        return store.GetPage(new DashboardHistoryQuery
+        {
+            SchedulerName = SchedulerName,
+            SchedulerInstanceId = node,
+            IncludeTotalCount = true
+        });
+    }
+
+    private static DashboardHistoryEntry Entry(DateTimeOffset firedAt, string jobName, string node = "node-a") => new(
+        SchedulerName: SchedulerName,
+        SchedulerInstanceId: node,
+        JobGroup: "DummyGroup",
+        JobName: jobName,
+        TriggerGroup: "DummyTriggerGroup",
+        TriggerName: "DummyTrigger",
+        FiredAtUtc: firedAt,
+        Duration: TimeSpan.FromMilliseconds(5),
+        Succeeded: true,
+        ExceptionMessage: null);
+
+    private static DashboardMisfireEntry Misfire(DateTimeOffset misfiredAt, string triggerName, string node = "node-a") => new(
+        SchedulerName: SchedulerName,
+        SchedulerInstanceId: node,
+        TriggerGroup: "DummyTriggerGroup",
+        TriggerName: triggerName,
+        JobKey: new JobKeyDto("DummyGroup", "DummyJob"),
+        MisfiredAtUtc: misfiredAt,
+        ScheduledFireTimeUtc: misfiredAt.AddMinutes(-5));
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardPluginRegistrationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardPluginRegistrationTest.cs
@@ -2,6 +2,7 @@ using FakeItEasy;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 
 using Quartz.Configuration;
 using Quartz.Dashboard.Hubs;
@@ -109,7 +110,10 @@ public class DashboardPluginRegistrationTest
     [Test]
     public async Task TheHistoryPluginBuiltForANamedSchedulerRecordsToThatContainersStore()
     {
-        DashboardHistoryStore store = new();
+        // the execution below is recorded at a constant fire time, so the store needs a clock standing
+        // beside it rather than the wall's — it forgets by age as well as by count
+        DashboardHistoryStore store = TestData.Dashboard.HistoryStore(
+            new FakeTimeProvider(new DateTimeOffset(2025, 1, 1, 0, 0, 30, TimeSpan.Zero)));
 
         ServiceCollection services = new();
         // registered before the dashboard, whose own store registration is a TryAdd, so this is the
@@ -167,13 +171,14 @@ public class DashboardPluginRegistrationTest
         await plugin.SchedulerStarted(scheduler);
 
         pushed.Should().ContainSingle("the plugin resolves its hub from the container it was built with")
-            .Which.Should().BeEquivalentTo(new SchedulerStateDto("acme", SchedulerStatus.Running));
+            .Which.Should().BeEquivalentTo(new SchedulerStateDto("acme", "acme-node", SchedulerStatus.Running));
     }
 
     private static IScheduler FakeScheduler(string name)
     {
         IScheduler scheduler = A.Fake<IScheduler>();
         A.CallTo(() => scheduler.SchedulerName).Returns(name);
+        A.CallTo(() => scheduler.SchedulerInstanceId).Returns(name + "-node");
         A.CallTo(() => scheduler.ListenerManager).Returns(A.Fake<IListenerManager>());
         return scheduler;
     }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardSchedulerStateEventsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardSchedulerStateEventsTest.cs
@@ -39,6 +39,9 @@ public class DashboardSchedulerStateEventsTest
             "a listener event names the state the scheduler has arrived in, and the dashboard shows that state");
 
         pushed.Should().OnlyContain(state => state.SchedulerName == "TestScheduler");
+        pushed.Should().OnlyContain(state => state.SchedulerInstanceId == "node-a",
+            "a cluster is one scheduler in several processes, each with a lifecycle of its own, so a "
+            + "state change says nothing until it says which node changed");
     }
 
     [Test]
@@ -73,6 +76,7 @@ public class DashboardSchedulerStateEventsTest
 
         IScheduler scheduler = A.Fake<IScheduler>();
         A.CallTo(() => scheduler.SchedulerName).Returns("TestScheduler");
+        A.CallTo(() => scheduler.SchedulerInstanceId).Returns("node-a");
         A.CallTo(() => scheduler.ListenerManager).Returns(A.Fake<IListenerManager>());
 
         DashboardLiveEventsPlugin plugin = new(provider);

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -8,6 +8,7 @@ using Quartz.Extensibility;
 using Quartz.Impl;
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
+using Quartz.Tests.AspNetCore.Support;
 
 namespace Quartz.Tests.AspNetCore.Dashboard;
 
@@ -683,7 +684,7 @@ public class InProcessQuartzApiClientTest
             repository,
             new StubSchedulerRegistry(repository, registeredButNotCreated),
             Options.Create(new QuartzDashboardOptions()),
-            new DashboardHistoryStore());
+            TestData.Dashboard.HistoryStore());
     }
 
     /// <summary>

--- a/src/Quartz.Tests.AspNetCore/Dashboard/QuartzDashboardHubClientProxyTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/QuartzDashboardHubClientProxyTest.cs
@@ -32,7 +32,7 @@ public class QuartzDashboardHubClientProxyTest
         // Touching Clients is what makes SignalR emit the proxy; sending is what invokes it.
         IQuartzDashboardHubClient client = hubContext.Clients.All;
 
-        var act = async () => await client.SchedulerStateChanged(new SchedulerStateDto("scheduler", SchedulerStatus.Running));
+        var act = async () => await client.SchedulerStateChanged(new SchedulerStateDto("scheduler", "node-a", SchedulerStatus.Running));
 
         act.Should().NotThrowAsync(
             "the typed-client proxy lives in a dynamic assembly that can only implement a public interface");

--- a/src/Quartz.Tests.AspNetCore/Dashboard/QuartzDashboardOptionsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/QuartzDashboardOptionsTest.cs
@@ -1,4 +1,7 @@
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
 namespace Quartz.Tests.AspNetCore.Dashboard;
 
 public class QuartzDashboardOptionsTest
@@ -48,5 +51,52 @@ public class QuartzDashboardOptionsTest
         options.TrimmedDashboardPath.Should().Be("/ops");
         options.EscapedDashboardPath.Should().Be("/ops");
         options.HasCustomDashboardPath.Should().BeTrue();
+    }
+
+    [Test]
+    public void HistoryIsBoundedByAgeAndByCountOutOfTheBox()
+    {
+        var options = new QuartzDashboardOptions();
+
+        options.HistoryRetention.Should().Be(TimeSpan.FromHours(24),
+            "an application that configures nothing still has to stop showing executions from an "
+            + "arbitrary distance in the past");
+        options.HistoryMaxEntriesPerScheduler.Should().Be(2000, "the count bound is what it has always been");
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void ARetentionWindowThatIsNotPositiveIsRejectedAtStartup(int hours)
+    {
+        var act = () => Build(options => options.HistoryRetention = TimeSpan.FromHours(hours));
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*HistoryRetention*",
+            "a window of zero forgets every execution the moment it is recorded, which looks exactly "
+            + "like a history plugin that was never installed");
+    }
+
+    [Test]
+    public void ACapOfZeroIsRejectedAtStartup()
+    {
+        var act = () => Build(options => options.HistoryMaxEntriesPerScheduler = 0);
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*HistoryMaxEntriesPerScheduler*");
+    }
+
+    [Test]
+    public void TheDefaultsPassValidation()
+    {
+        var act = () => Build(_ => { });
+
+        act.Should().NotThrow();
+    }
+
+    private static QuartzDashboardOptions Build(Action<QuartzDashboardOptions> configure)
+    {
+        ServiceCollection services = new();
+        services.AddQuartzDashboard(configure);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptions<QuartzDashboardOptions>>().Value;
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
+++ b/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
@@ -23,6 +23,7 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit.Analyzers">

--- a/src/Quartz.Tests.AspNetCore/Support/TestData.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestData.cs
@@ -393,10 +393,12 @@ public static class TestData
             TimeSpan duration,
             bool succeeded = true,
             string jobName = "DummyJob",
-            string? exceptionMessage = null)
+            string? exceptionMessage = null,
+            string schedulerInstanceId = SchedulerInstanceId)
         {
             return new DashboardHistoryEntry(
                 SchedulerName,
+                schedulerInstanceId,
                 JobGroup: "DummyGroup",
                 JobName: jobName,
                 TriggerGroup: "CronTriggerGroup",
@@ -405,6 +407,46 @@ public static class TestData
                 Duration: duration,
                 Succeeded: succeeded,
                 ExceptionMessage: exceptionMessage);
+        }
+
+        public static DashboardMisfireEntry MisfireEntry(
+            string triggerName = "CronTriggerKey",
+            string schedulerInstanceId = SchedulerInstanceId,
+            JobKeyDto? jobKey = null)
+        {
+            return new DashboardMisfireEntry(
+                SchedulerName,
+                schedulerInstanceId,
+                TriggerGroup: "CronTriggerGroup",
+                TriggerName: triggerName,
+                JobKey: jobKey,
+                MisfiredAtUtc: FiredAt,
+                ScheduledFireTimeUtc: FiredAt.AddMinutes(-1));
+        }
+
+        /// <summary>
+        /// A history store bounded the way an application that configured nothing would have it, on a
+        /// clock a test can move.
+        /// </summary>
+        internal static DashboardHistoryStore HistoryStore(
+            TimeProvider? timeProvider = null,
+            TimeSpan? retention = null,
+            int? maxEntriesPerScheduler = null)
+        {
+            QuartzDashboardOptions options = new();
+            if (retention is { } configuredRetention)
+            {
+                options.HistoryRetention = configuredRetention;
+            }
+
+            if (maxEntriesPerScheduler is { } configuredMax)
+            {
+                options.HistoryMaxEntriesPerScheduler = configuredMax;
+            }
+
+            return new DashboardHistoryStore(
+                Microsoft.Extensions.Options.Options.Create(options),
+                timeProvider ?? TimeProvider.System);
         }
 
         /// <summary>

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -5,62 +5,79 @@ namespace Quartz.Dashboard.Hubs
     {
         System.Threading.Tasks.Task JobExecuted(Quartz.Dashboard.Hubs.JobExecutionResultDto result);
         System.Threading.Tasks.Task JobExecuting(Quartz.Dashboard.Hubs.JobEventDto jobEvent);
-        System.Threading.Tasks.Task JobPaused(Quartz.Dashboard.Services.JobKeyDto jobKey);
-        System.Threading.Tasks.Task JobResumed(Quartz.Dashboard.Services.JobKeyDto jobKey);
+        System.Threading.Tasks.Task JobPaused(Quartz.Dashboard.Hubs.JobLifecycleDto jobEvent);
+        System.Threading.Tasks.Task JobResumed(Quartz.Dashboard.Hubs.JobLifecycleDto jobEvent);
         System.Threading.Tasks.Task SchedulerError(Quartz.Dashboard.Hubs.SchedulerErrorDto schedulerError);
         System.Threading.Tasks.Task SchedulerStateChanged(Quartz.Dashboard.Hubs.SchedulerStateDto state);
         System.Threading.Tasks.Task TriggerCompleted(Quartz.Dashboard.Hubs.TriggerEventDto triggerEvent);
         System.Threading.Tasks.Task TriggerFired(Quartz.Dashboard.Hubs.TriggerEventDto triggerEvent);
         System.Threading.Tasks.Task TriggerMisfired(Quartz.Dashboard.Hubs.TriggerEventDto triggerEvent);
-        System.Threading.Tasks.Task TriggerPaused(Quartz.Dashboard.Services.TriggerKeyDto triggerKey);
-        System.Threading.Tasks.Task TriggerResumed(Quartz.Dashboard.Services.TriggerKeyDto triggerKey);
+        System.Threading.Tasks.Task TriggerPaused(Quartz.Dashboard.Hubs.TriggerLifecycleDto triggerEvent);
+        System.Threading.Tasks.Task TriggerResumed(Quartz.Dashboard.Hubs.TriggerLifecycleDto triggerEvent);
     }
     public sealed class JobEventDto : System.IEquatable<Quartz.Dashboard.Hubs.JobEventDto>
     {
-        public JobEventDto(Quartz.Dashboard.Services.JobKeyDto JobKey, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, System.DateTimeOffset FireTimeUtc, string? FireInstanceId) { }
+        public JobEventDto(string SchedulerInstanceId, Quartz.Dashboard.Services.JobKeyDto JobKey, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, System.DateTimeOffset FireTimeUtc, string? FireInstanceId) { }
         public string? FireInstanceId { get; init; }
         public System.DateTimeOffset FireTimeUtc { get; init; }
         public Quartz.Dashboard.Services.JobKeyDto JobKey { get; init; }
+        public string SchedulerInstanceId { get; init; }
         public Quartz.Dashboard.Services.TriggerKeyDto TriggerKey { get; init; }
     }
     public sealed class JobExecutionResultDto : System.IEquatable<Quartz.Dashboard.Hubs.JobExecutionResultDto>
     {
-        public JobExecutionResultDto(Quartz.Dashboard.Services.JobKeyDto JobKey, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, System.DateTimeOffset FireTimeUtc, System.TimeSpan RunTime, bool Vetoed, string? ExceptionMessage) { }
+        public JobExecutionResultDto(string SchedulerInstanceId, Quartz.Dashboard.Services.JobKeyDto JobKey, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, System.DateTimeOffset FireTimeUtc, System.TimeSpan RunTime, bool Vetoed, string? ExceptionMessage) { }
         public string? ExceptionMessage { get; init; }
         public System.DateTimeOffset FireTimeUtc { get; init; }
         public Quartz.Dashboard.Services.JobKeyDto JobKey { get; init; }
         public System.TimeSpan RunTime { get; init; }
+        public string SchedulerInstanceId { get; init; }
         public Quartz.Dashboard.Services.TriggerKeyDto TriggerKey { get; init; }
         public bool Vetoed { get; init; }
     }
+    public sealed class JobLifecycleDto : System.IEquatable<Quartz.Dashboard.Hubs.JobLifecycleDto>
+    {
+        public JobLifecycleDto(string SchedulerInstanceId, Quartz.Dashboard.Services.JobKeyDto JobKey) { }
+        public Quartz.Dashboard.Services.JobKeyDto JobKey { get; init; }
+        public string SchedulerInstanceId { get; init; }
+    }
     public sealed class SchedulerErrorDto : System.IEquatable<Quartz.Dashboard.Hubs.SchedulerErrorDto>
     {
-        public SchedulerErrorDto(string SchedulerName, string Message, string? Cause, Quartz.Dashboard.Services.TriggerKeyDto? TriggerKey, Quartz.Dashboard.Services.JobKeyDto? JobKey) { }
+        public SchedulerErrorDto(string SchedulerName, string SchedulerInstanceId, string Message, string? Cause, Quartz.Dashboard.Services.TriggerKeyDto? TriggerKey, Quartz.Dashboard.Services.JobKeyDto? JobKey) { }
         public string? Cause { get; init; }
         public Quartz.Dashboard.Services.JobKeyDto? JobKey { get; init; }
         public string Message { get; init; }
+        public string SchedulerInstanceId { get; init; }
         public string SchedulerName { get; init; }
         public Quartz.Dashboard.Services.TriggerKeyDto? TriggerKey { get; init; }
     }
     public sealed class SchedulerStateDto : System.IEquatable<Quartz.Dashboard.Hubs.SchedulerStateDto>
     {
-        public SchedulerStateDto(string SchedulerName, Quartz.SchedulerStatus Status) { }
+        public SchedulerStateDto(string SchedulerName, string SchedulerInstanceId, Quartz.SchedulerStatus Status) { }
+        public string SchedulerInstanceId { get; init; }
         public string SchedulerName { get; init; }
         public Quartz.SchedulerStatus Status { get; init; }
     }
     public sealed class TriggerEventDto : System.IEquatable<Quartz.Dashboard.Hubs.TriggerEventDto>
     {
-        public TriggerEventDto(Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, Quartz.Dashboard.Services.JobKeyDto? JobKey, System.DateTimeOffset? FireTimeUtc) { }
+        public TriggerEventDto(string SchedulerInstanceId, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey, Quartz.Dashboard.Services.JobKeyDto? JobKey, System.DateTimeOffset? FireTimeUtc) { }
         public System.DateTimeOffset? FireTimeUtc { get; init; }
         public Quartz.Dashboard.Services.JobKeyDto? JobKey { get; init; }
+        public string SchedulerInstanceId { get; init; }
+        public Quartz.Dashboard.Services.TriggerKeyDto TriggerKey { get; init; }
+    }
+    public sealed class TriggerLifecycleDto : System.IEquatable<Quartz.Dashboard.Hubs.TriggerLifecycleDto>
+    {
+        public TriggerLifecycleDto(string SchedulerInstanceId, Quartz.Dashboard.Services.TriggerKeyDto TriggerKey) { }
+        public string SchedulerInstanceId { get; init; }
         public Quartz.Dashboard.Services.TriggerKeyDto TriggerKey { get; init; }
     }
 }
 namespace Quartz.Dashboard.Plugins
 {
-    public sealed class DashboardHistoryPlugin : Quartz.Extensibility.ISchedulerPlugin, Quartz.IJobListener
+    public sealed class DashboardHistoryPlugin : Quartz.Extensibility.ISchedulerPlugin, Quartz.IJobListener, Quartz.ITriggerListener
     {
-        public DashboardHistoryPlugin(System.IServiceProvider serviceProvider) { }
+        public DashboardHistoryPlugin(System.IServiceProvider serviceProvider, System.TimeProvider timeProvider) { }
         public string Name { get; }
         public System.Threading.Tasks.ValueTask Initialize(string pluginName, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask JobExecutionVetoed(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
@@ -68,6 +85,10 @@ namespace Quartz.Dashboard.Plugins
         public System.Threading.Tasks.ValueTask JobWasExecuted(Quartz.IJobExecutionContext context, Quartz.JobExecutionException? jobException, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Shutdown(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Start(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerComplete(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, Quartz.SchedulerInstruction triggerInstructionCode, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerFired(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask TriggerMisfired(Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<bool> VetoJobExecution(Quartz.ITrigger trigger, Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public sealed class DashboardLiveEventsPlugin : Quartz.Extensibility.ISchedulerPlugin, Quartz.IJobListener, Quartz.ISchedulerListener, Quartz.ITriggerListener
     {
@@ -146,12 +167,13 @@ namespace Quartz.Dashboard.Services
     }
     public sealed class DashboardHistoryEntry : System.IEquatable<Quartz.Dashboard.Services.DashboardHistoryEntry>
     {
-        public DashboardHistoryEntry(string SchedulerName, string JobGroup, string JobName, string TriggerGroup, string TriggerName, System.DateTimeOffset FiredAtUtc, System.TimeSpan Duration, bool Succeeded, string? ExceptionMessage) { }
+        public DashboardHistoryEntry(string SchedulerName, string SchedulerInstanceId, string JobGroup, string JobName, string TriggerGroup, string TriggerName, System.DateTimeOffset FiredAtUtc, System.TimeSpan Duration, bool Succeeded, string? ExceptionMessage) { }
         public System.TimeSpan Duration { get; init; }
         public string? ExceptionMessage { get; init; }
         public System.DateTimeOffset FiredAtUtc { get; init; }
         public string JobGroup { get; init; }
         public string JobName { get; init; }
+        public string SchedulerInstanceId { get; init; }
         public string SchedulerName { get; init; }
         public bool Succeeded { get; init; }
         public string TriggerGroup { get; init; }
@@ -161,6 +183,7 @@ namespace Quartz.Dashboard.Services
     {
         public DashboardHistoryQuery() { }
         public string? JobFilter { get; init; }
+        public string? SchedulerInstanceId { get; init; }
         public required string SchedulerName { get; init; }
         public string? TriggerFilter { get; init; }
     }
@@ -168,6 +191,24 @@ namespace Quartz.Dashboard.Services
     {
         public DashboardJobQuery() { }
         public string? GroupContains { get; init; }
+    }
+    public sealed class DashboardMisfireEntry : System.IEquatable<Quartz.Dashboard.Services.DashboardMisfireEntry>
+    {
+        public DashboardMisfireEntry(string SchedulerName, string SchedulerInstanceId, string TriggerGroup, string TriggerName, Quartz.Dashboard.Services.JobKeyDto? JobKey, System.DateTimeOffset MisfiredAtUtc, System.DateTimeOffset? ScheduledFireTimeUtc) { }
+        public Quartz.Dashboard.Services.JobKeyDto? JobKey { get; init; }
+        public System.DateTimeOffset MisfiredAtUtc { get; init; }
+        public System.DateTimeOffset? ScheduledFireTimeUtc { get; init; }
+        public string SchedulerInstanceId { get; init; }
+        public string SchedulerName { get; init; }
+        public string TriggerGroup { get; init; }
+        public string TriggerName { get; init; }
+    }
+    public sealed class DashboardMisfireQuery : Quartz.PagedQuery, System.IEquatable<Quartz.Dashboard.Services.DashboardMisfireQuery>
+    {
+        public DashboardMisfireQuery() { }
+        public string? SchedulerInstanceId { get; init; }
+        public required string SchedulerName { get; init; }
+        public string? TriggerFilter { get; init; }
     }
     public sealed class DashboardTriggerQuery : Quartz.PagedQuery, System.IEquatable<Quartz.Dashboard.Services.DashboardTriggerQuery>
     {
@@ -195,6 +236,9 @@ namespace Quartz.Dashboard.Services
     public interface IDashboardHistoryStore
     {
         System.Threading.Tasks.ValueTask Add(Quartz.Dashboard.Services.DashboardHistoryEntry entry, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask AddMisfire(Quartz.Dashboard.Services.DashboardMisfireEntry entry, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<int> CountMisfires(string schedulerName, System.DateTimeOffset since, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardMisfireEntry>> GetMisfires(Quartz.Dashboard.Services.DashboardMisfireQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardHistoryEntry>> GetPage(Quartz.Dashboard.Services.DashboardHistoryQuery query, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface IQuartzApiClient
@@ -213,6 +257,7 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.JobGroupDto>> GetJobGroups(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.TriggerHeaderDto>> GetJobTriggers(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.JobKeyDto>> GetJobs(string schedulerName, Quartz.Dashboard.Services.DashboardJobQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardMisfireEntry>?> GetMisfires(Quartz.Dashboard.Services.DashboardMisfireQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.SchedulerDetailDto> GetScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.SchedulerHeaderDto>> GetSchedulers(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ITrigger> GetTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
@@ -326,6 +371,8 @@ namespace Quartz
         public QuartzDashboardOptions() { }
         public string? AuthorizationPolicy { get; set; }
         public string DashboardPath { get; set; }
+        public int HistoryMaxEntriesPerScheduler { get; set; }
+        public System.TimeSpan HistoryRetention { get; set; }
         public bool ReadOnly { get; set; }
     }
     public static class QuartzDashboardServiceCollectionExtensions


### PR DESCRIPTION
A cluster is one scheduler running in several processes. Each node kept its own history of its own
executions and pushed its own live events, and neither said which node it was — so the History page
could not attribute a row to a machine and Live Logs could not tell a local event from a peer's. The
history store was bounded by count alone, which says nothing about a scheduler that has gone quiet: it
keeps whatever it last recorded, so the page shows executions from an arbitrary distance in the past
with nothing to say how old they are.

## What changed

**History carries the node.** `DashboardHistoryEntry` gains `SchedulerInstanceId`, filled from
`context.Scheduler.SchedulerInstanceId`. The History page has a **Node** column, a node filter, and stat
cards whose titles say which scope their figures cover — `Success rate (page)` unfiltered,
`Success rate (page, node-b)` when the filter names a node. The filter's options are the scheduler's
cluster nodes (read once per scheduler, not on every one-second refresh tick) unioned with any node the
loaded rows name that the listing did not — a node that has stopped checking in still has history worth
reading. It is a `node=` query parameter, so a narrowed listing is a link someone can send.

**Bounded by age as well as by count.** `QuartzDashboardOptions` gains `HistoryRetention`
(`TimeSpan`, 24 h) and `HistoryMaxEntriesPerScheduler` (`int`, 2000, previously a constant in the
store). Both are validated at startup the way `DashboardPath` is; neither may be zero. The window is
measured on the scheduler's `TimeProvider`, injected into the store — nothing here reads a wall clock.

**A misfire feed.** `DashboardHistoryPlugin` now implements `ITriggerListener` too and records a
`DashboardMisfireEntry` on `TriggerMisfired`. A misfire never becomes an execution, so it is invisible
in the execution history however long a reader stares at it; the History page lists them in a section
of its own. `IDashboardHistoryStore` gains `AddMisfire`, `GetMisfires(DashboardMisfireQuery)` and
`CountMisfires(name, since)` — the last for the Dashboard page's misfire count (#3419), exposed here
but not consumed.

**Live events carry the node.** `SchedulerStateDto` and every hub payload gain `SchedulerInstanceId`.
The interface stays `Task`-returning per the SignalR exemption in `AGENTS.md`. LiveLogs shows the node
beside each event and its toolbar names the node its own process is.

## Decisions a reviewer should weigh

- **`IDashboardHistoryStore` is public and documented as the persistence seam, so its three new members
  are a breaking change for anyone who implemented it.** Said so in the migration guide, in "Other
  Breaking Changes" and in the new section. A store that only records executions can throw
  `NotSupportedException` from the misfire members; a data source answering `null` for misfires makes
  the page omit the section rather than fail.
- **`TriggerPaused`/`TriggerResumed`/`JobPaused`/`JobResumed` take new payloads** —
  `TriggerLifecycleDto(SchedulerInstanceId, TriggerKey)` and `JobLifecycleDto(SchedulerInstanceId, JobKey)`
  — rather than `JobKeyDto`/`TriggerKeyDto` growing a node. Those are keys, `IQuartzApiClient` uses them
  everywhere, and a key does not belong to a node.
- **The store trims on read as well as on write.** The spec said "trims on write"; trimming only on
  write cannot answer for the scheduler the issue names, because a scheduler that has stopped running
  jobs never writes again. Both paths go through one `Trim`.
- **The age pass is a full `RemoveAll` scan rather than a walk in from the oldest end.** Entries are
  appended in arrival order, which is only the same as timestamp order while one node is writing; a
  store fed by a whole cluster would otherwise leave a late arrival stranded behind a fresher one. It is
  a scan of at most `HistoryMaxEntriesPerScheduler` entries under the list's lock, per execution.
- **`GetMisfires` takes a query object carrying `SchedulerName`**, as `GetPage(DashboardHistoryQuery)`
  does, rather than the literal `GetMisfires(schedulerName, …)` of the brief. `CountMisfires` does take
  the name positionally, since it has no other criteria to carry.
- **`DashboardHistoryPlugin`'s constructor takes a `TimeProvider`.** A misfire has no fire time of its
  own to record — the listener is handed a scheduler and a trigger — so the plugin needs a clock, and
  the scheduler-scoped provider hands it that scheduler's.
- **`CountMisfires` is on `IDashboardHistoryStore` only, not on `IQuartzApiClient`.** The brief said to
  expose it and not build the panel; #3419 will need one more member on the client when it does.

## Public API baseline

`src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt` re-accepted through
Verify. Additions and signature changes only, nothing removed:

- `DashboardHistoryEntry` gains `string SchedulerInstanceId` (second positional member).
- New: `DashboardMisfireEntry`, `DashboardMisfireQuery`, `TriggerLifecycleDto`, `JobLifecycleDto`.
- `DashboardHistoryQuery` gains `string? SchedulerInstanceId`.
- `IDashboardHistoryStore` gains `AddMisfire`, `GetMisfires`, `CountMisfires`.
- `IQuartzApiClient` gains `GetMisfires`.
- `QuartzDashboardOptions` gains `HistoryRetention` and `HistoryMaxEntriesPerScheduler`.
- `DashboardHistoryPlugin` implements `ITriggerListener`; its constructor takes `(IServiceProvider, TimeProvider)`.
- `SchedulerStateDto`, `SchedulerErrorDto`, `JobEventDto`, `JobExecutionResultDto`, `TriggerEventDto`
  each gain `SchedulerInstanceId`; `IQuartzDashboardHubClient`'s four pause/resume members take the new
  lifecycle payloads.

The same delta is in `docs/documentation/quartz-4.x/migration-guide.md` under
"History and live events say which node they came from", plus a row in "Other Breaking Changes".

## Verification

```
dotnet build Quartz.slnx                              Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit                     Passed! Failed: 0, Passed: 3457, Skipped: 4, Total: 3461
dotnet test src/Quartz.Tests.AspNetCore               Passed! Failed: 0, Passed: 490, Skipped: 0, Total: 490
dotnet fallout VerifyDocsSnippets                     Documentation snippets are up to date (90 markdown files checked)
npm run docs:check-links                              212 pages, 784 internal links, 453 fragments — no dead links or anchors
```

`Quartz.Tests.Integration` references only `Quartz`, `Quartz.Jobs`, `Quartz.Serialization.Newtonsoft`
and `Quartz.Extensions.Redis`, so nothing here reaches it; there is no `Quartz.Tests.AOT` on this
branch. Each of the three commits builds and passes the suites on its own.

## Not in scope

An ADO-backed history store, a history HTTP endpoint, and the Dashboard page's misfire panel (#3419) —
per the issue.

Closes #3422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
