### PR TITLE
The overview says what each execution group is doing and what state the triggers are in

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4121,7 +4121,7 @@ misfire handling.
 | — | `TriggerAcquisitionCriteria.ClusterInFlight` |
 | — | `IDriverDelegate.SelectExecutionGroupsInFlight(conn, cancellationToken)` |
 | `ExecutionLimitsResponse` / `SetExecutionLimitsRequest` carrying `Dictionary<string, int?>` | carrying `Dictionary<string, ExecutionLimitDto>`, where the DTO is `(int? MaxConcurrent, ExecutionLimitScope Scope)` |
-| `ExecutionLimitsDto(Dictionary<string, int?> Limits)` (dashboard) | `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits)` |
+| `ExecutionLimitsDto(Dictionary<string, int?> Limits)` (dashboard) | `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits, bool UsesTriggerGroupWhenUnset = false, bool CanReport = true)` — see [The dashboard's client speaks one currency](#the-dashboard-s-client-speaks-one-currency) |
 
 If you implement `IDriverDelegate` from scratch rather than deriving from `StdAdoDelegate`, the new
 member is a compile break — deliberately, because returning "nothing in flight" from a stub would fail
@@ -6016,8 +6016,11 @@ already had `JobKeyDto` and `TriggerKeyDto`. Now it says what Quartz says:
 | `GetCurrentlyExecutingJobs(name)` → `List<CurrentlyExecutingJobDto>` | `GetFireInstances(name, DashboardFireInstanceQuery)` → `PagedResult<FireInstanceDto>`, following `IScheduler` — see [What is running is a listing, not a list of contexts](#what-is-running-is-a-listing-not-a-list-of-contexts) |
 | `CurrentlyExecutingJobDto` | `FireInstanceDto`: `FireInstanceId` is non-null and leads, `JobKey` is nullable (an acquired firing has no job loaded yet), and `SchedulerInstanceId`, `FireInstanceState State` and `ScheduledFireTimeUtc` are new |
 | — | `GetClusterNodes(name)` → `List<ClusterNodeDto>` (new), behind the **Cluster** page — see [The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing) |
-| `IsJobGroupPaused(name, group)` → `bool` | `GetJobGroups(name)` → `List<JobGroupDto>`, each carrying `Name` and `Paused`; one call answers for every group instead of one |
-| `ExecutionLimitsDto(IReadOnlyDictionary<string, int?> Limits)` | `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits)` — concrete out, as everywhere else, and each entry carries the limit's [scope](#an-execution-limit-can-be-cluster-wide) as well as its number |
+| `IsJobGroupPaused(name, group)` → `bool` | `GetJobGroups(name, DashboardGroupQuery)` → `PagedResult<JobGroupDto>`, each carrying `Name` and `Paused`; one call answers for every group instead of one, and `Take = 0` with `Paused = true` counts the paused ones without listing them |
+| — | `GetTriggerGroups(name, DashboardGroupQuery)` → `PagedResult<TriggerGroupDto>` (new), the trigger-group twin of the above |
+| — | `CountMisfires(name, since)` → `int?` (new), null when the data source keeps no misfire feed — see [History and live events say which node they came from](#history-and-live-events-say-which-node-they-came-from) |
+| `ExecutionLimitsDto(IReadOnlyDictionary<string, int?> Limits)` | `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits, bool UsesTriggerGroupWhenUnset = false, bool CanReport = true)` — concrete out, as everywhere else; each entry carries the limit's [scope](#an-execution-limit-can-be-cluster-wide) as well as its number, and the keys are the spellings configuration and the HTTP API use (`_` for the ungrouped bucket, `*` for the catch-all) so that a firing can be joined to the limit governing it |
+| `GetExecutionLimits(name)` → `ExecutionLimitsDto?`, null both for "nothing is limited" and for "this scheduler cannot say" | → `ExecutionLimitsDto`, never null: nothing limited is an empty `Limits`, and a scheduler that cannot answer is `ExecutionLimitsDto.CannotReport`, whose `CanReport` is `false` |
 | `IDashboardHistoryStore.GetPage(name, page, pageSize, jobFilter, triggerFilter)` → `DashboardHistoryPage` | `GetPage(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>` |
 | `…Job(name, string group, string jobName)` — eight members | `…Job(name, JobKeyDto)` |
 | `…Trigger(name, string group, string triggerName)` — seven members | `…Trigger(name, TriggerKeyDto)` |
@@ -6114,7 +6117,7 @@ peer's. Both feeds carry the node now, and the history is bounded by age as well
 | — | `DashboardMisfireQuery : PagedQuery`, with `SchedulerName`, `SchedulerInstanceId` and `TriggerFilter` (new) |
 | `DashboardHistoryQuery` | gained `string? SchedulerInstanceId` — null lists every node's |
 | `IDashboardHistoryStore` | gained `AddMisfire`, `GetMisfires(DashboardMisfireQuery)` and `CountMisfires(name, since)` |
-| `IQuartzApiClient` | gained `GetMisfires(DashboardMisfireQuery)` → `PagedResult<DashboardMisfireEntry>?` |
+| `IQuartzApiClient` | gained `GetMisfires(DashboardMisfireQuery)` → `PagedResult<DashboardMisfireEntry>?` and `CountMisfires(name, since)` → `int?`, which is what the overview's misfire tile reads |
 | `QuartzDashboardOptions` | gained `TimeSpan HistoryRetention` (24 hours) and `int HistoryMaxEntriesPerScheduler` (2000) |
 | `DashboardHistoryPlugin(IServiceProvider)` | `DashboardHistoryPlugin(IServiceProvider, TimeProvider)`, and it implements `ITriggerListener` as well as `IJobListener` |
 | `SchedulerStateDto(SchedulerName, Status)` | `SchedulerStateDto(SchedulerName, SchedulerInstanceId, Status)` |

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -81,6 +81,56 @@ dashboard — with the authentication forwarding, execution limits and history s
 is designed in [#3387](https://github.com/quartznet/quartznet/issues/3387).
 :::
 
+## The overview
+
+The **Overview** page at `/quartz` is the one a scheduler is judged from. Beside the totals — jobs,
+triggers, firings in flight, triggers in error, nodes — it carries four breakdowns, because a total is
+rarely the thing that explains why work is not being done:
+
+- A **trigger-state histogram**: how many triggers are `Normal`, `Paused`, `Blocked`, `Error` and
+  `Complete`. Each count is a link to the Triggers page already narrowed to that state, which is also
+  what `/quartz/triggers?state=Paused` does for any state you name. The counts are counting queries, so
+  a scheduler with a hundred thousand triggers costs the same as one with ten.
+- A **paused-group** tile: how many trigger groups and how many job groups are paused. A group can be
+  paused while it holds nothing, and this counts such a group — which is exactly the one an operator
+  cannot find by looking at a listing.
+- A **misfire** tile: how many firings the scheduler missed inside the history store's retention window,
+  which the tile names — `Misfires (last 24 h)` at the default `HistoryRetention`, and whatever you
+  configured otherwise, so the label cannot promise a day a store set to remember an hour has already
+  forgotten. A data source that keeps no misfire feed shows a dash rather than a zero: it has not looked,
+  which is not the same as having looked and found none. See
+  [Execution history and misfires](#execution-history-and-misfires).
+- An **execution-group panel**: one row per [execution group](../tutorial/execution-groups.md), with the
+  limit that governs it, the scope that limit is counted in, what the group has in flight, and the
+  headroom left. It is described under [Execution groups](#execution-groups) below.
+
+## Execution groups
+
+The panel joins the limits the scheduler is running with — `IScheduler.GetExecutionLimits` — to the
+firings it has in flight, so that ceilings set in configuration are visible in the UI rather than only
+in the file that set them.
+
+- **Both firing states count.** A reservation holds a slot exactly as a running execution does, which is
+  what the acquisition filter counts against a limit; a panel that counted only the running ones would
+  show headroom the next acquisition cannot use.
+- **The counts are cluster-wide when the job store is persistent**, because the firing listing is: a
+  firing owned by another node is one of them. With an in-memory store they are this node's, and the
+  panel says which of the two you are looking at. Where a node-scoped limit is being compared against a
+  cluster-wide count — a clustered store — the panel says that too, since every node enforces its own
+  copy of such a limit.
+- **`other groups` is a rule, not a bucket.** The catch-all gives each group with no limit of its own an
+  allowance of its own rather than one shared between them, so it has nothing in flight against it. A
+  group governed by it says where its number came from. It never covers the ungrouped bucket, which is
+  the rule the scheduler applies.
+- **A derived group is labelled.** With
+  [`UseTriggerGroupWhenUnset`](../tutorial/execution-groups.md#letting-the-trigger-group-stand-in), a
+  trigger with no execution group is limited as though it belonged to a group named after its trigger
+  group; the panel resolves the key the same way and marks the row, so a group nobody typed is not a
+  puzzle.
+- **A scheduler that cannot report limits says so.** An `IQuartzApiClient` or `IScheduler` of your own
+  may not implement them; the panel then says it cannot tell rather than rendering as though nothing
+  were limited.
+
 ## The schedulers the dashboard covers
 
 `AddQuartzDashboard()` installs the dashboard's own two plugins — the live event feed and the execution
@@ -274,8 +324,15 @@ For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based autho
 
 ## Features
 
-- Scheduler overview and summary cards
-- Jobs and triggers listing with search and pagination
+- Scheduler overview and summary cards, with a trigger-state histogram (`Normal`, `Paused`, `Blocked`,
+  `Error`, `Complete`) whose counts link to the Triggers page narrowed to that state, a paused-group
+  tile counting paused trigger groups and job groups — a group paused while it holds nothing included —
+  and a misfire count over the history store's retention window, which the tile names
+- Execution-group panel on the overview — one row per group with its limit, the scope that limit is
+  counted in (`Node` or `Cluster`), what it has in flight and the headroom left; cluster-wide with a
+  persistent job store and per node otherwise, and it says which. See
+  [Execution groups](#execution-groups)
+- Jobs and triggers listing with search and pagination; `?state=` opens the trigger listing filtered
 - Job details and trigger details pages
 - Currently executing jobs view — cluster-wide with a persistent job store, showing which node owns each
   execution, and interrupting the one execution a row names rather than every execution of its job

--- a/docs/documentation/quartz-4.x/tutorial/execution-groups.md
+++ b/docs/documentation/quartz-4.x/tutorial/execution-groups.md
@@ -412,6 +412,10 @@ RAMJobStore requires no schema changes.
 ## Dashboard
 
 The Quartz Dashboard shows execution group information:
+- The overview page carries an execution-group panel: one row per group with its limit, the scope that
+  limit is counted in, what it has in flight and the headroom left — cluster-wide when the job store is
+  persistent — which is where to look to see whether a ceiling set here is the thing holding work back
+  (see [Dashboard](../packages/dashboard.md#execution-groups))
 - Trigger list page displays an "Execution Group" column
 - Trigger detail page shows the execution group
 - Currently executing page shows which execution group each running job belongs to

--- a/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
@@ -1,4 +1,5 @@
 @page "/quartz"
+@using System.Globalization
 @using Microsoft.Extensions.Options
 @using Quartz
 @using Quartz.Dashboard.Components.Shared
@@ -54,7 +55,42 @@
             <a class="qz-stat-card-link" href="@DashboardLink.To(Options.Value, "cluster")">
                 <StatCard Title="Nodes" Value="@NodesStatValue" Icon="🖧" Color="@NodesStatColor" />
             </a>
+            <StatCard Title="Paused Groups" Value="@PausedGroupsStatValue" Icon="⏸" Color="@PausedGroupsStatColor" />
+            @* No link: #3422 gave the dashboard a misfire feed but no page to show it on, and a tile
+               that goes nowhere is better than one that goes to a 404. *@
+            <StatCard Title="@MisfiresStatTitle" Value="@MisfiresStatValue" Icon="⏰" Color="@MisfiresStatColor" />
         </div>
+
+        <section class="qz-section">
+            <h2>Trigger states</h2>
+            <p class="qz-muted">
+                Every trigger the scheduler holds, by the state it is in. Each count is a link to the
+                triggers that make it up.
+            </p>
+            <table class="qz-table">
+                <thead>
+                    <tr>
+                        <th>State</th>
+                        <th>Triggers</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (TriggerState state in HistogramStates)
+                    {
+                        <tr>
+                            <td><StateIndicator State="@state.ToString()" /></td>
+                            <td>
+                                <a href="@TriggersInStateLink(state)">@CountInState(state)</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </section>
+
+        <ExecutionGroups SchedulerName="@Scheduler.ActiveSchedulerName"
+                         Persistent="@_storeIsPersistent"
+                         Clustered="@_storeIsClustered" />
 
         <section class="qz-section">
             <h2>Recent admin actions</h2>
@@ -108,6 +144,34 @@
     private int _errorTriggers;
     private int _nodes;
     private int _unhealthyNodes;
+    private int _pausedTriggerGroups;
+    private int _pausedJobGroups;
+    private int? _misfires;
+    private bool _storeIsPersistent;
+    private bool _storeIsClustered;
+
+    /// <summary>
+    /// How many triggers are in each of the states the histogram breaks them down by.
+    /// </summary>
+    private readonly Dictionary<TriggerState, int> _triggersByState = [];
+
+    /// <summary>
+    /// The states the histogram counts, in the order it shows them.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TriggerState.Executing" /> is not among them: the tile above already reports what is
+    /// running, and it counts firings rather than triggers, which is the more useful of the two numbers
+    /// and the one the Currently Executing page agrees with. <see cref="TriggerState.None" /> is what a
+    /// trigger that does not exist reports, so nothing can be in it.
+    /// </remarks>
+    private static readonly TriggerState[] HistogramStates =
+    [
+        TriggerState.Normal,
+        TriggerState.Paused,
+        TriggerState.Blocked,
+        TriggerState.Error,
+        TriggerState.Complete
+    ];
 
     /// <summary>
     /// Whether the active scheduler is a registration nothing has built, which the listing already said
@@ -129,6 +193,49 @@
         : $"{_nodes} ({_unhealthyNodes} overdue/failed)";
 
     private string NodesStatColor => _unhealthyNodes == 0 ? "info" : "error";
+
+    /// <summary>
+    /// The paused groups, both kinds in one tile: pausing a trigger group and pausing a job group are
+    /// different acts with the same consequence, and an operator hunting for why nothing is firing wants
+    /// to see both without knowing which was used.
+    /// </summary>
+    private string PausedGroupsStatValue => $"{_pausedTriggerGroups} trigger, {_pausedJobGroups} job";
+
+    private string PausedGroupsStatColor => _pausedTriggerGroups + _pausedJobGroups == 0 ? "info" : "warning";
+
+    /// <summary>
+    /// The window the misfire tile counts over: the history store's own retention, so the tile cannot
+    /// claim a day's worth of misfires from a store configured to remember an hour.
+    /// </summary>
+    private string MisfiresStatTitle
+    {
+        get
+        {
+            TimeSpan window = Options.Value.HistoryRetention;
+            string spelled = window.TotalHours >= 1
+                ? window.TotalHours.ToString("0.#", CultureInfo.InvariantCulture) + " h"
+                : window.TotalMinutes.ToString("0.#", CultureInfo.InvariantCulture) + " min";
+            return "Misfires (last " + spelled + ")";
+        }
+    }
+
+    /// <remarks>
+    /// A data source that keeps no misfire feed has not looked, which is a different fact from having
+    /// looked and found none — so it reads as a dash rather than as a clean bill of health.
+    /// </remarks>
+    private string MisfiresStatValue => _misfires?.ToString(CultureInfo.InvariantCulture) ?? "—";
+
+    private string MisfiresStatColor => _misfires > 0 ? "warning" : "info";
+
+    private int CountInState(TriggerState state)
+    {
+        return _triggersByState.TryGetValue(state, out int count) ? count : 0;
+    }
+
+    private string TriggersInStateLink(TriggerState state)
+    {
+        return DashboardLink.To(Options.Value, "triggers?state=" + state);
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -164,25 +271,59 @@
                 _currentlyExecuting = 0;
                 _nodes = 0;
                 _unhealthyNodes = 0;
+                _pausedTriggerGroups = 0;
+                _pausedJobGroups = 0;
+                _misfires = null;
+                _storeIsPersistent = false;
+                _storeIsClustered = false;
+                _triggersByState.Clear();
                 _recentActions.Clear();
                 return;
             }
 
             SchedulerDetailDto scheduler = await Api.GetScheduler(schedulerName);
             _schedulerStatus = scheduler.Status;
+            _storeIsPersistent = scheduler.Persistent;
+            _storeIsClustered = scheduler.Clustered;
 
             // Counting queries: Take = 0 fetches no items, only the exact totals the tiles show.
             PagedResult<JobKeyDto> jobs = await Api.GetJobs(schedulerName, new DashboardJobQuery { Take = 0 });
             PagedResult<TriggerHeaderDto> triggers = await Api.GetTriggers(schedulerName, new DashboardTriggerQuery { Take = 0 });
-            PagedResult<TriggerHeaderDto> errorTriggers = await Api.GetTriggers(schedulerName, new DashboardTriggerQuery { Take = 0, State = TriggerState.Error });
             PagedResult<FireInstanceDto> executing = await Api.GetFireInstances(schedulerName, new DashboardFireInstanceQuery { Take = 0 });
+
+            _triggersByState.Clear();
+            foreach (TriggerState state in HistogramStates)
+            {
+                PagedResult<TriggerHeaderDto> inState = await Api.GetTriggers(
+                    schedulerName,
+                    new DashboardTriggerQuery { Take = 0, State = state });
+                _triggersByState[state] = inState.TotalCount ?? 0;
+            }
+
+            // The paused groups are counted with the paused filter rather than by listing every group
+            // and tallying: a group can be paused while it holds nothing, and an unfiltered listing
+            // enumerates the groups that hold something.
+            PagedResult<TriggerGroupDto> pausedTriggerGroups = await Api.GetTriggerGroups(
+                schedulerName,
+                new DashboardGroupQuery { Take = 0, Paused = true });
+            PagedResult<JobGroupDto> pausedJobGroups = await Api.GetJobGroups(
+                schedulerName,
+                new DashboardGroupQuery { Take = 0, Paused = true });
+
+            // The store's own retention window, so the tile counts over exactly what the store still
+            // remembers rather than over a day it may already have forgotten.
+            _misfires = await Api.CountMisfires(
+                schedulerName,
+                DateTimeOffset.UtcNow - Options.Value.HistoryRetention);
 
             List<ClusterNodeDto> nodes = await Api.GetClusterNodes(schedulerName);
 
             _totalJobs = jobs.TotalCount ?? 0;
             _totalTriggers = triggers.TotalCount ?? 0;
             _currentlyExecuting = executing.TotalCount ?? 0;
-            _errorTriggers = errorTriggers.TotalCount ?? 0;
+            _errorTriggers = CountInState(TriggerState.Error);
+            _pausedTriggerGroups = pausedTriggerGroups.TotalCount ?? 0;
+            _pausedJobGroups = pausedJobGroups.TotalCount ?? 0;
             _nodes = nodes.Count;
             _unhealthyNodes = nodes.Count(node => node.State != ClusterNodeState.Alive);
 

--- a/src/Quartz.Dashboard/Components/Pages/Jobs.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Jobs.razor
@@ -175,8 +175,10 @@
             _jobs.AddRange(page.Items);
             _totalJobs = totalCount;
 
-            List<JobGroupDto> groups = await Api.GetJobGroups(schedulerName);
-            foreach (JobGroupDto group in groups)
+            // Every group, because the page labels each of the ones its current page shows, and it
+            // cannot know which those are before it has them.
+            PagedResult<JobGroupDto> groups = await Api.GetJobGroups(schedulerName, new DashboardGroupQuery { Take = int.MaxValue });
+            foreach (JobGroupDto group in groups.Items)
             {
                 _groupStates[group.Name] = group.Paused ? "Paused" : "Normal";
             }

--- a/src/Quartz.Dashboard/Components/Pages/Triggers.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Triggers.razor
@@ -19,6 +19,10 @@
         <button type="button" class="qz-button @GetStateFilterButtonClass(null)" @onclick="ShowAllStates">All states</button>
         <button type="button" class="qz-button @GetStateFilterButtonClass(TriggerState.Error)" @onclick="ShowErrorStateOnly">Error only</button>
         <button type="button" class="qz-button @GetStateFilterButtonClass(TriggerState.Executing)" @onclick="ShowExecutingStateOnly">Executing only</button>
+        @if (StateFilterIsUnbuttoned)
+        {
+            <span class="qz-muted">Showing @_stateFilter triggers only</span>
+        }
     </div>
 
     @if (_isLoading)
@@ -132,7 +136,27 @@
     private string _pendingTriggerKey = string.Empty;
     private TriggerState? _stateFilter;
 
+    /// <summary>
+    /// The state to open on, so that a count somewhere else can be a link to the triggers behind it —
+    /// the overview's trigger-state histogram is what asks for this.
+    /// </summary>
+    /// <remarks>
+    /// A string rather than a <see cref="TriggerState" /> because a query string is whatever the address
+    /// bar holds: a spelling that names no state opens the unfiltered listing rather than failing to
+    /// bind. The buttons are unaffected — they set the filter directly and never navigate.
+    /// </remarks>
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "state")]
+    public string? StateQuery { get; set; }
+
     private bool IsReadOnly => Options.Value.ReadOnly;
+
+    /// <summary>
+    /// Whether the active filter is a state the buttons cannot show as selected, which is what arriving
+    /// from a link is: the row offers all, error and executing, and the histogram links to five states.
+    /// </summary>
+    private bool StateFilterIsUnbuttoned =>
+        _stateFilter is not null and not TriggerState.Error and not TriggerState.Executing;
 
     private IEnumerable<IGrouping<string, TriggerHeaderDto>> GroupedTriggers => _triggers.GroupBy(trigger => trigger.Group);
 
@@ -150,6 +174,7 @@
     protected override async Task OnInitializedAsync()
     {
         Scheduler.OnSchedulerChanged += OnSchedulerChanged;
+        _stateFilter = Enum.TryParse(StateQuery, ignoreCase: true, out TriggerState requested) ? requested : null;
         await LoadDataAsync();
     }
 

--- a/src/Quartz.Dashboard/Components/Shared/ExecutionGroups.razor
+++ b/src/Quartz.Dashboard/Components/Shared/ExecutionGroups.razor
@@ -1,0 +1,424 @@
+@using System.Globalization
+@using Quartz
+@using Quartz.Dashboard.Services
+@implements IDisposable
+@inject IQuartzApiClient Api
+
+<section class="qz-section">
+    <h2>Execution groups</h2>
+
+    @if (!string.IsNullOrWhiteSpace(_error))
+    {
+        <ErrorAlert Message="@_error" OnRetry="LoadDataAsync" />
+    }
+    else if (!_limits.CanReport)
+    {
+        <p class="qz-muted">
+            This scheduler cannot report execution limits, so what each group may run is unknown here.
+        </p>
+    }
+    else if (_rows.Count == 0)
+    {
+        <p class="qz-muted">
+            No execution group is limited and nothing is in flight, so every trigger is free to fire.
+        </p>
+    }
+    else
+    {
+        <p class="qz-muted">@ScopeSentence</p>
+
+        <table class="qz-table">
+            <thead>
+                <tr>
+                    <th>Group</th>
+                    <th>Scope</th>
+                    <th>Limit</th>
+                    <th>In flight</th>
+                    <th>Headroom</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (GroupRow row in _rows)
+                {
+                    <tr>
+                        <td>
+                            @row.Label
+                            @if (row.IsDerived)
+                            {
+                                <span class="qz-muted">&nbsp;(from trigger group)</span>
+                            }
+                            @if (row.IsCatchAll)
+                            {
+                                <span class="qz-muted">&nbsp;(catch-all)</span>
+                            }
+                        </td>
+                        <td>@ScopeOf(row)</td>
+                        <td>
+                            @LimitOf(row)
+                            @if (row.LimitIsCatchAll)
+                            {
+                                <span class="qz-muted">&nbsp;(other groups)</span>
+                            }
+                        </td>
+                        <td>@InFlightOf(row)</td>
+                        <td>@HeadroomOf(row)</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+
+        @if (_hasCatchAllRow)
+        {
+            <p class="qz-muted">
+                <em>other groups</em> is the ceiling every group with no limit of its own gets, one
+                allowance each rather than one shared between them, so it counts nothing itself.
+            </p>
+        }
+
+        @if (_nodeScopedLimitsAreCountedClusterWide)
+        {
+            <p class="qz-muted">
+                A node-scoped limit is what one node may run, while the counts here are the whole
+                cluster's, so its headroom is smaller than what this node can still spend.
+            </p>
+        }
+
+        @if (_countsArePartial)
+        {
+            <p class="qz-muted">
+                The counts are taken from the first @_firingsCounted firings; there are more in flight.
+            </p>
+        }
+    }
+</section>
+
+@code {
+    /// <summary>
+    /// The panel joins what a scheduler allows — <c>IQuartzApiClient.GetExecutionLimits</c> — with what it
+    /// is running, so that the ceilings <c>execution-groups.md</c> teaches are visible somewhere other
+    /// than in the configuration file that set them.
+    /// </summary>
+    /// <remarks>
+    /// Both firing states are counted, because a reservation holds a slot exactly as a running execution
+    /// does: that is what the acquisition filter counts against a limit, and a panel that counted only
+    /// the running ones would show headroom the next acquisition cannot use.
+    /// </remarks>
+    private readonly List<GroupRow> _rows = [];
+
+    private ExecutionLimitsDto _limits = new([]);
+    private string? _error;
+    private bool _loadingInProgress;
+    private bool _countsArePartial;
+    private bool _hasCatchAllRow;
+    private bool _nodeScopedLimitsAreCountedClusterWide;
+    private int _firingsCounted;
+    private bool _hasLoaded;
+    private string? _loadedSchedulerName;
+    private PeriodicTimer? _refreshTimer;
+    private CancellationTokenSource? _refreshLoopCancellation;
+
+    [Parameter]
+    public string? SchedulerName { get; set; }
+
+    /// <summary>
+    /// Whether the scheduler's job store survives a restart, which is also what decides whose firings the
+    /// firing listing carries: a persistent store answers for the whole cluster, an in-memory one for
+    /// this node.
+    /// </summary>
+    [Parameter]
+    public bool Persistent { get; set; }
+
+    /// <summary>
+    /// Whether the store is clustered, which is the only case in which a node-scoped limit and a
+    /// cluster-wide count are different measurements.
+    /// </summary>
+    [Parameter]
+    public bool Clustered { get; set; }
+
+    private string ScopeSentence => Persistent
+        ? "Counted across the cluster: the job store is persistent, so a firing owned by any node is counted here."
+        : "Counted on this node: the job store keeps its firings in memory, so another node's work is not counted here.";
+
+    protected override void OnInitialized()
+    {
+        _refreshLoopCancellation = new CancellationTokenSource();
+        // Slower than the overview's executing count, for the reason the Cluster page is slower: every
+        // tick is two reads of a persistent store, and a limit changes on the scale of a deployment.
+        _refreshTimer = new PeriodicTimer(TimeSpan.FromSeconds(5));
+        _ = RunRefreshLoopAsync(_refreshLoopCancellation.Token);
+    }
+
+    /// <remarks>
+    /// Guarded on the scheduler rather than reloading on every parameter set: the overview re-renders
+    /// once a second to keep its executing count current, and each of those renders would otherwise be
+    /// two more reads of the store.
+    /// </remarks>
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_hasLoaded && string.Equals(_loadedSchedulerName, SchedulerName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _hasLoaded = true;
+        _loadedSchedulerName = SchedulerName;
+        await LoadDataAsync();
+    }
+
+    private async Task RunRefreshLoopAsync(CancellationToken cancellationToken)
+    {
+        if (_refreshTimer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            while (await _refreshTimer.WaitForNextTickAsync(cancellationToken))
+            {
+                try
+                {
+                    await InvokeAsync(async () =>
+                    {
+                        await LoadDataAsync();
+                        StateHasChanged();
+                    });
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    _error = ex.Message;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private async Task LoadDataAsync()
+    {
+        if (_loadingInProgress)
+        {
+            return;
+        }
+
+        _loadingInProgress = true;
+        _error = null;
+
+        try
+        {
+            _rows.Clear();
+            _limits = new ExecutionLimitsDto([]);
+            _countsArePartial = false;
+            _hasCatchAllRow = false;
+            _nodeScopedLimitsAreCountedClusterWide = false;
+            _firingsCounted = 0;
+
+            string? schedulerName = SchedulerName;
+            if (string.IsNullOrWhiteSpace(schedulerName))
+            {
+                return;
+            }
+
+            _limits = await Api.GetExecutionLimits(schedulerName);
+            if (!_limits.CanReport)
+            {
+                return;
+            }
+
+            // Both states, because a reservation holds a slot as surely as a running execution does.
+            PagedResult<FireInstanceDto> firings = await Api.GetFireInstances(
+                schedulerName,
+                new DashboardFireInstanceQuery { State = null });
+
+            _firingsCounted = firings.Items.Count;
+            _countsArePartial = firings.HasMore;
+            BuildRows(_limits, firings.Items);
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loadingInProgress = false;
+        }
+    }
+
+    private void BuildRows(ExecutionLimitsDto limits, IReadOnlyList<FireInstanceDto> firings)
+    {
+        Dictionary<string, int> inFlight = new(StringComparer.Ordinal);
+        HashSet<string> derived = new(StringComparer.Ordinal);
+
+        foreach (FireInstanceDto firing in firings)
+        {
+            // The scheduler's own resolution, so the panel and the acquisition filter cannot key the
+            // same firing differently when UseTriggerGroupWhenUnset is on.
+            string key = AsConfigurationKey(ExecutionLimits.ResolveGroupKey(
+                firing.ExecutionGroup,
+                firing.TriggerKey.Group,
+                limits.UsesTriggerGroupWhenUnset));
+
+            inFlight[key] = inFlight.TryGetValue(key, out int count) ? count + 1 : 1;
+
+            if (firing.ExecutionGroup is null && key != ExecutionLimits.DefaultGroupAlias)
+            {
+                derived.Add(key);
+            }
+        }
+
+        HashSet<string> keys = new(limits.Limits.Keys, StringComparer.Ordinal);
+        keys.UnionWith(inFlight.Keys);
+
+        List<GroupRow> rows = [];
+        foreach (string key in keys)
+        {
+            DashboardExecutionLimit? limit = ResolveLimit(limits, key, out bool limitIsCatchAll);
+            bool isCatchAll = key == ExecutionLimits.OtherGroups;
+
+            rows.Add(new GroupRow(
+                Key: key,
+                Label: LabelFor(key),
+                IsCatchAll: isCatchAll,
+                IsDerived: derived.Contains(key),
+                Limit: limit,
+                LimitIsCatchAll: limitIsCatchAll,
+                InFlight: inFlight.TryGetValue(key, out int count) ? count : 0));
+        }
+
+        // Named groups first, alphabetically; then the ungrouped bucket, which is a group only in the
+        // sense that the limits give it a bucket; then the catch-all, which is a rule about the rest.
+        rows.Sort(static (left, right) =>
+        {
+            int byKind = SortKind(left).CompareTo(SortKind(right));
+            return byKind != 0 ? byKind : string.Compare(left.Label, right.Label, StringComparison.OrdinalIgnoreCase);
+        });
+
+        _rows.AddRange(rows);
+        _hasCatchAllRow = limits.Limits.ContainsKey(ExecutionLimits.OtherGroups);
+        _nodeScopedLimitsAreCountedClusterWide = Clustered
+            && rows.Exists(static row => row.Limit is { Scope: ExecutionLimitScope.Node });
+    }
+
+    private static int SortKind(GroupRow row)
+    {
+        if (row.IsCatchAll)
+        {
+            return 2;
+        }
+
+        return row.Key == ExecutionLimits.DefaultGroupAlias ? 1 : 0;
+    }
+
+    /// <summary>
+    /// The limit that governs one group: its own when it has one, otherwise the catch-all — which is for
+    /// named groups only and never for the ungrouped bucket, the same rule the scheduler applies.
+    /// </summary>
+    private static DashboardExecutionLimit? ResolveLimit(ExecutionLimitsDto limits, string key, out bool fromCatchAll)
+    {
+        fromCatchAll = false;
+
+        if (limits.Limits.TryGetValue(key, out DashboardExecutionLimit own))
+        {
+            return own;
+        }
+
+        if (key != ExecutionLimits.DefaultGroupAlias
+            && limits.Limits.TryGetValue(ExecutionLimits.OtherGroups, out DashboardExecutionLimit catchAll))
+        {
+            fromCatchAll = true;
+            return catchAll;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The limits arrive keyed the way configuration spells a group; a firing resolves to the key the
+    /// limits hold internally, where the ungrouped bucket is the empty string.
+    /// </summary>
+    private static string AsConfigurationKey(string storageKey)
+    {
+        return storageKey == ExecutionLimits.DefaultGroupKey ? ExecutionLimits.DefaultGroupAlias : storageKey;
+    }
+
+    private static string LabelFor(string key)
+    {
+        if (key == ExecutionLimits.OtherGroups)
+        {
+            return "other groups";
+        }
+
+        return key == ExecutionLimits.DefaultGroupAlias ? "(no execution group)" : key;
+    }
+
+    private static string ScopeOf(GroupRow row)
+    {
+        return row.Limit is { } limit ? limit.Scope.ToString() : "—";
+    }
+
+    private static string LimitOf(GroupRow row)
+    {
+        if (row.Limit is not { } limit || limit.MaxConcurrent is not int maxConcurrent)
+        {
+            return "Unlimited";
+        }
+
+        return maxConcurrent == 0
+            ? "0 (forbidden)"
+            : maxConcurrent.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string InFlightOf(GroupRow row)
+    {
+        return row.IsCatchAll ? "—" : row.InFlight.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string HeadroomOf(GroupRow row)
+    {
+        if (row.IsCatchAll)
+        {
+            return "—";
+        }
+
+        if (row.Limit is not { } limit || limit.MaxConcurrent is not int maxConcurrent)
+        {
+            return "Unlimited";
+        }
+
+        return Math.Max(0, maxConcurrent - row.InFlight).ToString(CultureInfo.InvariantCulture);
+    }
+
+    public void Dispose()
+    {
+        _refreshLoopCancellation?.Cancel();
+        _refreshLoopCancellation?.Dispose();
+        _refreshTimer?.Dispose();
+    }
+
+    /// <summary>
+    /// One row: an execution group, the limit that governs it, and what it has in flight.
+    /// </summary>
+    private sealed record GroupRow(
+        string Key,
+        string Label,
+        bool IsCatchAll,
+        bool IsDerived,
+        DashboardExecutionLimit? Limit,
+        bool LimitIsCatchAll,
+        int InFlight);
+}

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -78,7 +78,15 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<PagedResult<JobKeyDto>> GetJobs(string schedulerName, DashboardJobQuery query, CancellationToken cancellationToken = default);
 
-    ValueTask<List<JobGroupDto>> GetJobGroups(string schedulerName, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Returns one page of job groups, ordered by name, each carrying whether it is paused.
+    /// </summary>
+    ValueTask<PagedResult<JobGroupDto>> GetJobGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns one page of trigger groups, ordered by name, each carrying whether it is paused.
+    /// </summary>
+    ValueTask<PagedResult<TriggerGroupDto>> GetTriggerGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default);
 
     ValueTask<JobDetailDto> GetJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
@@ -199,7 +207,46 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<PagedResult<DashboardMisfireEntry>?> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default);
 
-    ValueTask<ExecutionLimitsDto?> GetExecutionLimits(string schedulerName, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Counts the misfires the scheduler has recorded since <paramref name="since" />, or
+    /// <see langword="null" /> when the data source keeps no misfire feed.
+    /// </summary>
+    /// <remarks>
+    /// A count rather than a page, because the overview's tile asks "how bad is it right now" and a
+    /// store keeping its history in a database can answer that without loading rows it would discard.
+    /// Null is not zero: a data source with no feed has not looked, and the tile says so rather than
+    /// reporting a clean bill of health it did not earn.
+    /// </remarks>
+    ValueTask<int?> CountMisfires(string schedulerName, DateTimeOffset since, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the execution limits the scheduler is running with, or
+    /// <see cref="ExecutionLimitsDto.CannotReport" /> when this data source cannot say.
+    /// </summary>
+    /// <remarks>
+    /// Never <see langword="null" />: a scheduler with nothing limited answers with an empty
+    /// <see cref="ExecutionLimitsDto.Limits" />, which is a different fact from a scheduler that cannot
+    /// report limits at all, and the overview says which of the two it is looking at.
+    /// </remarks>
+    ValueTask<ExecutionLimitsDto> GetExecutionLimits(string schedulerName, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// One page of a group listing — job groups or trigger groups — optionally narrowed to the groups that
+/// are paused or to the ones that are not.
+/// </summary>
+public sealed record DashboardGroupQuery : PagedQuery
+{
+    /// <summary>
+    /// Limits the result by paused state: <see langword="true" /> for paused groups only,
+    /// <see langword="false" /> for unpaused only, <see langword="null" /> for every group.
+    /// </summary>
+    /// <remarks>
+    /// With <see cref="PagedQuery.Take" /> of zero this counts the paused groups, which the unfiltered
+    /// listing cannot be made to do: a group can be paused while it holds nothing, and the unfiltered
+    /// listing enumerates the groups that hold something.
+    /// </remarks>
+    public bool? Paused { get; init; }
 }
 
 /// <summary>
@@ -346,6 +393,8 @@ public sealed record JobKeyDto(string Group, string Name);
 
 public sealed record JobGroupDto(string Name, bool Paused);
 
+public sealed record TriggerGroupDto(string Name, bool Paused);
+
 public sealed record TriggerKeyDto(string Group, string Name);
 
 /// <summary>
@@ -426,10 +475,39 @@ public sealed record AddCalendarRequest(string CalendarName, ICalendar Calendar,
 public sealed record AddJobRequest(JobDetailDto Job, bool Replace, bool? StoreNonDurableWhileAwaitingScheduling);
 
 /// <summary>
-/// The execution limits a scheduler is running with, keyed by a display-friendly group name.
+/// The execution limits a scheduler is running with, keyed by the spelling configuration and the HTTP
+/// API use for a group: <c>_</c> for the bucket of triggers that carry no execution group, <c>*</c> for
+/// the catch-all applied to groups with no limit of their own, and otherwise the group's name.
 /// </summary>
-/// <param name="Limits">Each group's limit, with the scope it is counted in.</param>
-public sealed record ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits);
+/// <remarks>
+/// The keys are the configuration spellings rather than display text because the overview joins them to
+/// what is in flight, and a firing carries a group name or nothing at all. Rendering
+/// <see cref="ExecutionGroupScope" />'s three cases as words is the panel's job.
+/// </remarks>
+/// <param name="Limits">Each group's limit, with the scope it is counted in. Empty when the scheduler
+/// limits nothing, which leaves every group unlimited.</param>
+/// <param name="UsesTriggerGroupWhenUnset">
+/// Whether a trigger that carries no execution group is limited as though it belonged to a group named
+/// after its own trigger group — <see cref="ExecutionLimits.UsesTriggerGroupWhenUnset" />. The overview
+/// applies the same derivation when it counts what is in flight, or its counts and the scheduler's
+/// would key the same firing differently.
+/// </param>
+/// <param name="CanReport">
+/// Whether the scheduler could answer at all. <see langword="false" /> is not "nothing is limited": it
+/// is "this scheduler does not implement execution limits", and the two must not be shown alike.
+/// </param>
+public sealed record ExecutionLimitsDto(
+    Dictionary<string, DashboardExecutionLimit> Limits,
+    bool UsesTriggerGroupWhenUnset = false,
+    bool CanReport = true)
+{
+    /// <summary>
+    /// The answer for a scheduler whose implementation refuses the question — an <see cref="IScheduler" />
+    /// of an application's own may throw <see cref="NotSupportedException" /> rather than implement
+    /// limits.
+    /// </summary>
+    public static ExecutionLimitsDto CannotReport { get; } = new([], UsesTriggerGroupWhenUnset: false, CanReport: false);
+}
 
 /// <summary>
 /// One group's limit as the dashboard reads it.

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -150,27 +150,52 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return new PagedResult<JobKeyDto>(items, jobs.HasMore, jobs.TotalCount ?? items.Count);
     }
 
-    public async ValueTask<List<JobGroupDto>> GetJobGroups(string schedulerName, CancellationToken cancellationToken = default)
+    public async ValueTask<PagedResult<JobGroupDto>> GetJobGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(query);
+
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-
-        List<JobGroupDto> result = [];
-        JobGroupQuery query = new();
-        while (true)
+        JobGroupQuery storeQuery = new()
         {
-            PagedResult<JobGroup> groups = await scheduler.QueryJobGroups(query, cancellationToken).ConfigureAwait(false);
-            foreach (JobGroup group in groups.Items)
-            {
-                result.Add(new JobGroupDto(group.Name, group.Paused));
-            }
+            Paused = query.Paused,
+            Skip = query.Skip,
+            Take = query.Take,
+            IncludeTotalCount = true
+        };
 
-            if (!groups.HasMore)
-            {
-                return result;
-            }
+        PagedResult<JobGroup> groups = await scheduler.QueryJobGroups(storeQuery, cancellationToken).ConfigureAwait(false);
 
-            query = query with { Skip = query.Skip + groups.Items.Count };
+        List<JobGroupDto> items = new(groups.Items.Count);
+        foreach (JobGroup group in groups.Items)
+        {
+            items.Add(new JobGroupDto(group.Name, group.Paused));
         }
+
+        return new PagedResult<JobGroupDto>(items, groups.HasMore, groups.TotalCount ?? items.Count);
+    }
+
+    public async ValueTask<PagedResult<TriggerGroupDto>> GetTriggerGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
+        TriggerGroupQuery storeQuery = new()
+        {
+            Paused = query.Paused,
+            Skip = query.Skip,
+            Take = query.Take,
+            IncludeTotalCount = true
+        };
+
+        PagedResult<TriggerGroup> groups = await scheduler.QueryTriggerGroups(storeQuery, cancellationToken).ConfigureAwait(false);
+
+        List<TriggerGroupDto> items = new(groups.Items.Count);
+        foreach (TriggerGroup group in groups.Items)
+        {
+            items.Add(new TriggerGroupDto(group.Name, group.Paused));
+        }
+
+        return new PagedResult<TriggerGroupDto>(items, groups.HasMore, groups.TotalCount ?? items.Count);
     }
 
     public async ValueTask<JobDetailDto> GetJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
@@ -525,6 +550,11 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return await historyStore.GetMisfires(query, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<int?> CountMisfires(string schedulerName, DateTimeOffset since, CancellationToken cancellationToken = default)
+    {
+        return await historyStore.CountMisfires(schedulerName, since, cancellationToken).ConfigureAwait(false);
+    }
+
     private static GroupMatcher<TKey>? BuildGroupMatcher<TKey>(string? groupFilter) where TKey : Key<TKey>
     {
         return string.IsNullOrWhiteSpace(groupFilter) ? null : GroupMatcher<TKey>.GroupContains(groupFilter);
@@ -601,31 +631,39 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         }
     }
 
-    public async ValueTask<ExecutionLimitsDto?> GetExecutionLimits(string schedulerName, CancellationToken cancellationToken = default)
+    /// <remarks>
+    /// A scheduler that limits nothing and a scheduler that cannot say are different answers, and the
+    /// overview shows them differently: the first has every group unlimited, the second has an execution
+    /// panel that can only say so. Both used to arrive here as a bare <see langword="null" />.
+    /// </remarks>
+    public async ValueTask<ExecutionLimitsDto> GetExecutionLimits(string schedulerName, CancellationToken cancellationToken = default)
     {
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
+
+        ExecutionLimits? limits;
         try
         {
-            ExecutionLimits? limits = await scheduler.GetExecutionLimits(cancellationToken).ConfigureAwait(false);
-            if (limits is null || limits.IsEmpty)
-            {
-                return null;
-            }
-
-            Dictionary<string, DashboardExecutionLimit> dict = new();
-            foreach (ExecutionGroupLimit limit in limits.Groups)
-            {
-                // Use display-friendly keys
-                string key = limit.Group.IsDefault ? "(default)" : limit.Group.ToConfigurationKey();
-                dict[key] = new DashboardExecutionLimit(limit.MaxConcurrent, limit.Scope);
-            }
-
-            return new ExecutionLimitsDto(dict);
+            limits = await scheduler.GetExecutionLimits(cancellationToken).ConfigureAwait(false);
         }
         catch (NotSupportedException)
         {
-            // Scheduler implementation doesn't support execution limits (e.g. HTTP proxy)
-            return null;
+            // Every scheduler Quartz ships implements this, HttpScheduler included — it reads the HTTP
+            // API's execution-limits endpoint. An IScheduler of an application's own need not, and
+            // reporting its refusal as "nothing is limited" would be a fabricated answer.
+            return ExecutionLimitsDto.CannotReport;
         }
+
+        // The configuration spellings, so that the overview can join a firing's execution group to the
+        // limit that governs it: "_" for the ungrouped bucket, "*" for the catch-all, else the name.
+        Dictionary<string, DashboardExecutionLimit> groups = new(StringComparer.Ordinal);
+        if (limits is not null)
+        {
+            foreach (ExecutionGroupLimit limit in limits.Groups)
+            {
+                groups[limit.Group.ToConfigurationKey()] = new DashboardExecutionLimit(limit.MaxConcurrent, limit.Scope);
+            }
+        }
+
+        return new ExecutionLimitsDto(groups, limits?.UsesTriggerGroupWhenUnset ?? false);
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
@@ -50,6 +50,21 @@ internal sealed class DashboardComponentContext : BunitContext
         Services.AddSingleton<ToastService>();
         Services.AddSingleton<DashboardActionLogService>();
 
+        // The reads whose answer is a shape rather than a number: a page and a limits snapshot. Every
+        // test that overrides one of these does so with its own A.CallTo, which wins; what these are for
+        // is the tests that are about something else, so that a component reading one gets an honest
+        // empty answer rather than whatever a dummy would have invented.
+        A.CallTo(() => Api.GetExecutionLimits(A<string>._, A<CancellationToken>._))
+            .Returns(new ExecutionLimitsDto([]));
+        A.CallTo(() => Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<FireInstanceDto>([], HasMore: false, TotalCount: 0));
+        A.CallTo(() => Api.GetTriggerGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<TriggerGroupDto>([], HasMore: false, TotalCount: 0));
+        A.CallTo(() => Api.GetJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<JobGroupDto>([], HasMore: false, TotalCount: 0));
+        A.CallTo(() => Api.CountMisfires(A<string>._, A<DateTimeOffset>._, A<CancellationToken>._))
+            .Returns(0);
+
         SchedulerState = Services.GetRequiredService<SchedulerState>();
         SchedulerState.SelectedTimeZoneId = TimeZoneInfo.Utc.Id;
         Toasts = Services.GetRequiredService<ToastService>();

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
@@ -1,3 +1,5 @@
+using AngleSharp.Dom;
+
 using Bunit;
 
 using FakeItEasy;
@@ -190,6 +192,190 @@ public class DashboardPageTest
         page.Markup.Should().Contain("registered but has not been created");
         page.FindAll(".qz-stat-card").Should().BeEmpty("there is nothing to count");
         A.CallTo(() => context.Api.GetScheduler("acme", A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// The histogram breaks the triggers down by state, each count its own <c>Take = 0</c> query.
+    /// </summary>
+    /// <remarks>
+    /// Four numbers used to be all the overview had, and none of them said how many triggers were
+    /// paused, blocked or finished — the three answers to "why is nothing running" that the page was
+    /// most often opened for.
+    /// </remarks>
+    [Test]
+    public void TheHistogramCountsTheTriggersInEachState()
+    {
+        GivenTriggerStates(
+            (TriggerState.Normal, 40),
+            (TriggerState.Paused, 7),
+            (TriggerState.Blocked, 2),
+            (TriggerState.Error, 3),
+            (TriggerState.Complete, 11));
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        HistogramCounts(page).Should().Equal(["40", "7", "2", "3", "11"]);
+        page.StatCardValue("Error Triggers").Should().Be("3",
+            "the tile and the histogram row are the same count read once, so they cannot disagree");
+
+        foreach (TriggerState state in new[] { TriggerState.Normal, TriggerState.Paused, TriggerState.Blocked, TriggerState.Error, TriggerState.Complete })
+        {
+            A.CallTo(() => context.Api.GetTriggers(
+                    TestData.SchedulerName,
+                    A<DashboardTriggerQuery>.That.Matches(query => query.Take == 0 && query.State == state),
+                    A<CancellationToken>._))
+                .MustHaveHappened();
+        }
+    }
+
+    [Test]
+    public void EachHistogramCountLinksToTheTriggersBehindIt()
+    {
+        GivenTriggerStates((TriggerState.Paused, 7));
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.TextOfAll("a").Should().NotBeEmpty();
+        page.FindAll("tbody a").Select(link => link.GetAttribute("href")).Should().Contain(
+            "quartz/triggers?state=Paused",
+            "a count nobody can follow is a count nobody can act on");
+    }
+
+    /// <summary>
+    /// Pausing a trigger group and pausing a job group are different acts with the same consequence, and
+    /// the tile reports both.
+    /// </summary>
+    [Test]
+    public void ThePausedGroupsTileCountsBothKindsOfGroup()
+    {
+        GivenPausedGroups(triggerGroups: 2, jobGroups: 1);
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.StatCardValue("Paused Groups").Should().Be("2 trigger, 1 job");
+        page.FindAll(".qz-stat-card-warning").Should().NotBeEmpty(
+            "a paused group is why work is not being done, which is not an informational fact");
+
+        A.CallTo(() => context.Api.GetTriggerGroups(
+                TestData.SchedulerName,
+                A<DashboardGroupQuery>.That.Matches(query => query.Take == 0 && query.Paused == true),
+                A<CancellationToken>._))
+            .MustHaveHappened();
+        A.CallTo(() => context.Api.GetJobGroups(
+                TestData.SchedulerName,
+                A<DashboardGroupQuery>.That.Matches(query => query.Take == 0 && query.Paused == true),
+                A<CancellationToken>._))
+            .MustHaveHappened();
+    }
+
+    [Test]
+    public void NoPausedGroupsIsAnInformationalTileRatherThanAWarning()
+    {
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.StatCardValue("Paused Groups").Should().Be("0 trigger, 0 job");
+        page.FindAll(".qz-stat-card-warning").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The misfire tile counts over the history store's own retention window, and says which window
+    /// that is.
+    /// </summary>
+    /// <remarks>
+    /// A fixed "last 24 h" would overstate a store configured to remember an hour: the count could never
+    /// exceed what is retained, so the label would be promising a day it had already forgotten.
+    /// </remarks>
+    [Test]
+    public void TheMisfireTileCountsOverTheWindowTheHistoryStoreKeeps()
+    {
+        A.CallTo(() => context.Api.CountMisfires(A<string>._, A<DateTimeOffset>._, A<CancellationToken>._)).Returns(4);
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.StatCardValue("Misfires (last 24 h)").Should().Be("4");
+        page.FindAll(".qz-stat-card-warning").Should().NotBeEmpty(
+            "a scheduler that has missed four firings is not an informational fact");
+    }
+
+    [Test]
+    public void TheMisfireTileNamesTheRetentionWindowItWasConfiguredWith()
+    {
+        context.Options.HistoryRetention = TimeSpan.FromMinutes(30);
+        A.CallTo(() => context.Api.CountMisfires(A<string>._, A<DateTimeOffset>._, A<CancellationToken>._)).Returns(0);
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.StatCardValue("Misfires (last 30 min)").Should().Be("0");
+    }
+
+    /// <summary>
+    /// A data source with no misfire feed has not looked, which is not the same as having looked and
+    /// found none.
+    /// </summary>
+    [Test]
+    public void ADataSourceThatKeepsNoMisfiresSaysSoRatherThanReportingZero()
+    {
+        A.CallTo(() => context.Api.CountMisfires(A<string>._, A<DateTimeOffset>._, A<CancellationToken>._))
+            .Returns((int?) null);
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.StatCardValue("Misfires (last 24 h)").Should().Be("—",
+            "a dashboard that says '0 misfires' when it never counted is worse than one that says "
+            + "nothing");
+    }
+
+    [Test]
+    public void TheOverviewCarriesTheExecutionGroupPanel()
+    {
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.TextOfAll("h2").Should().Contain("Execution groups",
+            "the limits execution-groups.md teaches were configurable and invisible");
+        A.CallTo(() => context.Api.GetExecutionLimits(TestData.SchedulerName, A<CancellationToken>._))
+            .MustHaveHappened();
+    }
+
+    /// <summary>
+    /// The counts each state row shows, in the order the histogram lists them.
+    /// </summary>
+    private static List<string> HistogramCounts(IRenderedComponent<DashboardPage> page)
+    {
+        List<string> counts = [];
+        foreach (IElement row in page.FindAll("tbody tr"))
+        {
+            IElement? count = row.QuerySelector("a");
+            if (count is not null)
+            {
+                counts.Add(count.TextContent.Trim());
+            }
+        }
+
+        return counts;
+    }
+
+    private void GivenTriggerStates(params (TriggerState State, int Count)[] states)
+    {
+        Dictionary<TriggerState, int> byState = new();
+        foreach ((TriggerState state, int count) in states)
+        {
+            byState[state] = count;
+        }
+
+        A.CallTo(() => context.Api.GetTriggers(A<string>._, A<DashboardTriggerQuery>._, A<CancellationToken>._))
+            .ReturnsLazily((string _, DashboardTriggerQuery query, CancellationToken _) =>
+                new PagedResult<TriggerHeaderDto>(
+                    [],
+                    HasMore: false,
+                    TotalCount: query.State is { } state && byState.TryGetValue(state, out int count) ? count : 0));
+    }
+
+    private void GivenPausedGroups(int triggerGroups, int jobGroups)
+    {
+        A.CallTo(() => context.Api.GetTriggerGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<TriggerGroupDto>([], HasMore: false, TotalCount: triggerGroups));
+        A.CallTo(() => context.Api.GetJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<JobGroupDto>([], HasMore: false, TotalCount: jobGroups));
     }
 
     private void GivenCounts(int jobs, int triggers, int errorTriggers, int executing)

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/ExecutionGroupsPanelTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/ExecutionGroupsPanelTest.cs
@@ -1,0 +1,362 @@
+using AngleSharp.Dom;
+
+using Bunit;
+
+using FakeItEasy;
+
+using Quartz.Dashboard.Components.Shared;
+using Quartz.Dashboard.Services;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard.Components;
+
+/// <summary>
+/// The execution-group panel: the join between what a scheduler allows and what it is running.
+/// </summary>
+/// <remarks>
+/// Execution limits were configurable and invisible — <c>GetExecutionLimits</c> was implemented and no
+/// page called it — so the thing these tests are most about is that the panel's arithmetic matches the
+/// scheduler's: the same group key for a firing, the same catch-all rule, and the same two firing states
+/// counted against a limit.
+/// </remarks>
+public class ExecutionGroupsPanelTest
+{
+    private DashboardComponentContext context = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        context = new DashboardComponentContext();
+        context.WithScheduler();
+        GivenLimits(new ExecutionLimitsDto([]));
+        GivenFirings();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    [Test]
+    public void EachGroupIsARowSayingWhatItMayRunAndWhatItIsRunning()
+    {
+        GivenLimits(Limits(
+            ("batch", 4, ExecutionLimitScope.Node),
+            ("tenant-acme", 8, ExecutionLimitScope.Cluster)));
+        GivenFirings(
+            Firing("batch", FireInstanceState.Executing),
+            Firing("batch", FireInstanceState.Executing),
+            Firing("batch", FireInstanceState.Acquired),
+            Firing("tenant-acme", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 0).Should().Equal(["batch", "Node", "4", "3", "1"],
+            "a reservation holds a slot exactly as a running execution does, so the acquired firing "
+            + "counts against the limit the way the acquisition filter counts it");
+        RowCells(panel, 1).Should().Equal(["tenant-acme", "Cluster", "8", "1", "7"],
+            "a quota across the cluster and a ceiling per node are different promises, and the panel "
+            + "has to say which one it is showing");
+    }
+
+    [Test]
+    public void HeadroomStopsAtZeroRatherThanGoingNegative()
+    {
+        GivenLimits(Limits(("batch", 1, ExecutionLimitScope.Node)));
+        GivenFirings(
+            Firing("batch", FireInstanceState.Executing),
+            Firing("batch", FireInstanceState.Executing),
+            Firing("batch", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 0).Should().Equal(["batch", "Node", "1", "3", "0"],
+            "a limit lowered under work already in flight leaves nothing to spend, and '-2' would read "
+            + "as an arithmetic fault rather than as a group that is over its ceiling");
+    }
+
+    [Test]
+    public void AGroupWithNoLimitIsUnlimitedRatherThanZero()
+    {
+        GivenLimits(new ExecutionLimitsDto([]));
+        GivenFirings(Firing("reports", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 0).Should().Equal(["reports", "—", "Unlimited", "1", "Unlimited"],
+            "no limit configured is no restriction, and a blank or a zero would read as a group that "
+            + "cannot run");
+    }
+
+    [Test]
+    public void AnExplicitlyUnlimitedGroupReadsTheSameAsAnUnconfiguredOne()
+    {
+        GivenLimits(new ExecutionLimitsDto(new Dictionary<string, DashboardExecutionLimit>
+        {
+            ["reports"] = new(null, ExecutionLimitScope.Node)
+        }));
+        GivenFirings(Firing("reports", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 0).Should().Equal(["reports", "Node", "Unlimited", "1", "Unlimited"]);
+    }
+
+    [Test]
+    public void AForbiddenGroupSaysSoRatherThanShowingABareZero()
+    {
+        GivenLimits(Limits(("batch", 0, ExecutionLimitScope.Node)));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 0).Should().Equal(["batch", "Node", "0 (forbidden)", "0", "0"],
+            "zero is the one limit that is a policy rather than a number, and it is the answer to 'why "
+            + "is this group not running'");
+    }
+
+    [Test]
+    public void TriggersWithNoExecutionGroupGetTheirOwnRowWhenAnyAreInFlight()
+    {
+        GivenFirings(Firing(executionGroup: null, FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 0).Should().Equal(["(no execution group)", "—", "Unlimited", "1", "Unlimited"],
+            "work that belongs to no group is still work, and leaving it out would make the panel's "
+            + "totals disagree with the executing tile");
+    }
+
+    /// <summary>
+    /// The ungrouped bucket is never covered by the catch-all — the same rule the scheduler applies when
+    /// it takes a slot.
+    /// </summary>
+    [Test]
+    public void TheCatchAllNeverGovernsTheUngroupedBucket()
+    {
+        GivenLimits(Limits((ExecutionLimits.OtherGroups, 5, ExecutionLimitScope.Node)));
+        GivenFirings(
+            Firing(executionGroup: null, FireInstanceState.Executing),
+            Firing("reports", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 0).Should().Equal(["reports", "Node", "5 (other groups)", "1", "4"],
+            "a named group with no limit of its own gets the catch-all's ceiling, and the panel says "
+            + "where the number came from");
+        RowCells(panel, 1).Should().Equal(["(no execution group)", "—", "Unlimited", "1", "Unlimited"],
+            "the catch-all is for named groups only; charging the ungrouped bucket to it would show a "
+            + "ceiling the scheduler does not enforce");
+    }
+
+    [Test]
+    public void TheCatchAllIsShownAsARuleRatherThanAsABucketOfItsOwn()
+    {
+        GivenLimits(Limits((ExecutionLimits.OtherGroups, 5, ExecutionLimitScope.Cluster)));
+        GivenFirings(Firing("reports", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 1).Should().Equal(["other groups (catch-all)", "Cluster", "5", "—", "—"],
+            "each unlisted group gets an allowance of its own rather than sharing one, so the catch-all "
+            + "has nothing in flight against it and a count there would be a fiction");
+        panel.Markup.Should().Contain("allowance each rather than one shared between them",
+            "the footnote is what stops the dash reading as a rendering fault");
+    }
+
+    /// <summary>
+    /// With <c>UseTriggerGroupWhenUnset</c> on, a trigger that carries no execution group is limited as
+    /// though it belonged to a group named after its trigger group.
+    /// </summary>
+    /// <remarks>
+    /// The panel resolves the key through the scheduler's own rule, so the count it shows and the count
+    /// the acquisition filter makes cannot key the same firing differently. It labels the row, because a
+    /// group nobody typed appearing in a listing of execution groups is otherwise a puzzle.
+    /// </remarks>
+    [Test]
+    public void AnUngroupedFiringIsCountedUnderItsTriggerGroupWhenTheDerivationIsOn()
+    {
+        GivenLimits(new ExecutionLimitsDto(
+            new Dictionary<string, DashboardExecutionLimit> { ["nightly"] = new(2, ExecutionLimitScope.Node) },
+            UsesTriggerGroupWhenUnset: true));
+        GivenFirings(Firing(executionGroup: null, FireInstanceState.Executing, triggerGroup: "nightly"));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 0).Should().Equal(["nightly (from trigger group)", "Node", "2", "1", "1"],
+            "the trigger carries no execution group, so the row's name came from the derivation and the "
+            + "panel says so rather than inventing a group the schedule does not name");
+    }
+
+    [Test]
+    public void WithTheDerivationOffAnUngroupedFiringStaysUngrouped()
+    {
+        GivenLimits(Limits(("nightly", 2, ExecutionLimitScope.Node)));
+        GivenFirings(Firing(executionGroup: null, FireInstanceState.Executing, triggerGroup: "nightly"));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        RowCells(panel, 1).Should().Equal(["(no execution group)", "—", "Unlimited", "1", "Unlimited"],
+            "the derivation is opt-in, and applying it unasked would show a ceiling the scheduler is "
+            + "not enforcing");
+        RowCells(panel, 0).Should().Equal(["nightly", "Node", "2", "0", "2"]);
+    }
+
+    /// <summary>
+    /// A scheduler that cannot answer is not a scheduler with nothing limited.
+    /// </summary>
+    [Test]
+    public void ASchedulerThatCannotReportLimitsSaysSoRatherThanShowingNone()
+    {
+        GivenLimits(ExecutionLimitsDto.CannotReport);
+        GivenFirings(Firing("batch", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        panel.Markup.Should().Contain("cannot report execution limits",
+            "rendering it as 'nothing is limited' would have the panel state a fact nobody established");
+        panel.FindAll("tbody tr").Should().BeEmpty(
+            "there are no ceilings to compare the firings against, so a table of headroom would be "
+            + "guesswork");
+    }
+
+    [Test]
+    public void NothingLimitedAndNothingRunningSaysSoRatherThanShowingAnEmptyTable()
+    {
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        panel.Markup.Should().Contain("every trigger is free to fire");
+        panel.FindAll("table").Should().BeEmpty();
+    }
+
+    [TestCase(true, "Counted across the cluster")]
+    [TestCase(false, "Counted on this node")]
+    public void ThePanelSaysWhoseFiringsItIsCounting(bool persistent, string expected)
+    {
+        GivenFirings(Firing("batch", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render(persistent: persistent);
+
+        panel.Markup.Should().Contain(expected,
+            "a persistent store answers the firing query for the whole cluster and an in-memory one for "
+            + "this node, and the same number means different things in the two cases");
+    }
+
+    /// <summary>
+    /// The one comparison the panel cannot make exactly: a node-scoped ceiling against a cluster-wide
+    /// count.
+    /// </summary>
+    [Test]
+    public void ANodeScopedLimitCountedAcrossAClusterIsCalledOut()
+    {
+        GivenLimits(Limits(("batch", 4, ExecutionLimitScope.Node)));
+        GivenFirings(Firing("batch", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render(persistent: true, clustered: true);
+
+        panel.Markup.Should().Contain("A node-scoped limit is what one node may run",
+            "every node enforces its own copy of a node-scoped limit, so subtracting the cluster's work "
+            + "from it understates what this node can still start");
+    }
+
+    [Test]
+    public void ANodeScopedLimitOnAnUnclusteredSchedulerNeedsNoCaveat()
+    {
+        GivenLimits(Limits(("batch", 4, ExecutionLimitScope.Node)));
+        GivenFirings(Firing("batch", FireInstanceState.Executing));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        panel.Markup.Should().NotContain("A node-scoped limit is what one node may run",
+            "there is one node, so the per-node ceiling and the count are the same measurement");
+    }
+
+    [Test]
+    public void CountsTakenFromAPartialPageSayThatTheyAre()
+    {
+        GivenLimits(Limits(("batch", 4, ExecutionLimitScope.Node)));
+        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<FireInstanceDto>(
+                [Firing("batch", FireInstanceState.Executing)],
+                HasMore: true,
+                TotalCount: 900));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        panel.Markup.Should().Contain("there are more in flight",
+            "headroom read off a page rather than off the whole listing is a number an operator would "
+            + "otherwise act on");
+    }
+
+    [Test]
+    public void AFailedReadIsReportedRatherThanLeavingAnEmptyPanel()
+    {
+        A.CallTo(() => context.Api.GetExecutionLimits(A<string>._, A<CancellationToken>._))
+            .Throws(new InvalidOperationException("the scheduler is shutting down"));
+
+        IRenderedComponent<ExecutionGroups> panel = Render();
+
+        panel.Markup.Should().Contain("the scheduler is shutting down");
+    }
+
+    private IRenderedComponent<ExecutionGroups> Render(bool persistent = false, bool clustered = false)
+    {
+        return context.Render<ExecutionGroups>(parameters => parameters
+            .Add(x => x.SchedulerName, TestData.SchedulerName)
+            .Add(x => x.Persistent, persistent)
+            .Add(x => x.Clustered, clustered));
+    }
+
+    private void GivenLimits(ExecutionLimitsDto limits)
+    {
+        A.CallTo(() => context.Api.GetExecutionLimits(A<string>._, A<CancellationToken>._)).Returns(limits);
+    }
+
+    private void GivenFirings(params FireInstanceDto[] firings)
+    {
+        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+            .Returns(TestData.Dashboard.Page<FireInstanceDto>(firings.ToList()));
+    }
+
+    private static ExecutionLimitsDto Limits(params (string Group, int? MaxConcurrent, ExecutionLimitScope Scope)[] limits)
+    {
+        Dictionary<string, DashboardExecutionLimit> byGroup = new(StringComparer.Ordinal);
+        foreach ((string group, int? maxConcurrent, ExecutionLimitScope scope) in limits)
+        {
+            byGroup[group] = new DashboardExecutionLimit(maxConcurrent, scope);
+        }
+
+        return new ExecutionLimitsDto(byGroup);
+    }
+
+    private static FireInstanceDto Firing(
+        string? executionGroup,
+        FireInstanceState state,
+        string triggerGroup = "DEFAULT")
+    {
+        return new FireInstanceDto(
+            FireInstanceId: Guid.NewGuid().ToString("N"),
+            TriggerKey: new TriggerKeyDto(triggerGroup, "trigger-1"),
+            JobKey: state == FireInstanceState.Acquired ? null : new JobKeyDto("jobs", "job-1"),
+            SchedulerInstanceId: TestData.SchedulerInstanceId,
+            State: state,
+            FireTimeUtc: TestData.Dashboard.FiredAt,
+            ScheduledFireTimeUtc: TestData.Dashboard.FiredAt,
+            ExecutionGroup: executionGroup);
+    }
+
+    /// <summary>
+    /// One row's cells, with runs of whitespace — the markup's indentation and the non-breaking spaces
+    /// before each qualifier — collapsed to single spaces, so a test reads as the row does.
+    /// </summary>
+    private static List<string> RowCells(IRenderedComponent<ExecutionGroups> panel, int rowIndex)
+    {
+        List<string> cells = [];
+        foreach (IElement cell in panel.FindAll("tbody tr")[rowIndex].QuerySelectorAll("td"))
+        {
+            cells.Add(string.Join(' ', cell.TextContent.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries)));
+        }
+
+        return cells;
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/JobsPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/JobsPageTest.cs
@@ -200,6 +200,7 @@ public class JobsPageTest
             dtos.Add(new JobGroupDto(name, paused));
         }
 
-        A.CallTo(() => context.Api.GetJobGroups(A<string>._, A<CancellationToken>._)).Returns(dtos);
+        A.CallTo(() => context.Api.GetJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+            .Returns(TestData.Dashboard.Page<JobGroupDto>(dtos));
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/TriggersPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/TriggersPageTest.cs
@@ -143,6 +143,50 @@ public class TriggersPageTest
             "an empty cell reads as a rendering fault; an em dash reads as 'no execution group'");
     }
 
+    /// <summary>
+    /// The overview's trigger-state histogram links here, so a state named in the query string has to
+    /// open the listing already narrowed to it.
+    /// </summary>
+    [Test]
+    public void AStateInTheQueryStringOpensTheListingNarrowedToIt()
+    {
+        GivenTriggers([
+            .. TestData.Dashboard.TriggerHeaders("nightly", 2, TriggerState.Paused),
+            .. TestData.Dashboard.TriggerHeaders("reports", 3, TriggerState.Normal, firstIndex: 10)
+        ]);
+        context.Navigate("/quartz/triggers?state=Paused");
+
+        IRenderedComponent<Triggers> page = context.Render<Triggers>();
+
+        A.CallTo(() => context.Api.GetTriggers(
+                TestData.SchedulerName,
+                A<DashboardTriggerQuery>.That.Matches(query => query.State == TriggerState.Paused),
+                A<CancellationToken>._))
+            .MustHaveHappened();
+        page.TextOfAll("h2").Should().Equal(["nightly"], "only the paused triggers were asked for");
+        page.Markup.Should().Contain("Showing Paused triggers only",
+            "the buttons offer three of the states and the histogram links to five, so a filter none of "
+            + "them can show as selected has to be spelled out");
+    }
+
+    [Test]
+    public void AQueryStringNamingNoStateOpensTheUnfilteredListing()
+    {
+        GivenTriggers(TestData.Dashboard.TriggerHeaders("nightly", 2));
+        context.Navigate("/quartz/triggers?state=not-a-state");
+
+        IRenderedComponent<Triggers> page = context.Render<Triggers>();
+
+        A.CallTo(() => context.Api.GetTriggers(
+                TestData.SchedulerName,
+                A<DashboardTriggerQuery>.That.Matches(query => query.State == null),
+                A<CancellationToken>._))
+            .MustHaveHappened();
+        page.TextOfAll("td.qz-col-state").Should().HaveCount(2,
+            "a query string is whatever the address bar holds, and a spelling nothing recognises is not "
+            + "a reason to show an error where a listing belongs");
+    }
+
     private void GivenTriggers(IReadOnlyList<TriggerHeaderDto> triggers)
     {
         A.CallTo(() => context.Api.GetTriggers(A<string>._, A<DashboardTriggerQuery>._, A<CancellationToken>._))

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -501,11 +501,84 @@ public class InProcessQuartzApiClientTest
             await scheduler.PauseJobs(GroupMatcher<JobKey>.GroupEquals("paused"));
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
-            List<JobGroupDto> groups = await client.GetJobGroups(scheduler.SchedulerName);
+            PagedResult<JobGroupDto> groups = await client.GetJobGroups(scheduler.SchedulerName, new DashboardGroupQuery());
 
-            groups.Select(x => x.Name).Should().Contain(["paused", "running"], "every job group is listed");
-            groups.Single(x => x.Name == "paused").Paused.Should().BeTrue("the group was paused");
-            groups.Single(x => x.Name == "running").Paused.Should().BeFalse("the other group was not");
+            groups.Items.Select(x => x.Name).Should().Contain(["paused", "running"], "every job group is listed");
+            groups.Items.Single(x => x.Name == "paused").Paused.Should().BeTrue("the group was paused");
+            groups.Items.Single(x => x.Name == "running").Paused.Should().BeFalse("the other group was not");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// The paused-groups tile counts with the paused filter rather than by listing every group, and
+    /// <c>Take = 0</c> is what turns that filter into a count.
+    /// </summary>
+    /// <remarks>
+    /// The distinction is not academic: a group can be paused while it holds nothing, and the unfiltered
+    /// listing enumerates the groups that hold something, so tallying it would miss exactly the group an
+    /// operator most needs to be told about — one that was paused and then emptied.
+    /// </remarks>
+    [Test]
+    public async Task GroupListingsCountThePausedOnesWithoutListingThem()
+    {
+        IScheduler scheduler = await CreateScheduler("PausedGroupCountTest");
+        try
+        {
+            IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("job1", "reports").StoreDurably().Build();
+            await scheduler.AddJob(job, new AddJobOptions { Replace = true });
+            await scheduler.ScheduleJob(TriggerBuilder.Create()
+                .WithIdentity("trigger1", "nightly")
+                .ForJob(job)
+                .WithCronSchedule("0 0 1 * * ?")
+                .Build());
+
+            await scheduler.PauseJobs(GroupMatcher<JobKey>.GroupEquals("reports"));
+            await scheduler.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals("nightly"));
+            await scheduler.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals("empty-and-paused"));
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            PagedResult<TriggerGroupDto> pausedTriggerGroups = await client.GetTriggerGroups(
+                scheduler.SchedulerName,
+                new DashboardGroupQuery { Take = 0, Paused = true });
+            PagedResult<JobGroupDto> pausedJobGroups = await client.GetJobGroups(
+                scheduler.SchedulerName,
+                new DashboardGroupQuery { Take = 0, Paused = true });
+
+            pausedTriggerGroups.Items.Should().BeEmpty("Take = 0 is a count, not a page");
+            pausedTriggerGroups.TotalCount.Should().Be(2,
+                "a trigger group that was paused while empty is still paused, and only the filtered "
+                + "query reports it");
+            pausedJobGroups.TotalCount.Should().Be(1);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task GetTriggerGroupsReportsPausedStateInOneCall()
+    {
+        IScheduler scheduler = await CreateScheduler("GetTriggerGroupsTest");
+        try
+        {
+            IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("job1", "jobs").StoreDurably().Build();
+            await scheduler.AddJob(job, new AddJobOptions { Replace = true });
+            await scheduler.ScheduleJob(TriggerBuilder.Create().WithIdentity("t1", "paused").ForJob(job).WithCronSchedule("0 0 1 * * ?").Build());
+            await scheduler.ScheduleJob(TriggerBuilder.Create().WithIdentity("t2", "running").ForJob(job).WithCronSchedule("0 0 2 * * ?").Build());
+            await scheduler.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals("paused"));
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+            PagedResult<TriggerGroupDto> groups = await client.GetTriggerGroups(scheduler.SchedulerName, new DashboardGroupQuery());
+
+            groups.Items.Select(x => x.Name).Should().Contain(["paused", "running"], "every trigger group is listed");
+            groups.Items.Single(x => x.Name == "paused").Paused.Should().BeTrue("the group was paused");
+            groups.Items.Single(x => x.Name == "running").Paused.Should().BeFalse("the other group was not");
         }
         finally
         {
@@ -531,15 +604,16 @@ public class InProcessQuartzApiClientTest
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            ExecutionLimitsDto? limits = await client.GetExecutionLimits(scheduler.SchedulerName);
+            ExecutionLimitsDto limits = await client.GetExecutionLimits(scheduler.SchedulerName);
 
-            limits.Should().NotBeNull();
+            limits.CanReport.Should().BeTrue();
             limits.Limits.Should().BeEquivalentTo(new Dictionary<string, DashboardExecutionLimit>
             {
                 ["batch"] = new(2, ExecutionLimitScope.Node),
                 ["tenant-acme"] = new(8, ExecutionLimitScope.Cluster),
-                ["(default)"] = new(3, ExecutionLimitScope.Node),
-            });
+                ["_"] = new(3, ExecutionLimitScope.Node),
+            }, "the keys are the spellings configuration and the HTTP API use, which is what lets the "
+               + "overview join a firing's execution group to the limit governing it");
         }
         finally
         {
@@ -548,19 +622,88 @@ public class InProcessQuartzApiClientTest
     }
 
     [Test]
-    public async Task GetExecutionLimitsShouldBeNullWhenNothingIsLimited()
+    public async Task GetExecutionLimitsCarriesTheTriggerGroupDerivation()
+    {
+        IScheduler scheduler = await CreateScheduler("GetExecutionLimitsDerivationTest");
+        try
+        {
+            await scheduler.SetExecutionLimits(ExecutionLimitsBuilder.Create()
+                .ForOtherGroups(4)
+                .UseTriggerGroupWhenUnset()
+                .Build());
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+
+            ExecutionLimitsDto limits = await client.GetExecutionLimits(scheduler.SchedulerName);
+
+            limits.UsesTriggerGroupWhenUnset.Should().BeTrue(
+                "the overview has to apply the same derivation when it counts what is in flight, or its "
+                + "counts and the acquisition filter would key the same firing differently");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task GetExecutionLimitsIsEmptyRatherThanUnknownWhenNothingIsLimited()
     {
         IScheduler scheduler = await CreateScheduler("GetExecutionLimitsEmptyTest");
         try
         {
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            (await client.GetExecutionLimits(scheduler.SchedulerName)).Should().BeNull(
-                "a scheduler with no limits has nothing to show, which is not the same as showing zeros");
+            ExecutionLimitsDto limits = await client.GetExecutionLimits(scheduler.SchedulerName);
+
+            limits.Limits.Should().BeEmpty("nothing is limited");
+            limits.CanReport.Should().BeTrue(
+                "a scheduler that limits nothing has answered the question, and the overview says every "
+                + "group is unlimited rather than that it cannot tell");
         }
         finally
         {
             await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// A scheduler that refuses the question is a different answer from one that limits nothing, and the
+    /// client no longer flattens the two into a bare null.
+    /// </summary>
+    [Test]
+    public async Task GetExecutionLimitsSaysSoWhenTheSchedulerCannotReportThem()
+    {
+        IScheduler scheduler = await CreateScheduler("GetExecutionLimitsUnsupportedTest");
+        try
+        {
+            InProcessQuartzApiClient client = CreateClient(new LimitlessScheduler(scheduler));
+
+            ExecutionLimitsDto limits = await client.GetExecutionLimits(scheduler.SchedulerName);
+
+            limits.CanReport.Should().BeFalse(
+                "reporting a refusal as 'nothing is limited' would have the panel state a fact nobody "
+                + "established");
+            limits.Limits.Should().BeEmpty();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IScheduler" /> of an application's own that does not implement execution limits.
+    /// </summary>
+    private sealed class LimitlessScheduler : DelegatingScheduler
+    {
+        public LimitlessScheduler(IScheduler scheduler) : base(scheduler)
+        {
+        }
+
+        public override ValueTask<ExecutionLimits?> GetExecutionLimits(CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException("This scheduler does not implement execution limits.");
         }
     }
 

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -165,6 +165,11 @@ namespace Quartz.Dashboard.Services
         public string? GroupContains { get; init; }
         public Quartz.FireInstanceState? State { get; init; }
     }
+    public sealed class DashboardGroupQuery : Quartz.PagedQuery, System.IEquatable<Quartz.Dashboard.Services.DashboardGroupQuery>
+    {
+        public DashboardGroupQuery() { }
+        public bool? Paused { get; init; }
+    }
     public sealed class DashboardHistoryEntry : System.IEquatable<Quartz.Dashboard.Services.DashboardHistoryEntry>
     {
         public DashboardHistoryEntry(string SchedulerName, string SchedulerInstanceId, string JobGroup, string JobName, string TriggerGroup, string TriggerName, System.DateTimeOffset FiredAtUtc, System.TimeSpan Duration, bool Succeeded, string? ExceptionMessage) { }
@@ -218,8 +223,11 @@ namespace Quartz.Dashboard.Services
     }
     public sealed class ExecutionLimitsDto : System.IEquatable<Quartz.Dashboard.Services.ExecutionLimitsDto>
     {
-        public ExecutionLimitsDto(System.Collections.Generic.Dictionary<string, Quartz.Dashboard.Services.DashboardExecutionLimit> Limits) { }
+        public ExecutionLimitsDto(System.Collections.Generic.Dictionary<string, Quartz.Dashboard.Services.DashboardExecutionLimit> Limits, bool UsesTriggerGroupWhenUnset = false, bool CanReport = true) { }
+        public bool CanReport { get; init; }
         public System.Collections.Generic.Dictionary<string, Quartz.Dashboard.Services.DashboardExecutionLimit> Limits { get; init; }
+        public bool UsesTriggerGroupWhenUnset { get; init; }
+        public static Quartz.Dashboard.Services.ExecutionLimitsDto CannotReport { get; }
     }
     public sealed class FireInstanceDto : System.IEquatable<Quartz.Dashboard.Services.FireInstanceDto>
     {
@@ -245,22 +253,24 @@ namespace Quartz.Dashboard.Services
     {
         System.Threading.Tasks.ValueTask AddCalendar(string schedulerName, Quartz.Dashboard.Services.AddCalendarRequest request, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask AddJob(string schedulerName, Quartz.Dashboard.Services.AddJobRequest request, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<int?> CountMisfires(string schedulerName, System.DateTimeOffset since, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask DeleteCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask DeleteJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar> GetCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> GetCalendarNames(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.ClusterNodeDto>> GetClusterNodes(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.ExecutionLimitsDto?> GetExecutionLimits(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.ExecutionLimitsDto> GetExecutionLimits(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.FireInstanceDto>> GetFireInstances(string schedulerName, Quartz.Dashboard.Services.DashboardFireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardHistoryEntry>?> GetHistory(Quartz.Dashboard.Services.DashboardHistoryQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.JobDetailDto> GetJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.JobGroupDto>> GetJobGroups(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.JobGroupDto>> GetJobGroups(string schedulerName, Quartz.Dashboard.Services.DashboardGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.TriggerHeaderDto>> GetJobTriggers(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.JobKeyDto>> GetJobs(string schedulerName, Quartz.Dashboard.Services.DashboardJobQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardMisfireEntry>?> GetMisfires(Quartz.Dashboard.Services.DashboardMisfireQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.SchedulerDetailDto> GetScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.SchedulerHeaderDto>> GetSchedulers(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ITrigger> GetTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.TriggerGroupDto>> GetTriggerGroups(string schedulerName, Quartz.Dashboard.Services.DashboardGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.TriggerState> GetTriggerState(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.TriggerHeaderDto>> GetTriggers(string schedulerName, Quartz.Dashboard.Services.DashboardTriggerQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask InterruptFireInstance(string schedulerName, string fireInstanceId, System.Threading.CancellationToken cancellationToken = default);
@@ -340,6 +350,12 @@ namespace Quartz.Dashboard.Services
         public string? SchedulerInstanceId { get; init; }
         public string SchedulerName { get; init; }
         public Quartz.SchedulerStatus? Status { get; init; }
+    }
+    public sealed class TriggerGroupDto : System.IEquatable<Quartz.Dashboard.Services.TriggerGroupDto>
+    {
+        public TriggerGroupDto(string Name, bool Paused) { }
+        public string Name { get; init; }
+        public bool Paused { get; init; }
     }
     public sealed class TriggerHeaderDto : System.IEquatable<Quartz.Dashboard.Services.TriggerHeaderDto>
     {


### PR DESCRIPTION
The overview had four numbers on it. `IQuartzApiClient.GetExecutionLimits` was implemented and called by
no page, so the ceilings `execution-groups.md` teaches were configurable and invisible; there was no
breakdown by trigger state, no count of paused groups and no misfire count.

Closes #3419.

## Execution-group panel

A new `Components/Shared/ExecutionGroups.razor` joins `GetExecutionLimits` to `GetFireInstances`: one
row per group with the limit that governs it, the scope that limit is counted in (`Node`/`Cluster`),
what it has in flight, and the headroom left.

- **Both firing states count.** A reservation holds a slot exactly as a running execution does — that is
  what the acquisition filter counts against a limit — so a panel counting only the running ones would
  show headroom the next acquisition cannot use.
- **The counts are the cluster's when `SchedulerDetailDto.Persistent`**, because the firing listing is,
  and this node's otherwise; the panel says which. Where a *node*-scoped limit is being compared against
  a cluster-wide count — a clustered store — it says that too, since every node enforces its own copy.
- **The group key comes from `ExecutionLimits.ResolveGroupKey`**, the scheduler's own rule, so the panel
  and the acquisition filter cannot key the same firing differently under `UseTriggerGroupWhenUnset`. A
  row whose name came from that derivation is labelled *(from trigger group)*.
- **`*` is shown as the rule it is, not a bucket.** It gives each unlisted group an allowance of its own
  rather than one shared, so it has nothing in flight against it and shows a dash with a footnote; a
  group governed by it says *(other groups)* beside the number. It never covers the ungrouped bucket.
- The panel refreshes on a 5-second timer, the Cluster page's cadence and for its reason. It is guarded
  against the overview's own once-a-second re-render, which would otherwise be two store reads a second.

## `NotSupportedException` is no longer swallowed into a null

`GetExecutionLimits` now returns a non-nullable `ExecutionLimitsDto`. Nothing limited is an empty
`Limits`; a scheduler whose implementation refuses is `ExecutionLimitsDto.CannotReport`, and `CanReport`
distinguishes them. The panel then says *this scheduler cannot report execution limits* rather than
rendering as though nothing were limited.

**One correction to the issue's wording:** the comment claimed the refusal came from an HTTP proxy.
`HttpScheduler.GetExecutionLimits` implements the member by reading the HTTP API's `execution-limits`
endpoint — no scheduler Quartz ships throws here. The `catch` is still right for an `IScheduler` of an
application's own, and the comment now says that instead.

## Trigger-state histogram, paused groups, misfires

- A **Trigger states** section: `Normal`, `Paused`, `Blocked`, `Error`, `Complete`, each a `Take = 0`
  counting query and each count a link to the Triggers page narrowed to that state. The **Error
  Triggers** tile is now read out of the histogram rather than from a query of its own, so it costs one
  fewer round trip and the two cannot disagree.
- A **Paused Groups** tile: `n trigger, m job`. Counted with `Paused = true, Take = 0` rather than by
  listing every group and tallying — a group can be paused while it holds nothing, and the unfiltered
  listing enumerates the groups that *hold* something, so tallying would miss exactly the group nobody
  can find by looking.
- A **Misfires** tile. #3422 landed under this branch while it was in flight, so the seam is filled
  rather than left: `IQuartzApiClient.CountMisfires(name, since)` → `InProcessQuartzApiClient` →
  `IDashboardHistoryStore.CountMisfires`. It counts over `QuartzDashboardOptions.HistoryRetention` and
  names that window in the tile's title (`Misfires (last 24 h)` at the default), because a fixed day
  would overstate a store configured to remember an hour. `int?`, and a data source with no misfire feed
  shows a dash: it has not looked, which is not "looked and found none". No page links off it — #3422
  gave the dashboard a misfire feed but no page to show it on.

## Two API shapes that had to change first

- **`GetExecutionLimits`'s keys** are now the spellings configuration and the HTTP API use (`_`, `*`, the
  group name) rather than a display string `"(default)"`. A display string cannot be joined to a
  firing's execution group; rendering the three cases as words is the panel's job.
- **A group listing is a query.** `GetJobGroups(name)` → `GetJobGroups(name, DashboardGroupQuery)` →
  `PagedResult<JobGroupDto>`, with `GetTriggerGroups` joining it and `DashboardGroupQuery.Paused` giving
  the counting query above. This makes the group listings the same shape as every other listing on the
  interface, and it is the only way to count a paused-and-empty group.

## Baseline additions

`src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt`, re-accepted, and the
same delta carried into `docs/documentation/quartz-4.x/migration-guide.md`:

| Before | Now |
|---|---|
| `IQuartzApiClient.GetJobGroups(name, CancellationToken)` → `List<JobGroupDto>` | `GetJobGroups(name, DashboardGroupQuery, …)` → `PagedResult<JobGroupDto>` |
| — | `IQuartzApiClient.GetTriggerGroups(name, DashboardGroupQuery, …)` → `PagedResult<TriggerGroupDto>` |
| — | `IQuartzApiClient.CountMisfires(name, since, …)` → `int?` |
| `IQuartzApiClient.GetExecutionLimits(…)` → `ExecutionLimitsDto?` | → `ExecutionLimitsDto` |
| `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits)` | `+ bool UsesTriggerGroupWhenUnset = false, bool CanReport = true`, and `static ExecutionLimitsDto.CannotReport` |
| — | `DashboardGroupQuery : PagedQuery` with `bool? Paused` |
| — | `TriggerGroupDto(string Name, bool Paused)` |

## For a reviewer to decide

- **The histogram says `Normal`, not `Waiting`.** The issue asked for "Waiting"; the enum member is
  `TriggerState.Normal`, which is what the Triggers page, the trigger detail page and the HTTP API all
  say. Calling the same state two names one page apart seemed the worse of the two options — but the
  store column *is* `WAITING`, so if the label matters more than the enum, say so.
- **`?state=` on the Triggers page** is a small addition beyond the issue, made so the histogram counts
  can be links. Arriving with a state the button row cannot show as selected (`Normal`, `Blocked`,
  `Complete`) renders a muted *Showing X triggers only* beside the buttons; an unrecognised spelling
  opens the unfiltered listing rather than erroring.
- **The overview now makes eleven reads per load** (five of them the histogram's), all counting queries.
  Cheap individually, but it is eleven round trips on a persistent store where there used to be five.

## Verification

`dotnet build Quartz.slnx` — 0 warnings, 0 errors.
`dotnet test src/Quartz.Tests.Unit` — 3487 passed, 4 skipped.
`dotnet test src/Quartz.Tests.AspNetCore` — 523 passed (was 495 before the new tests).
`dotnet fallout VerifyDocsSnippets` — up to date, 90 markdown files checked.
`npm run docs:check-links` — 212 pages, 792 internal links, 460 fragments, no dead links or anchors.

`Quartz.Tests.AOT` and `Quartz.Tests.Integration` reference neither `Quartz.Dashboard` nor anything this
changes; both compile in the solution build and were not run.

Rebased onto `9a05ada9f` (#3422) rather than merged; the conflict was one hunk in `IQuartzApiClient.cs`
where both branches added a member next to `GetExecutionLimits`.
