### PR TITLE
Operating a cluster is written down

### DIFF
--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -125,6 +125,7 @@ export const sidebarEn: SidebarConfig = [
           "/documentation/quartz-4.x/multi-tenancy",
           "/documentation/faq",
           "/documentation/best-practices",
+          "/documentation/quartz-4.x/operations",
           "/documentation/tenancy-patterns",
           "/documentation/quartz-4.x/db/",
           "/documentation/database/schema-changes",

--- a/docs/documentation/database/schema-changes.md
+++ b/docs/documentation/database/schema-changes.md
@@ -53,9 +53,12 @@ Quartz.NET 3.x probes for `MISFIRE_ORIG_FIRE_TIME`, `EXECUTION_GROUP`, `PREFERRE
 turns the corresponding feature off — which is why those migrations are optional on 3.x.
 
 **4.x removed those probes** and assumes all four columns exist. It also adds a table 3.x never
-had, `QRTZ_PAUSED_JOB_GRPS`, and validates its whole schema at startup. So even a 3.x database
-that took every optional migration going will not work against 4.x until [4.0](#version-4-0) has
-been applied.
+had, `QRTZ_PAUSED_JOB_GRPS`, and checks at startup that every table it needs is queryable — so a
+database missing that table is refused there and then. So even a 3.x database that took every
+optional migration going will not work against 4.x until [4.0](#version-4-0) has been applied.
+
+The startup check is table-level, not column-level: a database that gained the table but none of
+the columns starts and then fails on the first statement that names one. Run the whole script.
 
 ---
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4470,7 +4470,10 @@ internal class's XML comment.
 **Nothing changes in the database.** The columns still hold the same strings; the conversion happens at the
 delegate boundary, and `AdoConstants.State*` stays public because the strings are the schema contract
 (the string mapping, `StoredTriggerStates`, stays in `Quartz.Impl.AdoJobStore` with them). A 4.0
-scheduler reads and writes rows a 3.x one wrote, and the two can share a cluster.
+scheduler reads and writes rows a 3.x one wrote, so the two can share a cluster for the length of a
+rolling upgrade — under conditions that are about calendars and execution limits rather than trigger
+states, and that
+[Operating a Cluster](operations.md#a-mixed-3-x-and-4-0-window) sets out.
 
 | `AdoConstants` constant | Stored value | `StoredTriggerState` member |
 |---|---|---|

--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -1,0 +1,701 @@
+---
+title: 'Operating a Cluster'
+---
+
+# Operating a Cluster
+
+The rest of the documentation says how to build a scheduler. This page is about running one that is
+already built: upgrading it without stopping it, giving each node a name that survives a restart,
+reading what the tables are telling you, and knowing what a restore of the database means for work
+that was in flight when the backup was taken.
+
+It is 4.x, and it assumes a clustered ADO.NET store. [Clustering](tutorial/advanced-enterprise-features.md)
+covers what a cluster is and how to configure one; [Best Practices](../best-practices.md) covers the
+decisions that shape a schedule. Everything here has been checked against the code in this repository,
+and where that code disagrees with received wisdom the sentence says so.
+
+## Rolling a new version through a cluster
+
+### Schema first, then nodes
+
+Quartz.NET never creates or migrates its own schema. A deployment therefore has two steps in a fixed
+order, and the order is not negotiable in either direction:
+
+1. **Apply the migration**, from [`database/migrations/`](https://github.com/quartznet/quartznet/tree/main/database/migrations),
+   every folder between the version the database is at and the version you are going to, in ascending
+   order.
+2. **Replace the nodes**, one at a time.
+
+The migrations are written to make that safe. Every statement checks before it acts, so a script is a
+no-op the second time and a partially-applied script is safe to re-run — the one exception being
+SQLite's `ADD COLUMN`, which has no conditional DDL. What they do is additive: columns and tables are
+added, never dropped or narrowed, so a node still running the old version keeps working against the
+migrated schema. Indexes are the one thing a migration does remove, and the next section says what that
+costs. That is the [expand phase of parallel change](https://martinfowler.com/bliki/ParallelChange.html)
+applied to a scheduler, and it is why the schema goes first: an old node tolerates a new schema, while
+a new node does not tolerate an old one.
+
+A node that meets a schema it cannot use refuses to start rather than misbehaving, which is what you
+want: the store issues a `SELECT 1` against every table it needs and fails with
+`SchedulerException: Database schema validation failed` if one is missing. Know its limit, though — it
+checks *tables*, not columns, so a database that is missing only a column gets past startup and fails on
+the first statement that names it. `JobStore:PerformSchemaValidation` turns the check off; there is no
+good reason to.
+
+::: warning
+The fresh-install scripts in [`database/tables/`](https://github.com/quartznet/quartznet/tree/main/database/tables)
+are not migrations. **Each one drops the existing Quartz schema before recreating it**, and the switch
+that governs the drops — `@DropDb` on SQL Server and MySQL, `DropDb` elsewhere, declared at the top of
+the file — defaults to **1**, meaning drop. Set it to `0` to get creation only, and on SQLite, which
+has no variables, delete the block between the `BEGIN DROP TABLES` and `END DROP TABLES` markers.
+:::
+
+### Replacing the nodes
+
+Once the schema is ahead of every node, replace the nodes one at a time. Three things happen as each
+one goes down and comes back that are worth knowing about in advance.
+
+**A clean shutdown gives its reservations back.** When the scheduling loop halts, every trigger it had
+acquired but not yet fired is released to `WAITING`, so another node picks it up on its next pass
+rather than waiting for the failure detector. A process that is killed rather than stopped does not do
+this, and its reservations wait for the check-in machinery below.
+
+**A clean shutdown does not delete the node's check-in row.** Nothing removes a `QRTZ_SCHEDULER_STATE`
+row on the way down; the row stays, with the timestamp the node last wrote, until a peer notices it has
+gone quiet and recovers it. So a node that stops is declared *failed* about fifteen seconds later on
+the default settings, exactly as if it had crashed — and if it was running jobs that request recovery,
+those jobs are scheduled again on another node. That is correct behaviour for a crash and
+indistinguishable from one here, which is the argument for
+[`WaitForJobsToComplete`](../best-practices.md#shutdown-has-a-deadline): a node that finishes its work
+before it exits has nothing left to recover.
+
+**A node that generates its instance id comes back as a different node.** `GenerateInstanceId` derives
+the id from the host name and a timestamp, so a restart produces a new one. The old id's check-in row
+and any fired-trigger rows it left behind are cleaned up by whichever node next notices them, and the
+new id starts clean. This is fine and is the default for a reason — but it means a node's identity in
+the dashboard, in the `INSTANCE_NAME` of every fired-trigger row, and in a `PREFERRED_NODE` pin does not
+survive the deployment. The next section is about when that matters.
+
+### A mixed 3.x and 4.0 window
+
+Upgrading a cluster from 3.x to 4.0 means the
+[mandatory 4.0 migration](../database/schema-changes.md#version-4-0) and then replacing nodes — so for
+however long the rollout takes, a 3.x node and a 4.0 node are running against one set of tables. Here is
+what has been checked against both branches' code, and what has not.
+
+**A 3.x node keeps working against the migrated schema.** The migration adds columns and one table and
+takes nothing away except optional indexes. 3.x's `INSERT` statements name their columns explicitly, so
+the new `PREFERRED_NODE_AUTO NOT NULL DEFAULT 0` takes its default rather than failing. And 3.x probes
+for `MISFIRE_ORIG_FIRE_TIME`, `EXECUTION_GROUP`, `PREFERRED_NODE` and `PREFERRED_NODE_AUTO` at startup:
+finding them present, it turns those features on, which is the state a fully-migrated 3.x database is in
+anyway.
+
+**The vocabularies the two versions read and write are identical.** The stored trigger states
+(`WAITING`, `ACQUIRED`, `EXECUTING`, `COMPLETE`, `BLOCKED`, `PAUSED`, `PAUSED_BLOCKED`, `ERROR`,
+`DELETED`), the pause-all marker, the trigger-type discriminators (`SIMPLE`, `CRON`, `CAL_INT`,
+`DAILY_I`, `RECUR`, `BLOB` — `RECUR` since 3.18), the lock names and the check-in row's columns are the
+same constants on both branches, and job data serializes to the same JSON. The failure predicate is the
+same code, so the two versions judge and recover each other by it; the acquisition compare-and-swap is
+the same statement, so neither takes a trigger the other has; the stale-acquired sweep is scoped to the
+sweeping node's own rows on both, so neither disturbs the other's reservations; and node-affinity pins
+are stored identically.
+
+So the core of scheduling holds across the window: neither version fires a trigger the other has taken,
+neither loses one, and neither refuses to start because of the other. What does not hold is a short list,
+and it is specific enough to plan around.
+
+**Do not let a 4.0 node write a calendar during the window.** This is the one break that will cost you
+firings rather than accuracy. 4.0 changed how three calendars are serialized: `WeeklyCalendar` and
+`MonthlyCalendar` write day names and day numbers where 3.x wrote a positional array of booleans, and
+`DailyCalendar` writes `RangeStart`/`RangeEnd` where 3.x wrote `RangeStartingTime`/`RangeEndingTime`.
+The compatibility is deliberately **one-way**: 4.0's readers accept either shape, and 3.x's readers accept
+only their own, so a calendar a 4.0 node stores is one a 3.x node throws on every time it reads it. And
+it does read it every time — a clustered store bypasses its calendar cache by design, so the failure is
+per firing rather than once. Existing rows are untouched and safe; it is `AddCalendar` from a 4.0 node
+that does the damage. Route calendar changes through the 3.x nodes until the last one is retired.
+
+**Both versions have to be on JSON, and on the same serializer.** 4.0 refuses `quartz.serializer.type
+= binary` at startup, so a cluster whose 3.x nodes wrote binary job data has no window at all — that is
+a migration to do before the rollout, not during it.
+
+**Defer section 5 of the migration until the last 3.x node is gone.** Sections 1 to 4 are the required
+ones; section 5 realigns the index set, and it *drops seven indexes that the 3.20 migration created for
+3.x* — `IDX_QRTZ_T_G_J`, `IDX_QRTZ_T_N_STATE`, `IDX_QRTZ_T_N_G_STATE`, `IDX_QRTZ_T_NEXT_FIRE_TIME`,
+`IDX_QRTZ_T_NFT_ST_MISFIRE_GRP`, `IDX_QRTZ_FT_G_J` and `IDX_QRTZ_FT_G_T`. Its replacements have the
+leading columns 4.x's queries want, not 3.x's; one of them, `IDX_QRTZ_T_NFT_ST_MISFIRE_GRP`, serves a
+3.x statement that has no 4.x counterpart at all. Nothing breaks, but a 3.x node scans where it used to
+seek, which on a large schedule is the difference between a misfire sweep that finishes and one that
+times out. The script is guarded and re-runnable, so running sections 1 to 4 now and the whole file
+again afterwards costs nothing.
+
+**Treat cluster-scoped execution limits as unavailable during the window, not merely approximate.**
+`ExecutionLimitScope.Cluster` is 4.x only, and a 4.0 node enforces it by counting `QRTZ_FIRED_TRIGGERS`
+grouped by `EXECUTION_GROUP`. 3.x never writes that column on a fired trigger — its own insert has a
+fixed column list that omits it — so every firing a 3.x node owns is counted as *ungrouped*. The effect
+is worse than under-counting: the limited group's ceiling misses the 3.x work entirely, and the
+ungrouped bucket is charged for it, so a group you did not limit can be throttled by work that belongs
+to one you did. Per-node limits are unaffected, because they never crossed nodes.
+[Job-type exclusions](how-tos/custom-job-store.md#excluding-job-types-from-acquisition) are 4.x-only in
+the same way, and are per-node by construction: a 3.x node will happily run a job type the 4.0 nodes
+were told to refuse.
+
+**Paused job groups are recorded by 4.0 nodes only.** `QRTZ_PAUSED_JOB_GRPS` is new in 4.x and 3.x has
+no code that touches it. What actually fires is decided by trigger state, which both versions agree
+about, so pausing a job group works in the window whichever node does it — but the *record* drifts, in
+both directions. A group paused by a 3.x node is not recorded, so `JobGroup.Paused` on a 4.0 node says
+`false` for a group whose every trigger is paused. A group paused by a 4.0 node and then resumed — or
+cleared — by a 3.x node leaves its row behind, so the 4.0 node goes on calling a group paused whose
+triggers are running, and goes on doing so indefinitely. Pause and resume from the same version, and
+reconcile the table when the rollout is done.
+
+**What has not been established.** Nothing in this repository tests two versions against one schema, and
+no release is validated for it; the findings above come from reading both branches, not from running
+them together. Java Quartz's documentation says nothing about version mixing either, so there is no
+upstream position to appeal to.
+
+The honest shape of the advice, then: the window is **workable under those conditions** and it is not a
+supported steady state. Keep it as short as the rollout needs. Hangfire, which does support this
+explicitly, is worth the comparison — it states that "1.6.X/1.7.X and 1.8.0 servers can co-exist in the
+same environment just fine, thanks to forward compatibility", and gates its risky migrations behind an
+`EnableHeavyMigrations` switch so the operator picks the moment. Quartz.NET makes no such promise, and
+the list above is what it offers instead.
+
+Rolling back is available for the same reason the window works: the migration is additive, so a 3.x node
+starts against the 4.0 schema without anything being undone. Only section 5's index drops would need
+putting back, by re-running [`migrations/3.20`](https://github.com/quartznet/quartznet/tree/main/database/migrations/3.20) —
+and any calendar a 4.0 node wrote would need rewriting from a 3.x one.
+
+## Naming a node in a container
+
+### What the default gives you, and what it does not
+
+`InstanceId` defaults to the literal string `NON_CLUSTERED`, and the instance id is how a node
+recognises its own check-in row and its own firings. Two nodes that share one are not two members of a
+cluster; they are one member as far as every query is concerned, each one treating the other's rows as
+its own. Nothing in Quartz.NET detects this — there is no validation that a clustered scheduler's id is
+unique, because no node can see what the others were configured with.
+
+So a clustered scheduler has to be told to derive one:
+
+```csharp
+q.ConfigureScheduler(options =>
+{
+    options.InstanceName = "orders";
+    options.GenerateInstanceId = true;
+});
+```
+
+`GenerateInstanceId` runs the registered `IInstanceIdGenerator`, which by default is the host name
+followed by a high-resolution timestamp. The flat key that means the same thing is
+`quartz.scheduler.instanceId = AUTO`. Only a clustered store calls the generator at all: a store with
+clustering switched off has nothing to distinguish itself from, so the id stays `NON_CLUSTERED`
+whatever the setting says.
+
+That default is **unique but not stable**. The timestamp makes a collision essentially impossible even
+between two containers reporting the same host name — but every restart is a new identity. Three
+things want a stable one:
+
+- **[Node affinity](tutorial/node-affinity.md)**, which pins a trigger to an instance id. A pin to an
+  id that no longer exists is a pin to nobody.
+- **Correlating a node across a deployment** — in the dashboard's Cluster page, in
+  `FireInstance.SchedulerInstanceId`, in the `quartz.scheduler.id` attribute on every span and log
+  scope.
+- **Reading the check-in table by hand** and expecting yesterday's rows to name the same machines.
+
+### Taking the id from the pod
+
+The pattern that gives a stable identity in Kubernetes is a **StatefulSet** plus the **Downward API**.
+A StatefulSet names its pods `$(statefulset name)-$(ordinal)`, and the docs are explicit that this
+"identity sticks to the Pod, regardless of which node it's (re)scheduled on". Inject that name and use
+it as the instance id:
+
+```yaml
+env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+```
+
+<!-- snippet: sample_operations_instance_id_from_pod_name -->
+```csharp
+// POD_NAME comes from the Downward API: fieldRef fieldPath: metadata.name. On a StatefulSet
+// that is "<set>-<ordinal>", which the same replica gets back after a restart.
+string? podName = Environment.GetEnvironmentVariable("POD_NAME");
+
+services.AddQuartz(q =>
+{
+    q.ConfigureScheduler(options =>
+    {
+        options.InstanceName = "orders";
+
+        if (podName is { Length: > 0 })
+        {
+            options.InstanceId = podName;
+        }
+        else
+        {
+            // Nothing injected the pod name — a developer's machine, or a manifest that has
+            // not been updated. Fall back to a generated id, which is unique but not stable.
+            options.GenerateInstanceId = true;
+        }
+    });
+
+    q.UsePersistentStore(store =>
+    {
+        store.UseSqlServer(connectionString);
+        store.UseSystemTextJsonSerializer();
+        store.UseClustering();
+    });
+});
+```
+<!-- endSnippet -->
+
+The fallback matters as much as the assignment: a manifest that has not been updated, or a developer
+running the same image locally, should not silently give every replica the id `NON_CLUSTERED`.
+
+`metadata.uid` is the wrong field to use instead. Kubernetes documents UIDs as existing "to
+distinguish between historical occurrences of similar entities" — a pod recreated under the same name
+gets a new one, which is precisely the churn the pod name avoids.
+
+There is also a generator that reads the id from the environment directly, selected with the flat value
+`quartz.scheduler.instanceId = SYS_PROP`; it reads the environment variable named
+`quartz.scheduler.instanceId`, or another one if
+`quartz.scheduler.instanceIdGenerator.systemPropertyName` names it. It exists for configuration files
+carried over from 3.x. In 4.x, reading the variable in code and assigning `InstanceId` says the same
+thing in one fewer indirection, and lets you write the fallback.
+
+### When two pods report the same host name
+
+The genuinely dangerous configuration is one where the host name is not unique *and* the id is derived
+from the host name alone. On a Deployment, pod names — and therefore host names — carry a random
+suffix, so they are unique per pod but change on every restart. The cases where two pods really do
+report the same name are `hostNetwork: true`, where every pod on a node reports the node's own host
+name, and a manifest that sets `spec.hostname` to a literal rather than templating it.
+
+Quartz.NET's default generator survives both, because of the timestamp. What does not survive is a
+configuration that names the host-name-only generator through
+`quartz.scheduler.instanceIdGenerator.type` — that one returns the host name unchanged, by design, for
+the case where "your scheduler instance will be the only one running on a particular machine". Under
+`hostNetwork` it is not.
+
+The failure that follows is the one Kubernetes describes for its own StatefulSets, and the wording
+transfers: "Having multiple members with the same identity can be disastrous". Concretely, in a Quartz
+cluster: each node treats the other's fired-trigger rows as its own, so a node's first check-in after a
+restart recovers firings that another node is still executing, and
+`[DisallowConcurrentExecution]` stops holding for exactly the jobs that were running.
+
+The rule the neighbours state the same way is worth repeating for its unanimity. Hangfire derives a
+server id from the machine name and process id and says that "since the defaults values provide
+uniqueness only on a process level, you should handle it manually" beyond that. Kafka: "Every node in a
+KRaft cluster must have a unique `node.id`". Orleans' Kubernetes hosting "sets `SiloOptions.SiloName` to
+the pod name" and requires that "silo names must match pod names". Elasticsearch's Kubernetes operator
+does the same thing implicitly — "Elasticsearch nodes have the same name as the Pod they are running
+on". Every one of them ends up at the pod name.
+
+## Check-in, node states and failover
+
+### What a check-in is
+
+Each node writes a row to `QRTZ_SCHEDULER_STATE` and updates its timestamp every `CheckinInterval` —
+7.5 seconds by default. That write is the whole of what a node claims about itself. There is no
+heartbeat between nodes, no leader, and no election: every judgement one node makes about another is
+that node reading a timestamp somebody else wrote and comparing it against its own clock.
+
+The first check-in happens during `Start()`, before the scheduler begins firing, and it is the one that
+does the most work: a node's first check-in also treats *its own* previous row as a failed instance, so
+whatever it left behind on its last run is recovered then. Subsequent check-ins take the cheap path —
+update the timestamp, look for failed peers, and take the cluster-wide locks only if there are any.
+
+Two details of that row are worth knowing because they are not what most people assume:
+
+- **The stored check-in interval is written once.** `CHECKIN_INTERVAL` is set when the row is inserted
+  and never updated afterwards — only `LAST_CHECKIN_TIME` is. A node with a stable instance id that
+  changes its `CheckinInterval` keeps advertising the old value to its peers until its row is deleted
+  and recreated, which happens after a recovery rather than at a restart. If you widen the interval
+  across a cluster, expect the change to take effect for the peers' arithmetic only after each node has
+  been declared failed once, or delete the rows while the cluster is stopped.
+- **Check-in failures are logged sparsely.** The cluster manager logs one line for every
+  `RetryableActionErrorLogThreshold` consecutive failures, which defaults to **4**. A database that is
+  down produces a quarter of the log lines you would expect.
+
+### When a peer takes over
+
+A node decides a peer has failed when this is true, all times read from the deciding node's own clock:
+
+> the peer's last check-in timestamp, plus the longer of *the peer's own stored check-in interval* and
+> *the time since this node last checked in*, plus this node's check-in misfire threshold, is in the
+> past.
+
+On the defaults — both intervals 7.5 seconds — that is about fifteen seconds after the last timestamp
+the peer wrote, of which only half is slack, since the peer writes one every 7.5 seconds.
+
+The middle term is the part that is usually left out of the summary, and it is a deliberate piece of
+self-protection: an observer that has itself been away from its check-in loop for a minute grants every
+peer a minute of slack. So a database outage that stops the whole cluster checking in does not end with
+the first node back declaring all the others dead.
+
+Everything else about it is the standard caution about failure detectors, and
+[Clocks in a cluster](../best-practices.md#clocks-in-a-cluster) has it: fifteen seconds is shorter than
+a long garbage-collection pause, shorter than the thirty seconds Azure documents for
+memory-preserving maintenance, and comfortably shorter than the clock skew of a machine with no
+time-synchronisation service. Raise `CheckinMisfireThreshold` past your environment's worst *pause*,
+not its worst clock error.
+
+What a takeover does is release the failed node's acquired triggers, schedule recovery triggers for the
+jobs of its interrupted executions that asked for recovery, delete the rest of its fired-trigger rows,
+release any node-affinity pins it claimed automatically, and delete its check-in row.
+
+One case is deliberately slower: recovering a `[DisallowConcurrentExecution]` job is held back on first
+detection, because a node that has missed a check-in may still be running it. While anything is held
+back, the failed node's check-in row is left in place with its stale timestamp — so it goes on being
+reported `Failed` rather than disappearing, which is the store keeping the node visible until it is
+finished with it.
+
+### Reading the cluster
+
+`IScheduler.QueryClusterNodes()` lists the nodes with a verdict on each, decided by the same predicate
+the recovery sweep applies — so the listing and the sweep cannot disagree:
+
+| State | Means |
+|---|---|
+| `Alive` | Checked in within its own check-in interval. |
+| `Overdue` | Has missed a check-in. Normal under load; nothing is recovered from an overdue node. |
+| `Failed` | Past the boundary above. The next check-in pass by any node takes its work over and deletes its row, after which it stops being listed. |
+
+A `Failed` node is therefore reported for a short while and then vanishes, which is what a healthy
+failover looks like from the outside. A node that stays `Failed` across several minutes of polling is
+one nobody is sweeping — check that at least one other node is running and that its cluster manager is
+not stuck on the database.
+
+The same listing is `GET {ApiPath}/schedulers/{name}/nodes` in the
+[HTTP API](packages/http-api.md#cluster-nodes) and the Cluster page of the
+[dashboard](packages/dashboard.md), which puts the `Acquired` and `Executing` counts for each node
+beside its state. `GET {ApiPath}/schedulers` is the other half of the picture: it lists every scheduler
+the process knows about, including registrations nothing has built yet, so a scheduler that never
+started is distinguishable from one that does not exist.
+
+## What the tables are telling you
+
+### Fired triggers: backlog or leak
+
+`QRTZ_FIRED_TRIGGERS` is the cluster's account of what is happening right now. A row is written when a
+trigger is **acquired**, updated when the trigger actually **fires**, and deleted when the firing
+completes. So the healthy steady state is a table whose row count tracks concurrency and whose oldest
+row is no older than your longest-running job.
+
+Growth is one of two things, and the difference is the age distribution rather than the count:
+
+- **A backlog** is many rows, all young, spread across the nodes that are alive. The cluster is running
+  as much as it can and more work is arriving than it finishes. The fix is capacity or a smaller
+  schedule, not a database operation.
+- **A leak** is rows that do not age out. Look at what they say about themselves: an old row in
+  `EXECUTING` state means a job that never returned — a synchronous call that hangs, an unawaited task
+  — and the node is genuinely still holding it. An old row in `ACQUIRED` state means a node reserved a
+  trigger and never fired it, which is [the stale-acquired case](../troubleshooting.md#triggers-stuck-in-acquired-state)
+  and is swept automatically. A row belonging to an instance id the cluster no longer lists is the real
+  orphan, and orphans are only swept when a node performs its *first* check-in — so a cluster that has
+  been up for months has never looked for them.
+
+`IScheduler.QueryFireInstances` answers all of that without SQL, and joins to the node listing on the
+instance id:
+
+<!-- snippet: sample_operations_stale_firings -->
+```csharp
+List<ClusterNode> nodes = await scheduler.QueryClusterNodes();
+HashSet<string> known = nodes.Select(node => node.InstanceId).ToHashSet(StringComparer.Ordinal);
+
+// State = null lists reservations as well as executions; the default lists executions only.
+PagedResult<FireInstance> firings = await scheduler.QueryFireInstances(new FireInstanceQuery
+{
+    State = null,
+    Take = 500
+});
+
+DateTimeOffset cutoff = timeProvider.GetUtcNow().AddHours(-1);
+
+foreach (FireInstance firing in firings.Items)
+{
+    // A row whose node is no longer listed is a leak: no peer will recognise it as its own,
+    // and only a node's first check-in sweeps firings with no scheduler-state row behind them.
+    if (!known.Contains(firing.SchedulerInstanceId))
+    {
+        logger.LogWarning(
+            "Firing {FireInstanceId} of {Trigger} belongs to {Node}, which the cluster no longer lists.",
+            firing.FireInstanceId, firing.TriggerKey, firing.SchedulerInstanceId);
+    }
+    else if (firing.FireTimeUtc < cutoff)
+    {
+        logger.LogWarning(
+            "Firing {FireInstanceId} of {Trigger} has been {State} on {Node} since {FireTime}.",
+            firing.FireInstanceId, firing.TriggerKey, firing.State, firing.SchedulerInstanceId,
+            firing.FireTimeUtc);
+    }
+}
+```
+<!-- endSnippet -->
+
+To clear a stale `EXECUTING` row that belongs to a node that is still alive, restart that node: its
+first check-in recovers its own leftovers. Nothing else sweeps a live node's rows, by design — the node
+is the authority on what it is running.
+
+### Nothing is firing
+
+When the table is empty and jobs are not running, the question is a different one. Work the store is
+deliberately holding back does not appear in `QRTZ_FIRED_TRIGGERS` at all, because it was never
+acquired. The three usual reasons, in the order they are worth checking:
+
+- **The scheduler is in standby.** `IScheduler.Status` says so, and the health check reports it as
+  *degraded* rather than unhealthy — which, as [the Aspire how-to](how-tos/aspire.md) explains, does not
+  survive an HTTP probe, because ASP.NET Core maps degraded to 200.
+- **A group is paused.** Pausing is durable and survives restarts. `QRTZ_PAUSED_TRIGGER_GRPS` holds
+  paused *trigger* groups, and it is the one that changes what happens next: a trigger stored into a
+  paused trigger group is stored `PAUSED`. `QRTZ_PAUSED_JOB_GRPS` is new in 4.x and holds paused *job*
+  groups, which is what makes `JobGroup.Paused` and `GET …/jobs/groups?paused=true` answer truthfully
+  and survive a restart — 3.x pauses a job group by pausing the triggers of the jobs in it at that
+  moment and recording nothing. Note that neither table pauses a *later* arrival into a paused job
+  group: pausing a job group pauses the triggers of the jobs that were in it, and a job added
+  afterwards fires. A group paused during an incident and never resumed is a common and entirely silent
+  cause of "nothing runs"; in the dashboard both listings carry the flag.
+- **Every trigger is blocked or in error.** `BLOCKED` means another firing of the same
+  `[DisallowConcurrentExecution]` job is running — see the leak above. `ERROR` means the job could not
+  be *built*, which is a composition-root failure rather than an execution failure and is fixed in the
+  application, then cleared with `ResetTriggerFromErrorState`.
+  [What the trigger states mean](../best-practices.md#what-the-trigger-states-mean) has the full table.
+
+There is a fourth reason, and it is the nastiest because everything reports healthy: **the node is
+reading the wrong tables.** A mistyped `JobStore:TablePrefix` connects to the right database, finds its
+own empty table set, passes schema validation because those tables exist, starts, answers healthy and
+fires nothing ever again. 4.x notices one shape of this — two schedulers in one container that share a
+database and disagree about the prefix — and logs a warning naming both, which it does rather than
+failing because separate table sets are a legitimate arrangement. It cannot notice the single-scheduler
+case at all. If a scheduler is silent and every other explanation has been ruled out, count the rows in
+the tables it is actually pointed at.
+
+## Backup and restore
+
+Back up the Quartz tables with the rest of the application's database, on the same schedule, and expect
+the same recovery point. Nothing about Quartz needs special backup treatment. What needs thought is the
+*restore*, because the Quartz tables are not only data — they are a distributed system's account of
+what is running.
+
+**Stop every node before restoring, and start them afterwards.** This is the rule every system with a
+shared coordination store states. Kubernetes puts it most plainly for etcd: "If any API servers are
+running in your cluster, you should not attempt to restore instances of etcd. Instead… stop *all* API
+server instances, restore state in all etcd instances, restart all API server instances." The hazard
+etcd's own documentation names is exactly the one here — a live process whose view of the store is
+suddenly older than its own memory of it. Airflow's guidance is milder but the same shape: back up the
+metadata database before any operation that modifies it, and "consider disabling the Airflow cluster
+while you perform such maintenance".
+
+**A point-in-time restore does not restore the work, only the record of it.** Both major engines
+document the semantics without hedging: SQL Server recovers to "the latest transaction commit that
+occurred at or before" the stop time, and PostgreSQL's own worked example is restoring to a minute
+before a mistake and losing everything after it. For a scheduler that means:
+
+- Triggers fire again from where the backup thought they were. A nightly job whose `PREV_FIRE_TIME` has
+  been rolled back will run that night again; jobs written to be
+  [idempotent](../best-practices.md#assume-the-job-will-run-more-than-once) do not care, and jobs that
+  are not, do.
+- Fired-trigger rows come back for firings that have already finished. Until they are swept, the
+  cluster believes those jobs are running, and `[DisallowConcurrentExecution]` holds their job keys.
+  Starting the nodes after the restore is what clears them: each node's first check-in recovers its own
+  rows, and rows belonging to instance ids that are gone are swept as orphans on the same pass.
+- Anything scheduled after the recovery point is gone, including one-off triggers an application
+  created in response to something. If those matter, they have to be re-derivable from whatever created
+  them.
+
+**Prefer redeploying the schedule to restoring it.** The definitions — jobs, triggers, calendars — are
+the part of the store that a deployment can put back. `AddJob` and `AddTrigger` in `AddQuartz`, or a
+scheduling data file, mean the schedule is described in source control and re-applied on every start;
+`SchedulingOptions.OverwriteExistingData` is on by default, so a start after a restore reconciles the
+definitions back to what the code says. That leaves the backup responsible only for runtime state,
+which is the part nobody can reconstruct anyway. This is the split Airflow makes structurally — DAGs
+are Python files under version control and the metadata database holds only runs — and the reason its
+restore guidance never mentions restoring workflow definitions.
+
+Two things a restore does not need: the `QRTZ_LOCKS` rows are written by the lock handler when they are
+missing, so a restore that loses them costs nothing, and Quartz keeps no state outside the database —
+there is no node-local file to restore alongside it.
+
+## Timeouts and transient failures
+
+### CommandTimeout
+
+`JobStore:CommandTimeout` bounds every statement the store issues, including the ones the lock handler
+takes its row lock with. Left unset, each statement gets whatever the ADO.NET provider gives a new
+command — usually 30 seconds. There is deliberately no per-statement override: every statement runs
+inside a lock the rest of the cluster is waiting on, so none of the store's work is more expendable
+than the rest.
+
+<!-- snippet: sample_operations_store_timeouts -->
+```csharp
+q.UsePersistentStore(store =>
+{
+    store.UseSqlServer(connectionString);
+    store.UseSystemTextJsonSerializer();
+    store.UseClustering();
+
+    store.Configure(options =>
+    {
+        // Every statement the store issues, the lock handler's included. Left unset it is
+        // whatever the provider gives a new command, usually 30 seconds.
+        options.CommandTimeout = TimeSpan.FromSeconds(15);
+
+        // A deadlock or a dropped connection is retried this many times, this far apart.
+        options.MaxTransientRetries = 3;
+        options.TransientRetryInterval = TimeSpan.FromSeconds(1);
+
+        // How long the check-in and misfire loops back off after a failure that was not
+        // transient — a database that is down rather than busy.
+        options.DbRetryInterval = TimeSpan.FromSeconds(15);
+    });
+});
+```
+<!-- endSnippet -->
+
+The case that decides the value is a node blocked on `QRTZ_LOCKS` behind a peer that stopped without
+releasing the lock. Until the command times out, that node's scheduling loop is doing nothing at all.
+A shorter timeout turns a long stall into a fast failure and a retry; too short a timeout turns a
+merely busy database into a retry storm. ADO.NET counts whole seconds, and Quartz rounds a configured
+value **up** — `00:00:01.500` is applied as 2 seconds — because rounding down would turn a sub-second
+value into `0`, which every provider reads as "wait forever".
+
+### What counts as transient
+
+A failure the store considers transient is retried `MaxTransientRetries` times (default 3),
+`TransientRetryInterval` apart (default 1 second). What qualifies, on 4.x:
+
+- a `TimeoutException`, from anywhere in the exception chain;
+- the driver's own verdict, `DbException.IsTransient`;
+- **a SQLSTATE in class `40`** — the standard's "transaction rollback" class, which covers `40001`
+  serialization failure and PostgreSQL's `40P01` deadlock detected, with `40002` excluded because a
+  deferred constraint violation fails identically on every attempt. This one is **4.x only**, and it is
+  what catches the drivers that do not implement `IsTransient` honestly: Firebird reports
+  `IsTransient: false` for a serialization failure, so before this the store treated the one condition
+  retrying exists for as fatal;
+- SQL Server's transient error numbers, read off `SqlException.Errors`, which is where 1205 (deadlock
+  victim) arrives because both SqlClients leave `SqlState` null;
+- SQLite's busy and locked codes.
+
+`AdoJobStoreBase.IsTransient` is the seam to override when a driver of your own reports something the
+list above misses.
+
+`DbRetryInterval` (default 15 seconds) is the different knob: it is how long the check-in and misfire
+loops back off after a failure that was *not* transient — a database that is down rather than busy —
+so that a cluster does not hammer a dead server every 7.5 seconds.
+
+Retrying is not free of consequence in a cluster. A check-in that fails for longer than the failure
+boundary means the peers write this node off while it is still working, so a database outage long
+enough to exhaust the retries is also long enough to produce spurious failovers. That is the reason the
+first section of [Best Practices](../best-practices.md#assume-the-job-will-run-more-than-once) starts
+where it does.
+
+## Sizing a cluster
+
+The arithmetic is on Best Practices and is not repeated here:
+[max concurrency is a permit count](../best-practices.md#max-concurrency-is-a-permit-count-not-a-thread-count),
+and [the connection pool is the thread pool plus three](../best-practices.md#the-connection-pool-is-the-thread-pool-plus-three).
+Four things change when the process is one of several.
+
+**The database's connection budget is shared and does not scale with the node count.** Ten nodes with a
+modest pool of 25 each present 250 connections to one server. The number to divide is the database's,
+so `MaxConcurrency` is derived from the budget divided by the number of nodes rather than chosen per
+node — which makes adding a node a decision about the database as much as about the application.
+
+**Every node runs its own misfire handler.** The misfire loop is not a cluster singleton: each node
+scans every `MisfireHandlerFrequency` (defaulting to `MisfireThreshold`, one minute), and with
+`DoubleCheckLockMisfireHandler` on — the default — the scan starts with a `COUNT` that takes no lock
+and only escalates to the cluster-wide lock when it finds something. So the baseline cost of a node is
+one count query per minute; the contended cost is one lock per minute per node with work to do.
+
+**Every node runs its own cluster manager.** One `SELECT` of the state table plus one `UPDATE` per node
+per `CheckinInterval`. At the default of 7.5 seconds, a ten-node cluster is 160 statements a minute
+before any job runs. This is the traffic that a shorter interval buys faster failure detection with.
+
+**Batching trades round trips for balance.** `MaxBatchSize` above 1 makes every acquisition cycle take
+the `TRIGGER_ACCESS` lock, including cycles that acquire nothing, and needs
+`BatchTriggerAcquisitionFireAheadTimeWindow` above zero to batch anything at all. Java Quartz's warning
+holds here too: the larger number comes at the cost of possible imbalanced load between nodes, because
+a node that acquires ten triggers has made them its own until it can run them.
+[Batching trigger acquisition](tutorial/advanced-enterprise-features.md#batching-trigger-acquisition)
+has the pair in full.
+
+Adding nodes does not make a single trigger fire faster, and it does not shorten a job. It adds
+capacity for concurrent firings and it adds a node to fail over to. If the schedule is dominated by one
+long job, a second node changes nothing about it.
+
+## Health checks and probes
+
+The check that ships with `Quartz.AspNetCore` asserts two things: that the scheduler is in a state that
+can fire, and that its job store answers a query. It reports *healthy* for a running scheduler whose
+store responds, *degraded* for one in standby, and *unhealthy* for one that was created but never
+started, is shutting down, has shut down, or whose store threw.
+
+<!-- snippet: sample_operations_readiness_probe -->
+```csharp
+// Tagged, so a readiness endpoint can select it while the liveness endpoint does not: a
+// scheduler in standby, or one whose database is unreachable, should leave the rotation
+// without the process being killed.
+services.AddQuartzHealthChecks(options => options.Tags.Add("ready"));
+```
+<!-- endSnippet -->
+
+Three limits are worth being deliberate about.
+
+**It does not assert that anything is firing.** A scheduler with an empty schedule, a paused group or a
+starved thread pool is healthy by this definition. Pair it with an alert on a job you expect to see
+regularly — the store is the source for that, since the shipped instruments do not cover it.
+
+**It says nothing about the cluster.** A node that has stopped checking in — because its cluster
+manager is wedged on the database while the rest of the process is fine — still answers healthy. The
+node listing is where that shows, not the health endpoint.
+
+**Degraded does not survive an HTTP probe by default.** ASP.NET Core maps `Degraded` to 200, exactly as
+it maps `Healthy`, so a standby scheduler looks healthy to anything that reads the status code. Map
+`Degraded` to 503 in `HealthCheckOptions.ResultStatusCodes` if a standby node should leave the
+rotation. Under Aspire this interacts with `WithHttpHealthCheck`, and
+[the Aspire how-to](how-tos/aspire.md) has the whole table, including the fact that a worker project
+has no health endpoint to poll at all.
+
+For what to watch besides the probe — the `Quartz` activity source, the `quartz` meter and what the
+instruments do and do not cover — see [Observability](packages/opentelemetry-integration.md), which
+lists the instruments, and [What to watch](../best-practices.md#what-to-watch).
+
+## See also
+
+- [Clustering](tutorial/advanced-enterprise-features.md) — configuring a cluster in the first place
+- [Troubleshooting](../troubleshooting.md) — symptoms and what to do about each
+- [Best Practices](../best-practices.md) — the decisions this page assumes have been made
+- [Database Schema](db/) and [Schema Changes](../database/schema-changes.md) — what the tables hold and
+  what each version added
+- [Configuration Reference](configuration/reference.md#persistent-job-store) — every setting named here,
+  with its default
+
+## Sources
+
+Prior art surveyed in August 2026. Quartz.NET's own behaviour is stated from the source in this
+repository rather than from any of these.
+
+- Kubernetes, [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
+  [Force delete StatefulSet Pods](https://kubernetes.io/docs/tasks/run-application/force-delete-stateful-set-pod/),
+  [Pod hostname](https://kubernetes.io/docs/concepts/workloads/pods/pod-hostname/),
+  [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) and
+  [Operating etcd clusters](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/)
+- etcd, [Disaster recovery](https://etcd.io/docs/v3.6/op-guide/recovery/)
+- Hangfire, [Upgrading to Hangfire 1.8](https://docs.hangfire.io/en/latest/upgrade-guides/upgrading-to-hangfire-1.8.html),
+  [Using SQL Server](https://docs.hangfire.io/en/latest/configuration/using-sql-server.html) and
+  [Running multiple server instances](https://docs.hangfire.io/en/latest/background-processing/running-multiple-server-instances.html)
+- Temporal, [Upgrade Server](https://docs.temporal.io/self-hosted-guide/upgrade-server)
+- Apache Airflow, [Upgrading](https://airflow.apache.org/docs/apache-airflow/stable/installation/upgrading.html)
+  and [Best Practices](https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html)
+- Apache Kafka, [KRaft](https://kafka.apache.org/33/operations/kraft/); Strimzi,
+  [Node ID management](https://strimzi.io/blog/2023/08/23/kafka-node-pools-node-id-management/)
+- Microsoft, [Orleans on Kubernetes](https://learn.microsoft.com/dotnet/orleans/deployment/kubernetes),
+  [Restore a SQL Server database to a point in time](https://learn.microsoft.com/sql/relational-databases/backup-restore/restore-a-sql-server-database-to-a-point-in-time-full-recovery-model)
+  and [Azure SQL recovery using backups](https://learn.microsoft.com/azure/azure-sql/database/recovery-using-backups)
+- PostgreSQL, [Continuous archiving and point-in-time recovery](https://www.postgresql.org/docs/current/continuous-archiving.html)
+- Elastic, [Elastic Cloud on Kubernetes orchestration](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-orchestration.html)
+- Camunda, [Restore a backup](https://docs.camunda.io/docs/self-managed/operational-guides/backup-restore/restore/)
+- Quartz (Java), [JDBC-JobStore clustering](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/configuration/ConfigJDBCJobStoreClustering.html)
+- Martin Fowler, [Parallel Change](https://martinfowler.com/bliki/ParallelChange.html)

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -43,7 +43,8 @@ This guide covers common issues users encounter with Quartz.NET and how to diagn
 **Causes:**
 
 * The scheduler instance that acquired the trigger crashed or lost connectivity before it could fire.
-* Transient database errors during the fire-and-complete cycle.
+* Transient database errors during the fire-and-complete cycle — the reservation was written, and the
+  statement that would have fired it or released it did not run.
 
 **Diagnosis:**
 
@@ -58,10 +59,37 @@ SELECT * FROM QRTZ_FIRED_TRIGGERS
 WHERE STATE = 'ACQUIRED';
 ```
 
-**Resolution:**
+**Resolution: the store already does this.** `RecoverStaleAcquiredTriggers` runs on the persistent
+store's misfire loop — every `MisfireHandlerFrequency`, which defaults to the misfire threshold, one
+minute — on both versions, and whether or not the scheduler is clustered. For each of **this node's
+own** fired-trigger rows still in `ACQUIRED` state past the stale threshold, it puts the trigger back to
+`WAITING` (from `ACQUIRED` or `BLOCKED`, since a `[DisallowConcurrentExecution]` job's trigger may have
+moved on) and deletes the row. It is worth knowing about because it is easy to mistake for something
+having gone wrong: rows disappear on their own, a minute or two after they stopped moving.
 
-1. **Restart the scheduler** — On startup, Quartz performs misfire recovery and will re-evaluate stuck triggers based on their misfire instruction.
-2. **Manual recovery** — If a restart is not possible, you can update stuck triggers back to `WAITING` state:
+The stale threshold is derived rather than configured: it is **twice the misfire threshold, with a floor
+of two minutes**. The floor is what keeps it clear of normal acquisition, which takes at most one
+`IdleWaitTime` — 30 seconds by default — plus the time to fire. Widening `MisfireThreshold` widens this
+with it; there is no separate setting.
+
+Two things it deliberately does not do:
+
+* It only touches rows carrying **its own** instance id. A row left by a node that is gone is cleaned up
+  by cluster recovery once that node is declared failed, not by this sweep — see
+  [Operating a Cluster (4.x)](quartz-4.x/operations.md#when-a-peer-takes-over).
+* It does not touch rows in `EXECUTING` state. Those describe a job the node believes is running, and
+  the node is the authority on that.
+
+So the ordinary answer is to wait one sweep, and if nothing changes, to find out which instance id owns
+the rows. In 4.x, `IScheduler.QueryFireInstances(new FireInstanceQuery { State = null })` lists them
+without SQL, and `QueryClusterNodes()` says which of those instance ids still exist.
+
+**Resolution, as a fallback:**
+
+1. **Restart the scheduler.** A non-clustered scheduler frees every `ACQUIRED` and `BLOCKED` trigger and
+   deletes every fired-trigger row at startup. A clustered one does the same for its own rows on its
+   first check-in.
+2. **Manual recovery** — if a restart is not possible, put the stuck triggers back to `WAITING`:
 
 ```sql
 UPDATE QRTZ_TRIGGERS
@@ -71,7 +99,9 @@ WHERE TRIGGER_STATE = 'ACQUIRED'
 ```
 
 ::: warning
-Only perform manual database updates as a last resort. Prefer restarting the scheduler to let Quartz handle recovery properly.
+Only perform manual database updates as a last resort, and never against a running cluster: the row you
+edit may be one a node is about to fire, and the fired-trigger row that pairs with it is left behind.
+Prefer letting the sweep or a restart handle it.
 :::
 
 **Prevention:**
@@ -79,6 +109,89 @@ Only perform manual database updates as a last resort. Prefer restarting the sch
 * Ensure adequate database connection pool sizing.
 * Use clustered mode if running multiple scheduler instances — it includes automatic recovery for failed nodes.
 * Keep jobs short-running to minimize the window for failures.
+
+## The Misfire Sweep Times Out
+
+**Symptoms:** `JobPersistenceException` with an inner timeout from the misfire handler, repeating every
+minute; `Handling the first N triggers of M misfired triggers` in the log and never catching up; the
+scheduler otherwise alive but firing late.
+
+**Cause:** the sweep is doing too much work per pass for the time it is allowed, or the query that finds
+misfired triggers is scanning. Three settings and one index decide it.
+
+The sweep runs on every node, and each pass starts with a `COUNT` that takes no cluster-wide lock — the
+double-check that avoids paying for the lock when there is nothing to do. That count is
+`WHERE SCHED_NAME = ? AND MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME <= ? AND TRIGGER_STATE = ?`, which the
+4.x index `IDX_QRTZ_T_NFT_ST_MISFIRE` on `(SCHED_NAME, MISFIRE_INSTR, NEXT_FIRE_TIME, TRIGGER_STATE)`
+serves. A schema that predates the [3.20 index migration](database/schema-changes.md#version-3-20) has a
+different index shape, and on a large `QRTZ_TRIGGERS` this query is where a slow database first shows.
+
+<!-- snippet: sample_troubleshooting_misfire_sweep -->
+```csharp
+q.UsePersistentStore(s =>
+{
+    s.UseSystemTextJsonSerializer();
+    s.UseSqlServer(connectionString);
+
+    s.Configure(options =>
+    {
+        // A pass handles at most this many triggers, then commits. Lower it when the
+        // sweep is timing out; the loop comes straight back for the rest.
+        options.MaxMisfiresToHandleAtATime = 20;
+
+        // How often the sweep runs. Defaults to MisfireThreshold.
+        options.MisfireHandlerFrequency = TimeSpan.FromMinutes(1);
+
+        // Applied to every statement the store issues, this one included.
+        options.CommandTimeout = TimeSpan.FromSeconds(30);
+    });
+});
+```
+<!-- endSnippet -->
+
+**Resolution:**
+
+* **Apply the current index set.** [`migrations/3.20`](https://github.com/quartznet/quartznet/tree/main/database/migrations/3.20)
+  on 3.x, or section 5 of [`migrations/4.0`](https://github.com/quartznet/quartznet/tree/main/database/migrations/4.0)
+  on 4.x. This is the fix that helps most and costs least.
+* **Lower `MaxMisfiresToHandleAtATime`** (default 20). It bounds one pass; the loop comes straight back
+  for the rest after a 50 ms pause, so a smaller number means more, shorter transactions rather than less
+  progress.
+* **Raise `CommandTimeout`** — `JobStore:CommandTimeout` in 4.x — if the statements are genuinely slow
+  rather than blocked. It applies to every statement the store issues, so raise it knowing that a node
+  waiting on the cluster-wide lock waits this long before it can fail and retry.
+* **Raise `MisfireThreshold`** if the schedule can tolerate more lateness. Fewer triggers cross the line,
+  so there is less to sweep.
+
+::: warning
+**A non-clustered scheduler's startup sweep is unbounded on purpose**, on both versions: it handles
+*every* misfired trigger in one pass, ignoring `MaxMisfiresToHandleAtATime`, so that a scheduler
+starting after a long outage is caught up before it begins firing. That is the pass most likely to time
+out on a large schedule, and lowering the batch size does not affect it — only the index and the timeout
+do. A clustered scheduler does no such pass: its startup work is the first cluster check-in, which
+recovers fired triggers rather than misfires, and the ordinary bounded sweep catches up afterwards.
+:::
+
+## Clock Skew Between Nodes
+
+**Symptoms:** jobs run twice; a node logs
+`This scheduler instance (…) is still active but was recovered by another instance in the cluster`;
+nodes flip between `Alive` and `Failed` in the cluster listing with no corresponding outage.
+
+**Cause:** clustered failure detection compares a timestamp one node wrote against another node's clock.
+A node whose clock runs ahead of a peer's by more than the slack in that comparison writes off a healthy
+peer, releases its acquired triggers and re-runs its recovery-requesting jobs — while it is still
+executing them.
+
+**Resolution:** run a time-synchronisation service on every node; that is the fix, and ordinary NTP is
+orders of magnitude inside the requirement. Where you cannot guarantee it — or cannot guarantee that the
+process gets CPU promptly, which produces the same symptom with a perfect clock — widen the window with
+`quartz.jobStore.clusterCheckinMisfireThreshold`.
+
+[Clocks in a cluster](best-practices.md#clocks-in-a-cluster) has the arithmetic, the size of the default
+window, and why a pause matters more than an inaccuracy. In 4.x,
+[Operating a Cluster (4.x)](quartz-4.x/operations.md#when-a-peer-takes-over) states the exact predicate, and
+`IScheduler.QueryClusterNodes()` shows what each node currently believes about the others.
 
 ## Misfire Handling
 
@@ -137,9 +250,11 @@ If triggers misfire frequently under normal operation, consider:
 
 **Cause:** The `QRTZ_JOB_DETAILS` table stores the full type name (including namespace and assembly) in the `JOB_CLASS_NAME` column. When the type moves, the stored reference no longer resolves.
 
-**Resolution:**
+The trigger for such a job goes to `ERROR` rather than firing, because the failure is in *building* the
+job rather than in running it — see
+[What the trigger states mean](best-practices.md#what-the-trigger-states-mean).
 
-Update the stored type name in the database:
+**Resolution — rewrite the stored name:**
 
 ```sql
 UPDATE QRTZ_JOB_DETAILS
@@ -147,11 +262,73 @@ SET JOB_CLASS_NAME = 'NewNamespace.NewClassName, NewAssembly'
 WHERE JOB_CLASS_NAME = 'OldNamespace.OldClassName, OldAssembly';
 ```
 
+Run it during the deployment that renames the type, and clear the affected triggers with
+`IScheduler.ResetTriggerFromErrorState` afterwards if any reached `ERROR` first.
+
+**Resolution — teach the scheduler the old name (4.x):**
+
+Every stored type name is resolved through `ITypeLoader`, which is a single method and a replaceable
+seam. An implementation that consults a rename table before falling back to `Type.GetType` makes the old
+name keep working without touching a row, which is what a rolling deployment needs: the nodes still
+running the old build write the old name while the new ones read it.
+
+<!-- snippet: sample_troubleshooting_type_loader_implementation -->
+```csharp
+/// <summary>
+/// Resolves the type names stored in JOB_CLASS_NAME, translating the ones that have since moved.
+/// </summary>
+public sealed class RenameAwareTypeLoader : ITypeLoader
+{
+    // Old assembly-qualified name as stored, new type. Keep an entry until every row that could
+    // carry the old name has been rewritten or has aged out.
+    private static readonly Dictionary<string, Type> renamed = new(StringComparer.Ordinal)
+    {
+        ["Acme.Jobs.NightlyReport, Acme.Jobs"] = typeof(NightlyRollupJob)
+    };
+
+    public Type? LoadType(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        if (renamed.TryGetValue(name, out Type? moved))
+        {
+            return moved;
+        }
+
+        // A name that cannot be resolved must throw rather than return null: Quartz only asks when
+        // it already knows a type is required.
+        return Type.GetType(name, throwOnError: true);
+    }
+}
+```
+<!-- endSnippet -->
+
+<!-- snippet: sample_troubleshooting_type_loader -->
+```csharp
+services.AddQuartz(q => q.UseTypeLoader<RenameAwareTypeLoader>());
+```
+<!-- endSnippet -->
+
+An implementation must **throw** rather than return `null` for a name it cannot resolve — Quartz only
+asks when it already knows a type is required, so a `null` surfaces later with nothing left to point at.
+`null` is reserved for a null or empty name.
+
+The loader Quartz ships already does this for **Quartz's own** 3.x → 4.0 renames: it retries
+`Quartz.Spi.*` as `Quartz.Extensibility.*`, `Quartz.Simpl.*` as `Quartz.Impl.*`, `Quartz.Job.*` as
+`Quartz.Jobs.*`, `Quartz.Plugin.*` as `Quartz.Plugins.*`, `Quartz.Listener.*` as `Quartz.Listeners.*`,
+the job stores' old names (`JobStoreTX`, `JobStoreCMT`) and the assemblies that were merged into the
+core package, logging a warning each time so the configuration can be corrected. It knows nothing about
+your types, which is what the sample above is for.
+
 **Prevention:**
 
 * Keep job class names and namespaces stable across releases.
 * If you must rename, apply the database update as part of your deployment process.
-* Consider using the `JobType` abstraction introduced in Quartz 4.x for more flexible type resolution.
+* Name the type in one place — a `public static readonly JobKey` on the job class, and registration
+  through `AddJob<T>()` rather than a type-name string.
 
 ## Database Connection Issues
 

--- a/src/Quartz.Documentation.Samples/OperationsSamples.cs
+++ b/src/Quartz.Documentation.Samples/OperationsSamples.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Documentation.Samples.Operations;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/operations.md.
+/// </summary>
+/// <remarks>
+/// In a namespace of its own so the operator-shaped helpers can carry the names the page uses without
+/// colliding with the shared types in <c>SampleTypes.cs</c>.
+/// </remarks>
+public static class OperationsSamples
+{
+    public static void InstanceIdFromPodName(IServiceCollection services, string connectionString)
+    {
+        #region sample_operations_instance_id_from_pod_name
+
+        // POD_NAME comes from the Downward API: fieldRef fieldPath: metadata.name. On a StatefulSet
+        // that is "<set>-<ordinal>", which the same replica gets back after a restart.
+        string? podName = Environment.GetEnvironmentVariable("POD_NAME");
+
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = "orders";
+
+                if (podName is { Length: > 0 })
+                {
+                    options.InstanceId = podName;
+                }
+                else
+                {
+                    // Nothing injected the pod name — a developer's machine, or a manifest that has
+                    // not been updated. Fall back to a generated id, which is unique but not stable.
+                    options.GenerateInstanceId = true;
+                }
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer(connectionString);
+                store.UseSystemTextJsonSerializer();
+                store.UseClustering();
+            });
+        });
+
+        #endregion
+    }
+
+    public static async ValueTask StaleFirings(IScheduler scheduler, TimeProvider timeProvider, ILogger logger)
+    {
+        #region sample_operations_stale_firings
+
+        List<ClusterNode> nodes = await scheduler.QueryClusterNodes();
+        HashSet<string> known = nodes.Select(node => node.InstanceId).ToHashSet(StringComparer.Ordinal);
+
+        // State = null lists reservations as well as executions; the default lists executions only.
+        PagedResult<FireInstance> firings = await scheduler.QueryFireInstances(new FireInstanceQuery
+        {
+            State = null,
+            Take = 500
+        });
+
+        DateTimeOffset cutoff = timeProvider.GetUtcNow().AddHours(-1);
+
+        foreach (FireInstance firing in firings.Items)
+        {
+            // A row whose node is no longer listed is a leak: no peer will recognise it as its own,
+            // and only a node's first check-in sweeps firings with no scheduler-state row behind them.
+            if (!known.Contains(firing.SchedulerInstanceId))
+            {
+                logger.LogWarning(
+                    "Firing {FireInstanceId} of {Trigger} belongs to {Node}, which the cluster no longer lists.",
+                    firing.FireInstanceId, firing.TriggerKey, firing.SchedulerInstanceId);
+            }
+            else if (firing.FireTimeUtc < cutoff)
+            {
+                logger.LogWarning(
+                    "Firing {FireInstanceId} of {Trigger} has been {State} on {Node} since {FireTime}.",
+                    firing.FireInstanceId, firing.TriggerKey, firing.State, firing.SchedulerInstanceId,
+                    firing.FireTimeUtc);
+            }
+        }
+
+        #endregion
+    }
+
+    public static void StoreTimeouts(IServiceCollection services, string connectionString)
+    {
+        services.AddQuartz(q =>
+        {
+            #region sample_operations_store_timeouts
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer(connectionString);
+                store.UseSystemTextJsonSerializer();
+                store.UseClustering();
+
+                store.Configure(options =>
+                {
+                    // Every statement the store issues, the lock handler's included. Left unset it is
+                    // whatever the provider gives a new command, usually 30 seconds.
+                    options.CommandTimeout = TimeSpan.FromSeconds(15);
+
+                    // A deadlock or a dropped connection is retried this many times, this far apart.
+                    options.MaxTransientRetries = 3;
+                    options.TransientRetryInterval = TimeSpan.FromSeconds(1);
+
+                    // How long the check-in and misfire loops back off after a failure that was not
+                    // transient — a database that is down rather than busy.
+                    options.DbRetryInterval = TimeSpan.FromSeconds(15);
+                });
+            });
+
+            #endregion
+        });
+    }
+
+    public static void ReadinessProbe(IServiceCollection services)
+    {
+        #region sample_operations_readiness_probe
+
+        // Tagged, so a readiness endpoint can select it while the liveness endpoint does not: a
+        // scheduler in standby, or one whose database is unreachable, should leave the rotation
+        // without the process being killed.
+        services.AddQuartzHealthChecks(options => options.Tags.Add("ready"));
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/VersionNeutralPageSamples.cs
+++ b/src/Quartz.Documentation.Samples/VersionNeutralPageSamples.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
+using Quartz.Extensibility;
 using Quartz.Listeners;
 
 namespace Quartz.Documentation.Samples;
@@ -77,6 +78,44 @@ public static class VersionNeutralPageSamples
         {
             options.WaitForJobsToComplete = true;
         });
+
+        #endregion
+    }
+
+    public static void MisfireSweep(IServiceCollection services, string connectionString)
+    {
+        services.AddQuartz(q =>
+        {
+            #region sample_troubleshooting_misfire_sweep
+
+            q.UsePersistentStore(s =>
+            {
+                s.UseSystemTextJsonSerializer();
+                s.UseSqlServer(connectionString);
+
+                s.Configure(options =>
+                {
+                    // A pass handles at most this many triggers, then commits. Lower it when the
+                    // sweep is timing out; the loop comes straight back for the rest.
+                    options.MaxMisfiresToHandleAtATime = 20;
+
+                    // How often the sweep runs. Defaults to MisfireThreshold.
+                    options.MisfireHandlerFrequency = TimeSpan.FromMinutes(1);
+
+                    // Applied to every statement the store issues, this one included.
+                    options.CommandTimeout = TimeSpan.FromSeconds(30);
+                });
+            });
+
+            #endregion
+        });
+    }
+
+    public static void RenamedJobTypes(IServiceCollection services)
+    {
+        #region sample_troubleshooting_type_loader
+
+        services.AddQuartz(q => q.UseTypeLoader<RenameAwareTypeLoader>());
 
         #endregion
     }
@@ -338,6 +377,40 @@ public sealed class JobName : IJob
 {
     public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 }
+
+#region sample_troubleshooting_type_loader_implementation
+
+/// <summary>
+/// Resolves the type names stored in JOB_CLASS_NAME, translating the ones that have since moved.
+/// </summary>
+public sealed class RenameAwareTypeLoader : ITypeLoader
+{
+    // Old assembly-qualified name as stored, new type. Keep an entry until every row that could
+    // carry the old name has been rewritten or has aged out.
+    private static readonly Dictionary<string, Type> renamed = new(StringComparer.Ordinal)
+    {
+        ["Acme.Jobs.NightlyReport, Acme.Jobs"] = typeof(NightlyRollupJob)
+    };
+
+    public Type? LoadType(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        if (renamed.TryGetValue(name, out Type? moved))
+        {
+            return moved;
+        }
+
+        // A name that cannot be resolved must throw rather than return null: Quartz only asks when
+        // it already knows a type is required.
+        return Type.GetType(name, throwOnError: true);
+    }
+}
+
+#endregion
 
 public sealed class FaqJob : IJob
 {


### PR DESCRIPTION
`docs/documentation/quartz-4.x/operations.md` is new, registered in the sidebar between Best Practices
and Tenancy Patterns, and covers exactly the list in #3445: rolling upgrade, instance ids in
containers, check-in and the three node states, `QRTZ_FIRED_TRIGGERS` growth and paused groups, backup
and restore, `CommandTimeout` and transient retry, health checks, and sizing.
`docs/documentation/troubleshooting.md` gains the four answers it was missing.

It links the neighbouring pages rather than restating them — the clustering tutorial for configuration,
Best Practices for pool sizing, clocks and shutdown deadlines, the Aspire how-to for the health-check
story, the observability page for the instruments.

## The mixed 3.x/4.0 window

The issue asked for a precise answer rather than a hedge, so this was verified against both branches by
a helper agent and then re-checked by hand. The core is safe: the migration is purely additive (a grep
for `ALTER COLUMN`, `MODIFY` and `DROP COLUMN` over `database/migrations/4.0/` returns nothing), 3.x's
`INSERT`s name their columns so `PREFERRED_NODE_AUTO NOT NULL DEFAULT 0` takes its default, the trigger
state strings and lock names are the same constants on both branches, and `CalcFailedIfAfter` is
line-for-line the same predicate. Four things are not, and the page names each with what it costs:

- **Calendars break one way.** 4.0 writes `WeeklyCalendar`/`MonthlyCalendar` as day names and numbers
  where 3.x wrote positional booleans, and `DailyCalendar` as `RangeStart`/`RangeEnd`. 4.0's reader
  accepts both shapes (`GetDayOfWeekArray`, `GetDailyCalendarRange`); 3.x's is `GetBooleanArray()` with
  no fallback. A clustered store bypasses its calendar cache, so a 4.0-written calendar throws on 3.x
  **per firing**. This one flips the advice from "keep it short" to "route `AddCalendar` through the
  3.x nodes".
- **A binary-configured 3.x node has no window**: 4.0 refuses `quartz.serializer.type = binary` at
  startup.
- **Migration section 5 drops seven indexes the 3.20 migration created for 3.x**, one of which
  (`IDX_QRTZ_T_NFT_ST_MISFIRE_GRP`) serves a 3.x statement with no 4.x counterpart. Run sections 1 to 4
  during the rollout and the whole file afterwards; it is guarded and re-runnable.
- **Cluster-scoped execution limits miscount, not merely under-count.** 3.x's `SqlInsertFiredTrigger`
  is a fixed 13-column list omitting `EXECUTION_GROUP`, so `ResolveGroupKey` charges every 3.x firing
  to the *ungrouped* bucket — the limited group's ceiling misses that work and an unlimited group can
  be throttled by it.

Paused job groups degrade in reporting only, in both directions: 3.x's `ResumeJobs` and `ClearData`
have no `DeletePausedJobGroup`, so a 4.0-written row outlives the resume.

## Two corrections elsewhere

The page contradicted two existing sentences, so they are corrected in the same commit: the migration
guide's trigger-state section said "the two can share a cluster" without qualification, and
`schema-changes.md` said 4.x "validates its whole schema at startup" when the check is `SELECT 1` per
table and not column-level.

## Sources

Prior art, read in this pass and listed on the page:

- Kubernetes — StatefulSets, [force-deleting a StatefulSet pod](https://kubernetes.io/docs/tasks/run-application/force-delete-stateful-set-pod/)
  ("at most one Pod with a given identity"; "can be disastrous… split brain"), pod hostname, Downward
  API, and [operating etcd](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/)
  ("stop *all* API server instances, restore state in all etcd instances, restart"); etcd's own
  disaster-recovery page for *why*
- Hangfire — [upgrading to 1.8](https://docs.hangfire.io/en/latest/upgrade-guides/upgrading-to-hangfire-1.8.html)
  ("can co-exist… thanks to forward compatibility", `EnableHeavyMigrations`) and
  [running multiple server instances](https://docs.hangfire.io/en/latest/background-processing/running-multiple-server-instances.html)
- Temporal (schema before server, one minor version at a time), Airflow (`db migrate`, "disabling the
  Airflow cluster while you perform such maintenance", DAGs-as-code), Kafka/Strimzi (`node.id`
  uniqueness and ordinal assignment), Orleans on Kubernetes ("silo names must match pod names"),
  Elastic Cloud on Kubernetes, Camunda, Vault's `setNodeId`
- SQL Server / Azure SQL / PostgreSQL point-in-time-restore semantics
- Martin Fowler, [Parallel Change](https://martinfowler.com/bliki/ParallelChange.html), for the
  expand-then-contract framing the schema-first order is an instance of
- Quartz (Java) JDBC-JobStore clustering, which says nothing at all about version mixing — a documented
  silence rather than a blessing

## Where the helpers disagreed, and how it was settled

Three research agents ran on independent slices (Kubernetes identity; rolling-upgrade guidance;
backup and restore), and a fourth verified the mixed-version question against both branches.

- **Same-hostname failure on Kubernetes.** The issue framed it as "every pod reports the same
  hostname". The Kubernetes slice came back saying that is *not* the default: a Deployment pod's
  hostname is unique per pod but churns, and genuine collisions need `hostNetwork: true` or a
  hardcoded `spec.hostname`. Reading `SimpleInstanceIdGenerator` settled it — host name **plus a
  high-resolution timestamp**, so Quartz survives a hostname collision anyway. The page says the real
  cost of the default is *instability*, not collision, and reserves the collision warning for the
  host-name-only generator reachable through `quartz.scheduler.instanceIdGenerator.type`.
- **Whether a mixed window is safe.** My own reading said "workable, keep it short". The verification
  agent found the calendar break, which the code confirms is one-way by design. The minority finding
  was the correct one, and the section was rewritten around it rather than averaged.
- **Rolling-upgrade ordering.** Hangfire documents code-then-schema; Temporal documents
  schema-then-code. Quartz.NET's own code decides it — 3.x probes for the new columns and 4.x's
  startup check refuses a missing table — so the page states schema-first from the code and cites the
  two only as contrast.

## Claims deliberately not made

- **No claim that the mixed window is supported or tested.** Nothing in the repository runs two
  versions against one schema; the page says so in as many words.
- **Blob-trigger and Newtonsoft payload compatibility across the versions was not compared**, beyond
  the calendars and the job data map. The page limits itself to what was checked.
- Nothing about the instruments #3421 is adding — the page points at the observability page for those.
- The `SYS_PROP` generator is mentioned but not recommended; the page prefers reading the environment
  variable in code, because that lets you write the fallback.

## Verification

| Command | Result |
|---|---|
| `dotnet build src/Quartz.Documentation.Samples/…` | Build succeeded. 0 Warning(s) 0 Error(s) |
| `dotnet fallout DocsSnippets` | Updated 2 files |
| `dotnet fallout VerifyDocsSnippets` | up to date (91 markdown files checked) |
| `npm run docs:check-links` | 213 pages, 812 internal links, 469 fragments — no dead links or anchors |
| `npx markdownlint-cli2` on the changed pages | 0 error(s) |
| `npm run docs:build` | Rendering 214 pages — success |
| `dotnet test --filter ~SourceEncoding` | Passed! 1 test |

The site build is there to prove the sidebar entry: `operations.html` renders, and "Operating a Cluster"
appears in the sidebar of the other 4.x pages. `markdownlint` on `migration-guide.md` reports nine
pre-existing MD004 errors at lines far from the edit; the same nine appear at the base commit.

`docs/documentation/quartz-3.x/` is untouched.

Closes #3445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
