### PR TITLE
Every shipped package says whether it can be trimmed

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3808,6 +3808,17 @@ is published by ILCompiler and **run** on Windows, Linux and macOS on every pull
 and firing over a real SQLite store and binding a whole scheduler out of an `IConfiguration`. The rest
 of the track is [#3341](https://github.com/quartznet/quartznet/issues/3341).
 
+**Every other shipped package now answers the question too**, which on 3.x none of them does. On 3.x an
+application that adds any plugin to a trimmed publish gets one `IL2104` per unmarked assembly and no
+detail; on 4.0, `Quartz.Jobs`, `Quartz.Plugins`, `Quartz.HttpClient`, `Quartz.AspNetCore`,
+`Quartz.Extensions.Redis` and `Quartz.Plugins.TimeZoneConverter` are marked trimmable and report their
+individual call sites — between none and two each, all of them a job type spelled as a string. No public
+member of any of them gained `[RequiresUnreferencedCode]` or `[DynamicallyAccessedMembers]`, so nothing
+you call changes shape. `Quartz.Serialization.Newtonsoft` and `Quartz.Dashboard` say the opposite
+deliberately, in their csproj and in their nuget.org readme: Json.NET's contract is reflection, and
+Blazor Server binds components and their parameters by name. The table is in
+[Which packages say whether they can be trimmed](tutorial/more-about-jobs.md#which-packages-say-whether-they-can-be-trimmed).
+
 ## Executing is a trigger state
 
 There was no way to ask whether a trigger's job is running right now. 3.x's
@@ -7846,6 +7857,7 @@ Parameters and behavior are unchanged:
 | Serializers outside a scheduler read a container-wide registry | Because the serializer maps are per-serializer, the HTTP API and `Quartz.HttpClient` read a `SystemTextJsonSerializerRegistry` registered in the container. Register it as a singleton to make a custom serializer visible to them. The dashboard no longer registers one of its own: it passes triggers and calendars through as themselves |
 | `SystemTextJsonSerializerRegistry` gained `AddTypeInfoResolver(IJsonTypeInfoResolver)` | Where reflection-based serialization is off — a `PublishTrimmed` or `PublishAot` application — this is how job-data values of the application's own types are answered for. Hand it a generated `JsonSerializerContext`'s `Default`. Everything Quartz writes, and every custom trigger or calendar registered with the registry, is already covered; with reflection on it changes nothing — see [Trimming annotations](#trimming-annotations) |
 | The `Quartz` package declares `IsAotCompatible`, and binds configuration with the source-generated binder | No API moved. Quartz reports no `IL3050` at all now: the `Quartz` section binds through code the compiler wrote rather than through `ConfigurationBinder`'s reflection, so an application configured from `appsettings.json` publishes native AOT as safely as one configured in code — with the reflection binder that preceded it, `MaxBatchSize`, `ShutdownJobInterruption` and the whole scheduler context arrived as their defaults out of a native publish, silently. The `IL2xxx` for the string-named paths are unchanged — see [Trimming annotations](#trimming-annotations) |
+| Every other shipped package says whether it is trimmable | No API moved, and no public member gained `[RequiresUnreferencedCode]` or `[DynamicallyAccessedMembers]`. Six packages are marked `IsTrimmable` and report their own reflective call sites where 3.x reported one `IL2104` per assembly; `Quartz.Serialization.Newtonsoft` and `Quartz.Dashboard` say `IsTrimmable=false` on purpose, and their readmes say why — see [Trimming annotations](#trimming-annotations) |
 | `IDriverDelegate` trigger states are `StoredTriggerState` | Eighteen members took the state as a `string`; the database still stores the same values — see [Trigger states are typed on the driver delegate](#trigger-states-are-typed-on-the-driver-delegate) |
 | The `…FromOtherStates` members take a state collection | Two or three fixed old-state parameters became one `IReadOnlyCollection<StoredTriggerState>` |
 | `FiredTriggerQuery.InstanceName` is `InstanceId` | With the `instanceName` parameters of the scheduler-state members; the `INSTANCE_NAME` column is unchanged |

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -582,6 +582,39 @@ shipped assembly, so an `UnconditionalSuppressMessage` never hides them from you
 own application's closure reaches, and none of it stops a scheduler from starting, firing and shutting
 down out of a native executable.
 
+### Which packages say whether they can be trimmed
+
+Every shipped package answers the question, because an unmarked assembly is not a "no" — it is silence.
+A trimmer keeps an unmarked assembly whole and collapses everything it cannot reason about into a single
+`IL2104: Assembly 'X' produced trim warnings`, which tells you nothing about what is at risk.
+
+| Package | Trimmable | What a trimmed publish reports against it |
+|---|---|---|
+| `Quartz` | yes, and `IsAotCompatible` | the string-named paths described above |
+| `Quartz.Jobs` | yes | one: `DirectoryScanJob` finds the listener named in its job data by walking the loaded assemblies for a type of that name |
+| `Quartz.Plugins` | yes | two: the XML and JSON schedule-file plugins name each job's type as text, which is what the file format is for |
+| `Quartz.HttpClient` | yes | one: a job read back over HTTP carries its type as a name |
+| `Quartz.AspNetCore` | yes | one: a job posted to the HTTP API names its type as a string |
+| `Quartz.Extensions.Redis` | yes | nothing |
+| `Quartz.Plugins.TimeZoneConverter` | yes | nothing |
+| `Quartz.Serialization.Newtonsoft` | **no** | Json.NET decides what a type looks like by reflecting over it, and has no source-generated form to move to |
+| `Quartz.Dashboard` | **no** | Blazor Server sets a component's `[Parameter]` properties by name and finds page components by type; that is the framework's model, not something the package can resolve |
+
+None of the trimmable ones needs anything of your application beyond what the sections above ask for:
+name job types as types, and register a job whose type a store or a request will later name as a string.
+Each records its remaining warnings in a `TrimAnalysisBaseline.cs` in the repository rather than in the
+shipped assembly, so you still see every one of them against your own build.
+
+The two that say **no** say it in their csproj and in their nuget.org readme, so it reads as a decision
+rather than an oversight. An application that publishes trimmed uses the System.Text.Json serializer
+built into `Quartz`, and drives its schedulers through the HTTP API rather than the dashboard — both of
+which are trimmable.
+
+`IsAotCompatible` is declared by `Quartz` alone for now, and it is a narrower claim than trimmability:
+that nothing needs code generated at run time. None of the other packages reports an `IL3050` either,
+so the claim would hold for the trimmable ones as well; making it is tracked on
+[#3341](https://github.com/quartznet/quartznet/issues/3341) rather than assumed here.
+
 ## JobExecutionException
 
 Finally, we need to inform you of a few details of the `IJob.Execute(..)` method. The only type of exception

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/CalendarEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/CalendarEndpoints.cs
@@ -43,7 +43,7 @@ internal static class CalendarEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertPaging(skip, take);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             CalendarQuery query = new()
             {
@@ -71,7 +71,7 @@ internal static class CalendarEndpoints
         string calendarName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var calendar = await scheduler.GetCalendarOrThrow(calendarName, cancellationToken).ConfigureAwait(false);
             return calendar;
@@ -107,7 +107,7 @@ internal static class CalendarEndpoints
         string calendarName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var calendarFound = await scheduler.DeleteCalendar(calendarName, cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(calendarFound);

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
@@ -97,7 +97,7 @@ internal static class JobEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertPaging(skip, take);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             GroupMatcher<JobKey> matcher = EndpointHelper.GetGroupMatcher<JobKey>(groupContains, groupEndsWith, groupStartsWith, groupEquals);
             JobQuery query = new()
@@ -128,7 +128,7 @@ internal static class JobEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertKeysToFetch(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             JobKey[] jobKeys = request.Select(x => x.AsJobKey()).ToArray();
             List<IJobDetail> jobDetails = await scheduler.GetJobDetails(jobKeys, cancellationToken).ConfigureAwait(false);
@@ -145,7 +145,7 @@ internal static class JobEndpoints
         string jobName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var jobDetail = await scheduler.GetJobDetailOrThrow(jobName, jobGroup, cancellationToken).ConfigureAwait(false);
 
@@ -163,7 +163,7 @@ internal static class JobEndpoints
         string jobName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var exists = await scheduler.Exists(new JobKey(jobName, jobGroup), cancellationToken).ConfigureAwait(false);
             return new ExistsResponse(exists);
@@ -179,7 +179,7 @@ internal static class JobEndpoints
         string jobName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var triggers = await scheduler.GetTriggersOfJob(new JobKey(jobName, jobGroup), cancellationToken).ConfigureAwait(false);
             return triggers;
@@ -231,7 +231,7 @@ internal static class JobEndpoints
             }
         }
 
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             FireInstanceQuery query = new()
             {
@@ -268,7 +268,7 @@ internal static class JobEndpoints
         string jobName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var applied = await scheduler.PauseJob(new JobKey(jobName, jobGroup), cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(applied);
@@ -286,7 +286,7 @@ internal static class JobEndpoints
         string? groupEquals = null,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var matcher = EndpointHelper.GetGroupMatcher<JobKey>(groupContains, groupEndsWith, groupStartsWith, groupEquals);
             var pausedGroups = await scheduler.PauseJobs(matcher, cancellationToken).ConfigureAwait(false);
@@ -303,7 +303,7 @@ internal static class JobEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var jobKeys = request.Jobs.Select(x => x.AsJobKey()).ToArray();
             var paused = await scheduler.PauseJobs(jobKeys, cancellationToken).ConfigureAwait(false);
@@ -320,7 +320,7 @@ internal static class JobEndpoints
         string jobName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var applied = await scheduler.ResumeJob(new JobKey(jobName, jobGroup), cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(applied);
@@ -338,7 +338,7 @@ internal static class JobEndpoints
         string? groupEquals = null,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var matcher = EndpointHelper.GetGroupMatcher<JobKey>(groupContains, groupEndsWith, groupStartsWith, groupEquals);
             var resumedGroups = await scheduler.ResumeJobs(matcher, cancellationToken).ConfigureAwait(false);
@@ -355,7 +355,7 @@ internal static class JobEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var jobKeys = request.Jobs.Select(x => x.AsJobKey()).ToArray();
             var resumed = await scheduler.ResumeJobs(jobKeys, cancellationToken).ConfigureAwait(false);
@@ -385,7 +385,7 @@ internal static class JobEndpoints
         string jobName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var interrupted = await scheduler.Interrupt(new JobKey(jobName, jobGroup), cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(interrupted);
@@ -400,7 +400,7 @@ internal static class JobEndpoints
         string fireInstanceId,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var interrupted = await scheduler.InterruptFireInstance(fireInstanceId, cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(interrupted);
@@ -416,7 +416,7 @@ internal static class JobEndpoints
         string jobName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var jobFound = await scheduler.DeleteJob(new JobKey(jobName, jobGroup), cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(jobFound);
@@ -440,7 +440,7 @@ internal static class JobEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var jobKeys = request.Jobs.Select(x => x.AsJobKey()).ToArray();
             var deleted = await scheduler.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
@@ -459,7 +459,7 @@ internal static class JobEndpoints
         EndpointHelper.AssertIsValid(request);
         return EndpointHelper.ExecuteWithOkResponse(schedulerName, schedulerRepository, async scheduler =>
         {
-            var newJob = request.Job.AsIJobDetail().JobDetail!;
+            IJobDetail newJob = RequestedJobDetail.From(request.Job);
             var options = new AddJobOptions
             {
                 Replace = request.Replace,
@@ -483,7 +483,7 @@ internal static class JobEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertPaging(skip, take);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             JobGroupQuery query = new()
             {
@@ -512,7 +512,7 @@ internal static class JobEndpoints
         string jobGroup,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             bool paused = await scheduler.IsJobGroupPaused(jobGroup, cancellationToken).ConfigureAwait(false);
             return new GroupPausedResponse(paused);

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -81,7 +81,7 @@ internal static class SchedulerEndpoints
             result[i] = SchedulerHeaderDto.Create(registration, scheduler);
         }
 
-        return EndpointHelper.JsonResponse(result);
+        return endpointHelper.JsonResponse(result);
     }
 
     [ProducesResponseType(typeof(SchedulerDto), StatusCodes.Status200OK)]
@@ -91,7 +91,7 @@ internal static class SchedulerEndpoints
         string schedulerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var metadata = await scheduler.GetMetadata(cancellationToken).ConfigureAwait(false);
             var result = SchedulerDto.Create(scheduler, metadata);
@@ -106,7 +106,7 @@ internal static class SchedulerEndpoints
         string schedulerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, scheduler =>
         {
             var context = scheduler.Context;
             var result = SchedulerContextDto.Create(context);
@@ -205,7 +205,7 @@ internal static class SchedulerEndpoints
         string schedulerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             List<ClusterNode> nodes = await scheduler.QueryClusterNodes(cancellationToken).ConfigureAwait(false);
 
@@ -226,7 +226,7 @@ internal static class SchedulerEndpoints
         string schedulerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             ExecutionLimits? limits = await scheduler.GetExecutionLimits(cancellationToken).ConfigureAwait(false);
             Dictionary<string, ExecutionLimitDto>? dict = null;

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
@@ -109,7 +109,7 @@ internal static class TriggerEndpoints
             throw new BadHttpRequestException("Both jobName and jobGroup must be given to filter by job");
         }
 
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             GroupMatcher<TriggerKey> matcher = EndpointHelper.GetGroupMatcher<TriggerKey>(groupContains, groupEndsWith, groupStartsWith, groupEquals);
             TriggerQuery query = new()
@@ -143,7 +143,7 @@ internal static class TriggerEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertKeysToFetch(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             TriggerKey[] triggerKeys = request.Select(x => x.AsTriggerKey()).ToArray();
             List<ITrigger> triggers = await scheduler.GetTriggers(triggerKeys, cancellationToken).ConfigureAwait(false);
@@ -160,7 +160,7 @@ internal static class TriggerEndpoints
         string triggerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var trigger = await scheduler.GetTriggerOrThrow(triggerName, triggerGroup, cancellationToken).ConfigureAwait(false);
             return trigger;
@@ -176,7 +176,7 @@ internal static class TriggerEndpoints
         string triggerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var exists = await scheduler.Exists(new TriggerKey(triggerName, triggerGroup), cancellationToken).ConfigureAwait(false);
             return new ExistsResponse(exists);
@@ -192,7 +192,7 @@ internal static class TriggerEndpoints
         string triggerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var state = await scheduler.GetTriggerState(new TriggerKey(triggerName, triggerGroup), cancellationToken).ConfigureAwait(false);
             return new TriggerStateDto(state);
@@ -208,7 +208,7 @@ internal static class TriggerEndpoints
         string triggerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var applied = await scheduler.ResetTriggerFromErrorState(new TriggerKey(triggerName, triggerGroup), cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(applied);
@@ -224,7 +224,7 @@ internal static class TriggerEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var triggerKeys = request.Triggers.Select(x => x.AsTriggerKey()).ToArray();
             var reset = await scheduler.ResetTriggersFromErrorState(triggerKeys, cancellationToken).ConfigureAwait(false);
@@ -241,7 +241,7 @@ internal static class TriggerEndpoints
         string triggerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var applied = await scheduler.PauseTrigger(new TriggerKey(triggerName, triggerGroup), cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(applied);
@@ -259,7 +259,7 @@ internal static class TriggerEndpoints
         string? groupEquals = null,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var matcher = EndpointHelper.GetGroupMatcher<TriggerKey>(groupContains, groupEndsWith, groupStartsWith, groupEquals);
             var pausedGroups = await scheduler.PauseTriggers(matcher, cancellationToken).ConfigureAwait(false);
@@ -276,7 +276,7 @@ internal static class TriggerEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var triggerKeys = request.Triggers.Select(x => x.AsTriggerKey()).ToArray();
             var paused = await scheduler.PauseTriggers(triggerKeys, cancellationToken).ConfigureAwait(false);
@@ -293,7 +293,7 @@ internal static class TriggerEndpoints
         string triggerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var applied = await scheduler.ResumeTrigger(new TriggerKey(triggerName, triggerGroup), cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(applied);
@@ -311,7 +311,7 @@ internal static class TriggerEndpoints
         string? groupEquals = null,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var matcher = EndpointHelper.GetGroupMatcher<TriggerKey>(groupContains, groupEndsWith, groupStartsWith, groupEquals);
             var resumedGroups = await scheduler.ResumeTriggers(matcher, cancellationToken).ConfigureAwait(false);
@@ -328,7 +328,7 @@ internal static class TriggerEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var triggerKeys = request.Triggers.Select(x => x.AsTriggerKey()).ToArray();
             var resumed = await scheduler.ResumeTriggers(triggerKeys, cancellationToken).ConfigureAwait(false);
@@ -349,7 +349,7 @@ internal static class TriggerEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertPaging(skip, take);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             TriggerGroupQuery query = new()
             {
@@ -378,7 +378,7 @@ internal static class TriggerEndpoints
         string triggerGroup,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             bool paused = await scheduler.IsTriggerGroupPaused(triggerGroup, cancellationToken).ConfigureAwait(false);
             return new GroupPausedResponse(paused);
@@ -395,7 +395,7 @@ internal static class TriggerEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             if (request.Job is null)
             {
@@ -403,7 +403,7 @@ internal static class TriggerEndpoints
                 return new ScheduleJobResponse(firstFireTime);
             }
 
-            var jobDetail = request.Job.AsIJobDetail().JobDetail!;
+            IJobDetail jobDetail = RequestedJobDetail.From(request.Job);
             var firstFireTimeWithJob = await scheduler.ScheduleJob(jobDetail, request.Trigger, cancellationToken).ConfigureAwait(false);
             return new ScheduleJobResponse(firstFireTimeWithJob);
         });
@@ -424,7 +424,7 @@ internal static class TriggerEndpoints
             var jobsAndTriggers = new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>>();
             foreach (var (jobDetailDto, triggers) in request.JobsAndTriggers)
             {
-                var jobDetail = jobDetailDto.AsIJobDetail().JobDetail!;
+                IJobDetail jobDetail = RequestedJobDetail.From(jobDetailDto);
                 jobsAndTriggers.Add(jobDetail, triggers);
             }
 
@@ -441,7 +441,7 @@ internal static class TriggerEndpoints
         string triggerName,
         CancellationToken cancellationToken = default)
     {
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var triggerFound = await scheduler.UnscheduleJob(new TriggerKey(triggerName, triggerGroup), cancellationToken).ConfigureAwait(false);
             return new OperationAppliedResponse(triggerFound);
@@ -466,7 +466,7 @@ internal static class TriggerEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var triggerKeys = request.Triggers.Select(x => x.AsTriggerKey()).ToArray();
             var unscheduled = await scheduler.UnscheduleJobs(triggerKeys, cancellationToken).ConfigureAwait(false);
@@ -486,7 +486,7 @@ internal static class TriggerEndpoints
         CancellationToken cancellationToken = default)
     {
         EndpointHelper.AssertIsValid(request);
-        return EndpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             var firstFireTimeUtc = await scheduler.RescheduleJob(new TriggerKey(triggerName, triggerGroup), request.NewTrigger, cancellationToken).ConfigureAwait(false);
             return new RescheduleJobResponse(firstFireTimeUtc);

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/EndpointHelper.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/EndpointHelper.cs
@@ -1,4 +1,9 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
 
 using Quartz.HttpApiContract;
 using Quartz.Extensibility;
@@ -8,12 +13,38 @@ namespace Quartz.AspNetCore.HttpApi.Util;
 
 internal sealed class EndpointHelper
 {
+    private readonly IOptions<JsonOptions> jsonOptions;
+
+    /// <summary>
+    /// Takes the application's HTTP JSON options, which <see cref="QuartzJsonOptionsSetup" /> has taught
+    /// the wire contract by the time they are read. The endpoints already receive this type as a
+    /// parameter, so writing a response through it costs no registration and no extra lookup.
+    /// </summary>
+    public EndpointHelper(IOptions<JsonOptions> jsonOptions)
+    {
+        this.jsonOptions = jsonOptions;
+    }
+
     /// <summary>
     /// The one place the API turns a response into JSON. Generic because every caller already has the
     /// static type in hand: erasing it to <see cref="object" /> binds the overload that has to rediscover
     /// the type at runtime, where this one carries it through to the serializer.
     /// </summary>
-    public static IResult JsonResponse<T>(T data) where T : notnull => Results.Json(data);
+    /// <remarks>
+    /// The metadata is asked for rather than left to be discovered. <c>HttpApiJsonContext</c> states every
+    /// body this API returns and sits in front of whatever resolver the options already had, so
+    /// <see cref="JsonSerializerOptions.GetTypeInfo" /> answers from generated metadata — and passing the
+    /// <see cref="JsonTypeInfo{T}" /> binds the <see cref="Results.Json{TValue}(TValue, JsonTypeInfo{TValue}, string, int?)" />
+    /// overload that carries neither <c>RequiresUnreferencedCode</c> nor <c>RequiresDynamicCode</c>. The
+    /// open half of the contract is unaffected: metadata generated for a type the options carry a
+    /// converter for defers to that converter, so an <see cref="ITrigger" /> or an <see cref="ICalendar" />
+    /// still goes out through Quartz's own.
+    /// </remarks>
+    public IResult JsonResponse<T>(T data) where T : notnull
+    {
+        JsonSerializerOptions serializerOptions = jsonOptions.Value.SerializerOptions;
+        return Results.Json(data, (JsonTypeInfo<T>) serializerOptions.GetTypeInfo(typeof(T)));
+    }
 
     public static GroupMatcher<T> GetGroupMatcher<T>(string? groupContains, string? groupEndsWith, string? groupStartsWith, string? groupEquals) where T : Key<T>
     {
@@ -181,7 +212,7 @@ internal sealed class EndpointHelper
         return await action(scheduler).ConfigureAwait(false);
     }
 
-    public static Task<IResult> ExecuteWithJsonResponse<T>(
+    public Task<IResult> ExecuteWithJsonResponse<T>(
         string schedulerName,
         ISchedulerRepository schedulerRepository,
         Func<IScheduler, Task<T>> action) where T : notnull

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/RequestedJobDetail.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/RequestedJobDetail.cs
@@ -1,0 +1,54 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.AspNetCore.Http;
+
+using Quartz.HttpApiContract;
+
+namespace Quartz.AspNetCore.HttpApi.Util;
+
+/// <summary>
+/// The one place a job carried by a request becomes an <see cref="IJobDetail" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three endpoints take a job in their body — add-job, schedule-job and schedule-jobs — and each used to
+/// read the job detail out of <see cref="JobDetailDto.AsIJobDetail" />'s result pair and null-forgive it,
+/// throwing away the reason the conversion gives when it fails. Here the reason is used, and the throw is
+/// the same <see cref="BadHttpRequestException" /> a validation failure raises.
+/// </para>
+/// <para>
+/// Gathering the three in one place also gathers what they have in common for trimming:
+/// <see cref="JobDetailDto.AsIJobDetail" /> is <c>[RequiresUnreferencedCode]</c>, because the job type on
+/// the wire is a string, and this type is where that statement stops travelling — the endpoints reach it
+/// from delegates the routing table holds, so carrying the attribute any further would put it on
+/// <c>MapQuartzHttpApi</c>, which every application serving this API calls. It is recorded in
+/// <c>TrimAnalysisBaseline.cs</c> instead, which says the rest.
+/// </para>
+/// </remarks>
+internal static class RequestedJobDetail
+{
+    public static IJobDetail From(JobDetailDto dto)
+    {
+        var (jobDetail, errorReason) = dto.AsIJobDetail();
+        return jobDetail ?? throw new BadHttpRequestException("Request validation failed: " + errorReason);
+    }
+}

--- a/src/Quartz.AspNetCore/ILLink.Suppressions.xml
+++ b/src/Quartz.AspNetCore/ILLink.Suppressions.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  The ILLink half of the baseline recorded in TrimAnalysisBaseline.cs beside this file. Same types, same
+  reasons — read that file; the reasoning lives there and is not repeated here.
+
+  Two files are needed because the two tools cannot be told the same way, which src/Quartz/ILLink.Suppressions.xml
+  explains in full: SuppressMessageAttribute is [Conditional("CODE_ANALYSIS")] and never reaches metadata,
+  so ILLink cannot see the C# baseline and is told through its link-attributes option instead. The
+  unconditional attribute would cover both and would be baked into the shipped assembly, silencing these
+  warnings for every consumer publishing a trimmed application — which is the lie neither file tells.
+
+  fullname carries a trailing '*' throughout, so that the compiler-generated closure and state-machine
+  types ILLink reports against are matched by the same entry as the type they belong to.
+
+  **Nothing in this repository applies this file today**, and that is worth knowing before trusting it.
+  Quartz.Examples.Worker and Quartz.Trimming.Canary are the only trimmed publishes here and both reference
+  Quartz alone, so ILLink never links this assembly and build/Build.cs reads src/Quartz/ILLink.Suppressions.xml
+  only. It exists because the C# baseline covers the analyzer and nothing else: an application that publishes
+  trimmed over this package hits ILLink, which sees through calls the analyzer does not, and this is the
+  form that answer has to take. Should a canary ever reference this package, add it there as an
+  _ILLinkSuppressions item and teach build/Build.cs to read this file as well as Quartz's own — until then
+  an entry here is checked by review rather than by CI, so keep it in step with the file beside it by hand.
+-->
+<linker>
+  <assembly fullname="Quartz.AspNetCore">
+
+    <!-- A job type named in a request body -->
+    <type fullname="Quartz.AspNetCore.HttpApi.Util.RequestedJobDetail*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">A job posted to the HTTP API names its type as a string; the attribute that says so cannot reach past MapQuartzHttpApi.</property>
+      </attribute>
+    </type>
+
+  </assembly>
+</linker>

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -7,6 +7,38 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Lewis Zou, Marko Lahma, Quartz.NET</Authors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      The request delegates are the compiler's job here, not RequestDelegateFactory's, and this property
+      has to come before the four below rather than after them. Turned on alone, the analyzers reported
+      116 warnings against this package, 114 of which were one thing: MapGet, MapPost and MapDelete take a
+      Delegate and say RequiresUnreferencedCode and RequiresDynamicCode, because binding its parameters
+      and writing its result is decided at run time by reflecting over the delegate. The generator decides
+      it at compile time instead, and ASP.NET Core ships it for exactly this reason - baselining those 114
+      would have recorded a warning the framework already has a fix for.
+
+      It intercepts all 57 Map* calls in Endpoints/: 4 in CalendarEndpoints, 20 in JobEndpoints, 13 in
+      SchedulerEndpoints and 20 in TriggerEndpoints, counted out of GeneratedRouteBuilderExtensions.g.cs
+      with EmitCompilerGeneratedFiles on and matched against the call sites in the source. Turning it off
+      is not quiet: with nothing suppressing them, the 114 come back as errors.
+    -->
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+    <!--
+      Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
+      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
+      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
+      warning is the reflective call site.
+
+      116 warnings when the analyzers were first turned on here, one now. The generator above took 114;
+      the last two were the API writing a response through JsonSerializerOptions alone, and the wire
+      contract has been source-generated since #3400, so EndpointHelper asks the options for the
+      JsonTypeInfo and passes it. This package therefore produces no IL3050 at all, and the single-file
+      analyzer found nothing. The one that is left is a job type named as a string in a request body,
+      recorded in TrimAnalysisBaseline.cs beside this file.
+    -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.AspNetCore/TrimAnalysisBaseline.cs
+++ b/src/Quartz.AspNetCore/TrimAnalysisBaseline.cs
@@ -1,0 +1,78 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+
+// The trim- and AOT-analysis warnings Quartz.AspNetCore still produces (https://github.com/quartznet/quartznet/issues/3431).
+//
+// Read src/Quartz/TrimAnalysisBaseline.cs first. The reasoning this file works to is written down there
+// and is not repeated here: why a suppression is scoped to the type rather than the member, why
+// SuppressMessage rather than the unconditional form, and — most of all — that adding an entry is the
+// wrong first move. The order to try fixes in, in short: resolve the type statically; else annotate with
+// [DynamicallyAccessedMembers] so the requirement travels to a caller that can satisfy it; else say
+// [RequiresUnreferencedCode] on surface a trimmed application can avoid, having checked where the
+// attribute propagates to.
+//
+// 116 warnings when the analyzers were first turned on here, one now, and 115 went away rather than being
+// written down. This package is the reason #3431 says the framework's own fix comes before the first line
+// of baseline:
+//
+//   - 114 were MapGet, MapPost and MapDelete, each an IL2026 and an IL3050, because a Delegate handed to
+//     the routing table has its parameters bound and its result written by RequestDelegateFactory
+//     reflecting over it at run time. EnableRequestDelegateGenerator in Quartz.AspNetCore.csproj has the
+//     compiler write that code instead, and it intercepts all 57 call sites — the csproj says how that
+//     was counted. Nothing about the endpoints changed to earn it.
+//   - Two were EndpointHelper.JsonResponse calling Results.Json with a JsonSerializerOptions and no
+//     metadata, which leaves System.Text.Json to reflect over the response type. The wire contract has
+//     been source-generated since #3400 (HttpApiJsonContext), and ConfigureWireFormat puts it in front of
+//     whatever resolver the options carry, so the answer was already there to be asked for: EndpointHelper
+//     takes the application's JsonOptions, asks GetTypeInfo, and passes the JsonTypeInfo — the overload
+//     that carries neither attribute. That made JsonResponse and ExecuteWithJsonResponse instance members,
+//     which is why the endpoints now call them through the EndpointHelper they were already being handed.
+//
+// So this package produces no IL3050 at all, and the single-file analyzer found nothing.
+//
+// One warning arrived rather than left, and it was here all along. The analyzer does not report an
+// IL2026 for a [RequiresUnreferencedCode] call whose result is read through a tuple element —
+// `dto.AsIJobDetail().JobDetail` says nothing, where `var (detail, reason) = dto.AsIJobDetail()` reports —
+// so the three endpoints that build a job out of a request body were silently calling one. Gathering them
+// into RequestedJobDetail, which uses the reason it is given instead of null-forgiving it away, makes the
+// call visible as well as better-behaved. Worth knowing when reading any of these files: a quiet analyzer
+// is not the same as no reflection.
+
+// --- A job type named in a request body -----------------------------------------------------------------
+// A job arrives over the API as a JobDetailDto, whose JobType is a string — deliberately, and JobDetailDto
+// says why: resolving a name on receipt would have this process walk its probing paths for whatever a
+// client sent it, which is a type disclosure side channel that does real work per request. So the name is
+// stored unresolved and AsIJobDetail says [RequiresUnreferencedCode] for the consequence: whoever runs
+// that job needs its type to have survived trimming.
+//
+// The entry below is where that statement stops travelling. RequestedJobDetail is reached from AddJob,
+// ScheduleJob and ScheduleJobs, which are delegates the routing table holds; the attribute on them would
+// land on the MapPost that converts them, then on MapEndpoints, then on MapQuartzHttpApi — which every
+// application serving this API calls, including one that only ever lists and pauses. That is the same wall
+// AddQuartz is in the core package, and the answer is the same: stop one member earlier and record it.
+//
+// An application publishing trimmed keeps its job types the ordinary way — reference them from AddJob<T>()
+// or JobBuilder.Create<T>() — and an API that is only read from needs nothing, because a job listed over
+// HTTP carries its type name and never resolves it.
+
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.AspNetCore.HttpApi.Util.RequestedJobDetail", Justification = "A job posted to the HTTP API names its type as a string; the attribute that says so cannot reach past MapQuartzHttpApi.")]

--- a/src/Quartz.Dashboard/Quartz.Dashboard.csproj
+++ b/src/Quartz.Dashboard/Quartz.Dashboard.csproj
@@ -6,7 +6,28 @@
     <RootNamespace>Quartz.Dashboard</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <NoWarn>$(NoWarn);IL2110;IL2111</NoWarn>
+    <!--
+      Not trimmable, said out loud rather than left to the default (issue #3431). Blazor Server is a
+      reflective framework by construction: a component's [Parameter] properties are set by name from the
+      render tree, its type is discovered by the router, and QuickGrid, EventCallback and the SignalR hub
+      proxy all bind members the compiler never sees referenced. The framework says so itself — the
+      Microsoft.AspNetCore.Components packages are not marked IsTrimmable, and Blazor Server has no
+      trimming story to opt into, unlike Blazor WebAssembly which links against a different runtime
+      profile.
+
+      So the honest statement is false, not a baseline: with the analyzers on this package reports 20
+      warnings that are all the framework's model rather than anything to fix here, and marking it
+      IsTrimmable would tell a trimmer it may cut into a component graph nothing statically references.
+      A trimmed application that references this package gets the one IL2104 for it, which is correct.
+      README.md says the same thing for anyone reading on nuget.org.
+
+      This is also where IL2110 and IL2111 used to be suppressed by NoWarn — the two ILLink codes for
+      reflecting over a DynamicallyAccessedMembers-annotated member, which is the [Parameter] model
+      exactly. Nothing emits them today, because nothing turns the trim analyzer on here; the suppression
+      was hiding a warning nobody was producing. If a future SDK starts reporting them for a Razor project,
+      that should be visible rather than pre-silenced.
+    -->
+    <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.Dashboard/README.md
+++ b/src/Quartz.Dashboard/README.md
@@ -50,8 +50,12 @@ members that nothing statically references. That is the framework's model rather
 package could resolve, and the Blazor packages themselves are not marked trimmable either.
 
 An application that publishes trimmed or native AOT therefore does so without the dashboard. `Quartz`,
-`Quartz.AspNetCore` and the HTTP API are trimmable, so a trimmed service can still be driven remotely —
-by the API, or by a dashboard hosted in a separate application.
+`Quartz.AspNetCore` and `Quartz.HttpClient` are trimmable, so a trimmed service can still be driven
+remotely over the HTTP API.
+
+Hosting the dashboard itself in another process is not something this package does today: the client it
+registers reads the schedulers in its own container. A supported remote dashboard is designed in
+[#3387](https://github.com/quartznet/quartznet/issues/3387).
 
 ## Documentation
 

--- a/src/Quartz.Dashboard/README.md
+++ b/src/Quartz.Dashboard/README.md
@@ -41,6 +41,18 @@ Execution-history views stay empty until the scheduler records history: add
 `q.UseJobHistoryLogging()` and `q.UseTriggerHistoryLogging()` from
 [Quartz.Plugins](https://www.nuget.org/packages/Quartz.Plugins).
 
+## Trimming
+
+This package is deliberately **not** trimmable, and does not declare `IsTrimmable`. Blazor Server is a
+reflective framework: a component's `[Parameter]` properties are set by name from the render tree, the
+router finds page components by type, and grids, event callbacks and the SignalR hub proxy all bind
+members that nothing statically references. That is the framework's model rather than anything this
+package could resolve, and the Blazor packages themselves are not marked trimmable either.
+
+An application that publishes trimmed or native AOT therefore does so without the dashboard. `Quartz`,
+`Quartz.AspNetCore` and the HTTP API are trimmable, so a trimmed service can still be driven remotely —
+by the API, or by a dashboard hosted in a separate application.
+
 ## Documentation
 
 The full guide covers custom paths and reverse proxies, authorization, integrating into an existing

--- a/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
+++ b/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
@@ -7,6 +7,22 @@
     <Description>Quartz.NET Redis integration - distributed lock handler for clustered scheduling; $(Description)</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
+      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
+      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
+      warning is the reflective call site.
+
+      There are none, and there were none the first time the analyzers were pointed at this package: the
+      lock handler talks to Redis over StackExchange.Redis with a Lua script and a connection string, and
+      names no type. So there is no TrimAnalysisBaseline.cs beside this file, and a warning appearing here
+      is a new one — fix it rather than starting a baseline for it. The claim stops at this assembly:
+      StackExchange.Redis says nothing about trimming, and what it reports is its own.
+    -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.HttpClient/HttpClientExtensions.cs
+++ b/src/Quartz.HttpClient/HttpClientExtensions.cs
@@ -22,6 +22,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 using Quartz.HttpApiContract;
 using Quartz.Impl.AdoJobStore;
@@ -30,6 +31,31 @@ namespace Quartz;
 
 internal static class HttpClientExtensions
 {
+    /// <summary>
+    /// The metadata for one body of the wire contract, asked of the options rather than discovered by
+    /// reflecting over <typeparamref name="T" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every body this file sends or reads is a contract type, and <c>HttpApiJsonContext</c> — which
+    /// <c>ConfigureWireFormat</c> puts in front of whatever resolver the options already had — states all
+    /// of them. So the answer comes from generated metadata, and passing it to
+    /// <see cref="HttpClientJsonExtensions" /> binds the overloads that carry neither
+    /// <c>RequiresUnreferencedCode</c> nor <c>RequiresDynamicCode</c>: what a trimmed or native AOT
+    /// application publishes over is the same code path a reflecting one runs.
+    /// </para>
+    /// <para>
+    /// The open half of the contract still goes through Quartz's converters, because a generated
+    /// <see cref="JsonTypeInfo" /> for a type the options carry a converter for is metadata that defers
+    /// to that converter — an <see cref="ITrigger" /> or an <see cref="ICalendar" /> reaches the registry
+    /// either way.
+    /// </para>
+    /// </remarks>
+    private static JsonTypeInfo<T> WireFormatOf<T>(JsonSerializerOptions serializerOptions)
+    {
+        return (JsonTypeInfo<T>) serializerOptions.GetTypeInfo(typeof(T));
+    }
+
     public static async ValueTask<TResponse> Get<TResponse>(
         this HttpClient client,
         string requestUri,
@@ -75,7 +101,7 @@ internal static class HttpClientExtensions
         JsonSerializerOptions serializerOptions,
         CancellationToken cancellationToken)
     {
-        using var response = await client.PostAsJsonAsync(requestUri, value, serializerOptions, cancellationToken).ConfigureAwait(false);
+        using var response = await client.PostAsJsonAsync(requestUri, value, WireFormatOf<TRequest>(serializerOptions), cancellationToken).ConfigureAwait(false);
         await response.CheckResponseStatusCode(serializerOptions, cancellationToken).ConfigureAwait(false);
     }
 
@@ -98,7 +124,7 @@ internal static class HttpClientExtensions
         JsonSerializerOptions serializerOptions,
         CancellationToken cancellationToken)
     {
-        using var response = await client.PostAsJsonAsync(requestUri, value, serializerOptions, cancellationToken).ConfigureAwait(false);
+        using var response = await client.PostAsJsonAsync(requestUri, value, WireFormatOf<TRequest>(serializerOptions), cancellationToken).ConfigureAwait(false);
         await response.CheckResponseStatusCode(serializerOptions, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadOrThrow<TResponse>(serializerOptions, cancellationToken).ConfigureAwait(false);
@@ -141,7 +167,7 @@ internal static class HttpClientExtensions
 
         try
         {
-            problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetailsDto>(serializerOptions, cancellationToken).ConfigureAwait(false);
+            problemDetails = await response.Content.ReadFromJsonAsync(WireFormatOf<ProblemDetailsDto>(serializerOptions), cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -204,7 +230,7 @@ internal static class HttpClientExtensions
 
     private static async Task<T> ReadOrThrow<T>(this HttpContent content, JsonSerializerOptions serializerOptions, CancellationToken cancellationToken)
     {
-        var result = await content.ReadFromJsonAsync<T>(serializerOptions, cancellationToken).ConfigureAwait(false);
+        var result = await content.ReadFromJsonAsync(WireFormatOf<T>(serializerOptions), cancellationToken).ConfigureAwait(false);
         return result ?? throw new HttpClientException("Could not deserialize response");
     }
 }

--- a/src/Quartz.HttpClient/ILLink.Suppressions.xml
+++ b/src/Quartz.HttpClient/ILLink.Suppressions.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  The ILLink half of the baseline recorded in TrimAnalysisBaseline.cs beside this file. Same types, same
+  reasons — read that file; the reasoning lives there and is not repeated here.
+
+  Two files are needed because the two tools cannot be told the same way, which src/Quartz/ILLink.Suppressions.xml
+  explains in full: SuppressMessageAttribute is [Conditional("CODE_ANALYSIS")] and never reaches metadata,
+  so ILLink cannot see the C# baseline and is told through its link-attributes option instead. The
+  unconditional attribute would cover both and would be baked into the shipped assembly, silencing these
+  warnings for every consumer publishing a trimmed application — which is the lie neither file tells.
+
+  fullname carries a trailing '*' throughout, so that the compiler-generated closure and state-machine
+  types ILLink reports against are matched by the same entry as the type they belong to.
+
+  **Nothing in this repository applies this file today**, and that is worth knowing before trusting it.
+  Quartz.Examples.Worker and Quartz.Trimming.Canary are the only trimmed publishes here and both reference
+  Quartz alone, so ILLink never links this assembly and build/Build.cs reads src/Quartz/ILLink.Suppressions.xml
+  only. It exists because the C# baseline covers the analyzer and nothing else: an application that publishes
+  trimmed over this package hits ILLink, which sees through calls the analyzer does not, and this is the
+  form that answer has to take. Should a canary ever reference this package, add it there as an
+  _ILLinkSuppressions item and teach build/Build.cs to read this file as well as Quartz's own — until then
+  an entry here is checked by review rather than by CI, so keep it in step with the file beside it by hand.
+-->
+<linker>
+  <assembly fullname="Quartz.HttpClient">
+
+    <!-- A job type named in an HTTP response -->
+    <type fullname="Quartz.HttpScheduler*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">A job read back over HTTP names its type as a string; IScheduler cannot carry the attribute that says so.</property>
+      </attribute>
+    </type>
+
+  </assembly>
+</linker>

--- a/src/Quartz.HttpClient/Quartz.HttpClient.csproj
+++ b/src/Quartz.HttpClient/Quartz.HttpClient.csproj
@@ -6,6 +6,23 @@
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
+      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
+      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
+      warning is the reflective call site.
+
+      Ten warnings when the analyzers were first turned on here, two now. Eight of them were the client
+      serializing and deserializing the wire contract through JsonSerializerOptions alone; the contract
+      has been source-generated since #3400, so the client asks the options for the JsonTypeInfo and
+      passes it, which is the overload that carries neither attribute. That is the whole of the package's
+      IL3050: there is none left, and the single-file analyzer found nothing. The two that remain are a
+      job type named as a string in an HTTP response, recorded in TrimAnalysisBaseline.cs beside this file.
+    -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.HttpClient/TrimAnalysisBaseline.cs
+++ b/src/Quartz.HttpClient/TrimAnalysisBaseline.cs
@@ -1,0 +1,64 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+
+// The trim- and AOT-analysis warnings Quartz.HttpClient still produces (https://github.com/quartznet/quartznet/issues/3431).
+//
+// Read src/Quartz/TrimAnalysisBaseline.cs first. The reasoning this file works to is written down there
+// and is not repeated here: why a suppression is scoped to the type rather than the member, why
+// SuppressMessage rather than the unconditional form, and — most of all — that adding an entry is the
+// wrong first move. The order to try fixes in, in short: resolve the type statically; else annotate with
+// [DynamicallyAccessedMembers] so the requirement travels to a caller that can satisfy it; else say
+// [RequiresUnreferencedCode] on surface a trimmed application can avoid, having checked where the
+// attribute propagates to.
+//
+// Ten warnings when the analyzers were first turned on here, two now, and the eight that went away went
+// away rather than being written down. They were four call sites in HttpClientExtensions — two
+// PostAsJsonAsync, two ReadFromJsonAsync — each an IL2026 and an IL3050 for the same reason: handed only
+// a JsonSerializerOptions, System.Text.Json has to reflect over the body's type to find out what it is.
+// It does not have to. Step 4 of #3341 made the wire contract source-generated (HttpApiJsonContext), and
+// ConfigureWireFormat puts that context in front of whatever resolver the options already had — so the
+// answer was already there to be asked for. HttpClientExtensions.WireFormatOf asks for it and passes the
+// JsonTypeInfo, which binds the overloads that carry neither attribute. Nothing about the bytes on the
+// wire changed; the converters still answer for the open half of the contract, because generated metadata
+// for a type the options carry a converter for is metadata that defers to that converter.
+//
+// So this package produces no IL3050 at all, and the single-file analyzer found nothing: the client reads
+// no file and knows no assembly's location.
+
+// --- A job type named in an HTTP response ---------------------------------------------------------------
+// A job travels over the API as a JobDetailDto, whose JobType is a string — deliberately, and the type
+// says why: resolving a name on receipt would have the receiving process walk its probing paths for
+// whatever a peer sent it, and would break a reader that has every right not to have the job's assembly
+// loaded. JobDetailDto.AsIJobDetail says [RequiresUnreferencedCode] for the consequence: whoever does
+// eventually run that job needs the type to have survived trimming.
+//
+// The entry below is where that statement stops travelling. The two call sites it covers are IScheduler
+// members — GetJobDetail and GetJobDetails — and IL2046 wants [RequiresUnreferencedCode] on both sides of
+// an interface member, which would put it on IScheduler and therefore on every scheduler including the
+// in-memory one, which is clean. So the attribute stops one member earlier and the fact is recorded here.
+//
+// An application publishing trimmed over this package keeps its job types the ordinary way: reference
+// them from AddJob<T>() or JobBuilder.Create<T>(). A client that only lists jobs rather than running them
+// needs nothing — the name is carried, not resolved.
+
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.HttpScheduler", Justification = "A job read back over HTTP names its type as a string; IScheduler cannot carry the attribute that says so.")]

--- a/src/Quartz.Jobs/ILLink.Suppressions.xml
+++ b/src/Quartz.Jobs/ILLink.Suppressions.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  The ILLink half of the baseline recorded in TrimAnalysisBaseline.cs beside this file. Same types, same
+  reasons — read that file; the reasoning lives there and is not repeated here.
+
+  Two files are needed because the two tools cannot be told the same way, which src/Quartz/ILLink.Suppressions.xml
+  explains in full: SuppressMessageAttribute is [Conditional("CODE_ANALYSIS")] and never reaches metadata,
+  so ILLink cannot see the C# baseline and is told through its link-attributes option instead. The
+  unconditional attribute would cover both and would be baked into the shipped assembly, silencing these
+  warnings for every consumer publishing a trimmed application — which is the lie neither file tells.
+
+  fullname carries a trailing '*' throughout, so that the compiler-generated closure and state-machine
+  types ILLink reports against are matched by the same entry as the type they belong to.
+
+  **Nothing in this repository applies this file today**, and that is worth knowing before trusting it.
+  Quartz.Examples.Worker and Quartz.Trimming.Canary are the only trimmed publishes here and both reference
+  Quartz alone, so ILLink never links this assembly and build/Build.cs reads src/Quartz/ILLink.Suppressions.xml
+  only. It exists because the C# baseline covers the analyzer and nothing else: an application that publishes
+  trimmed over this package hits ILLink, which sees through calls the analyzer does not, and this is the
+  form that answer has to take. Should a canary ever reference this package, add it there as an
+  _ILLinkSuppressions item and teach build/Build.cs to read this file as well as Quartz's own — until then
+  an entry here is checked by review rather than by CI, so keep it in step with the file beside it by hand.
+-->
+<linker>
+  <assembly fullname="Quartz.Jobs">
+
+    <!-- A listener named in the job data map -->
+    <type fullname="Quartz.Jobs.DirectoryScanJobModel*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">A directory-scan listener named as job data is found by walking the loaded assemblies for a type of that name.</property>
+      </attribute>
+    </type>
+
+  </assembly>
+</linker>

--- a/src/Quartz.Jobs/Quartz.Jobs.csproj
+++ b/src/Quartz.Jobs/Quartz.Jobs.csproj
@@ -6,6 +6,20 @@
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
+      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
+      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
+      warning is the reflective call site.
+
+      One is left, and it is the directory scan job's listener lookup - recorded in TrimAnalysisBaseline.cs
+      beside this file, which says why. Nothing else here reflects: the jobs are ordinary types the
+      container constructs.
+    -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.Jobs/TrimAnalysisBaseline.cs
+++ b/src/Quartz.Jobs/TrimAnalysisBaseline.cs
@@ -1,0 +1,50 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+
+// The trim- and AOT-analysis warnings Quartz.Jobs still produces (https://github.com/quartznet/quartznet/issues/3431).
+//
+// Read src/Quartz/TrimAnalysisBaseline.cs first. The reasoning this file works to is written down there
+// and is not repeated here: why a suppression is scoped to the type rather than the member, why
+// SuppressMessage rather than the unconditional form, and — most of all — that adding an entry is the
+// wrong first move. The order to try fixes in, in short: resolve the type statically; else annotate with
+// [DynamicallyAccessedMembers] so the requirement travels to a caller that can satisfy it; else say
+// [RequiresUnreferencedCode] on surface a trimmed application can avoid, having checked where the
+// attribute propagates to.
+//
+// One warning when the analyzers were first turned on here, one now, and it is the one below. The AOT
+// and single-file analyzers found nothing at all: the jobs in this package read the file system and are
+// otherwise ordinary types the container constructs.
+
+// --- A listener named in the job data map --------------------------------------------------------------
+// DirectoryScanJob takes the name of its IDirectoryScanListener as job data, which is a string by the
+// time the job runs. Where a service provider is available the name is read as a type name, and the only
+// place to look one up is the assemblies that happen to be loaded — the container is asked for the
+// listener only once its Type has been found that way. The answer is cached per name, so the walk is
+// once per listener rather than once per fire, but the trimmer still cannot follow it: a listener type
+// reached only this way has to be kept by the application, by registering it in the container or by
+// naming it in a TrimmerRootDescriptor.
+//
+// [RequiresUnreferencedCode] cannot say so from here: the only path in is DirectoryScanJob.Execute, and
+// IJob is an interface Quartz does not own both sides of.
+
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Jobs.DirectoryScanJobModel", Justification = "A directory-scan listener named as job data is found by walking the loaded assemblies for a type of that name.")]

--- a/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
+++ b/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
@@ -8,6 +8,22 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Authors>Sean Farrow, Quartz.NET</Authors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
+      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
+      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
+      warning is the reflective call site.
+
+      There are none, and there were none the first time the analyzers were pointed at this package: the
+      plugin registers one resolver with TimeZones and that resolver asks TZConvert for a TimeZoneInfo by
+      its IANA or Windows id, which is data rather than a type name. So there is no
+      TrimAnalysisBaseline.cs beside this file, and a warning appearing here is a new one — fix it rather
+      than starting a baseline for it.
+    -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.Plugins/ILLink.Suppressions.xml
+++ b/src/Quartz.Plugins/ILLink.Suppressions.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  The ILLink half of the baseline recorded in TrimAnalysisBaseline.cs beside this file. Same types, same
+  reasons — read that file; the reasoning lives there and is not repeated here.
+
+  Two files are needed because the two tools cannot be told the same way, which src/Quartz/ILLink.Suppressions.xml
+  explains in full: SuppressMessageAttribute is [Conditional("CODE_ANALYSIS")] and never reaches metadata,
+  so ILLink cannot see the C# baseline and is told through its link-attributes option instead. The
+  unconditional attribute would cover both and would be baked into the shipped assembly, silencing these
+  warnings for every consumer publishing a trimmed application — which is the lie neither file tells.
+
+  fullname carries a trailing '*' throughout, so that the compiler-generated closure and state-machine
+  types ILLink reports against are matched by the same entry as the type they belong to.
+
+  **Nothing in this repository applies this file today**, and that is worth knowing before trusting it.
+  Quartz.Examples.Worker and Quartz.Trimming.Canary are the only trimmed publishes here and both reference
+  Quartz alone, so ILLink never links this assembly and build/Build.cs reads src/Quartz/ILLink.Suppressions.xml
+  only. It exists because the C# baseline covers the analyzer and nothing else: an application that publishes
+  trimmed over this package hits ILLink, which sees through calls the analyzer does not, and this is the
+  form that answer has to take. Should a canary ever reference this package, add it there as an
+  _ILLinkSuppressions item and teach build/Build.cs to read this file as well as Quartz's own — until then
+  an entry here is checked by review rather than by CI, so keep it in step with the file beside it by hand.
+-->
+<linker>
+  <assembly fullname="Quartz.Plugins">
+
+    <!-- A job type named in a schedule file -->
+    <type fullname="Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">job_scheduling_data XML names each job's type as a string; ISchedulerPlugin and IFileScanListener cannot carry the attribute that says so.</property>
+      </attribute>
+    </type>
+    <type fullname="Quartz.Plugins.Json.JsonSchedulingDataProcessorPlugin*">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+        <argument>Trimming</argument>
+        <argument>IL2026</argument>
+        <property name="Justification">quartz_jobs.json names each job's type as a string; ISchedulerPlugin and IFileScanListener cannot carry the attribute that says so.</property>
+      </attribute>
+    </type>
+
+  </assembly>
+</linker>

--- a/src/Quartz.Plugins/Plugins/Json/JsonJobSchedulingData.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonJobSchedulingData.cs
@@ -19,7 +19,33 @@
 
 #endregion
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace Quartz.Plugins.Json;
+
+/// <summary>
+/// The shape of <c>quartz_jobs.json</c> as metadata the compiler wrote, so that reading the file needs
+/// no reflection over the types below.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The three reader settings live here rather than on a <see cref="JsonSerializerOptions" /> instance,
+/// because they are the file format: a hand-written schedule file is allowed comments, a trailing comma
+/// and whatever casing its author chose, and that has been true of this plugin since it shipped.
+/// </para>
+/// <para>
+/// <see cref="JsonSourceGenerationMode.Metadata" /> because the plugin only ever reads. Nothing writes
+/// this shape, so the generated writers would be dead code.
+/// </para>
+/// </remarks>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNameCaseInsensitive = true,
+    ReadCommentHandling = JsonCommentHandling.Skip,
+    AllowTrailingCommas = true)]
+[JsonSerializable(typeof(JsonJobSchedulingData))]
+internal sealed partial class JsonSchedulingDataContext : JsonSerializerContext;
 
 internal sealed class JsonJobSchedulingData
 {

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 
@@ -40,12 +41,13 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
 {
     public const string QuartzJsonFileName = "quartz_jobs.json";
 
-    private static readonly JsonSerializerOptions jsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true
-    };
+    /// <summary>
+    /// What a schedule file spells as text and the trimmer therefore cannot follow. The wording matches
+    /// <see cref="XmlSchedulingDataProcessor" />'s, because it is the same contract in a different file
+    /// format: the shape of the file is metadata the compiler wrote, and the job type inside it is not.
+    /// </summary>
+    private const string JobTypeNamedByString =
+        "Register every job type with AddJob<T>() or reference it from JobBuilder.Create<T>(); a type named only by a string in quartz_jobs.json is not guaranteed to survive trimming.";
 
     private readonly ILogger<JsonSchedulingDataProcessor> logger;
     private readonly TimeProvider timeProvider;
@@ -74,6 +76,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
     internal void ProtectJobGroup(string groupName) => protectedJobGroups.Add(groupName);
     internal void ProtectTriggerGroup(string groupName) => protectedTriggerGroups.Add(groupName);
 
+    [RequiresUnreferencedCode(JobTypeNamedByString)]
     public async Task ProcessJsonFileAndScheduleJobs(
         string fileName,
         IScheduler scheduler,
@@ -100,6 +103,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
         await ScheduleJobs(scheduler, cancellationToken).ConfigureAwait(false);
     }
 
+    [RequiresUnreferencedCode(JobTypeNamedByString)]
     internal void ProcessJsonContent(string json)
     {
         PrepareForProcessing();
@@ -108,7 +112,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
         jsonJobsToDelete.Clear();
         jsonTriggersToDelete.Clear();
 
-        var data = JsonSerializer.Deserialize<JsonJobSchedulingData>(json, jsonOptions)
+        JsonJobSchedulingData data = JsonSerializer.Deserialize(json, JsonSchedulingDataContext.Default.JsonJobSchedulingData)
             ?? throw new SchedulerConfigException("Job definition data from JSON was null after deserialization.");
 
         if (data.PreProcessingCommands is not null)
@@ -240,6 +244,7 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
         }
     }
 
+    [RequiresUnreferencedCode(JobTypeNamedByString)]
     private void ProcessJobs(List<JsonFileJobDefinition> jobDefs)
     {
         foreach (var jobDef in jobDefs)

--- a/src/Quartz.Plugins/Quartz.Plugins.csproj
+++ b/src/Quartz.Plugins/Quartz.Plugins.csproj
@@ -6,6 +6,23 @@
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
+      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
+      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
+      warning is the reflective call site.
+
+      Four warnings when the analyzers were first turned on here, two now, and neither of the two is a
+      new one: the schedule-file plugins hand a job type spelled as text to the scheduler, which is what
+      the file format is for. What went away is the JSON reader itself — quartz_jobs.json is read through
+      metadata the compiler wrote, so the shape of the file needs no reflection and needs no code
+      generated at run time either. The package produces no IL3050 at all, and the single-file analyzer
+      found nothing. TrimAnalysisBaseline.cs beside this file records the two that are left.
+    -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.Plugins/TrimAnalysisBaseline.cs
+++ b/src/Quartz.Plugins/TrimAnalysisBaseline.cs
@@ -1,0 +1,64 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+
+// The trim- and AOT-analysis warnings Quartz.Plugins still produces (https://github.com/quartznet/quartznet/issues/3431).
+//
+// Read src/Quartz/TrimAnalysisBaseline.cs first. The reasoning this file works to is written down there
+// and is not repeated here: why a suppression is scoped to the type rather than the member, why
+// SuppressMessage rather than the unconditional form, and — most of all — that adding an entry is the
+// wrong first move. The order to try fixes in, in short: resolve the type statically; else annotate with
+// [DynamicallyAccessedMembers] so the requirement travels to a caller that can satisfy it; else say
+// [RequiresUnreferencedCode] on surface a trimmed application can avoid, having checked where the
+// attribute propagates to.
+//
+// Four warnings when the analyzers were first turned on here, two now, and the two that went away went
+// away rather than being written down. Both belonged to reading quartz_jobs.json:
+//
+//   - The reader called JsonSerializer.Deserialize<T>(string, JsonSerializerOptions), which is IL2026 and
+//     IL3050 both, because the shape it deserializes into is discovered by reflecting over it.
+//     JsonSchedulingDataContext states that shape instead, so the file is read through metadata the
+//     compiler wrote. That is the whole of the package's IL3050: there is none left.
+//   - The job type inside the file was handed to JobBuilder.OfType as an IL2072. It is a string in a
+//     schedule file, so there is no annotation that could be true of it; what the file did not have was a
+//     way to say so. It says so now — ProcessJsonFileAndScheduleJobs, ProcessJsonContent and ProcessJobs
+//     carry [RequiresUnreferencedCode] with the same wording XmlSchedulingDataProcessor has always used,
+//     one file format apart — which moves the warning to the caller that cannot pass it on, below.
+//
+// The single-file analyzer found nothing: the plugins open files by path and read no assembly's location.
+
+// --- A job type named in a schedule file ---------------------------------------------------------------
+// Both file plugins exist to schedule what a file declares, and a file declares a job type as text. The
+// processors say [RequiresUnreferencedCode] out loud, so an application that loads a schedule file is
+// told at compile time; these two entries are where that statement stops travelling.
+//
+// It stops here because both plugins implement ISchedulerPlugin and IFileScanListener, and the file is
+// processed from Start and from FileUpdated. IL2046 wants the attribute on both sides of an interface
+// member, and Quartz does not own both sides of either interface — a plugin an application wrote must
+// stay free to implement them without the attribute. So the reflection is honest surface one member
+// earlier, and recorded here.
+//
+// The application-facing form of the fix is unchanged and is what the message says: register the job
+// types with AddJob<T>(), or reference them from JobBuilder.Create<T>(), and the trimmer keeps them.
+
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin", Justification = "job_scheduling_data XML names each job's type as a string; ISchedulerPlugin and IFileScanListener cannot carry the attribute that says so.")]
+[assembly: SuppressMessage("Trimming", "IL2026", Scope = "type", Target = "T:Quartz.Plugins.Json.JsonSchedulingDataProcessorPlugin", Justification = "quartz_jobs.json names each job's type as a string; ISchedulerPlugin and IFileScanListener cannot carry the attribute that says so.")]

--- a/src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj
+++ b/src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj
@@ -7,6 +7,21 @@
     <Description>Quartz.NET JSON Serialization Support; $(Description)</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      Not trimmable, said out loud rather than left to the default (issue #3431). Json.NET's contract is
+      reflection: a contract resolver walks the type it is handed, reads its members and constructs it,
+      and there is no source-generated form of that to move to — which is the difference between this
+      serializer and the System.Text.Json one built into Quartz, where a generated context names every
+      blob a store writes. Turned on, the analyzers report 16 trim warnings here, and every one of them
+      is that same fact arriving by a different route; a baseline of them would record the design of the
+      dependency rather than anything this package could fix.
+
+      An application that publishes trimmed uses the System.Text.Json serializer. This package stays for
+      the database that already has Json.NET's output in it, and marking it IsTrimmable would tell a
+      trimmer it may cut into the types a job data map is about to be deserialized into. README.md says
+      the same thing for anyone reading on nuget.org.
+    -->
+    <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.Serialization.Newtonsoft/README.md
+++ b/src/Quartz.Serialization.Newtonsoft/README.md
@@ -34,6 +34,19 @@ The same `UseNewtonsoftJsonSerializer` call configures a store built without a h
 `StoreJobDataAsStrings` is worth setting whichever serializer you use: it keeps job data out of the
 serializer altogether, which is what avoids surprises when a persisted type later changes shape.
 
+## Trimming
+
+This package is deliberately **not** trimmable, and does not declare `IsTrimmable`. Json.NET decides what
+a type looks like by reflecting over it — a contract resolver reads the members of whatever it is handed
+and constructs it — and there is no source-generated form of that to move to. Marking the package
+trimmable would tell the trimmer it may remove members that a job data map is about to be deserialized
+into, and the failure would arrive at run time when a job fires.
+
+Publish trimmed or native AOT with the System.Text.Json serializer instead, which is built into the
+`Quartz` package and is the default. It carries a source-generated contract for everything a job store
+writes, and `SystemTextJsonSerializerRegistry.AddTypeInfoResolver` is where an application's own job data
+value types are declared.
+
 ## Documentation
 
 <https://www.quartz-scheduler.net/documentation/quartz-4.x/packages/json-serialization.html>

--- a/src/Quartz.Tests.AspNetCore/HttpApi/RequestDelegatesAreSourceGeneratedTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/RequestDelegatesAreSourceGeneratedTest.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using System.Text;
+
+using Quartz.AspNetCore.HttpApi.Endpoints;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// Holds the one thing <c>EnableRequestDelegateGenerator</c> cannot say for itself: that the generator
+/// actually intercepted every <c>MapGet</c>, <c>MapPost</c> and <c>MapDelete</c> the API is built from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The property is a request, not a result. An interceptor that declines to intercept leaves
+/// <c>RequestDelegateFactory</c> to bind each handler's parameters and write its result by reflecting
+/// over the delegate at run time, and every other test in this project passes either way — reflection is
+/// perfectly correct in a process that has a JIT. What it is not is trim- or ahead-of-time-safe, and it
+/// is where 114 of this package's 116 trim warnings came from before the generator was turned on.
+/// </para>
+/// <para>
+/// Losing the property would be loud today, because nothing suppresses those warnings and
+/// <c>TreatWarningsAsErrors</c> is on. This test is for the case that is not loud: the generator
+/// declining one call site, or a future one it cannot express, which leaves the other 56 intercepted and
+/// says nothing about the one it dropped.
+/// </para>
+/// </remarks>
+public class RequestDelegatesAreSourceGeneratedTest
+{
+    /// <summary>
+    /// The Map* calls in each endpoint file, which together are every route the API serves. A route added
+    /// or removed changes the number here as well, and the point of writing it down is that the two have
+    /// to be changed together.
+    /// </summary>
+    private static readonly Dictionary<string, int> mappedRoutes = new(StringComparer.Ordinal)
+    {
+        ["CalendarEndpoints.cs"] = 4,
+        ["JobEndpoints.cs"] = 20,
+        ["SchedulerEndpoints.cs"] = 13,
+        ["TriggerEndpoints.cs"] = 20
+    };
+
+    [Test]
+    public void EveryMapCallInTheEndpointsIsIntercepted()
+    {
+        List<CustomAttributeData> interceptions = Interceptions();
+
+        interceptions.Should().HaveCount(mappedRoutes.Values.Sum(),
+            "every Map* call in the endpoint classes has to be intercepted — one that is not is bound by "
+            + "RequestDelegateFactory instead, which reflects over the handler and is neither trimmable "
+            + "nor ahead-of-time-safe");
+    }
+
+    [Test]
+    public void EveryEndpointClassHasItsRoutesIntercepted()
+    {
+        Dictionary<string, int> intercepted = Interceptions()
+            .GroupBy(FileOf)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+
+        intercepted.Should().BeEquivalentTo(mappedRoutes,
+            "the generator only intercepts call sites in the project it runs in, so counting them per "
+            + "file is what tells a whole endpoint class going unintercepted apart from the total "
+            + "happening to add up");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The generated route builder, which the compiler emits into Quartz.AspNetCore itself as a
+    /// file-local type — so its metadata name carries a hash of the generated file's own name and cannot
+    /// be written down.
+    /// </summary>
+    private static Type GeneratedRouteBuilder()
+    {
+        Type[] candidates = typeof(CalendarEndpoints).Assembly
+            .GetTypes()
+            .Where(type => type.Namespace == "Microsoft.AspNetCore.Http.Generated")
+            .Where(type => type.Name.EndsWith("GeneratedRouteBuilderExtensionsCore", StringComparison.Ordinal))
+            .ToArray();
+
+        candidates.Should().ContainSingle(
+            "the request delegate generator emits exactly one route builder per compilation, and none at "
+            + "all when EnableRequestDelegateGenerator is off in src/Quartz.AspNetCore/Quartz.AspNetCore.csproj");
+
+        return candidates[0];
+    }
+
+    private static List<CustomAttributeData> Interceptions() => GeneratedRouteBuilder()
+        .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+        .SelectMany(method => method.GetCustomAttributesData())
+        .Where(attribute => attribute.AttributeType.Name.EndsWith("InterceptsLocationAttribute", StringComparison.Ordinal))
+        .ToList();
+
+    /// <summary>
+    /// The source file an interception points at.
+    /// </summary>
+    /// <remarks>
+    /// Roslyn's version 1 location is base64 of a 16-byte content checksum, a 4-byte position and the
+    /// display file name. Nothing else decodes it, so a version this does not know about fails loudly
+    /// rather than being read as if it were version 1.
+    /// </remarks>
+    private static string FileOf(CustomAttributeData interception)
+    {
+        interception.ConstructorArguments[0].Value.Should().Be(1,
+            "this decodes Roslyn's version 1 interceptable location; a new version needs a new decoder here");
+
+        byte[] data = Convert.FromBase64String((string) interception.ConstructorArguments[1].Value!);
+        data.Length.Should().BeGreaterThan(20, "a version 1 location is a checksum, a position and a file name");
+
+        return Encoding.UTF8.GetString(data, 20, data.Length - 20);
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/HttpApi/RequestedJobDetailTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/RequestedJobDetailTest.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Http;
+
+using Quartz.AspNetCore.HttpApi.Util;
+using Quartz.HttpApiContract;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// The one place a job carried by a request becomes an <see cref="IJobDetail" />, which the three
+/// endpoints that take a job in their body go through.
+/// </summary>
+public class RequestedJobDetailTest
+{
+    [Test]
+    public void AJobTypeNameThatDoesNotResolveIsCarriedThrough()
+    {
+        IJobDetail jobDetail = RequestedJobDetail.From(CreateDto("Quartz.Tests.AspNetCore.NoSuchJob, No.Such.Assembly"));
+
+        jobDetail.JobType.FullName.Should().Be("Quartz.Tests.AspNetCore.NoSuchJob, No.Such.Assembly",
+            "the API stores the name a client sent rather than resolving it, which is what lets a job be "
+            + "added from a process that does not have its assembly");
+        jobDetail.Key.Should().Be(new JobKey("job-name", "job-group"));
+    }
+
+    [Test]
+    public void AJobTypeThatIsNotAJobTypeNameIsRejectedWithTheReason()
+    {
+        Action act = () => RequestedJobDetail.From(CreateDto("   "));
+
+        act.Should().Throw<BadHttpRequestException>()
+            .WithMessage("*Missing or malformed job type*",
+                "the conversion says why it failed, and the request that caused it is the one that should "
+                + "hear about it — reading the detail out of the pair and null-forgiving it turned this "
+                + "into a NullReferenceException, which is a 500 rather than a 400");
+    }
+
+    private static JobDetailDto CreateDto(string jobTypeName)
+    {
+        return new JobDetailDto(
+            Name: "job-name",
+            Group: "job-group",
+            JobType: jobTypeName,
+            Description: null,
+            Durable: true,
+            RequestsRecovery: false,
+            ConcurrentExecutionDisallowed: false,
+            PersistJobDataAfterExecution: false,
+            JobDataMap: new JobDataMap()
+        );
+    }
+}

--- a/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorTest.cs
@@ -312,6 +312,39 @@ public class JsonSchedulingDataProcessorTest
         processor.ParsedTriggers.Should().BeEmpty();
     }
 
+    /// <summary>
+    /// A schedule file is written by hand, so the reader has always allowed comments, a trailing comma
+    /// and whatever casing its author chose. Those three settings moved from a JsonSerializerOptions
+    /// instance onto the generated context's <c>[JsonSourceGenerationOptions]</c> when the file stopped
+    /// being read by reflection, and this is what says they moved rather than were dropped — a file like
+    /// the one below parses with none of them and fails with any one missing.
+    /// </summary>
+    [Test]
+    public void AHandWrittenFileKeepsItsComments_TrailingCommas_AndCasing()
+    {
+        var json = """
+        {
+            // the schedule this deployment runs
+            "schedule": {
+                "jobs": [{ "name": "handWritten", "jobType": "Quartz.Jobs.NativeJob, Quartz.Jobs", "durable": true, }],
+                /* one trigger for now */
+                "triggers": [{ "name": "handWrittenTrigger", "jobName": "handWritten", "simple": { "repeatCount": 0, "interval": "00:00:30" } }],
+            },
+        }
+        """;
+
+        var processor = CreateProcessor();
+        processor.ProcessJsonContent(json);
+
+        processor.ParsedJobs.Should().ContainSingle(
+            "camelCased property names are the ones a hand-written file most often uses, and the reader "
+            + "has always matched them case-insensitively")
+            .Which.Key.Name.Should().Be("handWritten");
+
+        ((ISimpleTrigger) processor.ParsedTriggers[0]).RepeatInterval.Should().Be(TimeSpan.FromSeconds(30),
+            "the trigger has to survive the comments and the trailing commas around it, not merely the job");
+    }
+
     [Test]
     public async Task DeleteInAllGroups_SkipsProtectedGroups()
     {


### PR DESCRIPTION
`src/Quartz/Quartz.csproj` was the only packable project that said anything about trimming. The other
eight said nothing, and nothing is not "no": a trimmer keeps an unmarked assembly whole and collapses
everything it cannot reason about into one `IL2104: Assembly 'X' produced trim warnings`. So an
application published trimmed over `Quartz` alone got a real answer, and the same application with any
plugin added got silence. All nine answer now.

## Per package, before and after

Counted by turning the trim, AOT and single-file analyzers on with `TreatWarningsAsErrors=false` and
reading the unique warnings out. The "before" column is higher than the inventory recorded on #3341
because that inventory was taken with the trim analyzer alone; these numbers include `IL3050`.

| Package | Before | After | Baselined | What the fix was |
|---|---:|---:|---:|---|
| `Quartz.AspNetCore` | 116 | 1 | 1 | `EnableRequestDelegateGenerator` (−114), `JsonTypeInfo` on the response writer (−2), and one warning the analyzer had never reported |
| `Quartz.HttpClient` | 10 | 2 | 2 (one entry) | `JsonTypeInfo` on four client call sites (−8) |
| `Quartz.Plugins` | 4 | 2 | 2 | a generated context for `quartz_jobs.json` (−2), and `[RequiresUnreferencedCode]` moving the third to where it stops |
| `Quartz.Jobs` | 1 | 1 | 1 | none available |
| `Quartz.Extensions.Redis` | 0 | 0 | 0 | — |
| `Quartz.Plugins.TimeZoneConverter` | 0 | 0 | 0 | — |
| `Quartz.Serialization.Newtonsoft` | 28 | — | — | `IsTrimmable=false`, deliberately |
| `Quartz.Dashboard` | 20 | — | — | `IsTrimmable=false`, deliberately |

Of `Quartz.Serialization.Newtonsoft`'s 28, sixteen are trim warnings — which is exactly the number the
#3341 inventory recorded — and twelve are `IL3050`. `Quartz.Dashboard`'s 20 was measured with the
pre-existing `NoWarn` for `IL2110`/`IL2111` still applied, against the inventory's 26.

**Not one of the six annotated packages produces an `IL3050`**, and the single-file analyzer found
nothing anywhere.

## Every baseline entry, with its reason

Six entries across four packages. Each is scoped to a type, each names the contract it is honouring,
and each is in a `TrimAnalysisBaseline.cs` + `ILLink.Suppressions.xml` pair with the same header
discipline as core's. No `NoWarn`.

| Package | Type | Code | Why it could not be fixed or annotated |
|---|---|---|---|
| `Quartz.Jobs` | `Quartz.Jobs.DirectoryScanJobModel` | IL2026 | `DirectoryScanJob` takes its listener's **name** as job data; where a service provider is present that name is read as a type name, and the only place to look one up is the assemblies that happen to be loaded. The only path in is `DirectoryScanJob.Execute`, and `IJob` is an interface Quartz does not own both sides of, so `[RequiresUnreferencedCode]` cannot say it |
| `Quartz.Plugins` | `Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin` | IL2026 | `job_scheduling_data` XML names each job's type as a string. The processor says `[RequiresUnreferencedCode]`; the plugin implements `ISchedulerPlugin` and `IFileScanListener`, and IL2046 wants the attribute on both sides of an interface member Quartz does not own both sides of |
| `Quartz.Plugins` | `Quartz.Plugins.Json.JsonSchedulingDataProcessorPlugin` | IL2026 | The same, for `quartz_jobs.json` |
| `Quartz.HttpClient` | `Quartz.HttpScheduler` | IL2026 (2 call sites) | A job read back over HTTP carries its type as a name — deliberately, so that a listing process does not walk its probing paths for whatever a peer sent it. `AsIJobDetail` says `[RequiresUnreferencedCode]`; the two callers are `IScheduler.GetJobDetail` and `.GetJobDetails`, and carrying it further would put it on `IScheduler` and therefore on `RAMJobStore`'s clean path too |
| `Quartz.AspNetCore` | `Quartz.AspNetCore.HttpApi.Util.RequestedJobDetail` | IL2026 | A job posted to the API names its type as a string. The three endpoints that build one are delegates the routing table holds, so the attribute would land on `MapPost`, then `MapEndpoints`, then `MapQuartzHttpApi` — which every application serving this API calls, including one that only lists and pauses. Same wall `AddQuartz` is in the core package |

Two things to flag about the ILLink halves:

- **Nothing in this repository applies them.** `Quartz.Examples.Worker` and `Quartz.Trimming.Canary`
  are the only trimmed publishes and both reference `Quartz` alone (confirmed), so `build/Build.cs`
  reads `src/Quartz/ILLink.Suppressions.xml` only and nothing needed to change there. They exist
  because the C# baseline covers the Roslyn analyzer and nothing else, and a consumer publishing
  trimmed over these packages hits ILLink. Each file says so in its header, and says what would have
  to change if a canary ever referenced the package. Until then they are checked by review, not CI.
- The canary is untouched: no side package's annotation changes anything it exercises.

## The `RequestDelegateGenerator` verification

`EnableRequestDelegateGenerator` goes in before the four annotation properties, and it is worth more
than the count suggests: 114 of the 116 warnings were `MapGet`/`MapPost`/`MapDelete`, which say
`RequiresUnreferencedCode` **and** `RequiresDynamicCode` because `RequestDelegateFactory` binds a
handler's parameters and writes its result by reflecting over the delegate. Baselining those would
have recorded a decision nobody made.

Verified the way #3476 verified the binder generator. `EmitCompilerGeneratedFiles=true`, then the 57
`InterceptsLocationAttribute`s decoded out of
`obj/…/GeneratedRouteBuilderExtensions.g.cs` and matched per file against the `Map*` call sites in the
source:

| File | `Map*` calls in source | Interceptions |
|---|---:|---:|
| `CalendarEndpoints.cs` | 4 | 4 |
| `JobEndpoints.cs` | 20 | 20 |
| `SchedulerEndpoints.cs` | 13 | 13 |
| `TriggerEndpoints.cs` | 20 | 20 |
| **Total** | **57** | **57** |

The generated type is `Microsoft.AspNetCore.Http.Generated.GeneratedRouteBuilderExtensionsCore`, and
`RequestDelegatesAreSourceGeneratedTest` reads the same counts back out of the built assembly's
metadata. Turning the property off is loud today — 114 errors — but the test is for the case that is
not loud: the generator declining one call site and leaving the other 56 intercepted. Checked that it
fails: built with `EnableRequestDelegateGenerator=false -p:TreatWarningsAsErrors=false`, both its
assertions fail with *"the request delegate generator emits exactly one route builder per compilation,
and none at all when EnableRequestDelegateGenerator is off"*.

## A finding: the analyzer under-reports, and this package was the proof

`Quartz.AspNetCore` calls `JobDetailDto.AsIJobDetail()`, which is `[RequiresUnreferencedCode]`, in
three endpoints — and reported **nothing**. It is the shape of the call:

```csharp
var jobDetail = request.Job.AsIJobDetail().JobDetail!;   // silent
var (jobDetail, reason) = request.Job.AsIJobDetail();    // IL2026
```

Reading the result through a tuple element makes the trim analyzer drop the invocation; deconstructing
it reports. Confirmed by patching one call site each way and rebuilding. Left alone, this package would
have claimed `IsTrimmable` with an empty baseline while calling a `RequiresUnreferencedCode` API three
times — exactly the silence the issue is about.

`RequestedJobDetail` gathers the three, which makes the call visible *and* is better code: it uses the
`ErrorReason` the conversion returns instead of null-forgiving it away, so a malformed job type is a
400 naming itself rather than a `NullReferenceException`. (`AssertIsValid` still runs first, so this is
defence in depth.) `RequestedJobDetailTest` covers both paths.

**Reviewer decision:** the alternative was `[RequiresUnreferencedCode]` on `MapQuartzHttpApi`. I did not
take it, for the reason core's baseline gives for stopping before `AddQuartz`: every application that
serves this API calls it, including one that never posts a job. Say the word if you would rather the
API declared it.

## What else changed, and why

**`Quartz.Plugins` — `quartz_jobs.json` is read from generated metadata.** `JsonSchedulingDataContext`
replaces `Deserialize<T>(string, JsonSerializerOptions)`. The three reader settings a hand-written file
depends on — comments, trailing commas, case-insensitive property names — moved onto the context's
`[JsonSourceGenerationOptions]`, where they read as the file format rather than as serializer setup;
there was no test holding any of them, so there is one now, parsing a file that needs all three.
`ProcessJsonFileAndScheduleJobs`, `ProcessJsonContent` and `ProcessJobs` gained
`[RequiresUnreferencedCode]` with the wording `XmlSchedulingDataProcessor` has always used. All
internal.

**`Quartz.HttpClient` and `Quartz.AspNetCore` — the wire contract is asked for, not discovered.**
`HttpApiJsonContext` has fronted the resolver chain since #3400, so `options.GetTypeInfo(typeof(T))`
already had the answer; passing the `JsonTypeInfo` binds the overloads that carry neither attribute.
Nothing about the bytes changed — the chain still ends in reflection where reflection exists, and
generated metadata for a type the options carry a converter for defers to that converter, so `ITrigger`
and `ICalendar` still go through Quartz's own. On the server this made `JsonResponse` and
`ExecuteWithJsonResponse` instance members of `EndpointHelper`, which the endpoints were already being
handed as a parameter and which until now held nothing; 45 call sites go through it instead of the type.

**`Quartz.Dashboard` — the `NoWarn` for `IL2110`/`IL2111` is gone.** Those are the two ILLink codes for
reflecting over a `DynamicallyAccessedMembers`-annotated member, which is Blazor's `[Parameter]` model
exactly. Nothing emits them today (checked: building with the `NoWarn` removed and the analyzers off
produces no `IL` warning at all), so it was silencing a warning nobody was producing. If a future SDK
starts reporting them for a Razor project, that should be visible rather than pre-silenced. Not asked
for by the issue; say so if you would rather keep it.

## `IsAotCompatible`

Out of scope per the issue, and not set on anything. For the record: **all six of the annotated packages
would be ready for it.** None produces an `IL3050` — `Quartz.Plugins` and `Quartz.HttpClient` lost
theirs to the generated contracts in this PR, `Quartz.AspNetCore` lost its 57 to the request delegate
generator, and `Quartz.Jobs`, `Quartz.Extensions.Redis` and `Quartz.Plugins.TimeZoneConverter` never had
any. The claim would be as checkable as `Quartz`'s; what it would lack is a canary that runs one of them
out of a native publish, which is the thing #3341 kept insisting a compile cannot substitute for.

## Public API and docs

Public API baselines are **byte-identical** — everything annotated or moved is `internal`. No public
member gained `[RequiresUnreferencedCode]` or `[DynamicallyAccessedMembers]`.

- `docs/documentation/quartz-4.x/tutorial/more-about-jobs.md` — the Native AOT section gains
  *Which packages say whether they can be trimmed*: a table of all nine, what a trimmed publish reports
  against each, and why the two that say no say no.
- `docs/documentation/quartz-4.x/migration-guide.md` — a paragraph in *Trimming annotations* and one
  appendix row, because on 3.x none of the eight is marked and a reader migrating wants to know.
- `src/Quartz.Serialization.Newtonsoft/README.md` and `src/Quartz.Dashboard/README.md` — a **Trimming**
  section each, CommonMark only, saying the package is deliberately not trimmable and what to use
  instead. The six trimmable packages' readmes are unchanged; the site holds the table, which is what
  `PackageReadmeTest`'s guidance asks for.

## Verification

Actual output, on this machine:

- `dotnet build Quartz.slnx` — **Build succeeded. 0 Warning(s), 0 Error(s)**, and separately at each of
  the six commits in turn
- `dotnet test src/Quartz.Tests.Unit` — **Failed: 0, Passed: 3497, Skipped: 4, Total: 3501**
- `dotnet test src/Quartz.Tests.AspNetCore` — **Failed: 0, Passed: 495, Total: 495**
- `dotnet fallout PublishTrimmed` — **Succeeded**; "the trimmed canary publish reported nothing outside
  the recorded baseline"; canary `PASS store`, `PASS binding`
- `dotnet fallout PublishAot` — **Succeeded**; "the native AOT canary publish reported nothing outside
  the recorded baseline"; native canary `PASS store`, `PASS binding`
- `dotnet fallout VerifyDocsSnippets` — **Documentation snippets are up to date (90 markdown files
  checked)**
- Redis integration leg — **Failed: 0, Passed: 12, Total: 12**, against a real `redis:7` container
  (Docker 29.5.3). `dotnet fallout IntegrationTest` skips itself off GitHub Actions and off Linux, so
  this was run as `QUARTZ_TEST_DATABASE=redis dotnet test src/Quartz.Tests.Integration --filter
  TestCategory=db-redis`, which is the filter `Build.cs` applies for `Database=redis`.

There is no `Quartz.Tests.AOT` project on this branch — `Quartz.Trimming.Canary` is what replaced it,
and it runs in both publish legs above. `PublishAot` needs `vswhere.exe` on `PATH` on this machine,
which is the local-only wrinkle #3470 recorded; CI is unaffected. `npm run docs:check-links` was not run
(no `node_modules` here); the docs workflow runs it on this PR.

Closes #3431
