### PR TITLE
A calendar's day is the local day, in every zone (3.x)

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
@@ -1,0 +1,325 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Globalization;
+
+using Quartz.Impl.Calendar;
+
+namespace Quartz.Tests.Unit.Impl.Calendar;
+
+/// <summary>
+/// Calendars across daylight saving transitions. A calendar is a predicate over instants written in
+/// wall-clock terms, so on a 23 or 25 hour day the wall clock it is written in and the elapsed time
+/// it covers stop being the same thing - an hour of exclusion becomes two, or none at all.
+/// </summary>
+/// <remarks>
+/// Every expectation here is a measured fact about the shipped behaviour, with the reasoning spelled
+/// out beside it, so that a deliberate change shows up as a failing test rather than a silent shift.
+/// The <see cref="TestTimeZones" /> Assume helpers state each transition premise, so a moved zone
+/// skips a case instead of failing it.
+/// </remarks>
+public class CalendarDstTests
+{
+    /// <summary>
+    /// A holiday excludes a local day, and <c>GetNextIncludedTimeUtc</c> has to answer with a time
+    /// the calendar includes, and with the first one.
+    /// </summary>
+    /// <remarks>
+    /// It did not, on any day whose clocks move (#3457). The day boundary was built as
+    /// <c>new DateTimeOffset(local.Date, local.Offset)</c> - midnight at the offset the
+    /// <em>queried instant</em> carries - which is a different instant from the day's own first one
+    /// whenever the offset changed between the two: an hour out in a zone that moves its clocks at
+    /// midnight, and on the neighbouring local day in a zone that moves them later.
+    /// </remarks>
+    [TestCase("SantiagoSpring", "2019-09-08", "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", "2019-04-06", "2019-04-07T02:30:00Z", "2019-04-07T04:00:00Z")]
+    [TestCase("AmmanSpring", "2017-03-31", "2017-03-31T10:00:00Z", "2017-03-31T21:00:00Z")]
+    [TestCase("AmmanFall", "2017-10-26", "2017-10-26T10:00:00Z", "2017-10-26T21:00:00Z")]
+    [TestCase("HelsinkiSpring", "2024-03-31", "2024-03-31T10:00:00Z", "2024-03-31T21:00:00Z")]
+    [TestCase("HelsinkiFall", "2024-10-27", "2024-10-27T10:00:00Z", "2024-10-27T22:00:00Z")]
+    [TestCase("EasternSpring", "2024-03-10", "2024-03-10T16:00:00Z", "2024-03-11T04:00:00Z")]
+    [TestCase("EasternFall", "2024-11-03", "2024-11-03T16:00:00Z", "2024-11-04T05:00:00Z")]
+    public void HolidayCalendar_NextIncludedTime_OnATransitionDay(string dayKey, string holidayText, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        DateTime holiday = DateTime.Parse(holidayText, CultureInfo.InvariantCulture);
+        DateTimeOffset askedAt = ParseUtc(askedAtText);
+        DateTimeOffset expected = ParseUtc(expectedText);
+
+        HolidayCalendar calendar = new HolidayCalendar { TimeZone = zone };
+        calendar.AddExcludedDate(holiday);
+
+        AssertNextIncludedTime(calendar, zone, askedAt, expected);
+    }
+
+    /// <summary>
+    /// The control for the case above: on a day with no transition in it the answer is plain local
+    /// midnight, in each of the zones the transition cases use.
+    /// </summary>
+    [TestCase("Helsinki", "2024-06-15", "2024-06-15T10:00:00Z", "2024-06-15T21:00:00Z")]
+    [TestCase("Eastern", "2024-01-15", "2024-01-15T16:00:00Z", "2024-01-16T05:00:00Z")]
+    [TestCase("Santiago", "2019-06-15", "2019-06-15T15:00:00Z", "2019-06-16T04:00:00Z")]
+    public void HolidayCalendar_NextIncludedTime_OnAnOrdinaryDay(string zoneKey, string holidayText, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+
+        DateTime holiday = DateTime.Parse(holidayText, CultureInfo.InvariantCulture);
+        DateTimeOffset askedAt = ParseUtc(askedAtText);
+        DateTimeOffset expected = ParseUtc(expectedText);
+
+        Assume.That(
+            zone.GetUtcOffset(TimeZoneInfo.ConvertTime(askedAt, zone).Date) == zone.GetUtcOffset(expected),
+            $"test premise: the clocks do not move on {holiday:yyyy-MM-dd} in zone {zone.Id}");
+
+        HolidayCalendar calendar = new HolidayCalendar { TimeZone = zone };
+        calendar.AddExcludedDate(holiday);
+
+        AssertNextIncludedTime(calendar, zone, askedAt, expected);
+    }
+
+    /// <summary>
+    /// A run of holidays is walked a day at a time, and the walk crosses the transition rather than
+    /// starting on it. Adding a day to a <see cref="DateTimeOffset" /> keeps the offset it already
+    /// had, so a walk that begins before the clocks move carries the old offset over them and lands
+    /// an hour out on the far side: a holiday that ends on a Sunday releases the scheduler at 01:00
+    /// on the Monday when the clocks went forward, and an hour before the holiday is over when they
+    /// went back.
+    /// </summary>
+    [TestCase("HelsinkiSpring", "2024-03-29,2024-03-30,2024-03-31", "2024-03-29T10:00:00Z", "2024-03-31T21:00:00Z")]
+    [TestCase("HelsinkiFall", "2024-10-25,2024-10-26,2024-10-27", "2024-10-25T10:00:00Z", "2024-10-27T22:00:00Z")]
+    [TestCase("SantiagoSpring", "2019-09-06,2019-09-07,2019-09-08", "2019-09-06T15:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", "2019-04-04,2019-04-05,2019-04-06", "2019-04-04T15:00:00Z", "2019-04-07T04:00:00Z")]
+    public void HolidayCalendar_NextIncludedTime_WalkingAcrossATransition(string dayKey, string holidaysText, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        DateTimeOffset askedAt = ParseUtc(askedAtText);
+        DateTimeOffset expected = ParseUtc(expectedText);
+
+        HolidayCalendar calendar = new HolidayCalendar { TimeZone = zone };
+        foreach (string holidayText in holidaysText.Split(','))
+        {
+            calendar.AddExcludedDate(DateTime.Parse(holidayText, CultureInfo.InvariantCulture));
+        }
+
+        AssertNextIncludedTime(calendar, zone, askedAt, expected);
+    }
+
+    /// <summary>
+    /// An annual calendar excludes a date of every year, and walks days the same way a holiday
+    /// calendar does, so it had the same boundary.
+    /// </summary>
+    [TestCase("SantiagoSpring", "2019-09-08", "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", "2019-04-06", "2019-04-06T12:00:00Z", "2019-04-07T04:00:00Z")]
+    public void AnnualCalendar_NextIncludedTime_OnATransitionDay(string dayKey, string excludedText, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        AnnualCalendar calendar = new AnnualCalendar { TimeZone = zone };
+        calendar.SetDayExcluded(DateTime.Parse(excludedText, CultureInfo.InvariantCulture), true);
+
+        AssertNextIncludedTime(calendar, zone, ParseUtc(askedAtText), ParseUtc(expectedText));
+    }
+
+    /// <summary>
+    /// So did a monthly calendar, which excludes a day of the month.
+    /// </summary>
+    [TestCase("SantiagoSpring", 8, "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", 6, "2019-04-06T12:00:00Z", "2019-04-07T04:00:00Z")]
+    public void MonthlyCalendar_NextIncludedTime_OnATransitionDay(string dayKey, int day, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        MonthlyCalendar calendar = new MonthlyCalendar { TimeZone = zone };
+        calendar.SetDayExcluded(day, true);
+
+        AssertNextIncludedTime(calendar, zone, ParseUtc(askedAtText), ParseUtc(expectedText));
+    }
+
+    /// <summary>
+    /// And so did a weekly calendar, which excludes a day of the week.
+    /// </summary>
+    [TestCase("SantiagoSpring", DayOfWeek.Sunday, "2019-09-08T10:00:00Z", "2019-09-09T03:00:00Z")]
+    [TestCase("SantiagoFall", DayOfWeek.Saturday, "2019-04-06T12:00:00Z", "2019-04-07T04:00:00Z")]
+    public void WeeklyCalendar_NextIncludedTime_OnATransitionDay(string dayKey, DayOfWeek excluded, string askedAtText, string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        WeeklyCalendar calendar = new WeeklyCalendar { TimeZone = zone };
+        calendar.SetDayExcluded(DayOfWeek.Saturday, false);
+        calendar.SetDayExcluded(DayOfWeek.Sunday, false);
+        calendar.SetDayExcluded(excluded, true);
+
+        AssertNextIncludedTime(calendar, zone, ParseUtc(askedAtText), ParseUtc(expectedText));
+    }
+
+    /// <summary>
+    /// A daily calendar was already right on these days, and this says why. It builds its day
+    /// boundaries at the queried instant's offset too, but compares them only with values carrying
+    /// that same offset, so every comparison it makes is a wall-clock one and stays correct whatever
+    /// the offset is. The window therefore lands where the wall clock says even on the day whose
+    /// midnight never happens, and on the day whose last hour happens twice it catches both passes.
+    /// </summary>
+    /// <remarks>
+    /// These are <see cref="ICalendar.IsTimeIncluded" /> cases only.
+    /// <see cref="DailyCalendar.GetNextIncludedTimeUtc" /> computes its window and day boundaries in
+    /// the offset the <em>argument</em> carries rather than in the calendar's zone, so asking it in
+    /// UTC about a calendar in another zone walks a step at a time and can step over an included
+    /// window entirely. That is a separate defect from the day boundary this fixture is about, it
+    /// predates it, and it is not fixed here (#3466).
+    /// </remarks>
+    [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T03:30:00Z", true)]
+    [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T04:30:00Z", false)]
+    [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T05:30:00Z", true)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T02:15:00Z", false)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T02:45:00Z", true)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T03:15:00Z", false)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T03:45:00Z", true)]
+    [TestCase("SantiagoFall", "23:00", "23:30", "2019-04-07T04:00:00Z", true)]
+    public void DailyCalendar_OnADayThatIsNot24HoursLong_ExcludesTheWallClockWindow(
+        string dayKey,
+        string from,
+        string to,
+        string instantText,
+        bool expectedIncluded)
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay(dayKey);
+
+        DateTimeOffset instant = ParseUtc(instantText);
+
+        DailyCalendar calendar = new DailyCalendar(from, to) { TimeZone = zone };
+
+        calendar.IsTimeIncluded(instant).Should().Be(expectedIncluded,
+            "{0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local and the excluded window is {2}-{3} of every local day",
+            instant, TimeZoneInfo.ConvertTime(instant, zone), from, to);
+    }
+
+    /// <summary>
+    /// Asserts the whole of the <c>GetNextIncludedTimeUtc</c> contract for one case: the instant it
+    /// is asked about is excluded, the expected answer is included, the minute before it is not, and
+    /// the answer is that instant.
+    /// </summary>
+    private static void AssertNextIncludedTime(ICalendar calendar, TimeZoneInfo zone, DateTimeOffset askedAt, DateTimeOffset expected)
+    {
+        calendar.IsTimeIncluded(askedAt).Should().BeFalse(
+            "the premise of the case: {0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local, which this calendar excludes",
+            askedAt, TimeZoneInfo.ConvertTime(askedAt, zone));
+
+        calendar.IsTimeIncluded(expected).Should().BeTrue(
+            "and {0:O}, which reads as {1:yyyy-MM-dd HH:mm zzz} local, is not excluded",
+            expected, TimeZoneInfo.ConvertTime(expected, zone));
+
+        // A minute rather than a millisecond, because the exact instant a zone changes offset is not
+        // agreed on to the millisecond: Windows cannot express a rule at local midnight and writes
+        // 23:59:59.999 of the day before instead. A minute is clear of the disagreement.
+        calendar.IsTimeIncluded(expected.AddMinutes(-1)).Should().BeFalse(
+            "and it is the first such instant - a minute earlier reads as {0:yyyy-MM-dd HH:mm zzz} local, which is still excluded",
+            TimeZoneInfo.ConvertTime(expected.AddMinutes(-1), zone));
+
+        DateTimeOffset actual = calendar.GetNextIncludedTimeUtc(askedAt);
+
+        actual.Should().Be(expected,
+            "the next included time after an excluded instant is the first instant the calendar includes, and {0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local (included={2})",
+            actual, TimeZoneInfo.ConvertTime(actual, zone), calendar.IsTimeIncluded(actual));
+    }
+
+    private static TimeZoneInfo ResolveZone(string zoneKey)
+    {
+        switch (zoneKey)
+        {
+            case "Helsinki":
+                return TestTimeZones.Helsinki;
+            case "Eastern":
+                return TestTimeZones.Eastern;
+            case "Santiago":
+                return TestTimeZones.Santiago;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test zone");
+        }
+    }
+
+    /// <summary>
+    /// The zone a transition-day case runs in, with that day's premise stated. Resolved per case
+    /// rather than from a shared table, because <see cref="TestTimeZones.Amman" /> ignores the test
+    /// when the zone is missing from the system.
+    /// </summary>
+    private static TimeZoneInfo ZoneForTransitionDay(string dayKey)
+    {
+        switch (dayKey)
+        {
+            case "SantiagoSpring":
+                // The clocks move at midnight: 2019-09-08 has no 00:00 local, it starts at 01:00 and
+                // is 23 hours long.
+                TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Santiago, new DateTime(2019, 9, 8, 0, 30, 0));
+                return TestTimeZones.Santiago;
+
+            case "SantiagoFall":
+                // The same transition the other way: the hour before midnight happens twice, so
+                // 2019-04-06 is 25 hours long and 2019-04-07 begins an hour later than the arithmetic
+                // of the day before it says.
+                TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Santiago, new DateTime(2019, 4, 6, 23, 30, 0));
+                return TestTimeZones.Santiago;
+
+            case "AmmanSpring":
+                // Midnight moves here too: 2017-03-31 has no 00:00 local. Jordan abolished DST in
+                // 2022, so this is frozen history rather than a rule that can move under the test.
+                TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Amman, new DateTime(2017, 3, 31, 0, 30, 0));
+                return TestTimeZones.Amman;
+
+            case "AmmanFall":
+                // The one zone here whose own midnight happens twice: 00:00-00:59 on 2017-10-27 is
+                // the repeated hour, so that day starts at the first of two midnights.
+                TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Amman, new DateTime(2017, 10, 27, 0, 30, 0));
+                return TestTimeZones.Amman;
+
+            case "HelsinkiSpring":
+                // Not at midnight: 03:00 EET becomes 04:00 EEST on 2024-03-31, so the day begins at
+                // +02:00 and every instant after the transition carries +03:00.
+                TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Helsinki, new DateTime(2024, 3, 31, 3, 30, 0));
+                return TestTimeZones.Helsinki;
+
+            case "HelsinkiFall":
+                // 04:00 EEST becomes 03:00 EET on 2024-10-27.
+                TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Helsinki, new DateTime(2024, 10, 27, 3, 30, 0));
+                return TestTimeZones.Helsinki;
+
+            case "EasternSpring":
+                // 02:00 EST becomes 03:00 EDT on 2024-03-10.
+                TestTimeZones.AssumeInvalidLocalTime(TestTimeZones.Eastern, new DateTime(2024, 3, 10, 2, 30, 0));
+                return TestTimeZones.Eastern;
+
+            case "EasternFall":
+                // 02:00 EDT becomes 01:00 EST on 2024-11-03.
+                TestTimeZones.AssumeAmbiguousLocalTime(TestTimeZones.Eastern, new DateTime(2024, 11, 3, 1, 30, 0));
+                return TestTimeZones.Eastern;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(dayKey), dayKey, "unknown transition day");
+        }
+    }
+
+    private static DateTimeOffset ParseUtc(string value)
+    {
+        return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 
 using Quartz.Impl.Calendar;
@@ -174,19 +175,18 @@ public class CalendarDstTests
     }
 
     /// <summary>
-    /// A daily calendar was already right on these days, and this says why. It builds its day
-    /// boundaries at the queried instant's offset too, but compares them only with values carrying
-    /// that same offset, so every comparison it makes is a wall-clock one and stays correct whatever
-    /// the offset is. The window therefore lands where the wall clock says even on the day whose
-    /// midnight never happens, and on the day whose last hour happens twice it catches both passes.
+    /// A daily calendar's day boundary was already right on these days, and this says why. It builds
+    /// its day boundaries at the queried instant's offset too, but compares them only with values
+    /// carrying that same offset, so every comparison it makes is a wall-clock one and stays correct
+    /// whatever the offset is. The window therefore lands where the wall clock says even on the day
+    /// whose midnight never happens, and on the day whose last hour happens twice it catches both
+    /// passes.
     /// </summary>
     /// <remarks>
     /// These are <see cref="ICalendar.IsTimeIncluded" /> cases only.
-    /// <see cref="DailyCalendar.GetNextIncludedTimeUtc" /> computes its window and day boundaries in
-    /// the offset the <em>argument</em> carries rather than in the calendar's zone, so asking it in
-    /// UTC about a calendar in another zone walks a step at a time and can step over an included
-    /// window entirely. That is a separate defect from the day boundary this fixture is about, it
-    /// predates it, and it is not fixed here (#3466).
+    /// <see cref="DailyCalendar.GetNextIncludedTimeUtc" /> had a defect of its own, which the cases
+    /// below this one are about: it computed the window and the day boundaries in the offset the
+    /// <em>argument</em> carried rather than in the calendar's zone (#3466).
     /// </remarks>
     [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T03:30:00Z", true)]
     [TestCase("SantiagoSpring", "01:00", "02:00", "2019-09-08T04:30:00Z", false)]
@@ -212,6 +212,234 @@ public class CalendarDstTests
         calendar.IsTimeIncluded(instant).Should().Be(expectedIncluded,
             "{0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local and the excluded window is {2}-{3} of every local day",
             instant, TimeZoneInfo.ConvertTime(instant, zone), from, to);
+    }
+
+    /// <summary>
+    /// The other half of the daily calendar's contract, on the days where the wall clock and elapsed
+    /// time part company: the next included time is the first instant the window lets go of, and it
+    /// is the same instant however the question is phrased.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It was not (#3466). The window's edges were named on the date the <em>argument</em> fell on
+    /// and paired with the offset it carried, while <see cref="ICalendar.IsTimeIncluded" /> converted
+    /// into the calendar's zone first, so a question asked in UTC about a calendar keeping another
+    /// zone's hours was answered against a window an offset away from the one being tested. The walk
+    /// then fell through to its last resort, a step at a time, and could step clean over an included
+    /// stretch on the way.
+    /// </para>
+    /// <para>
+    /// Each case states the answer it expects, and
+    /// <see cref="AssertDailyCalendarNextIncludedTime" /> holds it to the rest of the contract:
+    /// the answer is included, nothing between the question and the answer is, and asking in the
+    /// calendar's own zone rather than in UTC gives the same instant back.
+    /// </para>
+    /// </remarks>
+    // The reproduction from #3466: this one spun for minutes and answered five months late, because
+    // 21:00-22:00 read as UTC is never 21:00-22:00 read in Santiago.
+    [TestCase("SantiagoFall", "21:00", "22:00", true, "2019-04-07T01:30:00Z", "2019-04-08T01:00:00Z")]
+    // The window's edges are inside the hour that happens twice, so the day opens twice as well: once
+    // on each pass, and a question standing in the second pass is answered from the second.
+    [TestCase("SantiagoFall", "23:00", "23:30", false, "2019-04-07T02:15:00Z", "2019-04-07T02:30:00.001Z")]
+    [TestCase("SantiagoFall", "23:00", "23:30", false, "2019-04-07T03:15:00Z", "2019-04-07T03:30:00.001Z")]
+    // A window that runs to the end of the local day opens again at the next local midnight, which on
+    // the 25 hour day is two hours further off than the wall clock makes it look...
+    [TestCase("SantiagoFall", "22:00", "23:59:59:999", false, "2019-04-07T01:30:00Z", "2019-04-07T04:00:00Z")]
+    // ...and on the 23 hour day is a midnight that never happens, so the day opens at the end of the
+    // gap instead.
+    [TestCase("SantiagoSpring", "22:00", "23:59:59:999", false, "2019-09-08T02:00:00Z", "2019-09-08T04:00:00Z")]
+    // An inverted window that begins at that same missing midnight is one instant wide: only its
+    // inclusive end survives the gap.
+    [TestCase("SantiagoSpring", "00:00", "01:00", true, "2019-09-07T20:00:00Z", "2019-09-08T04:00:00Z")]
+    // The clock going back does not only repeat an hour, it takes the day back to before the window
+    // opened, so the calendar lets go at the transition itself rather than at the window's end.
+    [TestCase("HelsinkiFall", "03:30", "04:30", false, "2024-10-27T00:40:00Z", "2024-10-27T01:00:00Z")]
+    [TestCase("HelsinkiFall", "03:00", "03:15", true, "2024-10-27T00:20:00Z", "2024-10-27T01:00:00Z")]
+    // An edge inside the spring-forward gap is no instant at all; the day turns over at the end of
+    // the gap, not an hour past it.
+    [TestCase("HelsinkiSpring", "02:30", "03:30", false, "2024-03-31T00:45:00Z", "2024-03-31T01:00:00Z")]
+    [TestCase("HelsinkiSpring", "03:30", "04:30", true, "2024-03-31T00:30:00Z", "2024-03-31T01:00:00Z")]
+    // The controls: the same calendars on a day whose clocks do not move.
+    [TestCase("Santiago", "21:00", "22:00", true, "2019-06-15T22:00:00Z", "2019-06-16T01:00:00Z")]
+    [TestCase("Helsinki", "03:30", "04:30", false, "2024-06-15T01:00:00Z", "2024-06-15T01:30:00.001Z")]
+    public void DailyCalendar_NextIncludedTime_IsTheFirstInstantTheWindowLetsGoOf(
+        string zoneKey,
+        string from,
+        string to,
+        bool inverted,
+        string askedAtText,
+        string expectedText)
+    {
+        TimeZoneInfo zone = ZoneForCase(zoneKey);
+
+        DailyCalendar calendar = new DailyCalendar(from, to)
+        {
+            InvertTimeRange = inverted,
+            TimeZone = zone
+        };
+
+        AssertDailyCalendarNextIncludedTime(calendar, zone, ParseUtc(askedAtText), ParseUtc(expectedText));
+    }
+
+    /// <summary>
+    /// Asked about an instant it already includes, a calendar answers with the very next millisecond
+    /// - there being nothing to wait for. The days these are asked on are the awkward ones, because
+    /// the shape of the answer must not depend on where in a transition the question lands.
+    /// </summary>
+    [TestCase("SantiagoFall", "21:00", "22:00", true, "2019-04-08T01:30:00Z")]
+    [TestCase("HelsinkiFall", "03:30", "04:30", false, "2024-10-27T03:00:00Z")]
+    [TestCase("SantiagoSpring", "22:00", "23:59:59:999", false, "2019-09-08T04:00:00Z")]
+    public void DailyCalendar_NextIncludedTime_WhenTheDayIsAlreadyOpen_IsTheNextMillisecond(
+        string zoneKey,
+        string from,
+        string to,
+        bool inverted,
+        string askedAtText)
+    {
+        TimeZoneInfo zone = ZoneForCase(zoneKey);
+        DateTimeOffset askedAt = ParseUtc(askedAtText);
+
+        DailyCalendar calendar = new DailyCalendar(from, to)
+        {
+            InvertTimeRange = inverted,
+            TimeZone = zone
+        };
+
+        calendar.IsTimeIncluded(askedAt).Should().BeTrue(
+            "the premise of the case: {0:O} reads as {1:yyyy-MM-dd HH:mm zzz} local, which this calendar includes",
+            askedAt, TimeZoneInfo.ConvertTime(askedAt, zone));
+
+        calendar.GetNextIncludedTimeUtc(askedAt).Should().Be(askedAt.AddMilliseconds(1),
+            "the next included time after an included instant is the one right after it");
+    }
+
+    /// <summary>
+    /// The measured symptom of #3466, which is what made it a bug worth a number rather than an
+    /// inaccuracy: the answer was not merely wrong, it was arrived at a step at a time.
+    /// </summary>
+    /// <remarks>
+    /// Two bounds, because each says something the other does not. The call count is exact and does
+    /// not care how fast the machine is: a base calendar that includes everything is asked once per
+    /// pass of the loop, so counting its calls counts the passes. The elapsed time is what a user
+    /// noticed, and its bound is loose enough that only a walk could break it.
+    /// </remarks>
+    [Test]
+    public void DailyCalendar_NextIncludedTime_IsJumpedToRatherThanWalkedUpTo()
+    {
+        TimeZoneInfo zone = ZoneForTransitionDay("SantiagoFall");
+
+        CountingCalendar passes = new CountingCalendar();
+        DailyCalendar calendar = new DailyCalendar(passes, "21:00", "22:00")
+        {
+            InvertTimeRange = true,
+            TimeZone = zone
+        };
+
+        DateTimeOffset askedAt = ParseUtc("2019-04-07T01:30:00Z");
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        DateTimeOffset actual = calendar.GetNextIncludedTimeUtc(askedAt);
+        stopwatch.Stop();
+
+        actual.Should().Be(ParseUtc("2019-04-08T01:00:00Z"),
+            "the window is 21:00-22:00 in Santiago, and the first of those hours after {0:O} begins at {1:O}",
+            askedAt, ParseUtc("2019-04-08T01:00:00Z"));
+
+        passes.Calls.Should().BeLessThan(10,
+            "the answer is named from the window's own edges, where the walk it replaced tested every one of the 84,600 seconds in between");
+
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5),
+            "a bound no jump can miss and no stepping walk can meet");
+    }
+
+    /// <summary>
+    /// A base calendar that includes every instant and counts the times it was asked. Attaching one
+    /// counts the passes <see cref="DailyCalendar.GetNextIncludedTimeUtc" /> makes without the
+    /// calendar having to carry a counter of its own, since the loop asks its base calendar once per
+    /// pass and this one never changes the answer.
+    /// </summary>
+    private sealed class CountingCalendar : BaseCalendar
+    {
+        public int Calls { get; private set; }
+
+        public override bool IsTimeIncluded(DateTimeOffset timeStampUtc)
+        {
+            Calls++;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Asserts the whole of the daily calendar's <c>GetNextIncludedTimeUtc</c> contract for one case:
+    /// the instant asked about is excluded, the answer is the expected one, the answer is included,
+    /// nothing between the two is, and the same question asked in the calendar's own zone rather than
+    /// in UTC is answered with the same instant.
+    /// </summary>
+    private static void AssertDailyCalendarNextIncludedTime(
+        DailyCalendar calendar,
+        TimeZoneInfo zone,
+        DateTimeOffset askedAt,
+        DateTimeOffset expected)
+    {
+        calendar.IsTimeIncluded(askedAt).Should().BeFalse(
+            "the premise of the case: {0:O} reads as {1:yyyy-MM-dd HH:mm:ss.fff zzz} local, which this calendar excludes",
+            askedAt, TimeZoneInfo.ConvertTime(askedAt, zone));
+
+        calendar.IsTimeIncluded(expected).Should().BeTrue(
+            "and {0:O}, which reads as {1:yyyy-MM-dd HH:mm:ss.fff zzz} local, is not excluded",
+            expected, TimeZoneInfo.ConvertTime(expected, zone));
+
+        // How close to the answer the walk may come. Usually the millisecond before it, but where the
+        // answer is the instant the clocks moved, only to the minute: the exact instant a zone
+        // changes offset is not agreed on to the millisecond, because Windows cannot express a rule
+        // at local midnight and writes 23:59:59.999 of the day before instead, which puts the end of
+        // Santiago's spring-forward gap a millisecond earlier there than on IANA data.
+        TimeSpan slack = zone.GetUtcOffset(expected) == zone.GetUtcOffset(expected.AddMinutes(-1))
+            ? TimeSpan.FromMilliseconds(1)
+            : TimeSpan.FromMinutes(1);
+
+        calendar.IsTimeIncluded(expected - slack).Should().BeFalse(
+            "and it is the first such instant - {0} earlier reads as {1:yyyy-MM-dd HH:mm:ss.fff zzz} local, which is still excluded",
+            slack, TimeZoneInfo.ConvertTime(expected - slack, zone));
+
+        AssertNothingIncludedBetween(calendar, zone, askedAt, expected - slack);
+
+        DateTimeOffset askedInUtc = calendar.GetNextIncludedTimeUtc(askedAt);
+        askedInUtc.Should().Be(expected,
+            "the next included time after an excluded instant is the first instant the calendar includes, and {0:O} reads as {1:yyyy-MM-dd HH:mm:ss.fff zzz} local (included={2})",
+            askedInUtc, TimeZoneInfo.ConvertTime(askedInUtc, zone), calendar.IsTimeIncluded(askedInUtc));
+
+        DateTimeOffset askedInZone = calendar.GetNextIncludedTimeUtc(TimeZoneInfo.ConvertTime(askedAt, zone));
+        askedInZone.Should().Be(expected,
+            "the same instant asked about in the calendar's own zone rather than in UTC is the same question, so it has the same answer");
+    }
+
+    /// <summary>
+    /// Walks the span between a question and its answer a second at a time, so that an answer which
+    /// stepped over an included stretch fails rather than passes. A second rather than a millisecond
+    /// because every window in this fixture opens and closes on a whole minute; how close to the
+    /// answer the walk comes is the caller's business.
+    /// </summary>
+    private static void AssertNothingIncludedBetween(ICalendar calendar, TimeZoneInfo zone, DateTimeOffset after, DateTimeOffset until)
+    {
+        (until - after).Should().BeLessThan(TimeSpan.FromDays(2),
+            "the scan below walks the whole span, so a case has to keep it short enough to walk");
+
+        DateTimeOffset? included = null;
+        for (DateTimeOffset instant = after.AddSeconds(1); instant <= until; instant = instant.AddSeconds(1))
+        {
+            if (calendar.IsTimeIncluded(instant))
+            {
+                included = instant;
+                break;
+            }
+        }
+
+        included.Should().BeNull(
+            "nothing between {0:O} and the answer {1:O} may be included, or the answer is not the first one; this instant reads as {2} local",
+            after,
+            until,
+            included == null ? "-" : TimeZoneInfo.ConvertTime(included.Value, zone).ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture));
     }
 
     /// <summary>
@@ -256,6 +484,18 @@ public class CalendarDstTests
             default:
                 throw new ArgumentOutOfRangeException(nameof(zoneKey), zoneKey, "unknown test zone");
         }
+    }
+
+    /// <summary>
+    /// The zone a case runs in, whether it names a transition day or a plain zone. A case grid that
+    /// mixes the two - a transition day and the ordinary day that controls it - names them the same
+    /// way and lets this tell them apart.
+    /// </summary>
+    private static TimeZoneInfo ZoneForCase(string key)
+    {
+        return key.EndsWith("Spring", StringComparison.Ordinal) || key.EndsWith("Fall", StringComparison.Ordinal)
+            ? ZoneForTransitionDay(key)
+            : ResolveZone(key);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/TestTimeZones.cs
+++ b/src/Quartz.Tests.Unit/TestTimeZones.cs
@@ -46,6 +46,20 @@ internal static class TestTimeZones
     public static TimeZoneInfo CentralEuropean { get; } = TZConvert.GetTimeZoneInfo("Central European Standard Time");
 
     /// <summary>
+    /// Europe/Helsinki: EET/EEST, +02:00 in winter and +03:00 in summer, with the EU transition at
+    /// 01:00 UTC - which is 03:00 local in spring (03:00 becomes 04:00, so 03:30 is invalid) and
+    /// 04:00 local in autumn (04:00 becomes 03:00, so 03:30 is ambiguous). Spring forward
+    /// 2024-03-31, fall back 2024-10-27.
+    /// </summary>
+    /// <remarks>
+    /// Windows names the whole EET/EEST group "FLE Standard Time", which resolves to Europe/Kyiv on
+    /// a system carrying IANA data. Helsinki and Kyiv share the EU rules, so the transitions
+    /// asserted against this zone are the same instants either way - and the Assume helpers say so
+    /// out loud, so a zone database that ever disagreed would skip the test rather than fail it.
+    /// </remarks>
+    public static TimeZoneInfo Helsinki { get; } = TZConvert.GetTimeZoneInfo("FLE Standard Time");
+
+    /// <summary>
     /// America/Santiago: southern hemisphere and the transition happens at midnight, so on
     /// spring-forward day the date's own 00:00 does not exist (2019-09-08, 00:30 invalid) and on
     /// fall-back day the repeated hour crosses backwards over the date boundary

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -166,6 +166,34 @@ public class TimeZoneUtilTest
         TimeZoneUtil.WalkToGapEnd(alreadyValid, zone).Should().Be(alreadyValid, "a valid time is returned unchanged");
     }
 
+    // A local day does not always begin at midnight, and never at the offset some other instant of
+    // that day happens to carry: in Santiago the clocks move at midnight, so the spring-forward day
+    // begins at 01:00 and the day after the fall-back one begins an hour later than the arithmetic
+    // of the day before it says.
+    [TestCase("Santiago", "2019-09-08", "2019-09-08T04:00:00Z")]
+    [TestCase("Santiago", "2019-04-07", "2019-04-07T04:00:00Z")]
+    [TestCase("Santiago", "2019-06-15", "2019-06-15T04:00:00Z")]
+    [TestCase("Eastern", "2024-03-10", "2024-03-10T05:00:00Z")]
+    public void StartOfLocalDay_IsTheDaysOwnFirstInstant(string zoneKey, string localDate, string expectedUtc)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime date = DateTime.Parse(localDate, CultureInfo.InvariantCulture);
+
+        DateTimeOffset start = TimeZoneUtil.StartOfLocalDay(date, zone);
+
+        start.Should().Be(DateTimeOffset.Parse(expectedUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+            "the day's first instant is local midnight resolved in the zone, or the end of the gap where that midnight does not exist");
+
+        // A minute rather than a millisecond, because the exact instant a zone changes offset is not
+        // agreed on to the millisecond: Windows cannot express a rule at local midnight and writes
+        // 23:59:59.999 of the day before instead, so on Windows data Santiago's spring-forward day
+        // begins a millisecond earlier than IANA data says. A minute is clear of the disagreement.
+        TimeZoneInfo.ConvertTime(start.AddMinutes(-1), zone).Date.Should().Be(date.AddDays(-1),
+            "the minute before it belongs to the previous local day");
+
+        TimeZoneUtil.StartOfLocalDay(date.AddHours(13), zone).Should().Be(start, "only the date part of the argument is used");
+    }
+
     [Test]
     public void ResolveLocal_NegativeDaylightDeltaZone_DoesNotMoveBackwards()
     {

--- a/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Utils/TimeZoneUtilTest.cs
@@ -194,6 +194,88 @@ public class TimeZoneUtilTest
         TimeZoneUtil.StartOfLocalDay(date.AddHours(13), zone).Should().Be(start, "only the date part of the argument is used");
     }
 
+    // A boundary inside a spring-forward gap is crossed the moment the clocks move, which is earlier
+    // than the instant ResolveLocal hands a trigger for the same wall clock. The second case is why
+    // the gap is walked from the whole minute: a boundary a millisecond into the gap is still crossed
+    // at the transition, not a millisecond after it.
+    [TestCase("Eastern", "2024-03-10 02:30", "2024-03-10 03:00")]
+    [TestCase("Eastern", "2024-03-10 02:30:00.001", "2024-03-10 03:00")]
+    [TestCase("LordHowe", "2019-10-06 02:15", "2019-10-06 02:30")]
+    [TestCase("Santiago", "2019-09-08 00:30", "2019-09-08 01:00")]
+    public void FirstInstantAtOrAfterLocal_InvalidLocalTime_IsTheInstantTheClocksMoved(string zoneKey, string invalidLocal, string expectedRenderedLocal)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(invalidLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, local);
+
+        DateTimeOffset first = TimeZoneUtil.FirstInstantAtOrAfterLocal(local, zone);
+
+        TimeZoneInfo.ConvertTime(first, zone).DateTime
+            .Should().Be(DateTime.Parse(expectedRenderedLocal, CultureInfo.InvariantCulture),
+                "the clock reads the end of the gap the moment it passes a boundary inside it");
+
+        first.Should().BeBefore(TimeZoneUtil.ResolveLocal(local, zone),
+            "ResolveLocal answers a trigger's question - when does this wall clock happen - by shifting past the gap, which is later than the moment the clock passed the boundary");
+    }
+
+    [Test]
+    public void FirstInstantAtOrAfterLocal_LocalTimeThatExists_IsWhereResolveLocalPutsIt()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+
+        DateTime ambiguous = new DateTime(2024, 11, 3, 1, 30, 0);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, ambiguous);
+        TimeZoneUtil.FirstInstantAtOrAfterLocal(ambiguous, zone).Should().Be(TimeZoneUtil.ResolveLocal(ambiguous, zone),
+            "a wall clock that happens twice is first read at the first of the two");
+
+        DateTime plain = new DateTime(2024, 6, 15, 12, 0, 0);
+        TimeZoneUtil.FirstInstantAtOrAfterLocal(plain, zone).Should().Be(TimeZoneUtil.ResolveLocal(plain, zone),
+            "and one that happens once is read then");
+    }
+
+    [TestCase("Eastern", "2024-11-03 01:30", "2024-11-03T06:30:00Z")]
+    [TestCase("Santiago", "2019-04-06 23:30", "2019-04-07T03:30:00Z")]
+    [TestCase("LordHowe", "2019-04-07 01:45", "2019-04-06T15:15:00Z")]
+    public void TryResolveSecondPass_AmbiguousLocalTime_IsTheOccurrenceAfterTheTransition(string zoneKey, string ambiguousLocal, string expectedUtc)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(ambiguousLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        TimeZoneUtil.TryResolveSecondPass(local, zone, out DateTimeOffset second).Should().BeTrue();
+
+        second.Should().Be(DateTimeOffset.Parse(expectedUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+        second.Should().BeAfter(TimeZoneUtil.ResolveLocal(local, zone), "the second pass of a repeated wall clock comes after the first");
+        TimeZoneInfo.ConvertTime(second, zone).DateTime.Should().Be(local, "and it reads as the same wall clock");
+
+        TimeZoneUtil.TryResolveSecondPass(local.Date.AddHours(12), zone, out _).Should().BeFalse("noon is not ambiguous");
+    }
+
+    [TestCase("Eastern", "2024-11-03 01:30", "2024-11-03 01:00", "2024-11-03 02:00")]
+    [TestCase("CentralEuropean", "2018-10-28 02:30", "2018-10-28 02:00", "2018-10-28 03:00")]
+    [TestCase("LordHowe", "2019-04-07 01:45", "2019-04-07 01:30", "2019-04-07 02:00")]
+    [TestCase("Santiago", "2019-04-06 23:30", "2019-04-06 23:00", "2019-04-07 00:00")]
+    public void TryGetAmbiguousWindow_ReturnsWallClockWindow(string zoneKey, string ambiguousLocal, string expectedStart, string expectedEnd)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime local = DateTime.Parse(ambiguousLocal, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeAmbiguousLocalTime(zone, local);
+
+        TimeZoneUtil.TryGetAmbiguousWindow(local, zone, out DateTime windowStart, out DateTime windowEnd).Should().BeTrue();
+
+        windowStart.Should().Be(DateTime.Parse(expectedStart, CultureInfo.InvariantCulture));
+        windowEnd.Should().Be(DateTime.Parse(expectedEnd, CultureInfo.InvariantCulture));
+
+        // pairing the window start with the standard (smaller) offset yields the transition instant,
+        // which renders in the zone as the window start itself - the first instant of the second pass
+        TimeSpan standardOffset = zone.GetAmbiguousTimeOffsets(local).Min();
+        DateTimeOffset transition = new DateTimeOffset(windowStart, standardOffset);
+        TimeZoneInfo.ConvertTime(transition, zone).DateTime.Should().Be(windowStart);
+
+        TimeZoneUtil.TryGetAmbiguousWindow(local.Date.AddHours(12), zone, out _, out _)
+            .Should().BeFalse("noon is not ambiguous");
+    }
+
     [Test]
     public void ResolveLocal_NegativeDaylightDeltaZone_DoesNotMoveBackwards()
     {

--- a/src/Quartz/Impl/Calendar/AnnualCalendar.cs
+++ b/src/Quartz/Impl/Calendar/AnnualCalendar.cs
@@ -244,8 +244,13 @@ public class AnnualCalendar : BaseCalendar
         //apply the timezone
         timeStampUtc = TimeZoneUtil.ConvertTime(timeStampUtc, TimeZone);
 
-        // Get timestamp for 00:00:00, in the correct timezone offset
-        DateTimeOffset day = new DateTimeOffset(timeStampUtc.Date, timeStampUtc.Offset);
+        // The first instant of the local day, resolved in the zone: a day does not always begin at
+        // midnight, and the offset it begins at is not always the offset the queried instant
+        // carries. Each further day is reached by naming the next local date and resolving that,
+        // because adding a day to a DateTimeOffset keeps the old offset and so drifts by the
+        // transition delta the moment the walk crosses one.
+        DateTime date = timeStampUtc.Date;
+        DateTimeOffset day = TimeZoneUtil.StartOfLocalDay(date, TimeZone);
 
         if (!IsDayExcluded(day))
         {
@@ -255,7 +260,8 @@ public class AnnualCalendar : BaseCalendar
 
         while (IsDayExcluded(day))
         {
-            day = day.AddDays(1);
+            date = date.AddDays(1);
+            day = TimeZoneUtil.StartOfLocalDay(date, TimeZone);
         }
 
         return day;

--- a/src/Quartz/Impl/Calendar/DailyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/DailyCalendar.cs
@@ -61,6 +61,7 @@ public class DailyCalendar : BaseCalendar
     private const string InvalidMillis = "Invalid millis: ";
     private const string InvalidTimeRange = "Invalid time range: ";
     private const string Separator = " - ";
+    private const long OneMillis = 1;
     private const char Colon = ':';
 
     private const string TwoDigitFormat = "00";
@@ -74,7 +75,6 @@ public class DailyCalendar : BaseCalendar
     private int rangeEndingMinute;
     private int rangeEndingSecond;
     private int rangeEndingMillis;
-    private int precisionStepMillis = 1000;
 
     private DailyCalendar()
     {
@@ -441,29 +441,36 @@ public class DailyCalendar : BaseCalendar
         }
 
         //Before we start, apply the correct timezone offsets.
-        timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
+        return IsInsideTheOpenPartOfTheDay(TimeZoneUtil.ConvertTime(timeUtc, TimeZone));
+    }
 
-        DateTimeOffset startOfDayInMillis = GetStartOfDay(timeUtc);
-        DateTimeOffset endOfDayInMillis = GetEndOfDay(timeUtc);
-        DateTimeOffset timeRangeStartingTimeInMillis = GetTimeRangeStartingTimeUtc(timeUtc);
-        DateTimeOffset timeRangeEndingTimeInMillis = GetTimeRangeEndingTimeUtc(timeUtc);
+    /// <summary>
+    /// The calendar's own rule with no base calendar in it: whether the given instant, already
+    /// expressed in <see cref="BaseCalendar.TimeZone" />, reads as a wall clock this calendar
+    /// includes.
+    /// </summary>
+    /// <remarks>
+    /// Every value it compares against carries the same offset as <paramref name="timeInZone" />, so
+    /// every comparison it makes is a wall-clock one. That is what makes the window mean the same
+    /// thing on a day that is 23 or 25 hours long as it does on any other day: an hour of exclusion
+    /// as written can be no elapsed time at all, or two hours of it.
+    /// </remarks>
+    private bool IsInsideTheOpenPartOfTheDay(DateTimeOffset timeInZone)
+    {
+        DateTimeOffset startOfDayInMillis = GetStartOfDay(timeInZone);
+        DateTimeOffset endOfDayInMillis = GetEndOfDay(timeInZone);
+        DateTimeOffset timeRangeStartingTimeInMillis = GetTimeRangeStartingTimeUtc(timeInZone);
+        DateTimeOffset timeRangeEndingTimeInMillis = GetTimeRangeEndingTimeUtc(timeInZone);
         if (!InvertTimeRange)
         {
-            if (timeUtc >= startOfDayInMillis &&
-                timeUtc < timeRangeStartingTimeInMillis ||
-                timeUtc > timeRangeEndingTimeInMillis &&
-                timeUtc <= endOfDayInMillis)
-            {
-                return true;
-            }
-            return false;
+            return timeInZone >= startOfDayInMillis &&
+                   timeInZone < timeRangeStartingTimeInMillis ||
+                   timeInZone > timeRangeEndingTimeInMillis &&
+                   timeInZone <= endOfDayInMillis;
         }
-        if (timeUtc >= timeRangeStartingTimeInMillis &&
-            timeUtc <= timeRangeEndingTimeInMillis)
-        {
-            return true;
-        }
-        return false;
+
+        return timeInZone >= timeRangeStartingTimeInMillis &&
+               timeInZone <= timeRangeEndingTimeInMillis;
     }
 
     /// <summary>
@@ -471,77 +478,163 @@ public class DailyCalendar : BaseCalendar
     /// Calendar after the given time. Return the original value if timeStamp is
     /// included. Return 0 if all days are excluded.
     /// </summary>
+    /// <remarks>
+    /// The question is answered in <see cref="BaseCalendar.TimeZone" /> whatever offset it is asked
+    /// in, because the window is a wall-clock window of the calendar's own zone: the argument is
+    /// converted first, exactly as <see cref="IsTimeIncluded" /> converts it, and the day's edges are
+    /// named as wall-clock times on the local date and resolved back to instants there. Computing
+    /// them at the offset the argument happened to carry made the two methods disagree whenever those
+    /// offsets differed, and the walk then crept forward a step at a time through a stretch it had
+    /// already been told was excluded - minutes of spinning for an answer months out of place
+    /// (#3466).
+    /// </remarks>
     /// <param name="timeUtc"></param>
     /// <returns></returns>
     /// <seealso cref="ICalendar.GetNextIncludedTimeUtc"/>
     public override DateTimeOffset GetNextIncludedTimeUtc(DateTimeOffset timeUtc)
     {
-        DateTimeOffset nextIncludedTime = timeUtc.AddMilliseconds(precisionStepMillis);
+        DateTimeOffset nextIncludedTime = timeUtc.AddMilliseconds(OneMillis);
 
         while (!IsTimeIncluded(nextIncludedTime))
         {
-            if (!InvertTimeRange)
+            DateTimeOffset candidate;
+            if (!IsInsideTheOpenPartOfTheDay(TimeZoneUtil.ConvertTime(nextIncludedTime, TimeZone)))
             {
-                //If the time is in a range excluded by this calendar, we can
-                // move to the end of the excluded time range and continue
-                // testing from there. Otherwise, if nextIncludedTime is
-                // excluded by the baseCalendar, ask it the next time it
-                // includes and begin testing from there. Failing this, add one
-                // millisecond and continue testing.
-                if (nextIncludedTime >=
-                    GetTimeRangeStartingTimeUtc(nextIncludedTime) &&
-                    nextIncludedTime <=
-                    GetTimeRangeEndingTimeUtc(nextIncludedTime))
-                {
-                    nextIncludedTime =
-                        GetTimeRangeEndingTimeUtc(nextIncludedTime).AddMilliseconds(precisionStepMillis);
-                }
-                else if (CalendarBase != null &&
-                         !CalendarBase.IsTimeIncluded(nextIncludedTime))
-                {
-                    nextIncludedTime =
-                        CalendarBase.GetNextIncludedTimeUtc(nextIncludedTime);
-                }
-                else
-                {
-                    nextIncludedTime = nextIncludedTime.AddMilliseconds(precisionStepMillis);
-                }
+                // The calendar's own window is what holds this time back, and the window's own edges
+                // say when it lets go, so jump there rather than testing what lies between.
+                candidate = NextTimeThisCalendarIncludes(nextIncludedTime);
+            }
+            else if (CalendarBase != null &&
+                     !CalendarBase.IsTimeIncluded(nextIncludedTime))
+            {
+                // The window is open and the base calendar is what holds the time back; it knows when
+                // it lets go, so ask it and carry on testing from there.
+                candidate = CalendarBase.GetNextIncludedTimeUtc(nextIncludedTime);
             }
             else
             {
-                //If the time is in a range excluded by this calendar, we can
-                // move to the end of the excluded time range and continue
-                // testing from there. Otherwise, if nextIncludedTime is
-                // excluded by the baseCalendar, ask it the next time it
-                // includes and begin testing from there. Failing this, add one
-                // millisecond and continue testing.
-                if (nextIncludedTime <
-                    GetTimeRangeStartingTimeUtc(nextIncludedTime))
-                {
-                    nextIncludedTime =
-                        GetTimeRangeStartingTimeUtc(nextIncludedTime);
-                }
-                else if (nextIncludedTime >
-                         GetTimeRangeEndingTimeUtc(nextIncludedTime))
-                {
-                    //(move to start of next day)
-                    nextIncludedTime = GetEndOfDay(nextIncludedTime);
-                    nextIncludedTime = nextIncludedTime.AddMilliseconds(precisionStepMillis);
-                }
-                else if (CalendarBase != null &&
-                         !CalendarBase.IsTimeIncluded(nextIncludedTime))
-                {
-                    nextIncludedTime =
-                        CalendarBase.GetNextIncludedTimeUtc(nextIncludedTime);
-                }
-                else
-                {
-                    nextIncludedTime = nextIncludedTime.AddMilliseconds(precisionStepMillis);
-                }
+                candidate = nextIncludedTime.AddMilliseconds(OneMillis);
             }
+
+            // Both jumps move forward by construction; the millisecond step is what keeps a base
+            // calendar that answers with a time of its own choosing from spinning the loop.
+            nextIncludedTime = candidate > nextIncludedTime
+                ? candidate
+                : nextIncludedTime.AddMilliseconds(OneMillis);
         }
 
         return nextIncludedTime;
+    }
+
+    /// <summary>
+    /// The first instant after <paramref name="time" /> that this calendar's own window rule
+    /// includes, with no base calendar in it.
+    /// </summary>
+    /// <remarks>
+    /// The answer is named rather than walked up to. While the zone's offset holds still the wall
+    /// clock only enters the open part of a day at an edge of it, so the edges of the local date the
+    /// query lands in - and of the date after it, once that one has no open time left - are the only
+    /// instants worth asking about. Each is checked against the rule before it is taken, so an edge
+    /// the zone makes meaningless drops out on its own, and the earliest survivor is the answer.
+    /// </remarks>
+    private DateTimeOffset NextTimeThisCalendarIncludes(DateTimeOffset time)
+    {
+        DateTime date = TimeZoneUtil.ConvertTime(time, TimeZone).Date;
+
+        while (true)
+        {
+            DateTimeOffset? included = FirstIncludedInstantOnLocalDate(date, time);
+            if (included != null)
+            {
+                return included.Value;
+            }
+
+            // A calendar whose window leaves no open time on any day never has an answer to give;
+            // the walk then runs out of dates, which is the end the millisecond walk came to as well.
+            date = date.AddDays(1);
+        }
+    }
+
+    /// <summary>
+    /// The first instant of the given local date that is both past <paramref name="after" /> and
+    /// inside the open part of the day, or <see langword="null" /> when that date has none.
+    /// </summary>
+    private DateTimeOffset? FirstIncludedInstantOnLocalDate(DateTime date, DateTimeOffset after)
+    {
+        TimeZoneInfo timeZone = TimeZone;
+
+        // The wall clock at which the day opens, and the one at which it closes again. An ordinary
+        // calendar opens a millisecond past the window's end; an inverted one opens at its start.
+        DateTime opens = InvertTimeRange
+            ? RangeStartOnLocalDate(date)
+            : RangeEndOnLocalDate(date).AddMilliseconds(OneMillis);
+
+        DateTime closes = InvertTimeRange
+            ? RangeEndOnLocalDate(date).AddMilliseconds(OneMillis)
+            : RangeStartOnLocalDate(date);
+
+        // The day's own first instant, which is neither always midnight nor always at the offset the
+        // rest of the day carries.
+        DateTimeOffset? earliest = EarliestIncluded(soFar: null, TimeZoneUtil.StartOfLocalDay(date, timeZone), after);
+
+        // The instant the day opens at: the first instant the clock reads that edge or later. One
+        // that happens twice resolves to the first of the two, that being the first instant the day
+        // is open at, and one that never happens at all - the edge fell in a spring-forward gap - to
+        // the instant the clocks moved.
+        earliest = EarliestIncluded(earliest, TimeZoneUtil.FirstInstantAtOrAfterLocal(opens, timeZone), after);
+
+        // ...and, when that wall clock happens twice, the second of the two, for a query that already
+        // stands past the first.
+        if (TimeZoneUtil.TryResolveSecondPass(opens, timeZone, out DateTimeOffset opensAgain))
+        {
+            earliest = EarliestIncluded(earliest, opensAgain, after);
+        }
+
+        // A fall-back does not merely repeat a wall clock, it takes the clock back into a part of the
+        // day that was already over. That happens exactly when the edge the day closes at is inside
+        // the repeated hour: the transition lands on the wall clock that hour began with, which is
+        // before the closing edge and so back inside the open part of the day.
+        if (TimeZoneUtil.TryGetAmbiguousWindow(closes, timeZone, out DateTime repeatedFrom, out _)
+            && TimeZoneUtil.TryResolveSecondPass(repeatedFrom, timeZone, out DateTimeOffset clockGoesBack))
+        {
+            earliest = EarliestIncluded(earliest, clockGoesBack, after);
+        }
+
+        return earliest;
+    }
+
+    /// <summary>
+    /// The earlier of <paramref name="soFar" /> and <paramref name="candidate" />, keeping only a
+    /// candidate that lies past <paramref name="after" /> and that the calendar's own rule includes.
+    /// </summary>
+    private DateTimeOffset? EarliestIncluded(DateTimeOffset? soFar, DateTimeOffset candidate, DateTimeOffset after)
+    {
+        if (candidate <= after || !IsInsideTheOpenPartOfTheDay(TimeZoneUtil.ConvertTime(candidate, TimeZone)))
+        {
+            return soFar;
+        }
+
+        return soFar == null || candidate < soFar.Value ? candidate : soFar;
+    }
+
+    /// <summary>
+    /// The wall clock at which the time range starts on the given local date.
+    /// </summary>
+    private DateTime RangeStartOnLocalDate(DateTime date)
+    {
+        return new DateTime(date.Year, date.Month, date.Day,
+            rangeStartingHourOfDay, rangeStartingMinute,
+            rangeStartingSecond, rangeStartingMillis, DateTimeKind.Unspecified);
+    }
+
+    /// <summary>
+    /// The wall clock at which the time range ends on the given local date.
+    /// </summary>
+    private DateTime RangeEndOnLocalDate(DateTime date)
+    {
+        return new DateTime(date.Year, date.Month, date.Day,
+            rangeEndingHourOfDay, rangeEndingMinute,
+            rangeEndingSecond, rangeEndingMillis, DateTimeKind.Unspecified);
     }
 
     public override ICalendar Clone()
@@ -558,15 +651,26 @@ public class DailyCalendar : BaseCalendar
     /// Returns the start time of the time range of the day
     /// specified in <paramref name="timeUtc" />.
     /// </summary>
+    /// <remarks>
+    /// The day is the local day of <see cref="BaseCalendar.TimeZone" />, so the argument is converted
+    /// into the zone before its date is read: asked in UTC about a calendar that keeps another zone's
+    /// hours, the answer is about the local date the instant falls in rather than the UTC one. The
+    /// value is a wall clock paired with the offset that instant carries, which is what makes it
+    /// comparable with the instant it was derived from; around a transition that offset need not be
+    /// the one the edge itself would be resolved at, and
+    /// <see cref="GetNextIncludedTimeUtc" />, which needs instants rather than comparands, resolves
+    /// the edges through the zone instead.
+    /// </remarks>
     /// <returns>
     ///     a DateTime representing the start time of the
     ///     time range for the specified date.
     /// </returns>
     public DateTimeOffset GetTimeRangeStartingTimeUtc(DateTimeOffset timeUtc)
     {
-        DateTimeOffset rangeStartingTime = new DateTimeOffset(timeUtc.Year, timeUtc.Month, timeUtc.Day,
+        DateTimeOffset timeInZone = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
+        DateTimeOffset rangeStartingTime = new DateTimeOffset(timeInZone.Year, timeInZone.Month, timeInZone.Day,
             rangeStartingHourOfDay, rangeStartingMinute,
-            rangeStartingSecond, rangeStartingMillis, timeUtc.Offset);
+            rangeStartingSecond, rangeStartingMillis, timeInZone.Offset);
         return rangeStartingTime;
     }
 
@@ -574,15 +678,20 @@ public class DailyCalendar : BaseCalendar
     /// Returns the end time of the time range of the day
     /// specified in <paramref name="timeUtc" />
     /// </summary>
+    /// <remarks>
+    /// The day is the local day of <see cref="BaseCalendar.TimeZone" />; see
+    /// <see cref="GetTimeRangeStartingTimeUtc" />.
+    /// </remarks>
     /// <returns>
     /// A DateTime representing the end time of the
     /// time range for the specified date.
     /// </returns>
     public DateTimeOffset GetTimeRangeEndingTimeUtc(DateTimeOffset timeUtc)
     {
-        DateTimeOffset rangeEndingTime = new DateTimeOffset(timeUtc.Year, timeUtc.Month, timeUtc.Day,
+        DateTimeOffset timeInZone = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
+        DateTimeOffset rangeEndingTime = new DateTimeOffset(timeInZone.Year, timeInZone.Month, timeInZone.Day,
             rangeEndingHourOfDay, rangeEndingMinute,
-            rangeEndingSecond, rangeEndingMillis, timeUtc.Offset);
+            rangeEndingSecond, rangeEndingMillis, timeInZone.Offset);
         return rangeEndingTime;
     }
 
@@ -760,22 +869,6 @@ public class DailyCalendar : BaseCalendar
         this.rangeEndingMinute = rangeEndingMinute;
         this.rangeEndingSecond = rangeEndingSecond;
         this.rangeEndingMillis = rangeEndingMillis;
-            
-        CalculationPrecisionStep();
-    }
-
-    private void CalculationPrecisionStep()
-    {
-        if (rangeStartingMillis != 0 || rangeEndingMillis != 0)
-        {
-            precisionStepMillis = 1;
-        }
-        else if (rangeStartingSecond != 0 || rangeEndingSecond != 0)
-        {
-            precisionStepMillis = 1000;
-        }
-        else 
-            precisionStepMillis = 60000;
     }
 
     /// <summary>
@@ -813,7 +906,14 @@ public class DailyCalendar : BaseCalendar
     /// <summary>
     /// Gets the start of day, practically zeroes time part.
     /// </summary>
-    /// <param name="time">The time.</param>
+    /// <remarks>
+    /// A wall-clock comparand, not an instant: it is midnight at whatever offset
+    /// <paramref name="time" /> carries, which is the day's first instant only on a day whose offset
+    /// never changes. That is all <see cref="IsInsideTheOpenPartOfTheDay" /> asks of it, since it
+    /// compares it with a value carrying that same offset. Code that needs the instant a local day
+    /// begins at uses <see cref="TimeZoneUtil.StartOfLocalDay" />.
+    /// </remarks>
+    /// <param name="time">The time, already expressed in the calendar's zone.</param>
     /// <returns></returns>
     private static DateTimeOffset GetStartOfDay(DateTimeOffset time)
     {
@@ -823,7 +923,10 @@ public class DailyCalendar : BaseCalendar
     /// <summary>
     /// Gets the end of day, practically sets time parts to maximum allowed values.
     /// </summary>
-    /// <param name="time">The time.</param>
+    /// <remarks>
+    /// A wall-clock comparand; see <see cref="GetStartOfDay" />.
+    /// </remarks>
+    /// <param name="time">The time, already expressed in the calendar's zone.</param>
     /// <returns></returns>
     private static DateTimeOffset GetEndOfDay(DateTimeOffset time)
     {

--- a/src/Quartz/Impl/Calendar/HolidayCalendar.cs
+++ b/src/Quartz/Impl/Calendar/HolidayCalendar.cs
@@ -157,17 +157,19 @@ public class HolidayCalendar : BaseCalendar
         //apply the timezone
         timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
 
-        // Get timestamp for 00:00:00, with the correct timezone offset
-        DateTimeOffset day = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);
+        // The first instant of the local day the query lands in, resolved in the zone: a day does
+        // not always begin at midnight, and the offset it begins at is not always the offset the
+        // queried instant carries. Each further day is reached by naming the next local date and
+        // resolving that, because adding a day to a DateTimeOffset keeps the old offset and so
+        // drifts by the transition delta the moment the walk crosses one.
+        DateTime date = timeUtc.Date;
+        DateTimeOffset day = TimeZoneUtil.StartOfLocalDay(date, TimeZone);
+
         while (!IsTimeIncludedThisCalendar(day) || !base.IsTimeIncluded(timeUtc))
         {
-            day = day.AddDays(1);
-            timeUtc = timeUtc.AddDays(1);
-            //ensure earliest value is assigned to return value
-            if (day < timeUtc)
-            {
-                timeUtc = day;
-            }
+            date = date.AddDays(1);
+            day = TimeZoneUtil.StartOfLocalDay(date, TimeZone);
+            timeUtc = day;
         }
 
         return timeUtc;

--- a/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/MonthlyCalendar.cs
@@ -227,10 +227,15 @@ public class MonthlyCalendar : BaseCalendar
         //apply the timezone
         timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
 
-        // Get timestamp for 00:00:00, in the correct timezone offset
-        DateTimeOffset newTimeStamp = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);
+        // The first instant of the local day, resolved in the zone: a day does not always begin at
+        // midnight, and the offset it begins at is not always the offset the queried instant
+        // carries. Each further day is reached by naming the next local date and resolving that,
+        // because adding a day to a DateTimeOffset keeps the old offset and so drifts by the
+        // transition delta the moment the walk crosses one.
+        DateTime date = timeUtc.Date;
+        DateTimeOffset newTimeStamp = TimeZoneUtil.StartOfLocalDay(date, TimeZone);
 
-        int day = newTimeStamp.Day;
+        int day = date.Day;
 
         if (!IsDayExcluded(day))
         {
@@ -239,8 +244,9 @@ public class MonthlyCalendar : BaseCalendar
 
         while (IsDayExcluded(day))
         {
-            newTimeStamp = newTimeStamp.AddDays(1);
-            day = newTimeStamp.Day;
+            date = date.AddDays(1);
+            newTimeStamp = TimeZoneUtil.StartOfLocalDay(date, TimeZone);
+            day = date.Day;
         }
 
         return newTimeStamp;

--- a/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
+++ b/src/Quartz/Impl/Calendar/WeeklyCalendar.cs
@@ -247,17 +247,23 @@ public class WeeklyCalendar : BaseCalendar
         //apply the timezone
         timeUtc = TimeZoneUtil.ConvertTime(timeUtc, TimeZone);
 
-        // Get timestamp for 00:00:00, in the correct timezone offset
-        DateTimeOffset d = new DateTimeOffset(timeUtc.Date, timeUtc.Offset);
+        // The first instant of the local day, resolved in the zone: a day does not always begin at
+        // midnight, and the offset it begins at is not always the offset the queried instant
+        // carries. Each further day is reached by naming the next local date and resolving that,
+        // because adding a day to a DateTimeOffset keeps the old offset and so drifts by the
+        // transition delta the moment the walk crosses one.
+        DateTime date = timeUtc.Date;
+        DateTimeOffset d = TimeZoneUtil.StartOfLocalDay(date, TimeZone);
 
-        if (!IsDayExcluded(d.DayOfWeek))
+        if (!IsDayExcluded(date.DayOfWeek))
         {
             return d;
         } // return the original value with the correct offset time.
 
-        while (IsDayExcluded(d.DayOfWeek))
+        while (IsDayExcluded(date.DayOfWeek))
         {
-            d = d.AddDays(1);
+            date = date.AddDays(1);
+            d = TimeZoneUtil.StartOfLocalDay(date, TimeZone);
         }
 
         return d;

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -138,6 +138,25 @@ public static class TimeZoneUtil
     }
 
     /// <summary>
+    /// The first instant of the given local date in the given zone, carrying that zone's offset.
+    /// Only the date part of <paramref name="date"/> is used. Local midnight is resolved with
+    /// <see cref="ResolveLocal"/>, so a date whose own midnight falls in a spring-forward gap begins
+    /// at the end of that gap, and a date whose midnight happens twice begins at the first of the two.
+    /// </summary>
+    /// <remarks>
+    /// Building a day boundary as <c>new DateTimeOffset(local.Date, local.Offset)</c> — midnight at
+    /// the offset that some other instant of the day happens to carry — lands on the wrong instant
+    /// whenever the offset the date starts at is not the offset of the instant that named it, which
+    /// is every transition day: an hour out in a zone that moves its clocks at midnight, and on the
+    /// day before or the day after in a zone that moves them later.
+    /// </remarks>
+    internal static DateTimeOffset StartOfLocalDay(DateTime date, TimeZoneInfo timeZoneInfo)
+    {
+        DateTime midnight = new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, DateTimeKind.Unspecified);
+        return ConvertTime(ResolveLocal(midnight, timeZoneInfo), timeZoneInfo);
+    }
+
+    /// <summary>
     /// Walks forward from a wall-clock time inside a spring-forward gap to the first wall-clock
     /// time that exists in the given zone (the end of the gap). Returns the input unchanged when it
     /// is already valid.

--- a/src/Quartz/Util/TimeZoneUtil.cs
+++ b/src/Quartz/Util/TimeZoneUtil.cs
@@ -157,6 +157,96 @@ public static class TimeZoneUtil
     }
 
     /// <summary>
+    /// The first instant at which the zone's clock reads <paramref name="dateTime"/> or later.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A wall clock that exists resolves through <see cref="ResolveLocal"/>, so one that happens
+    /// twice answers with the first of the two. One that does not exist — it fell in a spring-forward
+    /// gap — is answered with the instant the clocks moved, that being the first instant the clock
+    /// reads past it. This is deliberately not what <see cref="ResolveLocal"/> alone says of an
+    /// in-gap time: a trigger asking when a wall clock happens is answered with the gap's end shifted
+    /// forward by the transition delta, whereas a boundary is crossed the moment the clock passes it.
+    /// </para>
+    /// <para>
+    /// The gap's end is walked to from the whole minute the given time falls in, because a zone
+    /// changes offset on a minute and walking from the time's own second would carry that second past
+    /// the transition.
+    /// </para>
+    /// </remarks>
+    internal static DateTimeOffset FirstInstantAtOrAfterLocal(DateTime dateTime, TimeZoneInfo timeZoneInfo)
+    {
+        if (!timeZoneInfo.IsInvalidTime(dateTime))
+        {
+            return ResolveLocal(dateTime, timeZoneInfo);
+        }
+
+        DateTime minute = new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, 0, dateTime.Kind);
+        return ResolveLocal(WalkToGapEnd(minute, timeZoneInfo), timeZoneInfo);
+    }
+
+    /// <summary>
+    /// The second of the two instants an ambiguous wall-clock time names — the one after the
+    /// fall-back transition. Returns false when the time is not ambiguous, so it also answers
+    /// "does this wall clock happen twice, and when is the second time".
+    /// </summary>
+    /// <remarks>
+    /// The second pass always carries the smaller of the two offsets: a clock that goes back is a
+    /// clock whose offset shrinks, whichever of the two periods the zone labels as its daylight one.
+    /// <see cref="ResolveLocal"/> resolves the same wall clock to the first of the two, which is
+    /// what a trigger wants; a caller that has already gone past the first pass wants this one.
+    /// </remarks>
+    internal static bool TryResolveSecondPass(DateTime dateTime, TimeZoneInfo timeZoneInfo, out DateTimeOffset instant)
+    {
+        if (!timeZoneInfo.IsAmbiguousTime(dateTime))
+        {
+            instant = default;
+            return false;
+        }
+
+        instant = new DateTimeOffset(dateTime, timeZoneInfo.GetAmbiguousTimeOffsets(dateTime).Min());
+        return true;
+    }
+
+    /// <summary>
+    /// Determines the wall-clock window that occurs twice around a fall-back transition. Returns
+    /// false when the given time is not ambiguous. On success <paramref name="windowStart"/> is the
+    /// first ambiguous wall-clock minute (pairing it with the standard offset yields the transition
+    /// instant, i.e. the first instant of the second pass) and <paramref name="windowEnd"/> is the
+    /// first wall-clock minute after the window. Boundaries are found by scanning a minute at a
+    /// time, which handles transition deltas that are not whole hours.
+    /// </summary>
+    internal static bool TryGetAmbiguousWindow(DateTime dateTime, TimeZoneInfo timeZoneInfo, out DateTime windowStart, out DateTime windowEnd)
+    {
+        if (!timeZoneInfo.IsAmbiguousTime(dateTime))
+        {
+            windowStart = default;
+            windowEnd = default;
+            return false;
+        }
+
+        DateTime minute = new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, 0, dateTime.Kind);
+
+        DateTime start = minute;
+        int guard = 0;
+        while (timeZoneInfo.IsAmbiguousTime(start.AddMinutes(-1)) && guard++ < MaxTransitionScanMinutes)
+        {
+            start = start.AddMinutes(-1);
+        }
+
+        DateTime end = minute;
+        guard = 0;
+        while (timeZoneInfo.IsAmbiguousTime(end) && guard++ < MaxTransitionScanMinutes)
+        {
+            end = end.AddMinutes(1);
+        }
+
+        windowStart = start;
+        windowEnd = end;
+        return true;
+    }
+
+    /// <summary>
     /// Walks forward from a wall-clock time inside a spring-forward gap to the first wall-clock
     /// time that exists in the given zone (the end of the gap). Returns the input unchanged when it
     /// is already valid.


### PR DESCRIPTION
Backport of #3465 and #3474 for #3457 and #3466. Both issues are milestoned 4.x and were fixed on
`main`; `3.x` carries the same two defects in the same shape, so this is the companion pair, written
in 3.x idiom rather than cherry-picked.

## 1. The day boundary is the local day's own first instant (#3457, #3465)

`HolidayCalendar`, `AnnualCalendar`, `MonthlyCalendar` and `WeeklyCalendar` built the boundary they
walk as `new DateTimeOffset(local.Date, local.Offset)` — midnight at the offset the *queried instant*
happened to carry — and advanced it with `AddDays`, which keeps that offset. Both assume a local day
begins at midnight at the same offset the rest of the day carries, and a transition day is exactly the
day where that is not true.

- **America/Santiago**, where the clocks move at midnight: on the 23 hour day (2019-09-08) the method
  answered with the excluded instant it was asked about; on the 25 hour day (2019-04-06) it overshot
  by 23 hours.
- **A zone that moves its clocks later in the day** lands one date out rather than one hour: in
  Europe/Helsinki on 2024-03-31 the day begins at `+02:00` while every instant after 03:00 local
  carries `+03:00`, so a query from the afternoon built midnight at `+03:00` and landed on 2024-03-30.
- **A run of excluded days** that crosses a transition drifts by the transition delta, because
  `AddDays(1)` carries the old offset over it.

The boundary is now `TimeZoneUtil.StartOfLocalDay(DateTime date, TimeZoneInfo)` (internal, new), which
resolves local midnight through the existing `ResolveLocal` — a midnight that does not exist is paired
with the pre-gap offset, which puts the instant at the end of the gap; a midnight that happens twice
takes the first of the two — and each further day is reached by naming the next local *date* and
resolving that.

One consequence worth naming: `HolidayCalendar`'s loop no longer keeps `min(timeUtc + 1 day, dayStart)`.
That `//ensure earliest value is assigned to return value` step is what returned an instant inside a
25 hour excluded day, because `timeUtc + 24h` does not leave a day that is 25 hours long. On every
ordinary day the two are the same value.

`CronCalendar` does not have the shape. `DailyCalendar`'s day boundary was already right — it compares
its boundaries only with values carrying the same offset, which makes every comparison a wall-clock one
— and the `DailyCalendar_OnADayThatIsNot24HoursLong_ExcludesTheWallClockWindow` cases pin that.

## 2. A daily calendar's window is a local window (#3466, #3474)

`DailyCalendar.GetNextIncludedTimeUtc` named the window's edges on the date the *argument* fell on and
paired them with the offset the argument carried, and took `GetStartOfDay`/`GetEndOfDay` the same way,
while `IsTimeIncluded` converts into the calendar's zone first. Asked in UTC about a calendar keeping
another zone's hours the two disagreed, and neither direction was benign: the jump landed on a window
an offset away from the one being tested, so the loop arrived somewhere `IsTimeIncluded` still called
excluded and fell through to its last resort — a precision step at a time, bounded only by where the
wrong window happened to end, so it could step clean over an included stretch.

Measured on this branch with the parent commit's `DailyCalendar.cs` (the reproduction from #3466, an
inverted 21:00–22:00 `America/Santiago` calendar asked at `2019-04-07T01:30Z`):

| | before | after |
|---|---|---|
| answer | `2019-09-09T00:00:59.999Z` — five months late | `2019-04-08T01:00Z` |
| how it got there | a minute of wall clock at a time, an hour of them a day, until the zone's September transition made the UTC-shaped window and the local one coincide | two passes of the loop, both named from the window's own edges |

The whole daily-calendar half of the new fixture takes **1 m 52 s** against the unfixed
`DailyCalendar.cs` and milliseconds against this one; one case
(`SantiagoSpring 00:00-01:00` inverted) took 42 s on its own. On `main`, where the step is a
millisecond rather than a minute, the same reproduction took 2 m 17 s and ~558 million passes.

The argument is converted into `TimeZone` first, as `IsTimeIncluded` does, and the answer is *named*
rather than walked up to: within a stretch of unchanging offset the wall clock only enters the open
part of a day at an edge of it, so the edges of the local date the query lands in — and of the date
after it, once that one has no open time left — are the only instants worth asking about. The
candidates are the instant the day opens at (`TimeZoneUtil.FirstInstantAtOrAfterLocal`, new), the
second reading of that edge where the clock repeats it (`TimeZoneUtil.TryResolveSecondPass`, new), the
instant the clocks moved where a fall-back takes the clock back to *before* the window opened
(`TimeZoneUtil.TryGetAmbiguousWindow`, new — this is the case a naive fix misses), and the day's own
first instant from `StartOfLocalDay`. Each is checked against the calendar's own rule before it is
taken, so an edge the zone makes meaningless drops out on its own, and the earliest survivor is the
answer.

`IsTimeIncluded` keeps its wall-clock semantics exactly; its body moved into a private
`IsInsideTheOpenPartOfTheDay` so that the jump and the test are the same rule, asked once. A
millisecond step remains as the guard that keeps a base calendar answering with a time of its own
choosing from spinning the loop.

## Port notes

The two fixes are the same mechanism as on `main`; the differences are all 3.x's.

- **No `DateOnly`/`TimeOnly`.** `Quartz` here targets `netstandard2.0` and `net462` as well, and
  PolySharp does not backfill those types, so the local date is carried as a `DateTime` and
  `StartOfLocalDay` takes one (only its date part is used; it builds midnight with
  `DateTimeKind.Unspecified` itself, so a caller cannot hand it a `Utc`-kind value that would throw in
  `DateTimeOffset`'s constructor). `DailyCalendar` has no `TimeRange`, so the window's edges are named
  from the eight `rangeStarting*`/`rangeEnding*` fields through two new private helpers,
  `RangeStartOnLocalDate`/`RangeEndOnLocalDate`, where `main` says `date.ToDateTime(rangeStart)`.
- **`TimeZoneUtil`, not `TimeZones`.** It already had `ResolveLocal` and `WalkToGapEnd` (from #3198),
  so the port brings over the four helpers it lacked: `StartOfLocalDay` (from #3465) and
  `FirstInstantAtOrAfterLocal`, `TryResolveSecondPass`, `TryGetAmbiguousWindow` (from #3474). All four
  are `internal`; no public API baseline moved.
- **`main`'s `TimeOnly.OnDate`** pairs the wall clock with the *argument's* offset. The two public
  `GetTimeRange*TimeUtc` methods reproduce that by hand from `timeInZone.Offset`, which is the same
  value.
- **No `CalendarDstTests` fixture existed here**; the file is new and carries only the cases these two
  fixes are about. The #3455 corpus that surrounds them on `main` is not backported.
- **`TestTimeZones` gains `Europe/Helsinki`**, copied from `main`, since the transition-not-at-midnight
  cases need it. Every case states its transition premise with the existing `Assume` helpers, so a
  moved time zone database skips the case rather than failing it.

## Points a reviewer has to decide

**1. `precisionStepMillis` (#2285) is removed.** It was a 3.x-only performance hack — `main` never took
it and still says `OneMillis` — that coarsened every step of the walk to a minute, a second or a
millisecond depending on the precision the range was written with. With the walk replaced by a jump
there is nothing left for it to speed up, and while it was in the way it made the answer wrong in a
second sense. Measured on the parent commit and on this one, with the calendar in UTC so that no time
zone is involved at all:

| calendar, asked at `2024-06-15T21:59Z` | before | after |
|---|---|---|
| `06:00`–`22:00` | `22:01:00.000Z` | `22:00:00.001Z` |
| `06:00:30`–`22:00:30` | `22:00:31.000Z` | `22:00:30.001Z` |
| `06:00`–`22:00`, asked at `05:00Z` (already included) | `05:01:00.000Z` | `05:00:00.001Z` |

Keeping it would have meant a test grid asserting answers rounded up
by as much as a minute, and the "nothing between the question and the answer is included" property
could not have been asserted at all. This is behaviour a 3.x caller of `GetNextIncludedTimeUtc` can
see: answers are now exact rather than up to a minute late, and asking about an instant the calendar
already includes gives back the next millisecond rather than the next minute. The perf test that came
with #2285, `NestedCalendarTests`, is unchanged and passes.

**2. `GetTimeRangeStartingTimeUtc`/`GetTimeRangeEndingTimeUtc` now convert their argument into the
zone.** These are public and carried the same offset assumption in public: asked in UTC about a
Santiago calendar they answered about the UTC date at `+00:00`, which no caller can use. They now read
the date of the *local* day the instant falls in. The value stays a wall-clock comparand — the edge
paired with the offset the given instant carries — because that is what makes it comparable with the
instant it came from and what `IsTimeIncluded` needs. For the call `IsTimeIncluded` makes, and for a
calendar left on the default `TimeZoneInfo.Local` asked with a local value (which is what
`DailyCalendarTest.TestStartEndTimes` does), the conversion is a no-op. No signature changed.

**3. One millisecond of imprecision survives, deliberately.** `WalkToGapEnd` and `TryGetAmbiguousWindow`
locate a transition by scanning a minute at a time. Windows zone data cannot express a rule at local
midnight and writes 23:59:59.999 of the day before instead, so Santiago's spring-forward gap ends a
millisecond earlier there than IANA data says; an answer that *is* a transition instant is therefore a
millisecond late on Windows and exact on Linux. The test helpers say so in a `slack` variable, and
`StartOfLocalDay_IsTheDaysOwnFirstInstant` steps back a minute rather than a millisecond for the same
reason.

**4. `AnnualCalendarTest.TestExclusionAndNextIncludedTime`** uses `DateTimeOffset.UtcNow.Date` and
asserts `test.AddDays(1)`. It is unchanged and passes, but on a machine whose local zone has a
transition that night the expected value it computes is now the wrong one — the true next midnight is
what the calendar answers. Left alone (CI runs in UTC), noted in case it ever flakes.

## Tests

`src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs` is new: 45 cases across Santiago, Helsinki,
America/New_York and Asia/Amman.

- `HolidayCalendar_NextIncludedTime_OnATransitionDay` (8), `_OnAnOrdinaryDay` (3, the controls),
  `_WalkingAcrossATransition` (4), and one transition-day case each for the annual, monthly and weekly
  calendars. **12 of the 21 fail on the parent commit** and pass here.
- `DailyCalendar_NextIncludedTime_IsTheFirstInstantTheWindowLetsGoOf` (12, inverted and not, inside the
  window and outside it, an edge in the gap, an edge in the repeated hour on both of its passes, a
  window running to the end of a 23- and of a 25-hour local day, and two ordinary-day controls),
  `_WhenTheDayIsAlreadyOpen_IsTheNextMillisecond` (3), and
  `_IsJumpedToRatherThanWalkedUpTo` (the no-crawl case: a counting base calendar bounds the passes at
  under 10, and a `Stopwatch` bounds the wall time at 5 s). **14 of the 24 daily cases fail on the
  parent commit**, and that run takes 1 m 52 s where the fixed one takes milliseconds.
- Every `GetNextIncludedTimeUtc` case goes through a helper that holds the whole contract: the instant
  asked about is excluded, the answer is included, nothing between the two is (walked a second at a
  time), and — for the daily cases — the same instant asked about in the calendar's own zone rather
  than in UTC gives the same answer back.

`TimeZoneUtilTest` covers the four new helpers directly, including the case that says why the gap is
walked from the whole minute.

## Release notes

Two entries for the next 3.x release:

- Calendars that exclude whole days (`HolidayCalendar`, `AnnualCalendar`, `MonthlyCalendar`,
  `WeeklyCalendar`) built their day boundary at the queried instant's offset, so on a day whose clocks
  move `GetNextIncludedTimeUtc` answered with an instant the calendar itself excludes, or with one up
  to a day out (#3457).
- `DailyCalendar.GetNextIncludedTimeUtc` computed its window in the offset the argument carried rather
  than in the calendar's own time zone, so a question asked in UTC about a calendar keeping another
  zone's hours could spin for minutes and answer months out of place; the answer is now jumped to
  rather than walked up to (#3466).

## Verification

```
dotnet build Quartz.slnx                          Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit  (net10.0)      Passed! Failed: 0, Passed: 1843, Skipped: 4, Total: 1847
dotnet test src/Quartz.Tests.Unit  (net472)       Passed! Failed: 0, Passed: 1832, Skipped: 5, Total: 1837
dotnet test src/Quartz.Tests.AspNetCore (net8.0)  Passed! Failed: 0, Passed:  122, Skipped: 0, Total:  122
Quartz.Tests.Integration, 'basic' leg  (net10.0)  Passed! Failed: 0, Passed:   25, Skipped: 0, Total:   25
Quartz.Tests.Integration, 'sqlite' leg (net10.0)  Passed! Failed: 0, Passed:   15, Skipped: 0, Total:   15
```

The library builds clean on all six target frameworks (`net462`, `net472`, `net8.0`, `net9.0`,
`net10.0`, `netstandard2.0`); the unit tests run on both of theirs. Docker was available, so the sqlite
integration leg — which exercises `DailyCalendar` through `SmokeTestPerformer` against a persistent
job store — was run as well.

Each commit builds and passes the full unit suite on its own.
