### PR TITLE
Configuration binds without reflection, and the package says it is AOT-compatible

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -25,7 +25,11 @@ services.AddQuartz(q => q.ConfigureScheduler(options => options.MaxBatchSize = 5
 ```
 
 Options are bound from the `Quartz` section by section name and validated at startup, so a bad value is
-reported against the setting that is wrong rather than failing later during scheduling. The sections are:
+reported against the setting that is wrong rather than failing later during scheduling. The binding is
+source-generated — the compiler writes a binder for each options type rather than reflecting over it at
+startup — which is what makes configuring from a file as safe under `PublishTrimmed` and `PublishAot`
+as configuring in code. Nothing is asked of your application for that; it is how `Quartz` is built. The
+sections are:
 
 | Section | Options | |
 |---|---|---|

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3755,20 +3755,28 @@ needs the same annotation:
 around fifty of them, at the reflective call sites listed in `src/Quartz/TrimAnalysisBaseline.cs`.
 
 That is not a regression: the same reflection was there before and the same code could break under
-trimming; you can now see which parts. Quartz is **not** trim-safe yet, and none of those warnings is
-suppressed in the shipped assembly, deliberately — suppressing them would hide a real risk from you.
-Configuration by flat `quartz.*` keys, jobs named as strings (`job_scheduling_data` XML, a persisted
-`JOB_CLASS_NAME`), and `JobDataMap` values bound onto job properties are the paths that need reflection;
-an application that configures in code, references its job types statically and keeps job data to
-primitives exercises far less of it. A **persistent job store** publishes trimmed, and publishes native
-AOT, when it is told how to reach its driver without naming one — `UseSqlServer(SqlClientFactory.Instance,
-connectionString)`, or a registered `DbDataSource`: the default System.Text.Json serializer carries a
-source-generated contract for every blob a store writes, and a custom trigger or calendar type is
-answered by the registry it was registered with. The one thing left open is a job-data value of a type
-of your own, which the registry is handed metadata for through
-`SystemTextJsonSerializerRegistry.AddTypeInfoResolver` — see
-[Trimming](tutorial/more-about-jobs.md#trimming) for the shape of that. Progress is tracked on
-[#3341](https://github.com/quartznet/quartznet/issues/3341).
+trimming; you can now see which parts. None of those warnings is suppressed in the shipped assembly,
+deliberately — suppressing them would hide a real risk from you. Configuration by flat `quartz.*` keys,
+jobs named as strings (`job_scheduling_data` XML, a persisted `JOB_CLASS_NAME`), and `JobDataMap` values
+bound onto job properties are the paths that need reflection; an application that configures in code,
+references its job types statically and keeps job data to primitives exercises far less of it. A
+**persistent job store** publishes trimmed, and publishes native AOT, when it is told how to reach its
+driver without naming one — `UseSqlServer(SqlClientFactory.Instance, connectionString)`, or a registered
+`DbDataSource`: the default System.Text.Json serializer carries a source-generated contract for every
+blob a store writes, and a custom trigger or calendar type is answered by the registry it was registered
+with. The one thing left open is a job-data value of a type of your own, which the registry is handed
+metadata for through `SystemTextJsonSerializerRegistry.AddTypeInfoResolver` — see
+[Trimming](tutorial/more-about-jobs.md#trimming) for the shape of that.
+
+`Quartz` also declares **`IsAotCompatible`** on 4.0, which 3.x does not. What it claims is narrow and
+checkable: nothing Quartz does needs code generated at run time, so a native AOT publish reports no
+`IL3050` against it at all. The last pair belonged to configuration binding, and binding the `Quartz`
+section is source-generated now — the compiler writes a binder for each options type — so configuring
+from `appsettings.json` is as ahead-of-time-safe as configuring in code, with nothing asked of your
+application. The `IL2xxx` above are unaffected by the claim and still reported; `Quartz.Trimming.Canary`
+is published by ILCompiler and **run** on Windows, Linux and macOS on every pull request, scheduling
+and firing over a real SQLite store and binding a whole scheduler out of an `IConfiguration`. The rest
+of the track is [#3341](https://github.com/quartznet/quartznet/issues/3341).
 
 ## Executing is a trigger state
 
@@ -7768,6 +7776,7 @@ Parameters and behavior are unchanged:
 | The dashboard's HTTP-backed API client is gone | `QuartzApiClient` was never registered; the dashboard renders the schedulers in its own process, and `QuartzDashboardOptions.BaseUrl` and `.ApiPath` went with it — see [The dashboard reads the schedulers in its own process](#the-dashboard-reads-the-schedulers-in-its-own-process) |
 | Serializers outside a scheduler read a container-wide registry | Because the serializer maps are per-serializer, the HTTP API and `Quartz.HttpClient` read a `SystemTextJsonSerializerRegistry` registered in the container. Register it as a singleton to make a custom serializer visible to them. The dashboard no longer registers one of its own: it passes triggers and calendars through as themselves |
 | `SystemTextJsonSerializerRegistry` gained `AddTypeInfoResolver(IJsonTypeInfoResolver)` | Where reflection-based serialization is off — a `PublishTrimmed` or `PublishAot` application — this is how job-data values of the application's own types are answered for. Hand it a generated `JsonSerializerContext`'s `Default`. Everything Quartz writes, and every custom trigger or calendar registered with the registry, is already covered; with reflection on it changes nothing — see [Trimming annotations](#trimming-annotations) |
+| The `Quartz` package declares `IsAotCompatible`, and binds configuration with the source-generated binder | No API moved. Quartz reports no `IL3050` at all now: the `Quartz` section binds through code the compiler wrote rather than through `ConfigurationBinder`'s reflection, so an application configured from `appsettings.json` publishes native AOT as safely as one configured in code — with the reflection binder that preceded it, `MaxBatchSize`, `ShutdownJobInterruption` and the whole scheduler context arrived as their defaults out of a native publish, silently. The `IL2xxx` for the string-named paths are unchanged — see [Trimming annotations](#trimming-annotations) |
 | `IDriverDelegate` trigger states are `StoredTriggerState` | Eighteen members took the state as a `string`; the database still stores the same values — see [Trigger states are typed on the driver delegate](#trigger-states-are-typed-on-the-driver-delegate) |
 | The `…FromOtherStates` members take a state collection | Two or three fixed old-state parameters became one `IReadOnlyCollection<StoredTriggerState>` |
 | `FiredTriggerQuery.InstanceName` is `InstanceId` | With the `instanceName` parameters of the scheduler-state members; the `INSTANCE_NAME` column is unchanged |

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -558,17 +558,29 @@ it as `UseSqlite(SqliteFactory.Instance, …)`, schedules a job, waits for the j
 it fired, and reads the job and the trigger back through `IScheduler`. That runs on every build, out of
 a fully trimmed publish and out of a native one, on Windows, Linux and macOS.
 
-**Publishing AOT reports Quartz's own warnings, and that is deliberate.** Quartz records its remaining
-reflective call sites in the repository rather than in the shipped assembly, so an
-`UnconditionalSuppressMessage` never hides them from you. Expect `IL2xxx` for the string-named
-configuration paths described above, and `IL3050` for one more: **configuration binding**.
-`Configure<TOptions>(name, section)` binds the `Quartz` section by reflecting over the options types;
-configuring in code with `AddQuartz(q => …)` rather than from `appsettings.json` avoids it.
+**Configuration binds without reflecting over anything.** The `Quartz` section reaches
+`QuartzSchedulerOptions` and its siblings through a binder the compiler wrote, not through
+`ConfigurationBinder`'s reflection, so an application configured from `appsettings.json` is as
+ahead-of-time-safe as one configured in code. That is what closed the last `IL3050` in the package —
+and it was more than a warning: built against the reflection binder, the repository's canary publishes
+natively and comes up with `MaxBatchSize`, `ShutdownJobInterruption` and the whole scheduler context at
+their defaults, silently. Nothing is asked of you to get the generated binder; it is how the package
+was built.
 
-That warning is not on the fire path of any scheduler, so an application that configures in code
-publishes AOT with warnings it can read and dismiss. The `Quartz` package still does not declare
-`IsAotCompatible` — the remaining warnings are what that claim would have to answer for, and the
-question is tracked on [issue #3341](https://github.com/quartznet/quartznet/issues/3341).
+**The `Quartz` package declares `IsAotCompatible`.** What that claims is that nothing Quartz does needs
+code generated at run time, which the build checks rather than asserts: `Quartz` compiles with the
+trim, AOT and single-file analyzers on and warnings as errors, and the canary is published by
+ILCompiler and run on every pull request.
+
+What it does not claim is that no `IL2xxx` remains. Publishing your application AOT still reports the
+string-named paths described above against Quartz — a job type named as text, the `JOB_CLASS_NAME`
+column an ADO.NET store reads back, the `quartz.plugin.*` and `quartz.*.listener.*` keys, and the
+provider error codes `TransientErrorDetector` reads off exception types Quartz does not reference. Each
+is either an API that says `[RequiresUnreferencedCode]`, so avoiding it is a compile-time decision, or
+a path only a configuration style reaches. Quartz records them in the repository rather than in the
+shipped assembly, so an `UnconditionalSuppressMessage` never hides them from you — you see what your
+own application's closure reaches, and none of it stops a scheduler from starting, firing and shutting
+down out of a native executable.
 
 ## JobExecutionException
 

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationBindingIsSourceGeneratedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationBindingIsSourceGeneratedTest.cs
@@ -1,0 +1,383 @@
+#nullable enable
+
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Holds the one thing <c>EnableConfigurationBindingGenerator</c> cannot say for itself: that the
+/// generator actually intercepted the binder calls, and that it bound every member of every options
+/// type it reached.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The property is a request, not a result. An interceptor that declines to intercept leaves the
+/// reflection binder in the compiled assembly, and every test in this project passes either way — the
+/// reflection binder is perfectly correct in a process that has a JIT. What it is not is
+/// ahead-of-time-safe: <c>Quartz.Trimming.Canary</c> built against it and published natively comes up
+/// with three of its eight configured values at their defaults and no error anywhere, which is the
+/// failure shape <see cref="ConfigurationIsNeverSilentlyDroppedTest"/> guards elsewhere — configuration
+/// accepted without complaint and then discarded.
+/// </para>
+/// <para>
+/// Two halves, because neither is sufficient. <see cref="TheBinderCallsInQuartzTypedOptionsAreIntercepted"/>
+/// reads the interception out of the built assembly's metadata, which is the only place the fact is
+/// recorded. Everything below it binds a section and reads the value back, which is what a reader
+/// actually cares about — and, unlike the metadata check, it fails when the generator quietly declines
+/// to bind one member of a type it did generate a binder for. That is not hypothetical: the generator
+/// skips a member whose type configuration cannot express, and says nothing about it.
+/// </para>
+/// <para>
+/// The samples are derived from a fresh instance's own value, so a sample can never coincide with the
+/// default it is meant to displace — an assertion that passed because the value was already what it was
+/// going to be would prove nothing.
+/// </para>
+/// </remarks>
+public class ConfigurationBindingIsSourceGeneratedTest
+{
+    /// <summary>
+    /// The six calls the generator has to intercept, which are all of the binder calls Quartz makes.
+    /// </summary>
+    private const int InterceptedBinderCalls = 6;
+
+    /// <summary>
+    /// The file those calls are written in. The generator intercepts call sites in the project being
+    /// compiled, so the fact that these are Quartz's own is what makes the fix reach consumers who set
+    /// nothing.
+    /// </summary>
+    private const string InterceptedFile = "QuartzTypedOptions.cs";
+
+    /// <summary>
+    /// Members the binder cannot reach, each with the reason it is out of reach. A new entry needs a
+    /// reason of the same kind: a value no configuration source can produce, which is therefore
+    /// documented as settable from code only.
+    /// </summary>
+    /// <remarks>
+    /// Ratified by <c>OptionsConventionTest</c>, whose S6 rule classifies a delegate as a scalar that is
+    /// "replaced, never edited" and so allows one on an options type. A member that is <em>not</em> a
+    /// delegate and cannot bind does not belong here: move it off the options type, or split the
+    /// binding, rather than excusing it.
+    /// </remarks>
+    private static readonly Dictionary<string, string> codeOnlyMembers = new(StringComparer.Ordinal)
+    {
+        ["Quartz.DataSourceOptions.DataSourceFactory"] =
+            "a Func<IServiceProvider, DbDataSource> is a value only code can supply, and the member says so"
+    };
+
+    [Test]
+    public void TheBinderCallsInQuartzTypedOptionsAreIntercepted()
+    {
+        List<CustomAttributeData> interceptions = Interceptions();
+
+        interceptions.Should().HaveCount(InterceptedBinderCalls,
+            "every Configure<TOptions>(name, section) call in QuartzTypedOptions has to be intercepted — "
+            + "one that is not leaves the reflection binder in place for that options type, which no "
+            + "diagnostic reports");
+
+        foreach (CustomAttributeData interception in interceptions)
+        {
+            FileOf(interception).Should().Be(InterceptedFile,
+                "the generator only intercepts call sites in the project it runs in, so an interception "
+                + "pointing anywhere else means the count above is being made up by some other file");
+        }
+    }
+
+    [Test]
+    public void TheGeneratedBinderKnowsEveryOptionsTypeTheQuartzSectionBinds()
+    {
+        Type[] bound =
+        [
+            typeof(QuartzSchedulerOptions),
+            typeof(ThreadPoolOptions),
+            typeof(InMemoryJobStoreOptions),
+            typeof(AdoJobStoreOptions),
+            typeof(ClusteringOptions),
+            typeof(DataSourceOptions)
+        ];
+
+        List<Type> generated = GeneratedBinder()
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(method => method.Name == "BindCore")
+            .SelectMany(method => method.GetParameters())
+            .Where(parameter => parameter.ParameterType.IsByRef)
+            .Select(parameter => parameter.ParameterType.GetElementType()!)
+            .ToList();
+
+        generated.Should().Contain(bound,
+            "each of these binds from its own section, and a type the generator wrote no binder for is "
+            + "one the reflection binder is still doing at runtime");
+    }
+
+    [Test]
+    public void TheSchedulerSectionBindsEveryMemberOfQuartzSchedulerOptions()
+    {
+        AssertEveryMemberBinds<QuartzSchedulerOptions>(QuartzTypedOptions.SchedulerSection);
+    }
+
+    [Test]
+    public void TheThreadPoolSectionBindsEveryMemberOfThreadPoolOptions()
+    {
+        AssertEveryMemberBinds<ThreadPoolOptions>(QuartzTypedOptions.ThreadPoolSection);
+    }
+
+    [Test]
+    public void TheJobStoreSectionBindsEveryMemberOfInMemoryJobStoreOptions()
+    {
+        AssertEveryMemberBinds<InMemoryJobStoreOptions>(QuartzTypedOptions.JobStoreSection);
+    }
+
+    [Test]
+    public void TheJobStoreSectionBindsEveryMemberOfAdoJobStoreOptions()
+    {
+        AssertEveryMemberBinds<AdoJobStoreOptions>(QuartzTypedOptions.JobStoreSection);
+    }
+
+    [Test]
+    public void TheClusteringSubSectionBindsEveryMemberOfClusteringOptions()
+    {
+        AssertEveryMemberBinds<ClusteringOptions>(
+            $"{QuartzTypedOptions.JobStoreSection}:{QuartzTypedOptions.ClusteringSection}");
+    }
+
+    [Test]
+    public void EachDataSourceChildBindsEveryMemberOfDataSourceOptions()
+    {
+        // The one call site that binds a section per child rather than a section per scheduler, and the
+        // one whose options are named after something other than the scheduler.
+        AssertEveryMemberBinds<DataSourceOptions>($"{QuartzTypedOptions.DataSourceSection}:reporting", "reporting");
+    }
+
+    [Test]
+    public void EveryCodeOnlyMemberIsStillEarningItsPlace()
+    {
+        foreach (string member in codeOnlyMembers.Keys)
+        {
+            PropertyInfo? property = BoundOptionsTypes()
+                .SelectMany(type => type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                .SingleOrDefault(candidate => Describe(candidate) == member);
+
+            property.Should().NotBeNull($"the list names {member}, which no longer exists");
+            SampleFor(property!, Activator.CreateInstance(property!.DeclaringType!)!).Should().BeNull(
+                $"{member} is bindable now, so excusing it hides a member the binder does write");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Fills every member of <typeparamref name="TOptions"/> from configuration and reads each one back
+    /// off the instance the container hands its own components.
+    /// </summary>
+    private static void AssertEveryMemberBinds<TOptions>(string sectionPath, string optionsName = "")
+        where TOptions : class, new()
+    {
+        TOptions probe = new();
+        Dictionary<string, string?> values = new(StringComparer.Ordinal);
+        Dictionary<PropertyInfo, object?> expected = new();
+        List<string> unbindable = [];
+
+        foreach (PropertyInfo property in Settable(typeof(TOptions)))
+        {
+            if (IsStringDictionary(property.PropertyType))
+            {
+                // Bound into rather than assigned, which is the code path the reflection binder needed
+                // RequiresDynamicCode for.
+                values[$"Quartz:{sectionPath}:{property.Name}:canary"] = "bound";
+                expected[property] = "bound";
+                continue;
+            }
+
+            if (SampleFor(property, probe) is not { } sample)
+            {
+                unbindable.Add($"{Describe(property)} is a {property.PropertyType.Name}");
+                continue;
+            }
+
+            values[$"Quartz:{sectionPath}:{property.Name}"] = sample;
+            expected[property] = Parse(property.PropertyType, sample);
+        }
+
+        unbindable.Should().BeEquivalentTo(
+            codeOnlyMembers
+                .Where(entry => entry.Key.StartsWith(typeof(TOptions).FullName + ".", StringComparison.Ordinal))
+                .Select(entry => UnbindableDescription(entry.Key)),
+            "the generator drops a member whose type configuration cannot express and says nothing about "
+            + "it, so a new one is a setting that binds from nowhere — move it off the options type, or "
+            + "split the binding, or say here why no configuration source could ever produce it");
+
+        ServiceCollection services = new();
+        services.BindQuartzOptions(Section(values));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+        TOptions bound = container.GetRequiredService<IOptionsMonitor<TOptions>>().Get(optionsName);
+
+        List<string> dropped = [];
+        foreach ((PropertyInfo property, object? want) in expected)
+        {
+            object? got = IsStringDictionary(property.PropertyType)
+                ? ((IReadOnlyDictionary<string, string>) property.GetValue(bound)!).GetValueOrDefault("canary")
+                : property.GetValue(bound);
+
+            if (!Equals(got, want))
+            {
+                dropped.Add($"{Describe(property)} bound as '{got ?? "null"}', wanted '{want ?? "null"}'");
+            }
+        }
+
+        dropped.Should().BeEmpty(
+            "every one of these was written into the configuration section the options type binds from, "
+            + "so a value still at its default is one the binder passed over");
+    }
+
+    private static IConfiguration Section(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build().GetSection("Quartz");
+    }
+
+    private static IEnumerable<Type> BoundOptionsTypes()
+    {
+        yield return typeof(QuartzSchedulerOptions);
+        yield return typeof(ThreadPoolOptions);
+        yield return typeof(InMemoryJobStoreOptions);
+        yield return typeof(AdoJobStoreOptions);
+        yield return typeof(ClusteringOptions);
+        yield return typeof(DataSourceOptions);
+    }
+
+    private static IEnumerable<PropertyInfo> Settable(Type type) => type
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Where(property => property.GetMethod is { IsPublic: true })
+        .OrderBy(property => property.Name, StringComparer.Ordinal);
+
+    /// <summary>
+    /// A value for the member that differs from the one a fresh instance already has, or
+    /// <see langword="null" /> when configuration cannot express the member's type at all.
+    /// </summary>
+    private static string? SampleFor(PropertyInfo property, object probe)
+    {
+        Type type = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+        object? current = property.GetValue(probe);
+
+        if (type == typeof(string) || type == typeof(object))
+        {
+            return $"bound-{property.Name}";
+        }
+
+        if (type == typeof(bool))
+        {
+            return current is true ? "false" : "true";
+        }
+
+        if (type == typeof(int))
+        {
+            return ((current as int? ?? 0) + 7).ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (type == typeof(TimeSpan))
+        {
+            return ((current as TimeSpan? ?? TimeSpan.Zero) + TimeSpan.FromSeconds(7)).ToString("c", CultureInfo.InvariantCulture);
+        }
+
+        if (type.IsEnum)
+        {
+            return Enum.GetNames(type).Last(name => !Equals(Enum.Parse(type, name), current));
+        }
+
+        return null;
+    }
+
+    private static object? Parse(Type propertyType, string sample)
+    {
+        Type type = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+
+        if (type == typeof(string) || type == typeof(object))
+        {
+            return sample;
+        }
+
+        if (type == typeof(bool))
+        {
+            return bool.Parse(sample);
+        }
+
+        if (type == typeof(int))
+        {
+            return int.Parse(sample, CultureInfo.InvariantCulture);
+        }
+
+        if (type == typeof(TimeSpan))
+        {
+            return TimeSpan.Parse(sample, CultureInfo.InvariantCulture);
+        }
+
+        return Enum.Parse(type, sample);
+    }
+
+    private static bool IsStringDictionary(Type type) =>
+        type.IsGenericType
+        && type.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+        && type.GetGenericArguments()[0] == typeof(string)
+        && type.GetGenericArguments()[1] == typeof(string);
+
+    /// <summary>
+    /// The generated binder, which the compiler emits into Quartz itself as a file-local type — so its
+    /// metadata name carries a hash of the generated file's own name and cannot be written down.
+    /// </summary>
+    private static Type GeneratedBinder()
+    {
+        Type[] candidates = typeof(IScheduler).Assembly
+            .GetTypes()
+            .Where(type => type.Namespace == "Microsoft.Extensions.Configuration.Binder.SourceGeneration")
+            .Where(type => type.Name.EndsWith("BindingExtensions", StringComparison.Ordinal))
+            .ToArray();
+
+        candidates.Should().ContainSingle(
+            "the configuration binding generator emits exactly one binder per compilation, and none at "
+            + "all when EnableConfigurationBindingGenerator is off in src/Quartz/Quartz.csproj");
+
+        return candidates[0];
+    }
+
+    private static List<CustomAttributeData> Interceptions() => GeneratedBinder()
+        .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+        .SelectMany(method => method.GetCustomAttributesData())
+        .Where(attribute => attribute.AttributeType.Name.EndsWith("InterceptsLocationAttribute", StringComparison.Ordinal))
+        .ToList();
+
+    /// <summary>
+    /// The source file an interception points at.
+    /// </summary>
+    /// <remarks>
+    /// Roslyn's version 1 location is base64 of a 16-byte content checksum, a 4-byte position and the
+    /// display file name. Nothing else decodes it, so a version this does not know about fails loudly
+    /// rather than being read as if it were version 1.
+    /// </remarks>
+    private static string FileOf(CustomAttributeData interception)
+    {
+        interception.ConstructorArguments[0].Value.Should().Be(1,
+            "this decodes Roslyn's version 1 interceptable location; a new version needs a new decoder here");
+
+        byte[] data = Convert.FromBase64String((string) interception.ConstructorArguments[1].Value!);
+        data.Length.Should().BeGreaterThan(20, "a version 1 location is a checksum, a position and a file name");
+
+        return Encoding.UTF8.GetString(data, 20, data.Length - 20);
+    }
+
+    private static string UnbindableDescription(string member)
+    {
+        string[] parts = member.Split('.');
+        Type type = BoundOptionsTypes().Single(candidate => candidate.Name == parts[^2]);
+        PropertyInfo property = type.GetProperty(parts[^1])!;
+        return $"{member} is a {property.PropertyType.Name}";
+    }
+
+    private static string Describe(PropertyInfo property) => $"{property.DeclaringType!.FullName}.{property.Name}";
+}

--- a/src/Quartz.Trimming.Canary/BindingCheck.cs
+++ b/src/Quartz.Trimming.Canary/BindingCheck.cs
@@ -1,0 +1,159 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Runtime.CompilerServices;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Quartz.Trimming.Canary;
+
+/// <summary>
+/// A scheduler configured entirely from an <see cref="IConfiguration" />, out of a trimmed or natively
+/// compiled publish, with every bound value read back off the thing that uses it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is issue #3430's artefact, and the reason it is here rather than in a unit test is that the
+/// reflection binder it replaced passes every unit test there is. Built against that binder and
+/// published <em>natively</em>, this check fails: <c>Scheduler:MaxBatchSize</c>,
+/// <c>Scheduler:ShutdownJobInterruption</c> and every entry of <c>Scheduler:Context</c> arrive as their
+/// defaults, with no error anywhere — which is what the IL3050 the baseline used to record was warning
+/// about, and what a configured application would have got out of a native publish. The same build
+/// published <c>TrimMode=full</c> passes, so the trimmed leg alone would not have caught it either.
+/// </para>
+/// <para>
+/// Each value is read back through whatever actually uses it rather than off the options object where
+/// possible: the scheduler's own name, its thread pool's size, and the scheduler context a job would
+/// read. The rest are read from the container's options, which is the same instance the component
+/// holding them was given.
+/// </para>
+/// <para>
+/// The store is <see cref="StoreCheck" />'s business, not this one's. A data source is configured here
+/// because the per-child <c>DataSource:&lt;name&gt;</c> bind is the sixth intercepted call site and the
+/// only one whose options are named after something other than the scheduler, but nothing opens a
+/// connection through it — the scheduler runs on the in-memory store.
+/// </para>
+/// </remarks>
+internal static class BindingCheck
+{
+    // Shared between the section and the assertion because the two are the same text. Anything the
+    // binder has to parse - a TimeSpan, an int, an enum - is written out on both sides instead, so that
+    // the configured spelling and the value expected of it never come from one place.
+    private const string SchedulerName = "BindingCanary";
+    private const string ConnectionString = "Data Source=binding-canary.db";
+    private const string TablePrefix = "CANARY_";
+    private const string ContextValue = "native";
+
+    /// <summary>
+    /// Runs the check, returning <see langword="null" /> when it passed and a message when it did not.
+    /// </summary>
+    public static async Task<string?> Run()
+    {
+        try
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    // Scheduler — a string, a TimeSpan, an int, an enum and a dictionary bound into.
+                    ["Quartz:Scheduler:InstanceName"] = SchedulerName,
+                    ["Quartz:Scheduler:InstanceId"] = "one",
+                    ["Quartz:Scheduler:IdleWaitTime"] = "00:00:20",
+                    ["Quartz:Scheduler:MaxBatchSize"] = "3",
+                    ["Quartz:Scheduler:ShutdownJobInterruption"] = nameof(ShutdownJobInterruption.Always),
+                    ["Quartz:Scheduler:Context:environment"] = ContextValue,
+
+                    ["Quartz:ThreadPool:MaxConcurrency"] = "7",
+
+                    // JobStore — the same section binds the in-memory and the ADO.NET options both.
+                    ["Quartz:JobStore:MisfireThreshold"] = "00:02:30",
+                    ["Quartz:JobStore:TablePrefix"] = TablePrefix,
+                    ["Quartz:JobStore:DataSource"] = "canary",
+                    ["Quartz:JobStore:Clustering:CheckinInterval"] = "00:00:11",
+
+                    ["Quartz:DataSource:canary:Provider"] = DataSourceOptions.Providers.Sqlite,
+                    ["Quartz:DataSource:canary:ConnectionString"] = ConnectionString,
+                })
+                .Build();
+
+            ServiceCollection services = new();
+            services.AddQuartz(configuration.GetSection("Quartz"));
+
+            ServiceProvider container = services.BuildServiceProvider();
+            await using ConfiguredAsyncDisposable containerDisposal = container.ConfigureAwait(false);
+
+            IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler().ConfigureAwait(false);
+            SchedulerMetadata metadata = await scheduler.GetMetadata().ConfigureAwait(false);
+
+            List<string> wrong = [];
+
+            Check(wrong, "Scheduler:InstanceName", SchedulerName, scheduler.SchedulerName);
+            Check(wrong, "ThreadPool:MaxConcurrency", 7, metadata.ThreadPoolSize);
+
+            // Asked for rather than indexed, so that a context the binder never filled is one more line
+            // in the report rather than the exception that ends it.
+            scheduler.Context.TryGetValue("environment", out object? contextValue);
+            Check(wrong, "Scheduler:Context:environment", ContextValue, contextValue);
+
+            QuartzSchedulerOptions schedulerOptions = container.GetRequiredService<IOptions<QuartzSchedulerOptions>>().Value;
+            Check(wrong, "Scheduler:IdleWaitTime", TimeSpan.FromSeconds(20), schedulerOptions.IdleWaitTime);
+            Check(wrong, "Scheduler:MaxBatchSize", 3, schedulerOptions.MaxBatchSize);
+            Check(wrong, "Scheduler:ShutdownJobInterruption", ShutdownJobInterruption.Always, schedulerOptions.ShutdownJobInterruption);
+
+            Check(wrong, "JobStore:MisfireThreshold", TimeSpan.FromSeconds(150),
+                container.GetRequiredService<IOptions<InMemoryJobStoreOptions>>().Value.MisfireThreshold);
+
+            Check(wrong, "JobStore:TablePrefix", TablePrefix,
+                container.GetRequiredService<IOptions<AdoJobStoreOptions>>().Value.TablePrefix);
+
+            Check(wrong, "JobStore:Clustering:CheckinInterval", TimeSpan.FromSeconds(11),
+                container.GetRequiredService<IOptions<ClusteringOptions>>().Value.CheckinInterval);
+
+            // The per-child bind, named after the data source rather than after the scheduler.
+            Check(wrong, "DataSource:canary:ConnectionString", ConnectionString,
+                container.GetRequiredService<IOptionsMonitor<DataSourceOptions>>().Get("canary").ConnectionString);
+
+            if (wrong.Count > 0)
+            {
+                return "FAIL binding: the configuration section was accepted and then not used." + Environment.NewLine
+                    + string.Join(Environment.NewLine, wrong);
+            }
+
+            await scheduler.Shutdown(waitForJobsToComplete: false).ConfigureAwait(false);
+
+            Console.WriteLine("PASS binding: a scheduler built from an IConfiguration carries every value the section named.");
+            return null;
+        }
+        catch (Exception e)
+        {
+            return $"FAIL binding: {e.GetType().FullName}: {e.Message}{Environment.NewLine}{e}";
+        }
+    }
+
+    private static void Check(List<string> wrong, string key, object expected, object? actual)
+    {
+        if (!Equals(expected, actual))
+        {
+            wrong.Add($"  {key}: bound as '{actual ?? "null"}', configuration said '{expected}'");
+        }
+    }
+}

--- a/src/Quartz.Trimming.Canary/Program.cs
+++ b/src/Quartz.Trimming.Canary/Program.cs
@@ -54,6 +54,13 @@ namespace Quartz.Trimming.Canary;
 /// only says a job did not fire — but the store is what the whole track was working towards, and it is
 /// the half that a compile can substitute for least.
 /// </para>
+/// <para>
+/// Last, <see cref="BindingCheck" /> builds a scheduler out of an <see cref="Microsoft.Extensions.Configuration.IConfiguration" />
+/// and reads every bound value back. That one is here for the same reason as the rest, and it is the
+/// only check whose failure needs the <em>native</em> leg rather than the trimmed one: built against
+/// the reflection binder this repository used to have, it passes trimmed and fails natively, with
+/// three of its values silently arriving as defaults.
+/// </para>
 /// </remarks>
 internal static class Program
 {
@@ -89,13 +96,18 @@ internal static class Program
             failures.Add(storeFailure);
         }
 
+        if (await BindingCheck.Run().ConfigureAwait(false) is { } bindingFailure)
+        {
+            failures.Add(bindingFailure);
+        }
+
         foreach (string failure in failures)
         {
             Console.WriteLine(failure);
         }
 
         Console.WriteLine(failures.Count == 0
-            ? "Quartz.Trimming.Canary: the store format round-trips, and a persistent store schedules, fires and reads back."
+            ? "Quartz.Trimming.Canary: the store format round-trips, a persistent store schedules, fires and reads back, and configuration binds."
             : $"Quartz.Trimming.Canary: {failures.Count} check(s) failed.");
 
         return failures.Count == 0 ? 0 : 1;

--- a/src/Quartz/ILLink.Suppressions.xml
+++ b/src/Quartz/ILLink.Suppressions.xml
@@ -9,14 +9,15 @@
   warning to silence. Removing an entry that looks unused because the analyzer is quiet about it fails
   the publish; verify against a clean `dotnet fallout PublishTrimmed`, not against the compile.
 
-  The other difference is that this file carries no IL3050, where TrimAnalysisBaseline.cs carries one.
-  That is not an omission. ILLink does not report IL3050 at all — dynamic code is ILCompiler's concern,
-  and ILCompiler cannot be handed this file: its command line offers a descriptor option and a
-  substitution option and no link-attributes option at all, and the SDK item below only ever reaches
-  ILLink. The only way to tell ILCompiler in the assembly would be to bake UnconditionalSuppressMessage
-  into it, which is exactly the lie the paragraph below refuses to tell. So a native AOT publish reports
-  every one of these against Quartz, and the CI leg that runs one reads the report instead of being
-  silenced — see the paragraph on ILCompiler further down.
+  Neither file carries an IL3050 any more — Quartz produces none, which is what let it claim
+  IsAotCompatible — but this one could not have carried one anyway. ILLink does not report IL3050 at
+  all: dynamic code is ILCompiler's concern, and ILCompiler cannot be handed this file, since its
+  command line offers a descriptor option and a substitution option and no link-attributes option at
+  all, and the SDK item below only ever reaches ILLink. The only way to tell ILCompiler in the assembly
+  would be to bake UnconditionalSuppressMessage into it, which is exactly the lie the paragraph below
+  refuses to tell. So a native AOT publish reports every one of these against Quartz, and the CI leg
+  that runs one reads the report instead of being silenced — see the paragraph on ILCompiler further
+  down.
 
   Two files are needed because the two tools cannot be told the same way. SuppressMessageAttribute is
   [Conditional("CODE_ANALYSIS")], so the C# baseline never reaches metadata and ILLink cannot see it;
@@ -172,14 +173,12 @@
       </attribute>
     </type>
 
-    <!-- Configuration binding -->
-    <type fullname="Quartz.Configuration.QuartzTypedOptions*">
-      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-        <argument>Trimming</argument>
-        <argument>IL2026</argument>
-        <property name="Justification">Binding the quartz configuration section reflects over the options types; the source-generated binder is the fix.</property>
-      </attribute>
-    </type>
+    <!--
+      Configuration binding was the last group here and is gone rather than re-justified. Quartz.csproj
+      sets EnableConfigurationBindingGenerator, so the six Configure<TOptions>(name, section) calls in
+      QuartzTypedOptions are intercepted and bound by generated code; nothing reflects over an options
+      type any more. See TrimAnalysisBaseline.cs beside this file.
+    -->
 
   </assembly>
 </linker>

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -8,26 +8,28 @@
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <!--
-      IsAotCompatible would turn these two on as well, and it is deliberately not set. Step 5 of #3341
-      turned them on by themselves instead, so that the warnings could be counted before the claim was
-      made: twelve IL3050 call sites, of which one was fixed and one answered at the call site. Step 6
-      took six more away rather than recording them, and the six that are left are one entry in
-      TrimAnalysisBaseline.cs — the configuration binder, whose fix is the source-generated one.
-
-      What stopped the claim was not a warning but a run, and step 6 fixed the run. A native AOT publish
-      switches reflection-based System.Text.Json off, and the default IObjectSerializer used to have no
-      resolver to fall back on when it was — so a native AOT application over RAMJobStore started, fired
-      its triggers and shut down cleanly, while one over a persistent store threw "Reflection-based
-      serialization has been disabled for this application" the first time it wrote a trigger. It no
-      longer does: Quartz.Trimming.Canary round-trips every blob a job store writes out of a trimmed
-      publish on every build, and out of a native AOT publish when run by hand.
-
-      What is left is the recorded set above, which is what an application publishing native AOT would
-      see reported against Quartz. Setting IsAotCompatible is therefore a judgement about those, not
-      about the store any more, and it is the one decision this file is still waiting on.
+      IsAotCompatible would turn these two on as well, and it is deliberately not set yet - issue
+      #3430 is where that is decided. What stood in the way was the options binder, which needed a
+      trimmer it could not satisfy and code generated at run time both; the generator below took the
+      pair away, and Quartz produces no IL3050 at all now. So what is left to judge is the IL2xxx
+      recorded in TrimAnalysisBaseline.cs - the string-named contracts - and nothing else.
     -->
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <!--
+      Binding is the compiler's job here, not the reflection binder's. The generator intercepts a
+      Configure<TOptions>(name, section) call in this project and replaces it with generated code, so it
+      has to be on where the call is written — turning it on in an application does nothing for the six
+      calls in QuartzTypedOptions, and consumers get the generated binder whether or not they set it.
+
+      Turning it off is not a quiet change: the two suppressions that used to cover those six calls are
+      deleted, so the IL2026 and IL3050 come straight back as errors. ConfigurationBindingIsSourceGeneratedTest
+      counts the interceptions in the built assembly as well, because that is the only place the fact is
+      recorded, and Quartz.Trimming.Canary binds a scheduler out of an IConfiguration and reads every
+      value back — the reflection binder passes that check trimmed and fails it natively, dropping three
+      of its eight values without a word.
+    -->
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -5,15 +5,48 @@
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      The claim, and what it is worth. IsAotCompatible turns on IsTrimmable and the trim, AOT and
+      single-file analyzers, and every one of them was already on here: issue #3341 turned them on step
+      by step so the warnings could be counted before the claim was made, rather than the other way
+      round. What the property adds is the statement, so the four properties below are spelled out
+      beside it rather than left implied — a reader can see what is claimed without knowing what the
+      SDK does with one flag.
+
+      Quartz produces no IL3050 at all. The last pair belonged to the options binder and went away with
+      EnableConfigurationBindingGenerator below, which makes the compiler write the binding code for
+      QuartzSchedulerOptions and its five siblings instead of reflecting over them at startup.
+
+      What an application publishing native AOT still sees reported against Quartz is trimming, not
+      dynamic code, and all of it is one habit: a type or a member named by a string. Each is either an
+      API that says [RequiresUnreferencedCode] out loud, so avoiding it is a compile-time decision, or a
+      path only a configuration style reaches:
+
+        - ITypeLoader / SimpleTypeLoader, and JobType(string) — a job type spelled as text. The typed
+          forms (JobBuilder.Create<T>(), OfType<T>(), AddJob<T>()) carry [DynamicallyAccessedMembers]
+          the whole way instead and warn about nothing.
+        - The persisted JOB_CLASS_NAME column, which StdAdoDelegate resolves when it reads a job back.
+          Unavoidable for a persistent store, and the reason the trim canary runs one: the type has to
+          survive trimming, which for an application's own job types it does.
+        - The quartz.plugin.* and quartz.*.listener.* property paths, and the leftover quartz.* keys the
+          property bridge applies by name. An application that configures in code reaches none of them —
+          which is what makes AddQuartz itself trimmable, and is held by a test.
+        - TransientErrorDetector, which decides whether a database error is worth retrying by reading
+          provider error codes off exception types Quartz deliberately does not reference.
+
+      Every one of those is recorded in TrimAnalysisBaseline.cs and mirrored in ILLink.Suppressions.xml,
+      neither of which ships — so a consumer is told about them, and a native AOT publish of Quartz
+      reports exactly that set and nothing else, which build/Build.cs checks on every pull request by
+      publishing Quartz.Trimming.Canary natively and running a whole SQLite store out of it.
+
+      Where the claim ends up: on SDK 10.0.400 the property writes
+      [AssemblyMetadata("IsAotCompatible", "True")] into the assembly and nothing at all into the
+      nuspec, which was checked by packing rather than assumed. So nuget.org shows nothing for it, and
+      the audience is the analyzers and a reader of this file.
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <!--
-      IsAotCompatible would turn these two on as well, and it is deliberately not set yet - issue
-      #3430 is where that is decided. What stood in the way was the options binder, which needed a
-      trimmer it could not satisfy and code generated at run time both; the generator below took the
-      pair away, and Quartz produces no IL3050 at all now. So what is left to judge is the IL2xxx
-      recorded in TrimAnalysisBaseline.cs - the string-named contracts - and nothing else.
-    -->
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <!--

--- a/src/Quartz/TrimAnalysisBaseline.cs
+++ b/src/Quartz/TrimAnalysisBaseline.cs
@@ -22,10 +22,11 @@
 using System.Diagnostics.CodeAnalysis;
 
 // The trim- and AOT-analysis warnings Quartz still produces (https://github.com/quartznet/quartznet/issues/3341).
-// It is a baseline, not an all-clear: none of these call sites is trim-safe, and the IL3050 ones are not
-// AOT-safe either. What the baseline buys is that a *new* one fails the build, because
-// TreatWarningsAsErrors makes an IL2xxx or an IL3xxx an error and nothing suppresses a warning that is
-// not listed here.
+// It is a baseline, not an all-clear: none of these call sites is trim-safe. There is no IL3050 left in
+// it, though, and that is not an accident of what has been looked at - Quartz needs no runtime code
+// generation anywhere, which is the whole of what IsAotCompatible in Quartz.csproj claims. What the
+// baseline buys is that a *new* warning of either kind fails the build, because TreatWarningsAsErrors
+// makes an IL2xxx or an IL3xxx an error and nothing suppresses a warning that is not listed here.
 //
 // Step 3 of that issue took the fire path out of this file. A job type that reached Quartz as a type -
 // JobBuilder.Create<T>(), OfType<T>(), AddJob<T>() - now carries [DynamicallyAccessedMembers] all the
@@ -68,6 +69,15 @@ using System.Diagnostics.CodeAnalysis;
 // call sites ask options.GetTypeInfo and pass the JsonTypeInfo - which is the overload that carries
 // neither attribute. Quartz.Trimming.Canary runs the round trip out of a trimmed publish, so the leg
 // proves the fix rather than the absence of a warning.
+//
+// Step 8 deleted the last two - the IL2026 and IL3050 on QuartzTypedOptions - and with them the last
+// IL3050 anywhere in Quartz, which is what let the package say IsAotCompatible. Their own justification
+// had named the fix, and it is EnableConfigurationBindingGenerator in Quartz.csproj: the compiler
+// intercepts the six Configure<TOptions>(name, section) calls and writes a binder for each options type,
+// so nothing reflects over one and nothing is generated at runtime. That entry, like step 6's, recorded
+// a warning a publish did more than warn about - the trim canary now binds a whole scheduler out of an
+// IConfiguration, and built against the reflection binder it passes trimmed and fails natively, with
+// MaxBatchSize, ShutdownJobInterruption and the whole scheduler context arriving as defaults.
 //
 // Adding an entry is the wrong first move. Reach for it only after establishing that the reflection is
 // genuinely unavoidable, and then say in the group comment why. The preferred fixes, in order:
@@ -140,12 +150,6 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Trimming", "IL2070", Scope = "type", Target = "T:Quartz.Impl.AdoJobStore.TransientErrorDetector", Justification = "Retry classification reads provider error codes off exception types Quartz deliberately does not reference.")]
 
-// --- Configuration binding ------------------------------------------------------------------------------
-// IServiceCollection.Configure<TOptions>(name, section) is RequiresUnreferencedCode and
-// RequiresDynamicCode both: the binder reflects over TOptions, and builds what it needs to set a
-// collection or a nullable property on it. The options types are ours and closed, so the
-// source-generated binder is the fix for both; that is a separate change from this baseline, and the
-// one entry here that a later step can expect to delete rather than argue for.
-
-[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Configuration.QuartzTypedOptions", Justification = "Binding the quartz configuration section reflects over the options types; the source-generated binder is the fix.")]
-[assembly: SuppressMessage("AOT", "IL3050", Scope = "type", Target = "T:Quartz.Configuration.QuartzTypedOptions", Justification = "Binding the quartz configuration section generates code for the options types; the source-generated binder is the fix.")]
+// Configuration binding was the last group in this file; step 8 above says where it went. Do not bring
+// it back by writing a Configure<TOptions>(section) call the generator cannot intercept, or an options
+// member it cannot bind - ConfigurationBindingIsSourceGeneratedTest holds both.


### PR DESCRIPTION
The last thing standing between Quartz and `IsAotCompatible` was the options binder, and it turned out
to be more than a warning.

`EnableConfigurationBindingGenerator` on `Quartz` makes the compiler intercept the six binder calls in
`QuartzTypedOptions` and write a binder for each options type; the two suppressions that covered them
are deleted, and with them the last `IL3050` anywhere in the package. `IsAotCompatible` is set, and the
26-line comment that used to explain why it was not is now an account of what the flag claims and what
the string-named contracts still report.

## The intercepted call sites

All six, read out of `obj/…/BindingExtensions.g.cs` with `EmitCompilerGeneratedFiles` on, and asserted
in metadata by `ConfigurationBindingIsSourceGeneratedTest`:

| Call site | Options type |
|---|---|
| `QuartzTypedOptions.cs(103,18)` | `QuartzSchedulerOptions` ← `Quartz:Scheduler` |
| `QuartzTypedOptions.cs(104,18)` | `ThreadPoolOptions` ← `Quartz:ThreadPool` |
| `QuartzTypedOptions.cs(110,18)` | `InMemoryJobStoreOptions` ← `Quartz:JobStore` |
| `QuartzTypedOptions.cs(111,18)` | `AdoJobStoreOptions` ← `Quartz:JobStore` |
| `QuartzTypedOptions.cs(115,18)` | `ClusteringOptions` ← `Quartz:JobStore:Clustering` |
| `QuartzTypedOptions.cs(121,22)` | `DataSourceOptions`, one per `Quartz:DataSource:<name>` child |

Those are every binder call Quartz makes: nothing in `Quartz.AspNetCore`, `Quartz.Dashboard`,
`Quartz.Server`, `Quartz.HttpClient`, `Quartz.Plugins`, `Quartz.Jobs` or `Quartz.Extensions.Redis` calls
`Configure<T>(section)`, `Bind` or `Get<T>` at all, so the generator is needed in one project and one
only. Consumers get the generated binder without setting anything, because the interception happens in
Quartz's own compilation.

**Turning it off is not quiet.** With the suppressions gone, `EnableConfigurationBindingGenerator=false`
fails the build with twelve errors — an `IL2026` and an `IL3050` at each of the six call sites. That is
a stronger guard than a test, and it is why the test's job is the *other* silent case (below).

## It was not only a warning

`Quartz.Trimming.Canary` gains a `BindingCheck`: an in-memory `ConfigurationBuilder` with a `Quartz`
section naming the thread pool size, the misfire threshold, a data-source connection string and five
more values, `AddQuartz(section)`, and every value read back — the scheduler's own name, its thread
pool's size through `GetMetadata()`, the scheduler context a job would read, and the options the
container hands its components.

Built against the **reflection binder** and published **natively**, that check fails:

```
FAIL binding: the configuration section was accepted and then not used.
  Scheduler:Context:environment: bound as 'null', configuration said 'native'
  Scheduler:MaxBatchSize: bound as '1', configuration said '3'
  Scheduler:ShutdownJobInterruption: bound as 'Never', configuration said 'Always'
```

Three of eight values silently at their defaults, no error anywhere. The same build published
`TrimMode=full` **passes**, so the trimmed leg alone would never have found it — this is the first
check in the canary that needs the native leg specifically. With the generated binder both legs pass.

I had first written the comments claiming the reflection binder fails *under trimming* because the
setters it calls by name are gone. I checked it, and that is wrong: trimmed, it binds everything, because
`QuartzPropertyBridge` sets those same properties in code and the trimmer keeps them. The wording in
every file says what was actually observed.

## Per-options-type audit

The generator emitted **no diagnostic at all** — no SYSLIB1100, no SYSLIB1101, and nothing like #3470's
CS0122 against a private nested type. Every member of every type it walks binds, with one exception:

| Type | Finding |
|---|---|
| `QuartzSchedulerOptions` | All eight members bind, including the get-only `Dictionary<string, string> Context`, which the generator binds *into* rather than replacing. |
| `ThreadPoolOptions`, `InMemoryJobStoreOptions`, `ClusteringOptions` | Bind whole. |
| `AdoJobStoreOptions` | All 21 members bind, including `TimeSpan?` (`CommandTimeout`, `MisfireHandlerFrequency`) and the nullable enum `IsolationLevel?`. These are exactly what the reflection binder needed `RequiresDynamicCode` for. |
| `DataSourceOptions` | `DataSourceServiceKey` (`object?`) binds, as a string. **`DataSourceFactory` (`Func<IServiceProvider, DbDataSource>?`) is skipped, silently.** |
| `SchedulingOptions`, `JobFactoryOptions`, `QuartzHostedServiceOptions`, `QuartzOptions` | Never bound from an `IConfiguration` section by `Quartz`, so the generator never walks them. `QuartzOptions.Scheduling` is filled by `JsonSchedulingHelper`, which reads its keys by hand; `JobFactoryOptions.ConfigureScope` is an `Action<>` and is set from code only. |

**`DataSourceFactory` stays where it is**, and I did not move it off the options type. Three reasons:
its own XML doc already says it is settable from code only; `OptionsConventionTest`'s ratified S6 rule
explicitly classifies a delegate as a scalar that is "replaced, never edited", so an options type may
carry one (`JobFactoryOptions.ConfigureScope` is the other); and the reflection binder ignored it too —
I checked, and `section.Bind(options)` with a `DataSourceFactory` key set "bound without complaint" on
both binders. `DataSourceServiceKey` likewise binds from a string under both. So nothing about
configuration behaviour changed here, in either direction. No `OptionsConventionTest` allow-list entry
was added.

What did need doing is making the silence impossible to repeat: `ConfigurationBindingIsSourceGeneratedTest`
fills **every** bindable member of each of the six types from configuration and reads it back, so a new
member whose type the generator cannot express fails the test with its own name, and the one excused
member is listed with its reason and re-checked for staleness.

## `IsAotCompatible` and the nuspec

Confirmed by packing rather than assumed. `dotnet --version` is **10.0.400**; after
`dotnet pack src/Quartz/Quartz.csproj -c Release`, `Quartz.nuspec` carries **nothing** for it — no
metadata entry, no package type, nothing nuget.org would render. What the property does write is
`[AssemblyMetadata("IsAotCompatible", "True")]` into the assembly, beside the `IsTrimmable` one. So step
5's finding still holds on 10.0.4xx; the audience for the claim is the analyzers and a reader of the
csproj, which is what the comment now says.

## Public API

Unmoved. No options member was added, removed or retyped, and
`src/Quartz.Tests.Unit/Verify/PublicApiTest_*.verified.txt` are byte-identical. The migration guide gains
a row anyway, because a package claiming `IsAotCompatible` is something a reader migrating from 3.x
wants to know, and the `Trimming annotations` section's "Quartz is **not** trim-safe yet / progress is
tracked on #3341" paragraph would otherwise have gone stale.

## Docs

- `tutorial/more-about-jobs.md` — the Native AOT section's last two paragraphs replaced: configuration
  binds without reflecting, the package declares `IsAotCompatible`, and what that does *not* claim.
- `configuration/reference.md` — one sentence at the top of the reference saying binding is
  source-generated and that nothing is asked of the application for it.
- `migration-guide.md` — the `Trimming annotations` section and one appendix row.

## Verification

Actual output, on this machine:

- `dotnet build Quartz.slnx` — **Build succeeded. 0 Warning(s), 0 Error(s)**
- `dotnet test src/Quartz.Tests.Unit` — **Failed: 0, Passed: 3466, Skipped: 4, Total: 3470**
- `dotnet test src/Quartz.Tests.AspNetCore` — **Failed: 0, Passed: 462, Total: 462**
- `dotnet fallout PublishTrimmed` — **Succeeded**; "the trimmed canary publish reported nothing outside
  the recorded baseline"; canary exit 0 with `PASS store` and `PASS binding`
- `dotnet fallout PublishAot` — **Succeeded**; "the native AOT canary publish reported nothing outside
  the recorded baseline"; **zero `IL3050` in the whole ILC report**; native canary exit 0 with
  `PASS store` and `PASS binding`
- `dotnet fallout VerifyDocsSnippets` — **up to date, 90 markdown files checked**
- `dotnet pack src/Quartz/Quartz.csproj -c Release` — nuspec inspected, see above

Not run locally: the integration suite (needs Docker, not started here — this change touches no store)
and `npm run docs:check-links` (no `node_modules` on this machine; the docs workflow runs it on this PR).
`PublishAot` needs `vswhere.exe` on `PATH` on this machine, which is the local-only wrinkle #3470
recorded; CI is unaffected.

Closes #3430
